### PR TITLE
feat(but): Add shell completion generation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "but-worktrees",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "command-group",
  "gitbutler-branch",
@@ -1673,6 +1674,15 @@ dependencies = [
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2348487adcd4631696ced64ccdb40d38ac4d31cae7f2eec8817fcea1b9d1c43c"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
 strum = { version = "0.27", features = ["derive"] }
 clap = { version = "4.5.48", features = ["derive", "env", "wrap_help"] }
+clap_complete = "4.5.59"
 chrono.workspace = true
 bstr.workspace = true
 regex = "1.11.3"

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -179,11 +179,11 @@ For examples see `but rub --help`."
         #[clap(long, short = 'r', default_value_t = true)]
         run_hooks: bool,
     },
-    /// Generate shell completion scripts for the specified shell.
+    /// Generate shell completion scripts for the specified or inferred shell.
     Completions {
-        /// The shell to generate completions for
+        /// The shell to generate completions for, or the one extracted from the `SHELL` environment variable.
         #[clap(value_enum)]
-        shell: clap_complete::Shell,
+        shell: Option<clap_complete::Shell>,
     },
 }
 

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -179,6 +179,12 @@ For examples see `but rub --help`."
         #[clap(long, short = 'r', default_value_t = true)]
         run_hooks: bool,
     },
+    /// Generate shell completion scripts for the specified shell.
+    Completions {
+        /// The shell to generate completions for
+        #[clap(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
@@ -250,6 +256,7 @@ pub enum CommandName {
     ForgeListUsers,
     ForgeForget,
     PublishReview,
+    Completions,
     #[default]
     Unknown,
 }

--- a/crates/but/src/completions.rs
+++ b/crates/but/src/completions.rs
@@ -1,17 +1,20 @@
 use std::io;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::CommandFactory;
-use clap_complete::{Shell, generate};
+use clap_complete::Shell;
 
 use crate::args::Args;
 
 /// Generate shell completions for the specified shell
-pub fn generate_completions(shell: Shell) -> Result<()> {
+pub fn generate_completions(shell: Option<Shell>) -> Result<()> {
+    let shell = shell.or_else(Shell::from_env).context(
+        "Couldn't extract shell from `SHELL` environment variable - please specify it manually",
+    )?;
     let mut cmd = Args::command();
     let bin_name = cmd.get_name().to_string();
 
-    generate(shell, &mut cmd, bin_name, &mut io::stdout());
+    clap_complete::generate(shell, &mut cmd, bin_name, &mut io::stdout());
 
     Ok(())
 }

--- a/crates/but/src/completions.rs
+++ b/crates/but/src/completions.rs
@@ -1,0 +1,17 @@
+use std::io;
+
+use anyhow::Result;
+use clap::CommandFactory;
+use clap_complete::{Shell, generate};
+
+use crate::args::Args;
+
+/// Generate shell completions for the specified shell
+pub fn generate_completions(shell: Shell) -> Result<()> {
+    let mut cmd = Args::command();
+    let bin_name = cmd.get_name().to_string();
+
+    generate(shell, &mut cmd, bin_name, &mut io::stdout());
+
+    Ok(())
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -392,6 +392,8 @@ fn print_grouped_help() {
 
     // Keep track of which commands we've already printed
     let mut printed_commands = HashSet::new();
+    const LONGEST_COMMAND_LEN: usize = 13;
+    const LONGEST_COMMAND_LEN_AND_ELLIPSIS: usize = LONGEST_COMMAND_LEN + 3;
 
     // Print grouped commands
     for (group_name, command_names) in &groups {
@@ -400,9 +402,14 @@ fn print_grouped_help() {
             if let Some(subcmd) = subcommands.iter().find(|c| c.get_name() == *cmd_name) {
                 let about = subcmd.get_about().unwrap_or_default().to_string();
                 // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
-                let available_width = terminal_width.saturating_sub(13);
+                let available_width =
+                    terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
                 let truncated_about = truncate_text(&about, available_width);
-                println!("  {:<10}{}", cmd_name.green(), truncated_about);
+                println!(
+                    "  {:<LONGEST_COMMAND_LEN$}{}",
+                    cmd_name.green(),
+                    truncated_about,
+                );
                 printed_commands.insert(cmd_name.to_string());
             }
         }
@@ -421,9 +428,13 @@ fn print_grouped_help() {
         for subcmd in misc_commands {
             let about = subcmd.get_about().unwrap_or_default().to_string();
             // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
-            let available_width = terminal_width.saturating_sub(13);
+            let available_width = terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
             let truncated_about = truncate_text(&about, available_width);
-            println!("  {:<10}{}", subcmd.get_name().green(), truncated_about);
+            println!(
+                "  {:<LONGEST_COMMAND_LEN$}{}",
+                subcmd.get_name().green(),
+                truncated_about
+            );
         }
         println!();
     }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -359,10 +359,11 @@ fn print_grouped_help() {
 
     // Helper function to truncate text to fit within available width
     let truncate_text = |text: &str, available_width: usize| -> String {
+        const ELLIPSIS_LEN: usize = 1;
         if text.len() <= available_width {
             text.to_string()
-        } else if available_width > 3 {
-            format!("{}...", &text[..available_width.saturating_sub(3)])
+        } else if available_width > ELLIPSIS_LEN {
+            format!("{}…", &text[..available_width.saturating_sub(ELLIPSIS_LEN)])
         } else {
             text.chars().take(available_width).collect()
         }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -13,6 +13,7 @@ mod base;
 mod branch;
 mod command;
 mod commit;
+mod completions;
 mod describe;
 mod forge;
 mod id;
@@ -307,6 +308,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             .ok();
             result
         }
+        Subcommands::Completions { shell } => completions::generate_completions(*shell),
     }
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/806d70d4-b421-48c2-97b2-a1b99ce3b3d5

This PR adds command-line completion support for the `but` command based on [`clap_complete`](https://docs.rs/clap_complete/latest/clap_complete/).

The code was primarily generated by Claude Sonnet 4.5, I reviewed and tested it, and made several adjustments after checking the `clap_complete` documentation and examples from similar projects (such as [Typst](https://github.com/typst/typst/blob/main/crates/typst-cli/src/completions.rs)) to ensure the generated code works correctly.

Supported shells for completion generation:

- bash
- zsh
- fish
- elvish
- powershell

Next step: integrate the completion setup into shell environments via installation scripts.