### PR TITLE
Show "Push" label in Gerrit mode

### DIFF
--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -190,7 +190,7 @@
 			onclick={() => handleClick({ withForce, skipForcePushProtection: false })}
 			icon={multipleBranches && !isLastBranchInStack ? 'push-below' : 'push'}
 		>
-			{withForce ? 'Force push' : 'Push'}
+			{isGerritMode ? 'Push' : withForce ? 'Force push' : 'Push'}
 		</Button>
 
 		<Modal


### PR DESCRIPTION
When a project is using Gerrit, the concept of a "force push" is misleading.
Update the Push button label to always read "Push" when Gerrit mode is enabled
so the UI uses terminology appropriate to Gerrit workflows. This change checks
the project's Gerrit mode and overrides the "Force push" text accordingly.