### PR TITLE
fix(codegen): correct claude-sonnet output price

### DIFF
--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -255,7 +255,7 @@ const pricing = [
 	{
 		name: 'claude-sonnet',
 		input: 3,
-		output: 6,
+		output: 15,
 		writeCache: 3.75,
 		readCache: 0.3
 	},


### PR DESCRIPTION
<img width="1300" height="711" alt="Screenshot 2025-10-01 at 10 17 32" src="https://github.com/user-attachments/assets/8b163ea1-1211-4f1d-8459-e532bdf5570e" />

https://www.claude.com/pricing#api

Claude Sonnet 4 and 4.5 are priced at $3/$15 for under 200k tokens, and $6/$22.5 for over 200k tokens.

I think $3/$6 is a typo.