### PR TITLE
Handle non-UTF8 encodings better when preparing unified diffs for the frontend (#10475)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "but-testsupport",
+ "chardetng",
  "gitbutler-error",
  "gitbutler-serde",
  "gix",
@@ -1552,6 +1553,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,7 +1685,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11147,7 +11159,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -28,6 +28,7 @@ gitbutler-serde.workspace = true
 gitbutler-error.workspace = true
 uuid.workspace = true
 toml.workspace = true
+chardetng = "0.1.17"
 
 [dev-dependencies]
 but-testsupport.workspace = true

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -310,3 +310,8 @@ cat <<EOF >>.git/config
 	textconv = "shift; echo ho"
 EOF
 )
+
+git init non-utf8-encodings
+(cd non-utf8-encodings
+  printf '\x80\xc4\xc0' > windows1252
+)

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -281,7 +281,6 @@ pub async fn handle_stop(nightly: bool) -> anyhow::Result<CursorHookOutput> {
         }
     }
 
-    // dbg!(input);
     Ok(CursorHookOutput::default())
 }
 


### PR DESCRIPTION
Fixes #10475.

### Tasks

* [x] test for reproduction
* [x] fix based on #10481
