### PR TITLE
Enable drag & drop into codegen for files, hunks, and commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ name = "but-claude"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "but-action",
  "but-broadcaster",
  "but-core",

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -32,6 +32,7 @@
 	import { getForgeLogo } from '@gitbutler/ui/utils/getForgeLogo';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
 	import { tick } from 'svelte';
+	import type { PromptAttachments } from '$lib/codegen/attachments.svelte';
 	import type { CommitStatusType } from '$lib/commits/commit';
 	import type { BranchDetails } from '$lib/stacks/stack';
 
@@ -41,10 +42,11 @@
 		laneId: string;
 		branches: BranchDetails[];
 		active: boolean;
+		attachments: PromptAttachments;
 		onselect?: () => void;
 	};
 
-	const { projectId, branches, stackId, laneId, active, onselect }: Props = $props();
+	const { projectId, branches, stackId, laneId, active, attachments, onselect }: Props = $props();
 	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
 	const modeService = inject(MODE_SERVICE);
@@ -356,6 +358,7 @@
 								<CodegenRow
 									{projectId}
 									{branchName}
+									{attachments}
 									{stackId}
 									{status}
 									selected={codegenSelected}

--- a/apps/desktop/src/components/CardOverlay.svelte
+++ b/apps/desktop/src/components/CardOverlay.svelte
@@ -64,9 +64,6 @@
 
 <style lang="postcss">
 	.dropzone-wrapper {
-		--dropzone-fill: oklch(from var(--clr-scale-pop-50) l c h / 0.1);
-		--dropzone-stroke: oklch(from var(--clr-scale-pop-50) l c h / 0.8);
-
 		display: none;
 		z-index: var(--z-floating);
 		position: absolute;
@@ -110,9 +107,9 @@
 			transform: scale(1.01);
 
 			.animated-rectangle rect {
-				fill: oklch(from var(--clr-scale-pop-50) l c h / 0.16);
-				stroke: oklch(from var(--clr-scale-pop-50) l c h / 1);
-				animation: dash 4s linear infinite;
+				fill: var(--dropzone-fill-hover);
+				stroke: var(--dropzone-stroke-hover);
+				animation: dropzone-dash 4s linear infinite;
 			}
 
 			.dropzone-label {
@@ -185,15 +182,6 @@
 			transition:
 				fill var(--transition-fast),
 				stroke var(--transition-fast);
-		}
-	}
-
-	@keyframes dash {
-		from {
-			stroke-dashoffset: 30;
-		}
-		to {
-			stroke-dashoffset: 0;
 		}
 	}
 </style>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -11,6 +11,7 @@
 	import SelectionView from '$components/SelectionView.svelte';
 	import WorktreeChanges from '$components/WorktreeChanges.svelte';
 	import CodegenMessages from '$components/codegen/CodegenMessages.svelte';
+	import { PromptAttachments } from '$lib/codegen/attachments.svelte';
 	import { stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
 	import { isParsedError } from '$lib/error/parser';
 	import { DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
@@ -67,6 +68,8 @@
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const uiState = inject(UI_STATE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
+
+	const attachments = new PromptAttachments();
 
 	// Component is read-only when stackId is undefined
 	const isReadOnly = $derived(!stableStackId);
@@ -564,6 +567,7 @@
 							{laneId}
 							stackId={stableStackId}
 							{active}
+							{attachments}
 							onselect={() => {
 								// Clear one selection when you modify the other.
 								idSelection.clear({ type: 'worktree', stackId: stableStackId });
@@ -612,6 +616,7 @@
 					stackId={stableStackId}
 					branchName={selection.branchName}
 					onclose={onclosePreview}
+					{attachments}
 				/>
 			{:else}
 				<div class="details-view__inner">

--- a/apps/desktop/src/components/VirtualList.svelte
+++ b/apps/desktop/src/components/VirtualList.svelte
@@ -207,12 +207,12 @@
 			topPadding = sumHeights(0, start);
 			totalHeight = sumHeights(0, heightMap.length);
 
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				if (viewport) {
 					viewport.scrollTop = viewport.scrollHeight;
 					hasInitialized = true;
 				}
-			});
+			}, 0);
 		} else {
 			// Normal top-down calculation
 			// There is some weird bug here that seems triggered when

--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { FileIcon, Icon } from '@gitbutler/ui';
+	import { abbreviatePath } from '@gitbutler/ui/utils/filePath';
+	import { fly } from 'svelte/transition';
+	import type { PromptAttachment } from '$lib/codegen/types';
+
+	type Props = {
+		attachments: PromptAttachment[];
+		showRemoveButton?: boolean;
+		onRemove?: (attachment: PromptAttachment) => void;
+	};
+
+	const { attachments, onRemove: onRemoveFile, showRemoveButton = true }: Props = $props();
+
+	function handleRemove(attachment: PromptAttachment): void {
+		onRemoveFile?.(attachment);
+	}
+</script>
+
+<div class="attachments">
+	{#each attachments as attachment}
+		<div class="attachment" in:fly={{ y: 10, duration: 150 }}>
+			<div class="attachment-content text-12 text-semibold">
+				{#if attachment.type === 'commit'}
+					<span class="path" title={attachment.subject.commitId}>
+						#{attachment.subject.commitId.slice(0, 6)}
+					</span>
+				{/if}
+				{#if attachment.type === 'file'}
+					<FileIcon fileName={attachment.subject.path} />
+
+					<span class="path" title={attachment.subject.path}>
+						{abbreviatePath(attachment.subject.path)}
+					</span>
+				{/if}
+				{#if attachment.type === 'hunk'}
+					{@const { path, start, end } = attachment.subject}
+					<FileIcon fileName={attachment.subject.path} />
+
+					<span class="path" title={attachment.subject.path}>
+						{abbreviatePath(path)}
+					</span>
+					<span>
+						{start}:{end}
+					</span>
+				{/if}
+			</div>
+
+			{#if showRemoveButton}
+				<button
+					type="button"
+					class="remove-button"
+					onclick={() => handleRemove(attachment)}
+					aria-label="Remove {attachment}"
+					title="Remove file"
+				>
+					<Icon name="cross-small" />
+				</button>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style lang="postcss">
+	.attachments {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+
+	.attachment {
+		display: flex;
+		flex-shrink: 1;
+		align-items: center;
+		justify-content: space-between;
+		height: var(--size-button);
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--size-button);
+		cursor: default;
+	}
+
+	.attachment-content {
+		display: flex;
+		flex: 1;
+		align-items: center;
+		padding: 0 8px;
+		overflow-x: hidden;
+		gap: 6px;
+	}
+
+	.path {
+		max-width: 400px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.remove-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: var(--size-button);
+		height: var(--size-button);
+		margin-left: -8px;
+		color: var(--clr-text-3);
+		transition: all 0.2s ease;
+
+		&:hover {
+			background-color: var(--clr-bg-error);
+			color: var(--clr-text-error);
+		}
+	}
+</style>

--- a/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if message.type === 'user'}
-	<CodegenUserMessage content={message.message} />
+	<CodegenUserMessage content={message.message} attachments={message.attachments} />
 {:else if message.type === 'claude'}
 	{#if 'subtype' in message && message.subtype === 'compaction'}
 		<CodegenServiceMessage style="neutral" face="compacted" reverseElementsOrder>

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -19,6 +19,7 @@
 	import emptyFolderSvg from '$lib/assets/empty-state/empty-folder.svg?raw';
 	import filesAndChecksSvg from '$lib/assets/empty-state/files-and-checks.svg?raw';
 	import vibecodingSvg from '$lib/assets/illustrations/vibecoding.svg?raw';
+	import { PromptAttachments } from '$lib/codegen/attachments.svelte';
 	import { useAvailabilityChecking } from '$lib/codegen/availabilityChecking.svelte';
 	import { CLAUDE_CODE_SERVICE } from '$lib/codegen/claude';
 	import { currentStatus, getTodos, lastInteractionTime, usageStats } from '$lib/codegen/messages';
@@ -65,6 +66,8 @@
 			aiRules.some((rule) => rule.action.subject.subject.target.subject === stack.id)
 		);
 	});
+
+	const attachments = new PromptAttachments();
 
 	let settingsModal: ClaudeCodeSettingsModal | undefined;
 
@@ -213,8 +216,9 @@
 			<!-- It's difficult to start at bottom unless we re-render `CodegenMessages` -->
 			{#key selectedBranch.head}
 				<CodegenMessages
-					isWorkspace={false}
 					{projectId}
+					{attachments}
+					isWorkspace={false}
 					stackId={selectedBranch.stackId}
 					branchName={selectedBranch.head}
 				/>

--- a/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
+	import AttachmentList from '$components/codegen/AttachmentList.svelte';
 	import { Markdown } from '@gitbutler/ui';
+	import type { PromptAttachment } from '$lib/codegen/types';
 
 	interface Props {
 		content?: string;
-		avatarUrl?: string;
+		attachments?: PromptAttachment[];
 	}
 
-	let { content }: Props = $props();
+	let { content, attachments }: Props = $props();
 </script>
 
 <div class="message-user">
 	<div class="text-13 text-body message-bubble">
 		<Markdown {content} />
+
+		{#if attachments && attachments.length > 0}
+			<hr class="message-user__divider" />
+			<AttachmentList {attachments} showRemoveButton={false} />
+		{/if}
 	</div>
 </div>
 
@@ -31,7 +38,7 @@
 		max-width: var(--message-max-width);
 		padding: 10px 14px;
 		overflow: hidden;
-		gap: 16px;
+		gap: 10px;
 		border-radius: var(--radius-ml);
 		border-bottom-right-radius: 0;
 		background-color: var(--clr-bg-2);
@@ -42,5 +49,11 @@
 		:global(.markdown pre) {
 			background-color: var(--clr-bg-1);
 		}
+	}
+
+	.message-user__divider {
+		width: 100%;
+		border: none;
+		border-top: 1px dotted var(--clr-border-2);
 	}
 </style>

--- a/apps/desktop/src/components/codegen/FileSearch.svelte
+++ b/apps/desktop/src/components/codegen/FileSearch.svelte
@@ -41,6 +41,8 @@
 			if (file && onselect) {
 				onselect(file);
 			}
+		} else if (key === 'Escape') {
+			dismissed = true;
 		}
 	}
 </script>

--- a/apps/desktop/src/lib/codegen/attachments.svelte.ts
+++ b/apps/desktop/src/lib/codegen/attachments.svelte.ts
@@ -1,0 +1,57 @@
+import { shallowCompare } from '@gitbutler/shared/compare';
+import { chipToasts } from '@gitbutler/ui';
+import type { PromptAttachment } from '$lib/codegen/types';
+
+const MAX_FILES = 10;
+
+export class PromptAttachments {
+	attachments = $state<PromptAttachment[]>([]);
+
+	setAttachments(files: PromptAttachment[]) {
+		this.attachments = files;
+	}
+
+	remove(attachment: PromptAttachment) {
+		this.attachments = this.attachments.filter(
+			(f) => f.type !== attachment.type || !shallowCompare(f.subject, attachment.subject)
+		);
+	}
+
+	add(items: PromptAttachment[]): void {
+		// Check total file count
+		if (this.attachments.length + items.length > MAX_FILES) {
+			chipToasts.error(`Cannot add ${items.length} files. Maximum of ${MAX_FILES} files allowed.`);
+			return;
+		}
+
+		// Validate and process each file
+		const newFiles: PromptAttachment[] = [];
+		for (const item of items) {
+			// Check for duplicates
+			const isDuplicate = this.attachments.find((a) => {
+				switch (a.type) {
+					case 'commit':
+						return a.type === item.type && a.subject.commitId === item.subject.commitId;
+					case 'file':
+						return a.type === item.type && a.subject.path === item.subject.path;
+					case 'hunk':
+						return (
+							a.type === item.type &&
+							a.subject.path === item.subject.path &&
+							a.subject.start === item.subject.start
+						);
+				}
+			});
+
+			if (isDuplicate) {
+				chipToasts.error(`Item is already attached.`);
+				return;
+			}
+
+			newFiles.push(item);
+		}
+
+		// Add new files
+		this.setAttachments([...this.attachments, ...newFiles]);
+	}
+}

--- a/apps/desktop/src/lib/codegen/claude.ts
+++ b/apps/desktop/src/lib/codegen/claude.ts
@@ -9,7 +9,8 @@ import {
 	type PromptTemplate,
 	type PromptDir,
 	type McpConfig,
-	type SubAgent
+	type SubAgent,
+	type PromptAttachment
 } from '$lib/codegen/types';
 import { hasBackendExtra } from '$lib/state/backendQuery';
 import {
@@ -140,6 +141,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					permissionMode: PermissionMode;
 					disabledMcpServers: string[];
 					addDirs: string[];
+					attachments?: PromptAttachment[];
 				}
 			>({
 				extraOptions: {

--- a/apps/desktop/src/lib/codegen/messageQueue.svelte.ts
+++ b/apps/desktop/src/lib/codegen/messageQueue.svelte.ts
@@ -11,7 +11,12 @@ import { UI_STATE, type GlobalStore, type StackState } from '$lib/state/uiState.
 import { inject } from '@gitbutler/core/context';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { chipToasts } from '@gitbutler/ui';
-import type { ModelType, PermissionMode, ThinkingLevel } from '$lib/codegen/types';
+import type {
+	ModelType,
+	PermissionMode,
+	PromptAttachment,
+	ThinkingLevel
+} from '$lib/codegen/types';
 import type { Reactive } from '@gitbutler/shared/storeUtils';
 
 export function useMessageQueue() {
@@ -137,7 +142,7 @@ export function useSendMessage({
 	function setPrompt(prompt: string) {
 		laneState?.prompt.set(prompt);
 	}
-	async function sendMessage(prompt: string) {
+	async function sendMessage(prompt: string, attachments?: PromptAttachment[]) {
 		if (!selectedBranch.current) return;
 		if (!laneState) return;
 		if (!prompt) return;
@@ -168,7 +173,8 @@ export function useSendMessage({
 				permissionMode: permissionMode.current,
 				claudeCodeService,
 				codegenAnalytics,
-				sendClaudeMessage
+				sendClaudeMessage,
+				attachments
 			});
 
 			setPrompt('');
@@ -179,7 +185,8 @@ export function useSendMessage({
 				prompt,
 				thinkingLevel: thinkingLevel.current,
 				model: model.current,
-				permissionMode: permissionMode.current
+				permissionMode: permissionMode.current,
+				attachments
 			};
 			if (queue) {
 				clientState.dispatch(
@@ -222,7 +229,8 @@ async function sendMessageInner({
 	permissionMode,
 	claudeCodeService,
 	codegenAnalytics,
-	sendClaudeMessage
+	sendClaudeMessage,
+	attachments
 }: {
 	prompt: string;
 	projectId: string;
@@ -234,6 +242,7 @@ async function sendMessageInner({
 	claudeCodeService: ClaudeCodeService;
 	codegenAnalytics: CodegenAnalytics;
 	sendClaudeMessage: ClaudeCodeService['sendMessage'][0];
+	attachments?: PromptAttachment[];
 }) {
 	if (prompt.startsWith('/compact')) {
 		await claudeCodeService.compactHistory({
@@ -281,7 +290,8 @@ async function sendMessageInner({
 			model,
 			permissionMode,
 			disabledMcpServers: laneState?.disabledMcpServers.current ?? [],
-			addDirs: laneState?.addedDirs.current ?? []
+			addDirs: laneState?.addedDirs.current ?? [],
+			attachments
 		},
 		{ properties: analyticsProperties }
 	);

--- a/apps/desktop/src/lib/codegen/messageQueueSlice.ts
+++ b/apps/desktop/src/lib/codegen/messageQueueSlice.ts
@@ -1,11 +1,17 @@
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
-import type { ModelType, PermissionMode, ThinkingLevel } from '$lib/codegen/types';
+import type {
+	ModelType,
+	PermissionMode,
+	PromptAttachment,
+	ThinkingLevel
+} from '$lib/codegen/types';
 
 type Message = {
 	thinkingLevel: ThinkingLevel;
 	model: ModelType;
 	permissionMode: PermissionMode;
 	prompt: string;
+	attachments?: PromptAttachment[];
 };
 
 export type MessageQueue = {

--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -7,7 +7,8 @@ import type {
 	ClaudeMessage,
 	ClaudePermissionRequest,
 	ClaudeStatus,
-	ClaudeTodo
+	ClaudeTodo,
+	PromptAttachment
 } from '$lib/codegen/types';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/index.mjs';
 
@@ -16,6 +17,7 @@ export type Message =
 	| {
 			type: 'user';
 			message: string;
+			attachments?: PromptAttachment[];
 	  }
 	/* Output from claude. This is grouped as: A claude message with a bunch of tool calls. */
 	| {
@@ -71,7 +73,8 @@ export function formatMessages(
 			wrapUpAgentSide();
 			out.push({
 				type: 'user',
-				message: event.content.subject.message
+				message: event.content.subject.message,
+				attachments: event.content.subject.attachments
 			});
 			lastAssistantMessage = undefined;
 		} else if (event.content.type === 'claudeOutput') {

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -1,6 +1,31 @@
 import type { Message, MessageParam, Usage } from '@anthropic-ai/sdk/resources/index.mjs';
 
 /**
+ * Represents a file attachment with full content (used in API input).
+ */
+export type PromptAttachment =
+	| {
+			type: 'file';
+			subject: {
+				path: string;
+			};
+	  }
+	| {
+			type: 'hunk';
+			subject: {
+				path: string;
+				start: number;
+				end: number;
+			};
+	  }
+	| {
+			type: 'commit';
+			subject: {
+				commitId: string;
+			};
+	  };
+
+/**
  * Result of checking Claude Code availability
  */
 export type ClaudeCheckResult =
@@ -112,7 +137,7 @@ export type ClaudeMessageContent =
 	/** Inserted via GitButler (what the user typed) */
 	| {
 			type: 'userInput';
-			subject: { message: string };
+			subject: { message: string; attachments?: PromptAttachment[] };
 	  }
 	| {
 			type: 'gitButlerMessage';

--- a/apps/desktop/src/styles/styles.css
+++ b/apps/desktop/src/styles/styles.css
@@ -1,6 +1,13 @@
 @import '@gitbutler/ui/main.css';
 @import './draggable.css';
 
+:root {
+	--dropzone-fill: oklch(from var(--clr-scale-pop-50) l c h / 0.1);
+	--dropzone-stroke: oklch(from var(--clr-scale-pop-50) l c h / 0.8);
+	--dropzone-fill-hover: oklch(from var(--clr-scale-pop-50) l c h / 0.16);
+	--dropzone-stroke-hover: oklch(from var(--clr-scale-pop-50) l c h / 1);
+}
+
 body {
 	width: 100vw;
 	height: 100vh;
@@ -25,6 +32,15 @@ body {
  */
 .drop-zone-hover * {
 	pointer-events: none;
+}
+
+@keyframes dropzone-dash {
+	from {
+		stroke-dashoffset: 30;
+	}
+	to {
+		stroke-dashoffset: 0;
+	}
 }
 
 /* CODE */

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -69,12 +69,46 @@ pub enum ClaudeMessageContent {
     GitButlerMessage(GitButlerMessage),
 }
 
+/// File attachment with full content.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachedHunk {
+    pub path: String,
+    pub start: usize,
+    pub end: usize,
+}
+
+/// File attachment with full content.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachedFile {
+    pub path: String,
+}
+
+/// File attachment with full content.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachedCommit {
+    pub commit_id: String,
+}
+
+/// Represents a file attachment with full content (used in API input).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+pub enum PromptAttachment {
+    Hunk(AttachedHunk),
+    File(AttachedFile),
+    Commit(AttachedCommit),
+}
+
 /// Represents user input in a Claude session.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInput {
     /// The user message
     pub message: String,
+    /// Optional attached file references
+    pub attachments: Option<Vec<PromptAttachment>>,
 }
 
 /// Metadata provided by GitButler.
@@ -182,6 +216,7 @@ pub struct ClaudeUserParams {
     pub permission_mode: PermissionMode,
     pub disabled_mcp_servers: Vec<String>,
     pub add_dirs: Vec<String>,
+    pub attachments: Option<Vec<PromptAttachment>>,
 }
 
 pub async fn send_claude_message(

--- a/crates/gitbutler-tauri/src/claude.rs
+++ b/crates/gitbutler-tauri/src/claude.rs
@@ -6,7 +6,9 @@ use but_api::{
     },
     error::Error,
 };
-use but_claude::{ClaudeMessage, ClaudeUserParams, ModelType, PermissionMode, ThinkingLevel};
+use but_claude::{
+    ClaudeMessage, ClaudeUserParams, ModelType, PermissionMode, PromptAttachment, ThinkingLevel,
+};
 use but_workspace::StackId;
 use gitbutler_project::ProjectId;
 use tauri::State;
@@ -25,6 +27,7 @@ pub async fn claude_send_message(
     permission_mode: PermissionMode,
     disabled_mcp_servers: Vec<String>,
     add_dirs: Vec<String>,
+    attachments: Option<Vec<PromptAttachment>>,
 ) -> Result<(), Error> {
     claude::claude_send_message(
         &app,
@@ -38,6 +41,7 @@ pub async fn claude_send_message(
                 permission_mode,
                 disabled_mcp_servers,
                 add_dirs,
+                attachments,
             },
         },
     )

--- a/packages/ui/src/lib/richText/RichTextEditor.svelte
+++ b/packages/ui/src/lib/richText/RichTextEditor.svelte
@@ -15,7 +15,8 @@
 		$getRoot as getRoot,
 		KEY_DOWN_COMMAND,
 		FOCUS_COMMAND,
-		BLUR_COMMAND
+		BLUR_COMMAND,
+		type SerializedEditorState
 	} from 'lexical';
 	import { type Snippet } from 'svelte';
 	import {
@@ -243,6 +244,18 @@
 		if (!composer) return;
 		const editor = composer.getEditor();
 		setEditorText(editor, text);
+	}
+
+	export function save() {
+		return composer?.getEditor().getEditorState().toJSON();
+	}
+
+	export function load(state: SerializedEditorState) {
+		const editor = composer?.getEditor();
+		const editorState = editor?.parseEditorState(state);
+		if (editorState) {
+			editor?.setEditorState(editorState);
+		}
 	}
 </script>
 

--- a/packages/ui/src/lib/utils/filePath.ts
+++ b/packages/ui/src/lib/utils/filePath.ts
@@ -9,3 +9,21 @@ export function splitFilePath(filepath: string): { filename: string; path: strin
 
 	return { filename, path };
 }
+
+export function abbreviatePath(path: string, maxParts: number = 4): string {
+	// Split the path into parts, filtering out empty strings
+	const parts = path.split('/').filter((p) => p.length > 0);
+
+	// Handle absolute paths (starting with /)
+	const isAbsolute = path.startsWith('/');
+
+	// If we have fewer parts than the max, return as-is
+	if (parts.length <= maxParts) {
+		return isAbsolute ? '/' + parts.join('/') : parts.join('/');
+	}
+
+	// Keep the last maxParts elements, replace the rest with a single ".."
+	const abbreviated = ['..', ...parts.slice(-maxParts)];
+
+	return isAbsolute ? '/' + abbreviated.join('/') : abbreviated.join('/');
+}


### PR DESCRIPTION
This is based on work done in an abandoned branch by Pavel and 
Caleb, and adds a dropzone to both the codegen row and the codegen text 
box.

Attachments are sent to the backend as `PromptAttachment[]`, and are
written into the prompt as context without validating against what's
on disk.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #10817 
- <kbd>&nbsp;1&nbsp;</kbd> #10816 👈 
<!-- GitButler Footer Boundary Bottom -->

