### PR TITLE
Use adjacent tagging for serialized claude messages

### DIFF
--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -17,14 +17,19 @@
 	}
 
 	function getTooltipText(attachment: PromptAttachment): string {
-		if (attachment.type === 'commit') {
-			return `${attachment.commitId}`;
-		} else if (attachment.type === 'file') {
-			const commitInfo = attachment.commitId ? ` (from commit ${attachment.commitId})` : '';
-			return `${attachment.path}${commitInfo}`;
-		} else if (attachment.type === 'lines') {
-			const commitInfo = attachment.commitId ? ` (from commit ${attachment.commitId})` : '';
-			return `Lines ${attachment.start}-${attachment.end}${attachment.path}${commitInfo}`;
+		switch (attachment.type) {
+			case 'file': {
+				const { commitId, path } = attachment;
+				const commitInfo = commitId ? ` (from commit ${commitId})` : '';
+				return `${path}${commitInfo}`;
+			}
+			case 'lines': {
+				const { commitId, path, start, end } = attachment;
+				const commitInfo = commitId ? ` (from commit ${commitId})` : '';
+				return `Lines ${start}-${end}${path}${commitInfo}`;
+			}
+			case 'commit':
+				return `${attachment.commitId}`;
 		}
 		return '';
 	}
@@ -44,28 +49,29 @@
 					{/if}
 					<!-- FILE -->
 					{#if attachment.type === 'file'}
-						<FileIcon fileName={attachment.path} />
+						{@const { path, commitId } = attachment}
+						<FileIcon fileName={path} />
 
 						<span class="path">
-							{splitFilePath(attachment.path).filename}
+							{splitFilePath(path).filename}
 						</span>
 
-						{#if attachment.commitId}
+						{#if commitId}
 							<Icon name="commit" color="var(--clr-text-3)" />
-							<Tooltip text={attachment.commitId}>
+							<Tooltip text={commitId}>
 								<span class="commit-badge">
-									#{attachment.commitId.slice(0, 6)}
+									#{commitId.slice(0, 6)}
 								</span>
 							</Tooltip>
 						{/if}
 					{/if}
 					<!-- LINES -->
 					{#if attachment.type === 'lines'}
-						{@const { start, end } = attachment}
-						<FileIcon fileName={attachment.path} />
+						{@const { commitId, path, start, end } = attachment}
+						<FileIcon fileName={path} />
 
 						<span class="path">
-							{splitFilePath(attachment.path).filename}
+							{splitFilePath(path).filename}
 						</span>
 
 						<Icon name="text" color="var(--clr-text-3)" />
@@ -73,11 +79,11 @@
 							{start}:{end}
 						</span>
 
-						{#if attachment.commitId}
+						{#if commitId}
 							<Icon name="commit" color="var(--clr-text-3)" />
-							<Tooltip text={attachment.commitId}>
+							<Tooltip text={commitId}>
 								<span class="commit-badge">
-									#{attachment.commitId.slice(0, 6)}
+									#{commitId.slice(0, 6)}
 								</span>
 							</Tooltip>
 						{/if}

--- a/apps/desktop/src/lib/codegen/attachmentService.svelte.ts
+++ b/apps/desktop/src/lib/codegen/attachmentService.svelte.ts
@@ -77,10 +77,9 @@ export class AttachmentService {
 	}
 }
 
-export const promptAttachmentAdapter = createEntityAdapter<
-	{ branchName: string; attachments: PromptAttachment[] },
-	string
->({
+export type PromptAttachmentRecord = { branchName: string; attachments: PromptAttachment[] };
+
+export const promptAttachmentAdapter = createEntityAdapter<PromptAttachmentRecord, string>({
 	selectId: (a) => a.branchName
 });
 

--- a/apps/desktop/src/lib/codegen/dropzone.ts
+++ b/apps/desktop/src/lib/codegen/dropzone.ts
@@ -57,7 +57,7 @@ export class CodegenCommitDropHandler implements DropzoneHandler {
 	}
 
 	ondrop(data: CommitDropData): void {
-		this.add([{ type: 'commit', branchName: this.branchName, commitId: data.commit.id }]);
+		this.add([{ type: 'commit', commitId: data.commit.id }]);
 	}
 }
 
@@ -106,7 +106,6 @@ export class CodegenHunkDropHandler implements DropzoneHandler {
 		this.add([
 			{
 				type: 'lines',
-				branchName: this.branchName,
 				path: data.change.path,
 				start: data.hunk.newStart,
 				end: data.hunk.newStart + data.hunk.newLines - 1,

--- a/crates/but-claude/src/db.rs
+++ b/crates/but-claude/src/db.rs
@@ -158,23 +158,10 @@ pub fn list_messages_by_session(
         .db()?
         .claude_messages()
         .list_by_session(&session_id.to_string())?;
-    Ok(messages
+    messages
         .into_iter()
-        .filter_map(|m| {
-            let message_id = m.id.clone();
-            match m.try_into() {
-                Ok(msg) => Some(msg),
-                Err(e) => {
-                    tracing::warn!(
-                        message_id = %message_id,
-                        error = %e,
-                        "Failed to deserialize claude message, skipping"
-                    );
-                    None
-                }
-            }
-        })
-        .collect())
+        .map(|m| m.try_into())
+        .collect::<Result<_, _>>()
 }
 
 /// Gets the most recent user input message

--- a/crates/but-claude/src/legacy.rs
+++ b/crates/but-claude/src/legacy.rs
@@ -1,0 +1,164 @@
+//! Legacy types for deserializing older Claude message formats.
+//!
+
+use serde::{Deserialize, Serialize};
+
+/// Represents the kind of content in a Claude message.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+pub enum ClaudeMessageContent {
+    /// Came from Claude standard out stream
+    ClaudeOutput(serde_json::Value),
+    /// Inserted via  GitButler (what the user typed)
+    UserInput(UserInput),
+    /// Metadata provided by GitButler around the Claude Code statuts
+    GitButlerMessage(GitButlerMessage),
+}
+
+impl From<ClaudeMessageContent> for crate::MessagePayload {
+    fn from(value: ClaudeMessageContent) -> Self {
+        match value {
+            ClaudeMessageContent::ClaudeOutput(data) => {
+                crate::MessagePayload::Claude(crate::ClaudeOutput { data })
+            }
+            ClaudeMessageContent::UserInput(user_input) => {
+                crate::MessagePayload::User(user_input.into())
+            }
+            ClaudeMessageContent::GitButlerMessage(gb_message) => {
+                crate::MessagePayload::System(gb_message.into())
+            }
+        }
+    }
+}
+
+/// Metadata provided by GitButler.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+pub enum GitButlerMessage {
+    /// Claude code has exited naturally.
+    ClaudeExit {
+        code: i32,
+        message: String,
+    },
+    /// Claude code has exited due to a user abortion.
+    UserAbort,
+    UnhandledException {
+        message: String,
+    },
+    /// Compact operation has started.
+    CompactStart,
+    /// Compact operation has finished.
+    CompactFinished {
+        summary: String,
+    },
+}
+
+impl From<GitButlerMessage> for crate::SystemMessage {
+    fn from(value: GitButlerMessage) -> Self {
+        match value {
+            GitButlerMessage::ClaudeExit { code, message } => {
+                crate::SystemMessage::ClaudeExit { code, message }
+            }
+            GitButlerMessage::UserAbort => crate::SystemMessage::UserAbort,
+            GitButlerMessage::UnhandledException { message } => {
+                crate::SystemMessage::UnhandledException { message }
+            }
+            GitButlerMessage::CompactStart => crate::SystemMessage::CompactStart,
+            GitButlerMessage::CompactFinished { summary } => {
+                crate::SystemMessage::CompactFinished { summary }
+            }
+        }
+    }
+}
+
+/// Represents user input in a Claude session.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserInput {
+    /// The user message
+    pub message: String,
+    /// Optional attached file references
+    pub attachments: Option<Vec<PromptAttachment>>,
+}
+
+impl From<UserInput> for crate::UserInput {
+    fn from(value: UserInput) -> Self {
+        crate::UserInput {
+            message: value.message,
+            attachments: value
+                .attachments
+                .map(|atts| atts.into_iter().map(|a| a.into()).collect()),
+        }
+    }
+}
+
+/// Represents a file attachment with full content (used in API input).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum PromptAttachment {
+    Lines(LinesAttachment),
+    File(FileAttachment),
+    Commit(CommitAttachment),
+}
+
+impl From<PromptAttachment> for crate::PromptAttachment {
+    fn from(value: PromptAttachment) -> Self {
+        match value {
+            PromptAttachment::Lines(lines) => crate::PromptAttachment::Lines(lines.into()),
+            PromptAttachment::File(file) => crate::PromptAttachment::File(file.into()),
+            PromptAttachment::Commit(commit) => crate::PromptAttachment::Commit(commit.into()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FileAttachment {
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_id: Option<String>,
+}
+
+impl From<FileAttachment> for crate::FileAttachment {
+    fn from(value: FileAttachment) -> Self {
+        crate::FileAttachment {
+            commit_id: value.commit_id,
+            path: value.path,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LinesAttachment {
+    path: String,
+    start: usize,
+    end: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_id: Option<String>,
+}
+
+impl From<LinesAttachment> for crate::LinesAttachment {
+    fn from(value: LinesAttachment) -> Self {
+        crate::LinesAttachment {
+            commit_id: value.commit_id,
+            path: value.path,
+            start: value.start,
+            end: value.end,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitAttachment {
+    commit_id: String,
+}
+
+impl From<CommitAttachment> for crate::CommitAttachment {
+    fn from(value: CommitAttachment) -> Self {
+        crate::CommitAttachment {
+            commit_id: value.commit_id,
+        }
+    }
+}

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) mod claude_transcript;
 pub use claude_transcript::Transcript;
 pub mod db;
 pub mod hooks;
+pub(crate) mod legacy;
 pub mod mcp;
 pub mod notifications;
 pub mod permissions;
@@ -79,14 +80,14 @@ impl ClaudeMessage {
         self.created_at
     }
 
-    pub fn content(&self) -> &ClaudeMessageContent {
-        &self.content
+    pub fn content(&self) -> &MessagePayload {
+        &self.payload
     }
 }
 
 /// The actual message payload from different sources.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "source")]
 pub enum MessagePayload {
     /// Output from Claude Code CLI stdout stream
     Claude(ClaudeOutput),
@@ -120,7 +121,7 @@ pub struct CommitAttachment {
 
 /// Represents a file attachment with full content (used in API input).
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "type")]
 pub enum PromptAttachment {
     Lines(LinesAttachment),
     File(FileAttachment),

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -175,7 +175,7 @@ async fn match_subcommand(
                             let output = serde_json::json!({
                                 "timestamp": msg.created_at().format("%Y-%m-%d %H:%M:%S").to_string(),
                                 "message": match msg.content() {
-                                    but_claude::ClaudeMessageContent::UserInput(input) => &input.message,
+                                    but_claude::MessagePayload::User(input) => &input.message,
                                     _ => "",
                                 }
                             });
@@ -191,7 +191,7 @@ async fn match_subcommand(
                                     .cyan()
                             );
                             match msg.content() {
-                                but_claude::ClaudeMessageContent::UserInput(input) => {
+                                but_claude::MessagePayload::User(input) => {
                                     println!("{}", input.message);
                                 }
                                 _ => {


### PR DESCRIPTION
Instead of `{type: 'claudeOutput', subject: {..}}` this code now serializes messages into `{type: 'claudeOutput', ...}`.