### PR TITLE
Enable more fine-grained caching for Rust enabled CI pipelines

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -94,8 +94,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -107,6 +105,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - run: sudo scripts/install-debian-dependencies.sh
+        name: Install Dependencies
       - run: cargo fmt --check --all
       - run: cargo check --workspace --all-targets
       - name: cargo clippy
@@ -138,16 +138,19 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     env:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      # TODO(qix-): we have to exclude the app here for now because for some
-      # TODO(qix-): reason it doesn't build with the docs feature enabled.
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.1
+        with:
+          shared-key: rust-docs
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - run: sudo scripts/install-debian-dependencies.sh
+        name: Install Dependencies
       - run: cargo doc --no-deps --all-features --document-private-items -p gitbutler-git
         env:
           RUSTDOCFLAGS: -Dwarnings
@@ -182,18 +185,7 @@ jobs:
         with:
           shared-key: rust-testing
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - run: |
-          sudo apt update
-          sudo apt install libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            cmake
+      - run: sudo scripts/install-debian-dependencies.sh
         name: Install Dependencies
       - run: |
           cargo test --workspace

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -99,11 +99,20 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.1
+        with:
+          shared-key: rust-lint
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - run: cargo fmt --check --all
       - run: cargo check --workspace --all-targets
+      - name: cargo clippy
+        run: |
+          rustup component add clippy
+          cargo clippy --workspace --all-targets -- -D warnings
 
   rust-but-binary-no-tauri:
     needs: changes
@@ -112,6 +121,11 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.1
+        with:
+          shared-key: rust-but-binary
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -166,7 +180,8 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.1
         with:
-          shared-key: unix-rust-testing-v2
+          shared-key: rust-testing
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - run: |
           sudo apt update
           sudo apt install libwebkit2gtk-4.1-dev \
@@ -186,16 +201,30 @@ jobs:
           GITBUTLER_TESTS_NO_CLEANUP: '1'
         name: cargo test
       - run: |
-          rustup component add clippy
-          cargo clippy --workspace --all-targets -- -D warnings
-        name: cargo clippy
-      - run: |
           set -e
           cargo check -p gitbutler-tauri --no-default-features
           for feature in devtools custom-protocol error-context; do
             cargo check -p gitbutler-tauri --no-default-features --features "$feature"
           done
         name: Check Tauri App
+
+  check-rust-windows:
+    needs: changes
+    runs-on: windows-latest
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.1
+        with:
+          shared-key: rust-testing
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: 'cargo check'
+        run: cargo check --workspace --all-targets --features windows
 
   check-rust:
     if: always()
@@ -213,23 +242,6 @@ jobs:
         with:
           allowed-skips: ${{ toJSON(needs) }}
           jobs: ${{ toJSON(needs) }}
-
-  check-rust-windows:
-    needs: changes
-    runs-on: windows-latest
-    if: ${{ needs.changes.outputs.rust == 'true' }}
-    env:
-      CARGO_TERM_COLOR: always
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.8.1
-        with:
-          shared-key: windows-rust-testing
-      - name: 'cargo check'
-        run: cargo check --workspace --all-targets --features windows
 
   # Check that all `actions/checkout` in CI jobs have `persist-credentials: false`.
   check-no-persist-credentials:

--- a/scripts/install-debian-dependencies.sh
+++ b/scripts/install-debian-dependencies.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# Install the dependencies needed to build tauri, mainly.
+
+apt update
+apt install libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            cmake


### PR DESCRIPTION
This should speed it up, particularly for the new `but` build.
The general idea is to just reuse caches from `master`, but to not bother saving them.

Also, keep specialised caches for related jobs.


### Tasks

* [x] rust cache optimisation
* [x] skip custom image (45s) for dependency installation.
* [x] ~~avoid apt-update~~ - not possible
