### PR TITLE
Update notify dependency to point to their main repo (instead of my fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "file-id"
 version = "0.2.3"
-source = "git+https://github.com/Byron/notify#1ef23915e81b9bd780c6cf76c9a649d11bf60d57"
+source = "git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6#978fe719b066a8ce76b9a9d346546b1569eecfb6"
 dependencies = [
  "windows-sys 0.60.2",
 ]

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -61,8 +61,8 @@ windows = { version = "0.62.0", features = [
     "Win32_System_Threading",
 ] }
 tokio = { workspace = true, optional = true, features = ["sync", "rt"] }
-# TODO: use released version once https://github.com/notify-rs/notify/pull/716 was merged and published.
-file-id = { git = "https://github.com/Byron/notify", version = "0.2.3" }
+# TODO: use released version once published.
+file-id = { git = "https://github.com/notify-rs/notify", rev = "978fe719b066a8ce76b9a9d346546b1569eecfb6", version = "0.2.3" }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"


### PR DESCRIPTION
The PR has now been merged, and we are just waiting for another release.

Possible now that https://github.com/notify-rs/notify/pull/716 was merged.

Just waiting for a new release.

It seems that there is also a debouncer related update, and we should probably
look into cleaning up our usage of `notify` to bring it to the next level.
