### PR TITLE
Fix initial bottom position in codegen

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -210,11 +210,14 @@
 
 	<div class="chat-view">
 		{#if selectedBranch}
-			<CodegenMessages
-				{projectId}
-				stackId={selectedBranch.stackId}
-				branchName={selectedBranch.head}
-			/>
+			<!-- It's difficult to start at bottom unless we re-render `CodegenMessages` -->
+			{#key selectedBranch.head}
+				<CodegenMessages
+					{projectId}
+					stackId={selectedBranch.stackId}
+					branchName={selectedBranch.head}
+				/>
+			{/key}
 
 			{@render rightSidebar(events.response || [])}
 		{:else}


### PR DESCRIPTION
Since chats are made of a virtual scroller it's best if we re-mount that
component when switching between sessions.