### PR TITLE
Upstream integration: Respect empty commits

### DIFF
--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -237,6 +237,7 @@
 				<ContextMenuItem
 					label="Add empty commit"
 					icon="new-empty-commit"
+					testId={TestId.BranchHeaderContextMenu_AddEmptyCommit}
 					onclick={async () => {
 						await insertBlankCommitInBranch({
 							projectId,

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -326,36 +326,6 @@ impl<'repo, 'cache, 'graph> IsCommitIntegrated<'repo, 'cache, 'graph> {
             upstream_change_ids,
         })
     }
-
-    /// Used to construct [`IsCommitIntegrated`] without a [`CommandContext`]. If
-    /// you have a `CommandContext` available, use [`Self::new`] instead.
-    pub(crate) fn new_basic(
-        gix_repo: &'repo gix::Repository,
-        repo: &'repo git2::Repository,
-        graph: &'graph mut MergeBaseCommitGraph<'repo, 'cache>,
-        target_commit_id: gix::ObjectId,
-        upstream_tree_id: gix::ObjectId,
-        mut upstream_commits: Vec<git2::Oid>,
-    ) -> Self {
-        // Ensure upstream commits are sorted for binary search
-        upstream_commits.sort();
-        let upstream_change_ids = upstream_commits
-            .iter()
-            .filter_map(|oid| {
-                let commit = repo.find_commit(*oid).ok()?;
-                commit.change_id()
-            })
-            .sorted()
-            .collect();
-        Self {
-            gix_repo,
-            graph,
-            target_commit_id,
-            upstream_tree_id,
-            upstream_commits,
-            upstream_change_ids,
-        }
-    }
 }
 
 impl IsCommitIntegrated<'_, '_, '_> {

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -24,6 +24,7 @@ export enum TestId {
 	BranchHeaderAddDependanttBranchModal = 'branch-header-add-dependent-branch-modal',
 	BranchHeaderAddDependanttBranchModal_ActionButton = 'branch-header-add-dependent-branch-modal-action-button',
 	BranchHeaderContextMenu_SquashAllCommits = 'branch-header-context-menu-squash-all-commits',
+	BranchHeaderContextMenu_AddEmptyCommit = 'branch-header-context-menu-add-empty-commit',
 	EditCommitMessageBox = 'edit-commit-message-box',
 	CommitDrawer = 'commit-drawer',
 	CommitDrawerActionUncommit = 'commit-drawer-action-uncommit',


### PR DESCRIPTION
Empty commits in a branch are respected and not considered integrated.

This save some compute time and avoids nuking branches with only empty commits unnecessarily.