### PR TITLE
v3 apply: remote handling

### DIFF
--- a/crates/but-core/src/settings.rs
+++ b/crates/but-core/src/settings.rs
@@ -1,6 +1,6 @@
 /// A module to bundle configuration we *write* per repository, but read as normal.
 pub mod git {
-    use std::{borrow::Cow, ffi::OsString, io::Write, path::Path};
+    use std::{borrow::Cow, ffi::OsString};
 
     use anyhow::Result;
     use bstr::{BString, ByteSlice};
@@ -106,6 +106,7 @@ pub mod git {
             pub gpg_ssh_program: Option<OsString>,
         }
     }
+    use crate::RepositoryExt;
     use types::GitConfigSettings;
 
     impl GitConfigSettings {
@@ -134,11 +135,7 @@ pub mod git {
         pub fn persist_to_local_config(&self, repo: &gix::Repository) -> Result<()> {
             // TODO: make this easier in `gix`. Could use config-snapshot-mut, but there is no way to
             //       auto-reload it/assure it's uptodate.
-            let local_config_path = repo.path().join("config");
-            let mut config = gix::config::File::from_path_no_includes(
-                local_config_path.clone(),
-                gix::config::Source::Local,
-            )?;
+            let mut config = repo.local_common_config_for_editing()?;
             if let Some(sign_commits) = self.gitbutler_sign_commits {
                 config.set_raw_value(
                     &GITBUTLER_SIGN_COMMITS,
@@ -162,29 +159,9 @@ pub mod git {
                 config.set_raw_value(&GPG_SSH_PROGRAM, gpg_ssh_program.as_bstr())?;
             }
 
-            write_config(&mut config, &local_config_path)?;
+            repo.write_local_common_config(&config)?;
             Ok(())
         }
-    }
-
-    fn write_config(config: &mut gix::config::File<'_>, local_config_path: &Path) -> Result<()> {
-        // Note: we don't use a lock file here to not risk changing the mode, and it's what Git does.
-        //       But we lock the file so there is no raciness.
-        let _lock = gix::lock::Marker::acquire_to_hold_resource(
-            local_config_path,
-            gix::lock::acquire::Fail::Immediately,
-            None,
-        )?;
-        let mut config_file = std::io::BufWriter::new(
-            std::fs::File::options()
-                .write(true)
-                .truncate(true)
-                .create(false)
-                .open(local_config_path)?,
-        );
-        config.write_to(&mut config_file)?;
-        config_file.flush()?;
-        Ok(())
     }
 
     fn osstring_into_bstring(s: &OsString) -> Option<BString> {

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, bail};
 use bstr::ByteSlice;
-use but_core::{RefMetadata, ref_metadata};
+use but_core::{RefMetadata, extract_remote_name, ref_metadata};
 use gix::{
     hashtable::hash_map::Entry,
     prelude::{ObjectIdExt, ReferenceExt},
@@ -320,7 +320,7 @@ impl Graph {
                     data.target_ref
                         .as_ref()
                         .and_then(|target| {
-                            remotes::extract_remote_name(target.as_ref(), &remote_names)
+                            extract_remote_name(target.as_ref(), &remote_names)
                                 .map(|remote| (1, remote))
                         })
                         .into_iter()
@@ -329,7 +329,7 @@ impl Graph {
                 .chain(workspaces.iter().flat_map(|(_, _, data)| {
                     data.stacks.iter().flat_map(|s| {
                         s.branches.iter().flat_map(|b| {
-                            remotes::extract_remote_name(b.ref_name.as_ref(), &remote_names)
+                            extract_remote_name(b.ref_name.as_ref(), &remote_names)
                                 .map(|remote| (1, remote))
                         })
                     })

--- a/crates/but-graph/src/init/remotes.rs
+++ b/crates/but-graph/src/init/remotes.rs
@@ -60,25 +60,6 @@ pub fn lookup_remote_tracking_branch_or_deduce_it(
     }))
 }
 
-pub fn extract_remote_name(
-    ref_name: &gix::refs::FullNameRef,
-    remotes: &gix::remote::Names<'_>,
-) -> Option<String> {
-    let (category, shorthand_name) = ref_name.category_and_short_name()?;
-    if !matches!(category, Category::RemoteBranch) {
-        return None;
-    }
-
-    let longest_remote = remotes
-        .iter()
-        .rfind(|reference_name| shorthand_name.starts_with(reference_name))
-        .ok_or(anyhow::anyhow!(
-            "Failed to find remote branch's corresponding remote"
-        ))
-        .ok()?;
-    Some(longest_remote.to_string())
-}
-
 pub fn lookup_remote_tracking_branch(
     repo: &OverlayRepo<'_>,
     ref_name: &gix::refs::FullNameRef,

--- a/crates/but-workspace/tests/fixtures/scenario/main-with-advanced-remote.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/main-with-advanced-remote.sh
@@ -9,3 +9,8 @@ commit M1
 commit only-on-remote
 setup_target_to_match_main
 git reset --hard @~1
+
+git checkout -b soon-tracking-of-feature
+  commit without-local-tracking
+git checkout main
+turn_into_remote_branch soon-tracking-of-feature feature

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -153,7 +153,7 @@ impl BranchManager<'_> {
             let ws = graph.to_workspace()?;
             let target = target.to_string();
             let branch_to_apply = target.as_str().try_into()?;
-            let out = but_workspace::branch::apply(
+            let mut out = but_workspace::branch::apply(
                 branch_to_apply,
                 &ws,
                 &repo,
@@ -169,7 +169,7 @@ impl BranchManager<'_> {
             )?;
             let ws = out.graph.to_workspace()?;
             let applied_branch_stack_id = ws
-                .find_segment_and_stack_by_refname(branch_to_apply)
+                .find_segment_and_stack_by_refname(out.applied_branches.pop().context("BUG: must mention the actually applied branch last")?.as_ref())
                 .with_context(||
                     format!("BUG: Can't find the branch to apply in workspace, but the 'apply' function should have failed instead \n{out:?}")
                 )?


### PR DESCRIPTION
Get a minimal viable version of `unapply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10672.

### Fixes

* [x] local tracking branches are created on demand and are wired correctly
    - [x] more real-world testing
* [ ] ⚠️ tips could be conflicted, deal with it when merging

### Tasks
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace.

### Next PR?

* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [x] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [x] don't apply the target branch!
- [x] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.


### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.




