### PR TITLE
Rewrite prompt templates

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { Button, Modal, SectionCard } from '@gitbutler/ui';
+	import type { PromptDir } from '$lib/codegen/types';
+
+	type Props = {
+		promptDirs: PromptDir[];
+		openPromptConfigDir: (path: string) => void;
+	};
+
+	let modal = $state<Modal>();
+
+	export function show() {
+		modal?.show();
+	}
+
+	const { promptDirs, openPromptConfigDir }: Props = $props();
+</script>
+
+<Modal bind:this={modal} title="Configure prompt templates">
+	<div class="flex flex-col gap-16">
+		<p class="text-13">
+			We have a tierd prompt configuration setup. Prompts are expected to be found in the following
+			locations.
+		</p>
+		<p class="text-13">
+			Project prompts take precidence over global prompts, and local prompts take precidence over
+			project prompts.
+		</p>
+
+		<div>
+			{#each promptDirs as dir, idx}
+				<SectionCard
+					roundedTop={idx === 0}
+					roundedBottom={idx === promptDirs.length - 1}
+					orientation="row"
+				>
+					{#snippet title()}
+						{dir.label}
+					{/snippet}
+
+					{#snippet caption()}
+						<div class="flex flex-col gap-6">
+							<p class="text-11">{dir.path}{dir.path.endsWith('/') ? '' : '/'}</p>
+							<p class="text-13">
+								Looks for files ending with: <span class="clr-text-1"
+									>{dir.filters.join(' or ')}</span
+								>
+							</p>
+						</div>
+					{/snippet}
+
+					{#snippet actions()}
+						<Button onclick={() => openPromptConfigDir(dir.path)}>Open in Editor</Button>
+					{/snippet}
+				</SectionCard>
+			{/each}
+		</div>
+	</div>
+</Modal>

--- a/apps/desktop/src/lib/codegen/claude.ts
+++ b/apps/desktop/src/lib/codegen/claude.ts
@@ -6,7 +6,8 @@ import {
 	type ThinkingLevel,
 	type ModelType,
 	type PermissionMode,
-	type PromptTemplates,
+	type PromptTemplate,
+	type PromptDir,
 	type McpConfig,
 	type SubAgent
 } from '$lib/codegen/types';
@@ -88,24 +89,24 @@ export class ClaudeCodeService {
 		return this.api.endpoints.getSessionDetails.fetch;
 	}
 
-	get promptTemplates() {
-		return this.api.endpoints.getPromptTemplates.useQuery;
+	promptTemplates(projectId: string) {
+		return this.api.endpoints.listPromptTemplates.useQuery({ projectId });
 	}
 
 	get fetchPromptTemplates() {
-		return this.api.endpoints.getPromptTemplates.fetch;
+		return this.api.endpoints.listPromptTemplates.fetch;
 	}
 
-	get writePromptTemplates() {
-		return this.api.endpoints.writePromptTemplates.mutate;
+	promptDirs(projectId: string) {
+		return this.api.endpoints.getPromptDirs.useQuery({ projectId });
 	}
 
-	get promptTemplatesPath() {
-		return this.api.endpoints.getPromptTemplatesPath.useQuery;
+	get fetchPromptDirs() {
+		return this.api.endpoints.getPromptDirs.fetch;
 	}
 
-	get fetchPromptTemplatesPath() {
-		return this.api.endpoints.getPromptTemplatesPath.fetch;
+	get createPromptDir() {
+		return this.api.endpoints.createPromptDir.mutate;
 	}
 
 	get mcpConfig() {
@@ -280,25 +281,20 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					unsubscribe();
 				}
 			}),
-			getPromptTemplates: build.query<PromptTemplates, undefined>({
-				extraOptions: { command: 'claude_get_prompt_templates' },
-				query: () => undefined
-			}),
-			writePromptTemplates: build.mutation<
-				undefined,
-				{
-					templates: PromptTemplates;
-				}
-			>({
-				extraOptions: {
-					command: 'claude_write_prompt_templates',
-					actionName: 'Write Prompt Templates'
-				},
+			listPromptTemplates: build.query<PromptTemplate[], { projectId: string }>({
+				extraOptions: { command: 'claude_list_prompt_templates' },
 				query: (args) => args
 			}),
-			getPromptTemplatesPath: build.query<string, undefined>({
-				extraOptions: { command: 'claude_get_prompt_templates_path' },
-				query: () => undefined
+			getPromptDirs: build.query<PromptDir[], { projectId: string }>({
+				extraOptions: { command: 'claude_get_prompt_dirs' },
+				query: (args) => args
+			}),
+			createPromptDir: build.mutation<undefined, { projectId: string; path: string }>({
+				extraOptions: {
+					command: 'claude_maybe_create_prompt_dir',
+					actionName: 'Create Prompt Directory'
+				},
+				query: (args) => args
 			}),
 			getMcpConfig: build.query<McpConfig, { projectId: string }>({
 				extraOptions: { command: 'claude_get_mcp_config' },

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -195,8 +195,10 @@ export type PromptTemplate = {
 	template: string;
 };
 
-export type PromptTemplates = {
-	templates: PromptTemplate[];
+export type PromptDir = {
+	label: string;
+	path: string;
+	filters: string[];
 };
 
 export type McpConfig = {

--- a/crates/but-api/src/commands/claude.rs
+++ b/crates/but-api/src/commands/claude.rs
@@ -172,27 +172,32 @@ pub async fn claude_compact_history(app: &App, params: CompactHistoryParams) -> 
 #[api_cmd]
 #[tauri::command(async)]
 #[instrument(err(Debug))]
-pub fn claude_get_prompt_templates() -> Result<prompt_templates::PromptTemplates, Error> {
-    let templates = prompt_templates::load_prompt_templates()?;
+pub fn claude_list_prompt_templates(
+    project_id: ProjectId,
+) -> Result<Vec<prompt_templates::PromptTemplate>, Error> {
+    let project = gitbutler_project::get(project_id)?;
+    let templates = prompt_templates::list_templates(&project)?;
     Ok(templates)
 }
 
 #[api_cmd]
 #[tauri::command(async)]
 #[instrument(err(Debug))]
-pub fn claude_write_prompt_templates(
-    templates: prompt_templates::PromptTemplates,
-) -> Result<(), Error> {
-    prompt_templates::write_prompt_templates(&templates)?;
-    Ok(())
+pub fn claude_get_prompt_dirs(
+    project_id: ProjectId,
+) -> Result<Vec<prompt_templates::PromptDir>, Error> {
+    let project = gitbutler_project::get(project_id)?;
+    let dirs = prompt_templates::prompt_dirs(&project)?;
+    Ok(dirs)
 }
 
 #[api_cmd]
 #[tauri::command(async)]
 #[instrument(err(Debug))]
-pub fn claude_get_prompt_templates_path() -> Result<String, Error> {
-    let path = prompt_templates::get_prompt_templates_path_string()?;
-    Ok(path)
+pub fn claude_maybe_create_prompt_dir(project_id: ProjectId, path: String) -> Result<(), Error> {
+    let project = gitbutler_project::get(project_id)?;
+    prompt_templates::maybe_create_dir(&project, &path)?;
+    Ok(())
 }
 
 #[tauri::command(async)]

--- a/crates/but-claude/src/prompt_templates.rs
+++ b/crates/but-claude/src/prompt_templates.rs
@@ -1,6 +1,10 @@
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Result;
+use gitbutler_project::Project;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -10,80 +14,138 @@ pub struct PromptTemplate {
     pub template: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PromptTemplates {
-    pub templates: Vec<PromptTemplate>,
+fn default_template() -> Vec<PromptTemplate> {
+    vec![
+        PromptTemplate {
+            label: "bug-fix".to_string(),
+            template: "Please fix the bug in this code:\n\n```\n// Your code here\n```\n\nExpected behavior:\nActual behavior:\nSteps to reproduce:".to_string(),
+        },
+        PromptTemplate {
+            label: "code-review".to_string(),
+            template: "Please review this code for:\n- Performance issues\n- Security vulnerabilities\n- Best practices\n- Code style\n\n```\n// Your code here\n```".to_string(),
+        },
+        PromptTemplate {
+            label: "refactor".to_string(),
+            template: "Please refactor this code to improve:\n- Readability\n- Performance\n- Maintainability\n\n```\n// Your code here\n```\n\nRequirements:".to_string(),
+        },
+    ]
 }
 
-impl Default for PromptTemplates {
-    fn default() -> Self {
-        Self {
-            templates: vec![
-                PromptTemplate {
-                    label: "Bug Fix".to_string(),
-                    template: "Please fix the bug in this code:\n\n```\n// Your code here\n```\n\nExpected behavior:\nActual behavior:\nSteps to reproduce:".to_string(),
-                },
-                PromptTemplate {
-                    label: "Code Review".to_string(),
-                    template: "Please review this code for:\n- Performance issues\n- Security vulnerabilities\n- Best practices\n- Code style\n\n```\n// Your code here\n```".to_string(),
-                },
-                PromptTemplate {
-                    label: "Refactor".to_string(),
-                    template: "Please refactor this code to improve:\n- Readability\n- Performance\n- Maintainability\n\n```\n// Your code here\n```\n\nRequirements:".to_string(),
-                },
-            ],
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptDir {
+    pub label: String,
+    pub path: PathBuf,
+    // What the paths should end with
+    pub filters: Vec<String>,
+}
+
+/// Fetch the directories where we look up the user provided templates.
+///
+/// We want the precidence to be Global < Project < Project Local
+///
+/// As such, items last in the array take precidence, and filters last in the
+/// filters list also take precidence over earlier ones.
+///
+/// The point of labeling these dirs is so we can also display where to find
+/// these directories in the frontend.
+pub fn prompt_dirs(project: &Project) -> Result<Vec<PromptDir>> {
+    Ok(vec![
+        PromptDir {
+            label: "Global".into(),
+            path: but_path::app_config_dir()?.join("prompt-templates"),
+            filters: vec![".md".into()],
+        },
+        PromptDir {
+            label: "Project".into(),
+            path: project.path.join(".gitbutler/prompt-templates"),
+            filters: vec![".md".into(), ".local.md".into()],
+        },
+    ])
+}
+
+pub fn list_templates(project: &Project) -> Result<Vec<PromptTemplate>> {
+    let dirs = prompt_dirs(project)?;
+    let mut out = HashMap::new();
+
+    for dir in dirs {
+        if dir.path.try_exists()? {
+            let entries = dir
+                .path
+                .read_dir()?
+                .filter_map(|entry| entry.ok())
+                .collect::<Vec<_>>();
+            // We could do the iteration the other way, which would be
+            // marginally faster, but this way we get the desired precidence.
+            for filter in &dir.filters {
+                let longer_filters = dir
+                    .filters
+                    .iter()
+                    .filter(|f| *f != filter && f.len() > filter.len())
+                    .collect::<Vec<_>>();
+                for entry in &entries {
+                    let file_name = entry.file_name();
+                    let file_name = file_name.to_string_lossy();
+                    let captured_by_longer_filter = !longer_filters.is_empty()
+                        && longer_filters.iter().any(|f| file_name.ends_with(*f));
+                    if entry.file_type()?.is_file()
+                        && let Some(label) = file_name.strip_suffix(filter)
+                        && !captured_by_longer_filter
+                    {
+                        let template = std::fs::read_to_string(entry.path())?;
+                        out.insert(
+                            label.to_owned(),
+                            PromptTemplate {
+                                label: label.to_owned(),
+                                template,
+                            },
+                        );
+                    }
+                }
+            }
+        } else {
+            // Special case the global dir to create defaults
+            if dir.label == "Global" {
+                for template in write_global_defaults(&dir.path)? {
+                    out.insert(template.label.clone(), template);
+                }
+            }
         }
     }
+
+    let mut out = out.into_values().collect::<Vec<_>>();
+    out.sort_by_key(|a| a.label.clone());
+
+    Ok(out)
 }
 
-const PROMPT_TEMPLATES_FILE: &str = "prompt-templates.json";
+pub fn maybe_create_dir(project: &Project, path: &str) -> Result<()> {
+    let path = Path::new(path);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        &project.path.join(path)
+    };
 
-fn get_prompt_templates_path() -> Result<std::path::PathBuf> {
-    let config_dir = but_path::app_config_dir()?;
-    Ok(config_dir.join(PROMPT_TEMPLATES_FILE))
-}
-
-pub fn load_prompt_templates() -> Result<PromptTemplates> {
-    let templates_path = get_prompt_templates_path()?;
-
-    if !templates_path.exists() {
-        let default_templates = PromptTemplates::default();
-        save_prompt_templates_to_path(&templates_path, &default_templates)?;
-        return Ok(default_templates);
+    if path.try_exists()? {
+        return Ok(());
     }
 
-    let content = std::fs::read_to_string(&templates_path)?;
-    let templates: PromptTemplates = serde_json::from_str(&content)?;
-
-    Ok(templates)
-}
-
-fn save_prompt_templates_to_path(path: &Path, templates: &PromptTemplates) -> Result<()> {
-    let config_dir = path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Invalid config path"))?;
-
-    std::fs::create_dir_all(config_dir)?;
-
-    let content = serde_json::to_string_pretty(templates)?;
-    std::fs::write(path, content)?;
+    std::fs::create_dir_all(path)?;
 
     Ok(())
 }
 
-pub fn write_prompt_templates(templates: &PromptTemplates) -> Result<()> {
-    let templates_path = get_prompt_templates_path()?;
-    save_prompt_templates_to_path(&templates_path, templates)
-}
+fn write_global_defaults(path: &Path) -> Result<Vec<PromptTemplate>> {
+    let defaults = default_template();
+    std::fs::create_dir_all(path)?;
 
-pub fn get_prompt_templates_path_string() -> Result<String> {
-    let templates_path = get_prompt_templates_path()?;
-
-    // Ensure file exists (create with defaults if not)
-    if !templates_path.exists() {
-        let default_templates = PromptTemplates::default();
-        save_prompt_templates_to_path(&templates_path, &default_templates)?;
+    for default in &defaults {
+        std::fs::write(
+            path.join(format!("{}.md", default.label)),
+            default.template.clone(),
+        )?;
     }
 
-    Ok(templates_path.to_string_lossy().to_string())
+    Ok(defaults)
 }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -511,12 +511,10 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
-        "claude_get_prompt_templates" => claude::claude_get_prompt_templates_cmd(request.params),
-        "claude_write_prompt_templates" => {
-            claude::claude_write_prompt_templates_cmd(request.params)
-        }
-        "claude_get_prompt_templates_path" => {
-            claude::claude_get_prompt_templates_path_cmd(request.params)
+        "claude_list_prompt_templates" => claude::claude_list_prompt_templates_cmd(request.params),
+        "claude_get_prompt_dirs" => claude::claude_get_prompt_dirs_cmd(request.params),
+        "claude_maybe_create_prompt_dir" => {
+            claude::claude_maybe_create_prompt_dir_cmd(request.params)
         }
         "claude_get_sub_agents" => {
             #[derive(Deserialize)]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -358,9 +358,9 @@ fn main() {
                     but_api::claude::claude_list_permission_requests,
                     but_api::claude::claude_update_permission_request,
                     but_api::claude::claude_check_available,
-                    but_api::claude::claude_get_prompt_templates,
-                    but_api::claude::claude_write_prompt_templates,
-                    but_api::claude::claude_get_prompt_templates_path,
+                    but_api::claude::claude_list_prompt_templates,
+                    but_api::claude::claude_get_prompt_dirs,
+                    but_api::claude::claude_maybe_create_prompt_dir,
                     but_api::claude::claude_get_mcp_config,
                     but_api::claude::claude_get_sub_agents,
                     but_api::claude::claude_verify_path


### PR DESCRIPTION
For release notes we should mention that if people have configured existing prompt templates, they will need to move them into markdown files in the right locations.

I've considered porting over old prompts, but I think it's probably more effort than it's worth considering current user numbers