### PR TITLE
v3 apply: remote handling

### DIFF
--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -1,4 +1,5 @@
 mod workspace {
+    use but_core::ref_metadata::WorkspaceCommitRelation::Merged;
     use but_core::ref_metadata::{StackKind::AppliedAndUnapplied, Workspace};
 
     #[test]
@@ -8,18 +9,18 @@ mod workspace {
 
         let a_ref = r("refs/heads/A");
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(100)),
+            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(100), Merged),
             (0, 0)
         );
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(200)),
+            ws.add_or_insert_new_stack_if_not_present(a_ref, Some(200), Merged),
             (0, 0)
         );
         assert_eq!(ws.stacks.len(), 1);
 
         let b_ref = r("refs/heads/B");
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0)),
+            ws.add_or_insert_new_stack_if_not_present(b_ref, Some(0), Merged),
             (0, 0)
         );
         assert_eq!(
@@ -29,7 +30,7 @@ mod workspace {
 
         let c_ref = r("refs/heads/C");
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(c_ref, None),
+            ws.add_or_insert_new_stack_if_not_present(c_ref, None, Merged),
             (2, 0)
         );
         assert_eq!(
@@ -67,7 +68,7 @@ mod workspace {
             "anchor doesn't exist"
         );
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(a_ref, None),
+            ws.add_or_insert_new_stack_if_not_present(a_ref, None, Merged),
             (0, 0)
         );
         assert_eq!(
@@ -88,7 +89,7 @@ mod workspace {
         );
 
         assert_eq!(
-            ws.add_or_insert_new_stack_if_not_present(a_ref, None),
+            ws.add_or_insert_new_stack_if_not_present(a_ref, None, Merged),
             (0, 2),
             "adding a new stack can 'fail' if the segment is already present, but not as stack tip"
         );
@@ -113,7 +114,7 @@ mod workspace {
                             archived: false,
                         },
                     ],
-                    in_workspace: true,
+                    workspacecommit_relation: Merged,
                 },
             ],
             target_ref: None,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -522,7 +522,7 @@ impl Graph {
             for segment in ws_metadata
                 .stacks
                 .into_iter()
-                .filter(|s| s.in_workspace)
+                .filter(|s| s.is_in_workspace())
                 .flat_map(|s| s.branches.into_iter())
             {
                 let Some(segment_tip) = repo

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -739,7 +739,7 @@ impl Graph {
             .collect();
         edges_pointing_to_named_segment.sort_by_key(|(_e, sidx, rn)| {
             let res = ws_data.stacks.iter().position(|s| {
-                s.in_workspace
+                s.is_in_workspace()
                     && s.branches
                         .first()
                         .is_some_and(|b| Some(&b.ref_name) == rn.as_ref())

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1,3 +1,4 @@
+use but_core::ref_metadata::WorkspaceCommitRelation;
 use but_core::{
     RefMetadata,
     ref_metadata::{StackId, WorkspaceStack, WorkspaceStackBranch},
@@ -2312,7 +2313,7 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
                 ref_name: ref_name.try_into()?,
                 archived: false,
             }],
-            in_workspace: true,
+            workspacecommit_relation: WorkspaceCommitRelation::Merged,
         });
         meta.branches.push((
             ref_name.try_into()?,

--- a/crates/but-graph/tests/graph/ref_metadata_legacy.rs
+++ b/crates/but-graph/tests/graph/ref_metadata_legacy.rs
@@ -1,5 +1,6 @@
 use std::{ops::Deref, path::PathBuf};
 
+use but_core::ref_metadata::WorkspaceCommitRelation::{Merged, Outside};
 use but_core::{
     RefMetadata,
     ref_metadata::{StackId, ValueInfo, WorkspaceStack, WorkspaceStackBranch},
@@ -56,7 +57,7 @@ fn read_only() -> anyhow::Result<()> {
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
         WorkspaceStack {
             id: 2,
@@ -78,7 +79,7 @@ fn read_only() -> anyhow::Result<()> {
                     archived: true,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
         WorkspaceStack {
             id: 3,
@@ -108,7 +109,7 @@ fn read_only() -> anyhow::Result<()> {
                     archived: true,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
         WorkspaceStack {
             id: 4,
@@ -122,7 +123,7 @@ fn read_only() -> anyhow::Result<()> {
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
         WorkspaceStack {
             id: 5,
@@ -132,7 +133,7 @@ fn read_only() -> anyhow::Result<()> {
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -382,7 +383,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
     let stack_id2 = StackId::from_number_for_testing(2);
     ws_md.stacks.push(WorkspaceStack {
         id: stack_id1,
-        in_workspace: true,
+        workspacecommit_relation: Merged,
         branches: vec![WorkspaceStackBranch {
             ref_name: branch1.clone(),
             archived: false,
@@ -390,7 +391,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
     });
     ws_md.stacks.push(WorkspaceStack {
         id: stack_id2,
-        in_workspace: false,
+        workspacecommit_relation: Outside,
         branches: vec![WorkspaceStackBranch {
             ref_name: branch2.clone(),
             archived: false,
@@ -411,7 +412,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 00000000-0000-0000-0000-000000000002,
@@ -421,7 +422,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
         ],
         target_ref: None,
@@ -446,7 +447,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 00000000-0000-0000-0000-000000000002,
@@ -456,7 +457,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
         ],
         target_ref: None,
@@ -464,8 +465,8 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
     }
     "#);
 
-    ws_md.stacks[0].in_workspace = false;
-    ws_md.stacks[1].in_workspace = true;
+    ws_md.stacks[0].workspacecommit_relation = Outside;
+    ws_md.stacks[1].workspacecommit_relation = Merged;
 
     // It's totally possible to change 'in_workspace' directly.
     store.set_workspace(&ws_md)?;
@@ -482,7 +483,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
             WorkspaceStack {
                 id: 00000000-0000-0000-0000-000000000002,
@@ -492,7 +493,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
         ],
         target_ref: None,
@@ -508,7 +509,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
     ] {
         ws_md.stacks.push(WorkspaceStack {
             id: StackId::from_number_for_testing(number),
-            in_workspace: true,
+            workspacecommit_relation: Merged,
             branches: vec![WorkspaceStackBranch {
                 ref_name: ref_name.try_into()?,
                 archived: false,
@@ -532,7 +533,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 00000000-0000-0000-0000-000000000004,
@@ -542,7 +543,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
         ],
         target_ref: None,
@@ -590,7 +591,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: false,
+            workspacecommit_relation: Outside,
         },
     ]
     "#);
@@ -598,7 +599,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
     let ignored_id = StackId::from_number_for_testing(2);
     ws.stacks.push(WorkspaceStack {
         id: ignored_id,
-        in_workspace: true,
+        workspacecommit_relation: Merged,
         branches: vec![WorkspaceStackBranch {
             ref_name: branch_name.clone(),
             archived: false,
@@ -622,7 +623,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -665,7 +666,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -740,7 +741,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -779,7 +780,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -810,7 +811,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
         .expect("can also set a valid id, it doesn't matter");
     ws.stacks.push(WorkspaceStack {
         id: second_id,
-        in_workspace: true,
+        workspacecommit_relation: Merged,
         branches: vec![WorkspaceStackBranch {
             ref_name: branch.as_ref().into(), /* always a matching name */
             archived: true,
@@ -838,7 +839,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
         WorkspaceStack {
             id: 2,
@@ -848,7 +849,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
                     archived: true,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -868,7 +869,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
     // Add it again, then remove it by removing the branch.
     ws.stacks.push(WorkspaceStack {
         id: StackId::from_number_for_testing(2),
-        in_workspace: true,
+        workspacecommit_relation: Merged,
         branches: vec![WorkspaceStackBranch {
             ref_name: second_stack.clone(),
             archived: true,
@@ -1004,7 +1005,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
     let mut ws = store.workspace(workspace_name)?;
     ws.stacks.push(WorkspaceStack {
         id: StackId::from_number_for_testing(1),
-        in_workspace: false,
+        workspacecommit_relation: Outside,
         branches: vec![
             WorkspaceStackBranch {
                 ref_name: "refs/heads/top".try_into()?,
@@ -1022,7 +1023,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
     });
     ws.stacks.push(WorkspaceStack {
         id: StackId::from_number_for_testing(2),
-        in_workspace: true,
+        workspacecommit_relation: Merged,
         branches: vec![WorkspaceStackBranch {
             ref_name: "refs/heads/second-branch".try_into()?,
             archived: false,
@@ -1049,7 +1050,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                     archived: true,
                 },
             ],
-            in_workspace: false,
+            workspacecommit_relation: Outside,
         },
         WorkspaceStack {
             id: 00000000-0000-0000-0000-000000000002,
@@ -1059,7 +1060,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -1085,7 +1086,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                     archived: true,
                 },
             ],
-            in_workspace: false,
+            workspacecommit_relation: Outside,
         },
         WorkspaceStack {
             id: 00000000-0000-0000-0000-000000000002,
@@ -1095,7 +1096,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                     archived: false,
                 },
             ],
-            in_workspace: true,
+            workspacecommit_relation: Merged,
         },
     ]
     "#);
@@ -1156,7 +1157,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
         ],
         target_ref: Some(
@@ -1197,7 +1198,7 @@ fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
         ],
         target_ref: Some(

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -393,7 +393,7 @@ pub fn assignments_with_fallback(
 /// This needs to be ran only after the worktree has changed.
 ///
 /// If `worktree_changes` is `None`, they will be fetched automatically.
-#[instrument(skip(ctx, worktree_assignments), err(Debug))]
+#[instrument(skip(ctx, worktree_assignments, deps), err(Debug))]
 fn reconcile_with_worktree_and_locks(
     ctx: &mut CommandContext,
     set_assignment_from_locks: bool,

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -223,21 +223,41 @@ async fn main() -> Result<()> {
 
 mod trace {
     use tracing::metadata::LevelFilter;
-    use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::{
+        Layer, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    };
 
     pub fn init(level: u8) -> anyhow::Result<()> {
-        tracing_subscriber::registry()
-            .with(
-                tracing_forest::ForestLayer::from(
-                    tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+        let filter = match level {
+            1 => LevelFilter::INFO,
+            2 => LevelFilter::DEBUG,
+            _ => LevelFilter::TRACE,
+        };
+        if level >= 4 {
+            tracing_subscriber::registry()
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .compact()
+                        .with_span_events(FmtSpan::CLOSE)
+                        .with_writer(std::io::stderr),
                 )
-                .with_filter(match level {
-                    1 => LevelFilter::INFO,
-                    2 => LevelFilter::DEBUG,
-                    _ => LevelFilter::TRACE,
-                }),
-            )
-            .init();
+                .with(
+                    tracing_forest::ForestLayer::from(
+                        tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+                    )
+                    .with_filter(filter),
+                )
+                .init()
+        } else {
+            tracing_subscriber::registry()
+                .with(
+                    tracing_forest::ForestLayer::from(
+                        tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+                    )
+                    .with_filter(filter),
+                )
+                .init();
+        }
         Ok(())
     }
 }

--- a/crates/but-testsupport/src/in_memory_meta.rs
+++ b/crates/but-testsupport/src/in_memory_meta.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use but_core::ref_metadata::WorkspaceCommitRelation;
 use but_core::{
     ref_metadata,
     ref_metadata::{Branch, StackId, Workspace, WorkspaceStackBranch},
@@ -180,7 +181,7 @@ impl InMemoryRefMetadata {
         let _stack = ref_metadata::WorkspaceStack {
             id: StackId::from_number_for_testing(stack_id as u128),
             branches: vec![stack_segment_from_partial_name(stack_name)],
-            in_workspace: false,
+            workspacecommit_relation: WorkspaceCommitRelation::Outside,
         };
         // Leave this for later, for now it's OK to use the vb.toml version.
         // Eventually we probably want to avoid using it.

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -109,7 +109,9 @@ pub(super) mod function {
 
     use std::borrow::{Borrow, Cow};
 
+    use crate::branch::create_reference::{Anchor, Position};
     use anyhow::{Context, bail};
+    use but_core::ref_metadata::WorkspaceCommitRelation::Merged;
     use but_core::{
         RefMetadata, ref_metadata,
         ref_metadata::{
@@ -117,8 +119,6 @@ pub(super) mod function {
         },
     };
     use gix::refs::transaction::PreviousValue;
-
-    use crate::branch::create_reference::{Anchor, Position};
 
     /// Create a new reference named `ref_name` to point at a commit relative to `anchor`.
     /// If `anchor` is `None` this means the branch should be placed above the lower bound of the workspace, effectively
@@ -360,7 +360,7 @@ pub(super) mod function {
         {
             // Just pretend its applied, and if it really is reachable, this will assure the
             // created ref name can be found.
-            ws_meta.stacks[stack_idx].in_workspace = true;
+            ws_meta.stacks[stack_idx].workspacecommit_relation = Merged;
             return Ok(());
         }
         match instruction {
@@ -385,7 +385,7 @@ pub(super) mod function {
             // create new
             Instruction::Independent => ws_meta.stacks.push(WorkspaceStack {
                 id: StackId::generate(),
-                in_workspace: true,
+                workspacecommit_relation: Merged,
                 branches: vec![WorkspaceStackBranch {
                     ref_name: new_ref.to_owned(),
                     archived: false,
@@ -406,7 +406,7 @@ pub(super) mod function {
                     })?;
                 let stack = &mut ws_meta.stacks[stack_idx];
                 // Just assure it's there, to facilitate the new branch actually shows up.
-                stack.in_workspace = true;
+                stack.workspacecommit_relation = Merged;
                 let branches = &mut stack.branches;
                 branches.insert(
                     match position {

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -13,6 +13,7 @@ use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};
 use gitbutler_stack::{Stack, StackBranch, StackId};
 use gix::date::parse::TimeBuf;
 use itertools::Itertools;
+use tracing::instrument;
 
 use crate::{
     RefInfo, StacksFilter, branch, head_info,
@@ -425,6 +426,7 @@ pub fn stack_details(
 // TODO: StackId shouldn't be used, instead use the ref-name or stack index as universal tip identifier.
 //       It's notable that there isn't always a ref-name available right now in case the ref advanced, but maybe this is something
 //       we can pull out of the metadata information.
+#[instrument(level = tracing::Level::DEBUG, skip(meta), err(Debug))]
 pub fn stack_details_v3(
     stack_id: Option<StackId>,
     repo: &gix::Repository,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -1,3 +1,11 @@
+use crate::{
+    ref_info::with_workspace_commit::utils::{
+        StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
+        named_writable_scenario_with_description_and_graph,
+    },
+    utils::r,
+};
+use but_core::ref_metadata::WorkspaceCommitRelation::Outside;
 use but_core::{RefMetadata, ref_metadata};
 use but_graph::init::{Options, Overlay};
 use but_testsupport::{
@@ -10,14 +18,6 @@ use but_workspace::branch::{
     checkout::UncommitedWorktreeChanges,
 };
 use gix::refs::Category;
-
-use crate::{
-    ref_info::with_workspace_commit::utils::{
-        StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
-        named_writable_scenario_with_description_and_graph,
-    },
-    utils::r,
-};
 
 #[test]
 fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
@@ -301,7 +301,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     // Reset the workspace to 'unapply', but keep the per-branch metadata.
     let mut ws_md = meta.workspace(ws.ref_name().expect("proper gb workspace"))?;
     for stack in &mut ws_md.stacks {
-        stack.in_workspace = false;
+        stack.workspacecommit_relation = Outside;
     }
     meta.set_workspace(&ws_md)?;
 
@@ -1047,7 +1047,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 2,
@@ -1057,7 +1057,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 3,
@@ -1067,7 +1067,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
             WorkspaceStack {
                 id: 4,
@@ -1077,7 +1077,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 5,
@@ -1087,7 +1087,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: false,
+                workspacecommit_relation: Outside,
             },
             WorkspaceStack {
                 id: 6,
@@ -1097,7 +1097,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
             WorkspaceStack {
                 id: 7,
@@ -1107,7 +1107,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
                         archived: false,
                     },
                 ],
-                in_workspace: true,
+                workspacecommit_relation: Merged,
             },
         ],
         target_ref: Some(

--- a/crates/but-workspace/tests/workspace/commit.rs
+++ b/crates/but-workspace/tests/workspace/commit.rs
@@ -422,11 +422,11 @@ mod from_new_merge_with_metadata {
     }
 
     mod utils {
+        use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack_with_segments};
+        use but_core::ref_metadata::WorkspaceCommitRelation::Merged;
         use but_core::ref_metadata::{StackId, WorkspaceStack, WorkspaceStackBranch};
         use but_graph::VirtualBranchesTomlMetadata;
         use gix::refs::Category;
-
-        use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack_with_segments};
 
         pub fn add_stacks(
             meta: &mut VirtualBranchesTomlMetadata,
@@ -450,7 +450,7 @@ mod from_new_merge_with_metadata {
                 .into_iter()
                 .map(|short_name| WorkspaceStack {
                     id: StackId::generate(),
-                    in_workspace: true,
+                    workspacecommit_relation: Merged,
                     branches: vec![WorkspaceStackBranch {
                         ref_name: Category::LocalBranch
                             .to_full_name(short_name)


### PR DESCRIPTION
Get a minimal viable version of `unapply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10642.

### Fixes

* [x] Introduce `State` for Stacks, with the new `Unmerged` variant (in workspace, but not merged not observable in worktree).
* [ ] local tracking branches are created on demand and are wired correctly
* [ ] ⚠️ tips could be conflicted, deal with it when merging

### Tasks
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace.

### Next PR?

* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [x] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [x] don't apply the target branch!
- [x] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.


### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.



