### PR TITLE
speed up tauri builds by preventing cache trashing!

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
 		"dev:web": "turbo watch --filter @gitbutler/web dev",
-		"dev:desktop": "cargo build -p but && cargo build -p gitbutler-git && pnpm tauri dev",
+		"dev:desktop": "export CARGO_TARGET_DIR=$PNPM_SCRIPT_SRC_DIR/target/tauri && cargo build -p but && cargo build -p gitbutler-git && pnpm tauri dev",
 		"dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
 		"package": "turbo run package",
 		"test": "turbo run test --no-daemon",
@@ -24,7 +24,7 @@
 		"build:test": "pnpm exec tauri build --config crates/gitbutler-tauri/tauri.conf.test.json -- --profile dev",
 		"start:desktop": "pnpm --filter @gitbutler/desktop run preview",
 		"check": "turbo run check --no-daemon",
-		"tauri": "tauri",
+		"tauri": "export CARGO_TARGET_DIR=$PNPM_SCRIPT_SRC_DIR/target/tauri && tauri",
 		"lint": "turbo run //#globallint --no-daemon",
 		"globallint": "prettier --check . && eslint .",
 		"prettier": "prettier --check",


### PR DESCRIPTION
This is truly fantastic and solves a long-standing problem.

Now it's totally fine to let it watch the rust source and rebuild, as it won't
interfere with your IDE and just rebuild what's needed. That's what we'd want it to do.

This comes at the expense of some disk-space, but it should be well worth it given the time saved
for each of us.
