### PR TITLE
fix: move traffic lights inset setup to window creation

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -177,20 +177,6 @@ fn main() {
                         menu::handle_event(handle, &window.clone(), &event)
                     });
 
-                    #[cfg(target_os = "macos")]
-                    use tauri::LogicalPosition;
-                    #[cfg(target_os = "macos")]
-                    use tauri_plugin_trafficlights_positioner::WindowExt;
-                    #[cfg(target_os = "macos")]
-                    // NOTE: Make sure you only call this ONCE per window.
-                    {
-                        if let Some(window) = tauri_app.get_window("main") {
-                            #[cfg(target_os = "macos")]
-                            // NOTE: Make sure you only call this ONCE per window.
-                            window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
-                        };
-                    }
-
                     Ok(())
                 })
                 .plugin(tauri_plugin_http::init())

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -325,7 +325,9 @@ pub fn create(
     use tauri::Manager;
     use tauri_plugin_trafficlights_positioner::WindowExt;
     if let Some(window) = window.get_window(label) {
-        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
+        // Note that these lights get reset when the Window label is changed!
+        // See https://github.com/tauri-apps/tauri/issues/13044 .
+        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 28.0))?;
     }
 
     Ok(window)

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -320,5 +320,13 @@ pub fn create(
     .disable_drag_drop_handler()
     .title_bar_style(tauri::TitleBarStyle::Overlay)
     .build()?;
+
+    use tauri::LogicalPosition;
+    use tauri::Manager;
+    use tauri_plugin_trafficlights_positioner::WindowExt;
+    if let Some(window) = window.get_window(label) {
+        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
+    }
+
     Ok(window)
 }


### PR DESCRIPTION
It turns out that the traffic light position setup was only executed after the main window was created, so the cloned project windows didn't get the same configuration.

https://github.com/gitbutlerapp/gitbutler/blob/d4a9f1761926bde3abe357c21bd50bc9ae60e379/crates/gitbutler-tauri/src/projects.rs#L108-L116

I believe moving the related code to `window::create` should fix this issue.
There's a comment in the original code saying "NOTE: Make sure you only call this ONCE per window." — this may not actually be necessary, since moving it into `window::create` should ensure it only runs once per window creation anyway.

Additionally, due to a Tauri bug (https://github.com/tauri-apps/tauri/issues/13044), the traffic light position resets after setting a window title.
However, the position setup code can be reapplied after the window is resized.
To demonstrate that this fix works, I tested it by changing the window size and observing whether the traffic light position is properly set again.

https://github.com/user-attachments/assets/d23d2f9a-e503-4c27-8782-d7cfba50e563

https://github.com/user-attachments/assets/ed1d3a9d-efac-4268-9215-ac014183a8d3

I also noticed that the traffic lights appear slightly larger on my build.
I'm not sure what causes this — it might be related to my local build, since even after reverting all changes, the buttons are still larger.

If they also appear larger on your build, it might be worth slightly adjusting the inset values to center them better:

```rust
// from
window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
// to
window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 28.0))?;
```

If this style change isn't desirable or if there's a flaw in my logic, please let me know how I can improve it.
You can also feel free to close this PR — but note that it's a dependency for my next PR (https://github.com/gitbutlerapp/gitbutler/pull/10574), so I'll need to adjust that one if this gets closed.