### PR TITLE
resizer-fixes

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -378,6 +378,7 @@
 							viewport={branchColumn}
 							persistId="branches-branch-column-1"
 							direction="right"
+							showBorder
 							defaultValue={20}
 							minWidth={10}
 							maxWidth={30}
@@ -388,14 +389,6 @@
 						<div class="commit-column" bind:this={commitColumn} class:non-local-pr={isNonLocalPr}>
 							{#if current.commitId}
 								<UnappliedCommitView {projectId} commitId={current.commitId} />
-								<Resizer
-									viewport={commitColumn}
-									persistId="branches-branch-column-2"
-									direction="right"
-									defaultValue={20}
-									minWidth={10}
-									maxWidth={30}
-								/>
 							{:else if current.branchName}
 								{#if current.inWorkspace && current.stackId}
 									<BranchView
@@ -416,17 +409,19 @@
 										{onerror}
 									/>
 								{/if}
-								<Resizer
-									viewport={commitColumn}
-									persistId="branches-branch-column-2"
-									direction="right"
-									defaultValue={20}
-									minWidth={10}
-									maxWidth={30}
-								/>
 							{:else if current.prNumber}
 								<PrBranchView {projectId} prNumber={current.prNumber} {onerror} />
 							{/if}
+
+							<Resizer
+								viewport={commitColumn}
+								persistId="branches-branch-column-2"
+								showBorder
+								direction="right"
+								defaultValue={20}
+								minWidth={10}
+								maxWidth={30}
+							/>
 						</div>
 					{/if}
 
@@ -493,7 +488,6 @@
 		flex-shrink: 0;
 		flex-direction: column;
 		max-height: 100%;
-		border-right: 1px solid var(--clr-border-2);
 		border-left: 1px solid var(--clr-border-2);
 	}
 
@@ -505,7 +499,6 @@
 		flex-direction: column;
 		max-height: 100%;
 		overflow: hidden;
-		border-right: 1px solid var(--clr-border-2);
 
 		&.non-local-pr {
 			flex-grow: 1;

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -79,7 +79,7 @@
 	bind:this={containerDiv}
 	bind:clientHeight
 	class:collapsed={$collapsed}
-	class:bottom-border={bottomBorder}
+	class:bottom-border={bottomBorder && !resizer}
 	class:transparent
 	class:grow
 	class:noshrink
@@ -164,8 +164,9 @@
 			viewport={containerDiv}
 			defaultValue={undefined}
 			passive={resizer.passive}
-			hidden={$collapsed}
+			disabled={$collapsed}
 			direction="down"
+			showBorder
 			{...resizer}
 			{maxHeight}
 		/>

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -40,7 +40,7 @@
 		class="draft-stack"
 		style:width={uiState.global.stackWidth.current + 'rem'}
 	>
-		<ConfigurableScrollableContainer>
+		<ConfigurableScrollableContainer childrenWrapHeight="100%">
 			<div class="draft-stack__scroll-wrap">
 				<div class="new-commit-view">
 					<NewCommitView {projectId} />
@@ -68,7 +68,6 @@
 					defaultValue={23}
 					minWidth={16}
 					maxWidth={64}
-					syncName="panel1"
 				/>
 			</div>
 		</ConfigurableScrollableContainer>
@@ -80,11 +79,13 @@
 			position: relative;
 			flex-shrink: 0;
 			flex-direction: column;
+			min-height: 100%;
 			border-right: 1px solid var(--clr-border-2);
 			animation: appear-in 0.2s ease-in-out forwards;
 		}
 		.draft-stack__scroll-wrap {
 			position: relative;
+			min-height: 100%;
 			padding: 12px;
 		}
 		.new-commit-view {

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -696,6 +696,7 @@
 		position: relative;
 		flex-shrink: 0;
 		flex-direction: column;
+		min-height: 100%;
 		padding: 0 12px;
 
 		/* Use CSS custom properties for details view width to avoid ResizeObserver errors */

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -578,6 +578,7 @@
 						viewport={stackViewEl!}
 						zIndex="var(--z-lifted)"
 						direction="right"
+						showBorder={!isDetailsViewOpen}
 						minWidth={RESIZER_CONFIG.panel1.minWidth}
 						maxWidth={RESIZER_CONFIG.panel1.maxWidth}
 						defaultValue={RESIZER_CONFIG.panel1.defaultValue}
@@ -663,6 +664,7 @@
 			viewport={compactDiv!}
 			persistId="resizer-panel2-${stackId}"
 			direction="right"
+			showBorder
 			minWidth={RESIZER_CONFIG.panel2.minWidth}
 			maxWidth={RESIZER_CONFIG.panel2.maxWidth}
 			defaultValue={RESIZER_CONFIG.panel2.defaultValue}
@@ -679,7 +681,7 @@
 		flex-shrink: 0;
 		height: 100%;
 		overflow: hidden;
-		border-right: 1px solid var(--clr-border-2);
+		/* border-right: 1px solid var(--clr-border-2); */
 		transition: opacity 0.15s;
 
 		&.dimmed {

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -802,6 +802,7 @@
 		<Resizer
 			direction="left"
 			viewport={rightSidebarRef}
+			showBorder
 			defaultValue={24}
 			minWidth={20}
 			maxWidth={35}
@@ -1150,7 +1151,6 @@
 		position: relative;
 		flex-direction: column;
 		height: 100%;
-		border-left: 1px solid var(--clr-border-2);
 	}
 
 	.right-sidebar__placeholder {


### PR DESCRIPTION
This pull request introduces several improvements to the resizable panel components across the desktop app, focusing on enhancing the visual presentation and consistency of resizer borders, improving the disabled state handling, and cleaning up redundant CSS borders. The changes also update prop names for clarity and add new customization options for resizer components.


The primary issue here is that resizers don’t take up the entire width:

<img width="1562" height="1009" alt="Screenshot 2025-09-26 at 12 25 26" src="https://github.com/user-attachments/assets/a6748b65-bc34-43ee-a948-6c24ccc993e4" />


**Resizer Component Enhancements:**

* Added a `showBorder` prop to the `Resizer` component for explicit control over border rendering, with corresponding CSS to draw borders in the correct orientation and position. [[1]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0L32-R35) [[2]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0R338-R373)
* Renamed the `hidden` prop to `disabled` for clarity, updating all logic and class names accordingly. [[1]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0L32-R35) [[2]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0L347-R387)
* Improved internal state naming (`dragging` → `isResizing`) and associated class changes for better code readability. [[1]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0L85-R88) [[2]](diffhunk://#diff-ae204c1bc8786016ea252e5357b671fe03db9d2881858888d129de651e69d2f0L300-R312)

**Usage of Resizer in UI Components:**

* Updated all usages of `Resizer` in `BranchesView.svelte`, `StackView.svelte`, `Drawer.svelte`, and `CodegenPage.svelte` to use the new `showBorder` and `disabled` props, ensuring consistent border rendering and correct disabled behavior. [[1]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dR381) [[2]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dR412-L429) [[3]](diffhunk://#diff-eff0645a5febba7666c2bb09d1b3aa522e06a1460085ca813b841ece4eb1bd6dL167-R169) [[4]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R581) [[5]](diffhunk://#diff-582753a02435d4eb2db7ad541181c3b4a46f5a323d1480aa914e9c9e0893e913R805)
* Removed redundant or conflicting CSS borders from adjacent panel containers, relying on the resizer border for visual separation instead. [[1]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dL496) [[2]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dL508) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L682-R684) [[4]](diffhunk://#diff-582753a02435d4eb2db7ad541181c3b4a46f5a323d1480aa914e9c9e0893e913L1153)

**Layout and Styling Improvements:**

* Ensured minimum height is set for certain flex containers to prevent layout issues when using scrollable or resizable panels. [[1]](diffhunk://#diff-d39bf58a939e29b45aa3aaf745015f2dc2eeffa86f97ec5429c146f21455768cR82-R88) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R701)
* Updated `ConfigurableScrollableContainer` usage to improve scroll area sizing in `StackDraft.svelte`.

These changes collectively improve the flexibility, accessibility, and visual consistency of resizable panels throughout the app.