### PR TITLE
V3 apply/unapply: MVP

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,4 +1,5 @@
 use crate::Id;
+use gix::refs::FullNameRef;
 
 /// Metadata about workspaces, associated with references that are designated to a workspace,
 /// i.e. `refs/heads/gitbutler/workspaces/<name>`.
@@ -35,6 +36,50 @@ pub struct Workspace {
     pub push_remote: Option<String>,
 }
 
+/// Mutations
+impl Workspace {
+    /// Insert `branch` as new stack if it's not yet contained in the workspace, and return
+    /// Returns `true` if the ref was newly added, or false if it already existed.
+    pub fn add_new_stack_if_not_present(&mut self, branch: &FullNameRef) -> bool {
+        if self.contains_ref(branch) {
+            return false;
+        };
+
+        self.stacks.push(WorkspaceStack {
+            id: StackId::generate(),
+            branches: vec![WorkspaceStackBranch {
+                ref_name: branch.to_owned(),
+                archived: false,
+            }],
+        });
+        true
+    }
+
+    /// Return `true` if the branch with `name` is the workspace target or the targets local tracking branch,
+    /// using `repo` for the lookup of the local tracking branch.
+    pub fn is_branch_the_target_or_its_local_tracking_branch(
+        &self,
+        name: &gix::refs::FullNameRef,
+        repo: &gix::Repository,
+    ) -> anyhow::Result<bool> {
+        let Some(target_ref) = self.target_ref.as_ref() else {
+            return Ok(false);
+        };
+
+        if target_ref.as_ref() == name {
+            Ok(true)
+        } else {
+            let Some((local_tracking_branch, _remote_name)) =
+                repo.upstream_branch_and_remote_for_tracking_branch(target_ref.as_ref())?
+            else {
+                return Ok(false);
+            };
+            Ok(local_tracking_branch.as_ref() == name)
+        }
+    }
+}
+
+/// Access
 impl Workspace {
     /// Return `true` if `name` is a reference mentioned in our [stacks](Workspace::stacks).
     pub fn contains_ref(&self, name: &gix::refs::FullNameRef) -> bool {
@@ -90,6 +135,18 @@ pub struct Branch {
     pub description: Option<String>,
     /// Information about possibly ongoing reviews in various forges.
     pub review: Review,
+}
+
+/// Mutations
+impl Branch {
+    /// Claim that we now updated the branch in some way, and possibly also set the created time
+    /// if `is_new_ref` is `true`
+    pub fn update_times(&mut self, is_new_ref: bool) {
+        self.ref_info.set_updated_to_now();
+        if is_new_ref {
+            self.ref_info.set_created_to_now();
+        }
+    }
 }
 
 impl std::fmt::Debug for Branch {

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -2,5 +2,6 @@ mod cmd;
 mod commit;
 mod diff;
 mod json_samples;
+mod ref_metadata;
 mod settings;
 mod unified_diff;

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -7,13 +7,17 @@ mod workspace {
         assert_eq!(ws.stacks.len(), 0);
 
         let a_ref = r("refs/heads/A");
-        assert!(ws.add_new_stack_if_not_present(a_ref));
-        assert!(!ws.add_new_stack_if_not_present(a_ref));
+        assert!(ws.add_or_insert_new_stack_if_not_present(a_ref, Some(100)));
+        assert!(!ws.add_or_insert_new_stack_if_not_present(a_ref, Some(200)));
         assert_eq!(ws.stacks.len(), 1);
 
         let b_ref = r("refs/heads/B");
-        assert!(ws.add_new_stack_if_not_present(b_ref));
-        assert_eq!(ws.stacks.len(), 2);
+        assert!(ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0)));
+        assert_eq!(ws.stack_names().collect::<Vec<_>>(), [b_ref, a_ref]);
+
+        let c_ref = r("refs/heads/C");
+        assert!(ws.add_or_insert_new_stack_if_not_present(c_ref, None));
+        assert_eq!(ws.stack_names().collect::<Vec<_>>(), [b_ref, a_ref, c_ref]);
     }
 
     fn r(name: &str) -> &gix::refs::FullNameRef {

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -1,0 +1,22 @@
+mod workspace {
+    use but_core::ref_metadata::Workspace;
+
+    #[test]
+    fn add_new_stack_if_not_present() {
+        let mut ws = Workspace::default();
+        assert_eq!(ws.stacks.len(), 0);
+
+        let a_ref = r("refs/heads/A");
+        assert!(ws.add_new_stack_if_not_present(a_ref));
+        assert!(!ws.add_new_stack_if_not_present(a_ref));
+        assert_eq!(ws.stacks.len(), 1);
+
+        let b_ref = r("refs/heads/B");
+        assert!(ws.add_new_stack_if_not_present(b_ref));
+        assert_eq!(ws.stacks.len(), 2);
+    }
+
+    fn r(name: &str) -> &gix::refs::FullNameRef {
+        name.try_into().expect("statically known ref")
+    }
+}

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -63,6 +63,53 @@ impl Graph {
     }
 }
 
+/// Merge-base computation
+impl Graph {
+    /// Compute the lowest merge-base between two segments.
+    /// Such a merge-base is reachable from all possible paths from `a` and `b`.
+    ///
+    /// The segment representing the merge-base is expected to not be empty, as its first commit
+    /// is usually what one is interested in.
+    // TODO: should be multi, with extra segments as third parameter
+    // TODO: actually find the lowest merge-base, right now it just finds the first merge-base, but that's not
+    //       the lowest.
+    pub fn first_merge_base(&self, a: SegmentIndex, b: SegmentIndex) -> Option<SegmentIndex> {
+        // TODO(perf): improve this by allowing to set bitflags on the segments themselves, to allow
+        //       marking them accordingly, just like Git does.
+        //       Right now we 'emulate' bitflags on pre-allocated data with two data sets, expensive
+        //       in comparison.
+        //       And yes, let's avoid `gix::Repository::merge_base` as we have free
+        //       generation numbers here and can avoid work duplication.
+        let mut segments_reachable_by_b = BTreeSet::new();
+        self.visit_all_segments_including_start_until(b, Direction::Outgoing, |s| {
+            segments_reachable_by_b.insert(s.id);
+            // Collect everything, keep it simple.
+            // This is fast* as completely in memory.
+            // *means slow compared to an array traversal with memory locality.
+            false
+        });
+
+        let mut candidate = None;
+        self.visit_all_segments_including_start_until(a, Direction::Outgoing, |s| {
+            if candidate.is_some() {
+                return true;
+            }
+            let prune = segments_reachable_by_b.contains(&s.id);
+            if prune {
+                candidate = Some(s.id);
+            }
+            prune
+        });
+        if candidate.is_none() {
+            // TODO: improve this - workspaces shouldn't be like this but if they are, do we deal with it well?
+            tracing::warn!(
+                "Couldn't find merge-base between segments {a:?} and {b:?} - this might lead to unexpected results"
+            )
+        }
+        candidate
+    }
+}
+
 /// Query
 /// ‼️Useful only if one knows the graph traversal was started where one expects, or else the graph may be partial.
 impl Graph {
@@ -128,6 +175,11 @@ impl Graph {
             true
         });
         sidx_with_commits.and_then(|sidx| self[sidx].commits.first())
+    }
+
+    /// The first commit reachable by skipping over empty segments starting at the entrypoint segment.
+    pub fn entrypoint_commit(&self) -> Option<&Commit> {
+        self.tip_skip_empty(self.entrypoint?.0)
     }
 
     /// Visit the ancestry of `start` along the first parents, itself excluded, until `stop` returns `true`.

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -171,6 +171,12 @@ impl Graph {
         self.hard_limit_hit = true;
     }
 
+    /// Lookup the segment of `sidx` and then find its sibling segment, if it has one.
+    pub fn lookup_sibling_segment(&self, sidx: SegmentIndex) -> Option<&Segment> {
+        self.inner
+            .node_weight(self.inner.node_weight(sidx)?.sibling_segment_id?)
+    }
+
     /// Return the entry-point of the graph as configured during traversal.
     /// It's useful for when one wants to know which commit was used to discover the entire graph.
     ///

--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -371,7 +371,7 @@ impl Graph {
                 .commit_id_by_index(e.dst)
                 .map(|c| c.to_hex_with_len(HEX).to_string())
                 .unwrap_or_else(|| "dst".into());
-            format!(", label = \"⚠️{src} → {dst} ({err})\", fontname = Courier")
+            format!(", label = \"⚠{src} → {dst} ({err})\", fontname = Courier")
         };
         let dot = petgraph::dot::Dot::with_attr_getters(&self.inner, &[], &edge_attrs, &node_attrs);
         format!("{dot:?}")

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -25,7 +25,7 @@ pub(crate) type Entrypoint = Option<(gix::ObjectId, Option<gix::refs::FullName>)
 
 /// A way to define information to be served from memory, instead of from the underlying data source, when
 /// [initializing](Graph::from_commit_traversal()) the graph.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Overlay {
     entrypoint: Entrypoint,
     nonoverriding_references: Vec<gix::refs::Reference>,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -29,6 +29,7 @@ pub(crate) type Entrypoint = Option<(gix::ObjectId, Option<gix::refs::FullName>)
 pub struct Overlay {
     entrypoint: Entrypoint,
     nonoverriding_references: Vec<gix::refs::Reference>,
+    overriding_references: Vec<gix::refs::Reference>,
     meta_branches: Vec<(gix::refs::FullName, ref_metadata::Branch)>,
     workspace: Option<(gix::refs::FullName, ref_metadata::Workspace)>,
 }

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -2,6 +2,7 @@ use crate::init::walk::RefsById;
 use crate::init::{Entrypoint, Overlay};
 use but_core::{RefMetadata, ref_metadata};
 use gix::prelude::ReferenceExt;
+use gix::refs::Target;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 
@@ -16,6 +17,13 @@ impl Overlay {
         self
     }
 
+    /// Serve the given `refs` from memory, which is like creating the reference or as if its value was set,
+    /// completely overriding the value in the repository.
+    pub fn with_references(mut self, refs: impl IntoIterator<Item = gix::refs::Reference>) -> Self {
+        self.overriding_references.extend(refs);
+        self
+    }
+
     /// Override the starting position of the traversal by setting it to `id`,
     /// and optionally, by providing the `ref_name` that points to `id`.
     pub fn with_entrypoint(
@@ -23,6 +31,13 @@ impl Overlay {
         id: gix::ObjectId,
         ref_name: Option<gix::refs::FullName>,
     ) -> Self {
+        if let Some(ref_name) = &ref_name {
+            self.overriding_references.push(gix::refs::Reference {
+                name: ref_name.to_owned(),
+                target: Target::Object(id),
+                peeled: Some(id),
+            })
+        }
         self.entrypoint = Some((id, ref_name));
         self
     }
@@ -58,14 +73,19 @@ impl Overlay {
         T: RefMetadata,
     {
         let Overlay {
-            nonoverriding_references,
+            mut nonoverriding_references,
+            mut overriding_references,
             meta_branches,
             workspace,
             entrypoint,
         } = self;
+        // Make sure that duplicates from later determine the value.
+        nonoverriding_references.reverse();
+        overriding_references.reverse();
         (
             OverlayRepo {
-                nonoverriding_references,
+                nonoverriding_references: nonoverriding_references.into_iter().collect(),
+                overriding_references: overriding_references.into_iter().collect(),
                 inner: repo,
             },
             OverlayMetadata {
@@ -80,7 +100,8 @@ impl Overlay {
 
 pub(crate) struct OverlayRepo<'repo> {
     inner: &'repo gix::Repository,
-    nonoverriding_references: Vec<gix::refs::Reference>,
+    nonoverriding_references: BTreeSet<gix::refs::Reference>,
+    overriding_references: BTreeSet<gix::refs::Reference>,
 }
 
 /// Note that functions with `'repo` in their return value technically leak the bare repo, and it's
@@ -94,7 +115,13 @@ impl<'repo> OverlayRepo<'repo> {
         &self,
         ref_name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<Option<gix::Reference<'repo>>> {
-        if let Some(rn) = self.inner.try_find_reference(ref_name)? {
+        if let Some(r) = self
+            .overriding_references
+            .iter()
+            .find(|r| r.name.as_ref() == ref_name)
+        {
+            Ok(Some(r.clone().attach(self.inner)))
+        } else if let Some(rn) = self.inner.try_find_reference(ref_name)? {
             Ok(Some(rn))
         } else if let Some(r) = self
             .nonoverriding_references
@@ -111,6 +138,13 @@ impl<'repo> OverlayRepo<'repo> {
         &self,
         ref_name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<gix::Reference<'repo>> {
+        if let Some(r) = self
+            .overriding_references
+            .iter()
+            .find(|r| r.name.as_ref() == ref_name)
+        {
+            return Ok(r.clone().attach(self.inner));
+        }
         Ok(self
             .inner
             .find_reference(ref_name)
@@ -202,6 +236,18 @@ impl<'repo> OverlayRepo<'repo> {
             };
         let mut all_refs_by_id = gix::hashtable::HashMap::<_, Vec<_>>::default();
         for prefix in prefixes {
+            // apply overrides - they are seen first and take the spot of everything.
+            for (commit_id, git_reference) in self
+                .overriding_references
+                .iter()
+                .filter(|rn| rn.name.as_bstr().starts_with(prefix.as_bytes()))
+                .filter_map(|rn| ref_filter(rn.clone().attach(self.inner)))
+            {
+                all_refs_by_id
+                    .entry(commit_id)
+                    .or_default()
+                    .push(git_reference);
+            }
             for (commit_id, git_reference) in self
                 .inner
                 .references()?
@@ -214,7 +260,7 @@ impl<'repo> OverlayRepo<'repo> {
                     .or_default()
                     .push(git_reference);
             }
-            // apply overrides
+            // apply overrides (new only)
             for (commit_id, git_reference) in self
                 .nonoverriding_references
                 .iter()

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -93,7 +93,6 @@ impl Graph {
         // Finally, once all segments were added, it's good to generations
         // have to figure out early abort conditions, or to know what's ahead of another.
         self.compute_generation_numbers();
-
         Ok(self)
     }
 

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -12,6 +12,7 @@ use gix::reference::Category;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 use petgraph::prelude::EdgeRef;
+use petgraph::visit::NodeRef;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::instrument;
 
@@ -439,6 +440,27 @@ impl Graph {
                         .map(|cidx| (sidx, &base_segment.commits[cidx]))
                 })
             })
+            .chain(
+                self.inner
+                    .neighbors_directed(ws_sidx, Direction::Outgoing)
+                    .filter_map(|s| {
+                        // This rule means that if there is no target, we'd want to put new independent stacks
+                        // onto segments which then are ambiguous so they get pulled out.
+                        if target.is_some() {
+                            return None;
+                        }
+                        // It's a very specialised filter… will that lead to strange behaviour later?
+                        let segment = &self[s];
+                        if segment.ref_name.is_some() {
+                            return None;
+                        }
+                        segment
+                            .commits
+                            .first()
+                            .filter(|c| !c.refs.is_empty())
+                            .map(|c| (s.id(), c))
+                    }),
+            )
             .collect();
         out.sort_by_key(|t| t.1.id);
         out.dedup_by_key(|t| t.1.id);
@@ -913,6 +935,37 @@ impl Graph {
         }
         for (remote_sidx, local_sidx) in links_from_remote_to_local {
             self[remote_sidx].sibling_segment_id = Some(local_sidx);
+
+            // If both remote and local point to the same commit, make sure that the remote points to the local segment.
+            if let Some((
+                (_remote_commit, _owner_of_commit_same_as_local),
+                (_local_commmit, owner_of_commit_same_as_remote),
+            )) = self
+                .first_commit_or_find_along_first_parent(remote_sidx)
+                .zip(self.first_commit_or_find_along_first_parent(local_sidx))
+                .filter(|((a, a_sidx), (b, b_sidx))| a.id == b.id && a_sidx == b_sidx)
+            {
+                let outgoing: Vec<_> = self
+                    .edges_directed_in_order_of_creation(remote_sidx, Direction::Outgoing)
+                    .into_iter()
+                    .map(EdgeOwned::from)
+                    .collect();
+                let remote_is_connected_to_local =
+                    outgoing.iter().any(|e| e.target.id() == local_sidx);
+                if !remote_is_connected_to_local
+                    && let Some(edge) = outgoing.iter().find(|e| {
+                        outgoing.len() == 1 || e.target.id() == owner_of_commit_same_as_remote
+                    })
+                {
+                    self.inner.remove_edge(edge.id);
+                    self.inner.add_edge(
+                        remote_sidx,
+                        local_sidx,
+                        edge.weight
+                            .adjusted_for(remote_sidx, local_sidx, &self.inner),
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -280,5 +280,32 @@ pub struct Edge {
     dst_id: Option<gix::ObjectId>,
 }
 
+impl Edge {
+    /// Useful when reusing an edge to assure it doesn't list commits that don't exist in `src_idx` and `dst_idx` anymore.
+    pub(crate) fn adjusted_for(
+        mut self,
+        src_sidx: SegmentIndex,
+        dst_sidx: SegmentIndex,
+        graph: &init::PetGraph,
+    ) -> Self {
+        let commits = &graph[src_sidx].commits;
+        let (id, idx) = commits
+            .last()
+            .map(|c| (Some(c.id), Some(commits.len() - 1)))
+            .unwrap_or_default();
+        self.src_id = id;
+        self.src = idx;
+
+        let commits = &graph[dst_sidx].commits;
+        let (id, idx) = commits
+            .first()
+            .map(|c| (Some(c.id), Some(0)))
+            .unwrap_or_default();
+        self.dst_id = id;
+        self.dst = idx;
+
+        self
+    }
+}
 /// An index into the [`Graph`].
 pub type SegmentIndex = petgraph::graph::NodeIndex;

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -27,6 +27,13 @@ impl Stack {
             .and_then(|s| s.commits.first().map(|c| c.id))
     }
 
+    /// Return the name of the first segment of the stack.
+    pub fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
+        self.segments
+            .first()
+            .and_then(|s| s.ref_name.as_ref().map(|rn| rn.as_ref()))
+    }
+
     /// Return the first commit of the first non-empty segment, or `None` this stack is completely empty, or has only empty segments.
     pub fn tip_skip_empty(&self) -> Option<gix::ObjectId> {
         self.segments.iter().find_map(|s| {
@@ -36,6 +43,7 @@ impl Stack {
             s.commits.first().map(|c| c.id)
         })
     }
+
     /// The [base](StackSegment::base) of the last of our segments.
     pub fn base(&self) -> Option<gix::ObjectId> {
         self.segments.last().and_then(|s| s.base)

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -789,7 +789,7 @@ impl Graph {
         out
     }
 
-    /// Return `(commit, start)` if `start` has a commit, or find the first commit downstream along the first parent.
+    /// Return `(commit, owner_sidx_of_commit)` if `start` has a commit, or find the first commit downstream along the first parent.
     pub(crate) fn first_commit_or_find_along_first_parent(
         &self,
         start: SegmentIndex,

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -70,6 +70,23 @@ impl Workspace<'_> {
             .all(|s| s.segments.iter().all(|s| !s.is_entrypoint))
     }
 
+    /// Return `true` if the branch with `name` is the workspace target or the targets local tracking branch.
+    pub fn is_branch_the_target_or_its_local_tracking_branch(
+        &self,
+        name: &gix::refs::FullNameRef,
+    ) -> bool {
+        let Some(t) = self.target.as_ref() else {
+            return false;
+        };
+
+        t.ref_name.as_ref() == name
+            || self
+                .graph
+                .lookup_sibling_segment(t.segment_index)
+                .and_then(|local_tracking_segment| local_tracking_segment.ref_name.as_ref())
+                .is_some_and(|local_tracking_ref| local_tracking_ref.as_ref() == name)
+    }
+
     /// Return the `commit` at the tip of the workspace itself, and do so by following empty segments along the
     /// first parent until the first commit is found.
     /// This importantly is different from the [`Graph::lookup_entrypoint()`] `commit`, as the entrypoint could be anywhere
@@ -265,6 +282,24 @@ pub enum WorkspaceKind {
 }
 
 impl WorkspaceKind {
+    /// Return `true` if this workspace has a managed reference, meaning we control certain aspects of it
+    /// by means of workspace metadata that is associated with that ref.
+    /// If `false`, we are more conservative and may not support all features.
+    pub fn has_managed_ref(&self) -> bool {
+        matches!(
+            self,
+            WorkspaceKind::Managed { .. } | WorkspaceKind::ManagedMissingWorkspaceCommit { .. }
+        )
+    }
+
+    /// Return `true` if we have a workspace commit, a commit that merges all stacks together.
+    /// Implies `has_managed_ref() == true`.
+    pub fn has_managed_commit(&self) -> bool {
+        matches!(self, WorkspaceKind::Managed { .. })
+    }
+}
+
+impl WorkspaceKind {
     fn managed(ref_name: &Option<gix::refs::FullName>) -> anyhow::Result<Self> {
         Ok(WorkspaceKind::Managed {
             ref_name: ref_name
@@ -279,7 +314,7 @@ impl WorkspaceKind {
 #[derive(Debug, Clone)]
 pub struct Target {
     /// The name of the target branch, i.e. the branch that all [Stacks](Stack) want to get merged into.
-    /// Typically, this is `origin/main`.
+    /// Typically, this is `refs/remotes/origin/main`.
     pub ref_name: gix::refs::FullName,
     /// The index to the respective segment in the graph.
     pub segment_index: SegmentIndex,
@@ -438,7 +473,7 @@ impl Graph {
             lower_bound: None,
         };
 
-        let ws_lower_bound = if ws.has_managed_ref() {
+        let ws_lower_bound = if ws.kind.has_managed_ref() {
             self.compute_lowest_base(ws.id, ws.target.as_ref(), self.extra_target)
                 .or_else(|| {
                     // target not available? Try the base of the workspace itself
@@ -501,7 +536,7 @@ impl Graph {
             *lower_bound_segment_id = None;
         }
 
-        if ws.has_managed_ref() && self[ws.id].commits.is_empty() {
+        if ws.kind.has_managed_ref() && self[ws.id].commits.is_empty() {
             ws.kind = WorkspaceKind::ManagedMissingWorkspaceCommit {
                 ref_name: ws_tip_segment
                     .ref_name
@@ -516,7 +551,7 @@ impl Graph {
                 .is_some_and(|rn| rn.as_bstr().starts_with_str("refs/heads/gitbutler/"))
         }
 
-        if ws.has_managed_ref() {
+        if ws.kind.has_managed_ref() {
             let (lowest_base, lowest_base_sidx) =
                 ws_lower_bound.map_or((None, None), |(base, sidx)| (Some(base), Some(sidx)));
             for stack_top_sidx in self
@@ -1070,15 +1105,6 @@ impl Workspace<'_> {
 
 /// Query
 impl<'graph> Workspace<'graph> {
-    /// Return `true` if this workspace is managed, meaning we control certain aspects of it.
-    /// If `false`, we are more conservative and may not support all features.
-    pub fn has_managed_ref(&self) -> bool {
-        matches!(
-            self.kind,
-            WorkspaceKind::Managed { .. } | WorkspaceKind::ManagedMissingWorkspaceCommit { .. }
-        )
-    }
-
     /// Return `true` if the workspace has workspace metadata associated with it.
     /// This is relevant when creating references for example.
     pub fn has_metadata(&self) -> bool {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1151,5 +1151,17 @@ EOF
     commit A3
     create_workspace_commit_once A
   )
+
+
+  git init no-ws-ref-no-ws-commit-two-branches
+  (cd no-ws-ref-no-ws-commit-two-branches
+    commit M1
+    commit M2
+
+    git branch A
+    git branch B
+
+    create_workspace_commit_once A B
+  )
 )
 

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -1,3 +1,4 @@
+use but_core::RefMetadata;
 use but_core::ref_metadata::StackId;
 use but_graph::VirtualBranchesTomlMetadata;
 use but_graph::virtual_branches_legacy_types::{Stack, StackBranch, Target};
@@ -51,6 +52,18 @@ pub fn add_workspace(meta: &mut VirtualBranchesTomlMetadata) {
         "definitely outside of the workspace just to have it",
         StackState::Inactive,
     );
+}
+
+pub fn remove_target(meta: &mut VirtualBranchesTomlMetadata) {
+    let mut ws_md = meta
+        .workspace(
+            "refs/heads/gitbutler/workspace"
+                .try_into()
+                .expect("statically known to be valid"),
+        )
+        .unwrap();
+    ws_md.target_ref = None;
+    meta.set_workspace(&ws_md).unwrap();
 }
 
 pub fn add_workspace_without_target(meta: &mut VirtualBranchesTomlMetadata) {

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -18,6 +18,8 @@
 		"oauthClientId": "cd51880daa675d9e6452"
 	},
 	"featureFlags": {
+		/// Use the V3 version of apply and unapply.
+		"apply3": false,
 		// Enables the v3 safe checkout.
 		"cv3": false,
 		/// Enable the usage of V3 workspace APIs.

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -27,6 +27,8 @@ pub struct FeatureFlags {
     pub ws3: bool,
     /// Turn on the set a v3 version of checkout
     pub cv3: bool,
+    /// Use the V3 version of apply and unapply.
+    pub apply3: bool,
     /// Enable undo/redo support.
     ///
     /// ### Progression for implementation

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -372,6 +372,7 @@ pub mod stacks {
         let app_settings = AppSettings {
             feature_flags: but_settings::app_settings::FeatureFlags {
                 ws3,
+                apply3: false,
                 cv3: false,
                 undo: false,
                 actions: false,

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -460,6 +460,28 @@ impl Stack {
 pub mod checkout;
 pub use checkout::function::{safe_checkout, safe_checkout_from_head};
 
+/// What to do if the applied branch conflicts with the existing branches?
+#[derive(Default, Debug, Copy, Clone)]
+pub enum OnWorkspaceMergeConflict {
+    /// Provide additional information about the stack(s) that conflicted and the files involved in it,
+    /// and don't materialise the merge, but continue on best-effort basis to merge as many stacks as possible.
+    #[default]
+    AbortAndReportConflictingStacks,
+    /// Despite possible conflicts, materialise the result with the conflicting stacks un-merged and unreachable from the workspace commit.
+    /// Note that the metadata of these branches is still available.
+    MaterializeAndReportConflictingStacks,
+}
+
+impl OnWorkspaceMergeConflict {
+    /// Return `true` if we are supposed to abort on merge conflict.
+    pub fn should_abort(&self) -> bool {
+        matches!(
+            self,
+            OnWorkspaceMergeConflict::AbortAndReportConflictingStacks
+        )
+    }
+}
+
 /// Functions and types related to applying a workspace branch.
 pub mod apply;
 pub use apply::function::apply;

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -1,5 +1,6 @@
 use crate::WorkspaceCommit;
 use crate::ui::StackEntryNoOpt;
+use anyhow::Context;
 use bstr::{BString, ByteSlice};
 
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
@@ -30,6 +31,51 @@ impl<'repo> WorkspaceCommit<'repo> {
         Ok(WorkspaceCommit {
             id: commit_id,
             inner: commit,
+        })
+    }
+
+    /// A way to create a commit from `workspace` stacks, with the `tree` being used as the tree of the workspace commit.
+    /// It's supposed to be the legitimate merge of the stacks contained in `workspace`.
+    /// Note that it will be written to `repo` immediately for persistence, with its object id returned.
+    pub(crate) fn from_graph_workspace(
+        workspace: &but_graph::projection::Workspace,
+        repo: &'repo gix::Repository,
+        tree: gix::ObjectId,
+    ) -> anyhow::Result<Self> {
+        let stacks: Vec<_> = workspace
+            .stacks
+            .iter()
+            .map(|s| {
+                let name = s.ref_name().map(|rn| rn.shorten().to_owned());
+                let s = crate::commit::Stack {
+                    tip: s.tip_skip_empty().or(s.base()).with_context(|| format!("Could not find any commit to serve as tip for stack {id:?} with name {name:?}", id = s.id))?,
+                    name,
+                };
+                anyhow::Ok(s)
+            })
+            .collect::<Result<_, _>>()?;
+        // We know the workspace commit is the same as the current HEAD, no need to merge, nothing changed
+        // use the same tree.
+        let mut ws_commit = Self::new_from_stacks(stacks, repo.object_hash());
+        ws_commit.tree = tree;
+
+        // also rewrite the author and commiter time, just to be sure we respect all settings. `new_from_stacks` doesn't have a repo.
+        fn try_time(
+            sig: Option<Result<gix::actor::SignatureRef<'_>, gix::config::time::Error>>,
+        ) -> Option<gix::date::Time> {
+            sig.transpose().ok().flatten().and_then(|s| s.time().ok())
+        }
+        if let Some(committer_time) = try_time(repo.committer()) {
+            ws_commit.committer.time = committer_time;
+        }
+        if let Some(author_time) = try_time(repo.committer()) {
+            ws_commit.author.time = author_time;
+        }
+
+        let id = repo.write_object(&ws_commit)?;
+        Ok(Self {
+            id,
+            inner: ws_commit,
         })
     }
 
@@ -80,11 +126,7 @@ impl<'repo> WorkspaceCommit<'repo> {
         message
             .push_str("https://docs.gitbutler.com/features/virtual-branches/integration-branch\n");
 
-        let author = gix::actor::Signature {
-            name: "GitButler".into(),
-            email: "gitbutler@gitbutler.com".into(),
-            time: commit_time("GIT_COMMITTER_DATE"),
-        };
+        let author = commit_signature(commit_time("GIT_COMMITTER_DATE"));
         gix::objs::Commit {
             tree: gix::ObjectId::empty_tree(object_hash),
             parents: stacks.iter().map(|s| s.tip).collect(),
@@ -94,6 +136,14 @@ impl<'repo> WorkspaceCommit<'repo> {
             message: message.into(),
             extra_headers: vec![],
         }
+    }
+}
+
+fn commit_signature(time: gix::date::Time) -> gix::actor::Signature {
+    gix::actor::Signature {
+        name: "GitButler".into(),
+        email: "gitbutler@gitbutler.com".into(),
+        time,
     }
 }
 

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -515,10 +515,7 @@ pub fn create_commit_and_update_refs(
                             .map(|stack| crate::ui::StackEntryNoOpt::try_new(repo, stack))
                             .collect::<Result<_, _>>()?;
                         stacks.sort_by(|a, b| a.name().cmp(&b.name()));
-                        let new_wc = WorkspaceCommit::create_commit_from_vb_state(
-                            &stacks,
-                            repo.object_hash(),
-                        );
+                        let new_wc = WorkspaceCommit::new_from_stacks(stacks, repo.object_hash());
                         repo.write_object(&new_wc)?.detach()
                     } else {
                         workspace_tip

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -61,7 +61,8 @@ pub mod snapshot;
 
 mod changeset;
 
-mod commit;
+/// Utility types for the [`WorkspaceCommit`].
+pub(crate) mod commit;
 
 /// Types used only when obtaining head-information.
 ///

--- a/crates/but-workspace/tests/fixtures/scenario/no-ws-ref-no-ws-commit-two-branches.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/no-ws-ref-no-ws-commit-two-branches.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A situation where no workspace reference is available yet.
+git init
+
+commit A
+setup_target_to_match_main
+
+git branch A
+git branch B
+

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-no-ws-commit-one-stack-one-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-no-ws-commit-one-stack-one-branch.sh
@@ -6,7 +6,8 @@ source "${BASH_SOURCE[0]%/*}/shared.sh"
 
 ### General Description
 
-# A ws-ref points to a commit, which is also owned by a stack. There is another branch outside of the workspace pointing to the same commit.
+# A ws-ref points to a non-managed commit, along with two branches pointing to the same.
+# This is an initial state where a workspace was newly created.
 git init
 commit A
 git branch A

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -6,14 +6,13 @@ use crate::utils::r;
 use but_core::RefMetadata;
 use but_graph::init::{Options, Overlay};
 use but_testsupport::{graph_workspace, id_at, visualize_commit_graph_all};
-use but_workspace::branch::apply::{
-    IntegrationMode, OnWorkspaceConflict, WorkspaceReferenceNaming,
-};
+use but_workspace::branch::OnWorkspaceMergeConflict;
+use but_workspace::branch::apply::{IntegrationMode, WorkspaceReferenceNaming};
 use but_workspace::branch::checkout::UncommitedWorktreeChanges;
 
 #[test]
 fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
-    let (_tmp, graph, mut repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-one-stack-ws-advanced",
             |_meta| {},
@@ -32,21 +31,16 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
             └── ·4979833 (🏘️)
     ");
 
-    let err = but_workspace::branch::apply(
-        r("refs/heads/B"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )
-    .unwrap_err();
+    let err =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())
+            .unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to work on workspace whose workspace commit isn't at the top",
         "cannot apply on a workspace that isn't proper"
     );
 
-    let err = but_workspace::branch::apply(r("HEAD"), &ws, &mut repo, &mut meta, default_options())
+    let err = but_workspace::branch::apply(r("HEAD"), &ws, &repo, &mut meta, default_options())
         .unwrap_err();
     assert_eq!(
         err.to_string(),
@@ -59,7 +53,7 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
 
 #[test]
 fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
-    let (_tmp, graph, mut repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-no-ws-commit-one-stack-one-branch",
             |_meta| {},
@@ -69,13 +63,8 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
 
     // Put "A" into the workspace, yielding a single branch.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -91,13 +80,8 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     // No commit was created, as it's not enabled by default.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
-    let out = but_workspace::branch::apply(
-        r("refs/heads/B"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -127,7 +111,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
 #[test]
 fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_target_branch()
 -> anyhow::Result<()> {
-    let (_tmp, _, mut repo, mut meta, _description) =
+    let (_tmp, _, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "no-ws-ref-no-ws-commit-two-branches",
             |_meta| {},
@@ -157,13 +141,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -186,9 +165,13 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let out = but_workspace::branch::apply(
         r("refs/heads/B"),
         &ws,
-        &mut repo,
+        &repo,
         &mut meta,
-        default_options(),
+        but_workspace::branch::apply::Options {
+            // Make it appear in place of A, in the center.
+            order: Some(1),
+            ..default_options()
+        },
     )?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
@@ -200,10 +183,10 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
-    ├── ≡📙:4:B on e5d0542
-    │   └── 📙:4:B
-    ├── ≡📙:3:A on e5d0542
-    │   └── 📙:3:A
+    ├── ≡📙:4:A on e5d0542
+    │   └── 📙:4:A
+    ├── ≡📙:3:B on e5d0542
+    │   └── 📙:3:B
     └── ≡📙:2:main on e5d0542
         └── 📙:2:main
     ");
@@ -228,7 +211,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
         &ws,
-        &mut repo,
+        &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
             integration_mode: IntegrationMode::AlwaysMerge,
@@ -243,7 +226,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace <> ✓!
     └── ≡📙:2:A
         └── 📙:2:A
             └── ·e5d0542 (🏘️) ►B, ►main
@@ -252,7 +235,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let out = but_workspace::branch::apply(
         r("refs/heads/B"),
         &ws,
-        &mut repo,
+        &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
             integration_mode: IntegrationMode::AlwaysMerge,
@@ -282,7 +265,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 #[test]
 fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target()
 -> anyhow::Result<()> {
-    let (_tmp, _, mut repo, mut meta, _description) =
+    let (_tmp, _, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "no-ws-ref-no-ws-commit-two-branches",
             |_meta| {},
@@ -300,13 +283,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -324,13 +302,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     // No commit was created, as it's not enabled by default, but a ws-ref was created, and it's checked out.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
 
-    let out = but_workspace::branch::apply(
-        r("refs/heads/B"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -352,9 +325,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 
     // Cannot put local tracking branch of target into workspace that has it configured.
     for branch in ["refs/heads/main", "refs/remotes/origin/main"] {
-        let err =
-            but_workspace::branch::apply(r(branch), &ws, &mut repo, &mut meta, default_options())
-                .unwrap_err();
+        let err = but_workspace::branch::apply(r(branch), &ws, &repo, &mut meta, default_options())
+            .unwrap_err();
         assert_eq!(
             err.to_string(),
             format!("Cannot add the target '{branch}' branch to its own workspace")
@@ -368,9 +340,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 }
 
 #[test]
-#[ignore = "TBD"]
 fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> anyhow::Result<()> {
-    let (_tmp, ws_graph, mut repo, mut meta, _description) =
+    let (_tmp, ws_graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-no-ws-commit-one-stack-one-branch",
             |_meta| {},
@@ -383,26 +354,32 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     let (b_id, b_ref) = id_at(&repo, "B");
     let graph = but_graph::Graph::from_commit_traversal(b_id, b_ref, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
+    // Note how the existing `gitbutler/workspace` disappears, which is expected here.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:B <> ✓!
-    └── ≡:0:B
-        └── :0:B
+    ⌂:1:B <> ✓!
+    └── ≡:1:B
+        └── :1:B
             └── ·e5d0542 ►A, ►main
     ");
 
     // Put "A" into the workspace, hence we want "A" and "B" in it.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
-        workspace_changed: false,
+        workspace_changed: true,
         workspace_ref_created: false,
     }
+    ");
+
+    let ws = out.graph.to_workspace()?;
+    // This apply brings both branches into the existing workspace, and it's where HEAD points to.
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:A on e5d0542
+    │   └── 📙:3:A
+    └── ≡📙:2:B on e5d0542
+        └── 📙:2:B
     ");
 
     // HEAD must now point to the workspace (that already existed)
@@ -412,9 +389,8 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
 }
 
 #[test]
-#[ignore = "TBD"]
 fn detached_head_journey() -> anyhow::Result<()> {
-    let (_tmp, graph, mut repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "detached-with-multiple-branches",
             |_meta| {},
@@ -437,25 +413,117 @@ fn detached_head_journey() -> anyhow::Result<()> {
             └── ·3183e43 (✓)
     ");
 
+    let out =
+        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())?;
+
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: true,
+    }
+    ");
+
+    let graph = out.graph;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    └── ≡📙:2:C on 3183e43
+        └── 📙:2:C
+            └── ·aaa195b (🏘️)
+    ");
+    // A new workspace reference was created, and checked out, without enforcing a workspace commit
+    // as there is no need.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 49d4b34 (A) A1
+    | * f57c528 (B) B1
+    |/  
+    | * aaa195b (HEAD -> gitbutler/workspace, C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+    }
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 49d4b34 (A) A1
+    | *   9af353b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | | * f57c528 (B) B1
+    | |/  
+    |/|   
+    | * aaa195b (C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+
+    let graph = out.graph;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓! on 3183e43
+    ├── ≡📙:3:B on 3183e43
+    │   └── 📙:3:B
+    │       └── ·f57c528 (🏘️)
+    └── ≡📙:2:C on 3183e43
+        └── 📙:2:C
+            └── ·aaa195b (🏘️)
+    ");
+
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
         &ws,
-        &mut repo,
+        &repo,
         &mut meta,
-        default_options(),
+        but_workspace::branch::apply::Options {
+            // Make 'A' appear at the front.
+            order: Some(0),
+            ..default_options()
+        },
     )?;
+
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
-        workspace_changed: false,
+        workspace_changed: true,
         workspace_ref_created: false,
     }
+    ");
+    let graph = out.graph;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓! on 3183e43
+    ├── ≡📙:4:B on 3183e43
+    │   └── 📙:4:B
+    │       └── ·f57c528 (🏘️)
+    ├── ≡📙:3:C on 3183e43
+    │   └── 📙:3:C
+    │       └── ·aaa195b (🏘️)
+    └── ≡📙:2:A on 3183e43
+        └── 📙:2:A
+            └── ·49d4b34 (🏘️)
+    ");
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   4912314 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\ \  
+    | | * f57c528 (B) B1
+    | * | aaa195b (C) C1
+    | |/  
+    * / 49d4b34 (A) A1
+    |/  
+    * 3183e43 (main) M1
     ");
     Ok(())
 }
 
 #[test]
 fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
-    let (_tmp, graph, mut repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-no-ws-commit-one-stack-one-branch",
             |meta| {
@@ -479,7 +547,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     let out = but_workspace::branch::apply(
         r("refs/heads/gitbutler/workspace"),
         &ws,
-        &mut repo,
+        &repo,
         &mut meta,
         default_options(),
     )?;
@@ -507,7 +575,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     ");
     // Already applied (the HEAD points to it, it literally IS the workspace).
     let out =
-        but_workspace::branch::apply(b_ref.as_ref(), &ws, &mut repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: false,
@@ -516,13 +584,8 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     ");
 
     // To apply A, we just checkout the surrounding workspace, as it's contained there.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -562,13 +625,8 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     ");
 
     // Nothing changed, the desired branch was already applied.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: false,
@@ -588,13 +646,8 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Apply the first branch, it must be independent.
     let ws = graph.to_workspace()?;
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -616,7 +669,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
 #[test]
 fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
-    let (_tmp, graph, mut repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-two-stacks",
             |meta| {
@@ -647,7 +700,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // Apply the workspace ref itself, it's a no-op
     let ws_ref = r("refs/heads/gitbutler/workspace");
-    let out = but_workspace::branch::apply(ws_ref, &ws, &mut repo, &mut meta, default_options())?;
+    let out = but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: false,
@@ -671,7 +724,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // Already applied (the HEAD points to it, it literally IS the workspace).
     let out =
-        but_workspace::branch::apply(b_ref.as_ref(), &ws, &mut repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: false,
@@ -679,8 +732,8 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     }
     ");
 
-    let err = but_workspace::branch::apply(ws_ref, &ws, &mut repo, &mut meta, default_options())
-        .unwrap_err();
+    let err =
+        but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, default_options()).unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to apply a reference that already is a workspace: 'gitbutler/workspace'",
@@ -689,13 +742,8 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     );
 
     // To apply, we just checkout the surrounding workspace.
-    let out = but_workspace::branch::apply(
-        r("refs/heads/A"),
-        &ws,
-        &mut repo,
-        &mut meta,
-        default_options(),
-    )?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         workspace_changed: true,
@@ -717,9 +765,8 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "TBD"]
 fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
-    let (mut repo, mut meta) =
+    let (repo, mut meta) =
         named_read_only_in_memory_scenario("ws-ref-no-ws-commit-one-stack-one-branch", "")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
@@ -735,12 +782,15 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
     let err = but_workspace::branch::apply(
         r("refs/heads/does-not-exist"),
         &ws,
-        &mut repo,
+        &repo,
         &mut *meta,
         default_options(),
     )
     .unwrap_err();
-    assert_eq!(err.to_string(), "TBD");
+    assert_eq!(
+        err.to_string(),
+        "Cannot apply non-existing branch 'does-not-exist'"
+    );
 
     // Nothing should be changed
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
@@ -755,7 +805,7 @@ fn unapply_nonexisting_branch_failure() -> anyhow::Result<()> {
 
 #[test]
 fn unborn_apply_needs_base() -> anyhow::Result<()> {
-    let (mut repo, mut meta) =
+    let (repo, mut meta) =
         named_read_only_in_memory_scenario("unborn-empty-detached-remote", "unborn")?;
     // Depending on the Git version it produces`* 3183e43 (orphan/main, orphan/HEAD) M1` on CI,
     // so a comment is used as reference.
@@ -773,7 +823,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     let out = but_workspace::branch::apply(
         r("refs/heads/main"),
         &ws,
-        &mut repo,
+        &repo,
         &mut *meta,
         default_options(),
     )?;
@@ -788,7 +838,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     let err = but_workspace::branch::apply(
         r("refs/remotes/orphan/main"),
         &ws,
-        &mut repo,
+        &repo,
         &mut *meta,
         default_options(),
     )
@@ -803,18 +853,11 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
 fn default_options() -> but_workspace::branch::apply::Options {
     but_workspace::branch::apply::Options {
         integration_mode: IntegrationMode::MergeIfNeeded,
-        on_workspace_conflict: OnWorkspaceConflict::AbortAndReportConflictingStack,
+        on_workspace_conflict: OnWorkspaceMergeConflict::AbortAndReportConflictingStacks,
         workspace_reference_naming: WorkspaceReferenceNaming::Default,
         uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
         order: None,
     }
-}
-
-#[test]
-#[ignore = "TBD"]
-fn apply_branch_resting_on_base() -> anyhow::Result<()> {
-    // THis can't work, but should fail gracefully.
-    Ok(())
 }
 
 mod utils {

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -3,7 +3,8 @@ use crate::ref_info::with_workspace_commit::utils::{
     named_writable_scenario_with_description_and_graph,
 };
 use crate::utils::r;
-use but_graph::init::Options;
+use but_core::RefMetadata;
+use but_graph::init::{Options, Overlay};
 use but_testsupport::{graph_workspace, id_at, visualize_commit_graph_all};
 use but_workspace::branch::apply::{
     IntegrationMode, OnWorkspaceConflict, WorkspaceReferenceNaming,
@@ -57,7 +58,6 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "TBD - needs fix so entrypoint change doesn't affect artificial stacks"]
 fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     let (_tmp, graph, mut repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
@@ -78,12 +78,17 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     )?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
-        workspace_changed: false,
+        workspace_changed: true,
         workspace_ref_created: false,
     }
     ");
-    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
-    // A ws commit was created as it's needed for the current commit implementation.
+    let graph = out.graph;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+    // No commit was created, as it's not enabled by default.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     let out = but_workspace::branch::apply(
@@ -95,11 +100,266 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     )?;
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
-        workspace_changed: false,
+        workspace_changed: true,
         workspace_ref_created: false,
     }
     ");
-    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    // Note how it will create a new stack (to keep it simple),
+    // in theory we could also add B as dependent branch.
+    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:B on e5d0542
+    │   └── 📙:3:B
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+
+    // Nothing changed visibly, still, it's all in the metadata.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    // TODO: create
+    // TODO: commit/uncommit
+    // TODO: unapply
+
+    Ok(())
+}
+
+#[test]
+fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_target_branch()
+-> anyhow::Result<()> {
+    let (_tmp, _, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "no-ws-ref-no-ws-commit-two-branches",
+            |_meta| {},
+        )?;
+
+    // Delete the target branch.
+    {
+        let mut ws_md = meta.workspace("refs/heads/gitbutler/workspace".try_into().unwrap())?;
+        assert!(ws_md.target_ref.is_some());
+        ws_md.target_ref.take();
+        meta.set_workspace(&ws_md)?;
+        let ws_md = meta.workspace("refs/heads/gitbutler/workspace".try_into().unwrap())?;
+        assert!(
+            ws_md.target_ref.is_none(),
+            "we just deleted it, it should be transferred"
+        );
+    }
+    let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    ⌂:0:main <> ✓!
+    └── ≡:0:main
+        └── :0:main
+            └── ·e5d0542 ►A, ►B
+    ");
+
+    // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
+    // which is currently checked out with `main`.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: true,
+    }
+    ");
+
+    let graph = out.graph;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:A on e5d0542
+    │   └── 📙:3:A
+    └── ≡📙:2:main on e5d0542
+        └── 📙:2:main
+    ");
+
+    // No commit was created, as it's not enabled by default, but a ws-ref was created, and it's checked out.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/B"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+    }
+    ");
+    let graph = out.graph;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:4:B on e5d0542
+    │   └── 📙:4:B
+    ├── ≡📙:3:A on e5d0542
+    │   └── 📙:3:A
+    └── ≡📙:2:main on e5d0542
+        └── 📙:2:main
+    ");
+
+    // Nothing changed visibly, still, it's all in the metadata.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
+
+    // Reset the workspace to 'unapply', but keep the per-branch metadata.
+    let mut ws_md = meta.workspace(ws.ref_name().expect("proper gb workspace"))?;
+    ws_md.stacks.clear();
+    meta.set_workspace(&ws_md)?;
+
+    let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    └── ≡:1:anon:
+        └── :1:anon:
+            └── ·e5d0542 (🏘️) ►A, ►B, ►main
+    ");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        but_workspace::branch::apply::Options {
+            integration_mode: IntegrationMode::AlwaysMerge,
+            ..default_options()
+        },
+    )?;
+    // A workspace commit was created, even though it does nothing.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 0cde2a9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * e5d0542 (origin/main, main, B, A) A
+    ");
+
+    let ws = out.graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    └── ≡📙:2:A
+        └── 📙:2:A
+            └── ·e5d0542 (🏘️) ►B, ►main
+    ");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/B"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        but_workspace::branch::apply::Options {
+            integration_mode: IntegrationMode::AlwaysMerge,
+            ..default_options()
+        },
+    )?;
+
+    // It's idempotent, but has to update the workspace commit nonetheless for the comment, which depends on the stacks.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 586a62e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\
+    * e5d0542 (origin/main, main, B, A) A
+    ");
+
+    let ws = out.graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:B on e5d0542
+    │   └── 📙:3:B
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target()
+-> anyhow::Result<()> {
+    let (_tmp, _, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "no-ws-ref-no-ws-commit-two-branches",
+            |_meta| {},
+        )?;
+
+    let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    ⌂:0:main <> ✓!
+    └── ≡:0:main
+        └── :0:main
+            └── ·e5d0542 ►A, ►B
+    ");
+
+    // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
+    // which is currently checked out with `main`.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: true,
+    }
+    ");
+
+    let graph = out.graph;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on e5d0542
+    └── ≡📙:3:A on e5d0542
+        └── 📙:3:A
+    ");
+
+    // No commit was created, as it's not enabled by default, but a ws-ref was created, and it's checked out.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/B"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+    }
+    ");
+    let graph = out.graph;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on e5d0542
+    ├── ≡📙:4:B on e5d0542
+    │   └── 📙:4:B
+    └── ≡📙:3:A on e5d0542
+        └── 📙:3:A
+    ");
+
+    // Nothing changed visibly, still, it's all in the metadata.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
+
+    // Cannot put local tracking branch of target into workspace that has it configured.
+    for branch in ["refs/heads/main", "refs/remotes/origin/main"] {
+        let err =
+            but_workspace::branch::apply(r(branch), &ws, &mut repo, &mut meta, default_options())
+                .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("Cannot add the target '{branch}' branch to its own workspace")
+        );
+    }
 
     // TODO: commit/uncommit
     // TODO: unapply
@@ -231,8 +491,12 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     ");
 
     let (b_id, b_ref) = id_at(&repo, "B");
-    let graph =
-        but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?;
+    let graph = but_graph::Graph::from_commit_traversal(
+        b_id,
+        b_ref.clone(),
+        &meta,
+        standard_traversal_options_with_extra_target(&repo),
+    )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
@@ -241,7 +505,6 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     └── ≡📙:2:A on e5d0542
         └── 📙:2:A
     ");
-
     // Already applied (the HEAD points to it, it literally IS the workspace).
     let out =
         but_workspace::branch::apply(b_ref.as_ref(), &ws, &mut repo, &mut meta, default_options())?;
@@ -252,8 +515,53 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     }
     ");
 
-    // To apply, we just checkout the surrounding workspace.
-    // TODO: doesn't work because A isn't a separate stack like it should.
+    // To apply A, we just checkout the surrounding workspace, as it's contained there.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+    }
+    ");
+
+    // Now the workspace ref itself is checked out.
+    let ws = out.graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:B on e5d0542
+    │   └── 📙:3:B
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+    // Even though the real repo seemingly didn't change, after all, our entrypoint was just 'virtual'.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    // make "A" an applied dependent branch that is included in B so apply will do nothing.
+    meta.data_mut().branches.clear();
+    add_stack_with_segments(&mut meta, 2, "B", StackState::InWorkspace, &["A"]);
+
+    let (b_id, b_ref) = id_at(&repo, "B");
+    let graph = but_graph::Graph::from_commit_traversal(
+        b_id,
+        b_ref.clone(),
+        &meta,
+        standard_traversal_options_with_extra_target(&repo),
+    )?;
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+    └── ≡👉📙:2:B on e5d0542
+        ├── 👉📙:2:B
+        └── 📙:3:A
+    ");
+
+    // Nothing changed, the desired branch was already applied.
     let out = but_workspace::branch::apply(
         r("refs/heads/A"),
         &ws,
@@ -267,6 +575,42 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         workspace_ref_created: false,
     }
     ");
+
+    // There is no known branch, and adding it will just add metadata.
+    meta.data_mut().branches.clear();
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        standard_traversal_options_with_extra_target(&repo),
+    )?;
+    // There is nothing yet.
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+
+    // Apply the first branch, it must be independent.
+    let ws = graph.to_workspace()?;
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+    }
+    ");
+    let graph = out.graph;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+
+    // TODO: apply second branch as new stack.
+
+    // NOTE: we could also do it as independent branch, but that just adds complexity and it's unclear when this will be used.
     Ok(())
 }
 
@@ -472,3 +816,26 @@ fn apply_branch_resting_on_base() -> anyhow::Result<()> {
     // THis can't work, but should fail gracefully.
     Ok(())
 }
+
+mod utils {
+    pub fn standard_traversal_options() -> but_graph::init::Options {
+        but_graph::init::Options {
+            collect_tags: true,
+            commits_limit_hint: None,
+            commits_limit_recharge_location: vec![],
+            hard_limit: None,
+            extra_target_commit_id: None,
+            dangerously_skip_postprocessing_for_debugging: false,
+        }
+    }
+
+    pub fn standard_traversal_options_with_extra_target(
+        repo: &gix::Repository,
+    ) -> but_graph::init::Options {
+        but_graph::init::Options {
+            extra_target_commit_id: Some(repo.rev_parse_single("main").expect("present").detach()),
+            ..standard_traversal_options()
+        }
+    }
+}
+use utils::{standard_traversal_options, standard_traversal_options_with_extra_target};

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -234,13 +234,12 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     let graph =
         but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?;
     let ws = graph.to_workspace()?;
-    // TODO: fix this - the entrypoint shouldn't alter the stack setup.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-    └── ≡👉📙:0:B
-        ├── 👉📙:0:B
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡👉📙:3:B on e5d0542
+    │   └── 👉📙:3:B
+    └── ≡📙:2:A on e5d0542
         └── 📙:2:A
-            └── ·e5d0542 (🏘️) ►main
     ");
 
     // Already applied (the HEAD points to it, it literally IS the workspace).


### PR DESCRIPTION
Get a minimal viable version of `apply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10338.

### Tasks

* [x] apply branch that is already in the stack, but hidden due to ambiguity (so no ref commit change is needed)
* [x] apply without existing workspace (ref should be created)
    - [x] make it work without target branch so single-branch can go to workspace mode as well.
* [x] *think about* having an early unapply as well
    - no, but leave TODOs for journeys that could be continued with unapply (probably most of them)
* [x] optional workspace commit creation
    - [x] make sure it always gets recreated if present for the commit message.
* [x] get order to work when setting workspace metadata
* [x] an actual merge - be sure this is in a nice workspace-based function.
* [x] can this already be made available behind a feature toggle?
 
### Next PR?

* [ ] test were we apply an unnamed segment (i.e. ambiguous)
* [ ] all the missing tests for `WorkspaceCommit::merge()`, but keep it minimal
     - [ ] implement 'force' as well
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace
    - remember: ghost-stacks when the stack is in the workspace metadata, but not reachable from the workspace commit.
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



