### PR TITLE
fix(ui): overflow-hidden and truncate to prevent overflow in chat and codegen badges

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
+++ b/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
@@ -36,7 +36,7 @@
 
 <div class="chat" use:focusable={{ vertical: true }}>
 	<div class="chat-header" use:focusable>
-		<div class="flex gap-10 justify-between">
+		<div class="flex gap-10 justify-between overflow-hidden">
 			{@render branchIcon()}
 
 			<div class="chat-header__title">
@@ -48,7 +48,7 @@
 			</div>
 		</div>
 
-		<div class="flex gap-8">
+		<div class="flex gap-8 overflow-hidden">
 			{@render contextActions()}
 		</div>
 	</div>

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -557,12 +557,14 @@
 								{/snippet}
 							</Button>
 
-							<div class="flex gap-4">
+							<div class="flex gap-4 overflow-hidden">
 								<div
 									class="text-11 context-utilization-badge"
 									style="--context-utilization: {stats.contextUtilization}"
 								>
-									{(stats.contextUtilization * 100).toFixed(0)}% context used
+									<span class="truncate">
+										{(stats.contextUtilization * 100).toFixed(0)}% context used
+									</span>
 								</div>
 
 								<div class="flex">


### PR DESCRIPTION
fixed: 

<img width="535" height="143" alt="image" src="https://github.com/user-attachments/assets/680a8b6f-0cae-4255-8e85-546a63f60d41" />
