### PR TITLE
fix: canonicalize and log current executable path

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -79,6 +79,7 @@ where
     Extra: Send + Clone,
 {
     let path = std::env::current_exe().map_err(Error::<E>::NoSelfExe)?;
+    let path = path.canonicalize().unwrap();
 
     // TODO(qix-): Get parent PID of connecting processes to make sure they're us.
     //let our_pid = std::process::id();


### PR DESCRIPTION
immediately going to close this as @Byron is working on a more proper fix, just sharing this with @krlvi 
