### PR TITLE
v3 apply/unapply: MVP

### DIFF
--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -8,19 +8,31 @@ mod workspace {
         assert_eq!(ws.stacks.len(), 0);
 
         let a_ref = r("refs/heads/A");
-        assert!(ws.add_or_insert_new_stack_if_not_present(a_ref, Some(100)));
-        assert!(!ws.add_or_insert_new_stack_if_not_present(a_ref, Some(200)));
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(100)),
+            (0, 0)
+        );
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(200)),
+            (0, 0)
+        );
         assert_eq!(ws.stacks.len(), 1);
 
         let b_ref = r("refs/heads/B");
-        assert!(ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0)));
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0)),
+            (0, 0)
+        );
         assert_eq!(
             ws.stack_names(AppliedAndUnapplied).collect::<Vec<_>>(),
             [b_ref, a_ref]
         );
 
         let c_ref = r("refs/heads/C");
-        assert!(ws.add_or_insert_new_stack_if_not_present(c_ref, None));
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(c_ref, None),
+            (2, 0)
+        );
         assert_eq!(
             ws.stack_names(AppliedAndUnapplied).collect::<Vec<_>>(),
             [b_ref, a_ref, c_ref]
@@ -55,7 +67,10 @@ mod workspace {
             None,
             "anchor doesn't exist"
         );
-        assert!(ws.add_or_insert_new_stack_if_not_present(a_ref, None));
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(a_ref, None),
+            (0, 0)
+        );
         assert_eq!(
             ws.insert_new_segment_above_anchor_if_not_present(b_ref, a_ref),
             Some(true),
@@ -71,6 +86,12 @@ mod workspace {
         assert_eq!(
             ws.insert_new_segment_above_anchor_if_not_present(c_ref, a_ref),
             Some(true)
+        );
+
+        assert_eq!(
+            ws.add_or_insert_new_stack_if_not_present(a_ref, None),
+            (0, 2),
+            "adding a new stack can 'fail' if the segment is already present, but not as stack tip"
         );
 
         insta::assert_snapshot!(but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")), @r#"

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -95,9 +95,9 @@ pub mod merge {
         /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
         /// One could be better and only repeat what didn't change, to avoid repeating unnecessarily.
         /// But that shouldn't usually matter unless in the biggest repositories with tree-merge times past a 500ms or so.
-        #[instrument(level = tracing::Level::DEBUG, skip(graph, repo), err(Debug))]
-        pub fn from_new_merge_with_metadata(
-            stacks: &[but_core::ref_metadata::WorkspaceStack],
+        #[instrument(level = tracing::Level::DEBUG, skip(stacks, graph, repo), err(Debug))]
+        pub fn from_new_merge_with_metadata<'a>(
+            stacks: impl IntoIterator<Item = &'a but_core::ref_metadata::WorkspaceStack>,
             graph: &but_graph::Graph,
             repo: &gix::Repository,
             hero_stack: Option<&gix::refs::FullNameRef>,
@@ -123,7 +123,7 @@ pub mod merge {
             }
             let mut missing_stacks = Vec::new();
             let mut tips: Vec<_> = stacks
-                .iter()
+                .into_iter()
                 .filter_map(|s| s.branches.first())
                 .filter_map(|top_segment| {
                     let stack_tip_name = top_segment.ref_name.as_ref();


### PR DESCRIPTION
Get a minimal viable version of `apply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10589.

### Tasks

* [x] apply non-stack-tip segment within a 'bigger' branch to ensure these can be applied as new tip
    - [x] assure dependent-branch variant works on pristine ws-metadata
* [x] conflict-tests for apply to validate stack ids and assure ws-metadata knows them as out-of-workspace
* [x] test apply from unborn HEAD

### Next PR?

* [ ] ⚠️ tips could be conflicted, deal with it
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace
    - remember: ghost-stacks when the stack is in the workspace metadata, but not reachable from the workspace commit.
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [x] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [x] don't apply the target branch!
- [x] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.


### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



