### PR TITLE
but: Display forge review unit symbol

### DIFF
--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -68,7 +68,7 @@ fn get_review_numbers(
     if let Some(reviews) = branch_review_map.get(branch_name) {
         let review_numbers = reviews
             .iter()
-            .map(|r| r.number.to_string())
+            .map(|r| format!("{}{}", r.unit_symbol, r.number))
             .collect::<Vec<String>>()
             .join(", ");
 

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -493,7 +493,7 @@ fn get_review_numbers(
     if let Some(reviews) = branch_review_map.get(branch_name) {
         let review_numbers = reviews
             .iter()
-            .map(|r| r.number.to_string())
+            .map(|r| format!("{}{}", r.unit_symbol, r.number))
             .collect::<Vec<String>>()
             .join(", ");
 

--- a/crates/gitbutler-forge/src/review.rs
+++ b/crates/gitbutler-forge/src/review.rs
@@ -234,6 +234,7 @@ pub struct ForgeReview {
     pub repository_https_url: Option<String>,
     pub repo_owner: Option<String>,
     pub reviewers: Vec<ForgeUser>,
+    pub unit_symbol: String,
 }
 
 impl From<but_github::PullRequest> for ForgeReview {
@@ -261,6 +262,7 @@ impl From<but_github::PullRequest> for ForgeReview {
                 .into_iter()
                 .map(ForgeUser::from)
                 .collect(),
+            unit_symbol: "#".to_string(),
         }
     }
 }


### PR DESCRIPTION
In order to be a bit more clear about what the numbers next to the branches mean, display the review unit symbol next to them