### PR TITLE
v3 Unapply: MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ name = "but-testsupport"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-core",
  "but-graph",
  "gix",
  "gix-testtools",

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -38,7 +38,7 @@ impl Context<'_> {
 impl Graph {
     /// Now that the graph is complete, perform additional structural improvements with
     /// the requirement of them to be computationally cheap.
-    #[instrument(skip(self, meta, repo, refs_by_id), err(Debug))]
+    #[instrument(level = tracing::Level::TRACE, skip(self, meta, repo, refs_by_id), err(Debug))]
     pub(super) fn post_processed<T: RefMetadata>(
         mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/init/types.rs
+++ b/crates/but-graph/src/init/types.rs
@@ -168,6 +168,7 @@ impl Queue {
 }
 
 /// A queue to keep track of tips, which additionally counts how much was queued over time.
+#[derive(Debug)]
 pub struct Queue {
     pub inner: VecDeque<QueueItem>,
     /// The current number of queued items.

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -404,7 +404,7 @@ impl Graph {
     /// The [`extra_target`](crate::init::Options::extra_target) options extends the workspace to include that target as base.
     /// This affects what we consider to be the part of the workspace.
     /// Typically, that's a previous location of the target segment.
-    #[instrument(skip(self), err(Debug))]
+    #[instrument(level = tracing::Level::TRACE, skip(self), err(Debug))]
     pub fn to_workspace(&self) -> anyhow::Result<Workspace<'_>> {
         self.to_workspace_inner(workspace::Downgrade::Allow)
     }

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1163,5 +1163,14 @@ EOF
 
     create_workspace_commit_once A B
   )
+
+  git init main-with-remote-and-workspace-ref
+  (cd main-with-remote-and-workspace-ref
+    commit M1
+    commit on-remote-only
+    setup_target_to_match_main
+    git reset --hard @~1
+    git branch gitbutler/workspace
+  )
 )
 

--- a/crates/but-testsupport/Cargo.toml
+++ b/crates/but-testsupport/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 termtree = "0.5.1"
 gix-testtools.workspace = true
 but-graph.workspace = true
+but-core.workspace = true
 regex = "1.11.3"
 
 [dev-dependencies]

--- a/crates/but-testsupport/src/in_memory_meta.rs
+++ b/crates/but-testsupport/src/in_memory_meta.rs
@@ -1,0 +1,153 @@
+use but_core::ref_metadata;
+use but_core::ref_metadata::{Branch, Workspace};
+use gix::refs::FullName;
+use std::any::Any;
+use std::ops::{Deref, DerefMut};
+
+/// A trivial in-memory implementation of the ref-metadata trait, and one that ideally works correctly.
+pub struct InMemoryRefMetadata {
+    /// All the workspaces that should be available. Manipulate directly.
+    pub workspaces: Vec<(gix::refs::FullName, ref_metadata::Workspace)>,
+    /// All the branches that should be available. Manipulate directly.
+    pub branches: Vec<(gix::refs::FullName, ref_metadata::Branch)>,
+}
+
+/// The handle used in the [InMemoryRefMetadata] implementation.
+pub struct InMemoryRefMetadataHandle<T> {
+    is_default: bool,
+    ref_name: gix::refs::FullName,
+    value: T,
+}
+
+impl<T> AsRef<gix::refs::FullNameRef> for InMemoryRefMetadataHandle<T> {
+    fn as_ref(&self) -> &gix::refs::FullNameRef {
+        self.ref_name.as_ref()
+    }
+}
+
+impl<T> ref_metadata::ValueInfo for InMemoryRefMetadataHandle<T> {
+    fn is_default(&self) -> bool {
+        self.is_default
+    }
+}
+
+impl<T> Deref for InMemoryRefMetadataHandle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for InMemoryRefMetadataHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl but_core::RefMetadata for InMemoryRefMetadata {
+    type Handle<T> = InMemoryRefMetadataHandle<T>;
+
+    fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn Any>)>> + '_ {
+        self.workspaces
+            .iter()
+            .cloned()
+            .map(|(name, v)| Ok((name, Box::new(v) as Box<dyn Any>)))
+            .chain(
+                self.branches
+                    .iter()
+                    .cloned()
+                    .map(|(name, v)| Ok((name, Box::new(v) as Box<dyn Any>))),
+            )
+    }
+
+    fn workspace(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<Self::Handle<Workspace>> {
+        Ok(self
+            .workspaces
+            .iter()
+            .find_map(|(rn, v)| {
+                (rn.as_ref() == ref_name).then(|| InMemoryRefMetadataHandle {
+                    is_default: false,
+                    ref_name: ref_name.to_owned(),
+                    value: v.clone(),
+                })
+            })
+            .unwrap_or_else(|| InMemoryRefMetadataHandle {
+                is_default: true,
+                ref_name: ref_name.to_owned(),
+                value: Workspace::default(),
+            }))
+    }
+
+    fn branch(&self, ref_name: &gix::refs::FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+        Ok(self
+            .branches
+            .iter()
+            .find_map(|(rn, v)| {
+                (rn.as_ref() == ref_name).then(|| InMemoryRefMetadataHandle {
+                    is_default: false,
+                    ref_name: ref_name.to_owned(),
+                    value: v.clone(),
+                })
+            })
+            .unwrap_or_else(|| InMemoryRefMetadataHandle {
+                is_default: true,
+                ref_name: ref_name.to_owned(),
+                value: Branch::default(),
+            }))
+    }
+
+    fn set_workspace(&mut self, value: &Self::Handle<Workspace>) -> anyhow::Result<()> {
+        let ref_name = &value.ref_name;
+        match self.workspaces.iter_mut().find(|w| w.0 == *ref_name) {
+            None => {
+                self.workspaces
+                    .push((ref_name.clone(), value.value.clone()));
+            }
+            Some(existing) => existing.1 = value.value.clone(),
+        };
+        Ok(())
+    }
+
+    fn set_branch(&mut self, value: &Self::Handle<Branch>) -> anyhow::Result<()> {
+        let ref_name = &value.ref_name;
+        match self.branches.iter_mut().find(|w| w.0 == *ref_name) {
+            None => {
+                self.branches.push((ref_name.clone(), value.value.clone()));
+            }
+            Some(existing) => existing.1 = value.value.clone(),
+        };
+        Ok(())
+    }
+
+    fn remove(&mut self, ref_name: &gix::refs::FullNameRef) -> anyhow::Result<bool> {
+        let branch_pos = self
+            .branches
+            .iter()
+            .position(|(rn, _v)| rn.as_ref() == ref_name);
+        let ws_pos = self
+            .workspaces
+            .iter()
+            .position(|(rn, _v)| rn.as_ref() == ref_name);
+        let res = match (branch_pos, ws_pos) {
+            (Some(b), Some(w)) => {
+                self.branches.remove(b);
+                self.workspaces.remove(w);
+                true
+            }
+            (None, Some(w)) => {
+                self.workspaces.remove(w);
+                true
+            }
+            (Some(b), None) => {
+                self.branches.remove(b);
+                true
+            }
+            (None, None) => false,
+        };
+        Ok(res)
+    }
+}

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 mod in_memory_meta;
-pub use in_memory_meta::{InMemoryRefMetadata, InMemoryRefMetadataHandle};
+pub use in_memory_meta::{InMemoryRefMetadata, InMemoryRefMetadataHandle, StackState};
 
 /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
 /// i.e. `hunk_header("-1,10", "+1,10")`.

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -8,6 +8,9 @@ pub use gix_testtools;
 use std::collections::HashMap;
 use std::path::Path;
 
+mod in_memory_meta;
+pub use in_memory_meta::{InMemoryRefMetadata, InMemoryRefMetadataHandle};
+
 /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
 /// i.e. `hunk_header("-1,10", "+1,10")`.
 /// Returns `( (old_start, old_lines), (new_start, new_lines) )`.

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -95,7 +95,7 @@ pub mod merge {
         /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
         /// One could be better and only repeat what didn't change, to avoid repeating unnecessarily.
         /// But that shouldn't usually matter unless in the biggest repositories with tree-merge times past a 500ms or so.
-        #[instrument(level = tracing::Level::DEBUG, skip(stacks, graph, repo), err(Debug))]
+        #[instrument(name = "re-merge workspace commit", level = tracing::Level::DEBUG, skip(stacks, graph, repo), err(Debug))]
         pub fn from_new_merge_with_metadata<'a>(
             stacks: impl IntoIterator<Item = &'a but_core::ref_metadata::WorkspaceStack>,
             graph: &but_graph::Graph,
@@ -297,7 +297,7 @@ pub mod merge {
 
                 if stacks.is_empty() {
                     bail!(
-                        "BUG: Cannot merge nothing, don't call me like that, we assume this is empty: {conflicting_stacks:#?}"
+                        "BUG: Cannot merge nothing, no tips ended up in the graph: `missing_stacks` = {missing_stacks:?}, `conflicting_stacks` = {conflicting_stacks:?}, `tips` = : {tips:?}"
                     )
                 }
 

--- a/crates/but-workspace/tests/fixtures/scenario/main-with-advanced-remote.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/main-with-advanced-remote.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+echo "A main branch with a remote that is advanced by one" >.git/description
+
+commit M1
+commit only-on-remote
+setup_target_to_match_main
+git reset --hard @~1


### PR DESCRIPTION
Get a minimal viable version of `unapply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10606.

### Fixes

* [x] remote tracking branches are transformed to local tracking branches
* [ ] local tracking branches are created on demand and are wired correctly
* [ ] ⚠️ tips could be conflicted, deal with it when merging

### Tasks
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace.

### Next PR?

* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [x] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [x] don't apply the target branch!
- [x] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.


### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



