### PR TITLE
Forge Settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "but-claude",
  "but-core",
  "but-feedback",
+ "but-forge-storage",
  "but-gerrit",
  "but-github",
  "but-graph",
@@ -1076,6 +1077,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "but-forge-storage"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "gitbutler-storage",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "but-gerrit"
 version = "0.0.0"
 dependencies = [
@@ -1097,6 +1108,7 @@ name = "but-github"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-forge-storage",
  "but-secret",
  "but-settings",
  "gitbutler-user",
@@ -3502,10 +3514,13 @@ name = "gitbutler-forge"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-forge-storage",
  "but-github",
  "git-url-parse",
  "gitbutler-fs",
+ "gitbutler-storage",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,7 @@ name = "but-forge-storage"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-secret",
  "gitbutler-storage",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
+ "but-path",
  "but-rebase",
  "but-rules",
  "but-secret",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ gitbutler-oxidize = { path = "crates/gitbutler-oxidize" }
 gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-forge = { path = "crates/gitbutler-forge" }
 gitbutler-hunk-dependency = { path = "crates/gitbutler-hunk-dependency" }
+but-forge-storage = {path = "crates/but-forge-storage" }
 but-settings = { path = "crates/but-settings" }
 gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 but = { path = "crates/but" }

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -53,6 +53,8 @@ but-broadcaster.workspace = true
 but-cherry-apply.workspace = true
 gitbutler-oplog.workspace = true
 but-hunk-dependency.workspace = true
+but-path.workspace = true
+but-forge-storage.workspace = true
 serde-error = "0.1.3"
 gix = { workspace = true, features = [
     "worktree-mutation",

--- a/crates/but-api/src/commands/forge.rs
+++ b/crates/but-api/src/commands/forge.rs
@@ -77,11 +77,13 @@ pub async fn list_reviews_cmd(
     let app_settings = AppSettings::load_from_default_path_creating()?;
     let ctx = CommandContext::open(&project, app_settings)?;
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
     gitbutler_forge::review::list_forge_reviews(
         &project.preferred_forge_user,
         &base_branch
             .forge_repo_info
             .context("No forge could be determined for this repository branch")?,
+        &storage,
     )
     .await
     .map_err(Into::into)
@@ -110,12 +112,14 @@ pub async fn publish_review_cmd(
     let app_settings = AppSettings::load_from_default_path_creating()?;
     let ctx = CommandContext::open(&project, app_settings)?;
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
     gitbutler_forge::review::create_forge_review(
         &project.preferred_forge_user,
         &base_branch
             .forge_repo_info
             .context("No forge could be determined for this repository branch")?,
         &params,
+        &storage,
     )
     .await
     .map_err(Into::into)

--- a/crates/but-api/src/commands/github.rs
+++ b/crates/but-api/src/commands/github.rs
@@ -41,7 +41,8 @@ impl From<AuthStatusResponse> for AuthStatusResponseSensitive {
 pub async fn check_auth_status(
     params: CheckAuthStatusParams,
 ) -> Result<AuthStatusResponseSensitive, Error> {
-    let status_result = but_github::check_auth_status(params).await;
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
+    let status_result = but_github::check_auth_status(params, &storage).await;
     match status_result {
         Ok(status) => Ok(status.into()),
         Err(e) => Err(e.into()),
@@ -52,7 +53,8 @@ pub async fn check_auth_status(
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn forget_github_username(username: String) -> Result<(), Error> {
-    but_github::forget_gh_access_token(&username).ok();
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
+    but_github::forget_gh_access_token(&username, &storage).ok();
     Ok(())
 }
 
@@ -60,7 +62,8 @@ pub fn forget_github_username(username: String) -> Result<(), Error> {
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn clear_all_github_tokens() -> Result<(), Error> {
-    but_github::clear_all_github_tokens().map_err(Into::into)
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
+    but_github::clear_all_github_tokens(&storage).map_err(Into::into)
 }
 
 #[derive(Debug, Serialize)]
@@ -103,14 +106,16 @@ pub async fn get_gh_user(
     params: GetGhUserParams,
 ) -> Result<Option<AuthenticatedUserSensitive>, Error> {
     let GetGhUserParams { username } = params;
-    but_github::get_gh_user(&username)
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
+    but_github::get_gh_user(&username, &storage)
         .await
         .map(|res| res.map(Into::into))
         .map_err(Into::into)
 }
 
 pub async fn list_known_github_usernames() -> Result<Vec<String>, Error> {
-    but_github::list_known_github_usernames()
+    let storage = but_forge_storage::controller::Controller::from_path(but_path::app_data_dir()?);
+    but_github::list_known_github_usernames(&storage)
         .await
         .map_err(Into::into)
 }

--- a/crates/but-forge-storage/Cargo.toml
+++ b/crates/but-forge-storage/Cargo.toml
@@ -15,3 +15,4 @@ serde.workspace = true
 anyhow.workspace = true
 serde_json = "1.0.145"
 gitbutler-storage.workspace = true
+but-secret.workspace = true

--- a/crates/but-forge-storage/Cargo.toml
+++ b/crates/but-forge-storage/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "but-forge-storage"
+version = "0.0.0"
+edition = "2024"
+repository = "https://github.com/gitbutlerapp/gitbutler"
+license-file = "../../LICENSE.md"
+description = "A GitButler CLI tool"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+readme = "../../README.md"
+publish = false
+rust-version = "1.89"
+
+[dependencies]
+serde.workspace = true
+anyhow.workspace = true
+serde_json = "1.0.145"
+gitbutler-storage.workspace = true

--- a/crates/but-forge-storage/src/controller.rs
+++ b/crates/but-forge-storage/src/controller.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use crate::storage;
+
+#[derive(Clone, Debug)]
+pub struct Controller {
+    settings_storage: storage::Storage,
+}
+
+impl Controller {
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        Self {
+            settings_storage: storage::Storage::from_path(&path),
+        }
+    }
+
+    /// Get all known GitHub accounts.
+    pub fn github_accounts(&self) -> anyhow::Result<Vec<crate::settings::GitHubAccount>> {
+        let settings = self.read_settings()?;
+        Ok(settings.github.known_accounts)
+    }
+
+    /// Add a GitHub account if it does not already exist.
+    pub fn add_github_account(
+        &self,
+        account: &crate::settings::GitHubAccount,
+    ) -> anyhow::Result<()> {
+        let mut settings = self.read_settings()?;
+
+        if settings.github.known_accounts.iter().any(|a| a == account) {
+            return Ok(());
+        }
+
+        settings.github.known_accounts.push(account.to_owned());
+        self.save_settings(&settings)
+    }
+
+    /// Clear all GitHub accounts.
+    /// Returns the list of access token keys that should be deleted.
+    pub fn clear_all_github_accounts(&self) -> anyhow::Result<Vec<String>> {
+        let mut settings = self.read_settings()?;
+        let access_tokens_to_delete = settings
+            .github
+            .known_accounts
+            .iter()
+            .map(|account| account.access_token_key().to_string())
+            .collect::<Vec<String>>();
+        settings.github.known_accounts.clear();
+        self.save_settings(&settings)?;
+
+        Ok(access_tokens_to_delete)
+    }
+
+    /// Remove a GitHub account.
+    pub fn remove_github_account(
+        &self,
+        account: &crate::settings::GitHubAccount,
+    ) -> anyhow::Result<()> {
+        let mut settings = self.read_settings()?;
+
+        settings.github.known_accounts.retain(|a| a != account);
+
+        self.save_settings(&settings)
+    }
+
+    fn read_settings(&self) -> anyhow::Result<crate::settings::ForgeSettings> {
+        self.settings_storage.read()
+    }
+
+    fn save_settings(&self, settings: &crate::settings::ForgeSettings) -> anyhow::Result<()> {
+        self.settings_storage.save(settings)
+    }
+}

--- a/crates/but-forge-storage/src/lib.rs
+++ b/crates/but-forge-storage/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod controller;
+pub mod settings;
+pub mod storage;

--- a/crates/but-forge-storage/src/settings.rs
+++ b/crates/but-forge-storage/src/settings.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ForgeSettings {
+    /// GitHub-specific settings.
+    pub github: GitHubSettings,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubSettings {
+    /// GitHub-specific settings.
+    pub known_accounts: Vec<GitHubAccount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum GitHubAccount {
+    OAuth {
+        // Username associated with the OAuth account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+    Pat {
+        // Username associated with the PAT account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+}
+
+impl GitHubAccount {
+    pub fn access_token_key(&self) -> &str {
+        match self {
+            GitHubAccount::OAuth {
+                access_token_key, ..
+            } => access_token_key,
+            GitHubAccount::Pat {
+                access_token_key, ..
+            } => access_token_key,
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        match self {
+            GitHubAccount::OAuth { username, .. } => username,
+            GitHubAccount::Pat { username, .. } => username,
+        }
+    }
+}
+
+impl PartialEq for GitHubAccount {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                GitHubAccount::OAuth {
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GitHubAccount::OAuth {
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => u1 == u2 && k1 == k2,
+            (
+                GitHubAccount::Pat {
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GitHubAccount::Pat {
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => u1 == u2 && k1 == k2,
+            (GitHubAccount::OAuth { .. }, GitHubAccount::Pat { .. }) => false,
+            (GitHubAccount::Pat { .. }, GitHubAccount::OAuth { .. }) => false,
+        }
+    }
+}

--- a/crates/but-forge-storage/src/storage.rs
+++ b/crates/but-forge-storage/src/storage.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Mutex};
 
-use crate::settings::ForgeSettings;
+use crate::settings::{ForgeSettings, GitHubAccount};
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 const FORGE_SETTINGS_FILE: &str = "forge_settings.json";
 
@@ -18,13 +19,15 @@ impl Storage {
     }
 
     pub fn read(&self) -> Result<ForgeSettings> {
-        match self.inner.read(FORGE_SETTINGS_FILE)? {
+        let settings = match self.inner.read(FORGE_SETTINGS_FILE)? {
             Some(settings) => {
                 let settings: ForgeSettings = serde_json::from_str(&settings)?;
-                Ok(settings)
+                settings
             }
-            None => Ok(Default::default()),
-        }
+            None => Default::default(),
+        };
+
+        self.migrate_accounts(settings)
     }
 
     pub fn save(&self, settings: &ForgeSettings) -> Result<()> {
@@ -32,4 +35,111 @@ impl Storage {
         self.inner.write(FORGE_SETTINGS_FILE, &data)?;
         Ok(())
     }
+
+    /// Migrate known GitHub accounts from secret storage to the new settings structure.
+    /// This can be removed after the stable release.
+    fn migrate_accounts(&self, settings: ForgeSettings) -> Result<ForgeSettings> {
+        let old_handle = "github_known_accounts";
+        let namespace = but_secret::secret::Namespace::BuildKind;
+
+        if settings.github.known_accounts.is_empty()
+            && let Some(known_accounts) = but_secret::secret::retrieve(old_handle, namespace)?
+        {
+            // Migrate old known accounts from secret storage
+            let known_account_keys: Vec<String> = serde_json::from_str(&known_accounts)?;
+            let mut new_settings = settings.clone();
+            for account_key in known_account_keys {
+                if let Some(migrated_account) = migrate_account(&account_key)? {
+                    new_settings.github.known_accounts.push(migrated_account);
+                }
+            }
+            self.save(&new_settings)?;
+            return Ok(new_settings);
+        }
+
+        Ok(settings)
+    }
+}
+
+// ===============================
+// Migration of GitHub accounts.
+//
+// All of the code below this line is only needed to migrate old GitHub accounts,
+// and can be removed after the stable release.
+// ===============================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum DeprecatedSerializableGitHubAccount {
+    OAuth {
+        username: String,
+        access_token: String,
+    },
+    Pat {
+        username: String,
+        access_token: String,
+    },
+}
+
+fn read_deprecated_github_secret(
+    account_secret_handle: &str,
+) -> Result<Option<DeprecatedSerializableGitHubAccount>> {
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    if let Some(secret_value) = but_secret::secret::retrieve(
+        account_secret_handle,
+        but_secret::secret::Namespace::BuildKind,
+    )? {
+        let account: DeprecatedSerializableGitHubAccount = serde_json::from_str(&secret_value)?;
+        Ok(Some(account))
+    } else {
+        Ok(None)
+    }
+}
+
+fn store_access_token_in_secret(account_secret_handle: &str, access_token: &str) -> Result<()> {
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    but_secret::secret::persist(
+        account_secret_handle,
+        &but_secret::Sensitive(access_token.to_string()),
+        but_secret::secret::Namespace::BuildKind,
+    )
+}
+
+fn migrate_account(account_secret_handle: &str) -> Result<Option<GitHubAccount>> {
+    // Read the deprecated account structure.
+    // If it fails to parse it we assume there is nothing to migrate.
+    if let Some(deprecated_account) = read_deprecated_github_secret(account_secret_handle)
+        .ok()
+        .flatten()
+    {
+        let new_account = match deprecated_account {
+            DeprecatedSerializableGitHubAccount::OAuth {
+                username,
+                access_token,
+            } => {
+                // Store the plain access token in the same secret
+                store_access_token_in_secret(account_secret_handle, &access_token)?;
+                GitHubAccount::OAuth {
+                    username: username.clone(),
+                    access_token_key: account_secret_handle.to_string(),
+                }
+            }
+            DeprecatedSerializableGitHubAccount::Pat {
+                username,
+                access_token,
+            } => {
+                // Store the plain access token in the same secret
+                store_access_token_in_secret(account_secret_handle, &access_token)?;
+                GitHubAccount::Pat {
+                    username: username.clone(),
+                    access_token_key: account_secret_handle.to_string(),
+                }
+            }
+        };
+
+        return Ok(Some(new_account));
+    }
+    Ok(None)
 }

--- a/crates/but-forge-storage/src/storage.rs
+++ b/crates/but-forge-storage/src/storage.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use crate::settings::ForgeSettings;
+use anyhow::Result;
+
+const FORGE_SETTINGS_FILE: &str = "forge_settings.json";
+
+#[derive(Debug, Clone)]
+pub(crate) struct Storage {
+    inner: gitbutler_storage::Storage,
+}
+
+impl Storage {
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        Storage {
+            inner: gitbutler_storage::Storage::new(path),
+        }
+    }
+
+    pub fn read(&self) -> Result<ForgeSettings> {
+        match self.inner.read(FORGE_SETTINGS_FILE)? {
+            Some(settings) => {
+                let settings: ForgeSettings = serde_json::from_str(&settings)?;
+                Ok(settings)
+            }
+            None => Ok(Default::default()),
+        }
+    }
+
+    pub fn save(&self, settings: &ForgeSettings) -> Result<()> {
+        let data = serde_json::to_string_pretty(settings)?;
+        self.inner.write(FORGE_SETTINGS_FILE, &data)?;
+        Ok(())
+    }
+}

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.89"
 serde.workspace = true
 but-settings.workspace = true
 but-secret.workspace = true
+but-forge-storage.workspace = true
 anyhow.workspace = true
 gitbutler-user.workspace = true
 serde_json = "1.0.145"

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -1,64 +1,73 @@
 use std::sync::Mutex;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use but_secret::{Sensitive, secret};
 use serde::{Deserialize, Serialize};
 
-/// Persist GitHub OAuth access tokens securely.
-pub fn persist_gh_access_token(login: &str, access_token: &Sensitive<String>) -> Result<()> {
-    let mut map = retrieve_github_account_map()?;
-    if let Some(entry) = map.iter_mut().find(|entry| match entry {
-        GitHubAccount::OAuth { username, .. } => username == login,
-        _ => false,
-    }) {
-        entry.set_access_token(access_token.clone());
-        persist_github_account(entry)
-    } else {
-        let account = GitHubAccount::OAuth {
-            username: login.to_string(),
-            access_token: access_token.clone(),
-        };
-        persist_github_account(&account)
-    }
+/// Persist GitHub account access tokens securely.
+pub fn persist_gh_access_token(
+    account_id: &GithubAccountIdentifier,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<()> {
+    let oauth_account = GitHubAccount::new(account_id, access_token.clone());
+    persist_github_account(&oauth_account, storage)
 }
 
-/// Delete a GitHub OAuth access token for a given username.
-pub fn delete_gh_access_token(login: &str) -> Result<()> {
-    let map = retrieve_github_account_map()?;
-    let account = map.into_iter().find(|entry| match entry {
-        GitHubAccount::OAuth { username, .. } => username == login,
-        _ => false,
-    });
+/// Delete a GitHub account access token for a given username.
+pub fn delete_gh_access_token(
+    account_id: &GithubAccountIdentifier,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<()> {
+    let account = find_github_account(account_id, storage)?;
     if let Some(account) = account {
-        delete_github_account(&account)
+        delete_github_account(&account, storage)
     } else {
         Ok(())
     }
 }
 
-/// Retrieve a GitHub OAuth access token for a given username.
-pub fn get_gh_access_token(login: &str) -> Result<Option<Sensitive<String>>> {
-    let map = retrieve_github_account_map()?;
-    Ok(map
-        .into_iter()
-        .find(|entry| entry.username() == login)
-        .map(|entry| entry.access_token()))
+/// Retrieve a GitHub account access token for a given username.
+pub fn get_gh_access_token(
+    account_id: &GithubAccountIdentifier,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<Option<Sensitive<String>>> {
+    let account = find_github_account(account_id, storage)?;
+    Ok(account.map(|acct| acct.access_token()))
 }
 
-pub fn list_known_github_usernames() -> Result<Vec<String>> {
-    let map = retrieve_github_account_map()?;
-    Ok(map.into_iter().map(|entry| entry.username()).collect())
+pub fn list_known_github_usernames(
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<Vec<String>> {
+    Ok(storage
+        .github_accounts()?
+        .iter()
+        .map(|account| account.username().to_string())
+        .collect::<Vec<String>>())
 }
 
-pub fn clear_all_github_tokens() -> Result<()> {
-    let map = retrieve_github_account_map()?;
-    for account in map {
-        delete_github_account(&account)?;
-    }
+pub fn clear_all_github_accounts(
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<()> {
+    delete_all_github_accounts(storage)?;
     Ok(())
 }
 
-const GITHUB_KNOWN_ACCOUTNS_LIST_KEY: &str = "github_known_accounts";
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "username")]
+pub enum GithubAccountIdentifier {
+    OAuthUsername(String),
+    PatUsername(String),
+}
+
+impl GithubAccountIdentifier {
+    pub fn oauth(username: &str) -> Self {
+        GithubAccountIdentifier::OAuthUsername(username.to_string())
+    }
+    pub fn pat(username: &str) -> Self {
+        GithubAccountIdentifier::PatUsername(username.to_string())
+    }
+}
 
 pub enum GitHubAccount {
     OAuth {
@@ -72,28 +81,40 @@ pub enum GitHubAccount {
     },
 }
 
-impl From<SerializableGitHubAccount> for GitHubAccount {
-    fn from(ser: SerializableGitHubAccount) -> Self {
-        match ser {
-            SerializableGitHubAccount::OAuth {
-                username,
-                access_token,
-            } => GitHubAccount::OAuth {
-                username,
-                access_token: Sensitive(access_token),
-            },
-            SerializableGitHubAccount::Pat {
-                username,
-                access_token,
-            } => GitHubAccount::Pat {
-                username,
-                access_token: Sensitive(access_token),
-            },
+impl From<&GitHubAccount> for but_forge_storage::settings::GitHubAccount {
+    fn from(account: &GitHubAccount) -> Self {
+        let access_token_key = account.secret_key();
+        match account {
+            GitHubAccount::OAuth { username, .. } => {
+                but_forge_storage::settings::GitHubAccount::OAuth {
+                    username: username.to_owned(),
+                    access_token_key,
+                }
+            }
+            GitHubAccount::Pat { username, .. } => {
+                but_forge_storage::settings::GitHubAccount::Pat {
+                    username: username.to_owned(),
+                    access_token_key,
+                }
+            }
         }
     }
 }
 
 impl GitHubAccount {
+    pub fn new(account_id: &GithubAccountIdentifier, access_token: Sensitive<String>) -> Self {
+        match account_id {
+            GithubAccountIdentifier::OAuthUsername(username) => GitHubAccount::OAuth {
+                username: username.to_string(),
+                access_token,
+            },
+            GithubAccountIdentifier::PatUsername(username) => GitHubAccount::Pat {
+                username: username.to_string(),
+                access_token,
+            },
+        }
+    }
+
     fn secret_key(&self) -> String {
         match self {
             GitHubAccount::OAuth { username, .. } => format!("github_oauth_{}", username),
@@ -102,17 +123,7 @@ impl GitHubAccount {
     }
 
     fn secret_value(&self) -> Result<Sensitive<String>> {
-        let ser = SerializableGitHubAccount::from(self);
-        let ser_string = serde_json::to_string(&ser)
-            .context("Failed to serialize GitHub account for secret storage")?;
-        Ok(Sensitive(ser_string))
-    }
-
-    fn username(&self) -> String {
-        match self {
-            GitHubAccount::OAuth { username, .. } => username.to_string(),
-            GitHubAccount::Pat { username, .. } => username.to_string(),
-        }
+        Ok(self.access_token())
     }
 
     fn access_token(&self) -> Sensitive<String> {
@@ -121,124 +132,20 @@ impl GitHubAccount {
             GitHubAccount::Pat { access_token, .. } => access_token.clone(),
         }
     }
-
-    fn set_access_token(&mut self, access_token: Sensitive<String>) {
-        match self {
-            GitHubAccount::OAuth {
-                access_token: at, ..
-            } => *at = access_token,
-            GitHubAccount::Pat {
-                access_token: at, ..
-            } => *at = access_token,
-        }
-    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum SerializableGitHubAccount {
-    OAuth {
-        username: String,
-        access_token: String,
-    },
-    Pat {
-        username: String,
-        access_token: String,
-    },
-}
-
-impl From<&GitHubAccount> for SerializableGitHubAccount {
-    fn from(account: &GitHubAccount) -> Self {
-        match account {
-            GitHubAccount::OAuth {
-                username,
-                access_token,
-            } => SerializableGitHubAccount::OAuth {
-                username: username.clone(),
-                access_token: access_token.clone().0,
-            },
-            GitHubAccount::Pat {
-                username,
-                access_token,
-            } => SerializableGitHubAccount::Pat {
-                username: username.clone(),
-                access_token: access_token.clone().0,
-            },
-        }
-    }
-}
-
-/// List all known GitHub account keys.
-fn retrieve_known_github_accounts_keys() -> Result<Vec<String>> {
+fn retrieve_github_secret(account_secret_key: &str) -> Result<Option<Sensitive<String>>> {
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    if let Some(serialized_list) =
-        secret::retrieve(GITHUB_KNOWN_ACCOUTNS_LIST_KEY, secret::Namespace::BuildKind)?
-    {
-        let list = serde_json::from_str::<Vec<String>>(&serialized_list.0)
-            .context("Failed to deserialize known GitHub accounts list")?;
-        Ok(list)
-    } else {
-        Ok(vec![])
-    }
+    secret::retrieve(account_secret_key, secret::Namespace::BuildKind)
 }
 
-/// Add a GitHub account key to the known list, if not already present.
-fn add_account_key_to_known_list(account_key: &str) -> Result<()> {
-    let mut keys = retrieve_known_github_accounts_keys()?;
-    if !keys.contains(&account_key.to_string()) {
-        keys.push(account_key.to_string());
-        static FAIR_QUEUE: Mutex<()> = Mutex::new(());
-        let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-        let serialized_list = serde_json::to_string(&keys)
-            .context("Failed to serialize known GitHub accounts list")?;
-        secret::persist(
-            GITHUB_KNOWN_ACCOUTNS_LIST_KEY,
-            &Sensitive(serialized_list),
-            secret::Namespace::BuildKind,
-        )
-    } else {
-        Ok(())
-    }
-}
-
-/// Delete a GitHub account key from the known list.
-fn delete_account_key_from_known_list(account_key: &str) -> Result<()> {
-    let mut keys = retrieve_known_github_accounts_keys()?;
-    if let Some(pos) = keys.iter().position(|k| k == account_key) {
-        keys.remove(pos);
-        static FAIR_QUEUE: Mutex<()> = Mutex::new(());
-        let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-        let serialized_list = serde_json::to_string(&keys)
-            .context("Failed to serialize known GitHub accounts list")?;
-        secret::persist(
-            GITHUB_KNOWN_ACCOUTNS_LIST_KEY,
-            &Sensitive(serialized_list),
-            secret::Namespace::BuildKind,
-        )
-    } else {
-        Ok(())
-    }
-}
-
-fn retrieve_github_account(account_secret_key: &str) -> Result<Option<GitHubAccount>> {
-    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
-    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    if let Some(serialized_account) =
-        secret::retrieve(account_secret_key, secret::Namespace::BuildKind)?
-    {
-        let ser =
-            serde_json::from_str::<SerializableGitHubAccount>(&serialized_account.0.to_string())
-                .context("Failed to deserialize GitHub account")?;
-        Ok(Some(ser.into()))
-    } else {
-        Ok(None)
-    }
-}
-
-fn persist_github_account(account: &GitHubAccount) -> Result<()> {
+fn persist_github_account(
+    account: &GitHubAccount,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<()> {
     let secret_key = account.secret_key();
-    add_account_key_to_known_list(&secret_key)?;
+    storage.add_github_account(&account.into())?;
 
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
@@ -249,21 +156,64 @@ fn persist_github_account(account: &GitHubAccount) -> Result<()> {
     )
 }
 
-fn delete_github_account(account: &GitHubAccount) -> Result<()> {
+fn delete_github_account(
+    account: &GitHubAccount,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<()> {
     let secret_key = account.secret_key();
-    delete_account_key_from_known_list(&secret_key)?;
+    storage.remove_github_account(&account.into())?;
+
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
     secret::delete(&secret_key, secret::Namespace::BuildKind)
 }
 
-fn retrieve_github_account_map() -> Result<Vec<GitHubAccount>> {
-    let keys = retrieve_known_github_accounts_keys()?;
-    let mut accounts = vec![];
-    for key in keys {
-        if let Some(account) = retrieve_github_account(&key)? {
-            accounts.push(account);
-        }
+fn delete_all_github_accounts(storage: &but_forge_storage::controller::Controller) -> Result<()> {
+    let keys_to_delete = storage.clear_all_github_accounts()?;
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    for key in keys_to_delete {
+        secret::delete(&key, secret::Namespace::BuildKind)?;
     }
-    Ok(accounts)
+    Ok(())
+}
+
+fn find_github_account(
+    account_id: &GithubAccountIdentifier,
+    storage: &but_forge_storage::controller::Controller,
+) -> Result<Option<GitHubAccount>> {
+    let accounts = storage.github_accounts()?;
+    let result = match account_id {
+        GithubAccountIdentifier::OAuthUsername(username) => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GitHubAccount::OAuth {
+                username: acct_username,
+                access_token_key,
+            } = account
+                && acct_username == username
+                && let Some(access_token) = retrieve_github_secret(access_token_key).ok().flatten()
+            {
+                return Some(GitHubAccount::OAuth {
+                    username: acct_username.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+        GithubAccountIdentifier::PatUsername(username) => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GitHubAccount::Pat {
+                username: acct_username,
+                access_token_key,
+            } = account
+                && acct_username == username
+                && let Some(access_token) = retrieve_github_secret(access_token_key).ok().flatten()
+            {
+                return Some(GitHubAccount::Pat {
+                    username: acct_username.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+    };
+    Ok(result)
 }

--- a/crates/gitbutler-forge/Cargo.toml
+++ b/crates/gitbutler-forge/Cargo.toml
@@ -13,3 +13,4 @@ gitbutler-fs.workspace = true
 gitbutler-storage.workspace = true
 but-github.workspace = true
 git-url-parse = "0.6.0"
+but-forge-storage.workspace = true

--- a/crates/gitbutler-forge/Cargo.toml
+++ b/crates/gitbutler-forge/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 rust-version = "1.89"
 [dependencies]
 serde = { workspace = true, features = ["std"] }
+serde_json = "1.0.145"
 anyhow = "1.0.100"
 gitbutler-fs.workspace = true
+gitbutler-storage.workspace = true
 but-github.workspace = true
 git-url-parse = "0.6.0"

--- a/crates/gitbutler-forge/src/review.rs
+++ b/crates/gitbutler-forge/src/review.rs
@@ -271,13 +271,14 @@ impl From<but_github::PullRequest> for ForgeReview {
 pub async fn list_forge_reviews(
     preferred_forge_user: &Option<String>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
+    storage: &but_forge_storage::controller::Controller,
 ) -> Result<Vec<ForgeReview>> {
     let crate::forge::ForgeRepoInfo {
         forge, owner, repo, ..
     } = forge_repo_info;
     match forge {
         ForgeName::GitHub => {
-            let pulls = but_github::pr::list(preferred_forge_user, owner, repo).await?;
+            let pulls = but_github::pr::list(preferred_forge_user, owner, repo, storage).await?;
             Ok(pulls.into_iter().map(ForgeReview::from).collect())
         }
         _ => Err(Error::msg(format!(
@@ -302,6 +303,7 @@ pub async fn create_forge_review(
     preferred_forge_user: &Option<String>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
     params: &CreateForgeReviewParams,
+    storage: &but_forge_storage::controller::Controller,
 ) -> Result<ForgeReview> {
     let crate::forge::ForgeRepoInfo {
         forge, owner, repo, ..
@@ -319,7 +321,7 @@ pub async fn create_forge_review(
                 base: &params.target_branch,
                 draft: params.draft,
             };
-            let pr = but_github::pr::create(preferred_forge_user, pr_params).await?;
+            let pr = but_github::pr::create(preferred_forge_user, pr_params, storage).await?;
             Ok(ForgeReview::from(pr))
         }
         _ => Err(Error::msg(format!(


### PR DESCRIPTION
Create a build-type-specific storage for forge-related settings.
Currently, the only information stored there is the GitHub account information.

Now:
- Known accounts and their metadata are stored in the file-based storage
- Secrets (access tokens) are stored plainly in the secret storage

This includes a migration step that runs only once and cleans up the previous secret that kept metadata stored.
