### PR TITLE
v3 apply: finishing touches?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "gix",
  "gix-testtools",
  "regex",
+ "snapbox",
  "termtree",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ chrono = { version = "0.4.42", default-features = false, features = ["std"] }
 md5 = "0.8.0"
 bitflags = "2.9.4"
 notify = "8.2.0"
+snapbox = "0.6.22"
 
 [profile.release]
 # There are no overrides here as we optimise for fast release builds,

--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -22,7 +22,7 @@ bitflags.workspace = true
 serde.workspace = true
 anyhow.workspace = true
 diesel_migrations = { version = "2.3.0", features = ["sqlite"] }
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 # other things
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot", "time", "sync", "macros"] }
 tracing.workspace = true

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -595,11 +595,10 @@ pub fn find(
 }
 
 /// Returns `([(workspace_tip, workspace_ref_name, workspace_info)], target_refs, desired_refs)` for all available workspace,
-/// or exactly one workspace if `maybe_ref_name`.
-/// already points to a workspace. That way we can discover the workspace containing any starting point, but only if needed.
+/// or exactly one workspace if `maybe_ref_name` has workspace metadata (and only then).
 ///
+/// That way we can discover the workspace containing any starting point, but only if needed.
 /// This means we process all workspaces if we aren't currently and clearly looking at a workspace.
-///
 /// Also prune all non-standard workspaces early, or those that don't have a tip.
 #[expect(clippy::type_complexity)]
 pub fn obtain_workspace_infos<T: RefMetadata>(

--- a/crates/but-testsupport/Cargo.toml
+++ b/crates/but-testsupport/Cargo.toml
@@ -9,6 +9,9 @@ rust-version = "1.89"
 [lib]
 doctest = false
 
+[features]
+snapbox = ["dep:snapbox"]
+
 [dependencies]
 gix.workspace = true
 anyhow.workspace = true
@@ -17,5 +20,6 @@ gix-testtools.workspace = true
 but-graph.workspace = true
 but-core.workspace = true
 regex = "1.11.3"
+snapbox = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -35,6 +35,7 @@ pub fn hunk_header(old: &str, new: &str) -> ((u32, u32), (u32, u32)) {
 pub fn git(repo: &gix::Repository) -> std::process::Command {
     let mut cmd = std::process::Command::new(gix::path::env::exe_invocation());
     cmd.current_dir(repo.workdir().expect("non-bare"));
+    isolate_env_std_cmd(&mut cmd);
     cmd
 }
 
@@ -75,7 +76,7 @@ pub fn hex_to_id(hex: &str) -> gix::ObjectId {
 
 /// Sets and environment that assures commits are reproducible.
 /// This needs the `testing` feature enabled in `but-core` as well to work.
-/// This changes the process environment, be aware.
+/// **This changes the process environment, be aware.**
 pub fn assure_stable_env() {
     let env = gix_testtools::Env::new()
         // TODO(gix): once everything is ported, all these can be configured on `gix::Repository`.
@@ -319,3 +320,9 @@ pub fn debug_str(input: &dyn std::fmt::Debug) -> String {
 mod graph;
 
 pub use graph::{graph_tree, graph_workspace};
+
+mod prepare_cmd_env;
+pub use prepare_cmd_env::isolate_env_std_cmd;
+
+#[cfg(feature = "snapbox")]
+pub use prepare_cmd_env::isolate_snapbox_cmd;

--- a/crates/but-testsupport/src/prepare_cmd_env.rs
+++ b/crates/but-testsupport/src/prepare_cmd_env.rs
@@ -1,0 +1,94 @@
+use std::borrow::Cow;
+use std::ffi::OsStr;
+
+/// Change the `cmd` environment to be very isolated, particularly when Git is involved.
+pub fn isolate_env_std_cmd(cmd: &mut std::process::Command) -> &mut std::process::Command {
+    for op in updates() {
+        match op {
+            EnvOp::Remove(var) => {
+                cmd.env_remove(var);
+            }
+            EnvOp::Add { name, value } => {
+                cmd.env(name, value);
+            }
+        }
+    }
+    cmd
+}
+
+/// Change the `cmd` environment to be very isolated, particularly when Git is involved.
+#[cfg(feature = "snapbox")]
+pub fn isolate_snapbox_cmd(mut cmd: snapbox::cmd::Command) -> snapbox::cmd::Command {
+    for op in updates() {
+        cmd = match op {
+            EnvOp::Remove(var) => cmd.env_remove(var),
+            EnvOp::Add { name, value } => cmd.env(name, value),
+        };
+    }
+    cmd
+}
+
+enum EnvOp {
+    Remove(&'static str),
+    Add {
+        name: &'static str,
+        value: Cow<'static, OsStr>,
+    },
+}
+
+fn updates() -> Vec<EnvOp> {
+    // Copied from gix-testtools/lib.rs, in an attempt to isolate everything as good as possible,
+    #[cfg(windows)]
+    const NULL_DEVICE: &str = "NUL";
+    #[cfg(not(windows))]
+    const NULL_DEVICE: &str = "/dev/null";
+
+    // particularly mutation.
+    let mut msys_for_git_bash_on_windows = std::env::var_os("MSYS").unwrap_or_default();
+    msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
+    [
+        EnvOp::Remove("GIT_DIR"),
+        EnvOp::Remove("GIT_INDEX_FILE"),
+        EnvOp::Remove("GIT_OBJECT_DIRECTORY"),
+        EnvOp::Remove("GIT_ALTERNATE_OBJECT_DIRECTORIES"),
+        EnvOp::Remove("GIT_WORK_TREE"),
+        EnvOp::Remove("GIT_COMMON_DIR"),
+        EnvOp::Remove("GIT_ASKPASS"),
+        EnvOp::Remove("SSH_ASKPASS"),
+    ]
+    .into_iter()
+    .chain(
+        [
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_GLOBAL", NULL_DEVICE),
+            ("GIT_TERMINAL_PROMPT", "false"),
+            ("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000"),
+            ("GIT_AUTHOR_EMAIL", "author@example.com"),
+            ("GIT_AUTHOR_NAME", "author"),
+            ("GIT_COMMITTER_DATE", "2000-01-02 00:00:00 +0000"),
+            ("GIT_COMMITTER_EMAIL", "committer@example.com"),
+            ("GIT_COMMITTER_NAME", "committer"),
+            ("GIT_CONFIG_COUNT", "4"),
+            ("GIT_CONFIG_KEY_0", "commit.gpgsign"),
+            ("GIT_CONFIG_VALUE_0", "false"),
+            ("GIT_CONFIG_KEY_1", "tag.gpgsign"),
+            ("GIT_CONFIG_VALUE_1", "false"),
+            ("GIT_CONFIG_KEY_2", "init.defaultBranch"),
+            ("GIT_CONFIG_VALUE_2", "main"),
+            ("GIT_CONFIG_KEY_3", "protocol.file.allow"),
+            ("GIT_CONFIG_VALUE_3", "always"),
+            ("CLICOLOR_FORCE", "1"),
+            ("RUST_BACKTRACE", "0"),
+        ]
+        .into_iter()
+        .map(|(name, value)| EnvOp::Add {
+            name,
+            value: Cow::Borrowed(OsStr::new(value)),
+        }),
+    )
+    .chain(Some(EnvOp::Add {
+        name: "MSYS",
+        value: Cow::Owned(msys_for_git_bash_on_windows),
+    }))
+    .collect()
+}

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -365,7 +365,8 @@ pub mod merge {
     }
 
     fn peel_to_tree(commit: gix::Id) -> anyhow::Result<gix::ObjectId> {
-        Ok(commit.object()?.peel_to_tree()?.id)
+        let commit = but_core::Commit::from_id(commit)?;
+        Ok(commit.tree_id_or_auto_resolution()?.detach())
     }
 }
 

--- a/crates/but-workspace/tests/fixtures/scenario/with-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-conflict.sh
@@ -3,7 +3,8 @@
 set -eu -o pipefail
 
 git init
-# A repository with a normal and an artificial conflicting commit
+echo "A repository with a normal and an artificial conflicting commit" >.git/description
+
 echo content >file && git add . && git commit -m "init"
 git tag normal
 

--- a/crates/but-workspace/tests/workspace/commit.rs
+++ b/crates/but-workspace/tests/workspace/commit.rs
@@ -239,6 +239,14 @@ mod from_new_merge_with_metadata {
     }
 
     #[test]
+    fn with_conflict_commits() -> anyhow::Result<()> {
+        let (repo, mut meta) = named_read_only_in_memory_scenario("with-conflict", "")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"");
+        // but_testsupport::git(&repo)
+        Ok(())
+    }
+
+    #[test]
     fn with_conflict_journey() -> anyhow::Result<()> {
         let (repo, mut meta) =
             named_read_only_in_memory_scenario("various-heads-for-merge-conflict", "")?;

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -70,7 +70,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-forest = { version = "0.2.0" }
 
 [dev-dependencies]
-but-testsupport.workspace = true
-snapbox = { version = "0.6.22", features = ["term-svg", "regex"] }
+but-testsupport = { workspace = true, features = ["snapbox"] }
+snapbox = { workspace = true, features = ["term-svg", "regex"] }
 shell-words = "1.1.0"
 insta.workspace = true

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -227,44 +227,7 @@ impl Sandbox {
     }
 
     fn with_updated_env(&self, cmd: snapbox::cmd::Command) -> snapbox::cmd::Command {
-        // Copied from gix-testtools/lib.rs, in an attempt to isolate everything as good as possible,
-        #[cfg(windows)]
-        const NULL_DEVICE: &str = "NUL";
-        #[cfg(not(windows))]
-        const NULL_DEVICE: &str = "/dev/null";
-
-        // particularly mutation.
-        let mut msys_for_git_bash_on_windows = env::var_os("MSYS").unwrap_or_default();
-        msys_for_git_bash_on_windows.push(" winsymlinks:nativestrict");
-        cmd.env_remove("GIT_DIR")
-            .env_remove("GIT_INDEX_FILE")
-            .env_remove("GIT_OBJECT_DIRECTORY")
-            .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_COMMON_DIR")
-            .env_remove("GIT_ASKPASS")
-            .env_remove("SSH_ASKPASS")
-            .env("MSYS", msys_for_git_bash_on_windows)
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
-            .env("GIT_TERMINAL_PROMPT", "false")
-            .env("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000")
-            .env("GIT_AUTHOR_EMAIL", "author@example.com")
-            .env("GIT_AUTHOR_NAME", "author")
-            .env("GIT_COMMITTER_DATE", "2000-01-02 00:00:00 +0000")
-            .env("GIT_COMMITTER_EMAIL", "committer@example.com")
-            .env("GIT_COMMITTER_NAME", "committer")
-            .env("GIT_CONFIG_COUNT", "4")
-            .env("GIT_CONFIG_KEY_0", "commit.gpgsign")
-            .env("GIT_CONFIG_VALUE_0", "false")
-            .env("GIT_CONFIG_KEY_1", "tag.gpgsign")
-            .env("GIT_CONFIG_VALUE_1", "false")
-            .env("GIT_CONFIG_KEY_2", "init.defaultBranch")
-            .env("GIT_CONFIG_VALUE_2", "main")
-            .env("GIT_CONFIG_KEY_3", "protocol.file.allow")
-            .env("GIT_CONFIG_VALUE_3", "always")
-            .env("CLICOLOR_FORCE", "1")
-            .env("RUST_BACKTRACE", "0")
+        but_testsupport::isolate_snapbox_cmd(cmd)
             .env("E2E_TEST_APP_DATA_DIR", self.app_root())
             .current_dir(self.projects_root())
     }


### PR DESCRIPTION
Get a minimal viable version of `unapply()` that only deals with the common case we can handle today, or simple cases that are new.

Follow-up of #10698.

### Fixes

* [x] ⚠️ tips could be conflicted, deal with it when merging
* [ ] investigate 'base' related behaviour for more intuitive results when applying into an empty branch.

### Tasks
* [ ] unapply: make sure to also delete metadata, even if the branch isn't actually in the workspace.

### Next PR?

* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [ ] proper worktree handling - we must not checkout branches that are already checked out in worktree (see `gix` code somewhere)
- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [x] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [x] don't apply the target branch!
- [x] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.


### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.





