### PR TITLE
fix(cursor): conditionally use 2x custom cursors on WebKit with supports rule

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -178,7 +178,12 @@
 		flex-direction: column;
 		width: 100%;
 		cursor: var(--cursor-custom);
-		cursor: var(--cursor-custom-2x);
+	}
+
+	@supports (-webkit-image-set(url('') 1x)) {
+		.cursor-wrapper {
+			cursor: var(--cursor-custom-2x);
+		}
 	}
 
 	.cursor-wrapper :global(a),
@@ -186,6 +191,14 @@
 	.cursor-wrapper :global([role='button']),
 	.cursor-wrapper :global([role='link']) {
 		cursor: var(--cursor-pointer);
-		cursor: var(--cursor-pointer-2x);
+	}
+
+	@supports (-webkit-image-set(url('') 1x)) {
+		.cursor-wrapper :global(a),
+		.cursor-wrapper :global(button),
+		.cursor-wrapper :global([role='button']),
+		.cursor-wrapper :global([role='link']) {
+			cursor: var(--cursor-pointer-2x);
+		}
 	}
 </style>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -5,10 +5,21 @@
 	--layout-col-gap: 20px;
 	--layout-side-paddings: 80px;
 	--cursor-custom: url('/images/cursors/cursor-default.svg') 0 0, auto;
-	--cursor-custom-2x: -webkit-image-set(url('/images/cursors/cursor-default-2x.svg') 2x) 0 0, auto;
+	--cursor-custom-2x:
+		-webkit-image-set(
+				url('/images/cursors/cursor-default-2x.svg') 1x,
+				url('/images/cursors/cursor-default-2x.svg') 2x
+			)
+			0 0,
+		auto;
 	--cursor-pointer: url('/images/cursors/cursor-pointer.svg') 2 0, pointer;
 	--cursor-pointer-2x:
-		-webkit-image-set(url('/images/cursors/cursor-pointer-2x.svg') 2x) 2 0, pointer;
+		-webkit-image-set(
+				url('/images/cursors/cursor-pointer.svg') 1x,
+				url('/images/cursors/cursor-pointer-2x.svg') 2x
+			)
+			2 0,
+		pointer;
 }
 
 body {


### PR DESCRIPTION
Looks like Firefox doesn't support `image-set` in CSS urls

Before:

https://github.com/user-attachments/assets/7516953f-e78c-440e-b412-e18f3c75328f


After:

https://github.com/user-attachments/assets/d245a158-4102-4e3c-b54e-dbab04f12c4e

