### PR TITLE
use the stable toolchain to safe space on CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "git+https://github.com/Byron/notify#1ef23915e81b9bd780c6cf76c9a649d11bf60d57"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3415,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "file-id 0.2.3",
  "futures",
  "gitbutler-error",
  "gix",
@@ -3449,7 +3458,7 @@ version = "0.0.0"
 dependencies = [
  "crossbeam-channel",
  "deser-hjson",
- "file-id",
+ "file-id 0.2.2",
  "gitbutler-notify-debouncer",
  "mock_instant",
  "notify",

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = false

--- a/crates/but-api-macros/Cargo.toml
+++ b/crates/but-api-macros/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 proc-macro = true
 

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -8,7 +8,7 @@ description = "A GitButler CLI tool"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 readme = "../../README.md"
 publish = false
-
+rust-version = "1.89"
 [features]
 
 [dependencies]

--- a/crates/but-bot/Cargo.toml
+++ b/crates/but-bot/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = false

--- a/crates/but-broadcaster/Cargo.toml
+++ b/crates/but-broadcaster/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
 serde.workspace = true

--- a/crates/but-claude/Cargo.toml
+++ b/crates/but-claude/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"
 serde.workspace = true

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but-cursor/Cargo.toml
+++ b/crates/but-cursor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = false

--- a/crates/but-debugging/Cargo.toml
+++ b/crates/but-debugging/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 test = false
 doctest = false

--- a/crates/but-gerrit/Cargo.toml
+++ b/crates/but-gerrit/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = false

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 description = "Types to represent Git commit graphs as connected segments, and perform various operations on these."
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = true

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 
 [lib]
 doctest = false

--- a/crates/but-hunk-dependency/Cargo.toml
+++ b/crates/but-hunk-dependency/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but-hunk-dependency/src/input.rs
+++ b/crates/but-hunk-dependency/src/input.rs
@@ -50,8 +50,10 @@ pub struct InputDiffHunk {
 impl InputDiffHunk {
     /// Compute the amount of lines that are left when substracting old-lines from new-lines.
     pub fn net_lines(&self) -> anyhow::Result<i32> {
-        self.new_lines
-            .checked_signed_diff(self.old_lines)
+        // TODO: use `checked_signed_diff` instead when stable.
+        (self.new_lines as i64)
+            .checked_sub(self.old_lines as i64)
+            .and_then(|n| i32::try_from(n).ok())
             .ok_or(anyhow!("u32 -> i32 conversion overflow"))
     }
 }

--- a/crates/but-path/Cargo.toml
+++ b/crates/but-path/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 
 [lib]
 doctest = false

--- a/crates/but-rebase/Cargo.toml
+++ b/crates/but-rebase/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 
 [lib]
 doctest = false

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -8,7 +8,7 @@ description = "A GitButler CLI tool"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 readme = "../../README.md"
 publish = false
-
+rust-version = "1.89"
 [[bin]]
 name = "but-server"
 path = "src/main.rs"

--- a/crates/but-settings/Cargo.toml
+++ b/crates/but-settings/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"
 serde = { workspace = true, features = ["std"] }

--- a/crates/but-status/Cargo.toml
+++ b/crates/but-status/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 gix.workspace = true
 anyhow.workspace = true

--- a/crates/but-testing/Cargo.toml
+++ b/crates/but-testing/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [[bin]]
 name = "but-testing"
 path = "src/main.rs"

--- a/crates/but-testsupport/Cargo.toml
+++ b/crates/but-testsupport/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 test = false

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -8,7 +8,7 @@ description = "A GitButler CLI tool"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 readme = "../../README.md"
 publish = false
-
+rust-version = "1.89"
 [[bin]]
 name = "but"
 path = "src/main.rs"

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 tracing.workspace = true
 anyhow = "1.0.100"

--- a/crates/gitbutler-branch/Cargo.toml
+++ b/crates/gitbutler-branch/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-cherry-pick/Cargo.toml
+++ b/crates/gitbutler-cherry-pick/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 gitbutler-commit.workspace = true
 git2.workspace = true

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [[bin]]
 name = "gitbutler-cli"
 path = "src/main.rs"

--- a/crates/gitbutler-command-context/Cargo.toml
+++ b/crates/gitbutler-command-context/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"
 git2.workspace = true

--- a/crates/gitbutler-commit/Cargo.toml
+++ b/crates/gitbutler-commit/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [features]
 # Set when building in test-mode to enable features that help with generating repeatable tests.
 testing = []

--- a/crates/gitbutler-diff/Cargo.toml
+++ b/crates/gitbutler-diff/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 git2.workspace = true
 gix.workspace = true

--- a/crates/gitbutler-error/Cargo.toml
+++ b/crates/gitbutler-error/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"

--- a/crates/gitbutler-filemonitor/Cargo.toml
+++ b/crates/gitbutler-filemonitor/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-filemonitor"
 version = "0.0.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.89"
 [lib]
 test = false
 doctest = false

--- a/crates/gitbutler-filemonitor/vendor/debouncer/Cargo.toml
+++ b/crates/gitbutler-filemonitor/vendor/debouncer/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-notify-debouncer"
 version = "0.0.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/gitbutler-forge/Cargo.toml
+++ b/crates/gitbutler-forge/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 serde = { workspace = true, features = ["std"] }
 anyhow = "1.0.100"

--- a/crates/gitbutler-fs/Cargo.toml
+++ b/crates/gitbutler-fs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 serde = { workspace = true, features = ["std"] }
 bstr.workspace = true

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-git"
 version = "0.0.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.89"
 [lib]
 path = "src/lib.rs"
 doctest = false
@@ -60,7 +60,9 @@ windows = { version = "0.62.0", features = [
     "Win32_System_IO",
     "Win32_System_Threading",
 ] }
-tokio = { workspace = true, optional = true, features = ["sync"] }
+tokio = { workspace = true, optional = true, features = ["sync", "rt"] }
+# TODO: use released version once https://github.com/notify-rs/notify/pull/716 was merged and published.
+file-id = { git = "https://github.com/Byron/notify", version = "0.2.3" }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/crates/gitbutler-git/src/lib.rs
+++ b/crates/gitbutler-git/src/lib.rs
@@ -7,7 +7,6 @@
 #![deny(missing_docs, unsafe_code)]
 #![allow(async_fn_in_trait)]
 #![allow(unknown_lints)]
-#![cfg_attr(windows, feature(windows_by_handle))]
 
 #[cfg(all(
     not(debug_assertions),

--- a/crates/gitbutler-hunk-dependency/Cargo.toml
+++ b/crates/gitbutler-hunk-dependency/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-hunk-dependency/src/input.rs
+++ b/crates/gitbutler-hunk-dependency/src/input.rs
@@ -37,8 +37,10 @@ pub struct InputDiff {
 
 impl InputDiff {
     pub fn net_lines(&self) -> anyhow::Result<i32> {
-        self.new_lines
-            .checked_signed_diff(self.old_lines)
+        // TODO: use `checked_signed_diff` instead when stable.
+        (self.new_lines as i64)
+            .checked_sub(self.old_lines as i64)
+            .and_then(|n| i32::try_from(n).ok())
             .ok_or(anyhow!("u32 -> i32 conversion overflow"))
     }
 }

--- a/crates/gitbutler-id/Cargo.toml
+++ b/crates/gitbutler-id/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 serde = { workspace = true, features = ["std"]}
 uuid.workspace = true

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 serde = { workspace = true, features = ["std"] }
 tracing.workspace = true

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-oxidize/Cargo.toml
+++ b/crates/gitbutler-oxidize/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow.workspace = true
 git2.workspace = true

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"
 parking_lot = { workspace = true, features = ["arc_lock"] }

--- a/crates/gitbutler-reference/Cargo.toml
+++ b/crates/gitbutler-reference/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 

--- a/crates/gitbutler-repo-actions/Cargo.toml
+++ b/crates/gitbutler-repo-actions/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 git2.workspace = true
 serde = { workspace = true, features = ["std"] }

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-secret/Cargo.toml
+++ b/crates/gitbutler-secret/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-serde/Cargo.toml
+++ b/crates/gitbutler-serde/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 git2.workspace = true
 gix.workspace = true

--- a/crates/gitbutler-stack/Cargo.toml
+++ b/crates/gitbutler-stack/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-storage/Cargo.toml
+++ b/crates/gitbutler-storage/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 gitbutler-fs.workspace = true

--- a/crates/gitbutler-sync/Cargo.toml
+++ b/crates/gitbutler-sync/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 anyhow = "1.0.100"
 tracing.workspace = true

--- a/crates/gitbutler-tagged-string/Cargo.toml
+++ b/crates/gitbutler-tagged-string/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 serde.workspace = true

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [lib]
 doctest = false
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/crates/gitbutler-testsupport/Cargo.toml
+++ b/crates/gitbutler-testsupport/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-testsupport"
 version = "0.0.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.89"
 [lib]
 path = "src/lib.rs"
 doctest = false

--- a/crates/gitbutler-time/Cargo.toml
+++ b/crates/gitbutler-time/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]

--- a/crates/gitbutler-url/Cargo.toml
+++ b/crates/gitbutler-url/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-
+rust-version = "1.89"
 [dependencies]
 url = { version = "2.5.4", features = ["serde"] }
 thiserror.workspace = true

--- a/crates/gitbutler-user/Cargo.toml
+++ b/crates/gitbutler-user/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-watcher"
 version = "0.0.0"
 edition = "2021"
 publish = false
-
+rust-version = "1.89"
 [lib]
 test = false
 doctest = false

--- a/crates/gitbutler-workspace/Cargo.toml
+++ b/crates/gitbutler-workspace/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.89"
 autotests = false
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,9 +2,7 @@
 channel = "nightly-2025-09-09"
 components = [
     "rustfmt",
-    "rustc-dev",
     "clippy",
     "rust-src",
-    "llvm-tools-preview",
 ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-09-09"
+channel = "stable"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
It seems we don't use any nightly features anymore, and dealing with an extra toolchain costs space and time.
Also it adds friction to contributors who need to download a new toolchain when trying to do anything with the project.
