### PR TITLE
Simplify codegen attachment struct

### DIFF
--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -22,22 +22,22 @@
 		<div class="attachment" in:fly={{ y: 10, duration: 150 }}>
 			<div class="attachment-content text-12 text-semibold">
 				{#if attachment.type === 'commit'}
-					<span class="path" title={attachment.subject.commitId}>
-						#{attachment.subject.commitId.slice(0, 6)}
+					<span class="path" title={attachment.commitId}>
+						#{attachment.commitId.slice(0, 6)}
 					</span>
 				{/if}
 				{#if attachment.type === 'file'}
-					<FileIcon fileName={attachment.subject.path} />
+					<FileIcon fileName={attachment.path} />
 
-					<span class="path" title={attachment.subject.path}>
-						{abbreviatePath(attachment.subject.path)}
+					<span class="path" title={attachment.path}>
+						{abbreviatePath(attachment.path)}
 					</span>
 				{/if}
 				{#if attachment.type === 'hunk'}
-					{@const { path, start, end } = attachment.subject}
-					<FileIcon fileName={attachment.subject.path} />
+					{@const { path, start, end } = attachment}
+					<FileIcon fileName={attachment.path} />
 
-					<span class="path" title={attachment.subject.path}>
+					<span class="path" title={attachment.path}>
 						{abbreviatePath(path)}
 					</span>
 					<span>

--- a/apps/desktop/src/lib/codegen/attachments.svelte.ts
+++ b/apps/desktop/src/lib/codegen/attachments.svelte.ts
@@ -12,9 +12,7 @@ export class PromptAttachments {
 	}
 
 	remove(attachment: PromptAttachment) {
-		this.attachments = this.attachments.filter(
-			(f) => f.type !== attachment.type || !shallowCompare(f.subject, attachment.subject)
-		);
+		this.attachments = this.attachments.filter((f) => !shallowCompare(attachment, f));
 	}
 
 	add(items: PromptAttachment[]): void {
@@ -31,15 +29,11 @@ export class PromptAttachments {
 			const isDuplicate = this.attachments.find((a) => {
 				switch (a.type) {
 					case 'commit':
-						return a.type === item.type && a.subject.commitId === item.subject.commitId;
+						return a.type === item.type && a.commitId === item.commitId;
 					case 'file':
-						return a.type === item.type && a.subject.path === item.subject.path;
+						return a.type === item.type && a.path === item.path;
 					case 'hunk':
-						return (
-							a.type === item.type &&
-							a.subject.path === item.subject.path &&
-							a.subject.start === item.subject.start
-						);
+						return a.type === item.type && a.path === item.path && a.start === item.start;
 				}
 			});
 

--- a/apps/desktop/src/lib/codegen/dropzone.ts
+++ b/apps/desktop/src/lib/codegen/dropzone.ts
@@ -57,7 +57,7 @@ export class CodegenCommitDropHandler implements DropzoneHandler {
 	}
 
 	ondrop(data: CommitDropData): void {
-		this.attachments.add([{ type: 'commit', subject: { commitId: data.commit.id } }]);
+		this.attachments.add([{ type: 'commit', commitId: data.commit.id }]);
 	}
 }
 
@@ -76,7 +76,7 @@ export class CodegenFileDropHandler implements DropzoneHandler {
 	}
 
 	ondrop(data: ChangeDropData): void {
-		this.attachments.add([{ type: 'file', subject: { path: data.change.path } }]);
+		this.attachments.add([{ type: 'file', path: data.change.path }]);
 	}
 }
 
@@ -98,11 +98,9 @@ export class CodegenHunkDropHandler implements DropzoneHandler {
 		this.attachments.add([
 			{
 				type: 'hunk',
-				subject: {
-					path: data.change.path,
-					start: data.hunk.newStart,
-					end: data.hunk.newStart + data.hunk.newLines - 1
-				}
+				path: data.change.path,
+				start: data.hunk.newStart,
+				end: data.hunk.newStart + data.hunk.newLines - 1
 			}
 		]);
 	}

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -6,23 +6,17 @@ import type { Message, MessageParam, Usage } from '@anthropic-ai/sdk/resources/i
 export type PromptAttachment =
 	| {
 			type: 'file';
-			subject: {
-				path: string;
-			};
+			path: string;
 	  }
 	| {
 			type: 'hunk';
-			subject: {
-				path: string;
-				start: number;
-				end: number;
-			};
+			path: string;
+			start: number;
+			end: number;
 	  }
 	| {
 			type: 'commit';
-			subject: {
-				commitId: string;
-			};
+			commitId: string;
 	  };
 
 /**

--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -661,17 +661,14 @@ async fn format_message_with_attachments(
 
     for attachment in attachments {
         match attachment {
-            PromptAttachment::File(file) => {
-                written_attachments.push(format!("- {}", file.path));
+            PromptAttachment::File { path } => {
+                written_attachments.push(format!("- {}", path));
             }
-            PromptAttachment::Hunk(hunk) => {
-                written_attachments.push(format!(
-                    "- {} (lines {}:{})",
-                    hunk.path, hunk.start, hunk.end
-                ));
+            PromptAttachment::Hunk { path, start, end } => {
+                written_attachments.push(format!("- {} (lines {}:{})", path, start, end));
             }
-            PromptAttachment::Commit(commit) => {
-                written_attachments.push(format!("- commit: {}", commit.commit_id));
+            PromptAttachment::Commit { commit_id } => {
+                written_attachments.push(format!("- commit: {}", commit_id));
             }
         }
     }

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -69,36 +69,21 @@ pub enum ClaudeMessageContent {
     GitButlerMessage(GitButlerMessage),
 }
 
-/// File attachment with full content.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AttachedHunk {
-    pub path: String,
-    pub start: usize,
-    pub end: usize,
-}
-
-/// File attachment with full content.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AttachedFile {
-    pub path: String,
-}
-
-/// File attachment with full content.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AttachedCommit {
-    pub commit_id: String,
-}
-
 /// Represents a file attachment with full content (used in API input).
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+#[serde(rename_all = "camelCase", tag = "type")]
 pub enum PromptAttachment {
-    Hunk(AttachedHunk),
-    File(AttachedFile),
-    Commit(AttachedCommit),
+    Hunk {
+        path: String,
+        start: usize,
+        end: usize,
+    },
+    File {
+        path: String,
+    },
+    Commit {
+        commit_id: String,
+    },
 }
 
 /// Represents user input in a Claude session.


### PR DESCRIPTION
Use flat `type` and properties rather than `type` and `subject` pair.