### PR TITLE
fix(ui): message max width from percentage to pixels

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -784,7 +784,7 @@
 	/* Needed for `focusCursor.svelte` to work correctly on `Drawer` components . */
 	.details-view__codegen,
 	.details-view__inner {
-		--message-max-width: 80%;
+		--message-max-width: 620px;
 		display: flex;
 		position: relative;
 		flex-direction: column;

--- a/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
@@ -59,7 +59,9 @@
 				<div class="compaction-summary__arrow" class:expanded>
 					<Icon name="chevron-right" />
 				</div>
-				<p class="text-13 text-italic clr-text-2">Conversation compacted to preserve context</p>
+				<p class="text-13 text-italic clr-text-2 truncate">
+					Conversation compacted to preserve context
+				</p>
 			</button>
 			{#if expanded}
 				<div class="text-13 compaction-summary__content">
@@ -77,6 +79,7 @@
 
 	.compaction-summary {
 		width: fit-content;
+		max-width: 100%;
 		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-ml);

--- a/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
@@ -28,7 +28,7 @@
 	.message-bubble {
 		display: flex;
 		flex-direction: column;
-		max-width: calc(var(--message-max-width) - 6%);
+		max-width: var(--message-max-width);
 		padding: 10px 14px;
 		overflow: hidden;
 		gap: 16px;


### PR DESCRIPTION
For small codegen sizes, 80% width is too little, so we should use pixels instead to make it take the full width on smaller screens.

before:

<img width="562" height="612" alt="image" src="https://github.com/user-attachments/assets/3eeba381-3af9-4ad8-8d9f-3fc827d1453d" />

after:

<img width="555" height="678" alt="image" src="https://github.com/user-attachments/assets/180613be-6e0c-400e-a0c0-1a63636e8a5f" />
