### PR TITLE
Pin the stable version to whatever the latest CI image contains!

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,6 @@
 name: 'Publish'
+env:
+  RUSTUP_TOOLCHAIN: stable
 on:
   schedule:
     # every day at 3am

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   RUST_BACKTRACE: full
+  RUSTUP_TOOLCHAIN: stable
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -169,7 +170,9 @@ jobs:
         env:
           GITBUTLER_TESTS_NO_CLEANUP: '1'
         name: cargo test
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: |
+          rustup component add clippy
+          cargo clippy --workspace --all-targets -- -D warnings
         name: cargo clippy
       - run: |
           set -e

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -1,4 +1,6 @@
 name: E2E Blackbox Tests
+env:
+  RUSTUP_TOOLCHAIN: stable
 on:
   pull_request:
     branches: [master]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
-channel = "stable"
+# IMPORTANT: This should match CI so it won't download the toolchain all the time.
+channel = "1.90"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
Otherwise builds will once again take longer (but we also can keep using our caches longer).

Note that the image documentation says it's Rust 1.89, but the Rust cache says it's
1.90. Let's trust that then.
