### PR TITLE
entrypoint-consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-attributes 0.27.0",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-date 0.10.5",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3971,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-path 0.10.20",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "itoa",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "dunce",
@@ -4180,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.1",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.16.0",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.5",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4629,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4666,7 +4666,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-features 0.43.1",
@@ -4718,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4764,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.5",
@@ -4790,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "gix-path 0.10.20",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "filetime",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4865,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.1",
@@ -4908,7 +4908,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "tracing-core",
 ]
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "thiserror 2.0.16",
@@ -5040,7 +5040,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#0a576b968e61e9a675ae630bae3f6c0fd9422ac3"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -11147,7 +11147,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -11,6 +11,8 @@ use std::ops::{Deref, Index, IndexMut};
 /// Mutation
 impl Graph {
     /// Insert `segment` to the graph so that it's not connected to any other segment, and return its index.
+    /// Note that as a side effect, the [entrypoint](Self::lookup_entrypoint()) will also be set if it's not
+    /// set yet.
     pub fn insert_root(&mut self, segment: Segment) -> SegmentIndex {
         let index = self.inner.add_node(segment);
         self.inner[index].id = index;

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -11,14 +11,21 @@ use std::ops::{Deref, Index, IndexMut};
 /// Mutation
 impl Graph {
     /// Insert `segment` to the graph so that it's not connected to any other segment, and return its index.
+    ///
     /// Note that as a side effect, the [entrypoint](Self::lookup_entrypoint()) will also be set if it's not
     /// set yet.
-    pub fn insert_root(&mut self, segment: Segment) -> SegmentIndex {
-        let index = self.inner.add_node(segment);
-        self.inner[index].id = index;
+    pub fn insert_segment_set_entrypoint(&mut self, segment: Segment) -> SegmentIndex {
+        let index = self.insert_segment(segment);
         if self.entrypoint.is_none() {
             self.entrypoint = Some((index, None))
         }
+        index
+    }
+
+    /// Insert `segment` to the graph so that it's not connected to any other segment, and return its index.
+    pub fn insert_segment(&mut self, segment: Segment) -> SegmentIndex {
+        let index = self.inner.add_node(segment);
+        self.inner[index].id = index;
         index
     }
 

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -145,7 +145,7 @@ impl Graph {
                 // It's OK to default-initialise this here as overlays are only used when redoing
                 // the traversal.
                 let (_repo, meta, _entrypoint) = Overlay::default().into_parts(repo, meta);
-                graph.insert_root(branch_segment_from_name_and_meta(
+                graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(
                     Some((ref_name, None)),
                     &meta,
                     None,
@@ -337,7 +337,7 @@ impl Graph {
             dangerously_skip_postprocessing_for_debugging,
         };
         if tip_is_not_workspace_commit {
-            let current = graph.insert_root(branch_segment_from_name_and_meta(
+            let current = graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(
                 None,
                 meta,
                 Some((&ctx.refs_by_id, tip)),
@@ -388,7 +388,16 @@ impl Graph {
             // The limits for the target ref and the worktree ref are synced so they can always find each other,
             // while being able to stop when the entrypoint is included.
             ws_segment.metadata = Some(SegmentMetadata::Workspace(ws_meta));
-            let ws_segment = graph.insert_root(ws_segment);
+            let ws_segment = graph.insert_segment(ws_segment);
+            if graph.entrypoint.is_none()
+                && graph
+                    .entrypoint_ref
+                    .as_ref()
+                    .zip(ref_name.as_ref())
+                    .is_some_and(|(a, b)| a == b)
+            {
+                graph.entrypoint = Some((ws_segment, None));
+            }
             // As workspaces typically have integration branches which can help us to stop the traversal,
             // pick these up first.
             _ = next.push_front_exhausted((
@@ -403,45 +412,45 @@ impl Graph {
             ));
 
             if let Some((target_ref, target_ref_id, local_tip_info)) = target {
-                let target_segment = graph.insert_root(branch_segment_from_name_and_meta(
+                let target_segment = graph.insert_segment(branch_segment_from_name_and_meta(
                     Some((target_ref, None)),
                     meta,
                     None,
                 )?);
-                let (local_sidx, local_goal) = if let Some((local_ref_name, target_local_tip)) =
-                    local_tip_info
-                {
-                    let local_sidx = graph.insert_root(branch_segment_from_name_and_meta_sibling(
-                        None,
-                        Some(target_segment),
-                        meta,
-                        Some((&ctx.refs_by_id, target_local_tip)),
-                    )?);
-                    // We use auto-naming based on ambiguity - if the name ends up something else,
-                    // remove the nodes sibling link.
-                    let has_sibling_link = {
-                        let s = &mut graph[local_sidx];
-                        if s.ref_name.as_ref().is_none_or(|rn| rn != &local_ref_name) {
-                            s.sibling_segment_id = None;
-                            false
-                        } else {
-                            true
-                        }
+                let (local_sidx, local_goal) =
+                    if let Some((local_ref_name, target_local_tip)) = local_tip_info {
+                        let local_sidx =
+                            graph.insert_segment(branch_segment_from_name_and_meta_sibling(
+                                None,
+                                Some(target_segment),
+                                meta,
+                                Some((&ctx.refs_by_id, target_local_tip)),
+                            )?);
+                        // We use auto-naming based on ambiguity - if the name ends up something else,
+                        // remove the nodes sibling link.
+                        let has_sibling_link = {
+                            let s = &mut graph[local_sidx];
+                            if s.ref_name.as_ref().is_none_or(|rn| rn != &local_ref_name) {
+                                s.sibling_segment_id = None;
+                                false
+                            } else {
+                                true
+                            }
+                        };
+                        let goal = goals.flag_for(target_local_tip).unwrap_or_default();
+                        _ = next.push_front_exhausted((
+                            target_local_tip,
+                            CommitFlags::NotInRemote | goal,
+                            Instruction::CollectCommit { into: local_sidx },
+                            max_limit
+                                .with_indirect_goal(tip, &mut goals)
+                                .without_allowance(),
+                        ));
+                        next.add_goal_to(tip, goal);
+                        (has_sibling_link.then_some(local_sidx), goal)
+                    } else {
+                        (None, CommitFlags::empty())
                     };
-                    let goal = goals.flag_for(target_local_tip).unwrap_or_default();
-                    _ = next.push_front_exhausted((
-                        target_local_tip,
-                        CommitFlags::NotInRemote | goal,
-                        Instruction::CollectCommit { into: local_sidx },
-                        max_limit
-                            .with_indirect_goal(tip, &mut goals)
-                            .without_allowance(),
-                    ));
-                    next.add_goal_to(tip, goal);
-                    (has_sibling_link.then_some(local_sidx), goal)
-                } else {
-                    (None, CommitFlags::empty())
-                };
                 _ = next.push_front_exhausted((
                     target_ref_id,
                     CommitFlags::Integrated,
@@ -468,7 +477,7 @@ impl Graph {
                 // have to adjust the existing queue item.
                 existing_segment
             } else {
-                let extra_target_sidx = graph.insert_root(branch_segment_from_name_and_meta(
+                let extra_target_sidx = graph.insert_segment(branch_segment_from_name_and_meta(
                     None,
                     meta,
                     Some((&ctx.refs_by_id, extra_target)),
@@ -517,7 +526,7 @@ impl Graph {
                     meta,
                     Some((&ctx.refs_by_id, segment_tip.detach())),
                 )?;
-                let segment = graph.insert_root(segment);
+                let segment = graph.insert_segment(segment);
                 _ = next.push_back_exhausted((
                     segment_tip.detach(),
                     CommitFlags::NotInRemote,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -357,10 +357,7 @@ impl Graph {
             let target = ws_meta.target_ref.as_ref().and_then(|trn| {
                 let tid = try_refname_to_id(repo, trn.as_ref())
                     .map_err(|err| {
-                        tracing::warn!(
-                            "Ignoring non-existing target branch {trn}: {err}",
-                            trn = trn.as_bstr()
-                        );
+                        tracing::warn!("Ignoring non-existing target branch {trn}: {err}");
                         err
                     })
                     .ok()??;

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -114,8 +114,9 @@ pub fn prioritize_initial_tips_and_assure_ws_commit_ownership<T: RefMetadata>(
                 .find(|t| t.0 == ws_tip)
                 .cloned()
                 .expect("each ws-tip has one entry on queue");
-            let new_anon_segment =
-                graph.insert_root(branch_segment_from_name_and_meta(None, meta, None)?);
+            let new_anon_segment = graph.insert_segment_set_entrypoint(
+                branch_segment_from_name_and_meta(None, meta, None)?,
+            );
             // This segment acts as stand-in - always process it even if the queue says it's done.
             _ = next.push_front_exhausted((
                 ws_tip,
@@ -728,11 +729,12 @@ pub fn try_queue_remote_tracking_branches<T: RefMetadata>(
         let Some(remote_tip) = try_refname_to_id(repo, remote_tracking_branch.as_ref())? else {
             continue;
         };
-        let remote_segment = graph.insert_root(branch_segment_from_name_and_meta(
-            Some((remote_tracking_branch.clone(), None)),
-            meta,
-            None,
-        )?);
+        let remote_segment =
+            graph.insert_segment_set_entrypoint(branch_segment_from_name_and_meta(
+                Some((remote_tracking_branch.clone(), None)),
+                meta,
+                None,
+            )?);
 
         let remote_limit = limit.with_indirect_goal(id, goals);
         // These flags are to be attached to `id` so it can propagate itself later.

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -624,15 +624,13 @@ pub fn obtain_workspace_infos<T: RefMetadata>(
     for (rn, data) in workspaces {
         if rn.category() != Some(Category::LocalBranch) {
             tracing::warn!(
-                "Skipped workspace at ref {} as workspaces can only ever be on normal branches",
-                rn.as_bstr()
+                "Skipped workspace at ref {rn} as workspaces can only ever be on normal branches",
             );
             continue;
         }
         if target_refs.contains(&rn) {
             tracing::warn!(
-                "Skipped workspace at ref {} as it was also a target ref for another workspace (or for itself)",
-                rn.as_bstr()
+                "Skipped workspace at ref {rn} as it was also a target ref for another workspace (or for itself)",
             );
             continue;
         }
@@ -642,16 +640,13 @@ pub fn obtain_workspace_infos<T: RefMetadata>(
             .filter(|trn| trn.category() != Some(Category::RemoteBranch))
         {
             tracing::warn!(
-                "Skipped workspace at ref {} as its target reference {target} was not a remote tracking branch",
-                rn.as_bstr(),
-                target = invalid_target_ref.as_bstr(),
+                "Skipped workspace at ref {rn} as its target reference {invalid_target_ref} was not a remote tracking branch",
             );
             continue;
         }
         let Some(ws_tip) = try_refname_to_id(repo, rn.as_ref())? else {
             tracing::warn!(
-                "Ignoring stale workspace ref '{ws_ref}', which didn't exist in Git but still had workspace data",
-                ws_ref = rn.as_bstr()
+                "Ignoring stale workspace ref '{rn}', which didn't exist in Git but still had workspace data",
             );
             continue;
         };

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -233,6 +233,10 @@ pub struct Graph {
     /// The [`CommitIndex`] is empty if the entry point is an empty segment, one that is supposed to receive
     /// commits later.
     entrypoint: Option<(SegmentIndex, Option<CommitIndex>)>,
+    /// The ref_name used when starting the graph traversal. It is set to help assure that the entrypoint stays
+    /// on the correctly named segment, knowing that the post-process may alter segments quite substantially
+    /// when crating independent and dependent branches.
+    entrypoint_ref: Option<gix::refs::FullName>,
     /// The segment index of the extra target as provided for traversal.
     extra_target: Option<SegmentIndex>,
     /// It's `true` only if we have stopped the traversal due to a hard limit.

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -230,8 +230,8 @@ pub struct Graph {
     inner: init::PetGraph,
     /// From where the graph was created. This is useful if one wants to focus on a subset of the graph.
     ///
-    /// The [`CommitIndex`] is empty if the entry point is an empty segment, one that is supposed to receive
-    /// commits later.
+    /// The [`CommitIndex`] is empty if the entry point is an empty segment, to indicate that the traversal
+    /// tip isn't contained in it.
     entrypoint: Option<(SegmentIndex, Option<CommitIndex>)>,
     /// The ref_name used when starting the graph traversal. It is set to help assure that the entrypoint stays
     /// on the correctly named segment, knowing that the post-process may alter segments quite substantially

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -519,7 +519,6 @@ impl Graph {
         if ws.has_managed_ref() {
             let (lowest_base, lowest_base_sidx) =
                 ws_lower_bound.map_or((None, None), |(base, sidx)| (Some(base), Some(sidx)));
-            // dbg!(lowest_base, lowest_base_sidx);
             for stack_top_sidx in self
                 .inner
                 .neighbors_directed(ws_tip_segment.id, Direction::Outgoing)

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -1060,8 +1060,7 @@ impl Workspace<'_> {
             }
             if !found_segment {
                 tracing::error!(
-                    "BUG: Couldn't find local segment with remote tracking ref '{rn}' - remote commits for it seem to be missing",
-                    rn = remote_tracking_ref_name.as_bstr()
+                    "BUG: Couldn't find local segment with remote tracking ref '{remote_tracking_ref_name}' - remote commits for it seem to be missing",
                 );
             }
         }

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -738,6 +738,13 @@ EOF
     git checkout gitbutler/workspace
   )
 
+  cp -R no-target-without-ws-commit-ambiguous no-target-without-ws-commit-ambiguous-with-remotes
+  (cd no-target-without-ws-commit-ambiguous-with-remotes
+    add_main_remote_setup
+    remote_tracking_caught_up A
+    remote_tracking_caught_up B
+  )
+
   git init no-target-with-ws-commit
   (cd no-target-with-ws-commit
     commit init

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -34,6 +34,7 @@ fn unborn() -> anyhow::Result<()> {
                 None,
             ),
         ),
+        entrypoint_ref: None,
         extra_target: None,
         hard_limit_hit: false,
         options: Options {
@@ -138,6 +139,7 @@ fn detached() -> anyhow::Result<()> {
                 ),
             ),
         ),
+        entrypoint_ref: None,
         extra_target: None,
         hard_limit_hit: false,
         options: Options {

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -28,7 +28,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    let local_target = graph.insert_root(local_target);
+    let local_target = graph.insert_segment_set_entrypoint(local_target);
     graph.connect_new_segment(
         local_target,
         None,
@@ -96,7 +96,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
 #[test]
 fn detached_head() {
     let mut graph = Graph::default();
-    graph.insert_root(Segment {
+    graph.insert_segment_set_entrypoint(Segment {
         commits: vec![commit(id("a"), None, CommitFlags::empty())],
         ..Default::default()
     });

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -131,8 +131,8 @@ fn recurse_segment(
     let connected_segments = {
         let mut m = BTreeMap::<_, Vec<_>>::new();
         let below = graph.segments_below_in_order(sidx).collect::<Vec<_>>();
-        for (cidx, sidx) in below {
-            m.entry(cidx).or_default().push(sidx);
+        for (source_cidx, sidx) in below {
+            m.entry(source_cidx).or_default().push(sidx);
         }
         m
     };

--- a/crates/but-workspace/src/branch/checkout/utils.rs
+++ b/crates/but-workspace/src/branch/checkout/utils.rs
@@ -208,11 +208,7 @@ impl std::fmt::Debug for Outcome {
                     Some(edits) => edits
                         .last()
                         .map(|edit| {
-                            format!(
-                                "Update {} to {:?}",
-                                edit.name.as_bstr(),
-                                edit.change.new_value()
-                            )
+                            format!("Update {} to {:?}", edit.name, edit.change.new_value())
                         })
                         .unwrap_or_default(),
                 },

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -168,7 +168,7 @@ pub fn branch_details_v3(
             .last()
             .map(|id| id.detach())
             .unwrap_or_else(|| {
-            tracing::warn!("No merge-base found between {name} and the integration branch {integration_branch_name}", name = name.as_bstr());
+            tracing::warn!("No merge-base found between {name} and the integration branch {integration_branch_name}");
                 // default to the tip just like the code previously did, resulting in no information
                 // TODO: we should probably indicate that there is no merge-base instead of just glossing over it.
                 branch_id.detach()

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -46,16 +46,10 @@ impl RemoteTrackingReference {
         remote_names: &gix::remote::Names,
     ) -> anyhow::Result<Self> {
         let (category, short_name) = ref_name.category_and_short_name().with_context(|| {
-            format!(
-                "Failed to categorize presume remote reference '{}'",
-                ref_name.as_bstr()
-            )
+            format!("Failed to categorize presume remote reference '{ref_name}'")
         })?;
         if category != Category::RemoteBranch {
-            bail!(
-                "Expected '{}' to be a remote tracking branch, but was {category:?}",
-                ref_name.as_bstr()
-            );
+            bail!("Expected '{ref_name}' to be a remote tracking branch, but was {category:?}");
         }
         let (longest_remote, short_name) = remote_names
             .iter()
@@ -76,10 +70,7 @@ impl RemoteTrackingReference {
                 "Failed to find remote branch's corresponding remote"
             ))
             .with_context(|| {
-                format!(
-                    "Remote reference '{}' couldn't be matched with any known remote",
-                    ref_name.as_bstr()
-                )
+                format!("Remote reference '{ref_name}' couldn't be matched with any known remote")
             })?;
 
         Ok(RemoteTrackingReference {

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1214,29 +1214,6 @@ fn errors() -> anyhow::Result<()> {
         );
     }
 
-    // Ambiguity (multiple refs in one spot).
-    for anchor in [
-        Anchor::at_id(id, Above),
-        Anchor::at_segment(ref_name.as_ref(), Above),
-    ] {
-        assert!(repo.try_find_reference(new_name)?.is_none());
-        let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
-            .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Reference 'does-not-matter' cannot be created as segment at c166d42d4ef2e5e742d33554d03805cfb0b24d11",
-            "Can't show this reference on top in ad-hoc workspaces (entrypoint rule, etc)"
-        );
-        assert!(
-            repo.try_find_reference(new_name)?.is_none(),
-            "the reference isn't physically available"
-        );
-        assert!(
-            meta.branch(ref_name.as_ref())?.is_default(),
-            "no data was stored"
-        );
-    }
-
     // Misaligned workspace - commit not included.
     let (id, ref_name) = id_at(&repo, "A");
     for anchor in [Anchor::at_id(id, Below), Anchor::at_id(id, Above)] {

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -323,9 +323,9 @@ fn branch_group_to_branch(
     let head_commit = if let Some(vbranch) = virtual_branch {
         Some(vbranch.head_oid(repo)?)
     } else if let Some(mut branch) = local_branches.into_iter().next() {
-        branch.peel_to_id_in_place_packed(packed).ok()
+        branch.peel_to_id_packed(packed).ok()
     } else if let Some(mut branch) = remote_branches.into_iter().next() {
-        branch.peel_to_id_in_place_packed(packed).ok()
+        branch.peel_to_id_packed(packed).ok()
     } else {
         None
     }


### PR DESCRIPTION
When setting the entrypoint to any branch within a workspace, we expect it to look exactly like it does when the entrypoint is the workspace commit itself.

This is simple for 'real' segments that are unambiguously named and have their own commits, but it's easy to get wrong when the checked out segment is heavily processed.

This is particularly true for dependent and independent segments which may be created in post.
We have to be sure to properly translate the entrypoint to the segment that has it, and/or the ref that has it.

Getting this right isn't only important for single-branch mode, but also for testing and implementing apply/unapply, where workspace consistency is just as important.

*In a way, this PR describes a set of missing tests, and having them will lead to less hacky post-processing code as it becomes more about 'following the rules and getting them righ' than to make individual tests work.*

### Tasks

* [x] reproduce issue with
    - [x] independent branches
    - [x] dependent branches
* [x] fix everything
    - [x] first round
    - [x] second round
* [x] make entrypoint handling explicit as `insert_root()` side-effect is ambiguous 
