### PR TITLE
Fix branch listing to show all local branches

### DIFF
--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -154,6 +154,8 @@ pub enum Subcommands {
         /// A resolvable reference name.
         ref_name: String,
     },
+    /// List all available branches for which details can be obtained.
+    BranchList,
     /// Returns everything we know about the given ref, or `HEAD`.
     RefInfo {
         /// Perform all possible computations.

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -108,6 +108,7 @@ pub fn parse_diff_spec(arg: &Option<String>) -> Result<Option<Vec<DiffSpec>>, an
 mod commit;
 use crate::command::discard_change::IndicesOrHeaders;
 pub use commit::commit;
+use gitbutler_branch_actions::BranchListingFilter;
 use gitbutler_command_context::CommandContext;
 
 pub mod diff;
@@ -726,4 +727,17 @@ fn path_to_rela_path(path: &Path) -> anyhow::Result<BString> {
         gix::path::to_unix_separators_on_windows(gix::path::os_str_into_bstr(path.as_os_str())?)
             .into_owned();
     Ok(rela_path)
+}
+
+pub fn branch_list(project: Option<Project>) -> anyhow::Result<()> {
+    let project = project.context("legacy code needs project")?;
+    let ctx = CommandContext::open(&project, AppSettings::default())?;
+    debug_print(gitbutler_branch_actions::list_branches(
+        &ctx,
+        Some(BranchListingFilter {
+            local: None,
+            applied: None,
+        }),
+        None,
+    )?)
 }

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -133,6 +133,10 @@ async fn main() -> Result<()> {
         args::Subcommands::Stacks { workspace_only } => {
             command::stacks::list(&args.current_dir, args.json, args.v3, *workspace_only)
         }
+        args::Subcommands::BranchList => {
+            let (_repo, project) = repo_and_maybe_project(&args, RepositoryOpenMode::Merge)?;
+            command::branch_list(project)
+        }
         args::Subcommands::BranchDetails { ref_name } => {
             command::stacks::branch_details(ref_name, &args.current_dir, args.v3)
         }


### PR DESCRIPTION
When there were branches without IDs or anonymous branches in slightly modern, maybe even somewhat corrupted workspaces, then nothing would be listed anymore.

Make sure we don't break apart in these cases, even though for correctness it will need a much more complete overhaul.
