### PR TITLE
Quick fix: increase the probability that remotes will find their bases.

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -90,7 +90,8 @@ impl Options {
     pub fn limited() -> Self {
         Options {
             collect_tags: false,
-            commits_limit_hint: Some(300),
+            // TODO: put this back down once the underlying issue is fixed.
+            commits_limit_hint: Some(600),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Otherwise it's possible that the workspace remains on an island that is cut off from what's visible from the remote.

Badly enough, the workspace can stop its search, so the remote will keep looking until the beginning of time.

Setting the soft-limit to something higher means it doesn't stop the search quite as early, which helps here.

The proper fix still needs to be done though.
