### PR TITLE
Use PUBLIC_CLOUD_HOST for default OpenGraph image

### DIFF
--- a/apps/web/src/lib/meta/opengraph.ts
+++ b/apps/web/src/lib/meta/opengraph.ts
@@ -94,6 +94,6 @@ export async function fillMeta(html: string, url: string) {
 	}
 
 	// Default fallback for non-review pages
-	metaTags = metaTags.replaceAll('%image%', `${env.PUBLIC_APP_HOST}og-image.png`);
+	metaTags = metaTags.replaceAll('%image%', `${env.PUBLIC_CLOUD_HOST}og-image.png`);
 	return html.replace('%metatags%', metaTags);
 }


### PR DESCRIPTION
Updated the default OpenGraph image URL in apps/web/src/lib/meta/opengraph.ts.

- Replaced env.PUBLIC_APP_HOST with env.PUBLIC_CLOUD_HOST when constructing the fallback og-image URL.
- This change ensures the generated OpenGraph image reference points to the cloud host rather than the app host.
