### PR TITLE
forge-provider-from-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,6 +3302,7 @@ dependencies = [
  "gitbutler-commit",
  "gitbutler-diff",
  "gitbutler-error",
+ "gitbutler-forge",
  "gitbutler-fs",
  "gitbutler-git",
  "gitbutler-hunk-dependency",

--- a/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
+++ b/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
@@ -40,7 +40,8 @@ const MOCK_BASE_BRANCH_DATA = {
 	conflicted: false,
 	diverged: false,
 	divergedAhead: [],
-	divergedBehind: []
+	divergedBehind: [],
+	forgeProvider: 'github'
 };
 
 export type BaseBranchData = typeof MOCK_BASE_BRANCH_DATA;

--- a/apps/desktop/cypress/e2e/support/mock/review.ts
+++ b/apps/desktop/cypress/e2e/support/mock/review.ts
@@ -3,7 +3,7 @@ import type { InvokeArgs } from '@tauri-apps/api/core';
 export type GetReviewTemplateParams = {
 	relativePath: string;
 	projectId: string;
-	forge: { name: string };
+	forge: string;
 };
 
 export function isGetReviewTemplateParams(
@@ -16,9 +16,7 @@ export function isGetReviewTemplateParams(
 		'relativePath' in args &&
 		'projectId' in args &&
 		'forge' in args &&
-		typeof args.forge === 'object' &&
-		args.forge !== null &&
-		'name' in args.forge
+		typeof args.forge === 'string'
 	);
 }
 

--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -5,6 +5,8 @@ export interface RemoteBranchInfo {
 	name: string;
 }
 
+export type ForgeProvider = 'github' | 'gitlab' | 'bitbucket' | 'azure';
+
 export class BaseBranch {
 	branchName!: string;
 	remoteName!: string;
@@ -23,6 +25,7 @@ export class BaseBranch {
 	diverged!: boolean;
 	divergedAhead!: string[];
 	divergedBehind!: string[];
+	forgeProvider!: ForgeProvider | null;
 
 	actualPushRemoteName(): string {
 		return this.pushRemoteName || this.remoteName;

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -53,6 +53,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 					owner: 'test-owner'
 				},
 				baseBranch: 'some-base',
+				detectedForgeProvider: undefined,
 				forgeOverride: undefined
 			})
 		).instanceOf(GitHub);
@@ -75,6 +76,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 					owner: 'test-owner'
 				},
 				baseBranch: 'some-base',
+				detectedForgeProvider: undefined,
 				forgeOverride: undefined
 			})
 		).instanceOf(GitLab);
@@ -97,8 +99,53 @@ describe.concurrent('DefaultforgeFactory', () => {
 					owner: 'test-owner'
 				},
 				baseBranch: 'some-base',
+				detectedForgeProvider: undefined,
 				forgeOverride: undefined
 			})
 		).instanceOf(GitLab);
+	});
+
+	test('Respects detectedForgeProvider: GitHub', async () => {
+		const factory = new DefaultForgeFactory({
+			gitHubClient,
+			gitHubApi,
+			gitLabClient,
+			gitLabApi,
+			posthog,
+			dispatch
+		});
+		const result = factory.build({
+			repo: {
+				domain: 'gitlab.com',
+				name: 'test-repo',
+				owner: 'test-owner'
+			},
+			baseBranch: 'main',
+			detectedForgeProvider: 'github',
+			forgeOverride: undefined
+		});
+		expect(result).instanceOf(GitHub);
+	});
+
+	test('Respects detectedForgeProvider: GitLab', async () => {
+		const factory = new DefaultForgeFactory({
+			gitHubClient,
+			gitHubApi,
+			gitLabClient,
+			gitLabApi,
+			posthog,
+			dispatch
+		});
+		const result = factory.build({
+			repo: {
+				domain: 'github.com',
+				name: 'test-repo',
+				owner: 'test-owner'
+			},
+			baseBranch: 'main',
+			detectedForgeProvider: 'gitlab',
+			forgeOverride: undefined
+		});
+		expect(result).instanceOf(GitLab);
 	});
 });

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -930,14 +930,14 @@ export class StackService {
 	}
 
 	templates(projectId: string, forgeName: string) {
-		return this.api.endpoints.templates.useQuery({ projectId, forge: { name: forgeName } });
+		return this.api.endpoints.templates.useQuery({ projectId, forge: forgeName });
 	}
 
 	async template(projectId: string, forgeName: string, relativePath: string) {
 		return await this.api.endpoints.template.fetch({
 			relativePath,
 			projectId,
-			forge: { name: forgeName }
+			forge: forgeName
 		});
 	}
 
@@ -1728,14 +1728,11 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 					unsubscribe();
 				}
 			}),
-			templates: build.query<string[], { projectId: string; forge: { name: string } }>({
+			templates: build.query<string[], { projectId: string; forge: string }>({
 				extraOptions: { command: 'pr_templates' },
 				query: (args) => args
 			}),
-			template: build.query<
-				string,
-				{ projectId: string; forge: { name: string }; relativePath: string }
-			>({
+			template: build.query<string, { projectId: string; forge: string; relativePath: string }>({
 				extraOptions: { command: 'pr_template' },
 				query: (args) => args
 			})

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -124,6 +124,7 @@
 			githubAuthenticated: !!githubAccessToken.accessToken.current,
 			githubIsLoading: githubAccessToken.isLoading.current,
 			gitlabAuthenticated: !!$gitlabConfigured,
+			detectedForgeProvider: baseBranch?.forgeProvider ?? undefined,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override
 		});
 	});

--- a/crates/but-api/src/commands/forge.rs
+++ b/crates/but-api/src/commands/forge.rs
@@ -48,3 +48,10 @@ pub fn pr_template(
         .content
         .context("PR template was not valid UTF-8")?)
 }
+
+#[api_cmd]
+#[cfg_attr(feature = "tauri", tauri::command(async))]
+#[instrument(err(Debug))]
+pub fn determine_forge_from_url(url: String) -> Result<Option<ForgeName>, Error> {
+    Ok(gitbutler_forge::determine_forge_from_url(&url))
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -384,6 +384,7 @@ async fn handle_command(
         // Forge commands
         "pr_templates" => forge::pr_templates_cmd(request.params),
         "pr_template" => forge::pr_template_cmd(request.params),
+        "determine_forge_from_url" => forge::determine_forge_from_url_cmd(request.params),
         // // Menu commands (limited - no menu_item_set_enabled as it's Tauri-specific)
         // "get_editor_link_scheme" => menu::get_editor_link_scheme(&ctx, request.params),
         // CLI commands

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -33,6 +33,7 @@ gitbutler-oxidize.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-hunk-dependency.workspace = true
 gitbutler-workspace.workspace = true
+gitbutler-forge.workspace = true
 but-workspace.workspace = true
 but-rebase.workspace = true
 but-core.workspace = true

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -11,6 +11,7 @@ use but_workspace::branch::checkout::UncommitedWorktreeChanges;
 use gitbutler_branch::GITBUTLER_WORKSPACE_REFERENCE;
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;
+use gitbutler_forge::forge::ForgeName;
 use gitbutler_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, RemoteRefname};
@@ -47,6 +48,7 @@ pub struct BaseBranch {
     pub diverged_ahead: Vec<git2::Oid>,
     #[serde(with = "gitbutler_serde::oid_vec")]
     pub diverged_behind: Vec<git2::Oid>,
+    pub forge_provider: Option<ForgeName>,
 }
 
 #[instrument(skip(ctx), err(Debug))]
@@ -383,6 +385,8 @@ pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Re
         target.remote_url.clone()
     };
 
+    let forge_provider = gitbutler_forge::determine_forge_from_url(&remote_url);
+
     let base = BaseBranch {
         branch_name: target.branch.fullname(),
         remote_name: target.branch.remote().to_string(),
@@ -405,6 +409,7 @@ pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Re
         diverged,
         diverged_ahead,
         diverged_behind,
+        forge_provider,
     };
     Ok(base)
 }

--- a/crates/gitbutler-forge/src/forge.rs
+++ b/crates/gitbutler-forge/src/forge.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(tag = "name", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Supported git forge types
 pub enum ForgeName {
     GitHub,

--- a/crates/gitbutler-forge/src/lib.rs
+++ b/crates/gitbutler-forge/src/lib.rs
@@ -1,2 +1,19 @@
+use crate::forge::ForgeName;
+
 pub mod forge;
 pub mod review;
+
+/// Determine the forge type from a given URL.
+pub fn determine_forge_from_url(url: &str) -> Option<ForgeName> {
+    if url.contains("github.com") {
+        Some(ForgeName::GitHub)
+    } else if url.contains("gitlab.com") || url.starts_with("gitlab.") {
+        Some(ForgeName::GitLab)
+    } else if url.contains("bitbucket.org") {
+        Some(ForgeName::Bitbucket)
+    } else if url.contains("azure.com") {
+        Some(ForgeName::Azure)
+    } else {
+        None
+    }
+}

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -293,6 +293,7 @@ fn main() {
                     open::show_in_finder,
                     forge::pr_templates,
                     forge::pr_template,
+                    forge::determine_forge_from_url,
                     but_api::settings::get_app_settings,
                     settings::update_onboarding_complete,
                     settings::update_telemetry,


### PR DESCRIPTION
## Overview

- Added backend logic to determine repository forge provider based on remote URL
- Integrated forge provider detection into API responses
- Updated frontend to consume forge provider from backend
- Improved type definitions and API interfaces