### PR TITLE
Fix the link provided in the GitButler workspace commit.

### DIFF
--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -54,16 +54,6 @@ jobs:
       - name: Setup rust-toolchain stable
         id: rust-toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - name: Setup node environment
         uses: ./.github/actions/init-env-node
       - id: get_playwright_version

--- a/apps/desktop/src/components/NotOnGitButlerBranch.svelte
+++ b/apps/desktop/src/components/NotOnGitButlerBranch.svelte
@@ -84,7 +84,7 @@
 				<p class="switchrepo__message text-13 text-body">
 					Due to GitButler managing multiple virtual branches, you cannot switch back and forth
 					between git branches and virtual branches easily.
-					<Link href="https://docs.gitbutler.com/features/virtual-branches/integration-branch">
+					<Link href="https://docs.gitbutler.com/features/branch-management/integration-branch">
 						Learn more
 					</Link>
 				</p>

--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -154,7 +154,7 @@
 					automatically manages a special branch <span class="text-bold">gitbutler/workspace</span>.
 					You can always switch back and forth as needed between normal git branches and the
 					Gitbutler workspace.
-					<Link href="https://docs.gitbutler.com/features/virtual-branches/integration-branch"
+					<Link href="https://docs.gitbutler.com/features/branch-management/integration-branch"
 						>Learn more</Link
 					>
 				</p>

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -279,7 +279,7 @@ impl<'repo> WorkspaceCommit<'repo> {
         }
         message.push_str("For more information about what we're doing here, check out our docs:\n");
         message
-            .push_str("https://docs.gitbutler.com/features/virtual-branches/integration-branch\n");
+            .push_str("https://docs.gitbutler.com/features/branch-management/integration-branch\n");
 
         let author = commit_signature(commit_time("GIT_COMMITTER_DATE"));
         gix::objs::Commit {

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -220,7 +220,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     )?;
     // A workspace commit was created, even though it does nothing.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 0cde2a9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * c18fa47 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e5d0542 (origin/main, main, B, A) A
     ");
 
@@ -245,7 +245,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     // It's idempotent, but has to update the workspace commit nonetheless for the comment, which depends on the stacks.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 586a62e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * df26e1f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\
     * e5d0542 (origin/main, main, B, A) A
     ");
@@ -453,7 +453,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 49d4b34 (A) A1
-    | *   9af353b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | *   08fe1a8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | |\  
     | | * f57c528 (B) B1
     | |/  
@@ -509,7 +509,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   4912314 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   f2f2560 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * f57c528 (B) B1
     | * | aaa195b (C) C1

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -305,7 +305,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     write_vrbranches_to_refs(&vb, &repo)?;
     // head was updated to point to the new workspace commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    *   3a78d15 (HEAD -> main) GitButler Workspace Commit
+    *   ed11351 (HEAD -> main) GitButler Workspace Commit
     |\  
     | * 2ed9fca (s2/top) new file with 15 lines
     * | b451685 (s1/top, feat1) insert 5 lines to the top

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -131,7 +131,7 @@ pub fn update_workspace_commit(
         message.push_str("\n\n");
     }
     message.push_str("For more information about what we're doing here, check out our docs:\n");
-    message.push_str("https://docs.gitbutler.com/features/virtual-branches/integration-branch\n");
+    message.push_str("https://docs.gitbutler.com/features/branch-management/integration-branch\n");
 
     let committer = gitbutler_repo::signature(SignaturePurpose::Committer)?;
     let author = gitbutler_repo::signature(SignaturePurpose::Author)?;


### PR DESCRIPTION
Maybe we could also have a redirect from

https://docs.gitbutler.com/features/virtual-branches/integration-branch

to

https://docs.gitbutler.com/features/branch-management/integration-branch
