### PR TITLE
Fix publishing script to avoid setting environment variables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"start:desktop": "pnpm --filter @gitbutler/desktop run preview",
 		"check": "turbo run check --no-daemon",
 		"tauri": "cross-env CARGO_TARGET_DIR=$PNPM_SCRIPT_SRC_DIR/target/tauri tauri",
+		"tauri-for-release": "tauri",
 		"lint": "turbo run //#globallint --no-daemon",
 		"globallint": "prettier --check . && eslint .",
 		"prettier": "prettier --check",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,7 +75,7 @@ OS="$(os)"
 DIST="release"
 
 function tauri() {
-	(cd "$PWD/.." && pnpm tauri "$@")
+	(cd "$PWD/.." && pnpm tauri-for-release "$@")
 }
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
That way, the produced binaries will still be at the expected location.
