### PR TITLE
move-branch-pr-tracking

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -71,6 +71,7 @@
 		trackingBranch?: string;
 		isNewBranch?: boolean;
 		prNumber?: number;
+		allOtherPrNumbersInStack: number[];
 		reviewId?: string;
 		pushStatus: PushStatus;
 		lastUpdatedAt?: number;
@@ -213,7 +214,9 @@
 									branchName,
 									args.isConflicted,
 									args.numberOfBranchesInStack,
-									args.numberOfCommits
+									args.numberOfCommits,
+									args.prNumber,
+									args.allOtherPrNumbersInStack
 								)
 							: undefined
 				}}

--- a/apps/desktop/src/components/MultiStackOfflaneDropzone.svelte
+++ b/apps/desktop/src/components/MultiStackOfflaneDropzone.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import Dropzone from '$components/Dropzone.svelte';
 	import MultiStackCreateNew from '$components/MultiStackCreateNew.svelte';
+	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
+	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { OutsideLaneDzHandler } from '$lib/stacks/dropHandler';
@@ -26,8 +28,21 @@
 	const uiState = inject(UI_STATE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const diffService = inject(DIFF_SERVICE);
+	const forge = inject(DEFAULT_FORGE_FACTORY);
+	const prService = $derived(forge.current.prService);
+	const baseBranchService = inject(BASE_BRANCH_SERVICE);
+	const baseBranchNameResponse = $derived(baseBranchService.baseBranchShortName(projectId));
+	const baseBranchName = $derived(baseBranchNameResponse.response);
 	const dzHandler = $derived(
-		new OutsideLaneDzHandler(stackService, projectId, uiState, uncommittedService, diffService)
+		new OutsideLaneDzHandler(
+			stackService,
+			prService,
+			projectId,
+			uiState,
+			uncommittedService,
+			diffService,
+			baseBranchName
+		)
 	);
 </script>
 

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -42,6 +42,23 @@ export default class BaseBranchService {
 		);
 	}
 
+	baseBranchShortName(projectId: string) {
+		return this.api.endpoints.baseBranch.useQuery(
+			{
+				projectId
+			},
+			{
+				transform: (data) =>
+					mapBaseBranch(data, (baseBranch) => {
+						if (baseBranch.branchName.startsWith(baseBranch.remoteName + '/')) {
+							return baseBranch.branchName.substring(baseBranch.remoteName.length + 1);
+						}
+						return baseBranch.branchName;
+					})
+			}
+		);
+	}
+
 	repo(projectId: string) {
 		return this.api.endpoints.baseBranch.useQuery(
 			{

--- a/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
@@ -228,7 +228,7 @@ function injectEndpoints(api: GitHubApi) {
 						action: 'update',
 						parameters: {
 							pull_number: number,
-							target_base: update.targetBase,
+							base: update.targetBase,
 							body: update.description,
 							state: update.state
 						},

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import type { ForgePrService } from '$lib/forge/interface/forgePrService';
+import type { BranchDetails } from '$lib/stacks/stack';
 
 export const STACKING_FOOTER_BOUNDARY_TOP = '<!-- GitButler Footer Boundary Top -->';
 export const STACKING_FOOTER_BOUNDARY_BOTTOM = '<!-- GitButler Footer Boundary Bottom -->';
@@ -30,6 +31,77 @@ export async function updatePrDescriptionTables(prService: ForgePrService, prNum
 	}
 }
 
+type PrUpdate = {
+	prNumber: number;
+	targetBase: string;
+	description: string;
+};
+
+export async function updateStackPrs(
+	prService: ForgePrService,
+	branchDetails: BranchDetails[],
+	baseBranchName: string
+) {
+	if (branchDetails.length <= 1) return;
+	const allPrNumbers = branchDetails.map((b) => b.prNumber).filter(isDefined);
+	const updates: PrUpdate[] = [];
+	let prevBranch: string | undefined = undefined;
+
+	for (let i = branchDetails.length - 1; i >= 0; i--) {
+		const details = branchDetails[i];
+		if (!details) continue;
+		const prNumber = details.prNumber;
+		if (!isDefined(prNumber)) {
+			prevBranch = details.name;
+			continue;
+		}
+		const pr = await prService.fetch(prNumber);
+
+		if (!isDefined(pr)) {
+			prevBranch = details.name;
+			continue;
+		}
+
+		updates.push({
+			prNumber,
+			description: updateBody(pr.body, pr.number, allPrNumbers, prService.unit.symbol),
+			targetBase: prevBranch ?? baseBranchName
+		});
+		prevBranch = details.name;
+	}
+
+	if (updates.length > 0) {
+		await Promise.all(
+			updates.map(async ({ prNumber, targetBase, description }) => {
+				await prService.update(prNumber, { description, targetBase });
+			})
+		);
+	}
+}
+
+/**
+ * Remove the PR description footer fromt the given PR numbers.
+ */
+export async function unstackPRs(
+	prService: ForgePrService,
+	prNumbers: number[],
+	baseBranchName: string
+) {
+	if (prService && prNumbers.length > 0) {
+		const prs = await Promise.all(prNumbers.map(async (id) => await prService.fetch(id)));
+		const updates = prs.filter(isDefined).map((pr) => ({
+			prNumber: pr.number,
+			description: clearFooter(pr.body)
+		}));
+
+		await Promise.all(
+			updates.map(async ({ prNumber, description }) => {
+				await prService.update(prNumber, { description, targetBase: baseBranchName });
+			})
+		);
+	}
+}
+
 /**
  * Replaces or inserts a new footer into an existing body of text.
  */
@@ -43,6 +115,20 @@ function updateBody(
 	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || '').trim();
 	const footer = generateFooter(prNumber, allPrNumbers, symbol);
 	const description = head + '\n\n' + footer + '\n\n' + tail;
+	return description;
+}
+
+/**
+ * Remove the footer from an existing body of text.
+ */
+function clearFooter(body: string | undefined) {
+	if (!body) return body;
+	if (!body.includes(STACKING_FOOTER_BOUNDARY_TOP)) return body;
+	if (!body.includes(STACKING_FOOTER_BOUNDARY_BOTTOM)) return body;
+
+	const head = (body?.split(STACKING_FOOTER_BOUNDARY_TOP).at(0) || '').trim();
+	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || '').trim();
+	const description = head + '\n\n' + tail;
 	return description;
 }
 


### PR DESCRIPTION
- Keep track of the PR number when moving a branch
- Add functions to handle moving stacked PRs
- Update PR descriptions and base branches correctly when moving branches
- Fix GitHub API payload for updating PR base
- Implement base branch service to get short branch names