### PR TITLE
v3 apply/unapply: MVP

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -237,7 +237,8 @@ impl std::fmt::Debug for Branch {
     }
 }
 
-struct MaybeDebug<'a, T: std::fmt::Debug>(&'a Option<T>);
+/// A utility to prevent `Option` from being too verbose in debug printings.
+pub struct MaybeDebug<'a, T: std::fmt::Debug>(pub &'a Option<T>);
 
 impl<T: std::fmt::Debug> std::fmt::Debug for MaybeDebug<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -110,7 +110,7 @@ pub(crate) mod function {
     /// to alter certain aspects of the workspace by applying the same branch again.
     #[instrument(level = tracing::Level::DEBUG, skip(workspace, repo, meta), err(Debug))]
     pub fn apply<'graph>(
-        branch: &gix::refs::FullNameRef,
+        branch: &FullNameRef,
         workspace: &but_graph::projection::Workspace<'graph>,
         repo: &gix::Repository,
         meta: &mut impl RefMetadata,

--- a/crates/but-workspace/tests/fixtures/scenario/various-heads-for-clean-merge.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/various-heads-for-clean-merge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  echo $name >$name && git add $name && git commit -m "add $name"
+}
+
+### Description
+# A couple of independent heads which merge cleanly, each adding a file.
+# A workspace ref is present to make it easier to discover the branches of interest in the graph.
+git init
+commit M
+git branch gitbutler/workspace
+
+for filename in A B C D; do
+  git checkout -b add-$filename main
+    commit-file $filename
+done

--- a/crates/but-workspace/tests/fixtures/scenario/various-heads-for-merge-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/various-heads-for-merge-conflict.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  local content=${2:-$1}
+  echo $content >$name && git add $name && git commit -m "add $content"
+}
+
+### Description
+# A couple of independent heads where some merge cleanly, and some done.
+# A workspace ref is present to make it easier to discover the branches of interest in the graph.
+git init
+commit M
+git branch gitbutler/workspace
+
+for filename in A B; do
+  git checkout -b clean-$filename main
+    commit-file $filename
+done
+
+git checkout -b conflict-C1 main
+  commit-file C C1
+
+git checkout -b conflict-C2 main
+  commit-file C C2

--- a/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  local content=${2:-$1}
+  echo $content >$name && git add $name && git commit -m "add $content"
+}
+
+### Description
+# A couple of independent heads where some merge cleanly, and some don't, with `conflict-hero` conflicting with two different branches.
+# A workspace ref is present to make it easier to discover the branches of interest in the graph.
+git init
+commit M
+git branch gitbutler/workspace
+
+for filename in A B C; do
+  git checkout -b clean-$filename main
+    commit-file $filename
+done
+
+git checkout -b conflict-F1 main
+  commit-file F1
+
+git checkout -b conflict-F2 main
+  commit-file F2
+
+git checkout -b conflict-hero main
+  commit-file F1 conflicting-F1
+  commit-file F2 conflicting-F2

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -220,7 +220,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     )?;
     // A workspace commit was created, even though it does nothing.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * c18fa47 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 5169839 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e5d0542 (origin/main, main, B, A) A
     ");
 
@@ -245,7 +245,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     // It's idempotent, but has to update the workspace commit nonetheless for the comment, which depends on the stacks.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * df26e1f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 0da7d7b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\
     * e5d0542 (origin/main, main, B, A) A
     ");
@@ -452,13 +452,12 @@ fn detached_head_journey() -> anyhow::Result<()> {
     }
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 49d4b34 (A) A1
-    | *   08fe1a8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    | |\  
-    | | * f57c528 (B) B1
-    | |/  
-    |/|   
-    | * aaa195b (C) C1
+    *   f2d8a20 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * f57c528 (B) B1
+    * | aaa195b (C) C1
+    |/  
+    | * 49d4b34 (A) A1
     |/  
     * 3183e43 (main) M1
     ");
@@ -509,7 +508,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   f2f2560 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   40e102f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * f57c528 (B) B1
     | * | aaa195b (C) C1
@@ -561,7 +560,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             └── ·7076dee (🏘️) ►D, ►E
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 6a706b7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8444317 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (origin/main, main) M
@@ -589,7 +588,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             └── ·7076dee (🏘️) ►D, ►E
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * badd1b4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 102321c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (origin/main, main) M

--- a/crates/but-workspace/tests/workspace/branch/checkout.rs
+++ b/crates/but-workspace/tests/workspace/branch/checkout.rs
@@ -22,11 +22,11 @@ fn update_unborn_head() -> anyhow::Result<()> {
         snapshot_tree: None,
         num_deleted_files: 0,
         num_added_or_updated_files: 0,
-        head_update: "Update refs/heads/main to Some(Object(Sha1(6f695b43b0a2fc309a7444d3e918226f1561c66c)))",
+        head_update: "Update refs/heads/main to Some(Object(Sha1(118ba3a86f303103ce45c23515d5cae2eca717c2)))",
     }
     "#);
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 6f695b4 (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 118ba3a (HEAD -> main) init");
     insta::assert_snapshot!(git_status(&repo)?, @r"");
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/commit.rs
+++ b/crates/but-workspace/tests/workspace/commit.rs
@@ -1,0 +1,462 @@
+mod from_new_merge_with_metadata {
+    use crate::ref_info::with_workspace_commit::utils::named_read_only_in_memory_scenario;
+    use bstr::ByteSlice;
+    use but_graph::init::Options;
+    use but_testsupport::{visualize_commit_graph_all, visualize_tree};
+    use but_workspace::WorkspaceCommit;
+    use gix::prelude::ObjectIdExt;
+
+    #[test]
+    fn without_conflict_journey() -> anyhow::Result<()> {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("various-heads-for-clean-merge", "")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * d3cce74 (add-A) add A
+        | * 115e41b (add-B) add B
+        |/  
+        | * 34c4591 (add-C) add C
+        |/  
+        | * 27ab782 (HEAD -> add-D) add D
+        |/  
+        * 85efbe4 (main, gitbutler/workspace) M
+        ");
+
+        let stacks = ["add-A"];
+        add_stacks(&mut meta, stacks);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+        let out =
+            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        // This commit is never signed.
+        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        tree f53c91092dbda83f3565e78c285f3e2ab0cfd968
+        parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+        author GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        committer GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        encoding UTF-8
+
+        GitButler Workspace Commit
+
+        This is a merge commit of the virtual branches in your workspace.
+
+        Due to GitButler managing multiple virtual branches, you cannot switch back and
+        forth between git branches and virtual branches easily. 
+
+        If you switch to another branch, GitButler will need to be reinitialized.
+        If you commit on this branch, GitButler will throw it away.
+
+        Here are the branches that are currently applied:
+         - add-A
+           branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+        For more information about what we're doing here, check out our docs:
+        https://docs.gitbutler.com/features/branch-management/integration-branch
+        ");
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(655bf328c5ea95493005bb2eeb9e0724b982430f),
+            stacks: [
+                Stack { tip: d3cce74, name: "add-A" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [],
+        }
+        "#);
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        f53c910
+        └── A:100644:f70f10e "A\n"
+        "#);
+
+        let stacks = ["add-D", "add-A", "add-C", "add-B"];
+        add_stacks(&mut meta, stacks);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            &graph,
+            &repo,
+            Some("refs/heads/has-no-effect-outside-conflicts".try_into()?),
+        )?;
+        // It retains order.
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(c4576e5fea31f865a3ce2b69db6ea4d69fbfb107),
+            stacks: [
+                Stack { tip: 27ab782, name: "add-D" },
+                Stack { tip: d3cce74, name: "add-A" },
+                Stack { tip: 34c4591, name: "add-C" },
+                Stack { tip: 115e41b, name: "add-B" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [],
+        }
+        "#);
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        // This commit is never signed.
+        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        tree 94e1f0c26d5b13dc3a95a88e64d82155373b5780
+        parent 27ab782831b1145249092d54c520a15bb6425cda
+        parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+        parent 34c4591eac5ade7cdf094c4fc48dea798ab73bbb
+        parent 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+        author GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        committer GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        encoding UTF-8
+
+        GitButler Workspace Commit
+
+        This is a merge commit of the virtual branches in your workspace.
+
+        Due to GitButler managing multiple virtual branches, you cannot switch back and
+        forth between git branches and virtual branches easily. 
+
+        If you switch to another branch, GitButler will need to be reinitialized.
+        If you commit on this branch, GitButler will throw it away.
+
+        Here are the branches that are currently applied:
+         - add-D
+           branch head: 27ab782831b1145249092d54c520a15bb6425cda
+         - add-A
+           branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+         - add-C
+           branch head: 34c4591eac5ade7cdf094c4fc48dea798ab73bbb
+         - add-B
+           branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+        For more information about what we're doing here, check out our docs:
+        https://docs.gitbutler.com/features/branch-management/integration-branch
+        ");
+        // Order isn't visible in the merged tree.
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        94e1f0c
+        ├── A:100644:f70f10e "A\n"
+        ├── B:100644:223b783 "B\n"
+        ├── C:100644:3cc58df "C\n"
+        └── D:100644:1784810 "D\n"
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn with_multi_line_conflict_journey() -> anyhow::Result<()> {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("various-heads-for-multi-line-merge-conflict", "")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * d3cce74 (clean-A) add A
+        | * 115e41b (clean-B) add B
+        |/  
+        | * 34c4591 (clean-C) add C
+        |/  
+        | * bf09eae (conflict-F1) add F1
+        |/  
+        | * f2ce66d (conflict-F2) add F2
+        |/  
+        | * 4bbb93c (HEAD -> conflict-hero) add conflicting-F2
+        | * 98519e9 add conflicting-F1
+        |/  
+        * 85efbe4 (main, gitbutler/workspace) M
+        ");
+
+        let stacks = [
+            "clean-A",
+            "conflict-F1",
+            "clean-B",
+            "conflict-F2",
+            "clean-C",
+            "conflict-hero",
+            "clean-A",
+        ];
+        add_stacks(&mut meta, stacks);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            &graph,
+            &repo,
+            Some("refs/heads/conflict-hero".try_into()?),
+        )?;
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(2da68ddfc57b6853126b1cc2b45ee627266b85b5),
+            stacks: [
+                Stack { tip: d3cce74, name: "clean-A" },
+                Stack { tip: 115e41b, name: "clean-B" },
+                Stack { tip: 34c4591, name: "clean-C" },
+                Stack { tip: 4bbb93c, name: "conflict-hero" },
+                Stack { tip: d3cce74, name: "clean-A" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [
+                ConflictingStack {
+                    tip: Sha1(bf09eaee36b845f0ee6af0b4e19731498b6a017b),
+                    ref_name: FullName(
+                        "refs/heads/conflict-F1",
+                    ),
+                },
+                ConflictingStack {
+                    tip: Sha1(f2ce66d01ec4227683e16ad679def2ee6aa0d282),
+                    ref_name: FullName(
+                        "refs/heads/conflict-F2",
+                    ),
+                },
+            ],
+        }
+        "#);
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        45db176
+        ├── A:100644:f70f10e "A\n"
+        ├── B:100644:223b783 "B\n"
+        ├── C:100644:3cc58df "C\n"
+        ├── F1:100644:2fc7694 "conflicting-F1\n"
+        └── F2:100644:ade95f4 "conflicting-F2\n"
+        "#);
+
+        // Just for show, see what happens if there is no hero.
+        let out =
+            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(63eb0a124467632279d5367b81d5b5627c929ca3),
+            stacks: [
+                Stack { tip: d3cce74, name: "clean-A" },
+                Stack { tip: bf09eae, name: "conflict-F1" },
+                Stack { tip: 115e41b, name: "clean-B" },
+                Stack { tip: f2ce66d, name: "conflict-F2" },
+                Stack { tip: 34c4591, name: "clean-C" },
+                Stack { tip: d3cce74, name: "clean-A" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [
+                ConflictingStack {
+                    tip: Sha1(4bbb93c2e76f7ae0fe61183ac3774943284ba9af),
+                    ref_name: FullName(
+                        "refs/heads/conflict-hero",
+                    ),
+                },
+            ],
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn with_conflict_journey() -> anyhow::Result<()> {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("various-heads-for-merge-conflict", "")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * d3cce74 (clean-A) add A
+        | * 115e41b (clean-B) add B
+        |/  
+        | * 6777bd8 (conflict-C1) add C1
+        |/  
+        | * f8392d2 (HEAD -> conflict-C2) add C2
+        |/  
+        * 85efbe4 (main, gitbutler/workspace) M
+        ");
+
+        // NOTE: the caller would be expected to have prepared a graph that contains these branches.
+        let stacks = ["clean-A", "conflict-C1", "clean-B", "conflict-C2"];
+        add_stacks(&mut meta, stacks);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+
+        let out =
+            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(02e643fe54118699dfc71edcee135ad7a825ccbf),
+            stacks: [
+                Stack { tip: d3cce74, name: "clean-A" },
+                Stack { tip: 6777bd8, name: "conflict-C1" },
+                Stack { tip: 115e41b, name: "clean-B" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [
+                ConflictingStack {
+                    tip: Sha1(f8392d239500de94b23f42c8ab5508dae1b3b657),
+                    ref_name: FullName(
+                        "refs/heads/conflict-C2",
+                    ),
+                },
+            ],
+        }
+        "#);
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        // In absence of a hero stack, the conflicting stack is simply not assigned.
+        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        tree fc2bf71918ed072ec412bdebb04ec7322f2cfb72
+        parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+        parent 6777bd8aff28a87a07739e2f309d3699d93685f9
+        parent 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+        author GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        committer GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        encoding UTF-8
+
+        GitButler Workspace Commit
+
+        This is a merge commit of the virtual branches in your workspace.
+
+        Due to GitButler managing multiple virtual branches, you cannot switch back and
+        forth between git branches and virtual branches easily. 
+
+        If you switch to another branch, GitButler will need to be reinitialized.
+        If you commit on this branch, GitButler will throw it away.
+
+        Here are the branches that are currently applied:
+         - clean-A
+           branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+         - conflict-C1
+           branch head: 6777bd8aff28a87a07739e2f309d3699d93685f9
+         - clean-B
+           branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+        For more information about what we're doing here, check out our docs:
+        https://docs.gitbutler.com/features/branch-management/integration-branch
+        ");
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        fc2bf71
+        ├── A:100644:f70f10e "A\n"
+        ├── B:100644:223b783 "B\n"
+        └── C:100644:e2cf5e7 "C1\n"
+        "#);
+
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            &graph,
+            &repo,
+            Some("refs/heads/conflict-C2".try_into()?),
+        )?;
+        // TODO: make clean-B show up!
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(ef4cd3a7261c7fdba387069af08f4844bf25e657),
+            stacks: [
+                Stack { tip: d3cce74, name: "clean-A" },
+                Stack { tip: 115e41b, name: "clean-B" },
+                Stack { tip: f8392d2, name: "conflict-C2" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [
+                ConflictingStack {
+                    tip: Sha1(6777bd8aff28a87a07739e2f309d3699d93685f9),
+                    ref_name: FullName(
+                        "refs/heads/conflict-C1",
+                    ),
+                },
+            ],
+        }
+        "#);
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        tree 39ba52245958cf3a0544caf68c75665b9ad6ea4f
+        parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+        parent 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+        parent f8392d239500de94b23f42c8ab5508dae1b3b657
+        author GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        committer GitButler <gitbutler@gitbutler.com> 968492580 +0000
+        encoding UTF-8
+
+        GitButler Workspace Commit
+
+        This is a merge commit of the virtual branches in your workspace.
+
+        Due to GitButler managing multiple virtual branches, you cannot switch back and
+        forth between git branches and virtual branches easily. 
+
+        If you switch to another branch, GitButler will need to be reinitialized.
+        If you commit on this branch, GitButler will throw it away.
+
+        Here are the branches that are currently applied:
+         - clean-A
+           branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+         - clean-B
+           branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+         - conflict-C2
+           branch head: f8392d239500de94b23f42c8ab5508dae1b3b657
+        For more information about what we're doing here, check out our docs:
+        https://docs.gitbutler.com/features/branch-management/integration-branch
+        ");
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        39ba522
+        ├── A:100644:f70f10e "A\n"
+        ├── B:100644:223b783 "B\n"
+        └── C:100644:c4b2d41 "C2\n"
+        "#);
+
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(["conflict-C2", "conflict-C2", "conflict-C1", "clean-A"]),
+            &graph,
+            &repo,
+            Some("refs/heads/conflict-C1".try_into()?),
+        )?;
+        insta::assert_debug_snapshot!(out, @r#"
+        Outcome {
+            workspace_commit_id: Sha1(6be4e1cdd58cd6b0564a518e9d55a59408352255),
+            stacks: [
+                Stack { tip: 6777bd8, name: "conflict-C1" },
+                Stack { tip: d3cce74, name: "clean-A" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [
+                ConflictingStack {
+                    tip: Sha1(f8392d239500de94b23f42c8ab5508dae1b3b657),
+                    ref_name: FullName(
+                        "refs/heads/conflict-C2",
+                    ),
+                },
+                ConflictingStack {
+                    tip: Sha1(f8392d239500de94b23f42c8ab5508dae1b3b657),
+                    ref_name: FullName(
+                        "refs/heads/conflict-C2",
+                    ),
+                },
+            ],
+        }
+        "#);
+
+        let commit = out.workspace_commit_id.attach(&repo).object()?;
+        insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
+        5c730c4
+        ├── A:100644:f70f10e "A\n"
+        └── C:100644:e2cf5e7 "C1\n"
+        "#);
+
+        Ok(())
+    }
+
+    mod utils {
+        use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack_with_segments};
+        use but_core::ref_metadata::{StackId, WorkspaceStack, WorkspaceStackBranch};
+        use but_graph::VirtualBranchesTomlMetadata;
+        use gix::refs::Category;
+
+        pub fn add_stacks(
+            meta: &mut VirtualBranchesTomlMetadata,
+            short_stack_names: impl IntoIterator<Item = &'static str>,
+        ) {
+            for (idx, stack_name) in short_stack_names.into_iter().enumerate() {
+                add_stack_with_segments(
+                    meta,
+                    idx as u128 + 1,
+                    stack_name,
+                    StackState::InWorkspace,
+                    &[],
+                );
+            }
+        }
+
+        pub fn to_stacks(
+            short_stack_names: impl IntoIterator<Item = &'static str>,
+        ) -> Vec<WorkspaceStack> {
+            short_stack_names
+                .into_iter()
+                .map(|short_name| WorkspaceStack {
+                    id: StackId::generate(),
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: Category::LocalBranch
+                            .to_full_name(short_name)
+                            .expect("known good short ref name"),
+                        archived: false,
+                    }],
+                })
+                .collect()
+        }
+    }
+    use utils::{add_stacks, to_stacks};
+}

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     CONTEXT_LINES, cat_commit, commit_from_outcome,
-    commit_whole_files_and_all_hunks_from_workspace, read_only_in_memory_scenario,
+    commit_whole_files_and_all_hunks_from_workspace, read_only_in_memory_scenario_env,
     visualize_commit, visualize_tree, writable_scenario, writable_scenario_with_ssh_key,
     write_local_config, write_sequence,
 };
@@ -11,7 +11,7 @@ use but_workspace::{DiffSpec, HunkHeader, commit_engine::Destination};
 fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     assure_stable_env();
 
-    let mut repo = read_only_in_memory_scenario("all-file-types-renamed-and-modified")?;
+    let mut repo = read_only_in_memory_scenario_env("all-file-types-renamed-and-modified")?;
     // Change the committer and author dates to be able to tell what it changes.
     {
         let mut config = repo.config_snapshot_mut();

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -2,6 +2,7 @@ use but_workspace::{DiffSpec, HunkHeader, flatten_diff_specs};
 
 mod branch;
 mod branch_details;
+mod commit;
 mod commit_engine;
 mod flatten_diff_specs;
 mod ref_info;


### PR DESCRIPTION
Get a minimal viable version of `apply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10554.

### Tasks

* [x] all the missing tests for `WorkspaceCommit::merge()`, but keep it minimal
     - [x] implement 'force' as well
* [x] more tests
* [x] probably also try precise algorithm
    - [x] improve current test to truly validate it (multi-file conflict)
* [x] turn assertion into `bail!(BUG)`
* [x] Fix CI

### Next PR?

* [ ] return conflicting tips with existing API and assure that these are unapplied correctly (while keeping their stack ids)
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace
    - remember: ghost-stacks when the stack is in the workspace metadata, but not reachable from the workspace commit.
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



