### PR TITLE
Add experimental option for codegen in workspace

### DIFF
--- a/apps/desktop/src/components/CodegenRow.svelte
+++ b/apps/desktop/src/components/CodegenRow.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { UI_STATE } from '$lib/state/uiState.svelte';
+	import { formatNumber } from '$lib/utils/number';
+	import { inject } from '@gitbutler/core/context';
+	import { Icon } from '@gitbutler/ui';
+	import { slide } from 'svelte/transition';
+	import type { ClaudeStatus } from '$lib/codegen/types';
+
+	type Props = {
+		projectId: string;
+		stackId: string | undefined;
+		branchName: string;
+		selected: boolean;
+		status: ClaudeStatus;
+		tokens: number;
+		cost: number;
+	};
+
+	const { stackId, branchName, selected, status, tokens, cost }: Props = $props();
+
+	const uiState = inject(UI_STATE);
+</script>
+
+{#if stackId}
+	{@const laneState = uiState.lane(stackId)}
+	<button
+		type="button"
+		class="codegen text-12"
+		onclick={() => {
+			laneState.selection.set({ branchName, codegen: true, previewOpen: true });
+		}}
+	>
+		{#if selected}
+			<div class="active" class:selected in:slide={{ axis: 'x', duration: 150 }}></div>
+		{/if}
+		<span class="description">
+			Codegen session
+
+			{#if !selected && status === 'running'}
+				<Icon name="spinner" />
+			{/if}
+		</span>
+		<span class="tokens">
+			{formatNumber(tokens, 0)}
+		</span>
+		<span class="p-right-12">
+			${formatNumber(cost, 2)}
+		</span>
+	</button>
+{/if}
+
+<style lang="postcss">
+	.codegen {
+		display: flex;
+		position: relative;
+		align-items: center;
+		width: 100%;
+		height: 32px;
+		gap: 8px;
+		border-top: 1px solid var(--clr-border-2);
+	}
+
+	.description {
+		flex-grow: 1;
+		margin-left: 12px;
+		text-align: left;
+	}
+	.selected {
+		position: absolute;
+		top: 50%;
+		left: 0;
+		width: 4px;
+		height: 45%;
+		transform: translateY(-50%);
+		border-radius: 0 var(--radius-ml) var(--radius-ml) 0;
+		background-color: var(--clr-selected-not-in-focus-element);
+		transition: transform var(--transition-fast);
+	}
+
+	.selected.active {
+		background-color: var(--clr-selected-in-focus-element);
+	}
+</style>

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -186,7 +186,7 @@
 					{projectId}
 					laneId={stack.id || 'banana'}
 					stackId={stack.id}
-					topBranch={stack.heads.at(0)?.name}
+					topBranchName={stack.heads.at(0)?.name}
 					bind:clientWidth={laneWidths[i]}
 					bind:clientHeight={lineHights[i]}
 					onVisible={(visible) => {

--- a/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
+++ b/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
@@ -6,15 +6,23 @@
 
 	type Props = {
 		branchName: string;
-		branchIcon: Snippet;
+		isWorkspace?: boolean;
+		branchIcon?: Snippet;
 		workspaceActions: Snippet;
-		contextActions: Snippet;
+		contextActions?: Snippet;
 		messages: Snippet;
-		input: Snippet;
+		input?: Snippet;
 	};
 
-	const { branchName, branchIcon, workspaceActions, contextActions, messages, input }: Props =
-		$props();
+	const {
+		branchName,
+		isWorkspace,
+		branchIcon,
+		workspaceActions,
+		contextActions,
+		messages,
+		input
+	}: Props = $props();
 
 	let scrollDistanceFromBottom = $state(0);
 	let bottomAnchor = $state<HTMLDivElement>();
@@ -37,20 +45,24 @@
 <div class="chat" use:focusable={{ vertical: true }}>
 	<div class="chat-header" use:focusable>
 		<div class="flex gap-10 justify-between overflow-hidden">
-			{@render branchIcon()}
+			{#if !isWorkspace}
+				{@render branchIcon?.()}
 
-			<div class="chat-header__title">
-				<h3 class="text-15 text-bold truncate">{branchName}</h3>
+				<div class="chat-header__title">
+					<h3 class="text-15 text-bold truncate">{branchName}</h3>
 
-				<div class="chat-header__title-actions">
-					{@render workspaceActions()}
+					<div class="chat-header__title-actions">
+						{@render workspaceActions()}
+					</div>
 				</div>
-			</div>
+			{/if}
 		</div>
 
-		<div class="flex gap-8 overflow-hidden">
-			{@render contextActions()}
-		</div>
+		{#if contextActions}
+			<div class="flex gap-8 overflow-hidden">
+				{@render contextActions()}
+			</div>
+		{/if}
 	</div>
 
 	<div class="chat-container">
@@ -71,7 +83,7 @@
 		{/if}
 	</div>
 
-	{@render input()}
+	{@render input?.()}
 </div>
 
 <style lang="postcss">
@@ -113,14 +125,17 @@
 		display: flex;
 		position: relative;
 		flex: 1;
+		flex-direction: column;
 		overflow: hidden;
 	}
 
 	.chat-messages {
 		display: flex;
+		flex-grow: 1;
 		flex-direction: column-reverse;
 		width: 100%;
-		padding: 0 20px;
+		height: 100%;
+		min-height: 10rem;
 		overflow-x: hidden;
 		overflow-y: scroll;
 		scrollbar-width: none; /* Firefox */

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -1,0 +1,686 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import BranchHeaderIcon from '$components/BranchHeaderIcon.svelte';
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import VirtualList from '$components/VirtualList.svelte';
+
+	import ClaudeCodeSettingsModal from '$components/codegen/ClaudeCodeSettingsModal.svelte';
+	import CodegenChatClaudeNotAvaliableBanner from '$components/codegen/CodegenChatClaudeNotAvaliableBanner.svelte';
+	import CodegenChatLayout from '$components/codegen/CodegenChatLayout.svelte';
+	import CodegenClaudeMessage from '$components/codegen/CodegenClaudeMessage.svelte';
+	import CodegenInput from '$components/codegen/CodegenInput.svelte';
+	import CodegenMcpConfigModal from '$components/codegen/CodegenMcpConfigModal.svelte';
+	import CodegenPromptConfigModal from '$components/codegen/CodegenPromptConfigModal.svelte';
+	import CodegenServiceMessageThinking from '$components/codegen/CodegenServiceMessageThinking.svelte';
+	import CodegenServiceMessageUseTool from '$components/codegen/CodegenServiceMessageUseTool.svelte';
+	import laneNewSvg from '$lib/assets/empty-state/lane-new.svg?raw';
+	import { CLAUDE_CODE_SERVICE } from '$lib/codegen/claude';
+	import { useSendMessage } from '$lib/codegen/messageQueue.svelte';
+	import {
+		currentStatus,
+		thinkingOrCompactingStartedAt,
+		userFeedbackStatus,
+		usageStats,
+		formatMessages
+	} from '$lib/codegen/messages';
+
+	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
+	import { vscodePath } from '$lib/project/project';
+	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
+	import { workspacePath } from '$lib/routes/routes.svelte';
+	import { RULES_SERVICE } from '$lib/rules/rulesService.svelte';
+	import { SETTINGS } from '$lib/settings/userSettings';
+	import { pushStatusToColor, pushStatusToIcon } from '$lib/stacks/stack';
+	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
+	import { combineResults } from '$lib/state/helpers';
+	import { UI_STATE } from '$lib/state/uiState.svelte';
+	import { getEditorUri, URL_SERVICE } from '$lib/utils/url';
+	import { inject } from '@gitbutler/core/context';
+	import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
+	import {
+		Badge,
+		Button,
+		chipToasts,
+		ContextMenu,
+		ContextMenuItem,
+		ContextMenuSection,
+		EmptyStatePlaceholder,
+		Modal
+	} from '@gitbutler/ui';
+
+	import { getColorFromBranchType } from '@gitbutler/ui/utils/getColorFromBranchType';
+	import type { ClaudeMessage, ThinkingLevel, ModelType, PermissionMode } from '$lib/codegen/types';
+
+	type Props = {
+		projectId: string;
+		branchName: string;
+		stackId: string;
+	};
+	const { projectId, stackId, branchName }: Props = $props();
+
+	const stableBranchName = $derived(branchName);
+
+	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
+	const stackService = inject(STACK_SERVICE);
+	const projectsService = inject(PROJECTS_SERVICE);
+	const rulesService = inject(RULES_SERVICE);
+	const uiState = inject(UI_STATE);
+	const urlService = inject(URL_SERVICE);
+	const userSettings = inject(SETTINGS);
+	const settingsService = inject(SETTINGS_SERVICE);
+	const claudeSettings = $derived($settingsService?.claude);
+
+	const stacks = $derived(stackService.stacks(projectId));
+	const claudeAvailable = $derived(claudeCodeService.checkAvailable(undefined));
+	const mcpConfigQuery = $derived(claudeCodeService.mcpConfig({ projectId }));
+
+	let settingsModal: ClaudeCodeSettingsModal | undefined;
+	let clearContextModal = $state<Modal>();
+	let modelContextMenu = $state<ContextMenu>();
+	let modelTrigger = $state<HTMLButtonElement>();
+	let thinkingModeContextMenu = $state<ContextMenu>();
+	let thinkingModeTrigger = $state<HTMLButtonElement>();
+	let permissionModeContextMenu = $state<ContextMenu>();
+	let permissionModeTrigger = $state<HTMLButtonElement>();
+	let templateContextMenu = $state<ContextMenu>();
+	let templateTrigger = $state<HTMLButtonElement>();
+	let mcpConfigModal = $state<CodegenMcpConfigModal>();
+	let promptConfigModal = $state<CodegenPromptConfigModal>();
+
+	const modelOptions: { label: string; value: ModelType }[] = [
+		{ label: 'Haiku', value: 'haiku' },
+		{ label: 'Sonnet', value: 'sonnet' },
+		{ label: 'Sonnet 1m', value: 'sonnet[1m]' },
+		{ label: 'Opus', value: 'opus' },
+		{ label: 'Opus Planning', value: 'opusplan' }
+	];
+
+	const thinkingLevels: { label: string; shortLabel: string; value: ThinkingLevel }[] = [
+		{ label: 'Normal', shortLabel: 'Normal', value: 'normal' },
+		{ label: 'Think', shortLabel: 'Think', value: 'think' },
+		{ label: 'Mega think', shortLabel: 'Mega', value: 'megaThink' },
+		{ label: 'Ultra think', shortLabel: 'Ultra', value: 'ultraThink' }
+	];
+
+	const permissionModeOptions: { label: string; value: PermissionMode }[] = [
+		{ label: 'Edit with permission', value: 'default' },
+		{ label: 'Planning', value: 'plan' },
+		{ label: 'Accept edits', value: 'acceptEdits' }
+	];
+
+	const promptTemplates = $derived(claudeCodeService.promptTemplates(projectId));
+	const promptDirs = $derived(claudeCodeService.promptDirs(projectId));
+
+	async function openPromptConfigDir(path: string) {
+		await claudeCodeService.createPromptDir({ projectId, path });
+
+		const editorUri = getEditorUri({
+			schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+			path: [path]
+		});
+
+		urlService.openExternalUrl(editorUri);
+	}
+
+	const projectState = uiState.project(projectId);
+	const selectedThinkingLevel = $derived(projectState.thinkingLevel.current);
+	const selectedModel = $derived(projectState.selectedModel.current);
+	const selectedPermissionMode = $derived(uiState.lane(stackId).permissionMode.current);
+
+	$effect(() => {
+		if (stacks.response) {
+			// Make sure the current selection is valid
+			const branchFound = stacks.response.some(
+				(s) => s.id === stackId && s.heads.some((h) => h.name === stableBranchName)
+			);
+			if (!branchFound) {
+				selectFirstBranch();
+			}
+		}
+	});
+
+	function selectFirstBranch() {
+		if (!stacks.response) return;
+
+		const firstStack = stacks.response[0];
+		const firstHead = firstStack?.heads[0];
+		if (firstHead && firstStack.id) {
+			projectState.selectedClaudeSession.set({
+				stackId: firstStack.id,
+				head: firstHead.name
+			});
+		} else {
+			projectState.selectedClaudeSession.set(undefined);
+		}
+	}
+
+	async function onApproval(id: string) {
+		await claudeCodeService.updatePermissionRequest({ projectId, requestId: id, approval: true });
+	}
+	async function onRejection(id: string) {
+		await claudeCodeService.updatePermissionRequest({ projectId, requestId: id, approval: false });
+	}
+	async function onAbort() {
+		await claudeCodeService.cancelSession({ projectId, stackId });
+	}
+
+	function selectModel(model: ModelType) {
+		projectState.selectedModel.set(model);
+		modelContextMenu?.close();
+	}
+
+	function selectThinkingLevel(level: ThinkingLevel) {
+		projectState.thinkingLevel.set(level);
+		thinkingModeContextMenu?.close();
+	}
+
+	function selectPermissionMode(mode: PermissionMode) {
+		uiState.lane(stackId).permissionMode.set(mode);
+		permissionModeContextMenu?.close();
+	}
+
+	function getPermissionModeIcon(
+		mode: PermissionMode
+	): 'edit-with-permissions' | 'checklist' | 'allow-all' {
+		switch (mode) {
+			case 'default':
+				return 'edit-with-permissions';
+			case 'plan':
+				return 'checklist';
+			case 'acceptEdits':
+				return 'allow-all';
+			default:
+				return 'edit-with-permissions';
+		}
+	}
+
+	function thinkingLevelToUiLabel(level: ThinkingLevel, short: boolean = false): string {
+		const thinkingLevel = thinkingLevels.find((t) => t.value === level);
+		if (!thinkingLevel) return 'Normal';
+		return short ? thinkingLevel.shortLabel : thinkingLevel.label;
+	}
+
+	const { prompt, setPrompt, sendMessage } = useSendMessage({
+		projectId: reactive(() => projectId),
+		selectedBranch: reactive(() => ({ stackId, head: stableBranchName })),
+		thinkingLevel: reactive(() => selectedThinkingLevel),
+		model: reactive(() => selectedModel),
+		permissionMode: reactive(() => selectedPermissionMode)
+	});
+
+	function insertTemplate(template: string) {
+		setPrompt(prompt + (prompt ? '\n\n' : '') + template);
+		templateContextMenu?.close();
+	}
+
+	function showInWorkspace() {
+		goto(`${workspacePath(projectId)}?stackId=${stackId}`);
+	}
+
+	async function openInEditor() {
+		const project = await projectsService.fetchProject(projectId);
+		if (!project) {
+			chipToasts.error('Project not found');
+			return;
+		}
+		urlService.openExternalUrl(
+			getEditorUri({
+				schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+				path: [vscodePath(project.path)],
+				searchParams: { windowId: '_blank' }
+			})
+		);
+	}
+
+	function getCurrentSessionId(events: ClaudeMessage[]): string | undefined {
+		// Get the most recent session ID from the messages
+		if (events.length === 0) return undefined;
+		const lastEvent = events[events.length - 1];
+		return lastEvent?.sessionId;
+	}
+
+	function clearContextAndRules() {
+		clearContextModal?.show();
+	}
+
+	let clearLoading = $state(false);
+	let compactLoading = $state(false);
+
+	async function compactContext() {
+		compactLoading = true;
+		try {
+			await claudeCodeService.compactHistory({
+				projectId,
+				stackId
+			});
+		} finally {
+			compactLoading = false;
+		}
+	}
+
+	async function performClearContextAndRules() {
+		clearLoading = true;
+
+		try {
+			const events = await claudeCodeService.fetchMessages({
+				projectId,
+				stackId
+			});
+			const sessionId = getCurrentSessionId(events);
+			if (!sessionId) return;
+
+			const rules = await rulesService.fetchListWorkspaceRules(projectId);
+
+			const toDelete = rules.filter((rule) =>
+				rule.filters.some(
+					(filter) => filter.type === 'claudeCodeSessionId' && filter.subject === sessionId
+				)
+			);
+
+			for (const rule of toDelete) {
+				await rulesService.deleteWorkspaceRuleMutate({
+					projectId,
+					id: rule.id
+				});
+			}
+		} finally {
+			clearLoading = false;
+		}
+	}
+
+	const isStackActiveQuery = $derived(claudeCodeService.isStackActive(projectId, stackId));
+	const isStackActive = $derived(isStackActiveQuery?.response || false);
+
+	// Check if there are rules to delete for the current session
+	const rules = $derived(rulesService.workspaceRules(projectId));
+	const hasRulesToClear = $derived(() => {
+		if (!events.response || !rules.response) return false;
+
+		const sessionId = getCurrentSessionId(events.response);
+		if (!sessionId) return false;
+
+		return rules.response.some((rule) =>
+			rule.filters.some(
+				(filter) => filter.type === 'claudeCodeSessionId' && filter.subject === sessionId
+			)
+		);
+	});
+
+	const events = $derived(claudeCodeService.messages({ projectId, stackId }));
+	const permissionRequests = $derived(claudeCodeService.permissionRequests({ projectId }));
+	const selectedBranchDetails = $derived(
+		stackService.branchDetails(projectId, stackId, stableBranchName)
+	);
+</script>
+
+<ReduxResult
+	result={combineResults(
+		events?.result,
+		permissionRequests.result,
+		selectedBranchDetails.result,
+		mcpConfigQuery.result
+	)}
+	{projectId}
+>
+	{#snippet children(
+		[events, permissionRequests, branchDetailsData, mcpConfig],
+		{ projectId: _projectId }
+	)}
+		{@const formattedMessages = formatMessages(events, permissionRequests, isStackActive)}
+		{@const iconName = pushStatusToIcon(branchDetailsData.pushStatus)}
+		{@const lineColor = getColorFromBranchType(pushStatusToColor(branchDetailsData.pushStatus))}
+		{@const enabledMcpServers = mcpConfig
+			? Object.keys(mcpConfig.mcpServers).length -
+				uiState.lane(stackId).disabledMcpServers.current.length
+			: 0}
+		<CodegenChatLayout branchName={stableBranchName} isWorkspace>
+			{#snippet branchIcon()}
+				<BranchHeaderIcon {iconName} color={lineColor} large />
+			{/snippet}
+			{#snippet workspaceActions()}
+				<Button
+					icon="workbench-small"
+					kind="outline"
+					size="tag"
+					reversedDirection
+					onclick={showInWorkspace}>Show in workspace</Button
+				>
+				<Button
+					icon="open-editor-small"
+					kind="outline"
+					size="tag"
+					tooltip="Open in {$userSettings.defaultCodeEditor.displayName}"
+					onclick={openInEditor}
+					reversedDirection
+				/>
+			{/snippet}
+			{#snippet contextActions()}
+				{@const stats = usageStats(events)}
+
+				<Button kind="outline" icon="mcp" reversedDirection onclick={() => mcpConfigModal?.open()}
+					>MCP
+
+					{#snippet badge()}
+						<Badge kind="soft">{enabledMcpServers}</Badge>
+					{/snippet}
+				</Button>
+
+				<div class="flex gap-4 overflow-hidden">
+					<div
+						class="text-11 context-utilization-badge"
+						style="--context-utilization: {stats.contextUtilization}"
+					>
+						<span class="truncate">
+							{(stats.contextUtilization * 100).toFixed(0)}% context used
+						</span>
+					</div>
+
+					<div class="flex">
+						<Button
+							icon="clear"
+							kind="outline"
+							tooltip="Clear context and associated rules"
+							disabled={!hasRulesToClear ||
+								formattedMessages.length === 0 ||
+								['running', 'compacting'].includes(currentStatus(events, isStackActive))}
+							loading={clearLoading}
+							customStyle="border-top-right-radius: 0; border-bottom-right-radius: 0;"
+							onclick={() => clearContextAndRules()}
+						/>
+						<Button
+							icon="compact"
+							kind="outline"
+							tooltip="Compact context"
+							customStyle="border-top-left-radius: 0; border-bottom-left-radius: 0; border-left: none;"
+							disabled={!hasRulesToClear ||
+								formattedMessages.length === 0 ||
+								['running', 'compacting'].includes(currentStatus(events, isStackActive))}
+							loading={compactLoading}
+							onclick={() => compactContext()}
+						/>
+					</div>
+				</div>
+			{/snippet}
+			{#snippet messages()}
+				{@const thinkingStatus = currentStatus(events, isStackActive)}
+				{@const startAt = thinkingOrCompactingStartedAt(events)}
+				{#if ['running', 'compacting'].includes(thinkingStatus) && startAt}
+					{@const status = userFeedbackStatus(formattedMessages)}
+					{#if status.waitingForFeedback}
+						<div class="p-left-20 p-right-20">
+							<CodegenServiceMessageUseTool toolCall={status.toolCall} />
+						</div>
+					{:else}
+						<div class="p-left-20 p-right-20">
+							<CodegenServiceMessageThinking
+								{startAt}
+								msSpentWaiting={status.msSpentWaiting}
+								overrideWord={thinkingStatus === 'compacting' ? 'compacting' : undefined}
+							/>
+						</div>
+					{/if}
+				{/if}
+
+				{#if formattedMessages.length === 0}
+					<div class="chat-view__placeholder">
+						<EmptyStatePlaceholder
+							image={laneNewSvg}
+							width={320}
+							topBottomPadding={0}
+							bottomMargin={0}
+						>
+							{#snippet title()}
+								Let's build something amazing
+							{/snippet}
+							{#snippet caption()}
+								Your branch is ready for AI-powered development. Describe what you'd like to build,
+								and I'll generate the code to get you started.
+							{/snippet}
+						</EmptyStatePlaceholder>
+					</div>
+				{:else}
+					<VirtualList
+						grow
+						stickToBottom
+						initialPosition="bottom"
+						items={formattedMessages}
+						batchSize={1}
+						start={0}
+						padding={{ left: 20, right: 20 }}
+					>
+						{#snippet chunkTemplate(messages)}
+							{#each messages as message}
+								<CodegenClaudeMessage {message} {onApproval} {onRejection} />
+							{/each}
+						{/snippet}
+					</VirtualList>
+				{/if}
+			{/snippet}
+
+			{#snippet input()}
+				{#if claudeAvailable.response?.status === 'available'}
+					{@const status = currentStatus(events, isStackActive)}
+					<CodegenInput
+						value={prompt.current}
+						onChange={(prompt) => setPrompt(prompt)}
+						loading={['running', 'compacting'].includes(status)}
+						compacting={status === 'compacting'}
+						{projectId}
+						selectedBranch={{ stackId, head: stableBranchName }}
+						onsubmit={sendMessage}
+						{onAbort}
+						sessionKey={`${stackId}-${stableBranchName}`}
+					>
+						{#snippet actionsOnLeft()}
+							{@const permissionModeLabel = permissionModeOptions.find(
+								(a) => a.value === selectedPermissionMode
+							)?.label}
+							<div class="flex m-right-4 gap-2">
+								<Button disabled kind="ghost" icon="attachment" reversedDirection />
+								<Button
+									bind:el={templateTrigger}
+									kind="ghost"
+									icon="script"
+									tooltip="Insert template"
+									onclick={(e) => templateContextMenu?.toggle(e)}
+								/>
+								<Button
+									bind:el={thinkingModeTrigger}
+									kind="ghost"
+									icon="thinking"
+									reversedDirection
+									onclick={() => thinkingModeContextMenu?.toggle()}
+									tooltip="Thinking mode"
+									children={selectedThinkingLevel === 'normal' ? undefined : thinkingBtnText}
+								/>
+								<Button
+									bind:el={permissionModeTrigger}
+									kind="ghost"
+									icon={getPermissionModeIcon(selectedPermissionMode)}
+									shrinkable
+									onclick={() => permissionModeContextMenu?.toggle()}
+									tooltip={$settingsService?.claude.dangerouslyAllowAllPermissions
+										? 'Permission modes disable when all permissions are allowed'
+										: permissionModeLabel}
+									disabled={$settingsService?.claude.dangerouslyAllowAllPermissions}
+								/>
+							</div>
+						{/snippet}
+
+						{#snippet actionsOnRight()}
+							{#if !claudeSettings?.useConfiguredModel}
+								<Button
+									bind:el={modelTrigger}
+									kind="ghost"
+									icon="chevron-down"
+									shrinkable
+									onclick={() => modelContextMenu?.toggle()}
+								>
+									{modelOptions.find((a) => a.value === selectedModel)?.label}
+								</Button>
+							{/if}
+						{/snippet}
+					</CodegenInput>
+				{:else}
+					<CodegenChatClaudeNotAvaliableBanner onSettingsBtnClick={() => settingsModal?.show()} />
+				{/if}
+			{/snippet}
+		</CodegenChatLayout>
+	{/snippet}
+</ReduxResult>
+
+<ReduxResult result={mcpConfigQuery.result} {projectId} {stackId}>
+	{#snippet children(mcpConfig, { stackId })}
+		{@const laneState = uiState.lane(stackId)}
+		<CodegenMcpConfigModal
+			bind:this={mcpConfigModal}
+			{mcpConfig}
+			disabledServers={laneState.disabledMcpServers.current}
+			toggleServer={(server) => {
+				const disabledServers = laneState.disabledMcpServers.current;
+				if (disabledServers.includes(server)) {
+					laneState.disabledMcpServers.set(disabledServers.filter((s) => s !== server));
+				} else {
+					laneState.disabledMcpServers.set([...disabledServers, server]);
+				}
+			}}
+		/>
+	{/snippet}
+</ReduxResult>
+
+{#snippet thinkingBtnText()}
+	{thinkingLevelToUiLabel(selectedThinkingLevel, true)}
+{/snippet}
+
+<Modal
+	bind:this={clearContextModal}
+	width="small"
+	type="warning"
+	title="Clear context"
+	onSubmit={async (close) => {
+		await performClearContextAndRules();
+		close();
+	}}
+>
+	Are you sure you want to clear the context and delete all rules associated with this Claude
+	session? This action cannot be undone.
+
+	{#snippet controls(close)}
+		<Button kind="outline" onclick={close}>Cancel</Button>
+		<Button style="error" type="submit">Clear context</Button>
+	{/snippet}
+</Modal>
+
+<ContextMenu bind:this={modelContextMenu} leftClickTrigger={modelTrigger} side="top" align="end">
+	<ContextMenuSection>
+		{#each modelOptions as option}
+			<ContextMenuItem
+				label={option.label}
+				selected={selectedModel === option.value}
+				onclick={() => selectModel(option.value)}
+			/>
+		{/each}
+	</ContextMenuSection>
+</ContextMenu>
+
+<ContextMenu
+	bind:this={thinkingModeContextMenu}
+	leftClickTrigger={thinkingModeTrigger}
+	align="start"
+	side="top"
+>
+	<ContextMenuSection>
+		{#each thinkingLevels as level}
+			<ContextMenuItem
+				label={level.label}
+				selected={selectedThinkingLevel === level.value}
+				onclick={() => selectThinkingLevel(level.value)}
+			/>
+		{/each}
+	</ContextMenuSection>
+</ContextMenu>
+
+<ContextMenu
+	bind:this={permissionModeContextMenu}
+	leftClickTrigger={permissionModeTrigger}
+	align="start"
+	side="top"
+>
+	<ContextMenuSection>
+		{#each permissionModeOptions as option}
+			<ContextMenuItem
+				label={option.label}
+				selected={selectedPermissionMode === option.value}
+				onclick={() => selectPermissionMode(option.value)}
+			/>
+		{/each}
+	</ContextMenuSection>
+</ContextMenu>
+
+<ContextMenu
+	bind:this={templateContextMenu}
+	leftClickTrigger={templateTrigger}
+	side="top"
+	align="start"
+>
+	<ContextMenuSection>
+		<ReduxResult result={promptTemplates.result} {projectId}>
+			{#snippet children(promptTemplates, { projectId: _projectId })}
+				{#each promptTemplates as template}
+					<ContextMenuItem
+						label={template.label}
+						onclick={() => insertTemplate(template.template)}
+					/>
+				{/each}
+			{/snippet}
+		</ReduxResult>
+	</ContextMenuSection>
+	<ContextMenuSection>
+		<ContextMenuItem
+			label="Edit templates"
+			icon="open-editor"
+			onclick={() => promptConfigModal?.show()}
+		/>
+	</ContextMenuSection>
+</ContextMenu>
+
+{#if promptDirs.response}
+	<CodegenPromptConfigModal
+		bind:this={promptConfigModal}
+		promptDirs={promptDirs.response}
+		{openPromptConfigDir}
+	/>
+{/if}
+
+<style lang="postcss">
+	.chat-view__placeholder {
+		display: flex;
+		flex: 1;
+		align-items: center;
+		justify-content: center;
+		padding: 0 32px;
+	}
+
+	.context-utilization-badge {
+		display: flex;
+		position: relative;
+		align-items: center;
+		justify-content: center;
+		height: var(--size-button);
+		padding: 0 8px;
+		overflow: hidden;
+		border-radius: var(--radius-m);
+		background-color: var(--clr-theme-ntrl-soft);
+		color: var(--clr-text-2);
+
+		&::after {
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			width: calc(var(--context-utilization) * 100%);
+			height: 3px;
+			background: var(--clr-text-3);
+			content: '';
+		}
+	}
+</style>

--- a/apps/desktop/src/components/codegen/CodegenSidebarEntry.svelte
+++ b/apps/desktop/src/components/codegen/CodegenSidebarEntry.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { formatNumber } from '$lib/utils/number';
 	import { Badge, Icon, TimeAgo, Tooltip, InfoButton } from '@gitbutler/ui';
 	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { slide, fade } from 'svelte/transition';
@@ -36,16 +37,6 @@
 	}: Props = $props();
 
 	let isOpen = $state(false);
-
-	function formatNumber(n: number, fractionDigits = 0) {
-		const options: Intl.NumberFormatOptions = {
-			maximumFractionDigits: fractionDigits,
-			minimumFractionDigits: fractionDigits
-		};
-
-		// Use the user's locale (undefined) so thousands separator will match their locale.
-		return new Intl.NumberFormat(undefined, options).format(n);
-	}
 </script>
 
 <div class="codegen-entry-wrapper" use:focusable={{ focusable: true, onAction: () => onclick?.() }}>

--- a/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
@@ -10,7 +10,7 @@
 	const { toolCalls }: Props = $props();
 
 	// If only one tool call, always expanded
-	let expanded = $state(toolCalls.length === 1);
+	let expanded = $derived(toolCalls.length === 1);
 	const toolDisplayLimit = 3;
 
 	const toolsToDisplay = $derived.by(() => {

--- a/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
-	import { ircEnabled, ircServer, codegenEnabled, fModeEnabled } from '$lib/config/uiFeatureFlags';
+	import {
+		ircEnabled,
+		ircServer,
+		codegenEnabled,
+		newCodegenEnabled,
+		fModeEnabled
+	} from '$lib/config/uiFeatureFlags';
 	import { USER } from '$lib/user/user';
 	import { inject } from '@gitbutler/core/context';
 	import { SectionCard, Spacer, Textbox, Toggle } from '@gitbutler/ui';
@@ -80,6 +86,21 @@
 				id="codegen"
 				checked={$codegenEnabled}
 				onclick={() => ($codegenEnabled = !$codegenEnabled)}
+			/>
+		{/snippet}
+	</SectionCard>
+	<SectionCard labelFor="new-codegen" roundedTop={false} roundedBottom={false} orientation="row">
+		{#snippet title()}
+			Codegen (workspace)
+		{/snippet}
+		{#snippet caption()}
+			Use Claude Code from the workspace.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="new-codegen"
+				checked={$newCodegenEnabled}
+				onclick={() => ($newCodegenEnabled = !$newCodegenEnabled)}
 			/>
 		{/snippet}
 	</SectionCard>

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -12,6 +12,7 @@ export const ircServer = persistWithExpiration('', 'feature-irc-server', 1440 * 
 export const rewrapCommitMessage = persistWithExpiration(true, 'rewrap-commit-msg', 1440 * 30);
 // V2 to make sure it's going to set everyone's to true untill the turn it to false again.
 export const codegenEnabled = persisted(true, 'feature-codegen-v2');
+export const newCodegenEnabled = persisted(false, 'feature-new-codegen');
 export type StagingBehavior = 'all' | 'selection' | 'none';
 export const stagingBehaviorFeature = persisted<StagingBehavior>('all', 'feature-staging-behavior');
 export const fModeEnabled = persisted(true, 'f-mode');

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -16,10 +16,11 @@ import type { StackDetails } from '$lib/stacks/stack';
 import type { RejectionReason } from '$lib/stacks/stackService.svelte';
 
 export type StackSelection = {
-	branchName: string;
+	branchName?: string;
 	commitId?: string;
 	upstream?: boolean;
 	previewOpen: boolean;
+	codegen?: boolean;
 };
 
 export type NewCommitMessage = {
@@ -382,7 +383,7 @@ function updateStackSelection(uiState: UiState, stackId: string, details: StackD
 	if (!selection) return;
 
 	// Clear selection if the selected branch is not in the list of branches
-	if (!branches.includes(selection.branchName)) {
+	if (selection.branchName && !branches.includes(selection.branchName)) {
 		laneState.selection.set(undefined);
 		return;
 	}

--- a/apps/desktop/src/lib/utils/number.ts
+++ b/apps/desktop/src/lib/utils/number.ts
@@ -1,0 +1,9 @@
+export function formatNumber(n: number, fractionDigits = 0) {
+	const options: Intl.NumberFormatOptions = {
+		maximumFractionDigits: fractionDigits,
+		minimumFractionDigits: fractionDigits
+	};
+
+	// Use the user's locale (undefined) so thousands separator will match their locale.
+	return new Intl.NumberFormat(undefined, options).format(n);
+}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -254,7 +254,9 @@
 
 	// Auto-fetch setup
 	async function fetchRemoteForProject() {
-		await baseBranchService.fetchFromRemotes(projectId, 'auto');
+		if (baseBranch?.lastFetchedMs && Date.now() - baseBranch.lastFetchedMs > 30 * 60 * 1000) {
+			await baseBranchService.fetchFromRemotes(projectId, 'auto');
+		}
 	}
 
 	function setupFetchInterval() {
@@ -262,7 +264,7 @@
 		if (autoFetchIntervalMinutes < 0) {
 			return;
 		}
-		fetchRemoteForProject();
+		// fetchRemoteForProject();
 		clearFetchInterval();
 		const intervalMs = autoFetchIntervalMinutes * 60 * 1000;
 		intervalId = setInterval(async () => {

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -124,7 +124,7 @@
 			<Icon name="draggable" />
 		</div>
 	{/if}
-	<ScrollableContainer horz whenToShow="always" padding={{ left: numberHeaderWidth }}>
+	<ScrollableContainer horz whenToShow="always">
 		<table class="table__section">
 			<thead class="table__title" class:draggable={!draggingDisabled}>
 				<tr>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -122,11 +122,12 @@
 		scrollTo({ top: 0, behavior: 'smooth' });
 	}
 
-	export function scrollToBottom() {
+	export function scrollToBottom(immediate?: boolean) {
 		if (viewport) {
+			viewport.scrollTop = viewport.scrollHeight - viewport.offsetHeight;
 			scrollTo({
 				top: viewport.scrollHeight,
-				behavior: 'smooth'
+				behavior: immediate ? undefined : 'smooth'
 			});
 		}
 	}
@@ -136,13 +137,16 @@
 	<div
 		bind:this={viewport}
 		bind:offsetHeight={viewportHeight}
+		style:flex-grow={wide ? 1 : 0}
 		onscroll={handleScroll}
 		class="viewport hide-native-scrollbar"
-		style="padding-top: {top}px; padding-bottom: {bottom}px; --overflow-x: {horz
-			? 'auto'
-			: 'hidden'}; --overflow-y: {horz ? 'hidden' : 'auto'}; --flex-direction: {horz
-			? 'row'
-			: 'column'};"
+		style:padding-top={top + 'px'}
+		style:padding-bottom={bottom + 'px'}
+		style:padding-left={padding?.left ? padding.left + 'px' : undefined}
+		style:padding-right={padding?.right ? padding.right + 'px' : undefined}
+		style:--overflow-x={horz ? 'auto' : 'hidden'}
+		style:--overflow-y={horz ? 'hidden' : 'auto'}
+		style:--flex-direction={horz ? 'row' : 'column'}
 	>
 		<div style:min-height={childrenWrapHeight} style:display={childrenWrapDisplay}>
 			{@render children()}


### PR DESCRIPTION
Add a new feature flag and UI for the new codegen experience. Introduces CodegenMessages chat component (682 lines), CodegenRow for branch list usage display, and integrates codegen sessions into StackView/BranchList with per-branch token/cost tracking.