### PR TITLE
Prevent windows from building the frontend again despite having downloaded it

### DIFF
--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${CI:-}" = "true" ]; then
+  echo "CI environment detected, expecting frontend build to be downloaded."
+else
+  fe_mode=${1:?First argument must be the mode to build the frontend with}
+  echo "Assuming local invocation, building frontend in $fe_mode mode"
+  pnpm build:desktop -- --mode "$fe_mode"
+fi
+
+cargo build --release -p gitbutler-git
+bash ./crates/gitbutler-tauri/inject-git-binaries.sh

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -2,7 +2,7 @@
 	"productName": "GitButler Nightly",
 	"identifier": "com.gitbutler.app.nightly",
 	"build": {
-		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode nightly && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
+		"beforeBuildCommand": "bash ./crates/gitbutler-tauri/tauri-before-build-command.sh nightly"
 	},
 	"bundle": {
 		"active": true,

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -2,7 +2,7 @@
 	"productName": "GitButler",
 	"identifier": "com.gitbutler.app",
 	"build": {
-		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode production && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
+		"beforeBuildCommand": "bash ./crates/gitbutler-tauri/tauri-before-build-command.sh production"
 	},
 	"bundle": {
 		"active": true,


### PR DESCRIPTION
This gives another 2minutes speedup by avoiding duplicate work.

### Tasks

* [x] works locally - before the script doesn't fail when building it locally
* [x] validate nightly build for Windows (actually try it)
