### PR TITLE
chore: ignore additional build artifact "but-*"

### DIFF
--- a/crates/gitbutler-tauri/.gitignore
+++ b/crates/gitbutler-tauri/.gitignore
@@ -3,3 +3,4 @@ gen/
 
 # Extra binaries, figure out why they end up in this directory on build.
 gitbutler-git-*
+but-*


### PR DESCRIPTION
<img width="376" height="228" alt="Screenshot 2025-10-08 at 05 43 32" src="https://github.com/user-attachments/assets/496f421c-1868-4927-98b8-d4ecb93f74f9" />

I believe these two production build files should be ignored.

They appear when building a production version locally, and other similar binaries in the same directory are already ignored.