### PR TITLE
but: v1 Add branch list subcommand and Display for BranchIdentity

### DIFF
--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -1,0 +1,70 @@
+use colored::Colorize;
+use gitbutler_branch_actions::BranchListingFilter;
+use gitbutler_project::Project;
+
+pub fn list(project: &Project, local: bool) -> Result<(), anyhow::Error> {
+    let filter = if local {
+        Some(BranchListingFilter {
+            local: Some(true),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
+    let applied_stacks =
+        but_api::workspace::stacks(project.id, Some(but_workspace::StacksFilter::InWorkspace))?;
+    print_applied_branches(&applied_stacks);
+    let branches = but_api::virtual_branches::list_branches(project.id, filter)?;
+
+    let (branches, remote_only_branches): (Vec<_>, Vec<_>) =
+        branches.into_iter().partition(|b| b.has_local);
+    for branch in branches {
+        // Skip branches that are part of applied stacks
+        if let Some(stack_ref) = branch.stack
+            && applied_stacks.iter().any(|s| s.id == Some(stack_ref.id))
+        {
+            continue;
+        }
+
+        println!("{}", branch.name);
+    }
+
+    for branch in remote_only_branches {
+        println!("{} {}", "(remote)".dimmed(), branch.name);
+    }
+    Ok(())
+}
+
+fn print_applied_branches(applied_stacks: &[but_workspace::ui::StackEntry]) {
+    for stack in applied_stacks {
+        let first_branch = stack.heads.first();
+        let last_branch = stack.heads.last();
+        for branch in &stack.heads {
+            let is_single_branch = stack.heads.len() == 1;
+            if is_single_branch {
+                let branch_entry = format!("* {}", branch.name);
+                println!("{}", branch_entry.green());
+                continue;
+            }
+
+            let Some(first_branch) = first_branch else {
+                continue;
+            };
+
+            let Some(last_branch) = last_branch else {
+                continue;
+            };
+
+            let branch_entry = if branch.name == first_branch.name {
+                format!("*- {}", branch.name)
+            } else if branch.name == last_branch.name {
+                format!("└─ {}", branch.name)
+            } else {
+                format!("├─ {}", branch.name)
+            };
+
+            println!("{}", branch_entry.green());
+        }
+    }
+}

--- a/crates/but/src/branch/mod.rs
+++ b/crates/but/src/branch/mod.rs
@@ -4,6 +4,8 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
 use std::io::{self, Write};
 
+mod list;
+
 #[derive(Debug, clap::Parser)]
 pub struct Platform {
     #[clap(subcommand)]
@@ -28,6 +30,12 @@ pub enum Subcommands {
         /// Force deletion without confirmation
         #[clap(long, short = 'f')]
         force: bool,
+    },
+    /// List the branches in the repository
+    List {
+        /// Show only local branches
+        #[clap(long, short = 'l')]
+        local: bool,
     },
 }
 
@@ -124,6 +132,7 @@ pub fn handle(cmd: &Subcommands, project: &Project, _json: bool) -> anyhow::Resu
             println!("Branch '{}' not found in any stack", branch_name);
             Ok(())
         }
+        Subcommands::List { local } => list::list(project, *local),
     }
 }
 

--- a/crates/gitbutler-branch/src/branch.rs
+++ b/crates/gitbutler-branch/src/branch.rs
@@ -81,3 +81,9 @@ impl TryFrom<&BStr> for BranchIdentity {
         gix::refs::PartialName::try_from(value.to_owned()).map(BranchIdentity)
     }
 }
+
+impl std::fmt::Display for BranchIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.as_ref().as_bstr().to_str_lossy())
+    }
+}


### PR DESCRIPTION
crates/but/src/branch/list.rs: Added new module implementing 'list' function to display branches. It queries applied stacks and virtual branches via but_api, partitions local and remote-only branches, skips branches that are part of applied stacks, and prints formatted entries. Uses colored output and includes helper print_applied_branches to render stack heads with tree-style prefixes.