### PR TITLE
publishing performance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -187,6 +187,7 @@ jobs:
             gir1.2-webkit2-4.1=2.44.0-2;
 
       - uses: actions/download-artifact@v5
+        name: Download SvelteKit build output
         with:
           name: sveltekit-build
           path: ./apps/desktop/build/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -134,6 +134,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.8.1
+        with:
+          shared-key: app-release-build
       - name: Init Node Environment
         uses: ./.github/actions/init-env-node
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,7 @@ rmcp = { version = "0.1.5" }
 serde_json_lenient = "0.2.3"
 
 [profile.release]
-codegen-units = 1 # Compile crates one after another so the compiler can optimize better
-lto = true        # Enables link to optimizations
+lto = "thin"      # Enables link to optimizations, but don't go all out on compile time.
 opt-level = "s"   # Optimize for binary size
 
 [profile.bench]

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -126,10 +126,12 @@ impl Project {
         // nexted insided of another via a gitignored folder.
         // We want to match on the longest project path.
         projects.sort_by(|a, b| {
-            b.path
-                .to_string_lossy()
+            a.path
+                .as_os_str()
                 .len()
-                .cmp(&a.path.to_string_lossy().len())
+                .cmp(&b.path.as_os_str().len())
+                // longest first
+                .reverse()
         });
         let resolved_path = if path.is_relative() {
             path.canonicalize().context("Failed to canonicalize path")?


### PR DESCRIPTION
The potential for savings is huge:

<img width="1045" height="716" alt="Screenshot 2025-10-14 at 05 54 40" src="https://github.com/user-attachments/assets/9012a2c1-031a-4557-a569-5ec50c6e9874" />

And I wouldn't be surprised if the slowest runners finish in 10m or so, with publishes going through in less than 15m.

### Tasks

* [x] add rust caching
* [x] create a release to build the cache
* [x] another release to see how fast it is now
* [x] see the timings with multi-threaded and how different `lto` options affect the publish
    - On CI this doesn't gain much, but locally it's a world of a difference, which I think helps development as the default release build is (relatively) fast now.