### PR TITLE
fix: Migrate the project git dir before validation

### DIFF
--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -207,6 +207,7 @@ impl Controller {
         #[cfg_attr(not(windows), allow(unused_mut))]
         let mut project = self.projects_storage.get(id)?;
         // BACKWARD-COMPATIBLE MIGRATION
+        project.migrate()?;
         if validate {
             let repo = project.open_isolated();
             if repo.is_err() {
@@ -223,7 +224,6 @@ impl Controller {
             }
         }
 
-        project.migrate()?;
         if !project.gb_dir().exists()
             && let Err(error) = std::fs::create_dir_all(project.gb_dir())
         {


### PR DESCRIPTION
Move up the migration step for the project’s git dir so that it happens before the validation.

This fixes the issue in which existing projects would not be ‘found’ even if they were still there