### PR TITLE
fix: Integration detection

### DIFF
--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -272,8 +272,6 @@ fn get_stack_status(
     stack_id: Option<StackId>,
     ctx: &CommandContext,
 ) -> Result<StackStatus> {
-    let mut unintegrated_branch_found = false;
-
     let mut last_head: git2::Oid = gix_to_git2_oid(new_target_commit_id);
 
     let mut branch_statuses: Vec<NameAndStatus> = vec![];
@@ -293,24 +291,18 @@ fn get_stack_status(
             continue;
         };
 
-        // If an integrated branch has been found, there is no need to bother
-        // with subsequent branches.
-        if !unintegrated_branch_found
-            && matches!(
-                branch_head.state,
-                but_workspace::ui::CommitState::Integrated
-            )
-        {
+        // Check if the branch in question has already been integrated
+        if matches!(
+            branch_head.state,
+            but_workspace::ui::CommitState::Integrated
+        ) {
             branch_statuses.push(NameAndStatus {
                 name: branch.name.to_string(),
                 status: BranchStatus::Integrated,
             });
 
             continue;
-        } else {
-            unintegrated_branch_found = true;
         }
-
         // Rebase the commits and see if any conflict
         // Rebasing is preferable to merging, as not everything that is
         // mergable is rebasable.

--- a/e2e/playwright/scripts/move-branch.sh
+++ b/e2e/playwright/scripts/move-branch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+echo "BRANCH DESTINATION: $1"
+echo "BRANCH TO MOVE: $2"
+echo "DIRECTORY: $3"
+
+# Apply remote branch to the workspace.
+pushd "$3"
+  $BUT_TESTING -j move-branch $1 $2
+popd

--- a/e2e/playwright/scripts/project-with-remote-branches.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches.sh
@@ -33,6 +33,15 @@ git commit -am "branch2: second commit"
 git checkout master
 popd
 
+# Create branch3
+pushd remote-project
+git checkout -b branch3
+echo "branch3 commit 1" >> b_file
+git add b_file
+git commit -am "branch3: first commit"
+git checkout master
+popd
+
 # Clone the remote into a folder and add the project to the application.
 git clone remote-project local-clone
 pushd local-clone

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -41,7 +41,7 @@ test('should be able to apply a remote branch', async ({ page, context }, testIn
 	await expect(header).toContainText('origin/master');
 
 	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
+	await expect(branchListCards).toHaveCount(3);
 
 	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
 	await expect(firstBranchCard).toBeVisible();
@@ -88,7 +88,7 @@ test('should be able to apply a remote branch and integrate the remote changes -
 	await expect(header).toContainText('origin/master');
 
 	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
+	await expect(branchListCards).toHaveCount(3);
 
 	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
 	await expect(firstBranchCard).toBeVisible();
@@ -345,7 +345,7 @@ test('should be able gracefully handle adding a branch that is ahead of our targ
 	await expect(header).toContainText('origin/master');
 
 	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
+	await expect(branchListCards).toHaveCount(3);
 
 	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
 	await expect(firstBranchCard).toBeVisible();
@@ -399,7 +399,7 @@ test('should be able gracefully handle adding a branch that is behind of our tar
 	await expect(header).toContainText('origin/master');
 
 	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
+	await expect(branchListCards).toHaveCount(3);
 
 	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
 	await expect(firstBranchCard).toBeVisible();

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -34,7 +34,7 @@ test('should be able to amend a file to a commit', async ({ page, context }, tes
 	await expect(header).toContainText('origin/master');
 
 	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
+	await expect(branchListCards).toHaveCount(3);
 
 	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
 	await expect(firstBranchCard).toBeVisible();

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -79,6 +79,56 @@ test('should handle the update of workspace with integrated branch gracefully', 
 	await waitForTestIdToNotExist(page, 'stack');
 });
 
+test('should handle the update of workspace with integrated parent branch in stack gracefully', async ({
+	page,
+	context
+}, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+	// Apply branch1
+	await gitbutler.runScript('apply-upstream-branch.sh', ['branch1', 'local-clone']);
+	await gitbutler.runScript('apply-upstream-branch.sh', ['branch3', 'local-clone']);
+	await gitbutler.runScript('move-branch.sh', ['branch3', 'branch1', 'local-clone']);
+
+	await page.goto('/');
+
+	// Should load the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// There should be one stack applied
+	let stacks = getByTestId(page, 'stack');
+	await expect(stacks).toHaveCount(1);
+	let branchCards = getByTestId(page, 'branch-card');
+	await expect(branchCards).toHaveCount(2);
+
+	// Branch one was merged in the forge
+	await gitbutler.runScript('merge-upstream-branch-to-base.sh', ['branch1']);
+
+	// Click the sync button
+	await clickByTestId(page, 'sync-button');
+
+	// Update the workspace
+	await clickByTestId(page, 'integrate-upstream-commits-button');
+
+	// The staus of the branch1 should be "Integrated"
+	const branch1Status = page.locator('[data-integration-row-branch-name="branch1"]').first();
+	await branch1Status.waitFor();
+	const statusBadge = branch1Status.getByTestId('integrate-upstream-series-row-status-badge');
+	await statusBadge.waitFor();
+	await expect(statusBadge).toHaveText('Integrated');
+
+	await clickByTestId(page, 'integrate-upstream-action-button');
+
+	// There should be one stack left with one branch
+	stacks = getByTestId(page, 'stack');
+	await expect(stacks).toHaveCount(1);
+	branchCards = getByTestId(page, 'branch-card');
+	await expect(branchCards).toHaveCount(1);
+});
+
 test('should handle the update of the workspace with multiple stacks gracefully', async ({
 	page,
 	context

--- a/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
+++ b/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
@@ -25,6 +25,7 @@
 	import Checkbox from '$components/Checkbox.svelte';
 	import Icon from '$components/Icon.svelte';
 	import SeriesIcon from '$components/SeriesIcon.svelte';
+	import { TestId } from '$lib/utils/testIds';
 	const {
 		testId,
 		series,
@@ -37,13 +38,16 @@
 </script>
 
 {#snippet stackBranch({ name, status }: Branch, isLast: boolean)}
-	<div class="series-branch {status}">
+	<div class="series-branch {status}" data-integration-row-branch-name={name}>
 		<div class="structure-lines" class:last={isLast}></div>
 		<div class="branch-info">
 			<span class="text-12 text-semibold truncate">{name}</span>
 
 			{#if status}
-				<span class="status-badge text-10 text-semibold">
+				<span
+					class="status-badge text-10 text-semibold"
+					data-testid={TestId.IntegrateUpstreamSeriesRowStatusBadge}
+				>
 					{#if status === 'conflicted'}
 						Conflicted
 					{:else if status === 'integrated'}

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -53,6 +53,7 @@ export enum TestId {
 	IntegrateUpstreamCommitsButton = 'integrate-upstream-commits-button',
 	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal',
 	IntegrateUpstreamSeriesRow = 'integrate-upstream-series-row',
+	IntegrateUpstreamSeriesRowStatusBadge = 'integrate-upstream-series-row-status-badge',
 	IntegrateUpstreamActionButton = 'integrate-upstream-action-button',
 	FileListModeOption = 'file-list-mode-option',
 	FileListTreeFolder = 'file-list-tree-folder',


### PR DESCRIPTION
If the branch in a stack has been determined to be integrated, propagate that status as such