### PR TITLE
but push UX updates

### DIFF
--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -22,6 +22,7 @@ mod oplog;
 mod push;
 mod rub;
 mod status;
+mod url_utils;
 mod worktree;
 
 #[tokio::main]

--- a/crates/but/src/push/mod.rs
+++ b/crates/but/src/push/mod.rs
@@ -6,139 +6,6 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
 use gitbutler_repo::RepoCommands;
 
-/// Generate branch URL for GitHub remote
-fn generate_github_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
-    if let Some(repo_path) = extract_github_repo_path(remote_url) {
-        Some(format!(
-            "https://github.com/{}/tree/{}",
-            repo_path, branch_name
-        ))
-    } else {
-        None
-    }
-}
-
-/// Generate branch URL for GitLab remote
-fn generate_gitlab_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
-    if let Some((host, repo_path)) = extract_gitlab_info(remote_url) {
-        Some(format!(
-            "https://{}/{}/-/tree/{}",
-            host, repo_path, branch_name
-        ))
-    } else {
-        None
-    }
-}
-
-/// Generate change URL for Gerrit remote
-fn generate_gerrit_change_url(remote_url: &str) -> Option<String> {
-    if let Some(base_url) = extract_gerrit_base_url(remote_url) {
-        Some(format!("{}/dashboard/self", base_url))
-    } else {
-        None
-    }
-}
-
-/// Extract GitHub repository path from various URL formats
-fn extract_github_repo_path(url: &str) -> Option<String> {
-    // Handle GitHub URLs: git@github.com:user/repo.git or https://github.com/user/repo.git
-    if !url.contains("github.com") {
-        return None;
-    }
-
-    // Find the part after github.com
-    let after_github = if let Some(pos) = url.find("github.com:") {
-        &url[pos + 11..] // Skip "github.com:"
-    } else if let Some(pos) = url.find("github.com/") {
-        &url[pos + 11..] // Skip "github.com/"
-    } else {
-        return None;
-    };
-
-    // Extract user/repo, removing .git suffix if present
-    let repo_path = after_github.trim_end_matches(".git");
-    let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
-    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-        Some(format!("{}/{}", parts[0], parts[1]))
-    } else {
-        None
-    }
-}
-
-/// Extract GitLab host and repository path from various URL formats
-fn extract_gitlab_info(url: &str) -> Option<(String, String)> {
-    // Handle GitLab URLs: git@gitlab.example.com:user/repo.git or https://gitlab.example.com/user/repo.git
-    if !url.contains("gitlab") {
-        return None;
-    }
-
-    // Extract host and path
-    if let Some(colon_pos) = url.rfind(':') {
-        if let Some(at_pos) = url[..colon_pos].rfind('@') {
-            // SSH format: git@gitlab.example.com:user/repo.git
-            let host = &url[at_pos + 1..colon_pos];
-            let path_part = &url[colon_pos + 1..];
-            let repo_path = path_part.trim_end_matches(".git");
-            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
-            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
-            }
-        }
-    } else if url.starts_with("https://") {
-        // HTTPS format: https://gitlab.example.com/user/repo.git
-        let after_https = &url[8..]; // Skip "https://"
-        if let Some(slash_pos) = after_https.find('/') {
-            let host = &after_https[..slash_pos];
-            let path_part = &after_https[slash_pos + 1..];
-            let repo_path = path_part.trim_end_matches(".git");
-            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
-            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
-            }
-        }
-    }
-    None
-}
-
-/// Extract Gerrit base URL from remote URL
-fn extract_gerrit_base_url(url: &str) -> Option<String> {
-    // Handle Gerrit URLs: ssh://user@gerrit.example.com:29418/project.git or https://gerrit.example.com/a/project.git
-    if url.contains("gerrit") || url.contains(":29418") {
-        if url.starts_with("ssh://") {
-            // SSH format: ssh://user@gerrit.example.com:29418/project.git
-            let after_ssh = &url[6..]; // Skip "ssh://"
-            if let Some(at_pos) = after_ssh.find('@') {
-                let after_at = &after_ssh[at_pos + 1..];
-                if let Some(colon_pos) = after_at.find(':') {
-                    let host = &after_at[..colon_pos];
-                    return Some(format!("https://{}", host));
-                }
-            }
-        } else if url.starts_with("https://") {
-            // HTTPS format: https://gerrit.example.com/a/project.git
-            let after_https = &url[8..]; // Skip "https://"
-            if let Some(slash_pos) = after_https.find('/') {
-                let host = &after_https[..slash_pos];
-                return Some(format!("https://{}", host));
-            }
-        }
-    }
-    None
-}
-
-/// Generate appropriate URL for the remote and branch
-fn generate_branch_url(remote_url: &str, branch_name: &str, is_gerrit: bool) -> Option<String> {
-    if is_gerrit {
-        generate_gerrit_change_url(remote_url)
-    } else if remote_url.contains("github.com") {
-        generate_github_branch_url(remote_url, branch_name)
-    } else if remote_url.contains("gitlab") {
-        generate_gitlab_branch_url(remote_url, branch_name)
-    } else {
-        None
-    }
-}
-
 #[derive(Debug, clap::Parser)]
 pub struct Args {
     /// Branch name or CLI ID to push
@@ -255,8 +122,6 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
         gerrit_flag,
     )?;
 
-    dbg!(&result);
-
     println!("Push completed successfully");
     println!("Pushed to remote: {}", result.remote);
     if !gerrit_mode && !result.branch_to_remote.is_empty() {
@@ -266,16 +131,18 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
     }
 
     // Get remote URL and generate branch URL if possible
-    if let Ok(remotes) = project.remotes() {
-        if let Some(remote) = remotes.iter().find(|r| r.name.as_ref() == Some(&result.remote)) {
-            if let Some(remote_url) = &remote.url {
-                if let Some(branch_url) = generate_branch_url(remote_url, &branch_name, gerrit_mode) {
-                    if gerrit_mode {
-                        println!("View changes: {}", branch_url);
-                    } else {
-                        println!("Branch URL: {}", branch_url);
-                    }
-                }
+    if let Ok(remotes) = project.remotes()
+        && let Some(remote_url) = remotes
+            .iter()
+            .find(|r| r.name.as_ref() == Some(&result.remote))
+            .and_then(|remote| remote.url.as_ref())
+    {
+        println!();
+        if let Some(branch_url) = crate::url_utils::generate_branch_url(remote_url, &branch_name, gerrit_mode) {
+            if gerrit_mode {
+                println!("View changes: {}", branch_url);
+            } else {
+                println!("Branch URL: {}", branch_url);
             }
         }
     }

--- a/crates/but/src/push/mod.rs
+++ b/crates/but/src/push/mod.rs
@@ -4,6 +4,140 @@ use but_workspace::StackId;
 use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
+use gitbutler_repo::RepoCommands;
+
+/// Generate branch URL for GitHub remote
+fn generate_github_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
+    if let Some(repo_path) = extract_github_repo_path(remote_url) {
+        Some(format!(
+            "https://github.com/{}/tree/{}",
+            repo_path, branch_name
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate branch URL for GitLab remote
+fn generate_gitlab_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
+    if let Some((host, repo_path)) = extract_gitlab_info(remote_url) {
+        Some(format!(
+            "https://{}/{}/-/tree/{}",
+            host, repo_path, branch_name
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate change URL for Gerrit remote
+fn generate_gerrit_change_url(remote_url: &str) -> Option<String> {
+    if let Some(base_url) = extract_gerrit_base_url(remote_url) {
+        Some(format!("{}/dashboard/self", base_url))
+    } else {
+        None
+    }
+}
+
+/// Extract GitHub repository path from various URL formats
+fn extract_github_repo_path(url: &str) -> Option<String> {
+    // Handle GitHub URLs: git@github.com:user/repo.git or https://github.com/user/repo.git
+    if !url.contains("github.com") {
+        return None;
+    }
+
+    // Find the part after github.com
+    let after_github = if let Some(pos) = url.find("github.com:") {
+        &url[pos + 11..] // Skip "github.com:"
+    } else if let Some(pos) = url.find("github.com/") {
+        &url[pos + 11..] // Skip "github.com/"
+    } else {
+        return None;
+    };
+
+    // Extract user/repo, removing .git suffix if present
+    let repo_path = after_github.trim_end_matches(".git");
+    let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some(format!("{}/{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
+/// Extract GitLab host and repository path from various URL formats
+fn extract_gitlab_info(url: &str) -> Option<(String, String)> {
+    // Handle GitLab URLs: git@gitlab.example.com:user/repo.git or https://gitlab.example.com/user/repo.git
+    if !url.contains("gitlab") {
+        return None;
+    }
+
+    // Extract host and path
+    if let Some(colon_pos) = url.rfind(':') {
+        if let Some(at_pos) = url[..colon_pos].rfind('@') {
+            // SSH format: git@gitlab.example.com:user/repo.git
+            let host = &url[at_pos + 1..colon_pos];
+            let path_part = &url[colon_pos + 1..];
+            let repo_path = path_part.trim_end_matches(".git");
+            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
+            }
+        }
+    } else if url.starts_with("https://") {
+        // HTTPS format: https://gitlab.example.com/user/repo.git
+        let after_https = &url[8..]; // Skip "https://"
+        if let Some(slash_pos) = after_https.find('/') {
+            let host = &after_https[..slash_pos];
+            let path_part = &after_https[slash_pos + 1..];
+            let repo_path = path_part.trim_end_matches(".git");
+            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
+            }
+        }
+    }
+    None
+}
+
+/// Extract Gerrit base URL from remote URL
+fn extract_gerrit_base_url(url: &str) -> Option<String> {
+    // Handle Gerrit URLs: ssh://user@gerrit.example.com:29418/project.git or https://gerrit.example.com/a/project.git
+    if url.contains("gerrit") || url.contains(":29418") {
+        if url.starts_with("ssh://") {
+            // SSH format: ssh://user@gerrit.example.com:29418/project.git
+            let after_ssh = &url[6..]; // Skip "ssh://"
+            if let Some(at_pos) = after_ssh.find('@') {
+                let after_at = &after_ssh[at_pos + 1..];
+                if let Some(colon_pos) = after_at.find(':') {
+                    let host = &after_at[..colon_pos];
+                    return Some(format!("https://{}", host));
+                }
+            }
+        } else if url.starts_with("https://") {
+            // HTTPS format: https://gerrit.example.com/a/project.git
+            let after_https = &url[8..]; // Skip "https://"
+            if let Some(slash_pos) = after_https.find('/') {
+                let host = &after_https[..slash_pos];
+                return Some(format!("https://{}", host));
+            }
+        }
+    }
+    None
+}
+
+/// Generate appropriate URL for the remote and branch
+fn generate_branch_url(remote_url: &str, branch_name: &str, is_gerrit: bool) -> Option<String> {
+    if is_gerrit {
+        generate_gerrit_change_url(remote_url)
+    } else if remote_url.contains("github.com") {
+        generate_github_branch_url(remote_url, branch_name)
+    } else if remote_url.contains("gitlab") {
+        generate_gitlab_branch_url(remote_url, branch_name)
+    } else {
+        None
+    }
+}
 
 #[derive(Debug, clap::Parser)]
 pub struct Args {
@@ -108,6 +242,8 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
     // Convert CLI args to gerrit flag with validation
     let gerrit_flag = get_gerrit_flag(args, &branch_name, gerrit_mode)?;
 
+    println!("Pushing branch '{}'...", branch_name);
+
     // Call push_stack
     let result: PushResult = but_api::stack::push_stack(
         project.id,
@@ -119,11 +255,28 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
         gerrit_flag,
     )?;
 
+    dbg!(&result);
+
     println!("Push completed successfully");
     println!("Pushed to remote: {}", result.remote);
     if !gerrit_mode && !result.branch_to_remote.is_empty() {
         for (branch, remote_ref) in &result.branch_to_remote {
             println!("  {} -> {}", branch, remote_ref);
+        }
+    }
+
+    // Get remote URL and generate branch URL if possible
+    if let Ok(remotes) = project.remotes() {
+        if let Some(remote) = remotes.iter().find(|r| r.name.as_ref() == Some(&result.remote)) {
+            if let Some(remote_url) = &remote.url {
+                if let Some(branch_url) = generate_branch_url(remote_url, &branch_name, gerrit_mode) {
+                    if gerrit_mode {
+                        println!("View changes: {}", branch_url);
+                    } else {
+                        println!("Branch URL: {}", branch_url);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/but/src/push/mod.rs
+++ b/crates/but/src/push/mod.rs
@@ -1,10 +1,78 @@
 use but_core::RepositoryExt;
 use but_settings::AppSettings;
 use but_workspace::StackId;
-use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
 use gitbutler_repo::RepoCommands;
+
+/// Display branch URL if available
+fn show_branch_url(project: &Project, branch_name: &str, gerrit_mode: bool) {
+    if let Ok(remotes) = project.remotes() {
+        if let Some(remote) = remotes.first() {
+            if let Some(remote_url) = &remote.url {
+                if let Some(branch_url) = crate::url_utils::generate_branch_url(remote_url, branch_name, gerrit_mode) {
+                    println!();
+                    if gerrit_mode {
+                        println!("View changes: {}", branch_url);
+                    } else {
+                        println!("Branch URL: {}", branch_url);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Extract a user-friendly error message from push errors
+fn extract_push_error_message(error: &but_api::error::Error) -> String {
+    // Use Debug formatting to get string representation
+    let error_str = format!("{:?}", error);
+
+    // Look for common Gerrit error patterns
+    if error_str.contains("no new changes") {
+        return "No new changes to push (commit may already exist in Gerrit)".to_string();
+    }
+
+    if error_str.contains("remote rejected") {
+        // Try to extract the rejection reason
+        if let Some(start) = error_str.find("remote rejected") {
+            if let Some(paren_start) = error_str[start..].find('(') {
+                if let Some(paren_end) = error_str[start + paren_start..].find(')') {
+                    let reason = &error_str[start + paren_start + 1..start + paren_start + paren_end];
+                    return format!("Remote rejected push: {}", reason);
+                }
+            }
+        }
+        return "Remote rejected the push".to_string();
+    }
+
+    if error_str.contains("failed to push some refs") {
+        return "Failed to push some refs to remote".to_string();
+    }
+
+    if error_str.contains("Permission denied") {
+        return "Permission denied - check your authentication credentials".to_string();
+    }
+
+    if error_str.contains("Could not resolve hostname") {
+        return "Could not resolve hostname - check your network connection".to_string();
+    }
+
+    // For other errors, try to extract the first meaningful line
+    let lines: Vec<&str> = error_str.lines().collect();
+    for line in &lines {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with("Error:") && !trimmed.starts_with("Caused by:") {
+            // Skip very long lines (like full git commands)
+            if trimmed.len() < 150 {
+                return trimmed.to_string();
+            }
+        }
+    }
+
+    // Fallback to first line if nothing better found
+    lines.first().unwrap_or(&"Unknown push error").trim().to_string()
+}
 
 #[derive(Debug, clap::Parser)]
 pub struct Args {
@@ -111,8 +179,8 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
 
     println!("Pushing branch '{}'...", branch_name);
 
-    // Call push_stack
-    let result: PushResult = but_api::stack::push_stack(
+    // Call push_stack and handle both success and error cases
+    let push_result = but_api::stack::push_stack(
         project.id,
         stack_id,
         args.with_force,
@@ -120,30 +188,30 @@ pub fn handle(args: &Args, project: &Project, _json: bool) -> anyhow::Result<()>
         branch_name.clone(),
         args.run_hooks,
         gerrit_flag,
-    )?;
+    );
 
-    println!("Push completed successfully");
-    println!("Pushed to remote: {}", result.remote);
-    if !gerrit_mode && !result.branch_to_remote.is_empty() {
-        for (branch, remote_ref) in &result.branch_to_remote {
-            println!("  {} -> {}", branch, remote_ref);
-        }
-    }
-
-    // Get remote URL and generate branch URL if possible
-    if let Ok(remotes) = project.remotes()
-        && let Some(remote_url) = remotes
-            .iter()
-            .find(|r| r.name.as_ref() == Some(&result.remote))
-            .and_then(|remote| remote.url.as_ref())
-    {
-        println!();
-        if let Some(branch_url) = crate::url_utils::generate_branch_url(remote_url, &branch_name, gerrit_mode) {
-            if gerrit_mode {
-                println!("View changes: {}", branch_url);
-            } else {
-                println!("Branch URL: {}", branch_url);
+    match push_result {
+        Ok(result) => {
+            println!("Push completed successfully");
+            println!("Pushed to remote: {}", result.remote);
+            if !gerrit_mode && !result.branch_to_remote.is_empty() {
+                for (branch, remote_ref) in &result.branch_to_remote {
+                    println!("  {} -> {}", branch, remote_ref);
+                }
             }
+
+            // Show URL for successful push
+            show_branch_url(project, &branch_name, gerrit_mode);
+        }
+        Err(e) => {
+            // Extract and display a more user-friendly error message
+            let error_msg = extract_push_error_message(&e);
+            println!("Push failed: {}", error_msg);
+
+            // Still show URL even when push fails
+            show_branch_url(project, &branch_name, gerrit_mode);
+
+            return Err(e.into());
         }
     }
 

--- a/crates/but/src/url_utils.rs
+++ b/crates/but/src/url_utils.rs
@@ -1,0 +1,169 @@
+/// Generate branch URL for GitHub remote
+pub fn generate_github_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
+    if let Some(repo_path) = extract_github_repo_path(remote_url) {
+        Some(format!(
+            "https://github.com/{}/tree/{}",
+            repo_path, branch_name
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate commit URL for GitHub remote
+pub fn generate_github_commit_url(remote_url: &str, commit_id: &str) -> Option<String> {
+    if let Some(repo_path) = extract_github_repo_path(remote_url) {
+        Some(format!(
+            "https://github.com/{}/commit/{}",
+            repo_path, commit_id
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate branch URL for GitLab remote
+pub fn generate_gitlab_branch_url(remote_url: &str, branch_name: &str) -> Option<String> {
+    if let Some((host, repo_path)) = extract_gitlab_info(remote_url) {
+        Some(format!(
+            "https://{}/{}/-/tree/{}",
+            host, repo_path, branch_name
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate commit URL for GitLab remote
+pub fn generate_gitlab_commit_url(remote_url: &str, commit_id: &str) -> Option<String> {
+    if let Some((host, repo_path)) = extract_gitlab_info(remote_url) {
+        Some(format!(
+            "https://{}/{}/-/commit/{}",
+            host, repo_path, commit_id
+        ))
+    } else {
+        None
+    }
+}
+
+/// Generate change URL for Gerrit remote
+pub fn generate_gerrit_change_url(remote_url: &str) -> Option<String> {
+    if let Some(base_url) = extract_gerrit_base_url(remote_url) {
+        Some(format!("{}/dashboard/self", base_url))
+    } else {
+        None
+    }
+}
+
+/// Generate appropriate URL for the remote and branch
+pub fn generate_branch_url(remote_url: &str, branch_name: &str, is_gerrit: bool) -> Option<String> {
+    if is_gerrit {
+        generate_gerrit_change_url(remote_url)
+    } else if remote_url.contains("github.com") {
+        generate_github_branch_url(remote_url, branch_name)
+    } else if remote_url.contains("gitlab") {
+        generate_gitlab_branch_url(remote_url, branch_name)
+    } else {
+        None
+    }
+}
+
+/// Generate appropriate URL for the remote and commit
+pub fn generate_commit_url(remote_url: &str, commit_id: &str, is_gerrit: bool) -> Option<String> {
+    if is_gerrit {
+        generate_gerrit_change_url(remote_url)
+    } else if remote_url.contains("github.com") {
+        generate_github_commit_url(remote_url, commit_id)
+    } else if remote_url.contains("gitlab") {
+        generate_gitlab_commit_url(remote_url, commit_id)
+    } else {
+        None
+    }
+}
+
+/// Extract GitHub repository path from various URL formats
+fn extract_github_repo_path(url: &str) -> Option<String> {
+    // Handle GitHub URLs: git@github.com:user/repo.git or https://github.com/user/repo.git
+    if !url.contains("github.com") {
+        return None;
+    }
+
+    // Find the part after github.com
+    let after_github = if let Some(pos) = url.find("github.com:") {
+        &url[pos + 11..] // Skip "github.com:"
+    } else if let Some(pos) = url.find("github.com/") {
+        &url[pos + 11..] // Skip "github.com/"
+    } else {
+        return None;
+    };
+
+    // Extract user/repo, removing .git suffix if present
+    let repo_path = after_github.trim_end_matches(".git");
+    let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some(format!("{}/{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
+/// Extract GitLab host and repository path from various URL formats
+fn extract_gitlab_info(url: &str) -> Option<(String, String)> {
+    // Handle GitLab URLs: git@gitlab.example.com:user/repo.git or https://gitlab.example.com/user/repo.git
+    if !url.contains("gitlab") {
+        return None;
+    }
+
+    // Extract host and path
+    if let Some(colon_pos) = url.rfind(':') {
+        if let Some(at_pos) = url[..colon_pos].rfind('@') {
+            // SSH format: git@gitlab.example.com:user/repo.git
+            let host = &url[at_pos + 1..colon_pos];
+            let path_part = &url[colon_pos + 1..];
+            let repo_path = path_part.trim_end_matches(".git");
+            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
+            }
+        }
+    } else if url.starts_with("https://") {
+        // HTTPS format: https://gitlab.example.com/user/repo.git
+        let after_https = &url[8..]; // Skip "https://"
+        if let Some(slash_pos) = after_https.find('/') {
+            let host = &after_https[..slash_pos];
+            let path_part = &after_https[slash_pos + 1..];
+            let repo_path = path_part.trim_end_matches(".git");
+            let parts: Vec<&str> = repo_path.splitn(3, '/').collect();
+            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some((host.to_string(), format!("{}/{}", parts[0], parts[1])));
+            }
+        }
+    }
+    None
+}
+
+/// Extract Gerrit base URL from remote URL
+fn extract_gerrit_base_url(url: &str) -> Option<String> {
+    // Handle Gerrit URLs: ssh://user@gerrit.example.com:29418/project.git or https://gerrit.example.com/a/project.git
+    if url.contains("gerrit") || url.contains(":29418") {
+        if url.starts_with("ssh://") {
+            // SSH format: ssh://user@gerrit.example.com:29418/project.git
+            let after_ssh = &url[6..]; // Skip "ssh://"
+            if let Some(at_pos) = after_ssh.find('@') {
+                let after_at = &after_ssh[at_pos + 1..];
+                if let Some(colon_pos) = after_at.find(':') {
+                    let host = &after_at[..colon_pos];
+                    return Some(format!("https://{}", host));
+                }
+            }
+        } else if url.starts_with("https://") {
+            // HTTPS format: https://gerrit.example.com/a/project.git
+            let after_https = &url[8..]; // Skip "https://"
+            if let Some(slash_pos) = after_https.find('/') {
+                let host = &after_https[..slash_pos];
+                return Some(format!("https://{}", host));
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
This improves `but push` to show urls you can follow up with, also not explode if you try to push to gerrit with no changes.

Here is GH:

```
❯ but push yv
Pushing branch 'canonicalize-askpass-call'...
Push completed successfully
Pushed to remote: origin
  canonicalize-askpass-call -> refs/remotes/origin/canonicalize-askpass-call

Branch URL: https://github.com/gitbutlerapp/gitbutler/tree/canonicalize-askpass-call
```

Here is gerrit now, it will show a url per commit on that branch:

```
❯ but push j7
Pushing branch 'sc-but-version'...
Push completed successfully
Pushed to remote: origin

Gerrit reviews:
  4bd7f7c: http://192.168.178.83:8080/c/testing/+/41
  62720f4: http://192.168.178.83:8080/c/testing/+/32
```