### PR TITLE
V3 apply/unapply: MVP

### DIFF
--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -2,7 +2,7 @@ mod workspace {
     use but_core::ref_metadata::Workspace;
 
     #[test]
-    fn add_new_stack_if_not_present() {
+    fn add_new_stack_if_not_present_journey() {
         let mut ws = Workspace::default();
         assert_eq!(ws.stacks.len(), 0);
 
@@ -18,6 +18,100 @@ mod workspace {
         let c_ref = r("refs/heads/C");
         assert!(ws.add_or_insert_new_stack_if_not_present(c_ref, None));
         assert_eq!(ws.stack_names().collect::<Vec<_>>(), [b_ref, a_ref, c_ref]);
+
+        assert!(ws.remove_segment(a_ref));
+        assert!(ws.remove_segment(b_ref));
+        assert!(!ws.remove_segment(b_ref));
+        assert!(ws.remove_segment(c_ref));
+        assert!(!ws.remove_segment(c_ref));
+
+        // Everything should be removed.
+        insta::assert_debug_snapshot!(ws, @r"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [],
+            target_ref: None,
+            push_remote: None,
+        }
+        ");
+    }
+
+    #[test]
+    fn insert_new_segment_above_anchor_if_not_present_journey() {
+        let mut ws = Workspace::default();
+        assert_eq!(ws.stacks.len(), 0);
+
+        let a_ref = r("refs/heads/A");
+        let b_ref = r("refs/heads/B");
+        assert_eq!(
+            ws.insert_new_segment_above_anchor_if_not_present(b_ref, a_ref),
+            None,
+            "anchor doesn't exist"
+        );
+        assert!(ws.add_or_insert_new_stack_if_not_present(a_ref, None));
+        assert_eq!(
+            ws.insert_new_segment_above_anchor_if_not_present(b_ref, a_ref),
+            Some(true),
+            "anchor existed and it was added"
+        );
+        assert_eq!(
+            ws.insert_new_segment_above_anchor_if_not_present(b_ref, a_ref),
+            Some(false),
+            "anchor existed and it was NOT added as it already existed"
+        );
+
+        let c_ref = r("refs/heads/C");
+        assert_eq!(
+            ws.insert_new_segment_above_anchor_if_not_present(c_ref, a_ref),
+            Some(true)
+        );
+
+        insta::assert_snapshot!(but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")), @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/B",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/A",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: None,
+            push_remote: None,
+        }
+        "#);
+
+        assert!(ws.remove_segment(b_ref));
+        assert!(ws.remove_segment(a_ref));
+        assert!(ws.remove_segment(c_ref));
+
+        // Everything should be removed.
+        insta::assert_debug_snapshot!(ws, @r"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [],
+            target_ref: None,
+            push_remote: None,
+        }
+        ");
     }
 
     fn r(name: &str) -> &gix::refs::FullNameRef {

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -36,6 +36,14 @@ pub struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Make an existing branch appear in the workspace.
+    Apply {
+        /// The 0-based place in the worktree into which the branch should be inserted.
+        #[clap(long, short = 'o')]
+        order: Option<usize>,
+        /// The name of the branch to apply to the workspace, like `feature` or `origin/other`.
+        branch_name: String,
+    },
     /// Add the given Git repository as project for use with GitButler.
     AddProject {
         /// The long name of the remote reference to track, like `refs/remotes/origin/main`,

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -7,6 +7,7 @@ use command::parse_diff_spec;
 use gix::bstr::BString;
 
 mod args;
+use crate::args::Subcommands;
 use crate::command::{RepositoryOpenMode, repo_and_maybe_project};
 use args::Args;
 
@@ -31,6 +32,7 @@ async fn main() -> Result<()> {
     }
 
     match &args.cmd {
+        Subcommands::Apply { branch_name, order } => command::apply(&args, branch_name, *order),
         args::Subcommands::AddProject {
             switch_to_workspace,
             path,
@@ -39,7 +41,6 @@ async fn main() -> Result<()> {
             path.to_owned(),
             switch_to_workspace.to_owned(),
         ),
-
         args::Subcommands::RemoveReference {
             permit_empty_stacks,
             keep_metadata,

--- a/crates/but-workspace/src/branch/checkout/function.rs
+++ b/crates/but-workspace/src/branch/checkout/function.rs
@@ -50,6 +50,7 @@ pub fn safe_checkout(
     repo: &gix::Repository,
     Options {
         uncommitted_changes: conflicting_worktree_changes_opts,
+        skip_head_update,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let source_tree = current_head_id.attach(repo).object()?.peel_to_tree()?;
@@ -138,7 +139,7 @@ pub fn safe_checkout(
     }
 
     let mut head_update = None;
-    if new_object.kind.is_commit() {
+    if new_object.kind.is_commit() && !skip_head_update {
         let needs_update = repo
             .head()?
             .id()

--- a/crates/but-workspace/src/branch/checkout/mod.rs
+++ b/crates/but-workspace/src/branch/checkout/mod.rs
@@ -17,6 +17,10 @@ pub enum UncommitedWorktreeChanges {
 pub struct Options {
     /// How to deal with uncommitted changes.
     pub uncommitted_changes: UncommitedWorktreeChanges,
+    /// If `true`, do not change `HEAD` to the new commit.
+    ///
+    /// This is typically to be avoided, but may be used if you want to change the HEAD location yourself.
+    pub skip_head_update: bool,
 }
 
 /// The successful outcome of [super::safe_checkout()] operation.

--- a/crates/but-workspace/tests/fixtures/scenario/no-ws-ref-stack-and-dependent-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/no-ws-ref-stack-and-dependent-branch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A target branch along with a stack and a depdendent branch at the same tip, without workspace commit.
+git init
+commit M
+setup_target_to_match_main
+git checkout -b A
+commit A1
+git branch D
+git branch E
+commit A2
+git branch B
+git branch C
+
+git checkout main

--- a/crates/but-workspace/tests/workspace/branch/checkout.rs
+++ b/crates/but-workspace/tests/workspace/branch/checkout.rs
@@ -827,6 +827,7 @@ fn unrelated_additions_do_not_affect_worktree_changes() -> anyhow::Result<()> {
 fn overwrite_options() -> checkout::Options {
     checkout::Options {
         uncommitted_changes: UncommitedWorktreeChanges::KeepConflictingInSnapshotAndOverwrite,
+        skip_head_update: false,
     }
 }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -70,6 +70,7 @@ fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Resu
             &gix_repo,
             but_workspace::branch::checkout::Options {
                 uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+                skip_head_update: false,
             },
         )?;
     } else {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -168,7 +168,7 @@ impl BranchManager<'_> {
             let applied_branch_stack_id = ws
                 .find_segment_and_stack_by_refname(branch_to_apply)
                 .with_context(||
-                    format!("Failed to apply branch and we probably have to handle more of the outcome\n{out:?}")
+                    format!("BUG: Can't find the branch to apply in workspace, but the 'apply' function should have failed instead \n{out:?}")
                 )?
                 .0
                 .id


### PR DESCRIPTION
Get a minimal viable version of `apply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10447.

### Tasks

* [x] `but-testing apply` for ease of use in the real-world
* [x] test were we apply an unnamed segment (i.e. ambiguous) and reproduce the issue of 'last ditch failure to add' which ends up with changed merge commit somehow.
* [ ] all the missing tests for `WorkspaceCommit::merge()`, but keep it minimal
     - [ ] implement 'force' as well

> [!WARNING]
> Current implementation seems does very strange things in conjunction with the 'old' unapply, workspace commit ends up in a strange state and it generally doesn't work as expected.

### Next PR?

* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace
    - remember: ghost-stacks when the stack is in the workspace metadata, but not reachable from the workspace commit.
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



