### PR TITLE
More defensively build the format string in case the workspace commit isn't managed (#10466)

### DIFF
--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -221,8 +221,8 @@ pub struct RefInfo {
 #[derive(Debug, Clone)]
 pub struct AncestorWorkspaceCommit {
     /// The commits along the first parent that are between the managed workspace reference and the managed workspace commit.
-    /// The vec is never empty.
-    pub commits_outside: Vec<crate::ref_info::Commit>,
+    /// The vec *should* not be empty, but it can be empty in practice for reasons yet to be discovered.
+    pub commits_outside: Vec<ref_info::Commit>,
     /// The index of the segment that actually holds the managed workspace commit.
     pub segment_with_managed_commit: SegmentIndex,
     /// The index of the workspace commit within the `commits` array in its parent segment.


### PR DESCRIPTION
Note that it's still unclear how the graph workspace can report that it's not pointed to by the managed workspace ref, yet the first commit it finds seems to be the managed workspace commit.

This really shouldn't be possible.

Fixes #10466 .
