### PR TITLE
GitHub Rust pt. I: Initial migration to the Rust end & Multiple GitHub users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
- "parking_lot",
+ "parking_lot 0.12.4",
  "percent-encoding",
  "windows-sys 0.59.0",
  "wl-clipboard-rs",
@@ -1090,6 +1090,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-settings",
+ "gitbutler-secret",
+ "octorust",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -1738,7 +1740,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2129,7 +2131,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2380,7 +2382,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3524,7 +3526,7 @@ dependencies = [
  "gitbutler-notify-debouncer",
  "mock_instant",
  "notify",
- "parking_lot",
+ "parking_lot 0.12.4",
  "pretty_assertions",
  "rstest",
  "serde",
@@ -3608,7 +3610,7 @@ dependencies = [
  "gitbutler-storage",
  "gitbutler-testsupport",
  "gix",
- "parking_lot",
+ "parking_lot 0.12.4",
  "resolve-path",
  "serde",
  "serde_json",
@@ -3815,7 +3817,7 @@ dependencies = [
  "gix",
  "log",
  "open",
- "parking_lot",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "tauri",
@@ -3866,7 +3868,7 @@ dependencies = [
  "gix-testtools",
  "keyring",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "serde_json",
  "tempfile",
  "termtree",
@@ -4315,7 +4317,7 @@ dependencies = [
  "libc",
  "libz-rs-sys",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "prodash 30.0.1",
  "thiserror 2.0.17",
  "walkdir",
@@ -4424,7 +4426,7 @@ checksum = "b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904"
 dependencies = [
  "gix-hash 0.18.0",
  "hashbrown 0.14.5",
- "parking_lot",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -4434,7 +4436,7 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fcb4448382e6e
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.16.0",
- "parking_lot",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -4648,7 +4650,7 @@ dependencies = [
  "gix-pack",
  "gix-path 0.10.20",
  "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "parking_lot",
+ "parking_lot 0.12.4",
  "serde",
  "tempfile",
  "thiserror 2.0.17",
@@ -4668,7 +4670,7 @@ dependencies = [
  "gix-path 0.10.20",
  "gix-tempfile 18.0.0",
  "memmap2",
- "parking_lot",
+ "parking_lot 0.12.4",
  "serde",
  "smallvec",
  "thiserror 2.0.17",
@@ -4745,7 +4747,7 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fcb4448382e6e
 dependencies = [
  "gix-command",
  "gix-config-value",
- "parking_lot",
+ "parking_lot 0.12.4",
  "rustix 1.1.2",
  "thiserror 2.0.17",
 ]
@@ -4980,7 +4982,7 @@ dependencies = [
  "gix-fs 0.15.0",
  "libc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "signal-hook",
  "signal-hook-registry",
  "tempfile",
@@ -4995,7 +4997,7 @@ dependencies = [
  "gix-fs 0.16.1",
  "libc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "tempfile",
 ]
 
@@ -5017,7 +5019,7 @@ dependencies = [
  "io-close",
  "is_ci",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "tar",
  "tempfile",
  "winnow 0.7.12",
@@ -5943,6 +5945,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6163,6 +6168,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6309,7 +6329,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -6408,6 +6428,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
+ "serde",
  "value-bag",
 ]
 
@@ -7255,6 +7276,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "octorust"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c488b641cf652f023d371f6d472191bf3b3fd8075a11f274e95d4fe6e5e3878"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "http 1.3.1",
+ "jsonwebtoken",
+ "log",
+ "mime",
+ "parse_link_header",
+ "pem",
+ "percent-encoding",
+ "reqwest 0.12.23",
+ "reqwest-conditional-middleware",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "reqwest-tracing",
+ "ring",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7410,12 +7464,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -7426,9 +7505,20 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse_link_header"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3687fe9debbbf2a019f381a8bc6b42049b22647449b39af54b3013985c0cf6de"
+dependencies = [
+ "http 0.2.12",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -7451,6 +7541,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -7876,7 +7976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -7885,7 +7985,7 @@ version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -8168,6 +8268,15 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
@@ -8354,6 +8463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-conditional-middleware"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad7fdf5c0a015763fcd164bee294b13fb7b6f89f1b55961d40f00c3e32d6b"
+dependencies = [
+ "async-trait",
+ "http 1.3.1",
+ "reqwest 0.12.23",
+ "reqwest-middleware",
+]
+
+[[package]]
 name = "reqwest-eventsource"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8370,12 +8491,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest 0.12.23",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.23",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "matchit 0.8.4",
+ "reqwest 0.12.23",
+ "reqwest-middleware",
+ "tracing",
+]
+
+[[package]]
 name = "resolve-path"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321e5e41b3b192dab6f1e75b9deacb6688b4b8c5e68906a78e8f43e7c2887bb5"
 dependencies = [
  "dirs 4.0.0",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -8566,7 +8749,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -8692,6 +8875,8 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "bytes",
+ "chrono",
  "dyn-clone",
  "indexmap 1.9.3",
  "schemars_derive 0.8.22",
@@ -9063,7 +9248,7 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "scc",
  "serial_test_derive",
 ]
@@ -9232,6 +9417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9297,7 +9494,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.59.0",
@@ -9347,7 +9544,7 @@ dependencies = [
  "fragile",
  "js-sys",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "thiserror 2.0.17",
  "tokio",
  "wasm-array-cp",
@@ -9375,7 +9572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.4",
  "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
@@ -9592,7 +9789,7 @@ dependencies = [
  "objc2-app-kit 0.3.1",
  "objc2-foundation 0.3.1",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "raw-window-handle",
  "scopeguard",
  "tao-macros",
@@ -10132,7 +10329,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -10282,7 +10479,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -11084,6 +11281,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11308,7 +11520,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -1,6 +1,7 @@
 import { getBaseBranchData, getRemoteBranches } from './mock/baseBranch';
 import { MOCK_BRANCH_LISTINGS } from './mock/branches';
 import { MOCK_TREE_CHANGES, MOCK_UNIFIED_DIFF } from './mock/changes';
+import { MOCK_AUTH_USER } from './mock/github';
 import { MOCK_OPEN_WORKSPACE_MODE } from './mock/mode';
 import { getProject, isGetProjectArgs, listProjects } from './mock/projects';
 import { getSecret, isGetSecretArgs } from './mock/secrets';
@@ -164,6 +165,8 @@ Cypress.on('window:before:load', (win) => {
 				return await Promise.resolve();
 			case 'update_feature_flags':
 				return await Promise.resolve();
+			case 'get_gh_user':
+				return MOCK_AUTH_USER;
 			case 'get_app_settings':
 				return MOCK_APP_SETTINGS;
 			case 'plugin:event|unlisten':

--- a/apps/desktop/cypress/e2e/support/mock/github.ts
+++ b/apps/desktop/cypress/e2e/support/mock/github.ts
@@ -1,0 +1,8 @@
+import type { AuthenticatedUser } from '$lib/forge/github/githubUserService.svelte';
+export const MOCK_AUTH_USER: AuthenticatedUser = {
+	accessToken: 'mock-access-token',
+	login: 'mockuser',
+	name: 'Mock User',
+	email: 'bla@user.com',
+	avatarUrl: 'https://avatars.githubusercontent.com/u/35891811?v=4'
+};

--- a/apps/desktop/cypress/e2e/support/mock/projects.ts
+++ b/apps/desktop/cypress/e2e/support/mock/projects.ts
@@ -15,7 +15,8 @@ export const MOCK_PROJECT_A: Project = {
 	use_diff_context: true,
 	snapshot_lines_threshold: 5,
 	is_open: false,
-	forge_override: undefined
+	forge_override: undefined,
+	preferred_forge_user: null
 };
 
 export function createMockProject(id: string, title: string, path: string): Project {

--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -36,5 +36,10 @@ export const MOCK_APP_SETTINGS: AppSettings = {
 	},
 	ui: {
 		useNativeTitleBar: false
+	},
+	forgeIntegrations: {
+		github: {
+			knownUsernames: []
+		}
 	}
 };

--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -39,7 +39,7 @@ export const MOCK_APP_SETTINGS: AppSettings = {
 	},
 	forgeIntegrations: {
 		github: {
-			knownUsernames: []
+			knownUsernames: ['but']
 		}
 	}
 };

--- a/apps/desktop/cypress/e2e/support/mock/user.ts
+++ b/apps/desktop/cypress/e2e/support/mock/user.ts
@@ -11,7 +11,5 @@ export const MOCK_USER: User = {
 	access_token: 'mock-access-token',
 	role: 'user',
 	supporter: true,
-	github_access_token: 'mock-github-token',
-	github_username: 'testuser',
 	login: 'testuser'
 };

--- a/apps/desktop/src/components/GithubIntegration.svelte
+++ b/apps/desktop/src/components/GithubIntegration.svelte
@@ -80,12 +80,8 @@
 		}
 	}
 
-	function forgetGitHub(): void {
-		if ($user) {
-			$user.github_access_token = '';
-			$user.github_username = '';
-			userService.setUser($user);
-		}
+	async function forgetGitHub() {
+		await githubUserService.forgetGitHubUsernames($usernames);
 	}
 </script>
 

--- a/apps/desktop/src/components/GithubIntegration.svelte
+++ b/apps/desktop/src/components/GithubIntegration.svelte
@@ -51,7 +51,7 @@
 		loading = true;
 		if (!$user) return;
 		try {
-			const accessToken = await githubUserService.checkAuthStatus({ deviceCode });
+			const { accessToken, login } = await githubUserService.checkAuthStatus({ deviceCode });
 			// We don't want to directly modify $user because who knows what state that puts you in
 			let mutableUser = structuredClone($user);
 			mutableUser.github_access_token = accessToken;
@@ -59,9 +59,7 @@
 
 			// After we call setUser, we want to re-clone the user store, as the userService itself sets the user store
 			mutableUser = structuredClone($user);
-			// TODO: Remove setting of gh username since it isn't used anywhere.
-			const githbLogin = await githubUserService.fetchGitHubLogin();
-			mutableUser.github_username = githbLogin.name || undefined;
+			mutableUser.github_username = login ?? undefined;
 			userService.setUser(mutableUser);
 			toasts.success('GitHub authenticated');
 		} catch (err: any) {

--- a/apps/desktop/src/components/GithubIntegration.svelte
+++ b/apps/desktop/src/components/GithubIntegration.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import GithubUserLoginState from '$components/GithubUserLoginState.svelte';
 	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import githubLogoSvg from '$lib/assets/unsized-logos/github.svg?raw';
 	import { CLIPBOARD_SERVICE } from '$lib/backend/clipboard';
+	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { GITHUB_USER_SERVICE } from '$lib/forge/github/githubUserService.svelte';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { URL_SERVICE } from '$lib/utils/url';
@@ -23,6 +25,8 @@
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 	const posthog = inject(POSTHOG_WRAPPER);
+	const appSettings = inject(SETTINGS_SERVICE);
+	const usernames = appSettings.knownGitHubUsernames;
 
 	// step flags
 	let codeCopied = $state(false);
@@ -92,7 +96,7 @@
 		<SectionCard orientation="row">
 			{#snippet iconSide()}
 				<div class="icon-wrapper">
-					{#if $user?.github_access_token}
+					{#if $usernames.length > 0}
 						<div class="icon-wrapper__tick">
 							<Icon name="success" color="success" size={18} />
 						</div>
@@ -102,18 +106,26 @@
 					</div>
 				</div>
 			{/snippet}
+
 			{#snippet title()}
 				GitHub
 			{/snippet}
+
 			{#snippet caption()}
 				Allows you to view and create Pull Requests.
 			{/snippet}
-			{#if $user?.github_access_token}
-				<Button kind="outline" {disabled} icon="bin-small" onclick={forgetGitHub}>Forget</Button>
-			{:else}
+
+			{#if $usernames.length > 1}
+				<Button kind="outline" {disabled} icon="bin-small" onclick={forgetGitHub} style="error"
+					>Forget all</Button
+				>
+			{:else if $usernames.length === 0}
 				<Button style="pop" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 			{/if}
 		</SectionCard>
+		{#each $usernames as username}
+			<GithubUserLoginState {username} {disabled} />
+		{/each}
 
 		{#if showAuthFlow}
 			<div in:fade={{ duration: 100 }}>

--- a/apps/desktop/src/components/GithubIntegration.svelte
+++ b/apps/desktop/src/components/GithubIntegration.svelte
@@ -127,6 +127,14 @@
 			<GithubUserLoginState {username} {disabled} />
 		{/each}
 
+		{#if $usernames.length > 0}
+			<div class="centered-row">
+				<Button style="pop" disabled={disabled || showAuthFlow} onclick={gitHubStartOauth}
+					>Add another account</Button
+				>
+			</div>
+		{/if}
+
 		{#if showAuthFlow}
 			<div in:fade={{ duration: 100 }}>
 				<SectionCard orientation="row">
@@ -317,5 +325,10 @@
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-1);
 		user-select: text;
+	}
+
+	.centered-row {
+		display: flex;
+		justify-content: center;
 	}
 </style>

--- a/apps/desktop/src/components/GithubUserLoginState.svelte
+++ b/apps/desktop/src/components/GithubUserLoginState.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import githubLogoSvg from '$lib/assets/unsized-logos/github.svg?raw';
+	import { GITHUB_USER_SERVICE } from '$lib/forge/github/githubUserService.svelte';
+	import { inject } from '@gitbutler/core/context';
+	import { Avatar, Button, SectionCard } from '@gitbutler/ui';
+
+	type Props = {
+		username: string;
+		disabled?: boolean;
+	};
+
+	const { username, disabled }: Props = $props();
+
+	const githubUserService = inject(GITHUB_USER_SERVICE);
+
+	const [forget, forgetting] = githubUserService.forgetGitHubUsername;
+	const ghUser = $derived(githubUserService.authenticatedUser(username));
+</script>
+
+<ReduxResult result={ghUser.result}>
+	{#snippet loading()}
+		<SectionCard orientation="row">
+			{#snippet iconSide()}
+				<div class="icon-wrapper__logo">
+					{@html githubLogoSvg}
+				</div>
+			{/snippet}
+			{#snippet title()}
+				<p>{username}</p>
+			{/snippet}
+		</SectionCard>
+	{/snippet}
+
+	{#snippet children(user)}
+		<SectionCard orientation="row">
+			{#snippet iconSide()}
+				{#if user?.avatarUrl}
+					<Avatar size="large" tooltip={username} srcUrl={user?.avatarUrl} />
+				{:else}
+					<div class="icon-wrapper__logo">
+						{@html githubLogoSvg}
+					</div>
+				{/if}
+			{/snippet}
+			{#snippet title()}
+				<p>{username}</p>
+			{/snippet}
+
+			<Button
+				kind="outline"
+				icon="bin-small"
+				disabled={disabled || user === null}
+				onclick={() => forget(username)}
+				loading={forgetting.current.isLoading}>Forget</Button
+			>
+		</SectionCard>
+	{/snippet}
+</ReduxResult>
+
+<style>
+	.icon-wrapper__logo {
+		width: 28px;
+		height: 28px;
+	}
+</style>

--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -1,9 +1,10 @@
 <script lang="ts" module>
 	type A = unknown;
 	type B = string | undefined;
+	type C = string | undefined;
 </script>
 
-<script lang="ts" generics="A, B extends string | undefined">
+<script lang="ts" generics="A, B extends string | undefined, C extends string | undefined">
 	import { isParsedError } from '$lib/error/parser';
 
 	import { Icon, InfoMessage } from '@gitbutler/ui';
@@ -11,31 +12,34 @@
 	import type { Result } from '$lib/state/helpers';
 	import type { Snippet } from 'svelte';
 
-	type Env<B> = {
-		projectId: string;
+	type Env<B, C> = {
+		projectId: C;
 		stackId: B;
 	};
 
-	type Props<A, B extends string | undefined> = {
+	type StackEnv<B> = B extends undefined ? { stackId?: B } : { stackId: B };
+	type ProjectEnv<C> = C extends undefined ? { projectId?: C } : { projectId: C };
+
+	type Props<A, B extends string | undefined, C extends string | undefined> = {
 		result: Result<A> | undefined;
-		projectId: string;
-		children: Snippet<[A, Env<B>]>;
+		children: Snippet<[A, Env<B, C>]>;
 		loading?: Snippet<[A | undefined]>;
 		error?: Snippet<[unknown]>;
 		onerror?: (err: unknown) => void;
-	} & (B extends undefined ? { stackId?: B } : { stackId: B });
+	} & StackEnv<B> &
+		ProjectEnv<C>;
 
-	const props: Props<A, B> = $props();
+	const props: Props<A, B, C> = $props();
 
 	type Display = {
 		result: Result<A> | undefined;
-		env: Env<B>;
+		env: Env<B, C>;
 	};
 
 	let cache: Display | undefined;
 
 	const display = $derived.by<Display>(() => {
-		const env = { projectId: props.projectId, stackId: props.stackId as B };
+		const env = { projectId: props.projectId as C, stackId: props.stackId as B };
 		if (props.result?.error) {
 			return { result: props.result, env };
 		}

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -73,9 +73,7 @@
 					locale: cloudUser.locale || 'en',
 					access_token: cloudUser.access_token || 'impossible-situation',
 					role: cloudUser.role || 'user',
-					supporter: cloudUser.supporter || false,
-					github_access_token: $user?.github_access_token,
-					github_username: $user?.github_username
+					supporter: cloudUser.supporter || false
 				};
 				userPicture = userData.picture;
 				userService.setUser(userData);
@@ -97,7 +95,6 @@
 				name: newName,
 				picture: selectedPictureFile
 			});
-			updatedUser.github_access_token = $user?.github_access_token; // prevent overwriting with null
 			userService.setUser(updatedUser);
 			chipToasts.success('Profile updated');
 			selectedPictureFile = undefined;

--- a/apps/desktop/src/components/profileSettings/IntegrationsSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/IntegrationsSettings.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
-	import AuthorizationBanner from '$components/AuthorizationBanner.svelte';
 	import GithubIntegration from '$components/GithubIntegration.svelte';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
-	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
 	import { SectionCard, Spacer, Toggle } from '@gitbutler/ui';
-
-	const userService = inject(USER_SERVICE);
-	const user = userService.user;
 
 	const settingsService = inject(SETTINGS_SERVICE);
 	const appSettings = settingsService.appSettings;
@@ -19,11 +14,7 @@
 	}
 </script>
 
-{#if !$user}
-	<AuthorizationBanner />
-	<Spacer />
-{/if}
-<GithubIntegration disabled={!$user} />
+<GithubIntegration />
 
 <Spacer />
 

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -142,7 +142,11 @@ export function initDependencies(args: {
 	// ============================================================================
 
 	const clientState = new ClientState(backend, gitHubClient, gitLabClient, ircClient, posthog);
-	const githubUserService = new GitHubUserService(backend, clientState['githubApi']);
+	const githubUserService = new GitHubUserService(
+		backend,
+		clientState.backendApi,
+		clientState['githubApi']
+	);
 
 	const uiState = new UiState(
 		reactive(() => clientState.uiState ?? uiStateSlice.getInitialState()),

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@gitbutler/core/context';
 import { getStorageItem, setStorageItem } from '@gitbutler/shared/persisted';
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import type { IBackend } from '$lib/backend';
 
 export const SETTINGS_SERVICE = new InjectionToken<SettingsService>('SettingsService');
@@ -15,6 +15,14 @@ export class SettingsService {
 		return () => {
 			unsubscribe();
 		};
+	});
+
+	/**
+	 * This are the GitHub usernames that are known to the application.
+	 * They are known but not necessarily active.
+	 */
+	readonly knownGitHubUsernames = derived(this.appSettings, (appSettings) => {
+		return appSettings?.forgeIntegrations.github.knownUsernames ?? [];
 	});
 
 	readonly subscribe = this.appSettings.subscribe;
@@ -160,6 +168,20 @@ export type AppSettings = {
 	reviews: Reviews;
 	/** UI settings */
 	ui: UiSettings;
+	/** Settings related to the forge integrations. */
+	forgeIntegrations: ForgeIntegrations;
+};
+
+export type ForgeIntegrations = {
+	/** Settings related to GitHub integration */
+	github: GitHubSettings;
+};
+
+export type GitHubSettings = {
+	/** The list of known GitHub users. This tracks the users that have authenticated through the application.
+	 * That does not mean that the user is currently "active" in the app, just that they have authenticated at some point.
+	 */
+	knownUsernames: string[];
 };
 
 export type TelemetrySettings = {

--- a/apps/desktop/src/lib/forge/azure/azure.ts
+++ b/apps/desktop/src/lib/forge/azure/azure.ts
@@ -18,6 +18,7 @@ export const AZURE_DOMAIN = 'dev.azure.com';
 export class AzureDevOps implements Forge {
 	readonly name: ForgeName = 'azure';
 	readonly authenticated: boolean;
+	readonly isLoading = false;
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
@@ -16,6 +16,7 @@ export const BITBUCKET_DOMAIN = 'bitbucket.org';
 export class BitBucket implements Forge {
 	readonly name: ForgeName = 'bitbucket';
 	readonly authenticated: boolean;
+	readonly isLoading = false;
 	private baseUrl: string;
 	private baseBranch: string;
 	private forkStr?: string;

--- a/apps/desktop/src/lib/forge/default/default.ts
+++ b/apps/desktop/src/lib/forge/default/default.ts
@@ -13,6 +13,7 @@ import type { TagDescription } from '@reduxjs/toolkit/query';
 export class DefaultForge implements Forge {
 	name: ForgeName;
 	authenticated = false;
+	isLoading = false;
 
 	constructor() {
 		this.name = 'default';

--- a/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
@@ -21,6 +21,7 @@ export type ForgeConfig = {
 	pushRepo?: RepoInfo;
 	baseBranch?: string;
 	githubAuthenticated?: boolean;
+	githubIsLoading?: boolean;
 	gitlabAuthenticated?: boolean;
 	forgeOverride?: ForgeName;
 };
@@ -33,7 +34,9 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 	private _config: any = undefined;
 	private _determinedForgeType = $state<ForgeName>('default');
 	private _canSetupIntegration = $derived.by(() => {
-		return isAvalilableForge(this._determinedForgeType) && !this._forge.authenticated
+		return isAvalilableForge(this._determinedForgeType) &&
+			!this._forge.authenticated &&
+			!this._forge.isLoading
 			? this._determinedForgeType
 			: undefined;
 	});
@@ -66,8 +69,15 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 			return;
 		}
 		this._config = config;
-		const { repo, pushRepo, baseBranch, githubAuthenticated, gitlabAuthenticated, forgeOverride } =
-			config;
+		const {
+			repo,
+			pushRepo,
+			baseBranch,
+			githubAuthenticated,
+			githubIsLoading,
+			gitlabAuthenticated,
+			forgeOverride
+		} = config;
 		if (repo && baseBranch) {
 			this._determinedForgeType = this.determineForgeType(repo);
 			this._forge = this.build({
@@ -75,6 +85,7 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 				pushRepo,
 				baseBranch,
 				githubAuthenticated,
+				githubIsLoading,
 				gitlabAuthenticated,
 				forgeOverride
 			});
@@ -88,6 +99,7 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 		pushRepo,
 		baseBranch,
 		githubAuthenticated,
+		githubIsLoading,
 		gitlabAuthenticated,
 		forgeOverride
 	}: {
@@ -95,6 +107,7 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 		pushRepo?: RepoInfo;
 		baseBranch: string;
 		githubAuthenticated?: boolean;
+		githubIsLoading?: boolean;
 		gitlabAuthenticated?: boolean;
 		forgeOverride: ForgeName | undefined;
 	}): Forge {
@@ -119,7 +132,8 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 				api: gitHubApi,
 				client: gitHubClient,
 				posthog: posthog,
-				authenticated: !!githubAuthenticated
+				authenticated: !!githubAuthenticated,
+				isLoading: githubIsLoading ?? false
 			});
 		}
 		if (forgeType === 'gitlab') {

--- a/apps/desktop/src/lib/forge/github/github.test.ts
+++ b/apps/desktop/src/lib/forge/github/github.test.ts
@@ -18,7 +18,8 @@ describe('GitHub', () => {
 			client: gitHubClient,
 			repo,
 			baseBranch: id,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 		const url = gh.commitUrl(id);
 		expect(url).toMatch(new RegExp(`/${id}$`));
@@ -35,7 +36,8 @@ describe('GitHub', () => {
 			client: gitHubClient,
 			repo: sshRepo,
 			baseBranch: id,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 
 		expect(gh.commitUrl('abc123')).toBe('https://github.com/test-owner/test-repo/commit/abc123');
@@ -52,7 +54,8 @@ describe('GitHub', () => {
 			client: gitHubClient,
 			repo: sshRepo,
 			baseBranch: 'main',
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 
 		const branch = gh.branch('feature-branch');
@@ -72,7 +75,8 @@ describe('GitHub', () => {
 			client: gitHubClient,
 			repo: sshRepo,
 			baseBranch: id,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 
 		expect(gh.commitUrl('abc123')).toBe('https://github.com/test-owner/test-repo/commit/abc123');
@@ -91,7 +95,8 @@ describe('GitHub', () => {
 			client: gitHubClient,
 			repo: enterpriseRepo,
 			baseBranch: id,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 
 		expect(gh.commitUrl('abc123')).toBe(

--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -19,6 +19,7 @@ export const GITHUB_DOMAIN = 'github.com';
 export class GitHub implements Forge {
 	readonly name: ForgeName = 'github';
 	readonly authenticated: boolean;
+	readonly isLoading: boolean;
 	private baseUrl: string;
 
 	private api: ReturnType<typeof injectEndpoints>;
@@ -28,11 +29,13 @@ export class GitHub implements Forge {
 			posthog?: PostHogWrapper;
 			client: GitHubClient;
 			api: GitHubApi;
+			isLoading: boolean;
 		}
 	) {
-		const { client, api, authenticated, repo } = params;
+		const { client, api, authenticated, repo, isLoading } = params;
 		const { owner, name } = repo;
 		this.authenticated = authenticated;
+		this.isLoading = isLoading;
 
 		// Use the protocol from repo if available, otherwise default to https
 		// For SSH remote URLs, always use HTTPS for browser compatibility

--- a/apps/desktop/src/lib/forge/github/githubBranch.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubBranch.test.ts
@@ -20,7 +20,8 @@ describe('GitHubBranch', () => {
 			client: gitHubClient,
 			repo,
 			baseBranch,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 		const branch = gh.branch(name);
 		expect(branch?.url).toMatch(new RegExp(`...${name}$`));
@@ -34,7 +35,8 @@ describe('GitHubBranch', () => {
 			repo,
 			baseBranch,
 			forkStr,
-			authenticated: true
+			authenticated: true,
+			isLoading: false
 		});
 		const branch = gh.branch(name);
 		expect(branch?.url).toMatch(new RegExp(`...${forkStr}:${name}$`));

--- a/apps/desktop/src/lib/forge/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.test.ts
@@ -21,6 +21,7 @@ describe('GitHubPrService', () => {
 			baseBranch: 'main',
 			api: gitHubApi,
 			authenticated: true,
+			isLoading: false,
 			client: gitHubClient
 		});
 		service = gh.prService;

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -21,7 +21,7 @@ type AuthStatusResponse = {
 	email: string | null;
 };
 
-type AuthenticatedUser = {
+export type AuthenticatedUser = {
 	accessToken: string;
 	login: string;
 	name: string | null;

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -54,6 +54,12 @@ export class GitHubUserService {
 		return this.backendApi.endpoints.forgetGitHubUsername.useMutation();
 	}
 
+	async forgetGitHubUsernames(usernames: string[]) {
+		for (const username of usernames) {
+			await this.backendApi.endpoints.forgetGitHubUsername.mutate(username);
+		}
+	}
+
 	authenticatedUser(username: string) {
 		return this.backendApi.endpoints.getAccessToken.useQuery(username);
 	}

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -1,8 +1,8 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
-import { providesList, ReduxTag } from '$lib/state/tags';
+import { providesItem, providesList, ReduxTag } from '$lib/state/tags';
 import { InjectionToken } from '@gitbutler/core/context';
 import type { IBackend } from '$lib/backend';
-import type { GitHubApi } from '$lib/state/clientState.svelte';
+import type { BackendApi, GitHubApi } from '$lib/state/clientState.svelte';
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 
 export const GITHUB_USER_SERVICE = new InjectionToken<GitHubUserService>('GitHubUserService');
@@ -21,18 +21,25 @@ type AuthStatusResponse = {
 	email: string | null;
 };
 
+type AuthenticatedUser = {
+	accessToken: string;
+	login: string;
+	name: string | null;
+	email: string | null;
+	avatarUrl: string | null;
+};
+
 export class GitHubUserService {
 	private api: ReturnType<typeof injectEndpoints>;
+	private backendApi: ReturnType<typeof injectBackendEndpoints>;
 
 	constructor(
 		private backend: IBackend,
+		backendApi: BackendApi,
 		gitHubApi: GitHubApi
 	) {
 		this.api = injectEndpoints(gitHubApi);
-	}
-
-	async fetchGitHubLogin() {
-		return await this.api.endpoints.getAuthenticated.fetch();
+		this.backendApi = injectBackendEndpoints(backendApi);
 	}
 
 	async initDeviceOauth() {
@@ -41,6 +48,14 @@ export class GitHubUserService {
 
 	async checkAuthStatus(params: { deviceCode: string }) {
 		return await this.backend.invoke<AuthStatusResponse>('check_auth_status', params);
+	}
+
+	get forgetGitHubUsername() {
+		return this.backendApi.endpoints.forgetGitHubUsername.useMutation();
+	}
+
+	authenticatedUser(username: string) {
+		return this.backendApi.endpoints.getAccessToken.useQuery(username);
 	}
 }
 
@@ -55,6 +70,33 @@ function injectEndpoints(api: GitHubApi) {
 						extra: api.extra
 					}),
 				providesTags: [providesList(ReduxTag.ForgeUser)]
+			})
+		})
+	});
+}
+
+function injectBackendEndpoints(api: BackendApi) {
+	return api.injectEndpoints({
+		endpoints: (build) => ({
+			forgetGitHubUsername: build.mutation<void, string>({
+				extraOptions: {
+					command: 'forget_github_username',
+					actionName: 'Forget GitHub Username'
+				},
+				query: (username) => ({
+					username
+				})
+			}),
+			getAccessToken: build.query<AuthenticatedUser | null, string>({
+				extraOptions: {
+					command: 'get_gh_user'
+				},
+				query: (username) => ({
+					username
+				}),
+				providesTags: (_result, _error, username) => [
+					...providesItem(ReduxTag.ForgeUser, `github:${username}`)
+				]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -14,6 +14,13 @@ type Verification = {
 	device_code: string;
 };
 
+type AuthStatusResponse = {
+	accessToken: string;
+	login: string;
+	name: string | null;
+	email: string | null;
+};
+
 export class GitHubUserService {
 	private api: ReturnType<typeof injectEndpoints>;
 
@@ -33,7 +40,7 @@ export class GitHubUserService {
 	}
 
 	async checkAuthStatus(params: { deviceCode: string }) {
-		return await this.backend.invoke<string>('check_auth_status', params);
+		return await this.backend.invoke<AuthStatusResponse>('check_auth_status', params);
 	}
 }
 

--- a/apps/desktop/src/lib/forge/github/hooks.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/hooks.svelte.ts
@@ -1,0 +1,55 @@
+import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
+import { GITHUB_USER_SERVICE } from '$lib/forge/github/githubUserService.svelte';
+import { PROJECTS_SERVICE } from '$lib/project/projectsService';
+import { inject } from '@gitbutler/core/context';
+import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
+import type { Reactive } from '@gitbutler/shared/storeUtils';
+
+type GitHubPreferences = {
+	preferredGitHubUsername: Reactive<string | undefined>;
+	githubUsernames: Reactive<string[]>;
+};
+
+/**
+ * Return the preferred GitHub username for the given project ID, based on the known
+ * GitHub usernames in the application settings and the project's preferred forge user.
+ */
+export function usePreferredGitHubUsername(projectId: Reactive<string>): GitHubPreferences {
+	let githubUsernames = $state<string[]>([]);
+	const appSettings = inject(SETTINGS_SERVICE);
+	const projectsService = inject(PROJECTS_SERVICE);
+	const knownGitHubUsernames = $derived(appSettings.knownGitHubUsernames);
+	knownGitHubUsernames.subscribe((value) => {
+		githubUsernames = value;
+	});
+
+	const projectQuery = $derived(projectsService.getProject(projectId.current));
+	const project = $derived(projectQuery.response);
+	const preferredUser = $derived.by(() => {
+		if (githubUsernames.length === 0) {
+			return undefined;
+		}
+		return (
+			githubUsernames.find((u) => u === project?.preferred_forge_user) ?? githubUsernames.at(0)
+		);
+	});
+
+	return {
+		preferredGitHubUsername: reactive(() => preferredUser),
+		githubUsernames: reactive(() => githubUsernames)
+	};
+}
+
+/**
+ * Return the GitHub access token for the given project ID, based on the preferred GitHub username.
+ */
+export function useGitHubAccessToken(projectId: Reactive<string>): Reactive<string | undefined> {
+	const githubUserService = inject(GITHUB_USER_SERVICE);
+	const { preferredGitHubUsername } = usePreferredGitHubUsername(projectId);
+	const ghUserResponse = $derived.by(() => {
+		if (preferredGitHubUsername.current === undefined) return undefined;
+		return githubUserService.authenticatedUser(preferredGitHubUsername.current);
+	});
+	const aceessToken = $derived(ghUserResponse?.response?.accessToken);
+	return reactive(() => aceessToken);
+}

--- a/apps/desktop/src/lib/forge/github/hooks.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/hooks.svelte.ts
@@ -40,10 +40,15 @@ export function usePreferredGitHubUsername(projectId: Reactive<string>): GitHubP
 	};
 }
 
+type GitHubAccess = {
+	accessToken: Reactive<string | undefined>;
+	isLoading: Reactive<boolean>;
+};
+
 /**
  * Return the GitHub access token for the given project ID, based on the preferred GitHub username.
  */
-export function useGitHubAccessToken(projectId: Reactive<string>): Reactive<string | undefined> {
+export function useGitHubAccessToken(projectId: Reactive<string>): GitHubAccess {
 	const githubUserService = inject(GITHUB_USER_SERVICE);
 	const { preferredGitHubUsername } = usePreferredGitHubUsername(projectId);
 	const ghUserResponse = $derived.by(() => {
@@ -51,5 +56,8 @@ export function useGitHubAccessToken(projectId: Reactive<string>): Reactive<stri
 		return githubUserService.authenticatedUser(preferredGitHubUsername.current);
 	});
 	const aceessToken = $derived(ghUserResponse?.response?.accessToken);
-	return reactive(() => aceessToken);
+	return {
+		accessToken: reactive(() => aceessToken),
+		isLoading: reactive(() => ghUserResponse?.result.isLoading ?? false)
+	};
 }

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.ts
@@ -22,6 +22,7 @@ export const GITLAB_SUB_DOMAIN = 'gitlab'; // For self hosted instance of Gitlab
 export class GitLab implements Forge {
 	readonly name: ForgeName = 'gitlab';
 	readonly authenticated: boolean;
+	readonly isLoading: boolean;
 	private baseUrl: string;
 	private baseBranch: string;
 	private forkStr?: string;
@@ -50,6 +51,8 @@ export class GitLab implements Forge {
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;
 		this.authenticated = authenticated;
+		// TODO: Set this correctly based on whether we're waiting for the credentials to be loaded or not.
+		this.isLoading = false;
 
 		this.api = injectEndpoints(api);
 

--- a/apps/desktop/src/lib/forge/interface/forge.ts
+++ b/apps/desktop/src/lib/forge/interface/forge.ts
@@ -14,6 +14,7 @@ export type ForgeName = 'github' | 'gitlab' | 'bitbucket' | 'azure' | 'default';
 
 export interface Forge {
 	readonly name: ForgeName;
+	readonly isLoading: boolean;
 	readonly authenticated: boolean;
 	// Lists PRs for the repo.
 	get listService(): ForgeListingService | undefined;

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -30,6 +30,7 @@ export type Project = {
 	// Produced just for the frontend to determine if the project is open in any window.
 	is_open: boolean;
 	forge_override: ForgeName | undefined;
+	preferred_forge_user: string | null;
 };
 
 export function vscodePath(path: string) {

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -49,6 +49,11 @@ export class ProjectsService {
 		await this.api.endpoints.updateProject.mutate({ project });
 	}
 
+	async updatePreferredForgeUser(projectId: string, preferred_forge_user: string | null) {
+		const project = await this.fetchProject(projectId, true);
+		await this.updateProject({ ...project, preferred_forge_user });
+	}
+
 	async deleteProject(projectId: string) {
 		return await this.api.endpoints.deleteProject.mutate({ projectId });
 	}

--- a/apps/desktop/src/lib/user/user.ts
+++ b/apps/desktop/src/lib/user/user.ts
@@ -14,7 +14,5 @@ export type User = {
 	access_token: string;
 	role: string | undefined;
 	supporter: boolean;
-	github_access_token: string | undefined;
-	github_username: string | undefined;
 	login?: string;
 };

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -51,12 +51,6 @@ export class UserService {
 		this.posthog.setAnonymousPostHogUser();
 		this.user.set(undefined);
 	}
-	readonly accessToken$ = derived(this.user, (user) => {
-		if (user?.github_access_token) {
-			return user.github_access_token;
-		}
-		return undefined;
-	});
 
 	constructor(
 		private backend: IBackend,

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -22,7 +22,6 @@
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
 	import { ircEnabled, ircServer, codegenEnabled, fModeEnabled } from '$lib/config/uiFeatureFlags';
-	import { GITHUB_CLIENT } from '$lib/forge/github/githubClient';
 	import { IRC_CLIENT } from '$lib/irc/ircClient.svelte';
 	import { IRC_SERVICE } from '$lib/irc/ircService.svelte';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
@@ -61,11 +60,6 @@
 
 	const userService = inject(USER_SERVICE);
 	const user = $derived(userService.user);
-
-	// GitHub token management
-	const gitHubClient = inject(GITHUB_CLIENT);
-	const accessToken = $derived($user?.github_access_token);
-	$effect(() => gitHubClient.setToken(accessToken));
 
 	// Project tracking
 	const projectsService = inject(PROJECTS_SERVICE);

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -105,7 +105,7 @@
 	const githubAccessToken = useGitHubAccessToken(reactive(() => projectId));
 
 	// GitHub setup
-	$effect.pre(() => gitHubClient.setToken(githubAccessToken.current));
+	$effect.pre(() => gitHubClient.setToken(githubAccessToken.accessToken.current));
 	$effect.pre(() => gitHubClient.setRepo({ owner: repoInfo?.owner, repo: repoInfo?.name }));
 
 	// GitLab setup
@@ -121,7 +121,8 @@
 			repo: repoInfo,
 			pushRepo: forkInfo,
 			baseBranch: baseBranchName,
-			githubAuthenticated: !!githubAccessToken.current,
+			githubAuthenticated: !!githubAccessToken.accessToken.current,
+			githubIsLoading: githubAccessToken.isLoading.current,
 			gitlabAuthenticated: !!$gitlabConfigured,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override
 		});

--- a/crates/but-api/src/commands/github.rs
+++ b/crates/but-api/src/commands/github.rs
@@ -1,6 +1,6 @@
 //! In place of commands.rs
 use anyhow::Result;
-use but_github::{AuthStatusResponse, CheckAuthStatusParams, Verification};
+use but_github::{AuthStatusResponse, AuthenticatedUser, CheckAuthStatusParams, Verification};
 use but_settings::AppSettingsWithDiskSync;
 
 use crate::{NoParams, error::Error};
@@ -21,4 +21,21 @@ pub async fn check_auth_status(
         }
         Err(e) => Err(e.into()),
     }
+}
+
+pub fn forget_github_username(
+    app_settings_sync: &AppSettingsWithDiskSync,
+    login: String,
+) -> Result<(), Error> {
+    but_github::forget_gh_access_token(&login)
+        .map_err(Into::into)
+        .and_then(|_| {
+            app_settings_sync
+                .remove_known_github_username(&login)
+                .map_err(Into::into)
+        })
+}
+
+pub async fn get_gh_user(login: String) -> Result<Option<AuthenticatedUser>, Error> {
+    but_github::get_gh_user(&login).await.map_err(Into::into)
 }

--- a/crates/but-api/src/commands/github.rs
+++ b/crates/but-api/src/commands/github.rs
@@ -1,6 +1,7 @@
 //! In place of commands.rs
 use anyhow::Result;
-use but_github::{CheckAuthStatusParams, Verification};
+use but_github::{AuthStatusResponse, CheckAuthStatusParams, Verification};
+use but_settings::AppSettingsWithDiskSync;
 
 use crate::{NoParams, error::Error};
 
@@ -8,8 +9,16 @@ pub async fn init_device_oauth(_params: NoParams) -> Result<Verification, Error>
     but_github::init_device_oauth().await.map_err(Into::into)
 }
 
-pub async fn check_auth_status(params: CheckAuthStatusParams) -> Result<String, Error> {
-    but_github::check_auth_status(params)
-        .await
-        .map_err(Into::into)
+pub async fn check_auth_status(
+    app_settings_sync: &AppSettingsWithDiskSync,
+    params: CheckAuthStatusParams,
+) -> Result<AuthStatusResponse, Error> {
+    let status_result = but_github::check_auth_status(params).await;
+    match status_result {
+        Ok(status) => {
+            app_settings_sync.add_known_github_username(&status.login)?;
+            Ok(status)
+        }
+        Err(e) => Err(e.into()),
+    }
 }

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -13,6 +13,8 @@ rust-version = "1.89"
 [dependencies]
 serde.workspace = true
 but-settings.workspace = true
+gitbutler-secret.workspace = true
 anyhow.workspace = true
 serde_json = "1.0.145"
 reqwest = { version = "0.12", features = ["json"] }
+octorust = "0.10.0"

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use octorust::{Client, auth::Credentials, types::UsersGetByUsernameResponseOneOf};
+use serde::{Deserialize, Serialize};
+
+pub struct GitHubClient {
+    github: Client,
+}
+
+impl GitHubClient {
+    pub fn new(access_token: &str) -> Result<Self> {
+        let github = Client::new(
+            String::from("gb-github-integration"),
+            Credentials::Token(String::from(access_token)),
+        )?;
+
+        Ok(Self { github })
+    }
+
+    pub async fn get_authenticated(&self) -> Result<AuthenticatedUser> {
+        self.github
+            .users()
+            .get_authenticated()
+            .await
+            .map(|response| match response.body {
+                UsersGetByUsernameResponseOneOf::PrivateUser(user) => {
+                    let name = (!user.name.is_empty()).then(|| user.name.clone());
+                    let email = (!user.email.is_empty()).then(|| user.email.clone());
+                    let avatar_url = (!user.avatar_url.is_empty()).then(|| user.avatar_url.clone());
+                    AuthenticatedUser {
+                        login: user.login,
+                        avatar_url,
+                        name,
+                        email,
+                    }
+                }
+                UsersGetByUsernameResponseOneOf::PublicUser(user) => {
+                    let name = (!user.name.is_empty()).then(|| user.name.clone());
+                    let email = (!user.email.is_empty()).then(|| user.email.clone());
+                    let avatar_url = (!user.avatar_url.is_empty()).then(|| user.avatar_url.clone());
+                    AuthenticatedUser {
+                        login: user.login,
+                        avatar_url,
+                        name,
+                        email,
+                    }
+                }
+            })
+            .map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AuthenticatedUser {
+    pub login: String,
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Mutex};
 
 use anyhow::{Context, Result};
 use but_settings::AppSettings;
+use gitbutler_secret::{Sensitive, secret};
 use serde::{Deserialize, Serialize};
+
+mod client;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Verification {
@@ -43,7 +46,16 @@ pub struct CheckAuthStatusParams {
     pub device_code: String,
 }
 
-pub async fn check_auth_status(params: CheckAuthStatusParams) -> Result<String> {
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthStatusResponse {
+    pub access_token: String,
+    pub login: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+pub async fn check_auth_status(params: CheckAuthStatusParams) -> Result<AuthStatusResponse> {
     #[derive(Debug, Deserialize, Serialize, Clone, Default)]
     struct AccessTokenContainer {
         access_token: String,
@@ -73,7 +85,34 @@ pub async fn check_auth_status(params: CheckAuthStatusParams) -> Result<String> 
 
     let rsp_body = res.text().await.context("Failed to get response body")?;
 
-    serde_json::from_str::<AccessTokenContainer>(&rsp_body)
+    let access_token = serde_json::from_str::<AccessTokenContainer>(&rsp_body)
         .map(|rsp_body| rsp_body.access_token)
-        .context("Failed to parse response body")
+        .context("Failed to parse response body")?;
+
+    let gh = client::GitHubClient::new(&access_token).context("Failed to create GitHub client")?;
+    let user = gh
+        .get_authenticated()
+        .await
+        .context("Failed to get authenticated user")?;
+
+    persist_gh_access_token(&user.login, &access_token)
+        .context("Failed to persist access token")?;
+
+    Ok(AuthStatusResponse {
+        access_token,
+        login: user.login,
+        name: user.name,
+        email: user.email,
+    })
+}
+
+fn persist_gh_access_token(login: &str, access_token: &str) -> Result<()> {
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    let handle = format!("github-access-token-{}", login);
+    secret::persist(
+        &handle,
+        &Sensitive(access_token.to_string()),
+        secret::Namespace::Global,
+    )
 }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -361,6 +361,26 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
+        "forget_github_username" => {
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result = github::forget_github_username(&app_settings_sync, params);
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
+        "get_gh_user" => {
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result = github::get_gh_user(params).await;
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
         // Forge commands
         "pr_templates" => forge::pr_templates_cmd(request.params),
         "pr_template" => forge::pr_template_cmd(request.params),

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -355,7 +355,7 @@ async fn handle_command(
             let params = serde_json::from_value(request.params).to_error();
             match params {
                 Ok(params) => {
-                    let result = github::check_auth_status(params).await;
+                    let result = github::check_auth_status(&app_settings_sync, params).await;
                     result.map(|r| json!(r))
                 }
                 Err(e) => Err(e),

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -69,5 +69,13 @@
 	"ui": {
 		// Whether to use the native system title bar.
 		"useNativeTitleBar": false
+	},
+	// Settings related to the forge integrations.
+	"forgeIntegrations": {
+		"github": {
+			// The list of known GitHub users. This tracks the users that have authenticated through the application.
+			// That does not mean that the user is currently "active" in the app, just that they have authenticated at some point.
+			"knownUsernames": []
+		}
 	}
 }

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -166,4 +166,41 @@ impl AppSettingsWithDiskSync {
         }
         settings.save()
     }
+
+    pub fn add_known_github_username(&self, username: &str) -> Result<()> {
+        let mut settings = self.get_mut_enforce_save()?;
+        if !settings
+            .forge_integrations
+            .github
+            .known_usernames
+            .contains(&username.to_string())
+        {
+            settings
+                .forge_integrations
+                .github
+                .known_usernames
+                .push(username.to_string());
+            settings.save()?;
+        }
+        Ok(())
+    }
+
+    pub fn remove_known_github_username(&self, username: &str) -> Result<()> {
+        let mut settings = self.get_mut_enforce_save()?;
+        if let Some(pos) = settings
+            .forge_integrations
+            .github
+            .known_usernames
+            .iter()
+            .position(|x| x == username)
+        {
+            settings
+                .forge_integrations
+                .github
+                .known_usernames
+                .remove(pos);
+            settings.save()?;
+        }
+        Ok(())
+    }
 }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -20,7 +20,7 @@ pub struct GitHubOAuthAppSettings {
     pub oauth_client_id: String,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct FeatureFlags {
     /// Enable the usage of V3 workspace APIs.
@@ -61,7 +61,7 @@ pub struct ExtraCsp {
     pub hosts: Vec<String>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Fetch {
     /// The frequency at which the app will automatically fetch. A negative value (e.g. -1) disables auto fetching.
@@ -85,16 +85,28 @@ pub struct Claude {
     pub use_configured_model: bool,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Reviews {
     /// Whether to auto-fill PR title and description from the first commit when a branch has only one commit.
     pub auto_fill_pr_description_from_commit: bool,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UiSettings {
     /// Whether to use the native system title bar.
     pub use_native_title_bar: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ForgeIntegrations {
+    pub github: GitHubIntegration,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubIntegration {
+    pub known_usernames: Vec<String>,
 }

--- a/crates/but-settings/src/lib.rs
+++ b/crates/but-settings/src/lib.rs
@@ -24,6 +24,8 @@ pub struct AppSettings {
     pub reviews: app_settings::Reviews,
     /// UI settings.
     pub ui: app_settings::UiSettings,
+    /// Settings related to the forge integrations.
+    pub forge_integrations: app_settings::ForgeIntegrations,
 }
 
 impl Default for AppSettings {

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -103,6 +103,8 @@ pub struct Project {
     pub snapshot_lines_threshold: Option<usize>,
     #[serde(default)]
     pub forge_override: Option<String>,
+    #[serde(default)]
+    pub preferred_forge_user: Option<String>,
 }
 
 /// Instantiation

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -33,6 +33,7 @@ pub struct UpdateRequest {
     pub forge_override: Option<String>,
     #[serde(default = "default_false")]
     pub unset_forge_override: bool,
+    pub preferred_forge_user: Option<String>,
 }
 
 fn default_false() -> bool {
@@ -109,6 +110,10 @@ impl Storage {
 
         if let Some(forge_override) = &update_request.forge_override {
             project.forge_override = Some(forge_override.clone());
+        }
+
+        if let Some(preferred_forge_user) = &update_request.preferred_forge_user {
+            project.preferred_forge_user = Some(preferred_forge_user.clone());
         }
 
         if update_request.unset_forge_override {

--- a/crates/gitbutler-tauri/src/github.rs
+++ b/crates/gitbutler-tauri/src/github.rs
@@ -2,7 +2,7 @@ use but_api::{
     commands::github::{self},
     NoParams,
 };
-use but_github::{AuthStatusResponse, CheckAuthStatusParams, Verification};
+use but_github::{AuthStatusResponse, AuthenticatedUser, CheckAuthStatusParams, Verification};
 use but_settings::AppSettingsWithDiskSync;
 use tauri::State;
 use tracing::instrument;
@@ -22,4 +22,18 @@ pub async fn check_auth_status(
     device_code: String,
 ) -> Result<AuthStatusResponse, Error> {
     github::check_auth_status(&app_settings_sync, CheckAuthStatusParams { device_code }).await
+}
+
+#[tauri::command(async)]
+#[instrument(skip(app_settings_sync), err(Debug))]
+pub async fn forget_github_username(
+    app_settings_sync: State<'_, AppSettingsWithDiskSync>,
+    username: String,
+) -> Result<(), Error> {
+    github::forget_github_username(&app_settings_sync, username)
+}
+#[tauri::command(async)]
+#[instrument(err(Debug))]
+pub async fn get_gh_user(username: String) -> Result<Option<AuthenticatedUser>, Error> {
+    github::get_gh_user(username).await
 }

--- a/crates/gitbutler-tauri/src/github.rs
+++ b/crates/gitbutler-tauri/src/github.rs
@@ -2,7 +2,9 @@ use but_api::{
     commands::github::{self},
     NoParams,
 };
-use but_github::{CheckAuthStatusParams, Verification};
+use but_github::{AuthStatusResponse, CheckAuthStatusParams, Verification};
+use but_settings::AppSettingsWithDiskSync;
+use tauri::State;
 use tracing::instrument;
 
 use but_api::error::Error;
@@ -14,7 +16,10 @@ pub async fn init_device_oauth() -> Result<Verification, Error> {
 }
 
 #[tauri::command(async)]
-#[instrument(err(Debug))]
-pub async fn check_auth_status(device_code: String) -> Result<String, Error> {
-    github::check_auth_status(CheckAuthStatusParams { device_code }).await
+#[instrument(skip(app_settings_sync), err(Debug))]
+pub async fn check_auth_status(
+    app_settings_sync: State<'_, AppSettingsWithDiskSync>,
+    device_code: String,
+) -> Result<AuthStatusResponse, Error> {
+    github::check_auth_status(&app_settings_sync, CheckAuthStatusParams { device_code }).await
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -278,6 +278,8 @@ fn main() {
                     menu::menu_item_set_enabled,
                     github::init_device_oauth,
                     github::check_auth_status,
+                    github::forget_github_username,
+                    github::get_gh_user,
                     askpass::submit_prompt_response,
                     remotes::list_remotes,
                     remotes::add_remote,


### PR DESCRIPTION
- Create a GitHub client in the RustEnd (very basic at the moment)
- Completely ignore the access token stored in the GitButler API server
- Allow for the user to have multiple GitHub accounts active
- Allow the user to select an account to use per project