### PR TITLE
simplify-branch-header-style-conditions

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -46,7 +46,7 @@
 
 	interface DraftBranchProps extends BranchCardProps {
 		type: 'draft-branch';
-		branchContent: Snippet;
+		branchContent?: Snippet;
 		buttons?: Snippet;
 	}
 
@@ -118,6 +118,7 @@
 
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
+
 	const showPrCreation = $derived(
 		exclusiveAction?.type === 'create-pr' &&
 			exclusiveAction.stackId === (args.type === 'stack-branch' ? args.stackId : undefined) &&
@@ -207,6 +208,7 @@
 				onclick={args.onclick}
 				menu={args.menu}
 				conflicts={args.isConflicted}
+				{showPrCreation}
 				dragArgs={{
 					disabled: args.isConflicted,
 					label: branchName,
@@ -272,20 +274,21 @@
 						</div>
 					{/if}
 				{/snippet}
+
+				{#snippet prCreation()}
+					<div class="review-wrapper" class:no-padding={uiState.global.useFloatingBox.current}>
+						<CreateReviewBox
+							{projectId}
+							{branchName}
+							stackId={args.stackId}
+							oncancel={() => {
+								projectState.exclusiveAction.set(undefined);
+							}}
+						/>
+					</div>
+				{/snippet}
 			</BranchHeader>
 		</Dropzone>
-		{#if showPrCreation}
-			<div class="review-wrapper" class:no-padding={uiState.global.useFloatingBox.current}>
-				<CreateReviewBox
-					{projectId}
-					{branchName}
-					stackId={args.stackId}
-					oncancel={() => {
-						projectState.exclusiveAction.set(undefined);
-					}}
-				/>
-			</div>
-		{/if}
 	{:else if args.type === 'normal-branch'}
 		<BranchHeader
 			{branchName}
@@ -366,7 +369,9 @@
 	{/if}
 
 	{#if args.type === 'stack-branch' || args.type === 'normal-branch' || args.type === 'draft-branch'}
-		{@render args.branchContent()}
+		{#if args.branchContent}
+			{@render args.branchContent()}
+		{/if}
 	{/if}
 </div>
 
@@ -450,6 +455,7 @@
 
 	.review-wrapper {
 		border-top: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-2);
 
 		&:not(.no-padding) {
 			padding: 12px;

--- a/apps/desktop/src/components/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/CommitGoesHere.svelte
@@ -70,10 +70,11 @@
 		}
 
 		&.draft {
-			border: 1px solid var(--clr-border-2);
-			border-radius: 0 0 var(--radius-ml) var(--radius-ml);
+			border-top: 1px solid var(--clr-border-2);
+			border-bottom: none;
 		}
 	}
+
 	.pin {
 		display: flex;
 		position: relative;

--- a/apps/desktop/src/components/FloatingCommitBox.svelte
+++ b/apps/desktop/src/components/FloatingCommitBox.svelte
@@ -70,10 +70,10 @@
 		background-color: var(--clr-bg-2);
 		color: var(--clr-text-2);
 		cursor: pointer;
-		transition: background-color 0.2s ease-in-out;
+		transition: background-color var(--transition-fast);
 
 		&:hover {
-			background-color: var(--clr-bg-1);
+			background-color: var(--clr-bg-1-muted);
 		}
 	}
 

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import BranchCard from '$components/BranchCard.svelte';
-	import CommitGoesHere from '$components/CommitGoesHere.svelte';
 	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import NewCommitView from '$components/NewCommitView.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
@@ -54,11 +53,7 @@
 							{branchName}
 							readonly={false}
 							lineColor="var(--clr-commit-local)"
-						>
-							{#snippet branchContent()}
-								<CommitGoesHere commitId={undefined} selected draft />
-							{/snippet}
-						</BranchCard>
+						/>
 					{/snippet}
 				</ReduxResult>
 				<Resizer


### PR DESCRIPTION
Fix transparent background when create a PR:

<img width="472" height="458" alt="Screenshot 2025-10-29 at 13 38 26" src="https://github.com/user-attachments/assets/6ddb6eb7-980f-4f7b-9a67-afa678aacdf2" />

---

Simplify conditions for branch header elements when they should be rounded. Move these elements into the branch header.

<img width="1343" height="901" alt="Screenshot 2025-10-29 at 13 17 18" src="https://github.com/user-attachments/assets/0f3c6068-67d2-4dc4-bacb-9587b6ad8acd" />
<img width="1070" height="643" alt="Screenshot 2025-10-29 at 13 17 28" src="https://github.com/user-attachments/assets/dcd83215-c425-45be-bed7-96b961616057" />
