### PR TITLE
fix(docs): update broken logo icon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-   <img align="center" width="128px" src="crates/gitbutler-tauri/icons/128x128@2x.png" />
+   <img align="center" width="128px" src="crates/gitbutler-tauri/icons/release/128x128@2x.png" />
 	<h1 align="center"><b>GitButler</b></h1>
 	<p align="center">
 		Git branch management tool, built from the ground up for modern workflows


### PR DESCRIPTION
This PR (https://github.com/gitbutlerapp/gitbutler/pull/10547) updated the application icons and changed the path for the release version icons, but it missed updating README.md.

I'm not sure if this reflects the intended look for the new icons, but fixing a broken link is never a bad idea.