### PR TITLE
feat: add UI settings to support native title bar style

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -33,5 +33,8 @@ export const MOCK_APP_SETTINGS: AppSettings = {
 	},
 	reviews: {
 		autoFillPrDescriptionFromCommit: true
+	},
+	ui: {
+		useNativeTitleBar: false
 	}
 };

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -45,6 +45,7 @@
 	const isWorkspace = $derived(isWorkspacePath());
 	const canUseActions = $derived($settingsStore?.featureFlags.actions ?? false);
 	const singleBranchMode = $derived($settingsStore?.featureFlags.singleBranch ?? false);
+	const useCustomTitleBar = $derived(!($settingsStore?.ui.useNativeTitleBar ?? false));
 	const backend = inject(BACKEND);
 
 	const mode = $derived(modeService.mode({ projectId }));
@@ -112,12 +113,12 @@
 <div
 	class="chrome-header"
 	class:mac={backend.platformName === 'macos'}
-	data-tauri-drag-region
+	data-tauri-drag-region={useCustomTitleBar}
 	class:single-branch={singleBranchMode}
 	use:focusable
 >
-	<div class="chrome-left" data-tauri-drag-region>
-		<div class="chrome-left-buttons" class:macos={backend.platformName === 'macos'}>
+	<div class="chrome-left" data-tauri-drag-region={useCustomTitleBar}>
+		<div class="chrome-left-buttons" class:has-traffic-lights={useCustomTitleBar}>
 			<SyncButton {projectId} disabled={actionsDisabled} />
 
 			{#if isHasUpstreamCommits}
@@ -138,7 +139,7 @@
 		</div>
 	</div>
 
-	<div class="chrome-center" data-tauri-drag-region>
+	<div class="chrome-center" data-tauri-drag-region={useCustomTitleBar}>
 		<div class="chrome-selector-wrapper">
 			<Select
 				searchable
@@ -244,7 +245,7 @@
 		{/if}
 	</div>
 
-	<div class="chrome-right" data-tauri-drag-region>
+	<div class="chrome-right" data-tauri-drag-region={useCustomTitleBar}>
 		{#if $ircEnabled}
 			<NotificationButton
 				hasUnread={isNotificationsUnread}
@@ -429,8 +430,8 @@
 		gap: 8px;
 	}
 
-	/** Mac padding added here to not affect header flex-box sizing. */
-	.mac .chrome-left-buttons {
+	/** Mac padding added here to not affect header flex-box sizing, only applied when using custom title bar. */
+	.mac .chrome-left-buttons.has-traffic-lights {
 		padding-left: 70px;
 	}
 

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -67,6 +67,10 @@ export class SettingsService {
 		await this.backend.invoke('update_fetch', { update });
 	}
 
+	async updateUi(update: Partial<UiSettings>) {
+		await this.backend.invoke('update_ui', { update });
+	}
+
 	private async nudge(): Promise<void> {
 		await this.autoOptInWs3();
 		await this.autoOptInRules();
@@ -154,6 +158,8 @@ export type AppSettings = {
 	claude: Claude;
 	/** Settings related to code reviews and pull requests */
 	reviews: Reviews;
+	/** UI settings */
+	ui: UiSettings;
 };
 
 export type TelemetrySettings = {
@@ -205,4 +211,9 @@ export type Claude = {
 export type Reviews = {
 	/** Whether to auto-fill PR title and description from the first commit when a branch has only one commit. */
 	autoFillPrDescriptionFromCommit: boolean;
+};
+
+export type UiSettings = {
+	/** Whether to use the native system title bar. */
+	useNativeTitleBar: boolean;
 };

--- a/crates/but-api/src/commands/settings.rs
+++ b/crates/but-api/src/commands/settings.rs
@@ -1,7 +1,7 @@
 //! In place of commands.rs
 use but_api_macros::api_cmd;
 use but_settings::api::{
-    ClaudeUpdate, FeatureFlagsUpdate, FetchUpdate, ReviewsUpdate, TelemetryUpdate,
+    ClaudeUpdate, FeatureFlagsUpdate, FetchUpdate, ReviewsUpdate, TelemetryUpdate, UiUpdate,
 };
 use but_settings::{AppSettings, AppSettingsWithDiskSync};
 use serde::Deserialize;
@@ -119,5 +119,20 @@ pub fn update_fetch(
 ) -> Result<(), Error> {
     app_settings_sync
         .update_fetch(params.update)
+        .map_err(|e| e.into())
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateUiParams {
+    pub update: UiUpdate,
+}
+
+pub fn update_ui(
+    app_settings_sync: &AppSettingsWithDiskSync,
+    params: UpdateUiParams,
+) -> Result<(), Error> {
+    app_settings_sync
+        .update_ui(params.update)
         .map_err(|e| e.into())
 }

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -64,5 +64,10 @@
 	"reviews": {
 		// Whether to auto-fill PR title and description from the first commit when a branch has only one commit.
 		"autoFillPrDescriptionFromCommit": true
+	},
+	// UI settings.
+	"ui": {
+		// Whether to use the native system title bar.
+		"useNativeTitleBar": false
 	}
 }

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -49,6 +49,13 @@ pub struct FetchUpdate {
     pub auto_fetch_interval_minutes: Option<isize>,
 }
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+/// Update request for [`crate::app_settings::UiSettings`].
+pub struct UiUpdate {
+    pub use_native_title_bar: Option<bool>,
+}
+
 /// Mutation, immediately followed by writing everything to disk.
 impl AppSettingsWithDiskSync {
     pub fn update_onboarding_complete(&self, update: bool) -> Result<()> {
@@ -148,6 +155,14 @@ impl AppSettingsWithDiskSync {
         let mut settings = self.get_mut_enforce_save()?;
         if let Some(auto_fetch_interval_minutes) = update.auto_fetch_interval_minutes {
             settings.fetch.auto_fetch_interval_minutes = auto_fetch_interval_minutes;
+        }
+        settings.save()
+    }
+
+    pub fn update_ui(&self, update: UiUpdate) -> Result<()> {
+        let mut settings = self.get_mut_enforce_save()?;
+        if let Some(use_native_title_bar) = update.use_native_title_bar {
+            settings.ui.use_native_title_bar = use_native_title_bar;
         }
         settings.save()
     }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -91,3 +91,10 @@ pub struct Reviews {
     /// Whether to auto-fill PR title and description from the first commit when a branch has only one commit.
     pub auto_fill_pr_description_from_commit: bool,
 }
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiSettings {
+    /// Whether to use the native system title bar.
+    pub use_native_title_bar: bool,
+}

--- a/crates/but-settings/src/lib.rs
+++ b/crates/but-settings/src/lib.rs
@@ -22,6 +22,8 @@ pub struct AppSettings {
     pub claude: app_settings::Claude,
     /// Settings related to code reviews and pull requests.
     pub reviews: app_settings::Reviews,
+    /// UI settings.
+    pub ui: app_settings::UiSettings,
 }
 
 impl Default for AppSettings {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -299,6 +299,7 @@ fn main() {
                     settings::update_claude,
                     settings::update_fetch,
                     settings::update_reviews,
+                    settings::update_ui,
                     action::list_actions,
                     action::handle_changes,
                     action::list_workflows,

--- a/crates/gitbutler-tauri/src/settings.rs
+++ b/crates/gitbutler-tauri/src/settings.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use but_api::commands::settings;
 use but_settings::api::{
-    ClaudeUpdate, FeatureFlagsUpdate, FetchUpdate, ReviewsUpdate, TelemetryUpdate,
+    ClaudeUpdate, FeatureFlagsUpdate, FetchUpdate, ReviewsUpdate, TelemetryUpdate, UiUpdate,
 };
 use but_settings::AppSettingsWithDiskSync;
 use tauri::State;
@@ -82,4 +82,13 @@ pub fn update_reviews(
     update: ReviewsUpdate,
 ) -> Result<(), Error> {
     settings::update_reviews(&app_settings_sync, settings::UpdateReviewsParams { update })
+}
+
+#[tauri::command(async)]
+#[instrument(skip(app_settings_sync), err(Debug))]
+pub fn update_ui(
+    app_settings_sync: State<'_, AppSettingsWithDiskSync>,
+    update: UiUpdate,
+) -> Result<(), Error> {
+    settings::update_ui(&app_settings_sync, settings::UpdateUiParams { update })
 }


### PR DESCRIPTION
<img width="1043" height="259" alt="Screenshot 2025-10-08 at 05 42 48" src="https://github.com/user-attachments/assets/7c074882-455d-4157-88fc-69db2850e807" />

This PR adds a toggle for enabling the native title bar style in the UI settings.
I added it as a hidden option in the internal JSON config instead of exposing it in the UI, since enabling it requires restarting the app — and I think using the native title bar somewhat breaks the app's overall design.
It's better not to expose it until the UI fully supports it.

Enabling the native title bar has a few benefits (mostly due to Tauri's limited native feature support), such as better drag behavior (three finger drag support) and more consistent double-click zoom behavior.

Tauri currently binds double-click on `data-tauri-drag-region` to "maximize", but on macOS this doesn't always match system behavior depending on user settings, which makes GitButler behave inconsistently compared to other apps.

https://github.com/tauri-apps/tauri/blob/19fb6f7cb0d702cb2f25f6f2d1e11014d9dada5d/crates/tauri/src/window/scripts/drag.js#L46-L48

Part of this PR depends on my previous one (https://github.com/gitbutlerapp/gitbutler/pull/10573). If that one can't be merged, I can modify this PR to make it standalone.
If you think adding this setting makes sense but I've missed something, please let me know how I can improve it. If you don't think this setting should exist, feel free to close it.