### PR TITLE
v3 apply/unapply: MVP

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+<stron@me.com> <35891811+estib-vega@users.noreply.github.com>

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -62,13 +62,12 @@ pub fn cherry_apply_status(
 
     let mut locked_stack = None;
     for stack in stacks {
-        dbg!(&stack);
         let tip = stack
             .heads
             .first()
             .context("Stacks always have a head")?
             .tip;
-        if dbg!(cherry_pick_conflicts(&repo, subject, tip)?) {
+        if cherry_pick_conflicts(&repo, subject, tip)? {
             if locked_stack.is_some() {
                 // Locked stack has already been set to another stack. Now there
                 // are at least two stacks that it should be locked to, so we
@@ -83,7 +82,6 @@ pub fn cherry_apply_status(
             }
         }
     }
-    dbg!(&locked_stack);
 
     if let Some(stack) = locked_stack {
         Ok(CherryApplyStatus::LockedToStack(stack))

--- a/crates/but-claude/src/compact.rs
+++ b/crates/but-claude/src/compact.rs
@@ -203,7 +203,6 @@ impl Claudes {
         let model_name = output["message"]["model"]
             .as_str()
             .context("could not find model property")?;
-        dbg!(&output);
 
         if let Some(model) = find_model(model_name.to_owned()) {
             let usage: ModelUsage = serde_json::from_value(output["message"]["usage"].clone())?;
@@ -212,7 +211,6 @@ impl Claudes {
                 + usage.cache_creation_input_tokens.unwrap_or(0)
                 + usage.input_tokens
                 + usage.output_tokens;
-            dbg!(total, model.context - COMPACTION_BUFFER);
             if total > (model.context - COMPACTION_BUFFER) {
                 self.compact(ctx.clone(), broadcaster.clone(), stack_id)
                     .await;

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -184,14 +184,14 @@ impl Workspace {
         }
     }
 
-    /// Return `true` if `name` is an applied reference mentioned in our [stacks](Workspace::stacks).
+    /// Return `true` if `name` is an reference mentioned in our [stacks](Workspace::stacks).
     /// Use `kind` for filtering.
     pub fn contains_ref(&self, name: &gix::refs::FullNameRef, kind: StackKind) -> bool {
         self.stacks(kind)
             .any(|stack| stack.branches.iter().any(|b| b.ref_name.as_ref() == name))
     }
 
-    /// Find a given `name` within our applied stack branches and return it for modification.
+    /// Find a given `name` within our stack branches and return it for modification.
     /// Use `kind` for filtering.
     pub fn find_branch_mut(
         &mut self,
@@ -206,7 +206,7 @@ impl Workspace {
         })
     }
 
-    /// Find a given `name` within our applied stack branches and return it.
+    /// Find a given `name` within our stack branches and return it.
     /// Use `kind` for filtering.
     pub fn find_branch(
         &self,
@@ -215,6 +215,21 @@ impl Workspace {
     ) -> Option<&WorkspaceStackBranch> {
         self.stacks(kind)
             .find_map(|stack| stack.branches.iter().find(|b| b.ref_name.as_ref() == name))
+    }
+
+    /// Find a given `name` within our stack branches and return the stack itself.
+    /// Use `kind` for filtering.
+    pub fn find_stack_with_branch(
+        &self,
+        name: &gix::refs::FullNameRef,
+        kind: StackKind,
+    ) -> Option<&WorkspaceStack> {
+        self.stacks(kind).find_map(|stack| {
+            stack
+                .branches
+                .iter()
+                .find_map(|b| (b.ref_name.as_ref() == name).then_some(stack))
+        })
     }
 
     /// Find the `(stack_idx, branch_idx)` of `name` within our applied stack branches and return it,

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -1,4 +1,5 @@
 mod workspace {
+    use but_core::ref_metadata::StackKind::AppliedAndUnapplied;
     use but_core::ref_metadata::Workspace;
 
     #[test]
@@ -13,11 +14,17 @@ mod workspace {
 
         let b_ref = r("refs/heads/B");
         assert!(ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0)));
-        assert_eq!(ws.stack_names().collect::<Vec<_>>(), [b_ref, a_ref]);
+        assert_eq!(
+            ws.stack_names(AppliedAndUnapplied).collect::<Vec<_>>(),
+            [b_ref, a_ref]
+        );
 
         let c_ref = r("refs/heads/C");
         assert!(ws.add_or_insert_new_stack_if_not_present(c_ref, None));
-        assert_eq!(ws.stack_names().collect::<Vec<_>>(), [b_ref, a_ref, c_ref]);
+        assert_eq!(
+            ws.stack_names(AppliedAndUnapplied).collect::<Vec<_>>(),
+            [b_ref, a_ref, c_ref]
+        );
 
         assert!(ws.remove_segment(a_ref));
         assert!(ws.remove_segment(b_ref));
@@ -74,24 +81,19 @@ mod workspace {
                     id: 1,
                     branches: [
                         WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/B",
-                            ),
+                            ref_name: "refs/heads/B",
                             archived: false,
                         },
                         WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C",
-                            ),
+                            ref_name: "refs/heads/C",
                             archived: false,
                         },
                         WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/A",
-                            ),
+                            ref_name: "refs/heads/A",
                             archived: false,
                         },
                     ],
+                    in_workspace: true,
                 },
             ],
             target_ref: None,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -506,6 +506,7 @@ impl Graph {
             for segment in ws_metadata
                 .stacks
                 .into_iter()
+                .filter(|s| s.in_workspace)
                 .flat_map(|s| s.branches.into_iter())
             {
                 let Some(segment_tip) = repo

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use bstr::{BStr, ByteSlice};
 use but_core::ref_metadata;
 use but_core::ref_metadata::StackId;
+use but_core::ref_metadata::StackKind::Applied;
 use gix::reference::Category;
 use itertools::Itertools;
 use petgraph::{Direction, prelude::EdgeRef, visit::NodeRef};
@@ -706,8 +707,7 @@ fn find_matching_stack_id(
 ) -> Option<StackId> {
     let metadata = metadata?;
     metadata
-        .stacks
-        .iter()
+        .stacks(Applied)
         .filter_map(|s| {
             let num_matching_refs = s
                 .branches
@@ -937,7 +937,7 @@ impl Workspace<'_> {
     /// (possibly allowing it to be turned off, etc).
     fn prune_archived_segments(&mut self) {
         let Some(md) = &self.metadata else { return };
-        let archived_stack_branches = md.stacks.iter().flat_map(|s| {
+        let archived_stack_branches = md.stacks(Applied).flat_map(|s| {
             s.branches
                 .iter()
                 .filter_map(|s| s.archived.then_some(s.ref_name.as_ref()))

--- a/crates/but-graph/src/ref_metadata_legacy.rs
+++ b/crates/but-graph/src/ref_metadata_legacy.rs
@@ -378,7 +378,7 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
             .branches
             .keys()
             .copied()
-            .filter(|sid| !seen_stack_ids.contains(&sid))
+            .filter(|sid| !seen_stack_ids.contains(sid))
             .collect();
         for sid in stacks_to_delete {
             self.data_mut().branches.remove(&sid);

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -49,7 +49,7 @@ pub fn add_workspace(meta: &mut VirtualBranchesTomlMetadata) {
     add_stack(
         meta,
         usize::MAX,
-        "definitely outside of the workspace just to have it",
+        "definitely-outside-of-the-workspace-just-to-have-it",
         StackState::Inactive,
     );
 }

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -43,6 +43,7 @@ pub mod merge {
     use but_graph::SegmentIndex;
     use gitbutler_oxidize::GixRepositoryExt;
     use gix::prelude::ObjectIdExt;
+    use tracing::instrument;
 
     /// A minimal stack for to represent a stack that conflicted.
     #[derive(Debug, Clone)]
@@ -94,6 +95,7 @@ pub mod merge {
         /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
         /// One could be better and only repeat what didn't change, to avoid repeating unnecessarily.
         /// But that shouldn't usually matter unless in the biggest repositories with tree-merge times past a 500ms or so.
+        #[instrument(level = tracing::Level::DEBUG, skip(graph, repo), err(Debug))]
         pub fn from_new_merge_with_metadata(
             stacks: &[but_core::ref_metadata::WorkspaceStack],
             graph: &but_graph::Graph,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -196,7 +196,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     // Reset the workspace to 'unapply', but keep the per-branch metadata.
     let mut ws_md = meta.workspace(ws.ref_name().expect("proper gb workspace"))?;
-    ws_md.stacks.clear();
+    for stack in &mut ws_md.stacks {
+        stack.in_workspace = false;
+    }
     meta.set_workspace(&ws_md)?;
 
     let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;

--- a/crates/but-workspace/tests/workspace/commit.rs
+++ b/crates/but-workspace/tests/workspace/commit.rs
@@ -448,6 +448,7 @@ mod from_new_merge_with_metadata {
                 .into_iter()
                 .map(|short_name| WorkspaceStack {
                     id: StackId::generate(),
+                    in_workspace: true,
                     branches: vec![WorkspaceStackBranch {
                         ref_name: Category::LocalBranch
                             .to_full_name(short_name)

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -164,7 +164,6 @@ impl BranchManager<'_> {
                 },
             )?;
             let ws = out.graph.to_workspace()?;
-            let unapplied_stacks_to_be_done = Vec::new();
             let applied_branch_stack_id = ws
                 .find_segment_and_stack_by_refname(branch_to_apply)
                 .with_context(||
@@ -173,7 +172,7 @@ impl BranchManager<'_> {
                 .0
                 .id
                 .context("BUG: newly applied stacks should always have a stack id")?;
-            return Ok((applied_branch_stack_id, unapplied_stacks_to_be_done));
+            return Ok((applied_branch_stack_id, out.conflicting_stack_ids));
         }
         let old_cwd = (!self.ctx.app_settings().feature_flags.cv3)
             .then(|| self.ctx.repo().create_wd_tree(0).map(|tree| tree.id()))


### PR DESCRIPTION
Get a minimal viable version of `apply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10576.

### Tasks

* [x] keep track of unapplied branches in new workspace data
    - should it be done with flags or as separate list?
* [x] return conflicting tips with existing API and assure that these are unapplied correctly (while keeping their stack ids)
* [ ] conflict-tests for apply to validate stack ids and assure ws-metadata knows them as out-of-workspace
    - [ ] apply non-stack-tip segment within a 'bigger' branch to ensure these can be applied as new tip
* [ ] test apply from unborn HEAD

### Next PR?

* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace
    - remember: ghost-stacks when the stack is in the workspace metadata, but not reachable from the workspace commit.
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



