### PR TITLE
Truncate help text to terminal width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "gitbutler-oplog",
  "gitbutler-oxidize",
  "gitbutler-project",
+ "gitbutler-repo",
  "gitbutler-serde",
  "gitbutler-stack",
  "gix",
@@ -795,6 +796,7 @@ dependencies = [
  "serde_json",
  "strum",
  "sysinfo",
+ "terminal_size",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -10347,6 +10349,16 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -10353,12 +10354,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.48.0",
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -31,6 +31,7 @@ rmcp.workspace = true
 command-group = { version = "5.0.1", features = ["with-tokio"] }
 sysinfo = "0.37.1"
 gitbutler-project.workspace = true
+gitbutler-repo.workspace = true
 gix.workspace = true
 but-core.workspace = true
 but-api.workspace = true
@@ -55,6 +56,7 @@ gitbutler-oxidize.workspace = true
 gitbutler-oplog.workspace = true
 colored = "3.0.0"
 serde_json = "1.0.145"
+terminal_size = "0.3"
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -21,7 +21,7 @@ posthog-rs = { version = "0.3.7" }
 serde.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
 strum = { version = "0.27", features = ["derive"] }
-clap = { version = "4.5.48", features = ["derive", "env"] }
+clap = { version = "4.5.48", features = ["derive", "env", "wrap_help"] }
 chrono = { version = "0.4.42" }
 bstr.workspace = true
 regex = "1.11.3"
@@ -56,7 +56,7 @@ gitbutler-oxidize.workspace = true
 gitbutler-oplog.workspace = true
 colored = "3.0.0"
 serde_json = "1.0.145"
-terminal_size = "0.3"
+terminal_size = "0.4.3"
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -298,20 +298,39 @@ where
 }
 
 fn print_grouped_help() {
-    use std::collections::HashSet;
-
     use clap::CommandFactory;
+    use std::collections::HashSet;
+    use terminal_size::{Width, terminal_size};
+
+    // Get terminal width, default to 80 if detection fails
+    let terminal_width = if let Some((Width(w), _)) = terminal_size() {
+        w as usize
+    } else {
+        80
+    };
+
+    // Helper function to truncate text to fit within available width
+    let truncate_text = |text: &str, available_width: usize| -> String {
+        if text.len() <= available_width {
+            text.to_string()
+        } else if available_width > 3 {
+            format!("{}...", &text[..available_width.saturating_sub(3)])
+        } else {
+            text.chars().take(available_width).collect()
+        }
+    };
 
     let cmd = Args::command();
     let subcommands: Vec<_> = cmd.get_subcommands().collect();
 
     // Define command groupings and their order (excluding MISC)
     let groups = [
-        ("Inspection".yellow(), vec!["log", "status"]),
+        ("Inspection".yellow(), vec!["status", "log"]),
         (
-            "Stack Operation".yellow(),
-            vec!["commit", "push", "rub", "new", "describe", "branch"],
+            "Branching and Committing".yellow(),
+            vec!["commit", "push", "new", "branch", "base", "mark", "unmark"],
         ),
+        ("Editing Commits".yellow(), vec!["rub", "describe"]),
         (
             "Operation History".yellow(),
             vec!["oplog", "undo", "restore", "snapshot"],
@@ -331,8 +350,11 @@ fn print_grouped_help() {
         println!("{group_name}:");
         for cmd_name in command_names {
             if let Some(subcmd) = subcommands.iter().find(|c| c.get_name() == *cmd_name) {
-                let about = subcmd.get_about().unwrap_or_default();
-                println!("  {:<10}{about}", cmd_name.green());
+                let about = subcmd.get_about().unwrap_or_default().to_string();
+                // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
+                let available_width = terminal_width.saturating_sub(13);
+                let truncated_about = truncate_text(&about, available_width);
+                println!("  {:<10}{}", cmd_name.green(), truncated_about);
                 printed_commands.insert(cmd_name.to_string());
             }
         }
@@ -349,16 +371,29 @@ fn print_grouped_help() {
     if !misc_commands.is_empty() {
         println!("{}:", "Other Commands".yellow());
         for subcmd in misc_commands {
-            let about = subcmd.get_about().unwrap_or_default();
-            println!("  {:<10}{}", subcmd.get_name().green(), about);
+            let about = subcmd.get_about().unwrap_or_default().to_string();
+            // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
+            let available_width = terminal_width.saturating_sub(13);
+            let truncated_about = truncate_text(&about, available_width);
+            println!("  {:<10}{}", subcmd.get_name().green(), truncated_about);
         }
         println!();
     }
 
     println!("{}:", "Options".yellow());
-    println!(
-        "  -C, --current-dir <PATH>  Run as if but was started in PATH instead of the current working directory [default: .]"
-    );
-    println!("  -j, --json                Whether to use JSON output format");
-    println!("  -h, --help                Print help");
+    // Truncate long option descriptions if needed
+    let option_descriptions = [
+        (
+            "  -C, --current-dir <PATH>",
+            "Run as if but was started in PATH instead of the current working directory [default: .]",
+        ),
+        ("  -j, --json", "Whether to use JSON output format"),
+        ("  -h, --help", "Print help"),
+    ];
+
+    for (flag, desc) in option_descriptions {
+        let available_width = terminal_width.saturating_sub(flag.len() + 2);
+        let truncated_desc = truncate_text(desc, available_width);
+        println!("{}  {}", flag, truncated_desc);
+    }
 }


### PR DESCRIPTION
Adjust help display to respect the current terminal size so long descriptions do not overflow. 

Add terminal_size crate, detect terminal width, and truncate subcommand and option descriptions to fit the available space. Reorganize command groups and tweak displayed commands to better reflect grouping.