### PR TITLE
Set specific version of MacOS to avoid Traffic-light issue

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,7 +93,7 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
         platform:
           - macos-13 # [macOs, x64]
-          - macos-latest # [macOs, ARM64]
+          - macos-15 # [macOs, ARM64]
           - ubuntu-24.04 # [linux, x64]
           - windows-latest # [windows, x64]
 


### PR DESCRIPTION
While we manually adjust traffic lights, and in some way have our design depend on it, we need to be sure we don't just switch over to macOS 26.

This needs preparation.

