### PR TITLE
testing-stuff

### DIFF
--- a/apps/desktop/src/lib/utils/cookies.ts
+++ b/apps/desktop/src/lib/utils/cookies.ts
@@ -1,4 +1,4 @@
 export function getCookie(name: string): string | undefined {
-	const parsedCookies = document.cookie.split('; ').map((c) => c.split('=', 2));
+	const parsedCookies = document.cookie.split(';').map((c) => c.trim().split('=', 2));
 	return parsedCookies.find(([k, _v]) => k === name)?.[1];
 }

--- a/e2e/playwright/fixtures/.gitconfig
+++ b/e2e/playwright/fixtures/.gitconfig
@@ -11,3 +11,5 @@
 	aiAnthropicKeyOption = bringYourOwn
 [init]
 	defaultBranch = main
+[commit]
+	gpgsign = false

--- a/e2e/playwright/tests/addingAProject.spec.ts
+++ b/e2e/playwright/tests/addingAProject.spec.ts
@@ -9,7 +9,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should handle gracefully adding an existing project', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -17,7 +17,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should be able to apply a remote branch', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler.destroy();
+	await gitbutler.destroy();
 });
 
 test('should be able to amend a file to a commit', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should show commit-msg hook rejection error', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/editMode.spec.ts
+++ b/e2e/playwright/tests/editMode.spec.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should be able to edit a commit through the edit mode', async ({

--- a/e2e/playwright/tests/moveBranch.spec.ts
+++ b/e2e/playwright/tests/moveBranch.spec.ts
@@ -9,7 +9,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('move branch to top of other stack and tear it off', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/projectOffboarding.spec.ts
+++ b/e2e/playwright/tests/projectOffboarding.spec.ts
@@ -9,7 +9,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should be able to delete the last project gracefuly', async ({ page, context }, testInfo) => {

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -5,6 +5,7 @@ import {
 	clickByTestId,
 	fillByTestId,
 	getByTestId,
+	sleep,
 	textEditorFillByTestId,
 	waitForTestId
 } from '../src/util.ts';
@@ -17,7 +18,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should start the application and be able to commit', async ({ page, context }, testInfo) => {
@@ -123,6 +124,9 @@ test('no author setup - should start the application and be able to commit', asy
 
 	// Should see the author missing modal
 	await waitForTestId(page, 'global-modal-author-missing');
+	// Idk why, but someone this fills the input too quickly and... something...
+	// causes it to get unset
+	await sleep(30);
 	await fillByTestId(page, 'global-modal-author-missing-name-input', 'Test User');
 	await fillByTestId(page, 'global-modal-author-missing-email-input', 'test@example.com');
 	await clickByTestId(page, 'global-modal-author-missing-action-button', true);

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -9,7 +9,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	gitbutler?.destroy();
+	await gitbutler?.destroy();
 });
 
 test('should handle the update of workspace with one conflicting branch gracefully', async ({


### PR DESCRIPTION
Changes made:
- Updated cookie parsing. Objectively this didn't need to be done, but this should be more compatible
- Make sure there is no GPG signing in the test.
- Use cookie for setting the right port. This way we can have just one build of the FE compiled and running

When running locally, 4 workers are used. This is already saturating my processor so any more doesn't make sense