### PR TITLE
Assure the traffic-light offset works for MacOS Pre-Tahoe...

### DIFF
--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -327,7 +327,14 @@ pub fn create(
     if let Some(window) = window.get_window(label) {
         // Note that these lights get reset when the Window label is changed!
         // See https://github.com/tauri-apps/tauri/issues/13044 .
-        window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 28.0))?;
+        // TODO: stop doing this entirely and work with the defaults, my preference,
+        //       create a build script that makes it clear which MacOS version we are using
+        //       to conditionally compile the right value.
+        let y_offset_for_small_dots_in_pre_tahoe = 25.0;
+        window.setup_traffic_lights_inset(LogicalPosition::new(
+            16.0,
+            y_offset_for_small_dots_in_pre_tahoe,
+        ))?;
     }
 
     Ok(window)


### PR DESCRIPTION
...because that's the system we build on.

This means the traffic lights will be smaller, which affects the offset. This is quite terrible and it would be better if we wouldn't mess with it at all, especially given the buggy location right after startup due to https://github.com/tauri-apps/tauri/issues/13044.
