### PR TITLE
Improve marketing pages css grid layout

### DIFF
--- a/apps/web/src/lib/components/marketing/Header.svelte
+++ b/apps/web/src/lib/components/marketing/Header.svelte
@@ -81,7 +81,7 @@
 <style lang="scss">
 	.header {
 		display: flex;
-		grid-column: narrow-start / off-gridded;
+		grid-column: narrow-start / off-center;
 		align-items: center;
 		justify-content: space-between;
 		padding-top: 40px;

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -207,7 +207,7 @@
 				1fr
 				[narrow-start]
 				1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr
-				[narrow-end off-gridded]
+				[narrow-end off-center]
 				1fr
 				[full-end];
 		}
@@ -216,7 +216,7 @@
 			grid-template-columns:
 				[full-start narrow-start]
 				1fr 1fr 1fr 1fr
-				[narrow-end full-end off-gridded];
+				[narrow-end full-end off-center];
 		}
 	}
 

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -186,11 +186,11 @@
 		grid-template-rows: auto 1fr auto;
 		grid-template-columns:
 			[full-start]
-			1fr 1fr
+			repeat(2, 1fr)
 			[narrow-start]
-			1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr
+			repeat(8, 1fr)
 			[narrow-end]
-			1fr 1fr
+			1fr [off-center] 1fr
 			[full-end];
 		column-gap: var(--layout-col-gap);
 		row-gap: 24px;
@@ -206,7 +206,7 @@
 				[full-start]
 				1fr
 				[narrow-start]
-				1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr
+				repeat(10, 1fr)
 				[narrow-end off-center]
 				1fr
 				[full-end];
@@ -215,7 +215,7 @@
 		@media (--mobile-viewport) {
 			grid-template-columns:
 				[full-start narrow-start]
-				1fr 1fr 1fr 1fr
+				repeat(4, 1fr)
 				[narrow-end full-end off-center];
 		}
 	}

--- a/apps/web/src/routes/(home)/components/Features.svelte
+++ b/apps/web/src/routes/(home)/components/Features.svelte
@@ -208,7 +208,7 @@
 	@media (max-width: 740px) {
 		.features {
 			grid-template-columns: 1fr;
-			grid-column: narrow-start / off-gridded;
+			grid-column: narrow-start / off-center;
 			margin-top: 24px;
 		}
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -133,7 +133,7 @@
 	{@render children?.()}
 {/if}
 
-<style>
+<style lang="postcss">
 	.marketing-page {
 		display: grid;
 		grid-template-columns:

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -142,7 +142,7 @@
 			[narrow-start]
 			repeat(8, 1fr)
 			[narrow-end]
-			1fr [off-gridded] 1fr
+			1fr [off-center] 1fr
 			[full-end];
 		column-gap: var(--layout-col-gap);
 		row-gap: 60px;
@@ -159,7 +159,7 @@
 				1fr
 				[narrow-start]
 				repeat(10, 1fr)
-				[narrow-end off-gridded]
+				[narrow-end off-center]
 				1fr
 				[full-end];
 		}
@@ -168,7 +168,7 @@
 			grid-template-columns:
 				[full-start narrow-start]
 				repeat(4, 1fr)
-				[narrow-end full-end off-gridded];
+				[narrow-end full-end off-center];
 			row-gap: 40px;
 		}
 	}


### PR DESCRIPTION
This pull request standardizes the naming convention for a grid column in the layout and component styles by replacing all instances of `off-gridded` with `off-center`. This change ensures consistency across the codebase and likely improves the clarity of the grid structure.

**Grid column naming updates:**

* Replaced `off-gridded` with `off-center` in the main layout grid definitions in `apps/web/src/routes/+layout.svelte`. [[1]](diffhunk://#diff-56fd8007dec0b8cf438ba8040f625d337e889b9ebfdd0f7793ad30231c9ba1f2L145-R145) [[2]](diffhunk://#diff-56fd8007dec0b8cf438ba8040f625d337e889b9ebfdd0f7793ad30231c9ba1f2L162-R162) [[3]](diffhunk://#diff-56fd8007dec0b8cf438ba8040f625d337e889b9ebfdd0f7793ad30231c9ba1f2L171-R171)
* Updated grid column names from `off-gridded` to `off-center` in the responsive grid templates in `apps/web/src/routes/(app)/+layout.svelte`. [[1]](diffhunk://#diff-029fbf51b7377671d99facd9b672c5c2e06ab65381fc9105c1bad313324b7044L210-R210) [[2]](diffhunk://#diff-029fbf51b7377671d99facd9b672c5c2e06ab65381fc9105c1bad313324b7044L219-R219)
* Changed the grid-column property from `off-gridded` to `off-center` in the `Header.svelte` and `Features.svelte` components to match the new naming convention. [[1]](diffhunk://#diff-0ad0034b9716daaa12210e3f694aa6352fa948acb21f7725ece76ca950c0d7fdL84-R84) [[2]](diffhunk://#diff-d73034ff1aeede2f978ad03ff33405714fd70f4ce0c85c29124012af007bab10L211-R211)