### PR TITLE
ui-fixes

### DIFF
--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -75,6 +75,8 @@
 	{noshrink}
 	bottomBorder={changes.length > 0}
 	persistId={`changed-files-drawer-${projectId}-${stackId || 'default'}`}
+	childrenWrapHeight={changes.length > 0 ? 'auto' : '100%'}
+	childrenWrapDisplay={changes.length > 0 ? 'block' : 'flex'}
 >
 	{#snippet header()}
 		<h4 class="text-14 text-semibold truncate">{title}</h4>
@@ -123,6 +125,7 @@
 	.filelist-wrapper {
 		display: flex;
 		flex-direction: column;
+		height: 100%;
 		margin-bottom: 16px;
 		background-color: var(--clr-bg-1);
 

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -24,6 +24,8 @@
 		resizer?: Partial<ComponentProps<typeof Resizer>>;
 		defaultCollapsed?: boolean;
 		notScrollable?: boolean;
+		childrenWrapHeight?: string;
+		childrenWrapDisplay?: 'block' | 'content' | 'flex';
 		onclose?: () => void;
 		ontoggle?: (collapsed: boolean) => void;
 	};
@@ -41,6 +43,8 @@
 		clientHeight = $bindable(),
 		defaultCollapsed = false,
 		notScrollable = false,
+		childrenWrapHeight,
+		childrenWrapDisplay,
 		ontoggle,
 		onclose
 	}: Props = $props();
@@ -98,7 +102,7 @@
 				{@render children()}
 			</div>
 		{:else}
-			<ConfigurableScrollableContainer>
+			<ConfigurableScrollableContainer {childrenWrapHeight} {childrenWrapDisplay}>
 				<div class="drawer__content" bind:clientHeight={contentHeight}>
 					{@render children()}
 				</div>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -390,19 +390,22 @@
 				draggableFiles
 				selectionId={createCommitSelection({ commitId, stackId: stackId })}
 				noshrink={!!previewKey}
+				grow={!previewKey}
 				changes={changes.changes.filter(
 					(change) => !(change.path in (changes.conflictEntries?.entries ?? {}))
 				)}
 				stats={changes.stats}
 				conflictEntries={changes.conflictEntries}
 				{ancestorMostConflictedCommitId}
-				resizer={{
-					persistId: `changed-files-${stackId}`,
-					direction: 'down',
-					minHeight: 8,
-					maxHeight: 32,
-					defaultValue: 16
-				}}
+				resizer={previewKey
+					? {
+							persistId: `changed-files-${stackId}`,
+							direction: 'down',
+							minHeight: 8,
+							maxHeight: 32,
+							defaultValue: 16
+						}
+					: undefined}
 				autoselect
 				allowUnselect={false}
 			/>
@@ -426,15 +429,18 @@
 				autoselect
 				selectionId={createBranchSelection({ stackId: stackId, branchName, remote: undefined })}
 				noshrink={!!previewKey}
+				grow={!previewKey}
 				changes={changes.changes}
 				stats={changes.stats}
-				resizer={{
-					persistId: `changed-files-${stackId}`,
-					direction: 'down',
-					minHeight: 8,
-					maxHeight: 32,
-					defaultValue: 16
-				}}
+				resizer={previewKey
+					? {
+							persistId: `changed-files-${stackId}`,
+							direction: 'down',
+							minHeight: 8,
+							maxHeight: 32,
+							defaultValue: 16
+						}
+					: undefined}
 				allowUnselect={false}
 			/>
 		{/snippet}
@@ -617,11 +623,13 @@
 					{/if}
 
 					<!-- MIDDLE SECTION: Changed Files (with resizer) -->
-					{#if branchName && commitId}
-						{@render commitChangedFiles(commitId)}
-					{:else if branchName}
-						{@render branchChangedFiles(branchName)}
-					{/if}
+					<div class="changed-files-section" class:expand={!(assignedStackId || selectedFile)}>
+						{#if branchName && commitId}
+							{@render commitChangedFiles(commitId)}
+						{:else if branchName}
+							{@render branchChangedFiles(branchName)}
+						{/if}
+					</div>
 
 					<!-- BOTTOM SECTION: File Preview (no resizer) -->
 					{#if assignedStackId || selectedFile}
@@ -770,6 +778,7 @@
 		top: 12px;
 		flex-shrink: 0;
 		flex-direction: column;
+		height: 100%;
 		max-height: calc(100% - 24px);
 		margin-right: 2px;
 		overflow: hidden;
@@ -783,12 +792,24 @@
 	.details-view__inner {
 		display: flex;
 		position: relative;
+		flex: 1;
 		flex-direction: column;
 		overflow: hidden;
 	}
 
 	:global(.dark) .details-view {
 		box-shadow: 0 10px 50px 5px color(srgb 0 0 0 / 0.5);
+	}
+
+	.changed-files-section {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+
+		&.expand {
+			flex: 1;
+			min-height: 0; /* Allow shrinking */
+		}
 	}
 
 	.file-preview-section {

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -600,15 +600,13 @@
 			use:focusable={{ vertical: true }}
 		>
 			{#if stableStackId && selection?.branchName && selection?.codegen}
-				<div class="details-view__codegen">
-					<CodegenMessages
-						isWorkspace
-						projectId={stableProjectId}
-						stackId={stableStackId}
-						branchName={selection.branchName}
-						onclose={onclosePreview}
-					/>
-				</div>
+				<CodegenMessages
+					isWorkspace
+					projectId={stableProjectId}
+					stackId={stableStackId}
+					branchName={selection.branchName}
+					onclose={onclosePreview}
+				/>
 			{:else}
 				<div class="details-view__inner">
 					<!-- TOP SECTION: Branch/Commit Details (no resizer) -->
@@ -782,9 +780,7 @@
 	}
 
 	/* Needed for `focusCursor.svelte` to work correctly on `Drawer` components . */
-	.details-view__codegen,
 	.details-view__inner {
-		--message-max-width: 620px;
 		display: flex;
 		position: relative;
 		flex-direction: column;

--- a/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
+++ b/apps/desktop/src/components/codegen/CodegenChatLayout.svelte
@@ -109,6 +109,7 @@
 	}
 
 	.chat-container {
+		--message-max-width: 620px;
 		display: flex;
 		position: relative;
 		flex: 1;

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -334,18 +334,21 @@
 			{/snippet}
 			{#snippet inWorkspaceInlineContextActions()}
 				{@const stats = usageStats(events)}
+				{@const contextUsage = Math.round(stats.contextUtilization * 100)}
 				<div class="flex gap-8 items-center">
-					<Tooltip text="{(stats.contextUtilization * 100).toFixed(0)}% context used">
+					<Tooltip text="{contextUsage}% context used">
 						<div
 							class="context-utilization-piechart"
-							style="--context-utilization: {stats.contextUtilization}"
+							style="--context-utilization: {contextUsage}%"
 						></div>
 					</Tooltip>
 
-					<KebabButton
-						bind:el={workspaceContextActionsKebab}
-						onclick={() => contextActionsContextMenu?.toggle()}
-					/>
+					{#if contextUsage > 0}
+						<KebabButton
+							bind:el={workspaceContextActionsKebab}
+							onclick={() => contextActionsContextMenu?.toggle()}
+						/>
+					{/if}
 				</div>
 			{/snippet}
 			{#snippet inWorkspaceInlineActions()}
@@ -400,7 +403,7 @@
 						style="--context-utilization: {stats.contextUtilization}"
 					>
 						<span class="truncate">
-							{(stats.contextUtilization * 100).toFixed(0)}% context used
+							{Math.round(stats.contextUtilization * 100)}% context used
 						</span>
 					</div>
 
@@ -656,6 +659,7 @@
 		!events.response ||
 		events.response.length === 0 ||
 		['running', 'compacting'].includes(currentStatus(events.response, isStackActive))}
+
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Clear context and rules"
@@ -728,8 +732,8 @@
 		height: 16px;
 		border-radius: 50%;
 		background: conic-gradient(
-			var(--clr-text-2) calc(var(--context-utilization) * 360deg),
-			var(--clr-border-2) calc(var(--context-utilization) * 360deg)
+			var(--clr-text-2) var(--context-utilization),
+			var(--clr-border-2) var(--context-utilization)
 		);
 	}
 

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -570,8 +570,6 @@
 		width: 100%;
 		height: 100%;
 		gap: 8px;
-		/* SHARABLE */
-		--message-max-width: 620px;
 	}
 
 	.chat-view {

--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -291,14 +291,6 @@
 	data-remove-from-panning
 	role="presentation"
 	class="editor-wrapper hide-native-scrollbar"
-	style:--lexical-input-client-text-wrap={useRuler && !forceSansFont ? 'nowrap' : 'normal'}
-	style:--code-block-font={useRuler && !forceSansFont
-		? $userSettings.diffFont
-		: 'var(--font-default)'}
-	style:--code-block-tab-size={$userSettings.tabSize && !forceSansFont ? $userSettings.tabSize : 4}
-	style:--code-block-ligatures={$userSettings.diffLigatures && !forceSansFont
-		? 'common-ligatures'
-		: 'normal'}
 	onclick={stopPropagation}
 	ondblclick={stopPropagation}
 	onmousedown={stopPropagation}
@@ -323,7 +315,7 @@
 			}}
 		>
 			{#if useRuler && enableRuler}
-				<MessageEditorRuler />
+				<MessageEditorRuler monospaceFont={$userSettings.diffFont} />
 			{/if}
 
 			<div class="message-textarea__wrapper">
@@ -340,6 +332,10 @@
 					onKeyDown={handleKeyDown}
 					{disabled}
 					{wrapCountValue}
+					useMonospaceFont={useRuler && !forceSansFont}
+					monospaceFont={$userSettings.diffFont}
+					tabSize={$userSettings.tabSize}
+					enableLigatures={$userSettings.diffLigatures}
 				>
 					{#snippet plugins()}
 						<Formatter bind:this={formatter} />

--- a/apps/desktop/src/components/editor/MessageEditorRuler.svelte
+++ b/apps/desktop/src/components/editor/MessageEditorRuler.svelte
@@ -2,6 +2,12 @@
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
 
+	interface Props {
+		monospaceFont?: string;
+	}
+
+	let { monospaceFont }: Props = $props();
+
 	const uiState = inject(UI_STATE);
 	const rulerCountValue = uiState.global.rulerCountValue;
 
@@ -11,6 +17,7 @@
 <div
 	class="message-ruler-container"
 	style:--ruler-position="calc({lineWidth}px - var(--lexical-input-client-padding))"
+	style:--ruler-font={monospaceFont || 'var(--font-default)'}
 >
 	<div class="message-ruler-dummy" bind:clientWidth={lineWidth}>
 		<!-- Create a dummy amount of text to measure the width -->
@@ -52,7 +59,7 @@
 		padding: var(--lexical-input-client-padding);
 		color: red;
 		font-size: var(--lexical-input-font-size);
-		font-family: var(--code-block-font);
+		font-family: var(--ruler-font);
 		opacity: 0;
 	}
 </style>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -19,7 +19,7 @@
 		viewport?: HTMLDivElement;
 		viewportHeight?: number;
 		childrenWrapHeight?: string;
-		childrenWrapDisplay?: 'block' | 'content'; // 'content' is used for virtual lists to avoid unnecessary height calculations
+		childrenWrapDisplay?: 'block' | 'content' | 'flex'; // 'content' is used for virtual lists to avoid unnecessary height calculations
 		/** used only with virtual list. */
 		top?: number;
 		bottom?: number;

--- a/packages/ui/src/lib/richText/RichTextEditor.svelte
+++ b/packages/ui/src/lib/richText/RichTextEditor.svelte
@@ -38,7 +38,7 @@
 		HistoryPlugin
 	} from 'svelte-lexical';
 
-	type Props = {
+	interface Props {
 		namespace: string;
 		markdown: boolean;
 		onError: (error: unknown) => void;
@@ -55,7 +55,11 @@
 		initialText?: string;
 		disabled?: boolean;
 		wrapCountValue?: number;
-	};
+		useMonospaceFont?: boolean;
+		monospaceFont?: string;
+		tabSize?: number;
+		enableLigatures?: boolean;
+	}
 
 	let {
 		disabled,
@@ -73,7 +77,11 @@
 		onInput,
 		onKeyDown,
 		initialText,
-		wrapCountValue
+		wrapCountValue,
+		useMonospaceFont,
+		monospaceFont,
+		tabSize,
+		enableLigatures
 	}: Props = $props();
 
 	/** Standard configuration for our commit message editor. */
@@ -246,6 +254,14 @@
 		class:plain-text={!markdown}
 		class:disabled={isDisabled}
 		style:min-height={minHeight}
+		style:--code-block-font={useMonospaceFont && monospaceFont
+			? monospaceFont
+			: 'var(--font-default)'}
+		style:--code-block-tab-size={useMonospaceFont && tabSize ? tabSize : 4}
+		style:--code-block-ligatures={useMonospaceFont && enableLigatures
+			? 'common-ligatures'
+			: 'normal'}
+		style:--lexical-input-client-text-wrap={useMonospaceFont ? 'nowrap' : 'normal'}
 	>
 		<div class="editor">
 			<ContentEditable />


### PR DESCRIPTION
Preview lanes now take the full height. This was needed for:
- Making preview lanes always look the same, which helps from a UX perspective
- Enabling future features like a "slide-in" preview, where having 100% height is necessary
- Simplifying conditions, since the codegen should be a full-height component

<img width="1467" height="888" alt="image" src="https://github.com/user-attachments/assets/e3074518-2fe0-4eef-b2e6-5a38cc58d3ab" />

<img width="1090" height="844" alt="image" src="https://github.com/user-attachments/assets/ebf4536f-1ff4-4047-b7c2-624baf5dff09" />

<img width="1092" height="832" alt="image" src="https://github.com/user-attachments/assets/6b03de3d-a527-436d-b326-d976dd2e75a5" />


<img width="1076" height="847" alt="image" src="https://github.com/user-attachments/assets/cfd4860f-c33c-4ea2-8590-1a79af723440" />

---

Summary
- fixes and refinements across multiple components.

What changed
- Compute and display rounded context usage; hide kebab menu when value is zero.
- Use monospace font only when needed (restore regular font for typical messages).
- Unify CSS variable and remove extra wrapper for codegen messages.
- Update drawer to take full height when in codegen mode or when no file preview is present.

Notes
- These are visual/UX refinements; no functional behavior changes beyond display adjustments.