### PR TITLE
fix(cli): remove COLOR_OVERRIDE env handling rely on default behavior

### DIFF
--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -25,14 +25,6 @@ mod status;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Ok(color_override) = std::env::var("COLOR_OVERRIDE") {
-        match color_override.to_lowercase().as_str() {
-            "true" | "1" | "on" | "yes" => colored::control::set_override(true),
-            "false" | "0" | "off" | "no" => colored::control::set_override(false),
-            _ => {}
-        }
-    }
-
     // Check if help is requested with no subcommand
     if std::env::args().len() == 1
         || std::env::args().any(|arg| arg == "--help" || arg == "-h") && std::env::args().len() == 2


### PR DESCRIPTION
Follow up from https://github.com/gitbutlerapp/gitbutler/pull/10562#discussion_r2410459896

@schacon FYI you can set the colorize with
`CLICOLOR_FORCE=1` or `NO_COLOR=1` depending on what you need. The original PR was redundant, but I was ignorant