### PR TITLE
fix(ui): replace generic user check with forge-specific validation

### DIFF
--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -21,6 +21,7 @@
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { mapErrorToToast } from '$lib/forge/github/errorMap';
 	import { GitHubPrService } from '$lib/forge/github/githubPrService.svelte';
+	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { type PullRequest } from '$lib/forge/interface/types';
 	import { PrPersistedStore } from '$lib/forge/prContents';
 	import { updatePrDescriptionTables as updatePrStackInfo } from '$lib/forge/shared/prFooter';
@@ -66,6 +67,8 @@
 	const appSettings = settingsService.appSettings;
 
 	const user = userService.user;
+	const gitLabState = inject(GITLAB_STATE);
+	const gitLabConfigured = $derived(gitLabState.configured);
 
 	const [pushStack, stackPush] = stackService.pushStack;
 
@@ -192,7 +195,16 @@
 
 	export async function createReview() {
 		if (isExecuting) return;
-		if (!$user) return;
+
+		if (forge.determinedForgeType === 'github' && !$user) {
+			chipToasts.error('You must be signed in to GitHub to create a Pull Request.');
+			return;
+		} else if (forge.determinedForgeType === 'gitlab' && !gitLabConfigured) {
+			chipToasts.error(
+				'You must configure the GitLab integration before creating a Merge Request.'
+			);
+			return;
+		}
 
 		const effectivePRBody = (await messageEditor?.getPlaintext()) ?? '';
 		// Declare early to have them inside the function closure, in case


### PR DESCRIPTION
## 🧢 Changes

Hi! This PR replaces generic user check with forge-specific validation:

If the user is configured and the forge type is GitHub, check the user. Display an error toast to inform the user that
the GitHub integration is not configured.

<img width="810" height="126" alt="CleanShot 2025-10-15 at 21 25 16@2x" src="https://github.com/user-attachments/assets/f284f04d-a0ee-4798-8858-6a418e14dfae" />



If the user is not configured and the forge type is GitLab, skip the user check and instead verify the GitLab configuration state. Display an error toast to provide feedback that the GitLab integration is not configured.

<img width="1052" height="112" alt="CleanShot 2025-10-15 at 21 25 33@2x" src="https://github.com/user-attachments/assets/64baf83b-67e7-4fe3-a489-f66bef266437" />


## ☕️ Reasoning

When the user clicks on the `Create MR` button then nothing happens. The old check was too generic and didn't handle GitHub and GitLab properly. This PR makes sure each integration is checked correctly and users get proper feedback. I put some generic error messages there but happy to adjust them. Thanks!

## 🎫 Affected issues

Fixes: https://github.com/gitbutlerapp/gitbutler/issues/9964

