### PR TITLE
Revert "Adjust traffic light size to match the new native size"

### DIFF
--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -325,9 +325,9 @@ pub fn create(
     use tauri::Manager;
     use tauri_plugin_trafficlights_positioner::WindowExt;
     if let Some(window) = window.get_window(label) {
-        // Note that these lights get reset when the Window label is changed!
+        // Note that traffic lights position get reset when the Window title is changed!
         // See https://github.com/tauri-apps/tauri/issues/13044 .
-        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 28.0))?;
+        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
     }
 
     Ok(window)


### PR DESCRIPTION
This reverts commit 5357fa8d7e28977bbb8707d997b139fb4e56b3e7.

Introduced by https://github.com/gitbutlerapp/gitbutler/pull/10573

<img width="290" height="90" alt="Screenshot 2025-10-09 at 14 34 24" src="https://github.com/user-attachments/assets/17f79e41-1b0e-4711-8d46-c54f3cc6cdce" />

In the latest nightly build, the traffic light icons have shifted significantly downward.

Considering that only builds made with the macOS 26 image seem to produce larger traffic lights, and that the original positioning still looks ok even with the larger buttons.

<img width="348" height="93" alt="Screenshot 2025-10-09 at 18 08 28" src="https://github.com/user-attachments/assets/d56c25b4-3915-4806-aa0c-f9ad18b35227" />

I suggest keeping the original code.

Reference: https://github.com/actions/runner-images
