### PR TITLE
feat(codegen): include optional commitId on attachments

### DIFF
--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -20,9 +20,11 @@
 		if (attachment.type === 'commit') {
 			return `${attachment.commitId}`;
 		} else if (attachment.type === 'file') {
-			return `${attachment.path}`;
+			const commitInfo = attachment.commitId ? ` (from commit ${attachment.commitId})` : '';
+			return `${attachment.path}${commitInfo}`;
 		} else if (attachment.type === 'lines') {
-			return `Lines ${attachment.start}-${attachment.end} of ${attachment.path}`;
+			const commitInfo = attachment.commitId ? ` (from commit ${attachment.commitId})` : '';
+			return `Lines ${attachment.start}-${attachment.end}${attachment.path}${commitInfo}`;
 		}
 		return '';
 	}
@@ -47,6 +49,15 @@
 						<span class="path">
 							{splitFilePath(attachment.path).filename}
 						</span>
+
+						{#if attachment.commitId}
+							<Icon name="commit" color="var(--clr-text-3)" />
+							<Tooltip text={attachment.commitId}>
+								<span class="commit-badge">
+									#{attachment.commitId.slice(0, 6)}
+								</span>
+							</Tooltip>
+						{/if}
 					{/if}
 					<!-- LINES -->
 					{#if attachment.type === 'lines'}
@@ -61,6 +72,15 @@
 						<span>
 							{start}:{end}
 						</span>
+
+						{#if attachment.commitId}
+							<Icon name="commit" color="var(--clr-text-3)" />
+							<Tooltip text={attachment.commitId}>
+								<span class="commit-badge">
+									#{attachment.commitId.slice(0, 6)}
+								</span>
+							</Tooltip>
+						{/if}
 					{/if}
 				</div>
 			</Tooltip>
@@ -112,6 +132,11 @@
 		max-width: 400px;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.commit-badge {
+		color: var(--clr-text-3);
 		white-space: nowrap;
 	}
 

--- a/apps/desktop/src/lib/codegen/dropzone.ts
+++ b/apps/desktop/src/lib/codegen/dropzone.ts
@@ -77,10 +77,12 @@ export class CodegenFileDropHandler implements DropzoneHandler {
 
 	async ondrop(data: ChangeDropData): Promise<void> {
 		const changes = await data.treeChanges();
+		const commitId = data.selectionId.type === 'commit' ? data.selectionId.commitId : undefined;
 		const attachments: PromptAttachment[] = changes.map((change) => ({
 			type: 'file',
 			branchName: this.branchName,
-			path: change.path
+			path: change.path,
+			commitId
 		}));
 		this.add(attachments);
 	}
@@ -107,7 +109,8 @@ export class CodegenHunkDropHandler implements DropzoneHandler {
 				branchName: this.branchName,
 				path: data.change.path,
 				start: data.hunk.newStart,
-				end: data.hunk.newStart + data.hunk.newLines - 1
+				end: data.hunk.newStart + data.hunk.newLines - 1,
+				commitId: data.commitId
 			}
 		]);
 	}

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -7,12 +7,14 @@ export type PromptAttachment = { branchName: string } & (
 	| {
 			type: 'file';
 			path: string;
+			commitId?: string;
 	  }
 	| {
 			type: 'lines';
 			path: string;
 			start: number;
 			end: number;
+			commitId?: string;
 	  }
 	| {
 			type: 'commit';

--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -647,9 +647,15 @@ fn validate_attachment(attachment: &PromptAttachment) -> Result<()> {
     match attachment {
         PromptAttachment::File(file) => {
             validate_path(&file.path)?;
+            if let Some(commit_id) = &file.commit_id {
+                validate_commit_id(commit_id)?;
+            }
         }
         PromptAttachment::Lines(lines) => {
             validate_path(&lines.path)?;
+            if let Some(commit_id) = &lines.commit_id {
+                validate_commit_id(commit_id)?;
+            }
         }
         PromptAttachment::Commit(commit) => {
             validate_commit_id(&commit.commit_id)?;

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -73,6 +73,8 @@ pub enum ClaudeMessageContent {
 #[serde(rename_all = "camelCase")]
 pub struct FileAttachment {
     path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -81,6 +83,8 @@ pub struct LinesAttachment {
     path: String,
     start: usize,
     end: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Add optional commitId to PromptAttachment union types so file and lines 
attachments can carry the source commit reference. Surface the commit id
in the UI: append "(from commit <id>)" to display strings and render a 
small commit badge + tooltip with the short id next to file and line 
attachments. Ensure the badge truncates with nowrap and use the dropzone
selection commit when creating attachments so dropped files/lines retain
their originating commit.

This makes attachments fully traceable to a commit, improving context
for generated prompts and preserving selection provenance.