### PR TITLE
feat: add Trae IDE protocol handler support

### DIFF
--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -52,7 +52,8 @@
 		{ schemeIdentifer: 'vscode-insiders', displayName: 'VSCode Insiders' },
 		{ schemeIdentifer: 'windsurf', displayName: 'Windsurf' },
 		{ schemeIdentifer: 'zed', displayName: 'Zed' },
-		{ schemeIdentifer: 'cursor', displayName: 'Cursor' }
+		{ schemeIdentifer: 'cursor', displayName: 'Cursor' },
+		{ schemeIdentifer: 'trae', displayName: 'Trae' }
 	];
 	const editorOptionsForSelect = editorOptions.map((option) => ({
 		label: option.displayName,

--- a/crates/but-api/src/commands/open.rs
+++ b/crates/but-api/src/commands/open.rs
@@ -19,6 +19,7 @@ pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
         "zed",
         "windsurf",
         "cursor",
+        "trae",
     ]
     .contains(&target_url.scheme())
     {


### PR DESCRIPTION
This pull request adds **Trae IDE** as an editor option in GitButler.

Now, users can open files directly in **Trae IDE** using the same pattern followed for **VSCode**, **Cursor**, **Zed**, and **Windsurf**.

## Changes Made
- Added `trae` scheme to the allowed URL schemes list in `crates/but-api/src/commands/open.rs`
- Added Trae IDE option to the editor selection dropdown in `apps/desktop/src/components/profileSettings/GeneralSettings.svelte`

## Testing
- Verified that the code compiles successfully
- Confirmed that Trae appears as an option in the editor selection dropdown
- Confirmed that selecting Trae IDE generates the correct `trae://` protocol URLs