### PR TITLE
Simplify codegen list item

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -360,7 +360,6 @@
 									{stackId}
 									{status}
 									selected={codegenSelected}
-									tokens={usage.tokens}
 									cost={usage.cost}
 								/>
 							{/if}


### PR DESCRIPTION
Remove tokens used, and never use the summary from the session details 
for the one-line summary.