### PR TITLE
optional `tauri` for `but-api`

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -105,6 +105,21 @@ jobs:
       - run: cargo fmt --check --all
       - run: cargo check --workspace --all-targets
 
+  rust-but-binary-no-tauri:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - run: |
+          sudo apt update
+          sudo apt install -y libdbus-1-dev pkg-config
+      - run: cargo build -p but
+
   rust-docs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -9,7 +9,9 @@ authors = ["GitButler <gitbutler@gitbutler.com>"]
 readme = "../../README.md"
 publish = false
 rust-version = "1.89"
+
 [features]
+tauri = ["dep:tauri"]
 
 [dependencies]
 serde.workspace = true
@@ -17,7 +19,7 @@ tokio = { workspace = true, features = ["full"] }
 anyhow.workspace = true
 serde_json = "1.0.145"
 tracing.workspace = true
-tauri = { version = "^2.7.0", features = ["unstable"] } # For the #[tauri::command(async)] macro only
+tauri = { version = "^2.7.0", features = ["unstable"], optional = true } # For the #[tauri::command(async)] macro only
 
 but-settings.workspace = true
 but-github.workspace = true

--- a/crates/but-api/src/commands/cherry_apply.rs
+++ b/crates/but-api/src/commands/cherry_apply.rs
@@ -8,7 +8,7 @@ use gitbutler_stack::StackId;
 use tracing::instrument;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn cherry_apply_status(
     project_id: ProjectId,
@@ -25,7 +25,7 @@ pub fn cherry_apply_status(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn cherry_apply(project_id: ProjectId, subject: String, target: StackId) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;

--- a/crates/but-api/src/commands/claude.rs
+++ b/crates/but-api/src/commands/claude.rs
@@ -61,7 +61,7 @@ pub fn claude_get_messages(
     Ok(messages)
 }
 
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub async fn claude_get_session_details(
     project_id: ProjectId,
@@ -92,7 +92,7 @@ pub async fn claude_get_session_details(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn claude_list_permission_requests(
     project_id: ProjectId,
@@ -102,7 +102,7 @@ pub fn claude_list_permission_requests(
     Ok(but_claude::db::list_all_permission_requests(&mut ctx)?)
 }
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn claude_update_permission_request(
     project_id: ProjectId,
@@ -130,7 +130,7 @@ pub async fn claude_cancel_session(app: &App, params: CancelSessionParams) -> Re
     Ok(cancelled)
 }
 
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub async fn claude_check_available() -> Result<ClaudeCheckResult, Error> {
     let app_settings = AppSettings::load_from_default_path_creating()?;
@@ -170,7 +170,7 @@ pub async fn claude_compact_history(app: &App, params: CompactHistoryParams) -> 
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn claude_list_prompt_templates(
     project_id: ProjectId,
@@ -181,7 +181,7 @@ pub fn claude_list_prompt_templates(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn claude_get_prompt_dirs(
     project_id: ProjectId,
@@ -192,7 +192,7 @@ pub fn claude_get_prompt_dirs(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn claude_maybe_create_prompt_dir(project_id: ProjectId, path: String) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -200,7 +200,7 @@ pub fn claude_maybe_create_prompt_dir(project_id: ProjectId, path: String) -> Re
     Ok(())
 }
 
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub async fn claude_get_mcp_config(project_id: ProjectId) -> Result<McpConfig, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -209,7 +209,7 @@ pub async fn claude_get_mcp_config(project_id: ProjectId) -> Result<McpConfig, E
     Ok(mcp_config.mcp_servers())
 }
 
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub async fn claude_get_sub_agents(
     project_id: ProjectId,
@@ -219,7 +219,7 @@ pub async fn claude_get_sub_agents(
     Ok(sub_agents)
 }
 
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub async fn claude_verify_path(project_id: ProjectId, path: String) -> Result<bool, Error> {
     let project = gitbutler_project::get(project_id)?;

--- a/crates/but-api/src/commands/cli.rs
+++ b/crates/but-api/src/commands/cli.rs
@@ -7,14 +7,14 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn install_cli() -> Result<(), Error> {
     do_install_cli().map_err(Error::from)
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn cli_path() -> Result<String, Error> {
     let cli_path = get_cli_path()?;

--- a/crates/but-api/src/commands/config.rs
+++ b/crates/but-api/src/commands/config.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 use but_api_macros::api_cmd;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_gb_config(project_id: ProjectId) -> Result<GitConfigSettings, Error> {
     but_core::open_repo(gitbutler_project::get(project_id)?.path)?
@@ -19,7 +19,7 @@ pub fn get_gb_config(project_id: ProjectId) -> Result<GitConfigSettings, Error> 
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn set_gb_config(project_id: ProjectId, config: GitConfigSettings) -> Result<(), Error> {
     but_core::open_repo(gitbutler_project::get(project_id)?.path)?
@@ -28,7 +28,7 @@ pub fn set_gb_config(project_id: ProjectId, config: GitConfigSettings) -> Result
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn store_author_globally_if_unset(
     project_id: ProjectId,
@@ -57,7 +57,7 @@ pub struct AuthorInfo {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 /// Return the Git author information as the project repository would see it.
 pub fn get_author_info(project_id: ProjectId) -> Result<AuthorInfo, Error> {

--- a/crates/but-api/src/commands/diff.rs
+++ b/crates/but-api/src/commands/diff.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 /// Provide a unified diff for `change`, but fail if `change` is a [type-change](but_core::ModeFlags::TypeChange)
 /// or if it involves a change to a [submodule](gix::object::Kind::Commit).
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn tree_change_diffs(
     project_id: ProjectId,
@@ -46,7 +46,7 @@ pub struct CommitDetails {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn commit_details(
     project_id: ProjectId,
@@ -73,7 +73,7 @@ pub fn commit_details(
 /// Note that `stack_id` is deprecated in favor of `branch_name`
 /// *(which should be a full ref-name as well and make `remote` unnecessary)*
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn changes_in_branch(
     project_id: ProjectId,
@@ -112,7 +112,7 @@ fn changes_in_branch_inner(ctx: CommandContext, branch: Refname) -> anyhow::Resu
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn changes_in_worktree(project_id: ProjectId) -> anyhow::Result<WorktreeChanges, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -165,7 +165,7 @@ pub fn changes_in_worktree(project_id: ProjectId) -> anyhow::Result<WorktreeChan
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn assign_hunk(
     project_id: ProjectId,

--- a/crates/but-api/src/commands/forge.rs
+++ b/crates/but-api/src/commands/forge.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn pr_templates(project_id: ProjectId, forge: ForgeName) -> Result<Vec<String>, Error> {
     let project = gitbutler_project::get_validated(project_id)?;
@@ -22,7 +22,7 @@ pub fn pr_templates(project_id: ProjectId, forge: ForgeName) -> Result<Vec<Strin
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn pr_template(
     project_id: ProjectId,

--- a/crates/but-api/src/commands/git.rs
+++ b/crates/but-api/src/commands/git.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 use crate::error::ToError as _;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_remote_branches(project_id: ProjectId) -> Result<Vec<RemoteRefname>, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -23,7 +23,7 @@ pub fn git_remote_branches(project_id: ProjectId) -> Result<Vec<RemoteRefname>, 
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_test_push(
     project_id: ProjectId,
@@ -37,7 +37,7 @@ pub fn git_test_push(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_test_fetch(
     project_id: ProjectId,
@@ -54,7 +54,7 @@ pub fn git_test_fetch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_index_size(project_id: ProjectId) -> Result<usize, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -68,7 +68,7 @@ pub fn git_index_size(project_id: ProjectId) -> Result<usize, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn delete_all_data() -> Result<(), Error> {
     for project in gitbutler_project::list().context("failed to list projects")? {
@@ -79,7 +79,7 @@ pub fn delete_all_data() -> Result<(), Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_set_global_config(key: String, value: String) -> Result<String, Error> {
     let mut config = git2::Config::open_default().to_error()?;
@@ -88,7 +88,7 @@ pub fn git_set_global_config(key: String, value: String) -> Result<String, Error
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_remove_global_config(key: String) -> Result<(), Error> {
     let mut config = git2::Config::open_default().to_error()?;
@@ -97,7 +97,7 @@ pub fn git_remove_global_config(key: String) -> Result<(), Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_get_global_config(key: String) -> Result<Option<String>, Error> {
     let config = git2::Config::open_default().to_error()?;

--- a/crates/but-api/src/commands/modes.rs
+++ b/crates/but-api/src/commands/modes.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn operating_mode(project_id: ProjectId) -> Result<OperatingMode, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -22,7 +22,7 @@ pub fn operating_mode(project_id: ProjectId) -> Result<OperatingMode, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn enter_edit_mode(
     project_id: ProjectId,
@@ -37,7 +37,7 @@ pub fn enter_edit_mode(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn abort_edit_and_return_to_workspace(project_id: ProjectId) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -49,7 +49,7 @@ pub fn abort_edit_and_return_to_workspace(project_id: ProjectId) -> Result<(), E
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn save_edit_and_return_to_workspace(project_id: ProjectId) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -61,7 +61,7 @@ pub fn save_edit_and_return_to_workspace(project_id: ProjectId) -> Result<(), Er
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn edit_initial_index_state(
     project_id: ProjectId,
@@ -73,7 +73,7 @@ pub fn edit_initial_index_state(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn edit_changes_from_initial(project_id: ProjectId) -> Result<Vec<TreeChange>, Error> {
     let project = gitbutler_project::get(project_id)?;

--- a/crates/but-api/src/commands/open.rs
+++ b/crates/but-api/src/commands/open.rs
@@ -85,14 +85,14 @@ pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn open_url(url: String) -> Result<(), Error> {
     Ok(open_that(&url)?)
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn show_in_finder(path: String) -> Result<(), Error> {
     // Cross-platform implementation to open file/directory in the default file manager

--- a/crates/but-api/src/commands/oplog.rs
+++ b/crates/but-api/src/commands/oplog.rs
@@ -40,7 +40,7 @@ use crate::error::Error;
 /// # Errors
 /// Returns an error if the project cannot be found or if there is an issue accessing the oplog.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn list_snapshots(
     project_id: ProjectId,
@@ -69,7 +69,7 @@ pub fn list_snapshots(
 /// # Errors
 /// Returns an error if the project cannot be found or if there is an issue creating the snapshot.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_snapshot(
     project_id: ProjectId,
@@ -97,7 +97,7 @@ pub fn create_snapshot(
 /// This includes the state of the working directory as well as commmit history and references.
 /// Additionally, a new snapshot is created in the oplog to record the restore action.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn restore_snapshot(project_id: ProjectId, sha: String) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id).context("failed to get project")?;
@@ -122,7 +122,7 @@ pub fn restore_snapshot(project_id: ProjectId, sha: String) -> Result<(), Error>
 /// # Errors
 /// Returns an error if the project cannot be found, if the snapshot SHA is invalid, or if there is an issue computing the diff.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn snapshot_diff(
     project_id: ProjectId,

--- a/crates/but-api/src/commands/projects.rs
+++ b/crates/but-api/src/commands/projects.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tracing::instrument;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_project(project: projects::UpdateRequest) -> Result<projects::Project, Error> {
     Ok(gitbutler_project::update(&project)?)
@@ -14,14 +14,14 @@ pub fn update_project(project: projects::UpdateRequest) -> Result<projects::Proj
 /// Adds an existing git repository as a GitButler project.
 /// If the directory is not a git repository, an error is returned.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn add_project(path: PathBuf) -> Result<projects::AddProjectOutcome, Error> {
     Ok(gitbutler_project::add(&path)?)
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_project(
     project_id: ProjectId,
@@ -35,7 +35,7 @@ pub fn get_project(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn delete_project(project_id: ProjectId) -> Result<(), Error> {
     gitbutler_project::delete(project_id).map_err(Into::into)

--- a/crates/but-api/src/commands/remotes.rs
+++ b/crates/but-api/src/commands/remotes.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn list_remotes(project_id: ProjectId) -> Result<Vec<GitRemote>, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -15,7 +15,7 @@ pub fn list_remotes(project_id: ProjectId) -> Result<Vec<GitRemote>, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn add_remote(project_id: ProjectId, name: String, url: String) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;

--- a/crates/but-api/src/commands/repo.rs
+++ b/crates/but-api/src/commands/repo.rs
@@ -17,7 +17,7 @@ use crate::error::Error;
 use crate::error::ToError;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_get_local_config(project_id: ProjectId, key: String) -> Result<Option<String>, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -25,7 +25,7 @@ pub fn git_get_local_config(project_id: ProjectId, key: String) -> Result<Option
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_set_local_config(
     project_id: ProjectId,
@@ -37,7 +37,7 @@ pub fn git_set_local_config(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn check_signing_settings(project_id: ProjectId) -> Result<bool, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -45,7 +45,7 @@ pub fn check_signing_settings(project_id: ProjectId) -> Result<bool, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn git_clone_repository(repository_url: String, target_dir: PathBuf) -> Result<(), Error> {
     let should_interrupt = AtomicBool::new(false);
@@ -61,7 +61,7 @@ pub fn git_clone_repository(repository_url: String, target_dir: PathBuf) -> Resu
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_uncommited_files(project_id: ProjectId) -> Result<Vec<RemoteBranchFile>, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -70,7 +70,7 @@ pub fn get_uncommited_files(project_id: ProjectId) -> Result<Vec<RemoteBranchFil
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_commit_file(
     project_id: ProjectId,
@@ -83,7 +83,7 @@ pub fn get_commit_file(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_workspace_file(
     project_id: ProjectId,
@@ -94,7 +94,7 @@ pub fn get_workspace_file(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn pre_commit_hook(
     project_id: ProjectId,
@@ -107,7 +107,7 @@ pub fn pre_commit_hook(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn pre_commit_hook_diffspecs(
     project_id: ProjectId,
@@ -136,7 +136,7 @@ pub fn pre_commit_hook_diffspecs(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn post_commit_hook(project_id: ProjectId) -> Result<HookResult, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -145,7 +145,7 @@ pub fn post_commit_hook(project_id: ProjectId) -> Result<HookResult, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn message_hook(project_id: ProjectId, message: String) -> Result<MessageHookResult, Error> {
     let project = gitbutler_project::get(project_id)?;

--- a/crates/but-api/src/commands/rules.rs
+++ b/crates/but-api/src/commands/rules.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_workspace_rule(
     project_id: ProjectId,
@@ -26,7 +26,7 @@ pub fn create_workspace_rule(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn delete_workspace_rule(project_id: ProjectId, id: String) -> Result<(), Error> {
     let ctx = &mut CommandContext::open(
@@ -37,7 +37,7 @@ pub fn delete_workspace_rule(project_id: ProjectId, id: String) -> Result<(), Er
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_workspace_rule(
     project_id: ProjectId,
@@ -51,7 +51,7 @@ pub fn update_workspace_rule(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn list_workspace_rules(project_id: ProjectId) -> Result<Vec<WorkspaceRule>, Error> {
     let ctx = &mut CommandContext::open(

--- a/crates/but-api/src/commands/secret.rs
+++ b/crates/but-api/src/commands/secret.rs
@@ -6,14 +6,14 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn secret_get_global(handle: String) -> Result<Option<String>, Error> {
     Ok(secret::retrieve(&handle, secret::Namespace::Global)?.map(|s| s.0))
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn secret_set_global(handle: String, secret: String) -> Result<(), Error> {
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());

--- a/crates/but-api/src/commands/settings.rs
+++ b/crates/but-api/src/commands/settings.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_app_settings() -> Result<AppSettings, Error> {
     let app_settings = AppSettings::load_from_default_path_creating()?;

--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -41,7 +41,7 @@ pub mod create_reference {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_reference(
     project_id: ProjectId,
@@ -91,7 +91,7 @@ pub fn create_reference(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_branch(
     project_id: ProjectId,
@@ -155,7 +155,7 @@ pub fn create_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn remove_branch(
     project_id: ProjectId,
@@ -193,7 +193,7 @@ pub fn remove_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_branch_name(
     project_id: ProjectId,
@@ -208,7 +208,7 @@ pub fn update_branch_name(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_branch_description(
     project_id: ProjectId,
@@ -228,7 +228,7 @@ pub fn update_branch_description(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_branch_pr_number(
     project_id: ProjectId,
@@ -248,7 +248,7 @@ pub fn update_branch_pr_number(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn push_stack(
     project_id: ProjectId,
@@ -272,7 +272,7 @@ pub fn push_stack(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn push_stack_to_review(
     project_id: ProjectId,

--- a/crates/but-api/src/commands/users.rs
+++ b/crates/but-api/src/commands/users.rs
@@ -59,7 +59,7 @@ impl TryFrom<User> for UserWithSecrets {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_user() -> Result<Option<UserWithSecrets>, Error> {
     match gitbutler_user::get_user()? {
@@ -75,7 +75,7 @@ pub fn get_user() -> Result<Option<UserWithSecrets>, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn set_user(user: User) -> Result<User, Error> {
     gitbutler_user::set_user(&user)?;
@@ -83,7 +83,7 @@ pub fn set_user(user: User) -> Result<User, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn delete_user() -> Result<(), Error> {
     gitbutler_user::delete_user()?;

--- a/crates/but-api/src/commands/virtual_branches.rs
+++ b/crates/but-api/src/commands/virtual_branches.rs
@@ -26,14 +26,14 @@ use crate::error::Error;
 // Parameter structs for all functions
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn normalize_branch_name(name: String) -> Result<String, Error> {
     Ok(normalize_name(&name)?)
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_virtual_branch(
     project_id: ProjectId,
@@ -97,7 +97,7 @@ pub fn create_virtual_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn delete_local_branch(
     project_id: ProjectId,
@@ -111,7 +111,7 @@ pub fn delete_local_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_virtual_branch_from_branch(
     project_id: ProjectId,
@@ -128,7 +128,7 @@ pub fn create_virtual_branch_from_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn integrate_upstream_commits(
     project_id: ProjectId,
@@ -148,7 +148,7 @@ pub fn integrate_upstream_commits(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_initial_integration_steps_for_branch(
     project_id: ProjectId,
@@ -169,7 +169,7 @@ pub fn get_initial_integration_steps_for_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn integrate_branch_with_steps(
     project_id: ProjectId,
@@ -184,7 +184,7 @@ pub fn integrate_branch_with_steps(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_base_branch_data(project_id: ProjectId) -> Result<Option<BaseBranch>, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -197,7 +197,7 @@ pub fn get_base_branch_data(project_id: ProjectId) -> Result<Option<BaseBranch>,
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn set_base_branch(
     project_id: ProjectId,
@@ -225,7 +225,7 @@ pub fn set_base_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn push_base_branch(project_id: ProjectId, with_force: bool) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -235,7 +235,7 @@ pub fn push_base_branch(project_id: ProjectId, with_force: bool) -> Result<(), E
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_stack_order(
     project_id: ProjectId,
@@ -248,7 +248,7 @@ pub fn update_stack_order(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn unapply_stack(project_id: ProjectId, stack_id: StackId) -> Result<(), Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -271,7 +271,7 @@ pub fn unapply_stack(project_id: ProjectId, stack_id: StackId) -> Result<(), Err
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn can_apply_remote_branch(
     project_id: ProjectId,
@@ -285,7 +285,7 @@ pub fn can_apply_remote_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn list_commit_files(
     project_id: ProjectId,
@@ -298,7 +298,7 @@ pub fn list_commit_files(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn amend_virtual_branch(
     project_id: ProjectId,
@@ -314,7 +314,7 @@ pub fn amend_virtual_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn undo_commit(
     project_id: ProjectId,
@@ -329,7 +329,7 @@ pub fn undo_commit(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn insert_blank_commit(
     project_id: ProjectId,
@@ -353,7 +353,7 @@ pub fn insert_blank_commit(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn reorder_stack(
     project_id: ProjectId,
@@ -367,7 +367,7 @@ pub fn reorder_stack(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn find_git_branches(
     project_id: ProjectId,
@@ -380,7 +380,7 @@ pub fn find_git_branches(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn list_branches(
     project_id: ProjectId,
@@ -393,7 +393,7 @@ pub fn list_branches(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn get_branch_listing_details(
     project_id: ProjectId,
@@ -406,7 +406,7 @@ pub fn get_branch_listing_details(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn squash_commits(
     project_id: ProjectId,
@@ -432,7 +432,7 @@ pub fn squash_commits(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn fetch_from_remotes(
     project_id: ProjectId,
@@ -465,7 +465,7 @@ pub fn fetch_from_remotes(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn move_commit(
     project_id: ProjectId,
@@ -481,7 +481,7 @@ pub fn move_commit(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn move_branch(
     project_id: ProjectId,
@@ -503,7 +503,7 @@ pub fn move_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn tear_off_branch(
     project_id: ProjectId,
@@ -517,7 +517,7 @@ pub fn tear_off_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_commit_message(
     project_id: ProjectId,
@@ -534,7 +534,7 @@ pub fn update_commit_message(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn find_commit(
     project_id: ProjectId,
@@ -547,7 +547,7 @@ pub fn find_commit(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn upstream_integration_statuses(
     project_id: ProjectId,
@@ -564,7 +564,7 @@ pub fn upstream_integration_statuses(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn integrate_upstream(
     project_id: ProjectId,
@@ -580,7 +580,7 @@ pub fn integrate_upstream(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn resolve_upstream_integration(
     project_id: ProjectId,

--- a/crates/but-api/src/commands/workspace.rs
+++ b/crates/but-api/src/commands/workspace.rs
@@ -26,7 +26,7 @@ fn ref_metadata_toml(project: &Project) -> anyhow::Result<VirtualBranchesTomlMet
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn head_info(project_id: ProjectId) -> Result<but_workspace::ui::RefInfo, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -50,7 +50,7 @@ pub fn head_info(project_id: ProjectId) -> Result<but_workspace::ui::RefInfo, Er
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn stacks(
     project_id: ProjectId,
@@ -70,7 +70,7 @@ pub fn stacks(
 
 #[cfg(unix)]
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn show_graph_svg(project_id: ProjectId) -> Result<(), Error> {
     use but_settings::AppSettings;
@@ -125,7 +125,7 @@ pub fn show_graph_svg(project_id: ProjectId) -> Result<(), Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn stack_details(
     project_id: ProjectId,
@@ -148,7 +148,7 @@ pub fn stack_details(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn branch_details(
     project_id: ProjectId,
@@ -186,7 +186,7 @@ pub fn branch_details(
 /// `stack_branch_name` is the short name of the reference that the UI knows is present in a given segment.
 /// It is necessary to insert the new commit into the right bucket.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn create_commit_from_worktree_changes(
     project_id: ProjectId,
@@ -231,7 +231,7 @@ pub fn create_commit_from_worktree_changes(
 /// Note that submodules *must* be provided as diffspec without hunks, as attempting to generate
 /// hunks would fail.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn amend_commit_from_worktree_changes(
     project_id: ProjectId,
@@ -269,7 +269,7 @@ pub fn amend_commit_from_worktree_changes(
 ///
 /// Returns the `worktree_changes` that couldn't be applied,
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn discard_worktree_changes(
     project_id: ProjectId,
@@ -314,7 +314,7 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn move_changes_between_commits(
     project_id: ProjectId,
@@ -349,7 +349,7 @@ pub fn move_changes_between_commits(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn split_branch(
     project_id: ProjectId,
@@ -392,7 +392,7 @@ pub fn split_branch(
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn split_branch_into_dependent_branch(
     project_id: ProjectId,
@@ -431,7 +431,7 @@ pub fn split_branch_into_dependent_branch(
 /// specified.
 /// If `assign_to` is not provided, the changes will be unassigned.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn uncommit_changes(
     project_id: ProjectId,
@@ -514,7 +514,7 @@ pub fn uncommit_changes(
 /// Immediately after the changes are committed, the branch is unapplied from the workspace, and the "stash" branch can be re-applied at a later time
 /// In theory it should be possible to specify an existing "dumping" branch for this, but currently this endpoint expects a new branch.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn stash_into_branch(
     project_id: ProjectId,
@@ -581,7 +581,7 @@ pub fn stash_into_branch(
 /// Returns a new available branch name based on a simple template - user_initials-branch-count
 /// The main point of this is to be able to provide branch names that are not already taken.
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn canned_branch_name(project_id: ProjectId) -> Result<String, Error> {
     let project = gitbutler_project::get(project_id)?;
@@ -593,7 +593,7 @@ pub fn canned_branch_name(project_id: ProjectId) -> Result<String, Error> {
 }
 
 #[api_cmd]
-#[tauri::command(async)]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn target_commits(
     project_id: ProjectId,

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -66,7 +66,7 @@ but-workspace.workspace = true
 but-core.workspace = true
 but-action.workspace = true
 but-bot.workspace = true
-but-api.workspace = true
+but-api = { workspace = true, features = ["tauri"] }
 but-claude.workspace = true
 but-github.workspace = true
 open = "5"


### PR DESCRIPTION
By default, we will not build the `but-api` with `tauri`, forcing all crates that need it to explicitly enable it. This is only done for `gitbutler-tauri`.

Lastly, add a CI job to validate it can build without tauri.
