### PR TITLE
Refactor: stack view component

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -226,10 +226,6 @@
 		checkFilesForCommit();
 	}
 
-	export function onclose() {
-		selection.set(undefined);
-	}
-
 	function onclosePreviewOnly() {
 		// Clear file selections for the active branch or commit
 		if (activeSelectionId) {
@@ -324,7 +320,6 @@
 		{projectId}
 		{selectionId}
 		diffOnly={true}
-		onclose={() => {}}
 		draggableFiles={selectionId.type === 'commit'}
 	/>
 {/snippet}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -271,20 +271,28 @@
 
 	// Set initial CSS custom properties when details view opens/closes
 	$effect(() => {
-		if (stackViewEl) {
+		const element = stackViewEl;
+		if (element) {
 			if (isDetailsViewOpen) {
 				// Set default width if not already set or is zero
-				const currentWidth = stackViewEl.style.getPropertyValue('--details-view-width');
+				const currentWidth = element.style.getPropertyValue('--details-view-width');
 				if (!currentWidth || currentWidth === '0rem') {
-					stackViewEl.style.setProperty(
+					element.style.setProperty(
 						'--details-view-width',
 						`${RESIZER_CONFIG.panel2.defaultValue}rem`
 					);
 				}
 			} else {
-				stackViewEl.style.setProperty('--details-view-width', '0rem');
+				element.style.setProperty('--details-view-width', '0rem');
 			}
 		}
+
+		// Cleanup function to reset the property when the effect reruns or component unmounts
+		return () => {
+			if (element) {
+				element.style.removeProperty('--details-view-width');
+			}
+		};
 	});
 
 	let selectionPreviewScrollContainer: HTMLDivElement | undefined = $state();

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -554,21 +554,23 @@
 					</div>
 
 					<!-- RESIZE PANEL 1 -->
-					<Resizer
-						persistId="resizer-panel1-${stackId}"
-						viewport={stackViewEl!}
-						zIndex="var(--z-lifted)"
-						direction="right"
-						showBorder={!isDetailsViewOpen}
-						minWidth={RESIZER_CONFIG.panel1.minWidth}
-						maxWidth={RESIZER_CONFIG.panel1.maxWidth}
-						defaultValue={RESIZER_CONFIG.panel1.defaultValue}
-						syncName="panel1"
-						onWidth={(newWidth) => {
-							// Update the persisted stack width when panel1 resizer changes
-							persistedStackWidth.set(newWidth);
-						}}
-					/>
+					{#if stackViewEl}
+						<Resizer
+							persistId="resizer-panel1-${stackId}"
+							viewport={stackViewEl}
+							zIndex="var(--z-lifted)"
+							direction="right"
+							showBorder={!isDetailsViewOpen}
+							minWidth={RESIZER_CONFIG.panel1.minWidth}
+							maxWidth={RESIZER_CONFIG.panel1.maxWidth}
+							defaultValue={RESIZER_CONFIG.panel1.defaultValue}
+							syncName="panel1"
+							onWidth={(newWidth) => {
+								// Update the persisted stack width when panel1 resizer changes
+								persistedStackWidth.set(newWidth);
+							}}
+						/>
+					{/if}
 				{/snippet}
 			</ReduxResult>
 		</div>
@@ -641,17 +643,19 @@
 		</div>
 
 		<!-- DETAILS VIEW WIDTH RESIZER - Only show when details view is open -->
-		<Resizer
-			viewport={compactDiv!}
-			persistId="resizer-panel2-${stackId}"
-			direction="right"
-			showBorder
-			minWidth={RESIZER_CONFIG.panel2.minWidth}
-			maxWidth={RESIZER_CONFIG.panel2.maxWidth}
-			defaultValue={RESIZER_CONFIG.panel2.defaultValue}
-			syncName="panel2"
-			onWidth={updateDetailsViewWidth}
-		/>
+		{#if compactDiv}
+			<Resizer
+				viewport={compactDiv}
+				persistId="resizer-panel2-${stackId}"
+				direction="right"
+				showBorder
+				minWidth={RESIZER_CONFIG.panel2.minWidth}
+				maxWidth={RESIZER_CONFIG.panel2.maxWidth}
+				defaultValue={RESIZER_CONFIG.panel2.defaultValue}
+				syncName="panel2"
+				onWidth={updateDetailsViewWidth}
+			/>
+		{/if}
 	{/if}
 </div>
 

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -132,7 +132,6 @@
 	let stackViewEl = $state<HTMLDivElement>();
 	let compactDiv = $state<HTMLDivElement>();
 
-	let changedFilesCollapsed = $state<boolean>();
 	let active = $state(false);
 
 	const defaultBranchQuery = $derived(stackService.defaultBranch(projectId, stackId));
@@ -374,9 +373,6 @@
 				draggableFiles
 				selectionId={createCommitSelection({ commitId, stackId: stackId })}
 				noshrink={!!previewKey}
-				ontoggle={(collapsed) => {
-					changedFilesCollapsed = collapsed;
-				}}
 				changes={changes.changes.filter(
 					(change) => !(change.path in (changes.conflictEntries?.entries ?? {}))
 				)}
@@ -413,9 +409,6 @@
 				autoselect
 				selectionId={createBranchSelection({ stackId: stackId, branchName, remote: undefined })}
 				noshrink={!!previewKey}
-				ontoggle={() => {
-					changedFilesCollapsed = !changedFilesCollapsed;
-				}}
 				changes={changes.changes}
 				stats={changes.stats}
 				resizer={{

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -231,10 +231,12 @@
 	}
 
 	function onclosePreviewOnly() {
-		const source = selection.current;
-		if (source) {
-			selection.set({ ...source, previewOpen: false });
+		// Clear file selections for the active branch or commit
+		if (activeSelectionId) {
+			idSelection.clear(activeSelectionId);
 		}
+		// Clear the lane selection (branch/commit)
+		selection.set(undefined);
 	}
 
 	const startCommitVisible = $derived(uncommittedService.startCommitVisible(stackId));

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -255,9 +255,14 @@
 		return undefined;
 	}
 
-	let isDetailsViewOpen = $derived(
-		(!!(branchName || commitId || selectedFile) && previewOpen) || !!assignedKey
-	);
+	// Details view can be opened in two ways:
+	// 1. User selects a branch/commit/file and opens preview
+	// 2. Files are assigned to this stack (assignedKey exists)
+	const hasActiveSelection = $derived(!!(branchName || commitId || selectedFile));
+	const isPreviewOpenForSelection = $derived(hasActiveSelection && previewOpen);
+	const hasAssignedFiles = $derived(!!assignedKey);
+
+	let isDetailsViewOpen = $derived(isPreviewOpenForSelection || hasAssignedFiles);
 
 	const DETAILS_RIGHT_PADDING_REM = 1.125;
 


### PR DESCRIPTION
This pull request refactors the `StackView.svelte` component to improve state management, event handling, and UI consistency, particularly around the details view and resizer behavior. The changes aim to make the code more robust, easier to maintain, and to ensure UI elements behave correctly as the state changes.

**Details view and selection handling improvements:**

* Simplified and clarified the logic for determining when the details view is open by splitting out derived state variables (`hasActiveSelection`, `isPreviewOpenForSelection`, `hasAssignedFiles`) and using them to compute `isDetailsViewOpen`.
* Updated the `onclosePreviewOnly` function to clear both the file selection and the lane selection, ensuring the UI resets appropriately when closing previews.

https://github.com/user-attachments/assets/1cb15e7a-e689-401d-8a8a-6a7d7989ba02

**Resizer and DOM element handling:**

* Added conditional rendering for `Resizer` components to ensure they are only mounted when their corresponding DOM elements (`stackViewEl`, `compactDiv`) exist, preventing potential runtime errors. [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R557-R560) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R573) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R646-R648) [[4]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R659)
* Improved the effect that manages the CSS custom property for the details view width by introducing a cleanup function to reset the property when the effect reruns or the component unmounts.

**State and event cleanup:**

* Removed the unused `changedFilesCollapsed` state and related event handlers, streamlining the code and reducing unnecessary state management. [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L135) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L372-L374) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L411-L413)
* Removed an unused `onclose` prop from a snippet component, cleaning up the interface.

