### PR TITLE
ui-commit-goes-here-fixes

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -461,6 +461,7 @@
 		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
 		border-radius: 0 0 var(--radius-ml) var(--radius-ml);
+		background-color: var(--clr-bg-1);
 
 		&.rounded {
 			border-radius: var(--radius-ml);

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -77,6 +77,7 @@
 	let active = $state(false);
 
 	const actionsVisible = $derived(!draft && !isCommitting && (buttons || menu));
+	const isCommittingEmpty = $derived(isCommitting && isEmpty);
 
 	const draggableBranchConfig = $derived.by<DraggableConfig>(() => {
 		if (!dragArgs) {
@@ -111,7 +112,7 @@
 		class:selected
 		class:active
 		class:draft
-		class:rounded={!actionsVisible && roundedBottom}
+		class:rounded={!actionsVisible && roundedBottom && !isCommittingEmpty}
 		class:commiting={isCommitting}
 		{onclick}
 		onkeypress={onclick}

--- a/apps/desktop/src/components/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/CommitGoesHere.svelte
@@ -159,7 +159,7 @@
 		top: 50%;
 		left: 38px;
 		padding: 3px 6px;
-		transform: translateY(-50%) translateX(-10%) scale(0.95);
+		transform: translateY(-50%) translateX(10%) scale(0.95);
 		border-radius: var(--radius-ml);
 		background-color: var(--clr-theme-pop-element);
 		color: var(--clr-core-ntrl-100);

--- a/apps/desktop/src/components/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/CommitGoesHere.svelte
@@ -37,6 +37,7 @@
 		data-testid={TestId.CommitHereButton}
 		data-testid-commit-id={commitId}
 		class="commit-here"
+		class:commit-here_first={first}
 		class:commit-here_last={last}
 		type="button"
 		{onclick}
@@ -66,6 +67,11 @@
 		&.last {
 			border-top: 1px solid var(--clr-border-2);
 			border-bottom: none;
+		}
+
+		&.draft {
+			border: 1px solid var(--clr-border-2);
+			border-radius: 0 0 var(--radius-ml) var(--radius-ml);
 		}
 	}
 	.pin {
@@ -118,6 +124,11 @@
 			& .commit-here__label {
 				transform: translateY(-50%) translateX(0) scale(1);
 				opacity: 1;
+			}
+
+			&.commit-here_first {
+				height: 30px;
+				margin-top: 0;
 			}
 
 			&.commit-here_last {

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -56,7 +56,7 @@
 							lineColor="var(--clr-commit-local)"
 						>
 							{#snippet branchContent()}
-								<CommitGoesHere commitId={undefined} selected last />
+								<CommitGoesHere commitId={undefined} selected draft />
 							{/snippet}
 						</BranchCard>
 					{/snippet}


### PR DESCRIPTION
PR includes minor UI fixes for the "commit goes here" component:
- prevent clipping of the very top "commit goes here" label
- fix states when elements should be rounded
- some smaller fixes