### PR TITLE
Show only first commit-message line in status output

### DIFF
--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -382,7 +382,9 @@ fn print_commit(
     };
 
     let mut message = message
-        .replace('\n', " ")
+        .lines()
+        .next()
+        .unwrap_or("")
         .chars()
         .take(50)
         .collect::<String>()


### PR DESCRIPTION
Only display the first line of the commit message in status output to 
avoid showing multi-line content such as the Change-Id or full review 
URL. 

Previously the code replaced newlines with spaces and then 
truncated, which could include unwanted trailing metadata; now it takes 
just the first line, then truncates to 50 characters to ensure concise, 
single-line status display.