### PR TITLE
Rust GH: List the PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -3203,6 +3203,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3250,18 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "git-url-parse"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
+dependencies = [
+ "getset",
+ "nom 8.0.0",
+ "thiserror 2.0.17",
+ "url",
 ]
 
 [[package]]
@@ -3475,6 +3499,8 @@ name = "gitbutler-forge"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-github",
+ "git-url-parse",
  "gitbutler-fs",
  "serde",
 ]
@@ -5418,7 +5444,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -6799,6 +6825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7961,6 +7996,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8490,7 +8547,7 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "mime",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
  "reqwest 0.12.23",
  "thiserror 1.0.69",
@@ -10896,7 +10953,7 @@ checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
 dependencies = [
  "fnv",
  "memchr",
- "nom",
+ "nom 7.1.3",
  "once_cell",
  "petgraph 0.6.5",
 ]

--- a/apps/desktop/cypress/e2e/branches.cy.ts
+++ b/apps/desktop/cypress/e2e/branches.cy.ts
@@ -168,44 +168,6 @@ describe('Branches', () => {
 		cy.getByTestId('delete-local-branch-confirmation-modal').should('not.exist');
 	});
 
-	it('should be able to apply a branch from a fork', () => {
-		const forkRemoteName = 'fork-remote';
-		// Click on the PR branch card
-		cy.getByTestId('pr-list-card')
-			.should('be.visible')
-			.should('have.length', mockBackend.getMockPRListings().length)
-			.click();
-
-		// The PR branch drawe should be visible
-		cy.getByTestId('pr-branch-view')
-			.should('be.visible')
-			.should('contain', mockBackend.getMockPr().head.ref)
-			.should('contain', mockBackend.getMockPr().title)
-			.should('contain', mockBackend.getMockPr().body);
-
-		// The button to apply the branch from a fork should be visible
-		cy.getByTestId('branches-view-apply-from-fork-button')
-			.should('be.visible')
-			.should('be.enabled')
-			.click();
-
-		// The create remote branch modal should be visible
-		cy.getByTestId('branches-view-create-remote-modal')
-			.should('be.visible')
-			.within(() => {
-				cy.get('input[type="text"]').type(forkRemoteName);
-			});
-
-		// Click on the action button to create the remote branch
-		cy.getByTestId('branches-view-create-remote-modal-action-button')
-			.should('be.visible')
-			.should('be.enabled')
-			.click();
-
-		// Should have navigation to the workspace
-		cy.urlMatches(`/${PROJECT_ID}/workspace`);
-	});
-
 	it('should be able to preivew multiple branches', () => {
 		// Should be able to navigate the different branches
 		for (const branch of mockBackend.branchListings) {

--- a/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
+++ b/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
@@ -41,7 +41,12 @@ const MOCK_BASE_BRANCH_DATA = {
 	diverged: false,
 	divergedAhead: [],
 	divergedBehind: [],
-	forgeProvider: 'github'
+	forgeRepoInfo: {
+		forge: 'github',
+		owner: 'example',
+		repo: 'repo',
+		protocol: 'https'
+	}
 };
 
 export type BaseBranchData = typeof MOCK_BASE_BRANCH_DATA;

--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -7,6 +7,13 @@ export interface RemoteBranchInfo {
 
 export type ForgeProvider = 'github' | 'gitlab' | 'bitbucket' | 'azure';
 
+export type ForgeRepoInfo = {
+	forge: ForgeProvider;
+	owner: string;
+	repo: string;
+	protocol: string;
+};
+
 export class BaseBranch {
 	branchName!: string;
 	remoteName!: string;
@@ -25,7 +32,7 @@ export class BaseBranch {
 	diverged!: boolean;
 	divergedAhead!: string[];
 	divergedBehind!: string[];
-	forgeProvider!: ForgeProvider | null;
+	forgeRepoInfo!: ForgeRepoInfo | null;
 
 	actualPushRemoteName(): string {
 		return this.pushRemoteName || this.remoteName;

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -176,6 +176,7 @@ export function initDependencies(args: {
 	const forgeFactory = new DefaultForgeFactory({
 		gitHubClient,
 		gitLabClient,
+		backendApi: clientState['backendApi'],
 		gitHubApi: clientState['githubApi'],
 		gitLabApi: clientState['gitlabApi'],
 		dispatch: clientState.dispatch,

--- a/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
@@ -10,7 +10,7 @@ import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { ForgeProvider } from '$lib/baseBranch/baseBranch';
 import type { GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
 import type { Forge, ForgeName } from '$lib/forge/interface/forge';
-import type { GitHubApi, GitLabApi } from '$lib/state/clientState.svelte';
+import type { BackendApi, GitHubApi, GitLabApi } from '$lib/state/clientState.svelte';
 import type { ReduxTag } from '$lib/state/tags';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { Reactive } from '@gitbutler/shared/storeUtils';
@@ -45,6 +45,7 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 
 	constructor(
 		private params: {
+			backendApi: BackendApi;
 			gitHubClient: GitHubClient;
 			gitHubApi: GitHubApi;
 			gitLabClient: GitLabClient;
@@ -132,10 +133,11 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 		};
 
 		if (forgeType === 'github') {
-			const { gitHubClient, gitHubApi, posthog } = this.params;
+			const { gitHubClient, gitHubApi, posthog, backendApi } = this.params;
 			return new GitHub({
 				...baseParams,
 				api: gitHubApi,
+				backendApi,
 				client: gitHubClient,
 				posthog: posthog,
 				authenticated: !!githubAuthenticated,

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -3,7 +3,7 @@ import { PostHogWrapper } from '$lib/analytics/posthog';
 import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import { GitHub } from '$lib/forge/github/github';
 import { GitLab } from '$lib/forge/gitlab/gitlab';
-import { type GitHubApi } from '$lib/state/clientState.svelte';
+import { type BackendApi, type GitHubApi } from '$lib/state/clientState.svelte';
 import { mockCreateBackend } from '$lib/testing/mockBackend';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { expect, test, describe, vi } from 'vitest';
@@ -27,6 +27,9 @@ describe.concurrent('DefaultforgeFactory', () => {
 		injectEndpoints: vi.fn(),
 		enhanceEndpoints: undefined as any
 	};
+	const MockBackendApi = vi.fn();
+	MockBackendApi.prototype.injectEndpoints = vi.fn();
+	const backendApi: BackendApi = new MockBackendApi();
 	const gitHubClient = { onReset: () => {} } as any as GitHubClient;
 	const gitLabClient = { onReset: () => {} } as any as GitLabClient;
 
@@ -40,6 +43,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 		const factory = new DefaultForgeFactory({
 			gitHubClient,
 			gitHubApi,
+			backendApi,
 			gitLabClient,
 			gitLabApi,
 			posthog,
@@ -63,6 +67,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 		const factory = new DefaultForgeFactory({
 			gitHubClient,
 			gitHubApi,
+			backendApi,
 			gitLabClient,
 			gitLabApi,
 			posthog,
@@ -86,6 +91,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 		const factory = new DefaultForgeFactory({
 			gitHubClient,
 			gitHubApi,
+			backendApi,
 			gitLabClient,
 			gitLabApi,
 			posthog,
@@ -109,6 +115,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 		const factory = new DefaultForgeFactory({
 			gitHubClient,
 			gitHubApi,
+			backendApi,
 			gitLabClient,
 			gitLabApi,
 			posthog,
@@ -132,6 +139,7 @@ describe.concurrent('DefaultforgeFactory', () => {
 			gitHubClient,
 			gitHubApi,
 			gitLabClient,
+			backendApi,
 			gitLabApi,
 			posthog,
 			dispatch

--- a/apps/desktop/src/lib/forge/github/github.test.ts
+++ b/apps/desktop/src/lib/forge/github/github.test.ts
@@ -1,9 +1,14 @@
 import { GitHub } from '$lib/forge/github/github';
 import { setupMockGitHubApi } from '$lib/testing/mockGitHubApi.svelte';
-import { expect, test, describe } from 'vitest';
+import { expect, test, describe, vi } from 'vitest';
+import type { BackendApi } from '$lib/state/clientState.svelte';
 
 describe('GitHub', () => {
 	const { gitHubApi, gitHubClient } = setupMockGitHubApi();
+
+	const MockBackendApi = vi.fn();
+	MockBackendApi.prototype.injectEndpoints = vi.fn();
+	const backendApi: BackendApi = new MockBackendApi();
 
 	const id = 'some-branch';
 	const repo = {
@@ -16,6 +21,7 @@ describe('GitHub', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo,
 			baseBranch: id,
 			authenticated: true,
@@ -34,6 +40,7 @@ describe('GitHub', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo: sshRepo,
 			baseBranch: id,
 			authenticated: true,
@@ -52,6 +59,7 @@ describe('GitHub', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo: sshRepo,
 			baseBranch: 'main',
 			authenticated: true,
@@ -73,6 +81,7 @@ describe('GitHub', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo: sshRepo,
 			baseBranch: id,
 			authenticated: true,
@@ -93,6 +102,7 @@ describe('GitHub', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo: enterpriseRepo,
 			baseBranch: id,
 			authenticated: true,

--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -10,7 +10,7 @@ import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { GitHubClient } from '$lib/forge/github/githubClient';
 import type { Forge, ForgeName } from '$lib/forge/interface/forge';
 import type { ForgeArguments } from '$lib/forge/interface/types';
-import type { GitHubApi } from '$lib/state/clientState.svelte';
+import type { BackendApi, GitHubApi } from '$lib/state/clientState.svelte';
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 import type { TagDescription } from '@reduxjs/toolkit/query';
 
@@ -29,6 +29,7 @@ export class GitHub implements Forge {
 			posthog?: PostHogWrapper;
 			client: GitHubClient;
 			api: GitHubApi;
+			backendApi: BackendApi;
 			isLoading: boolean;
 		}
 	) {
@@ -58,8 +59,8 @@ export class GitHub implements Forge {
 
 	get listService() {
 		if (!this.authenticated) return;
-		const { api: gitHubApi } = this.params;
-		return new GitHubListingService(gitHubApi);
+		const { api: gitHubApi, backendApi } = this.params;
+		return new GitHubListingService(gitHubApi, backendApi);
 	}
 
 	get prService() {

--- a/apps/desktop/src/lib/forge/github/githubBranch.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubBranch.test.ts
@@ -1,10 +1,15 @@
 import { GitHub } from '$lib/forge/github/github';
 import { setupMockGitHubApi } from '$lib/testing/mockGitHubApi.svelte';
-import { expect, test, describe } from 'vitest';
+import { expect, test, describe, vi } from 'vitest';
+import type { BackendApi } from '$lib/state/clientState.svelte';
 
 // TODO: Rewrite this proof-of-concept into something valuable.
 describe('GitHubBranch', () => {
 	const { gitHubClient, gitHubApi } = setupMockGitHubApi();
+
+	const MockBackendApi = vi.fn();
+	MockBackendApi.prototype.injectEndpoints = vi.fn();
+	const backendApi: BackendApi = new MockBackendApi();
 
 	const name = 'some-branch';
 	const baseBranch = 'some-base';
@@ -18,6 +23,7 @@ describe('GitHubBranch', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo,
 			baseBranch,
 			authenticated: true,
@@ -32,6 +38,7 @@ describe('GitHubBranch', () => {
 		const gh = new GitHub({
 			api: gitHubApi,
 			client: gitHubClient,
+			backendApi,
 			repo,
 			baseBranch,
 			forkStr,

--- a/apps/desktop/src/lib/forge/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.test.ts
@@ -3,6 +3,7 @@ import { setupMockGitHubApi } from '$lib/testing/mockGitHubApi.svelte';
 import { type RestEndpointMethodTypes } from '@octokit/rest';
 import { expect, test, describe, vi, beforeEach } from 'vitest';
 import type { ForgePrService as GitHubPrService } from '$lib/forge/interface/forgePrService';
+import type { BackendApi } from '$lib/state/clientState.svelte';
 
 // TODO: Rewrite this proof-of-concept into something valuable.
 describe('GitHubPrService', () => {
@@ -12,6 +13,10 @@ describe('GitHubPrService', () => {
 	const { gitHubClient, gitHubApi, octokit } = setupMockGitHubApi();
 
 	beforeEach(() => {
+		const MockBackendApi = vi.fn();
+		MockBackendApi.prototype.injectEndpoints = vi.fn();
+		const backendApi: BackendApi = new MockBackendApi();
+
 		gh = new GitHub({
 			repo: {
 				domain: 'github.com',
@@ -19,6 +24,7 @@ describe('GitHubPrService', () => {
 				owner: 'test-owner'
 			},
 			baseBranch: 'main',
+			backendApi,
 			api: gitHubApi,
 			authenticated: true,
 			isLoading: false,

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -13,6 +13,36 @@ export type ForgeUser = {
 	name: string;
 };
 
+export type ForgeUserDetailed = {
+	id: number;
+	login: string;
+	name: string | null;
+	email: string | null;
+	avatarUrl: string | null;
+	isBot: boolean;
+};
+
+export type ForgeReview = {
+	htmlUrl: string;
+	number: number;
+	title: string;
+	body: string | null;
+	author: ForgeUserDetailed | null;
+	labels: Label[];
+	draft: boolean;
+	sourceBranch: string;
+	targetBranch: string;
+	sha: string;
+	createdAt: string | null;
+	modifiedAt: string | null;
+	mergedAt: string | null;
+	closedAt: string | null;
+	repositorySshUrl: string | null;
+	repositoryHttpsUrl: string | null;
+	repoOwner: string | null;
+	reviewers: ForgeUserDetailed[];
+};
+
 export interface PullRequest {
 	htmlUrl: string;
 	number: number;
@@ -32,6 +62,40 @@ export interface PullRequest {
 	repositoryHttpsUrl?: string;
 	repoOwner?: string;
 	reviewers: ForgeUser[];
+}
+
+export function mapForgeReviewToPullRequest(pr: ForgeReview): PullRequest {
+	return {
+		htmlUrl: pr.htmlUrl,
+		number: pr.number,
+		title: pr.title,
+		body: pr.body ?? undefined,
+		author: pr.author
+			? {
+					name: pr.author.name ?? pr.author.login,
+					email: pr.author.email ?? undefined,
+					gravatarUrl: pr.author.avatarUrl ?? undefined,
+					isBot: pr.author.isBot
+				}
+			: null,
+		labels: pr.labels,
+		draft: pr.draft,
+		sourceBranch: pr.sourceBranch,
+		targetBranch: pr.targetBranch,
+		sha: pr.sha,
+		createdAt: pr.createdAt ?? '',
+		modifiedAt: pr.modifiedAt ?? '',
+		mergedAt: pr.mergedAt ?? undefined,
+		closedAt: pr.closedAt ?? undefined,
+		repositorySshUrl: pr.repositorySshUrl ?? undefined,
+		repositoryHttpsUrl: pr.repositoryHttpsUrl ?? undefined,
+		repoOwner: pr.repoOwner ?? undefined,
+		reviewers: pr.reviewers.map((r) => ({
+			id: r.id,
+			srcUrl: r.avatarUrl ?? '',
+			name: r.name ?? r.login
+		}))
+	};
 }
 
 export interface PullRequestPermissions {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -124,7 +124,7 @@
 			githubAuthenticated: !!githubAccessToken.accessToken.current,
 			githubIsLoading: githubAccessToken.isLoading.current,
 			gitlabAuthenticated: !!$gitlabConfigured,
-			detectedForgeProvider: baseBranch?.forgeProvider ?? undefined,
+			detectedForgeProvider: baseBranch?.forgeRepoInfo?.forge ?? undefined,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override
 		});
 	});

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -6,6 +6,8 @@ use but_settings::AppSettings;
 use serde::{Deserialize, Serialize};
 
 mod client;
+pub mod pr;
+pub use client::{GitHubPrLabel, GitHubUser, PullRequest};
 mod token;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -1,0 +1,37 @@
+use anyhow::{Context, Result, bail};
+
+pub async fn list(
+    preferred_username: &Option<String>,
+    owner: &str,
+    repo: &str,
+) -> Result<Vec<crate::client::PullRequest>> {
+    let known_usernames = crate::token::list_known_github_usernames()?;
+    let Some(default_username) = known_usernames.first() else {
+        bail!("No authenticated GitHub users found. Please authenticate with GitHub first.");
+    };
+
+    let login = if let Some(username) = preferred_username {
+        if known_usernames.contains(username) {
+            username
+        } else {
+            bail!(
+                "Preferred GitHub username '{}' has not authenticated yet. Please choose another username or authenticate with the desired account first.",
+                username
+            );
+        }
+    } else {
+        default_username
+    };
+
+    if let Some(access_token) = crate::token::get_gh_access_token(login)? {
+        let gh = crate::client::GitHubClient::new(&access_token)
+            .context("Failed to create GitHub client")?;
+        let pulls = gh
+            .list_open_pulls(owner, repo)
+            .await
+            .context("Failed to list open pull requests")?;
+        Ok(pulls)
+    } else {
+        Ok(vec![])
+    }
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -381,6 +381,16 @@ async fn handle_command(
         "pr_templates" => forge::pr_templates_cmd(request.params),
         "pr_template" => forge::pr_template_cmd(request.params),
         "determine_forge_from_url" => forge::determine_forge_from_url_cmd(request.params),
+        "list_reviews" => {
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result = forge::list_reviews_cmd(params).await;
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
         // // Menu commands (limited - no menu_item_set_enabled as it's Tauri-specific)
         // "get_editor_link_scheme" => menu::get_editor_link_scheme(&ctx, request.params),
         // CLI commands

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -5,7 +5,7 @@ use but_workspace::branch::checkout::UncommitedWorktreeChanges;
 use gitbutler_branch::GITBUTLER_WORKSPACE_REFERENCE;
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;
-use gitbutler_forge::forge::ForgeName;
+use gitbutler_forge::forge::ForgeRepoInfo;
 use gitbutler_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, RemoteRefname};
@@ -49,7 +49,7 @@ pub struct BaseBranch {
     pub diverged_ahead: Vec<git2::Oid>,
     #[serde(with = "gitbutler_serde::oid_vec")]
     pub diverged_behind: Vec<git2::Oid>,
-    pub forge_provider: Option<ForgeName>,
+    pub forge_repo_info: Option<ForgeRepoInfo>,
 }
 
 #[instrument(skip(ctx), err(Debug))]
@@ -386,7 +386,7 @@ pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Re
         target.remote_url.clone()
     };
 
-    let forge_provider = gitbutler_forge::determine_forge_from_url(&remote_url);
+    let forge_repo_info = gitbutler_forge::derive_forge_repo_info(&remote_url);
 
     let base = BaseBranch {
         branch_name: target.branch.fullname(),
@@ -410,7 +410,7 @@ pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Re
         diverged,
         diverged_ahead,
         diverged_behind,
-        forge_provider,
+        forge_repo_info,
     };
     Ok(base)
 }

--- a/crates/gitbutler-forge/Cargo.toml
+++ b/crates/gitbutler-forge/Cargo.toml
@@ -9,3 +9,5 @@ rust-version = "1.89"
 serde = { workspace = true, features = ["std"] }
 anyhow = "1.0.100"
 gitbutler-fs.workspace = true
+but-github.workspace = true
+git-url-parse = "0.6.0"

--- a/crates/gitbutler-forge/src/forge.rs
+++ b/crates/gitbutler-forge/src/forge.rs
@@ -9,3 +9,18 @@ pub enum ForgeName {
     Bitbucket,
     Azure,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ForgeRepoInfo {
+    pub forge: ForgeName,
+    pub owner: String,
+    pub repo: String,
+    pub protocol: String,
+}
+
+impl PartialEq for ForgeRepoInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.forge == other.forge && self.owner == other.owner && self.repo == other.repo
+    }
+}

--- a/crates/gitbutler-forge/src/lib.rs
+++ b/crates/gitbutler-forge/src/lib.rs
@@ -1,19 +1,42 @@
-use crate::forge::ForgeName;
+use git_url_parse::{GitUrl, types::provider::GenericProvider};
+
+use crate::forge::{ForgeName, ForgeRepoInfo};
 
 pub mod forge;
 pub mod review;
 
-/// Determine the forge type from a given URL.
-pub fn determine_forge_from_url(url: &str) -> Option<ForgeName> {
-    if url.contains("github.com") {
+fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
+    if host.contains("github.com") {
         Some(ForgeName::GitHub)
-    } else if url.contains("gitlab.com") || url.starts_with("gitlab.") {
+    } else if host.contains("gitlab.com") || host.starts_with("gitlab.") {
         Some(ForgeName::GitLab)
-    } else if url.contains("bitbucket.org") {
+    } else if host.contains("bitbucket.org") {
         Some(ForgeName::Bitbucket)
-    } else if url.contains("azure.com") {
+    } else if host.contains("azure.com") {
         Some(ForgeName::Azure)
     } else {
         None
     }
+}
+
+/// Derive the forge repository information from a remote URL.
+pub fn derive_forge_repo_info(url: &str) -> Option<ForgeRepoInfo> {
+    let git_url = GitUrl::parse(url).ok()?;
+    let host = git_url.host()?;
+    let protocol = git_url.scheme()?;
+
+    let provider_info: GenericProvider = git_url.provider_info().ok()?;
+
+    Some(ForgeRepoInfo {
+        forge: determine_forge_from_host(host)?,
+        owner: provider_info.owner().to_string(),
+        repo: provider_info.repo().to_string(),
+        protocol: protocol.to_string(),
+    })
+}
+
+/// Determine the forge type from a given URL.
+pub fn determine_forge_from_url(url: &str) -> Option<ForgeName> {
+    let repo_info = derive_forge_repo_info(url)?;
+    Some(repo_info.forge)
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -294,6 +294,7 @@ fn main() {
                     forge::pr_templates,
                     forge::pr_template,
                     forge::determine_forge_from_url,
+                    forge::list_reviews,
                     but_api::settings::get_app_settings,
                     settings::update_onboarding_complete,
                     settings::update_telemetry,


### PR DESCRIPTION
## Description

- Implement a way for the Rust side to list reviews (PRs) for a given project.
- The GitHub listing service calls on the newly implemented review listing API.

The design of this API allows for extending it to different forge service providers (e.g. GitLab)