### PR TITLE
macOS cross compilation testing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -141,10 +141,11 @@ jobs:
       - name: Install Rust targets for macOS
         if: runner.os == 'macOS' && matrix.target != ''
         run: rustup target add ${{ matrix.target }}
-      - name: Rust Cache
+      - name: Rust Cache ${{ matrix.target }}
         uses: Swatinem/rust-cache@v2.8.1
+        if: runner.os == 'macOS' && matrix.target != ''
         with:
-          shared-key: app-release-build-${{ github.event.inputs.channel || 'nightly' }}
+          shared-key: app-release-build-${{ github.event.inputs.channel || 'nightly' }}${{ matrix.target }}
       - name: Init Node Environment
         uses: ./.github/actions/init-env-node
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,11 +91,15 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
-        platform:
-          - macos-13 # [macOs, x64]
-          - macos-15 # [macOs, ARM64]
-          - ubuntu-24.04 # [linux, x64]
-          - windows-latest # [windows, x64]
+        include:
+          - platform: macos-15 # [macOs, ARM64] - default target
+            target: ''
+          - platform: macos-15 # [macOs, x64] - cross-compile
+            target: x86_64-apple-darwin
+          - platform: ubuntu-24.04 # [linux, x64]
+            target: ''
+          - platform: windows-latest # [windows, x64]
+            target: ''
 
     runs-on: ${{ matrix.platform }}
 
@@ -134,6 +138,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
+      - name: Install Rust targets for macOS
+        if: runner.os == 'macOS' && matrix.target != ''
+        run: rustup target add ${{ matrix.target }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.1
         with:
@@ -201,11 +208,20 @@ jobs:
       - name: Build binary
         shell: bash
         run: |
-          ./scripts/release.sh \
-            --sign \
-            --channel                    "${{ env.channel }}" \
-            --dist                       "./release" \
-            --version                    "${{ env.version }}"
+          if [ -n "${{ matrix.target }}" ]; then
+            ./scripts/release.sh \
+              --sign \
+              --channel                    "${{ env.channel }}" \
+              --dist                       "./release" \
+              --version                    "${{ env.version }}" \
+              --target                     "${{ matrix.target }}"
+          else
+            ./scripts/release.sh \
+              --sign \
+              --channel                    "${{ env.channel }}" \
+              --dist                       "./release" \
+              --version                    "${{ env.version }}"
+          fi
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -218,10 +234,19 @@ jobs:
           APPIMAGE_KEY_PASSPHRASE: ${{ secrets.APPIMAGE_KEY_PASSPHRASE }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
 
+      - name: Set artifact name suffix
+        shell: bash
+        run: |
+          # Only add suffix for macOS x86_64 to distinguish from ARM64
+          if [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
+            echo "artifact_suffix=-x86_64" >> $GITHUB_ENV
+          else
+            echo "artifact_suffix=" >> $GITHUB_ENV
+          fi
       - name: Upload Artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: '${{ env.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          name: '${{ env.channel }}-${{ matrix.platform }}${{ env.artifact_suffix }}-${{ github.run_number }}'
           path: release/
           if-no-files-found: error
 
@@ -329,19 +354,32 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
-        platform:
-          - macos-13 # [macOs, x64]
-          - macos-15 # [macOs, ARM64]
-          - ubuntu-24.04 # [linux, x64]
-          - windows-latest # [windows, x64]
+        include:
+          - platform: macos-15 # [macOs, ARM64] - default target
+            target: ''
+          - platform: macos-15 # [macOs, x64] - cross-compile
+            target: x86_64-apple-darwin
+          - platform: ubuntu-24.04 # [linux, x64]
+            target: ''
+          - platform: windows-latest # [windows, x64]
+            target: ''
     steps:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
+      - name: Set artifact name suffix
+        shell: bash
+        run: |
+          # Only add suffix for macOS x86_64 to distinguish from ARM64
+          if [ "${{ matrix.target }}" = "x86_64-apple-darwin" ]; then
+            echo "artifact_suffix=-x86_64" >> $GITHUB_ENV
+          else
+            echo "artifact_suffix=" >> $GITHUB_ENV
+          fi
       - name: Download artifacts
         uses: actions/download-artifact@v6
         with:
-          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}${{ env.artifact_suffix }}-${{ github.run_number }}'
           path: release
       - name: Extract version
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -138,12 +138,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
-      - name: Install Rust targets for macOS
-        if: runner.os == 'macOS' && matrix.target != ''
-        run: rustup target add ${{ matrix.target }}
+      - name: Set Cargo build target to ${{ matrix.target }}
+        shell: bash
+        if: matrix.target != ''
+        run: |
+          echo "CARGO_BUILD_TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+          rustup target add ${{ matrix.target }}
+      # The cache doesn't pick up the environment variable set above, so we have to set it ourselves.
       - name: Rust Cache ${{ matrix.target }}
         uses: Swatinem/rust-cache@v2.8.1
-        if: runner.os == 'macOS' && matrix.target != ''
         with:
           shared-key: app-release-build-${{ github.event.inputs.channel || 'nightly' }}${{ matrix.target }}
       - name: Init Node Environment
@@ -209,20 +212,11 @@ jobs:
       - name: Build binary
         shell: bash
         run: |
-          if [ -n "${{ matrix.target }}" ]; then
-            ./scripts/release.sh \
-              --sign \
-              --channel                    "${{ env.channel }}" \
-              --dist                       "./release" \
-              --version                    "${{ env.version }}" \
-              --target                     "${{ matrix.target }}"
-          else
-            ./scripts/release.sh \
-              --sign \
-              --channel                    "${{ env.channel }}" \
-              --dist                       "./release" \
-              --version                    "${{ env.version }}"
-          fi
+          ./scripts/release.sh \
+            --sign \
+            --channel                    "${{ env.channel }}" \
+            --dist                       "./release" \
+            --version                    "${{ env.version }}"
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -7,8 +7,15 @@ function log {
 }
 
 ROOT="$(dirname "$THIS")/../.."
-TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
-TARGET_ROOT="${CARGO_TARGET_DIR:-$ROOT/target}/${TRIPLE_OVERRIDE:-}/release"
+
+# Use CARGO_BUILD_TARGET if set, otherwise use rustc default triple
+if [ -n "${CARGO_BUILD_TARGET:-}" ]; then
+    TRIPLE="$CARGO_BUILD_TARGET"
+else
+    TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
+fi
+
+TARGET_ROOT="${CARGO_TARGET_DIR:-$ROOT/target}/${TRIPLE_OVERRIDE:-${CARGO_BUILD_TARGET:+$CARGO_BUILD_TARGET/}}release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
 # BINARIES

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -15,7 +15,7 @@ else
     TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
 fi
 
-TARGET_ROOT="${CARGO_TARGET_DIR:-$ROOT/target}/${TRIPLE_OVERRIDE:-${CARGO_BUILD_TARGET:+$CARGO_BUILD_TARGET/}}release"
+TARGET_ROOT="${CARGO_TARGET_DIR:-$ROOT/target}/${TRIPLE_OVERRIDE:-${CARGO_BUILD_TARGET:+$CARGO_BUILD_TARGET}}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
 # BINARIES


### PR DESCRIPTION
The motivation is twofold:

* macOS 15 uses ARM runners which are much faster than the ones for macOS 13.
* macOS 13 is deprecated and these runners may one day go away
* there seems to be no disadvantage to build tauri apps on more recent macOS versions, as they are supposedly working on older macOS' as well.

Inspired by https://github.com/tauri-apps/tauri-action and https://github.com/tauri-apps/tauri-action/pull/749.
More context [on Discord](https://discord.com/channels/1060193121130000425/1432062926625177600/1432228586328424579).

Supersedes #10852.

### Tasks

* [x] rust-cache split
* [x] make Windows build work - it shouldn't have to care at all.
* [x] validate build and suffixes
* [x] make rust-cache work
* [x] final publish to validate rust caches
