### PR TITLE
Refactor push so that it can take mut ctx

### DIFF
--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -259,9 +259,9 @@ pub fn push_stack(
     run_hooks: bool,
 ) -> Result<PushResult, Error> {
     let project = gitbutler_project::get(project_id)?;
-    let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
+    let mut ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     gitbutler_branch_actions::stack::push_stack(
-        &ctx,
+        &mut ctx,
         stack_id,
         with_force,
         skip_force_push_protection,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -15,7 +15,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
 
         ctx,
         ..
-    } = &Test::default();
+    } = &mut Test::default();
 
     gitbutler_project::update_with_path(
         data_dir.as_ref().unwrap(),

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -8,7 +8,7 @@ use super::*;
 #[test]
 fn integration() {
     let Test { repo, ctx, .. } =
-        &Test::new_with_settings(|settings| settings.feature_flags.ws3 = false);
+        &mut Test::new_with_settings(|settings| settings.feature_flags.ws3 = false);
 
     gitbutler_branch_actions::set_base_branch(
         ctx,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -142,7 +142,7 @@ fn forcepush_allowed() {
 
         ctx,
         ..
-    } = &Test::default();
+    } = &mut Test::default();
 
     gitbutler_branch_actions::set_base_branch(
         ctx,


### PR DESCRIPTION
It's a bit less efficient to recreate the graph for every loop 
iteraration but it is valuable to be able to get a mutable ctx for db 
operations