### PR TITLE
Codegen UI fixes - part 1

### DIFF
--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { FileIcon, Icon } from '@gitbutler/ui';
-	import { abbreviatePath } from '@gitbutler/ui/utils/filePath';
+	import { FileIcon, Icon, Tooltip, FileName } from '@gitbutler/ui';
+	import { abbreviatePath, splitFilePath } from '@gitbutler/ui/utils/filePath';
 	import { fly } from 'svelte/transition';
 	import type { PromptAttachment } from '$lib/codegen/types';
 
@@ -15,36 +15,48 @@
 	function handleRemove(attachment: PromptAttachment): void {
 		onRemoveFile?.(attachment);
 	}
+
+	function getTooltipText(attachment: PromptAttachment): string {
+		if (attachment.type === 'commit') {
+			return `${attachment.commitId}`;
+		} else if (attachment.type === 'file') {
+			return `${attachment.path}`;
+		} else if (attachment.type === 'lines') {
+			return `Lines ${attachment.start}-${attachment.end} of ${attachment.path}`;
+		}
+		return '';
+	}
 </script>
 
 <div class="attachments">
 	{#each attachments as attachment}
 		<div class="attachment" in:fly={{ y: 10, duration: 150 }}>
-			<div class="attachment-content text-12 text-semibold">
-				{#if attachment.type === 'commit'}
-					<span class="path" title={attachment.commitId}>
-						#{attachment.commitId.slice(0, 6)}
-					</span>
-				{/if}
-				{#if attachment.type === 'file'}
-					<FileIcon fileName={attachment.path} />
+			<Tooltip text={getTooltipText(attachment)}>
+				<div class="attachment-content text-12 text-semibold">
+					<!-- COMMIT -->
+					{#if attachment.type === 'commit'}
+						<span class="path">
+							#{attachment.commitId.slice(0, 6)}
+						</span>
+					{/if}
+					<!-- FILE -->
+					{#if attachment.type === 'file'}
+						<FileName filePath={attachment.path} />
+					{/if}
+					<!-- LINES -->
+					{#if attachment.type === 'lines'}
+						{@const { path, start, end } = attachment}
+						<FileIcon fileName={attachment.path} />
 
-					<span class="path" title={attachment.path}>
-						{abbreviatePath(attachment.path)}
-					</span>
-				{/if}
-				{#if attachment.type === 'lines'}
-					{@const { path, start, end } = attachment}
-					<FileIcon fileName={attachment.path} />
-
-					<span class="path" title={attachment.path}>
-						{abbreviatePath(path)}
-					</span>
-					<span>
-						{start}:{end}
-					</span>
-				{/if}
-			</div>
+						<span class="path">
+							{abbreviatePath(path)}
+						</span>
+						<span>
+							{start}:{end}
+						</span>
+					{/if}
+				</div>
+			</Tooltip>
 
 			{#if showRemoveButton}
 				<button

--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { FileIcon, Icon, Tooltip, FileName } from '@gitbutler/ui';
-	import { abbreviatePath, splitFilePath } from '@gitbutler/ui/utils/filePath';
+	import { FileIcon, Icon, Tooltip } from '@gitbutler/ui';
+	import { splitFilePath } from '@gitbutler/ui/utils/filePath';
 	import { fly } from 'svelte/transition';
 	import type { PromptAttachment } from '$lib/codegen/types';
 
@@ -35,22 +35,29 @@
 				<div class="attachment-content text-12 text-semibold">
 					<!-- COMMIT -->
 					{#if attachment.type === 'commit'}
+						<Icon name="commit" color="var(--clr-text-2)" />
 						<span class="path">
 							#{attachment.commitId.slice(0, 6)}
 						</span>
 					{/if}
 					<!-- FILE -->
 					{#if attachment.type === 'file'}
-						<FileName filePath={attachment.path} />
-					{/if}
-					<!-- LINES -->
-					{#if attachment.type === 'lines'}
-						{@const { path, start, end } = attachment}
 						<FileIcon fileName={attachment.path} />
 
 						<span class="path">
-							{abbreviatePath(path)}
+							{splitFilePath(attachment.path).filename}
 						</span>
+					{/if}
+					<!-- LINES -->
+					{#if attachment.type === 'lines'}
+						{@const { start, end } = attachment}
+						<FileIcon fileName={attachment.path} />
+
+						<span class="path">
+							{splitFilePath(attachment.path).filename}
+						</span>
+
+						<Icon name="text" color="var(--clr-text-3)" />
 						<span>
 							{start}:{end}
 						</span>

--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -126,18 +126,20 @@
 	{/if}
 	<div class="text-input dialog-input" data-remove-from-panning>
 		<CodegenInputQueued {projectId} {stackId} {branchName} />
-		{#if attachments.length > 0}
-			<div class="attached-files-section">
-				<AttachmentList
-					{attachments}
-					onRemove={(a) => attachmentService.removeByBranch(branchName, a)}
-				/>
-			</div>
-		{/if}
+
 		<Dropzone {handlers}>
 			{#snippet overlay({ hovered, activated })}
 				<CardOverlay {hovered} {activated} label="Reference" />
 			{/snippet}
+			{#if attachments.length > 0}
+				<div class="attached-files-section">
+					<AttachmentList
+						{attachments}
+						onRemove={(a) => attachmentService.removeByBranch(branchName, a)}
+					/>
+				</div>
+			{/if}
+
 			<RichTextEditor
 				bind:this={editorRef}
 				bind:value

--- a/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
@@ -16,7 +16,6 @@
 		<Markdown {content} />
 
 		{#if attachments && attachments.length > 0}
-			<hr class="message-user__divider" />
 			<AttachmentList {attachments} showRemoveButton={false} />
 		{/if}
 	</div>
@@ -49,11 +48,5 @@
 		:global(.markdown pre) {
 			background-color: var(--clr-bg-1);
 		}
-	}
-
-	.message-user__divider {
-		width: 100%;
-		border: none;
-		border-top: 1px dotted var(--clr-border-2);
 	}
 </style>


### PR DESCRIPTION
- Removed the divider between the text and attachments. It was unnecessary and took up too much space — the difference is clear without it.

<img width="640" height="232" alt="image" src="https://github.com/user-attachments/assets/13891a26-33d5-48ca-9272-f03d6c0d2aee" />

- Use tooltips instead of native titles for faster performance and consistency with the rest tooltips.

https://github.com/user-attachments/assets/2752aa34-fd0b-447e-9c18-a8bfb13e3f90

- Updated design for previewing commit and hunk attachments.

<img width="405" height="138" alt="image" src="https://github.com/user-attachments/assets/af49428b-c45e-4860-a28b-e06a6ee65449" />
