### PR TITLE
build: optimize frontend build size

### DIFF
--- a/apps/desktop/svelte.config.js
+++ b/apps/desktop/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 			pages: 'build',
 			assets: 'build',
 			fallback: 'index.html',
-			precompress: true,
+			precompress: false,
 			strict: false
 		})
 	},

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
 		// minify production builds
 		minify: !process.env.TAURI_ENV_DEBUG ? 'esbuild' : false,
 		// ship sourcemaps for better sentry error reports
-		sourcemap: 'inline'
+		sourcemap: true
 	},
 	test: {
 		includeSource: ['src/**/*.test.{js,ts}'],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
 		setupFiles: ['./vitest-setup.js']
 	},
 	build: {
-		sourcemap: 'inline'
+		sourcemap: true
 	},
 	resolve: {
 		alias: {

--- a/packages/shared/svelte.config.js
+++ b/packages/shared/svelte.config.js
@@ -9,7 +9,7 @@ const config = {
 			pages: 'build',
 			assets: 'build',
 			fallback: 'index.html',
-			precompress: true,
+			precompress: false,
 			strict: false
 		})
 	},

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
 		environment: 'jsdom'
 	},
 	build: {
-		sourcemap: 'inline'
+		sourcemap: true
 	}
 });

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -9,7 +9,7 @@ const config = {
 			pages: 'build',
 			assets: 'build',
 			fallback: 'index.html',
-			precompress: true,
+			precompress: false,
 			strict: false
 		}),
 		alias: {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
 		include: ['src/**/*.(test|spec).?(m)[jt]s?(x)']
 	},
 	build: {
-		sourcemap: 'inline'
+		sourcemap: true
 	}
 });


### PR DESCRIPTION
- Previous build: [build.zip](https://github.com/user-attachments/files/23162677/build.zip)
- This PR build: [build-min.zip](https://github.com/user-attachments/files/23162679/build-min.zip)

Build command: `pnpm build:desktop -- --mode nightly`

Uncompressed build: 46.5 MB -> 25.5 MB (~ 45% reduction)
ZIP compressed build: 24.8 MB -> 7.4 MB (~ 70% reduction)

For more details: https://discord.com/channels/1060193121130000425/1432062926625177600/1432292511551979592

References: https://svelte.dev/docs/kit/adapter-node#Options-precompress