### PR TITLE
Only implement the `serde` traits (and derives) that are actually used.

### DIFF
--- a/crates/but-action/src/action.rs
+++ b/crates/but-action/src/action.rs
@@ -173,7 +173,7 @@ pub fn list_actions(
     Ok(ActionListing { total, actions })
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionListing {
     pub total: i64,

--- a/crates/but-action/src/workflow.rs
+++ b/crates/but-action/src/workflow.rs
@@ -90,7 +90,7 @@ pub enum Trigger {
 }
 
 /// Represents a workflow that was executed by GitButler.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Workflow {
     /// Unique identifier for the workflow.
@@ -230,7 +230,7 @@ pub fn list_workflows(
     Ok(WorkflowList { total, workflows })
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowList {
     total: i64,

--- a/crates/but-api/src/commands/config.rs
+++ b/crates/but-api/src/commands/config.rs
@@ -46,7 +46,7 @@ pub fn store_author_globally_if_unset(
 }
 
 /// Represents the author information from the git configuration.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct AuthorInfo {
     /// The name of the author.
     #[serde(with = "bstring_opt_lossy")]

--- a/crates/but-api/src/commands/diff.rs
+++ b/crates/but-api/src/commands/diff.rs
@@ -36,7 +36,7 @@ pub fn tree_change_diffs(
     Ok(change.unified_diff(&repo, app_settings.context_lines)?)
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitDetails {
     pub commit: but_workspace::ui::Commit,

--- a/crates/but-api/src/commands/github.rs
+++ b/crates/but-api/src/commands/github.rs
@@ -3,13 +3,13 @@ use crate::{NoParams, error::Error};
 use anyhow::Result;
 use but_github::{AuthStatusResponse, AuthenticatedUser, CheckAuthStatusParams, Verification};
 use but_settings::AppSettingsWithDiskSync;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 pub async fn init_device_oauth(_params: NoParams) -> Result<Verification, Error> {
     but_github::init_device_oauth().await.map_err(Into::into)
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthStatusResponseSensitive {
     pub access_token: String,
@@ -63,7 +63,7 @@ pub fn forget_github_username(
         })
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticatedUserSensitive {
     pub access_token: String,

--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -33,7 +33,7 @@ use anyhow::{Result, bail};
 use but_broadcaster::Broadcaster;
 use but_workspace::StackId;
 use gitbutler_command_context::CommandContext;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::{
     collections::HashMap,
     io::{BufRead, BufReader, PipeReader, Read as _},
@@ -620,7 +620,7 @@ impl Default for Claudes {
 }
 
 /// Result of checking Claude Code availability
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ClaudeCheckResult {
     /// Claude Code is available and returned a version

--- a/crates/but-claude/src/prompt_templates.rs
+++ b/crates/but-claude/src/prompt_templates.rs
@@ -5,9 +5,9 @@ use std::{
 
 use anyhow::Result;
 use gitbutler_project::Project;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptTemplate {
     pub label: String,
@@ -31,7 +31,7 @@ fn default_template() -> Vec<PromptTemplate> {
     ]
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptDir {
     pub label: String,

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -41,7 +41,7 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
 }
 
 /// All the changes that were made to the tree, including stats
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeChanges {
     /// The changes that were made to the tree.
@@ -125,7 +125,7 @@ impl From<gix::object::tree::diff::Stats> for TreeStats {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeStats {
     /// The total amount of lines added.

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use but_secret::Sensitive;
 use octorust::{Client, auth::Credentials, types::UsersGetByUsernameResponseOneOf};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 pub struct GitHubClient {
     github: Client,
@@ -50,7 +50,7 @@ impl GitHubClient {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize)]
 pub struct AuthenticatedUser {
     pub login: String,
     pub avatar_url: Option<String>,

--- a/crates/but-worktrees/src/list.rs
+++ b/crates/but-worktrees/src/list.rs
@@ -1,18 +1,18 @@
 use anyhow::Result;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::access::WorktreeReadPermission;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{Worktree, WorktreeHealthStatus, db::list_worktrees, gc::get_health};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 /// This gets used as a public API in the CLI so be careful when modifying.
 pub struct ListWorktreeOutcome {
     pub entries: Vec<WorktreeListEntry>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 /// This gets used as a public API in the CLI so be careful when modifying.
 pub struct WorktreeListEntry {

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::{Project, access::WorktreeReadPermission};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{Worktree, WorktreeSource, db::save_worktree, git::git_worktree_add};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 /// This gets used as a public API in the CLI so be careful when modifying.
 pub struct NewWorktreeOutcome {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -22,10 +22,10 @@ use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{BranchOwnershipClaims, Stack, StackId};
 use gitbutler_time::time::now_since_unix_epoch_ms;
 use gitbutler_workspace::branch_trees::{update_uncommited_changes_with_tree, WorkspaceState};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tracing::instrument;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBranchFromBranchOutcome {
     pub stack_id: StackId,

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -11,11 +11,11 @@ use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_stack::{StackBranch, VirtualBranchesHandle};
 use gitbutler_workspace::branch_trees::{update_uncommited_changes, WorkspaceState};
 use gix::refs::transaction::PreviousValue;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::BranchManagerExt;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveBranchResult {
     /// The stacks that were deleted as a result of the move.

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -13,7 +13,7 @@ use gitbutler_oxidize::{ObjectIdExt, OidExt, RepoExt};
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_stack::{StackId, VirtualBranchesHandle};
 use gitbutler_workspace::branch_trees::{update_uncommited_changes, WorkspaceState};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// move a commit from one stack to another
 ///
@@ -100,7 +100,7 @@ fn get_source_branch_diffs(
     Ok(uncommitted_changes_diff)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase", tag = "type", content = "subject")]
 pub enum MoveCommitIllegalAction {
     /// The commit being moved has dependencies on some of its parent commits.


### PR DESCRIPTION
As follow-up on #10669.
