### PR TITLE
v3 unapply: MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,11 +1144,14 @@ name = "but-debug"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-api",
  "but-core",
  "but-ctx",
  "but-graph",
  "but-testsupport",
+ "but-workspace",
  "clap",
+ "gitbutler-reference",
  "gix",
  "insta",
  "open",

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -1,15 +1,22 @@
 use std::collections::HashMap;
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow, bail};
 use bstr::ByteSlice;
 use but_api_macros::but_api;
 use but_core::{
     DiffSpec, RefMetadata,
     ref_metadata::{StackId, StackKind, WorkspaceStack},
-    sync::RepoExclusive,
+    sync::{RepoExclusive, RepoShared},
+    worktree::checkout::UncommitedWorktreeChanges,
 };
 use but_ctx::{Context, ThreadSafeContext};
 use but_error::bail_precondition;
+use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
+use but_rebase::graph_rebase::{
+    Editor,
+    mutate::{InsertSide, RelativeToRef},
+};
+use but_workspace::branch::unapply::WorkspaceDisposition;
 use but_workspace::legacy::ui::{StackEntryNoOpt, StackHeadInfo};
 use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
 use gitbutler_branch_actions::{
@@ -22,6 +29,7 @@ use gitbutler_branch_actions::{
 };
 use gitbutler_git::GitContextExt as _;
 use gitbutler_operating_modes::ensure_open_workspace_mode;
+use gitbutler_oplog::OplogExt;
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, normalize_branch_name as normalize_name};
 use gix::reference::Category;
@@ -552,8 +560,6 @@ mod tests {
     }
 }
 
-#[but_api(napi)]
-#[instrument(err(Debug))]
 /// Take the stack identified by `stack_id` out of the workspace.
 ///
 /// This acquires exclusive worktree access from `ctx` before collecting the
@@ -561,6 +567,8 @@ mod tests {
 ///
 /// See [`unapply_stack_with_perm()`] for how assigned changes are collected before
 /// delegating to the underlying mutation.
+#[but_api(napi)]
+#[instrument(err(Debug))]
 pub fn unapply_stack(ctx: &mut Context, stack_id: StackId) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     unapply_stack_with_perm(ctx, stack_id, guard.write_permission())
@@ -576,8 +584,27 @@ pub fn unapply_stack_with_perm(
     stack_id: StackId,
     perm: &mut RepoExclusive,
 ) -> Result<()> {
+    if ctx.settings.feature_flags.unapply_v3 {
+        return unapply_stack_v3_with_perm(ctx, stack_id, perm);
+    }
+
+    let assigned_diffspec = assigned_diffspec_for_stack(ctx, stack_id, perm.read_permission())?;
+    gitbutler_branch_actions::unapply_stack(ctx, perm, stack_id, assigned_diffspec)?;
+    Ok(())
+}
+
+/// Return the worktree diffspecs currently assigned to `stack_id`.
+///
+/// This reconciles persisted hunk assignments with current worktree changes,
+/// keeps only assignments owned by `stack_id`, and flattens them into the
+/// diffspec list consumed by unapply implementations.
+fn assigned_diffspec_for_stack(
+    ctx: &Context,
+    stack_id: StackId,
+    perm: &RepoShared,
+) -> Result<Vec<DiffSpec>> {
     let context_lines = ctx.settings.context_lines;
-    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
         db.hunk_assignments_mut()?,
         &repo,
@@ -592,8 +619,166 @@ pub fn unapply_stack_with_perm(
             .map(|a| a.into())
             .collect::<Vec<DiffSpec>>(),
     );
-    drop((repo, ws, db));
-    gitbutler_branch_actions::unapply_stack(ctx, perm, stack_id, assigned_diffspec)?;
+    Ok(assigned_diffspec)
+}
+
+/// Unapply a stack through the newer workspace metadata implementation.
+///
+/// This deliberately keeps the workspace reference and workspace merge commit in
+/// place for compatibility with the legacy API surface while trying the new
+/// unapply implementation behind `feature_flags.unapply_v3`.
+/// We implement plumbing here, particularly relative to assignment handling,
+/// to facilitate the eventual removal of `gitbutler-branch-actions`.
+///
+/// # Control-flow
+///
+/// - verify that the project is in open workspace mode;
+/// - collect currently assigned worktree changes for `stack_id`;
+/// - identify the workspace metadata branch representing the stack;
+/// - create a best-effort unapply snapshot with all stack branch names as trailers;
+/// - commit assigned changes below the branch being unapplied so they travel with it;
+/// - delegate the actual workspace mutation to [`but_workspace::branch::unapply()`]
+///   and update the cached workspace projection with the returned workspace.
+///
+/// # What makes this legacy
+///
+/// - use of `stack_id` should be brnach name or maybe even stack index (i.e. index in workspace projection,
+///   along with other identification, maybe even as much as we have)
+/// - Ideally, this new way of identifying stacks by bundling various identifiers, is also used in `unapply()`
+///   itself and a simple [`but_graph::Workspace`] method.
+fn unapply_stack_v3_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    ensure_open_workspace_mode(ctx, perm.read_permission())
+        .context("Unapplying a stack requires open workspace mode")?;
+
+    let assigned_diffspec = assigned_diffspec_for_stack(ctx, stack_id, perm.read_permission())?;
+    let stack_branches = stack_branch_names(ctx, stack_id, perm)?;
+    let Some(branch_to_unapply) = stack_branches.first().cloned() else {
+        return Ok(());
+    };
+
+    let trailers = stack_branches
+        .iter()
+        .map(|branch| Trailer::Branch(branch.shorten().to_string()));
+    let details = SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(trailers);
+    let _snapshot = ctx.create_snapshot(details, perm).ok();
+
+    commit_assigned_diffspec(ctx, branch_to_unapply.as_ref(), assigned_diffspec, perm)?;
+
+    let mut meta = ctx.legacy_meta_mut(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let outcome = but_workspace::branch::unapply(
+        branch_to_unapply.as_ref(),
+        &ws,
+        &repo,
+        &mut meta,
+        but_workspace::branch::unapply::Options {
+            // TODO: change this to `RemoveWorkspaceMergeCommitKeepWorkspaceReference` once we know all
+            //       algorithms can deal with it (which should be the case if there is no legacy).
+            workspace_disposition: WorkspaceDisposition::KeepWorkspaceCommit,
+            uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+        },
+    )?;
+    *ws = outcome.workspace.into_owned();
+    // Keeping the workspace merge commit can make legacy reconciliation infer the
+    // removed stack as applied again, so persist the explicit workspace metadata.
+    meta.write_unreconciled()?;
+    Ok(())
+}
+
+/// Return branch names for the projected workspace stack identified by `stack_id`.
+///
+/// The returned names describe the stack as it appears in the current
+/// workspace: tip-most branch first, then branches closer to the workspace base.
+fn stack_branch_names(
+    ctx: &mut Context,
+    stack_id: StackId,
+    perm: &mut RepoExclusive,
+) -> Result<Vec<gix::refs::FullName>> {
+    let (_repo, ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let Some(stack) = ws.stacks.iter().find(|stack| stack.id == Some(stack_id)) else {
+        return Err(
+            anyhow!("branch with ID {stack_id} not found").context(but_error::Code::BranchNotFound)
+        );
+    };
+
+    if stack
+        .segments
+        .first()
+        .is_none_or(|s| s.ref_name().is_none())
+    {
+        bail!("Cannot unapply anonymous segments yet even if they have a stack id");
+    }
+
+    Ok(stack
+        .segments
+        .iter()
+        .filter_map(|segment| {
+            segment
+                .ref_info
+                .as_ref()
+                .map(|ref_info| ref_info.ref_name.clone())
+        })
+        .collect())
+}
+
+/// Commit assigned worktree changes so they remain with the branch being unapplied.
+///
+/// `ctx` supplies repository, workspace, metadata, and diff settings used to
+/// create the assignment commit. `branch` is the reference the new "WIP
+/// Assignments" commit is inserted below. `assigned_diffspec` is the list of
+/// worktree hunks or files to include; an empty list is a no-op. `perm` is the
+/// caller-held exclusive repository permission used while mutating history and
+/// refreshing the cached workspace state.
+///
+/// # TODOs
+///
+/// - The "WIP Assignments" commit feels like an elaborate PoC and ideally, there is
+///   a well-tested and general way to deal with this.
+///   The [new snapshot system](but_core::snapshot) can be used to store and attach all kinds
+///   of data in Git and maybe that can be used to make assignments visible, but hide them from
+///   plain Git. Maybe showing them as plain git commit even is a good thing, i.e. it's discoverable
+///   and could be uncommitted to geth the cahnges back, but ideally this functionality is at
+///   least more integrated where it matters and maybe implemented and tested in the crate
+///   that implements assignments.
+/// - The assignment commit is materialised immediately, even though it could be held in limbo
+///   and combined with unapply later to materisalise everything at once. Right now this would
+///   be hard to achieve though, but it's definitely possible.
+fn commit_assigned_diffspec(
+    ctx: &mut Context,
+    branch: &gix::refs::FullNameRef,
+    assigned_diffspec: Vec<DiffSpec>,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    if assigned_diffspec.is_empty() {
+        return Ok(());
+    }
+
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = but_workspace::commit::commit_create(
+        editor,
+        assigned_diffspec,
+        RelativeToRef::Reference(branch),
+        InsertSide::Below,
+        "WIP Assignments",
+        ctx.settings.context_lines,
+    )?;
+    if !outcome.rejected_specs.is_empty() {
+        tracing::warn!(
+            ?outcome.rejected_specs,
+            "Failed to commit at least one hunk"
+        );
+    }
+    if outcome.commit_selector.is_some() {
+        outcome.rebase.materialize()?;
+        drop((repo, ws));
+        ctx.reload_repo_and_invalidate_workspace(perm)?;
+    }
     Ok(())
 }
 

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -642,7 +642,7 @@ fn assigned_diffspec_for_stack(
 ///
 /// # What makes this legacy
 ///
-/// - use of `stack_id` should be brnach name or maybe even stack index (i.e. index in workspace projection,
+/// - use of `stack_id` should be branch name or maybe even stack index (i.e. index in workspace projection,
 ///   along with other identification, maybe even as much as we have)
 /// - Ideally, this new way of identifying stacks by bundling various identifiers, is also used in `unapply()`
 ///   itself and a simple [`but_graph::Workspace`] method.

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -670,15 +670,18 @@ fn unapply_stack_v3_with_perm(
 
     let mut meta = ctx.legacy_meta_mut(perm)?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let workspace_disposition = if ctx.settings.feature_flags.unapply_v3_pgm {
+        WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
+    } else {
+        WorkspaceDisposition::KeepWorkspaceCommit
+    };
     let outcome = but_workspace::branch::unapply(
         branch_to_unapply.as_ref(),
         &ws,
         &repo,
         &mut meta,
         but_workspace::branch::unapply::Options {
-            // TODO: change this to `RemoveWorkspaceMergeCommitKeepWorkspaceReference` once we know all
-            //       algorithms can deal with it (which should be the case if there is no legacy).
-            workspace_disposition: WorkspaceDisposition::KeepWorkspaceCommit,
+            workspace_disposition,
             uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
         },
     )?;

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -48,6 +48,25 @@ pub struct Workspace {
     pub push_remote: Option<String>,
 }
 
+/// A projected workspace stack used to reconcile persisted workspace metadata.
+///
+/// This is intentionally smaller than the full workspace projection so metadata
+/// code does not depend on graph presentation types and only sees what it needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedWorkspaceStack {
+    /// Existing stable stack id from projection, if one was already known.
+    ///
+    /// `Some(id)` means reconciliation may use that id to match an existing
+    /// metadata stack, or preserve it when creating metadata for a projected
+    /// stack that is missing from metadata.
+    ///
+    /// `None` means reconciliation should create a new stack id if the projected
+    /// stack does not match any existing metadata stack.
+    pub id: Option<StackId>,
+    /// Branch names in stack order, from tip toward base.
+    pub branches: Vec<gix::refs::FullName>,
+}
+
 impl std::fmt::Debug for Workspace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Workspace {
@@ -72,6 +91,86 @@ impl std::fmt::Debug for Workspace {
 
 /// Mutations
 impl Workspace {
+    /// Add missing metadata for stacks visible in the current workspace projection.
+    ///
+    /// This is additive with respect to branch names: projected branches are
+    /// added to metadata when missing, existing branch metadata is preserved,
+    /// and branches not present in `projected_stacks` are not removed.
+    ///
+    /// Projected stacks are authoritative for grouping. If a projected branch is
+    /// already in another metadata stack, it is moved to the projected stack.
+    /// Metadata stacks made empty by such moves are removed. Existing metadata
+    /// may contain duplicate branch names across stacks; these are tolerated as
+    /// stale hints. Projected branch names must still be unique.
+    pub fn reconcile_projected_stacks(
+        &mut self,
+        projected_stacks: impl IntoIterator<Item = ProjectedWorkspaceStack>,
+        mut new_stack_id: impl FnMut(&gix::refs::FullNameRef) -> StackId,
+    ) -> Result<()> {
+        let projected_stacks = projected_stacks
+            .into_iter()
+            .filter(|stack| !stack.branches.is_empty())
+            .collect::<Vec<_>>();
+        ensure_unique_branch_names(
+            projected_stacks
+                .iter()
+                .flat_map(|stack| stack.branches.iter().map(|branch| branch.as_ref())),
+            "projected workspace",
+        )?;
+
+        for ProjectedWorkspaceStack {
+            id: projected_stack_id,
+            branches: projected_branches,
+        } in projected_stacks
+        {
+            let owning_stack_idx = projected_stack_id
+                .and_then(|id| self.stacks.iter().position(|stack| stack.id == id))
+                .or_else(|| {
+                    projected_branches.iter().find_map(|branch| {
+                        self.find_owner_indexes_by_name(
+                            branch.as_ref(),
+                            StackKind::AppliedAndUnapplied,
+                        )
+                        .map(|(stack_idx, _branch_idx)| stack_idx)
+                    })
+                });
+
+            if let Some(stack_idx) = owning_stack_idx {
+                let mut branches = Vec::new();
+                for branch in projected_branches {
+                    branches.push(
+                        remove_branch_from_stacks(&mut self.stacks, stack_idx, branch.as_ref())
+                            .unwrap_or(WorkspaceStackBranch {
+                                ref_name: branch,
+                                archived: false,
+                            }),
+                    );
+                }
+                let stack = &mut self.stacks[stack_idx];
+                branches.extend(std::mem::take(&mut stack.branches));
+                stack.branches = branches;
+                stack.workspacecommit_relation = WorkspaceCommitRelation::Merged;
+            } else {
+                let stack_id = projected_stack_id
+                    .unwrap_or_else(|| new_stack_id(projected_branches[0].as_ref()));
+                self.stacks.push(WorkspaceStack {
+                    id: stack_id,
+                    branches: projected_branches
+                        .into_iter()
+                        .map(|ref_name| WorkspaceStackBranch {
+                            ref_name,
+                            archived: false,
+                        })
+                        .collect(),
+                    workspacecommit_relation: WorkspaceCommitRelation::Merged,
+                });
+            }
+        }
+        self.stacks.retain(|stack| !stack.branches.is_empty());
+
+        Ok(())
+    }
+
     /// Remove the named segment `branch`, which removes the whole stack if it's empty after removing a segment
     /// of that name.
     /// Returns `true` if it was removed or `false` if it wasn't found.
@@ -88,6 +187,39 @@ impl Workspace {
         if stack.branches.is_empty() {
             self.stacks.remove(stack_idx);
         }
+        true
+    }
+
+    /// Remove `branch` from applied workspace metadata, and return `true` if it was removed from the metadata,
+    /// or `false` if it wasn't present.
+    ///
+    /// If `branch` is the only segment in its stack, the whole stack metadata entry is removed so
+    /// virtual apply/unapply roundtrips return to the original empty-workspace shape.
+    ///
+    /// If `branch` is the tip of a multi-segment stack, the remaining stack is marked outside
+    /// the workspace because its visible tip was removed. This is necessary
+    /// to keep previous stacks alive in metadata, in case they are re-applied later, to return
+    /// to the same shape.
+    #[expect(clippy::indexing_slicing)]
+    pub fn unapply_branch(&mut self, branch: &FullNameRef) -> bool {
+        let Some((stack_idx, segment_idx)) =
+            self.find_owner_indexes_by_name(branch, StackKind::Applied)
+        else {
+            return false;
+        };
+
+        let stack_len = self.stacks[stack_idx].branches.len();
+        if stack_len == 1 {
+            // There is nothing to remember, remove the whole stack.
+            self.stacks.remove(stack_idx);
+        } else if segment_idx == 0 {
+            // The tip of the stack should be removed, mark the whole stack as outside, to remember its configuration.
+            self.stacks[stack_idx].workspacecommit_relation = WorkspaceCommitRelation::Outside;
+        } else {
+            // It's a segment in the middle, remove its metadata.
+            self.stacks[stack_idx].branches.remove(segment_idx);
+        }
+
         true
     }
 
@@ -198,6 +330,43 @@ impl Workspace {
             .map(Ok)
             .unwrap_or_else(|| self.remote_url_with_fallback(repo))
     }
+}
+
+fn ensure_unique_branch_names<'a>(
+    names: impl IntoIterator<Item = &'a gix::refs::FullNameRef>,
+    source: &str,
+) -> Result<()> {
+    let mut seen = Vec::<gix::refs::FullName>::new();
+    for name in names {
+        if seen.iter().any(|seen| seen.as_ref() == name) {
+            bail!("Cannot reconcile {source}: branch name '{name}' occurs more than once");
+        }
+        seen.push(name.to_owned());
+    }
+    Ok(())
+}
+
+fn remove_branch_from_stacks(
+    stacks: &mut [WorkspaceStack],
+    preferred_stack_idx: usize,
+    name: &gix::refs::FullNameRef,
+) -> Option<WorkspaceStackBranch> {
+    if let Some(stack) = stacks.get_mut(preferred_stack_idx)
+        && let Some(branch_idx) = stack
+            .branches
+            .iter()
+            .position(|branch| branch.ref_name.as_ref() == name)
+    {
+        return Some(stack.branches.remove(branch_idx));
+    }
+
+    stacks.iter_mut().find_map(|stack| {
+        let branch_idx = stack
+            .branches
+            .iter()
+            .position(|branch| branch.ref_name.as_ref() == name)?;
+        Some(stack.branches.remove(branch_idx))
+    })
 }
 
 /// Determine what kind of stack a query operation is interested in.

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, bail};
 use bstr::ByteSlice;
 use but_oxidize::ObjectIdExt;
 use gix::{
@@ -35,6 +35,7 @@ pub fn safe_checkout_from_head(
 ///
 /// If `new_head_id` is a *commit*, we will also set `HEAD` (or the ref it points to if symbolic) to the `new_head_id`.
 /// We will also update the `.git/index` to match the `new_head_id^{tree}`.
+/// GitButler-conflicted commits are rejected by default before any worktree, index, or ref update.
 /// Note that the value for [`super::UncommitedWorktreeChanges`] is critical to determine what happens if a change would be overwritten.
 ///
 /// We will always handle changes in the worktree safely to avoid loss of uncommitted information. This also means that deletions
@@ -54,10 +55,17 @@ pub fn safe_checkout(
         uncommitted_changes: conflicting_worktree_changes_opts,
         skip_head_update,
         merge_base_override,
+        allow_conflicted_commit_checkout,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let source_tree = current_head_id.attach(repo).object()?.peel_to_tree()?;
     let new_object = new_head_id.attach(repo).object()?;
+    if !allow_conflicted_commit_checkout
+        && new_object.kind.is_commit()
+        && crate::Commit::from_id(new_head_id.attach(repo))?.is_conflicted()
+    {
+        bail!("Refusing to check out conflicted commit {new_head_id}");
+    }
     let mut destination_tree = new_object.clone().peel_to_tree()?;
 
     let mut delegate = super::utils::Delegate::default();

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -28,6 +28,12 @@ pub struct Options {
     /// commit/amend so the consumed hunks cancel in the 3-way merge and don't
     /// reappear as uncommitted changes.
     pub merge_base_override: Option<gix::ObjectId>,
+    /// Allow checking out GitButler-managed conflicted commits.
+    ///
+    /// Most callers should keep the default refusal and surface a higher-level
+    /// conflict workflow instead. Rebase materialization may opt in when it
+    /// intentionally created the conflicted commit it is about to materialize.
+    pub allow_conflicted_commit_checkout: bool,
 }
 
 /// The successful outcome of [super::safe_checkout()] operation.

--- a/crates/but-core/tests/core/ref_metadata.rs
+++ b/crates/but-core/tests/core/ref_metadata.rs
@@ -1,6 +1,7 @@
 mod workspace {
+    use bstr::ByteSlice;
     use but_core::ref_metadata::{
-        StackId,
+        ProjectedWorkspaceStack, StackId,
         StackKind::{Applied, AppliedAndUnapplied},
         Workspace,
         WorkspaceCommitRelation::{Merged, Outside},
@@ -59,6 +60,194 @@ mod workspace {
             push_remote: None,
         }
         "#);
+    }
+
+    #[test]
+    fn unapply_branch_returns_false_if_absent() {
+        let mut ws = Workspace {
+            stacks: vec![
+                stack(1, Merged, ["refs/heads/A"]),
+                stack(2, Outside, ["refs/heads/outside"]),
+            ],
+            ..Workspace::default()
+        };
+
+        assert!(
+            !ws.unapply_branch(r("refs/heads/missing")),
+            "an unknown branch is not removed from applied workspace metadata"
+        );
+        assert!(
+            !ws.unapply_branch(r("refs/heads/outside")),
+            "an outside branch is not removed from applied workspace metadata"
+        );
+        insta::assert_snapshot!(
+            but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")),
+            "absent applied branches leave workspace metadata unchanged",
+            @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: 2,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/outside",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Outside,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn unapply_branch_removes_single_branch_stack() {
+        let mut ws = Workspace {
+            stacks: vec![
+                stack(1, Merged, ["refs/heads/A"]),
+                stack(2, Merged, ["refs/heads/B"]),
+            ],
+            ..Workspace::default()
+        };
+
+        assert!(
+            ws.unapply_branch(r("refs/heads/A")),
+            "single-branch applied stacks are removed entirely"
+        );
+        insta::assert_snapshot!(
+            but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")),
+            "removing the only branch in an applied stack removes that stack metadata",
+            @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/B",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn unapply_branch_marks_multi_segment_stack_outside_when_tip_is_removed() {
+        let mut ws = Workspace {
+            stacks: vec![stack(
+                1,
+                Merged,
+                ["refs/heads/A", "refs/heads/B", "refs/heads/C"],
+            )],
+            ..Workspace::default()
+        };
+
+        assert!(
+            ws.unapply_branch(r("refs/heads/A")),
+            "removing the tip of a multi-segment applied stack marks it outside"
+        );
+        insta::assert_snapshot!(
+            but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")),
+            "the status quo retains the branch metadata but moves the stack outside",
+            @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/B",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/C",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Outside,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#
+        );
+    }
+
+    #[test]
+    fn unapply_branch_removes_middle_segment_metadata() {
+        let mut ws = Workspace {
+            stacks: vec![stack(
+                1,
+                Merged,
+                ["refs/heads/A", "refs/heads/B", "refs/heads/C"],
+            )],
+            ..Workspace::default()
+        };
+
+        assert!(
+            ws.unapply_branch(r("refs/heads/B")),
+            "removing a middle segment drops that branch metadata"
+        );
+        insta::assert_snapshot!(
+            but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")),
+            "middle segment removal keeps the stack applied and removes only that branch",
+            @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/C",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#
+        );
     }
 
     #[test]
@@ -188,10 +377,406 @@ mod workspace {
         );
     }
 
+    #[test]
+    fn reconcile_projected_stacks_starts_from_empty_metadata() -> anyhow::Result<()> {
+        let mut ws = Workspace::default();
+
+        ws.reconcile_projected_stacks(
+            [
+                projected_stack(None, ["refs/heads/A"]),
+                projected_stack(None, ["refs/heads/C", "refs/heads/B"]),
+            ],
+            stack_id_from_name,
+        )?;
+
+        insta::assert_snapshot!(but_testsupport::sanitize_uuids_and_timestamps(format!("{ws:#?}")), @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 1,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: 2,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/C",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/B",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn reconcile_projected_stacks_is_additive_and_preserves_existing_branch_metadata()
+    -> anyhow::Result<()> {
+        let archived_extra_ref = r("refs/heads/old-extra");
+        let mut ws = Workspace {
+            stacks: vec![WorkspaceStack {
+                id: StackId::from_number_for_testing(1),
+                branches: vec![
+                    WorkspaceStackBranch {
+                        ref_name: r("refs/heads/B").to_owned(),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: archived_extra_ref.to_owned(),
+                        archived: true,
+                    },
+                ],
+                workspacecommit_relation: Outside,
+            }],
+            ..Workspace::default()
+        };
+
+        ws.reconcile_projected_stacks(
+            [projected_stack(None, ["refs/heads/C", "refs/heads/B"])],
+            stack_id_from_name,
+        )?;
+
+        assert_eq!(
+            branch_names(&ws.stacks[0]),
+            ["refs/heads/C", "refs/heads/B", "refs/heads/old-extra"],
+            "projected branches are ordered first, while unused existing branches are retained"
+        );
+        assert!(
+            ws.stacks[0].branches[2].archived,
+            "existing branch metadata is preserved"
+        );
+        assert_eq!(ws.stacks[0].workspacecommit_relation, Merged);
+        insta::assert_debug_snapshot!(ws, @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000001,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/C",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/B",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/old-extra",
+                            archived: true,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn reconcile_projected_stacks_rejects_duplicate_projected_names() {
+        let mut ws = Workspace::default();
+        let err = ws
+            .reconcile_projected_stacks(
+                [
+                    projected_stack(None, ["refs/heads/A"]),
+                    projected_stack(None, ["refs/heads/A"]),
+                ],
+                stack_id_from_name,
+            )
+            .expect_err("duplicate projected names violate workspace metadata constraints");
+
+        assert_eq!(
+            err.to_string(),
+            "Cannot reconcile projected workspace: branch name 'refs/heads/A' occurs more than once"
+        );
+    }
+
+    #[test]
+    fn reconcile_projected_stacks_tolerates_duplicate_existing_metadata_names() -> anyhow::Result<()>
+    {
+        let matching_stack_id = StackId::from_number_for_testing(2);
+        let mut ws = Workspace {
+            stacks: vec![
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(1),
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: r("refs/heads/A").to_owned(),
+                        archived: false,
+                    }],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: matching_stack_id,
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: r("refs/heads/A").to_owned(),
+                        archived: true,
+                    }],
+                    workspacecommit_relation: Outside,
+                },
+            ],
+            ..Workspace::default()
+        };
+
+        ws.reconcile_projected_stacks(
+            [projected_stack(Some(matching_stack_id), ["refs/heads/A"])],
+            stack_id_from_name,
+        )?;
+        insta::assert_debug_snapshot!(ws, "projected stacks prefer pulling from equally identified metadata stacks, so the Outside stacks turns Merged", @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000001,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000002,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/A",
+                            archived: true,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#);
+
+        assert_eq!(
+            ws.stacks.len(),
+            2,
+            "duplicate metadata hints in other stacks are tolerated"
+        );
+        assert_eq!(branch_names(&ws.stacks[0]), ["refs/heads/A"]);
+        assert_eq!(branch_names(&ws.stacks[1]), ["refs/heads/A"]);
+        assert!(
+            ws.stacks[1].branches[0].archived,
+            "the preferred stack keeps its own branch metadata"
+        );
+        assert_eq!(ws.stacks[1].workspacecommit_relation, Merged);
+        Ok(())
+    }
+
+    #[test]
+    fn reconcile_projected_stacks_moves_existing_branch_names_between_metadata_stacks()
+    -> anyhow::Result<()> {
+        let mut ws = Workspace {
+            stacks: vec![
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(1),
+                    branches: vec![
+                        WorkspaceStackBranch {
+                            ref_name: r("refs/heads/B").to_owned(),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: r("refs/heads/E").to_owned(),
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(2),
+                    branches: vec![
+                        WorkspaceStackBranch {
+                            ref_name: r("refs/heads/C").to_owned(),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: r("refs/heads/D").to_owned(),
+                            archived: true,
+                        },
+                    ],
+                    workspacecommit_relation: Outside,
+                },
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(3),
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: r("refs/heads/unrelated").to_owned(),
+                        archived: false,
+                    }],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            ..Workspace::default()
+        };
+
+        ws.reconcile_projected_stacks(
+            [projected_stack(
+                None,
+                ["refs/heads/D", "refs/heads/C", "refs/heads/B"],
+            )],
+            stack_id_from_name,
+        )?;
+
+        insta::assert_debug_snapshot!(ws, "projected stack grouping moves existing branch metadata between stacks, while unrelated branch metadata remains", @r#"
+        Workspace {
+            ref_info: RefInfo { created_at: None, updated_at: None },
+            stacks: [
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000001,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/E",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000002,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/D",
+                            archived: true,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/C",
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/B",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: 00000000-0000-0000-0000-000000000003,
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: "refs/heads/unrelated",
+                            archived: false,
+                        },
+                    ],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            target_ref: None,
+            target_commit_id: None,
+            push_remote: None,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn reconcile_projected_stacks_removes_stacks_emptied_by_moves() -> anyhow::Result<()> {
+        let mut ws = Workspace {
+            stacks: vec![
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(1),
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: r("refs/heads/B").to_owned(),
+                        archived: false,
+                    }],
+                    workspacecommit_relation: Merged,
+                },
+                WorkspaceStack {
+                    id: StackId::from_number_for_testing(2),
+                    branches: vec![WorkspaceStackBranch {
+                        ref_name: r("refs/heads/C").to_owned(),
+                        archived: false,
+                    }],
+                    workspacecommit_relation: Merged,
+                },
+            ],
+            ..Workspace::default()
+        };
+
+        ws.reconcile_projected_stacks(
+            [projected_stack(None, ["refs/heads/C", "refs/heads/B"])],
+            stack_id_from_name,
+        )?;
+
+        assert_eq!(
+            ws.stacks.len(),
+            1,
+            "the stack that only contained moved branch B should be removed"
+        );
+        assert_eq!(
+            branch_names(&ws.stacks[0]),
+            ["refs/heads/C", "refs/heads/B"]
+        );
+        Ok(())
+    }
+
     fn r(name: &str) -> &gix::refs::FullNameRef {
         name.try_into().expect("statically known ref")
     }
     fn new_stack_id(_: &gix::refs::FullNameRef) -> StackId {
         StackId::generate()
+    }
+    fn stack_id_from_name(name: &gix::refs::FullNameRef) -> StackId {
+        StackId::from_number_for_testing(name.shorten().chars().map(|c| c as u128).sum())
+    }
+    fn projected_stack<const N: usize>(
+        id: Option<StackId>,
+        branches: [&str; N],
+    ) -> ProjectedWorkspaceStack {
+        ProjectedWorkspaceStack {
+            id,
+            branches: branches
+                .into_iter()
+                .map(|name| r(name).to_owned())
+                .collect(),
+        }
+    }
+    fn stack<const N: usize>(
+        id: u128,
+        workspacecommit_relation: but_core::ref_metadata::WorkspaceCommitRelation,
+        branches: [&str; N],
+    ) -> WorkspaceStack {
+        WorkspaceStack {
+            id: StackId::from_number_for_testing(id),
+            branches: branches
+                .into_iter()
+                .map(|name| WorkspaceStackBranch {
+                    ref_name: r(name).to_owned(),
+                    archived: false,
+                })
+                .collect(),
+            workspacecommit_relation,
+        }
+    }
+    fn branch_names(stack: &WorkspaceStack) -> Vec<&str> {
+        stack
+            .branches
+            .iter()
+            .map(|branch| branch.ref_name.as_bstr().to_str().expect("utf8"))
+            .collect()
     }
 }

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -83,6 +83,33 @@ fn no_op_trees_never_touch_worktree() -> anyhow::Result<()> {
 }
 
 #[test]
+fn conflicted_commits_cannot_be_checked_out() -> anyhow::Result<()> {
+    let repo = crate::commit::conflict_repo("normal-and-artificial")?;
+    let normal = repo.rev_parse_single("normal")?.detach();
+    let conflicted = repo.rev_parse_single("conflicted")?.detach();
+
+    let err = safe_checkout(normal, conflicted, &repo, Default::default())
+        .expect_err("safe_checkout must reject GitButler-conflicted commits");
+    assert_eq!(
+        err.to_string(),
+        "Refusing to check out conflicted commit 84503317a1e1464381fcff65ece14bc1f4315b7c",
+    );
+
+    safe_checkout(
+        repo.head_id()?.detach(),
+        conflicted,
+        &repo,
+        checkout::Options {
+            allow_conflicted_commit_checkout: true,
+            ..Default::default()
+        },
+    )
+    .expect("internal callers can explicitly opt into conflicted commit checkout");
+
+    Ok(())
+}
+
+#[test]
 fn pure_deletion_checkout_does_not_restore_unrelated_worktree_deletions() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
     insta::assert_snapshot!(git_status(&repo)?, @r"

--- a/crates/but-debug/Cargo.toml
+++ b/crates/but-debug/Cargo.toml
@@ -15,9 +15,14 @@ path = "src/main.rs"
 doctest = false
 
 [dependencies]
+but-api = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
 but-ctx.workspace = true
 but-graph.workspace = true
+but-workspace.workspace = true
+
+gitbutler-reference.workspace = true
+
 anyhow.workspace = true
 clap = { workspace = true, features = [
     "env",

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -30,13 +30,60 @@ pub struct Args {
 /// The debugging subcommands supported by `but-debug`.
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Call selected but-api entry points directly.
+    Api(ApiArgs),
     /// Archive a repository for debugging.
     Dump(DumpArgs),
     /// Return a segmented graph starting from `HEAD`.
     Graph(GraphArgs),
+    /// Apply a local branch using the new but-workspace apply path.
+    Apply(ApplyArgs),
+    /// Unapply a local branch using the new but-workspace unapply path.
+    Unapply(UnapplyArgs),
     /// Debug revision graph operations.
     #[clap(visible_alias = "rev")]
     Revision(RevisionArgs),
+}
+
+/// Arguments for direct `but-api` calls.
+#[derive(Debug, clap::Args)]
+pub struct ApiArgs {
+    /// The API command to run.
+    #[command(subcommand)]
+    pub cmd: ApiSubcommands,
+}
+
+/// The `but-api` entry points exposed by `but-debug`.
+#[derive(Debug, clap::Subcommand)]
+pub enum ApiSubcommands {
+    /// Apply a branch through `but_api::legacy::virtual_branches::create_virtual_branch_from_branch`.
+    Apply(ApiApplyArgs),
+    /// Unapply a stack through `but_api::legacy::virtual_branches::unapply_stack`.
+    #[command(name = "unapply-stack")]
+    UnapplyStack(ApiUnapplyStackArgs),
+}
+
+/// Arguments for `but-debug api apply`.
+#[derive(Debug, clap::Args)]
+pub struct ApiApplyArgs {
+    /// Shared workspace debug output options.
+    #[command(flatten)]
+    pub debug: DebugWorkspaceArgs,
+    /// Optional pull request number to store on the applied branch.
+    #[arg(long)]
+    pub pr_number: Option<usize>,
+    /// Branch or full ref name to apply.
+    pub branch: String,
+}
+
+/// Arguments for `but-debug api unapply-stack`.
+#[derive(Debug, clap::Args)]
+pub struct ApiUnapplyStackArgs {
+    /// Shared workspace debug output options.
+    #[command(flatten)]
+    pub debug: DebugWorkspaceArgs,
+    /// Stack UUID, stack tip branch name, or any branch name in the stack.
+    pub stack: String,
 }
 
 /// Arguments for the `dump` debugging subcommand.
@@ -145,6 +192,83 @@ pub struct GraphArgs {
     pub dot_show: bool,
     /// The name of the ref to start the graph traversal at.
     pub ref_name: Option<String>,
+}
+
+/// Arguments for direct workspace mutation commands.
+#[derive(Debug, clap::Args)]
+pub struct ApplyArgs {
+    /// Shared workspace debug output options.
+    #[command(flatten)]
+    pub debug: DebugWorkspaceArgs,
+    /// Branch or full ref name to apply or unapply.
+    pub ref_name: String,
+}
+
+/// Arguments for direct workspace unapply commands.
+#[derive(Debug, clap::Args)]
+pub struct UnapplyArgs {
+    /// Shared workspace debug output options.
+    #[command(flatten)]
+    pub debug: DebugWorkspaceArgs,
+    /// How the workspace should be represented after unapplying.
+    #[arg(long, value_enum, default_value_t = WorkspaceDispositionArg::KeepWorkspaceReference)]
+    pub disposition: WorkspaceDispositionArg,
+    /// Branch or full ref name to unapply.
+    pub ref_name: String,
+}
+
+/// Workspace disposition choices exposed by `but-debug unapply`.
+#[derive(Debug, Copy, Clone, clap::ValueEnum)]
+pub enum WorkspaceDispositionArg {
+    /// Preserve the managed workspace commit even if it is no longer necessary.
+    KeepWorkspaceCommit,
+    /// Collapse unnecessary workspace commits, but keep the workspace reference checked out.
+    KeepWorkspaceReference,
+    /// Delete the workspace reference after switching away when it is no longer necessary.
+    PreventUnnecessaryWorkspaceReferences,
+    /// Delete the workspace reference when possible, otherwise keep the workspace merge commit for compatibility.
+    PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+}
+
+impl From<WorkspaceDispositionArg> for but_workspace::branch::unapply::WorkspaceDisposition {
+    fn from(value: WorkspaceDispositionArg) -> Self {
+        use but_workspace::branch::unapply::WorkspaceDisposition as T;
+        match value {
+            WorkspaceDispositionArg::KeepWorkspaceCommit => T::KeepWorkspaceCommit,
+            WorkspaceDispositionArg::KeepWorkspaceReference => T::KeepWorkspaceReference,
+            WorkspaceDispositionArg::PreventUnnecessaryWorkspaceReferences => {
+                T::PreventUnnecessaryWorkspaceReferences
+            }
+            WorkspaceDispositionArg::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit => {
+                T::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
+            }
+        }
+    }
+}
+
+/// Shared option for commands that can debug-print the post-operation workspace.
+#[derive(Debug, clap::Args)]
+pub struct DebugWorkspaceArgs {
+    /// Debug-print the workspace after the mutation.
+    #[arg(long, visible_alias = "ws")]
+    pub debug_workspace: bool,
+    /// Re-read the workspace from repository state before emitting post-operation workspace output.
+    #[arg(long, visible_alias = "invalidate")]
+    pub invalidate_workspace: bool,
+}
+
+impl DebugWorkspaceArgs {
+    /// Emit the workspace details controlled only by these debug options.
+    pub fn emit_workspace(
+        &self,
+        workspace: &but_graph::Workspace,
+        err: &mut dyn std::io::Write,
+    ) -> anyhow::Result<()> {
+        if self.debug_workspace {
+            writeln!(err, "{workspace:#?}")?;
+        }
+        Ok(())
+    }
 }
 
 /// Arguments for the `revision` subcommand.

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -59,7 +59,7 @@ pub enum ApiSubcommands {
     /// Apply a branch through `but_api::legacy::virtual_branches::create_virtual_branch_from_branch`.
     Apply(ApiApplyArgs),
     /// Unapply a stack through `but_api::legacy::virtual_branches::unapply_stack`.
-    #[command(name = "unapply-stack")]
+    #[command(name = "unapply-stack", visible_alias = "unapply")]
     UnapplyStack(ApiUnapplyStackArgs),
 }
 

--- a/crates/but-debug/src/command/api.rs
+++ b/crates/but-debug/src/command/api.rs
@@ -1,0 +1,119 @@
+//! Direct `but-api` debug commands.
+
+use std::{io, str::FromStr};
+
+use anyhow::{Context as _, Result, bail};
+use but_core::ref_metadata::StackId;
+use gitbutler_reference::Refname;
+use gix::bstr::ByteSlice;
+use gix::reference::Category;
+
+use crate::args::{
+    ApiApplyArgs, ApiArgs, ApiSubcommands, ApiUnapplyStackArgs, Args, DebugWorkspaceArgs,
+};
+
+/// Execute the `api` subcommand.
+pub(crate) fn run(
+    args: &Args,
+    api_args: &ApiArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    match &api_args.cmd {
+        ApiSubcommands::Apply(apply_args) => apply(args, apply_args, out, err),
+        ApiSubcommands::UnapplyStack(unapply_args) => unapply_stack(args, unapply_args, out, err),
+    }
+}
+
+fn apply(
+    args: &Args,
+    apply_args: &ApiApplyArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let mut ctx = discover_context(args)?;
+    let branch = branch_refname(&apply_args.branch)?;
+    let outcome = but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
+        &mut ctx,
+        branch,
+        apply_args.pr_number,
+    )?;
+    writeln!(out, "{outcome:#?}")?;
+    emit_after(&ctx, &apply_args.debug, err)?;
+    Ok(())
+}
+
+fn unapply_stack(
+    args: &Args,
+    unapply_args: &ApiUnapplyStackArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let mut ctx = discover_context(args)?;
+    let stack_id = resolve_stack_id(&ctx, &unapply_args.stack)?;
+    but_api::legacy::virtual_branches::unapply_stack(&mut ctx, stack_id)?;
+    writeln!(out, "unapplied stack {stack_id}")?;
+    emit_after(&ctx, &unapply_args.debug, err)?;
+    Ok(())
+}
+
+fn discover_context(args: &Args) -> Result<but_ctx::Context> {
+    but_ctx::Context::discover(&args.current_dir).with_context(|| {
+        format!(
+            "Could not open GitButler context at '{}'",
+            args.current_dir.display()
+        )
+    })
+}
+
+fn branch_refname(branch: &str) -> Result<Refname> {
+    let full_name = if branch.starts_with("refs/") {
+        branch.to_owned()
+    } else {
+        Category::LocalBranch
+            .to_full_name(branch)
+            .map_err(anyhow::Error::from)?
+            .to_string()
+    };
+    Refname::from_str(&full_name).map_err(anyhow::Error::from)
+}
+
+fn emit_after(
+    ctx: &but_ctx::Context,
+    debug: &DebugWorkspaceArgs,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    if debug.invalidate_workspace {
+        ctx.invalidate_workspace_cache()?;
+    }
+    let (_guard, _repo, workspace, _db) = ctx.workspace_and_db()?;
+    debug.emit_workspace(&workspace, err)
+}
+
+fn resolve_stack_id(ctx: &but_ctx::Context, stack: &str) -> Result<StackId> {
+    fn stack_matches(stack: &but_graph::workspace::Stack, name: &str) -> bool {
+        stack.segments.iter().any(|segment| {
+            segment.ref_name().is_some_and(|ref_name| {
+                ref_name.as_bstr() == name.as_bytes()
+                    || ref_name.shorten().as_bstr() == name.as_bytes()
+            })
+        })
+    }
+    if let Ok(stack_id) = stack.parse::<StackId>() {
+        return Ok(stack_id);
+    }
+
+    let (_guard, _repo, workspace, _db) = ctx.workspace_and_db()?;
+    let mut matches = workspace.stacks.iter().filter_map(|workspace_stack| {
+        stack_matches(workspace_stack, stack)
+            .then_some(workspace_stack.id)
+            .flatten()
+    });
+    let Some(stack_id) = matches.next() else {
+        bail!("Could not resolve stack '{stack}' by UUID or workspace branch name");
+    };
+    if matches.next().is_some() {
+        bail!("Stack name '{stack}' is ambiguous in the current workspace");
+    }
+    Ok(stack_id)
+}

--- a/crates/but-debug/src/command/mod.rs
+++ b/crates/but-debug/src/command/mod.rs
@@ -1,5 +1,7 @@
 //! A place for each `but-debug` command implementation.
 
+pub(crate) mod api;
 pub(crate) mod dump;
 pub(crate) mod graph;
 pub(crate) mod revision;
+pub(crate) mod workspace;

--- a/crates/but-debug/src/command/workspace.rs
+++ b/crates/but-debug/src/command/workspace.rs
@@ -1,0 +1,104 @@
+//! Direct workspace mutation debug commands.
+
+use std::io;
+
+use anyhow::{Context as _, Result};
+use but_core::worktree::checkout::UncommitedWorktreeChanges;
+use but_workspace::branch::{
+    OnWorkspaceMergeConflict,
+    apply::{WorkspaceMerge, WorkspaceReferenceNaming},
+};
+
+use crate::args::{ApplyArgs, Args, DebugWorkspaceArgs, UnapplyArgs};
+
+/// Apply a branch through `but-workspace`, bypassing app/API wiring.
+pub(crate) fn apply(
+    args: &Args,
+    mutation_args: &ApplyArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+    let branch = ref_name(&repo, &mutation_args.ref_name)?;
+
+    let outcome = but_workspace::branch::apply(
+        branch.as_ref(),
+        &ws,
+        &repo,
+        &mut meta,
+        but_workspace::branch::apply::Options {
+            workspace_merge: WorkspaceMerge::MergeIfNeeded,
+            on_workspace_conflict: OnWorkspaceMergeConflict::AbortAndReportConflictingStacks,
+            workspace_reference_naming: WorkspaceReferenceNaming::Default,
+            uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+            order: None,
+            new_stack_id: None,
+        },
+    )?;
+
+    writeln!(out, "{outcome:#?}")?;
+    *ws = outcome.workspace.into_owned();
+    emit_after(&ws, &mutation_args.debug, err)
+}
+
+/// Unapply a branch through `but-workspace`, bypassing app/API wiring.
+pub(crate) fn unapply(
+    args: &Args,
+    mutation_args: &UnapplyArgs,
+    out: &mut dyn io::Write,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+    let branch = ref_name(&repo, &mutation_args.ref_name)?;
+
+    let outcome = but_workspace::branch::unapply(
+        branch.as_ref(),
+        &ws,
+        &repo,
+        &mut meta,
+        but_workspace::branch::unapply::Options {
+            workspace_disposition: mutation_args.disposition.into(),
+            uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+        },
+    )?;
+
+    writeln!(out, "{outcome:#?}")?;
+    *ws = outcome.workspace.into_owned();
+    emit_after(&ws, &mutation_args.debug, err)
+}
+
+pub(crate) fn emit_after(
+    ws: &but_graph::Workspace,
+    debug: &DebugWorkspaceArgs,
+    err: &mut dyn io::Write,
+) -> Result<()> {
+    emit_stack_summary(ws, err)?;
+    debug.emit_workspace(ws, err)
+}
+
+fn emit_stack_summary(ws: &but_graph::Workspace, err: &mut dyn io::Write) -> Result<()> {
+    writeln!(
+        err,
+        "workspace stacks after: {} ({})",
+        ws.stacks.len(),
+        ws.stacks
+            .iter()
+            .filter_map(|stack| stack.ref_name())
+            .map(|ref_name| ref_name.shorten().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )?;
+    Ok(())
+}
+
+fn ref_name(repo: &gix::Repository, name: &str) -> Result<gix::refs::FullName> {
+    repo.find_reference(name)
+        .with_context(|| format!("Could not resolve ref '{name}'"))
+        .map(|reference| reference.name().to_owned())
+}

--- a/crates/but-debug/src/lib.rs
+++ b/crates/but-debug/src/lib.rs
@@ -25,8 +25,13 @@ pub fn handle_args(
 
     let _span = tracing::info_span!("run").entered();
     match &args.cmd {
+        Subcommands::Api(api_args) => command::api::run(&args, api_args, out, err),
         Subcommands::Dump(dump_args) => command::dump::run(&args, dump_args, out, err),
         Subcommands::Graph(graph_args) => command::graph::run(&args, graph_args, out, err),
+        Subcommands::Apply(apply_args) => command::workspace::apply(&args, apply_args, out, err),
+        Subcommands::Unapply(unapply_args) => {
+            command::workspace::unapply(&args, unapply_args, out, err)
+        }
         Subcommands::Revision(revision_args) => command::revision::run(&args, revision_args, out),
     }
 }

--- a/crates/but-graph/src/projection/workspace/mod.rs
+++ b/crates/but-graph/src/projection/workspace/mod.rs
@@ -50,6 +50,12 @@ pub struct Workspace {
     pub target_commit: Option<TargetCommit>,
     /// Read-only workspace metadata with additional information, or `None` if nothing was present.
     /// If this is `Some()` the `kind` is always [`WorkspaceKind::Managed`]
+    ///
+    /// # WARNING
+    ///
+    /// Do not use this data to understand the workspace. It's unreconciled metadata which may
+    /// have nothing to do with the actual workspace.
+    /// To see that, look at [Self::stacks].
     pub metadata: Option<ref_metadata::Workspace>,
 }
 

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -450,20 +450,33 @@ pub fn assign(
     Ok(())
 }
 
+/// Reconcile persisted hunk assignments with the current worktree state.
+///
+/// `db` is the mutable hunk-assignment store that is read from and updated with
+/// the reconciled assignments. `repo` is used to compute worktree changes and
+/// render hunk patches when `worktree_changes` is not provided. `ws`
+/// supplies the current stack and workspace projection used to derive stack IDs and
+/// validate assignment ownership. `worktree_changes` can provide a caller-owned
+/// worktree change list to re-use for performance, and when it is `None`,
+/// changes are read from `repo`.
+/// `context_lines` controls the amount of diff context used while converting
+/// each worktree change into hunk assignments.
+///
+/// Returns `(assignments, fallback_error)`. `assignments` is the reconciled list
+/// that was also persisted back to `db`. `fallback_error` is a warning channel
+/// for callers: when present, assignment computation recovered by using a less
+/// precise fallback and kept returning usable `assignments`, but the original
+/// error is preserved so callers can log or surface degraded accuracy. It is
+/// `None` when assignment reconciliation completed normally.
 pub fn assignments_with_fallback(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
-    workspace: &but_graph::Workspace,
+    ws: &but_graph::Workspace,
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
     context_lines: u32,
 ) -> Result<(Vec<HunkAssignment>, Option<anyhow::Error>)> {
-    let hunk_assignments = reconcile_worktree_changes_with_worktree(
-        db,
-        repo,
-        workspace,
-        worktree_changes,
-        context_lines,
-    )?;
+    let hunk_assignments =
+        reconcile_worktree_changes_with_worktree(db, repo, ws, worktree_changes, context_lines)?;
     Ok((hunk_assignments, None))
 }
 

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -693,6 +693,7 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
         if !is_workspace_ref_name(ref_name) {
             bail!("This backend doesn't support saving arbitrary workspaces");
         }
+        let previous_content = self.snapshot.content.clone();
 
         // Find exactly one stack-id per branch name, and assign all branches to it.
         // `stacks` is the target state, and we have to make an actual stack look like it.
@@ -876,7 +877,7 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
             changed_target = true;
         }
 
-        if changed_target {
+        if changed_target || self.snapshot.content != previous_content {
             self.snapshot.set_changed_to_necessitate_write();
         }
         Ok(())

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -556,6 +556,73 @@ fn create_workspace_and_stacks_with_branches_from_scratch_with_workspace_and_una
 }
 
 #[test]
+fn set_workspace_stack_only_changes_are_written_on_drop() -> anyhow::Result<()> {
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    store.data_mut().default_target = None;
+    let first_stack_id = StackId::from_number_for_testing(1);
+    let second_stack_id = StackId::from_number_for_testing(2);
+    let first_head = gix::ObjectId::from_str("1111111111111111111111111111111111111111")?;
+    let second_head = gix::ObjectId::from_str("2222222222222222222222222222222222222222")?;
+
+    let mut first_stack = LegacyStack::new_with_just_heads(
+        vec![StackBranch {
+            head: first_head,
+            name: "first".into(),
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }],
+        0,
+        true,
+    );
+    first_stack.id = first_stack_id;
+    let mut second_stack = LegacyStack::new_with_just_heads(
+        vec![StackBranch {
+            head: second_head,
+            name: "second".into(),
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }],
+        1,
+        true,
+    );
+    second_stack.id = second_stack_id;
+
+    store
+        .data_mut()
+        .branches
+        .insert(first_stack_id, first_stack);
+    store
+        .data_mut()
+        .branches
+        .insert(second_stack_id, second_stack);
+    store.set_changed_to_necessitate_write();
+    store.write_unreconciled()?;
+
+    let toml_path = store.path().to_owned();
+    drop(store);
+
+    let ws_ref: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
+    let mut store = VirtualBranchesTomlMetadata::from_path(&toml_path)?;
+    let mut ws = store.workspace(ws_ref.as_ref())?;
+    assert_eq!(ws.stacks.len(), 2, "fixture starts with both stacks");
+    ws.stacks.retain(|stack| stack.id == first_stack_id);
+    store.set_workspace(&ws)?;
+    drop(store);
+
+    let store = VirtualBranchesTomlMetadata::from_path(&toml_path)?;
+    let ws = store.workspace(ws_ref.as_ref())?;
+    assert_eq!(
+        ws.stacks.len(),
+        1,
+        "stack-only workspace metadata changes must be persisted on drop"
+    );
+    assert_eq!(ws.stacks[0].id, first_stack_id);
+    Ok(())
+}
+
+#[test]
 fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()> {
     let (mut store, _tmp) = empty_vb_store_rw()?;
     store.data_mut().default_target = None;

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -52,6 +52,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                             uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
                             skip_head_update: true,
                             merge_base_override,
+                            allow_conflicted_commit_checkout: true,
                         },
                     )?;
                 }

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -25,6 +25,8 @@
 		"cv3": false,
 		/// Enable the V3 unapply implementation.
 		"unapplyV3": false,
+		/// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
+		"unapplyV3Pgm": false,
 		/// Enable undo/redo support.
 		"undo": false,
 		/// Enable processing of workspace rules.

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -23,8 +23,8 @@
 	"featureFlags": {
 		// Enables the v3 safe checkout.
 		"cv3": false,
-		/// Enable the usage of V3 workspace APIs.
-		"ws3": true,
+		/// Enable the V3 unapply implementation.
+		"unapplyV3": false,
 		/// Enable undo/redo support.
 		"undo": false,
 		/// Enable processing of workspace rules.

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -18,6 +18,7 @@ pub struct TelemetryUpdate {
 /// Update request for [`crate::app_settings::FeatureFlags`].
 pub struct FeatureFlagsUpdate {
     pub cv3: Option<bool>,
+    pub unapply_v3: Option<bool>,
     pub rules: Option<bool>,
     pub single_branch: Option<bool>,
     pub irc: Option<bool>,
@@ -120,6 +121,7 @@ impl AppSettingsWithDiskSync {
         &self,
         FeatureFlagsUpdate {
             cv3,
+            unapply_v3,
             rules,
             single_branch,
             irc,
@@ -128,6 +130,9 @@ impl AppSettingsWithDiskSync {
         let mut settings = self.get_mut_enforce_save()?;
         if let Some(cv3) = cv3 {
             settings.feature_flags.cv3 = cv3;
+        }
+        if let Some(unapply_v3) = unapply_v3 {
+            settings.feature_flags.unapply_v3 = unapply_v3;
         }
         if let Some(rules) = rules {
             settings.feature_flags.rules = rules;

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -19,6 +19,7 @@ pub struct TelemetryUpdate {
 pub struct FeatureFlagsUpdate {
     pub cv3: Option<bool>,
     pub unapply_v3: Option<bool>,
+    pub unapply_v3_pgm: Option<bool>,
     pub rules: Option<bool>,
     pub single_branch: Option<bool>,
     pub irc: Option<bool>,
@@ -122,6 +123,7 @@ impl AppSettingsWithDiskSync {
         FeatureFlagsUpdate {
             cv3,
             unapply_v3,
+            unapply_v3_pgm,
             rules,
             single_branch,
             irc,
@@ -133,6 +135,9 @@ impl AppSettingsWithDiskSync {
         }
         if let Some(unapply_v3) = unapply_v3 {
             settings.feature_flags.unapply_v3 = unapply_v3;
+        }
+        if let Some(unapply_v3_pgm) = unapply_v3_pgm {
+            settings.feature_flags.unapply_v3_pgm = unapply_v3_pgm;
         }
         if let Some(rules) = rules {
             settings.feature_flags.rules = rules;

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -42,6 +42,8 @@ pub struct FeatureFlags {
     pub cv3: bool,
     /// Enable the V3 unapply implementation.
     pub unapply_v3: bool,
+    /// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
+    pub unapply_v3_pgm: bool,
     /// Enable undo/redo support.
     ///
     /// ### Progression for implementation

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -40,6 +40,8 @@ but_schemars::register_sdk_type!(GitHubOAuthAppSettings);
 pub struct FeatureFlags {
     /// Turn on the set a v3 version of checkout
     pub cv3: bool,
+    /// Enable the V3 unapply implementation.
+    pub unapply_v3: bool,
     /// Enable undo/redo support.
     ///
     /// ### Progression for implementation

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -335,6 +335,23 @@ pub fn visualize_tree(tree_id: gix::Id<'_>) -> termtree::Tree<String> {
 ///   are encountered.
 #[cfg(unix)]
 pub fn visualize_disk_tree_skip_dot_git(root: &Path) -> anyhow::Result<termtree::Tree<String>> {
+    visualize_disk_tree_skip_dot_git_with_optional_hashes(root, false)
+}
+
+/// Just like [`visualize_disk_tree_skip_dot_git()`], but also show SHA-1 blob hashes for files.
+/// For convenience, skip `.git` and don't display the root.
+#[cfg(unix)]
+pub fn visualize_disk_tree_with_hashes_skip_dot_git(
+    root: &Path,
+) -> anyhow::Result<termtree::Tree<String>> {
+    visualize_disk_tree_skip_dot_git_with_optional_hashes(root, true)
+}
+
+#[cfg(unix)]
+fn visualize_disk_tree_skip_dot_git_with_optional_hashes(
+    root: &Path,
+    show_hashes: bool,
+) -> anyhow::Result<termtree::Tree<String>> {
     use std::os::unix::fs::MetadataExt;
     fn normalize_mode(mode: u32) -> u32 {
         let filetype_bits = 0o170000 & mode;
@@ -344,17 +361,27 @@ pub fn visualize_disk_tree_skip_dot_git(root: &Path) -> anyhow::Result<termtree:
         filetype_bits | normalized_permission_bits
     }
 
-    fn label(p: &Path, md: &std::fs::Metadata) -> String {
-        format!(
+    fn label(p: &Path, md: &std::fs::Metadata, show_hash: bool) -> anyhow::Result<String> {
+        let mut label = format!(
             "{name}:{mode:o}",
             name = p.file_name().unwrap().to_str().unwrap(),
             mode = normalize_mode(md.mode()),
-        )
+        );
+        if show_hash && let Ok(contents) = std::fs::read(p) {
+            let id =
+                gix::objs::compute_hash(gix::hash::Kind::Sha1, gix::object::Kind::Blob, &contents)?;
+            label.push_str(&format!(":{id}"));
+        }
+        Ok(label)
     }
 
-    fn tree(p: &Path, show_label: bool) -> std::io::Result<termtree::Tree<String>> {
+    fn tree(
+        p: &Path,
+        show_label: bool,
+        show_hashes: bool,
+    ) -> anyhow::Result<termtree::Tree<String>> {
         let mut cur = termtree::Tree::new(if show_label {
-            label(p, &p.symlink_metadata()?)
+            label(p, &p.symlink_metadata()?, show_hashes)?
         } else {
             ".".into()
         });
@@ -364,15 +391,15 @@ pub fn visualize_disk_tree_skip_dot_git(root: &Path) -> anyhow::Result<termtree:
         for entry in entries {
             let md = entry.metadata()?;
             if md.is_dir() && entry.file_name() != ".git" {
-                cur.push(tree(&entry.path(), true)?);
+                cur.push(tree(&entry.path(), true, show_hashes)?);
             } else {
-                cur.push(termtree::Tree::new(label(&entry.path(), &md)));
+                cur.push(termtree::Tree::new(label(&entry.path(), &md, show_hashes)?));
             }
         }
         Ok(cur)
     }
 
-    Ok(tree(root, false)?)
+    tree(root, false, show_hashes)
 }
 
 /// Write a `sequence` of numbers into `repo`.workdir / `filename`, where `sequences` can be `Some((1, 5))`,
@@ -579,6 +606,14 @@ fn writable_scenario_inner<T>(
 /// Windows dummy
 #[cfg(not(unix))]
 pub fn visualize_disk_tree_skip_dot_git(_root: &Path) -> anyhow::Result<termtree::Tree<String>> {
+    anyhow::bail!("BUG: must not run on Windows - results won't be desirable");
+}
+
+/// Windows dummy
+#[cfg(not(unix))]
+pub fn visualize_disk_tree_with_hashes_skip_dot_git(
+    _root: &Path,
+) -> anyhow::Result<termtree::Tree<String>> {
     anyhow::bail!("BUG: must not run on Windows - results won't be desirable");
 }
 

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -467,6 +467,7 @@ impl Sandbox {
             feature_flags: FeatureFlags {
                 cv3: true,
                 unapply_v3: true,
+                unapply_v3_pgm: false,
                 undo: true,
                 rules: true,
                 single_branch: true,

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -466,6 +466,8 @@ impl Sandbox {
             },
             feature_flags: FeatureFlags {
                 cv3: true,
+                // TODO: turn on, it should all work like before.
+                unapply_v3: false,
                 undo: true,
                 rules: true,
                 single_branch: true,

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -466,8 +466,7 @@ impl Sandbox {
             },
             feature_flags: FeatureFlags {
                 cv3: true,
-                // TODO: turn on, it should all work like before.
-                unapply_v3: false,
+                unapply_v3: true,
                 undo: true,
                 rules: true,
                 single_branch: true,

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -4,7 +4,7 @@ use but_core::{
     WORKSPACE_REF_NAME, ref_metadata::StackId, worktree::checkout::UncommitedWorktreeChanges,
 };
 
-use crate::branch::OnWorkspaceMergeConflict;
+use crate::branch::{OnWorkspaceMergeConflict, try_find_validated_ref};
 
 /// Returned by [apply()].
 pub struct Outcome<'workspace> {
@@ -136,9 +136,7 @@ use anyhow::{Context as _, bail};
 use but_core::{
     ObjectStorageExt, RefMetadata, RepositoryExt, extract_remote_name_and_short_name, ref_metadata,
     ref_metadata::{
-        StackKind,
-        StackKind::AppliedAndUnapplied,
-        Workspace,
+        StackKind, Workspace,
         WorkspaceCommitRelation::{Merged, Outside},
     },
 };
@@ -153,7 +151,15 @@ use gix::{
 };
 use tracing::instrument;
 
-use crate::{WorkspaceCommit, commit::merge::Tip, ref_info::WorkspaceExt};
+use crate::{
+    WorkspaceCommit,
+    branch::{
+        anon_stacks, correlate_conflicting_stack_ids,
+        correlate_conflicting_stack_ids_and_remove_from_workspace, ensure_no_missing_stacks,
+    },
+    commit::merge::Tip,
+    ref_info::WorkspaceExt,
+};
 
 /// Apply `branch` to the given `workspace`, and possibly create the workspace reference in `repo`
 /// along with its `meta`-data if it doesn't exist yet.
@@ -195,7 +201,7 @@ pub fn apply<'ws>(
     let new_stack_id = new_stack_id.unwrap_or(generate_new_stack_id);
     let branch_orig = branch;
     let (mut branch_ref, mut incoming_branch_is_remote_tracking_without_local_tracking) =
-        (try_find_validated_ref(repo, branch)?, false);
+        (try_find_validated_ref(repo, branch, "apply")?, false);
     if ws.is_branch_the_target_or_its_local_tracking_branch(branch) {
         bail!("Cannot add the target '{branch}' branch to its own workspace");
     }
@@ -215,7 +221,7 @@ pub fn apply<'ws>(
         // Pretend the upstream branch is also the local tracking name.
         incoming_branch_is_remote_tracking_without_local_tracking = true;
         branch = upstream_branch_name;
-        branch_ref = try_find_validated_ref(repo, branch.as_ref())?;
+        branch_ref = try_find_validated_ref(repo, branch.as_ref(), "apply")?;
     }
     let conflicting_stack_ids = Vec::new();
     if ws.is_reachable_from_entrypoint(branch.as_ref()) {
@@ -475,7 +481,7 @@ pub fn apply<'ws>(
     let mut in_memory_repo = repo.clone().for_tree_diffing()?.with_object_memory();
     let mut merge_result = WorkspaceCommit::from_new_merge_with_metadata(
         filter_superseded_metadata_stacks(
-            ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
+            ws_md.stacks.iter(),
             &existing_stacks_superseded_by_branch,
         ),
         filter_superseded_anon_stacks(
@@ -596,7 +602,7 @@ pub fn apply<'ws>(
             find_superseded_stacks(branch.as_ref(), &ws, &mut ws_md);
         merge_result = WorkspaceCommit::from_new_merge_with_metadata(
             filter_superseded_metadata_stacks(
-                ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
+                ws_md.stacks.iter(),
                 &existing_stacks_superseded_by_branch,
             ),
             filter_superseded_anon_stacks(
@@ -686,27 +692,6 @@ pub fn apply<'ws>(
         workspace_merge: Some(merge_result),
         conflicting_stack_ids,
         applied_branches,
-    })
-}
-
-fn anon_stacks(stacks: &[but_graph::workspace::Stack]) -> impl Iterator<Item = (usize, Tip)> {
-    stacks.iter().enumerate().filter_map(|(idx, s)| {
-        if s.ref_name().is_none() {
-            s.tip_skip_empty().and_then(|cid| {
-                s.segments.first().map(|s| {
-                    (
-                        idx,
-                        Tip {
-                            name: None,
-                            commit_id: cid,
-                            segment_idx: s.id,
-                        },
-                    )
-                })
-            })
-        } else {
-            None
-        }
     })
 }
 
@@ -881,38 +866,6 @@ fn add_branch_as_stack_forcefully(
     stack.workspacecommit_relation = Merged;
 }
 
-fn correlate_conflicting_stack_ids(
-    ws: &Workspace,
-    conflicts: &[crate::commit::merge::ConflictingStack],
-) -> Vec<StackId> {
-    conflicts
-        .iter()
-        .filter_map(|cs| cs.ref_name.as_ref())
-        .filter_map(|ref_name| {
-            ws.find_stack_with_branch(ref_name.as_ref(), AppliedAndUnapplied)
-                .map(|stack| stack.id)
-        })
-        .collect()
-}
-
-/// Note that we chose to put it outside the workspace, instead of just leaving it unmerged.
-fn correlate_conflicting_stack_ids_and_remove_from_workspace(
-    ws: &mut Workspace,
-    conflicts: &[crate::commit::merge::ConflictingStack],
-) -> Vec<StackId> {
-    let conflicting_stack_ids = correlate_conflicting_stack_ids(ws, conflicts);
-    for conflicting_id in &conflicting_stack_ids {
-        let stack = ws
-            .stacks
-            .iter_mut()
-            .find(|s| s.id == *conflicting_id)
-            .expect("if it was found before it will be found as id");
-        // TODO: this might as well be 'Unmerged' to keep them in the workspace, but not let them be merged.
-        stack.workspacecommit_relation = Outside;
-    }
-    conflicting_stack_ids
-}
-
 fn persist_metadata_and_gitconfig<T: RefMetadata>(
     meta: &mut T,
     branches_to_apply: &[gix::refs::FullName],
@@ -1024,34 +977,6 @@ fn needs_workspace_commit_without_remerge(
         },
         WorkspaceMerge::MergeIfNeeded => false,
     }
-}
-
-fn ensure_no_missing_stacks(merge: &crate::commit::merge::Outcome) -> anyhow::Result<()> {
-    if merge.missing_stacks.is_empty() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(
-            "Somehow some of the new stacks weren't part of the graph: {:#?}",
-            merge.missing_stacks
-        ))
-    }
-}
-
-fn try_find_validated_ref<'repo>(
-    repo: &'repo gix::Repository,
-    branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<Option<gix::Reference<'repo>>> {
-    let branch_ref = repo.try_find_reference(branch)?;
-    if branch_ref
-        .as_ref()
-        .is_some_and(|r| matches!(r.target(), gix::refs::TargetRef::Symbolic(_)))
-    {
-        bail!(
-            "Refusing to apply symbolic ref '{}' due to potential ambiguity",
-            branch.shorten()
-        );
-    }
-    Ok(branch_ref)
 }
 
 fn generate_new_stack_id(_: &gix::refs::FullNameRef) -> StackId {

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -8,8 +8,10 @@ use crate::branch::OnWorkspaceMergeConflict;
 
 /// Returned by [apply()].
 pub struct Outcome<'workspace> {
-    /// The newly created workspace, if owned, useful to project a workspace and see how the workspace looks like with the branch applied.
-    /// If borrowed, the graph already contains the desired branch and nothing had to be applied.
+    /// The newly created workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks like now.
+    ///
+    /// If borrowed, the graph already contained the desired branch and nothing had to be applied. Note that metadata changes
+    /// might not be included in this case, as they aren't the source of truth.
     pub workspace: Cow<'workspace, but_graph::Workspace>,
     /// The name of the branch(es) that were actually applied.
     ///
@@ -119,7 +121,8 @@ pub struct Options {
     /// How the workspace reference should be named should it be created.
     /// The creation is always needed if there are more than one branch applied.
     pub workspace_reference_naming: WorkspaceReferenceNaming,
-    /// How the worktree checkout should behave int eh light of uncommitted changes in the worktree.
+    /// How the worktree checkout should behave when uncommitted changes are present in the worktree that it would
+    /// want to modify to accommodate the new workspace commit, with the applied stack added.
     pub uncommitted_changes: UncommitedWorktreeChanges,
     /// If not `None`, the applied branch should be merged into the workspace commit at the N'th parent position.
     /// This is useful if the tip of a branch (at a specific position) was unapplied, and a segment within that branch

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -598,7 +598,7 @@ pub(crate) fn try_find_validated_ref<'repo>(
 pub mod apply;
 pub use apply::apply;
 
-/// Functions and types related to removing a branch to the workspace.
+/// Functions and types related to removing a branch from the workspace.
 pub mod unapply;
 pub use unapply::function::unapply;
 

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -476,9 +476,13 @@ impl OnWorkspaceMergeConflict {
     }
 }
 
-/// Functions and types related to applying a workspace branch.
+/// Functions and types related to adding a branch to the workspace.
 pub mod apply;
 pub use apply::apply;
+
+/// Functions and types related to removing a branch to the workspace.
+pub mod unapply;
+pub use unapply::function::unapply;
 
 /// related types for removing a workspace reference.
 pub mod remove_reference;

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -410,7 +410,7 @@
 //!                                      junctions', decide which parent to
 //!                                      walk along.
 //! ```
-use but_core::ref_metadata::StackId;
+use but_core::ref_metadata::{StackId, StackKind, WorkspaceCommitRelation::Outside};
 
 use crate::ref_info;
 
@@ -474,6 +474,124 @@ impl OnWorkspaceMergeConflict {
             OnWorkspaceMergeConflict::AbortAndReportConflictingStacks
         )
     }
+}
+
+/// Convert unnamed projected stacks into merge tips while preserving their parent order.
+///
+/// Named stacks are driven by workspace metadata, but anonymous stacks have no metadata entry
+/// and must be supplied explicitly when rebuilding a workspace merge commit.
+///
+/// Each returned tuple is `(parent_index, tip)`: `parent_index` is the stack's position in the
+/// projected workspace so the merge builder can insert the anonymous tip at the same parent slot,
+/// and `tip` is the commit/segment pair to merge, with no ref name attached.
+pub(crate) fn anon_stacks(
+    stacks: &[but_graph::workspace::Stack],
+) -> impl Iterator<Item = (usize, crate::commit::merge::Tip)> {
+    stacks.iter().enumerate().filter_map(|(idx, s)| {
+        if s.ref_name().is_none() {
+            s.tip_skip_empty().and_then(|cid| {
+                s.segments.first().map(|s| {
+                    (
+                        idx,
+                        crate::commit::merge::Tip {
+                            name: None,
+                            commit_id: cid,
+                            segment_idx: s.id,
+                        },
+                    )
+                })
+            })
+        } else {
+            None
+        }
+    })
+}
+
+/// Ensure every metadata stack that should be merged was visible in the graph.
+pub(crate) fn ensure_no_missing_stacks(
+    merge: &crate::commit::merge::Outcome,
+) -> anyhow::Result<()> {
+    if merge.missing_stacks.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Somehow some of the workspace stacks weren't part of the graph: {:#?}",
+            merge.missing_stacks
+        ))
+    }
+}
+
+/// Map conflicting merge tips back to stable workspace stack ids.
+///
+/// Each entry in `conflicts` may carry the ref name of the tip that could not be merged. That ref
+/// name is looked up in `ws_md` across both applied and unapplied stacks, and the owning stack's
+/// stable id is returned.
+///
+/// Conflicts without a ref name, or whose ref name is no longer known to the
+/// workspace metadata, are skipped.
+pub(crate) fn correlate_conflicting_stack_ids(
+    ws_md: &but_core::ref_metadata::Workspace,
+    conflicts: &[crate::commit::merge::ConflictingStack],
+) -> Vec<StackId> {
+    conflicts
+        .iter()
+        .filter_map(|cs| cs.ref_name.as_ref())
+        .filter_map(|ref_name| {
+            ws_md
+                .find_stack_with_branch(ref_name.as_ref(), StackKind::AppliedAndUnapplied)
+                .map(|stack| stack.id)
+        })
+        .collect()
+}
+
+/// Mark conflicting stacks as outside the workspace and return their stable stack ids.
+///
+/// This is used when the caller chooses to materialize the best-effort merge result: the
+/// conflicting branches remain known in metadata, but are no longer represented in the
+/// checked-out workspace tree.
+///
+/// For each conflicting stack id given in `conflicts` and found in `ws_md`, this changes only
+/// `WorkspaceStack::workspacecommit_relation` to `Outside`. The stack entry and its branch list
+/// stay in `ws_md`, so the branch can still be re-applied later with its metadata intact.
+pub(crate) fn correlate_conflicting_stack_ids_and_remove_from_workspace(
+    ws_md: &mut but_core::ref_metadata::Workspace,
+    conflicts: &[crate::commit::merge::ConflictingStack],
+) -> Vec<StackId> {
+    let conflicting_stack_ids = correlate_conflicting_stack_ids(ws_md, conflicts);
+    for conflicting_id in &conflicting_stack_ids {
+        let stack = ws_md
+            .stacks
+            .iter_mut()
+            .find(|s| s.id == *conflicting_id)
+            .expect("if it was found before it will be found as id");
+        // TODO: this might as well be 'Unmerged' to keep them in the workspace, but not let them be merged.
+        stack.workspacecommit_relation = Outside;
+    }
+    conflicting_stack_ids
+}
+
+/// Find `branch` in `repo` and reject it if it resolves to a symbolic reference.
+///
+/// `operation` is used only for the error message so callers such as apply and unapply can share
+/// validation while still reporting the action they refused to perform.
+///
+/// Missing references are returned as `Ok(None)` so each caller can decide whether absence is an error or a no-op.
+pub(crate) fn try_find_validated_ref<'repo>(
+    repo: &'repo gix::Repository,
+    branch: &gix::refs::FullNameRef,
+    operation: &str,
+) -> anyhow::Result<Option<gix::Reference<'repo>>> {
+    let branch_ref = repo.try_find_reference(branch)?;
+    if branch_ref
+        .as_ref()
+        .is_some_and(|r| matches!(r.target(), gix::refs::TargetRef::Symbolic(_)))
+    {
+        anyhow::bail!(
+            "Refusing to {operation} symbolic ref '{}' due to potential ambiguity",
+            branch.shorten()
+        );
+    }
+    Ok(branch_ref)
 }
 
 /// Functions and types related to adding a branch to the workspace.

--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -1,0 +1,98 @@
+use crate::branch::OnWorkspaceMergeConflict;
+use but_core::ref_metadata::StackId;
+use but_core::worktree::checkout::UncommitedWorktreeChanges;
+use std::borrow::Cow;
+
+/// Returned by [unapply()](function::unapply()).
+pub struct Outcome<'workspace> {
+    /// The newly created workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks like now.
+    ///
+    /// If borrowed, the graph already didn't contain the desired branch and nothing had to be unapplied. Note that metadata changes
+    /// might not be included in this case, as they aren't the source of truth.
+    pub workspace: Cow<'workspace, but_graph::Workspace>,
+    /// The unapply operation ended in checking out the last remaining stack in the workspace, whose tip name is listed here.
+    /// This will only happen if the commit to check out is named.
+    ///
+    /// If a remote tracking branch is given to apply, it will actually apply its local tracking branch, which is created on demand as well.
+    /// Further, if there is no target or if the current branch isn't the target branch, then the current branch and the given one
+    /// will be applied.
+    pub checked_out: Option<gix::refs::FullName>,
+    /// `true` if we created the given workspace ref as it didn't exist yet.
+    pub workspace_ref_created: bool,
+    /// If not `None`, an actual merge was attempted, but depending on [the settings](OnWorkspaceMergeConflict),
+    /// this was persisted or not.
+    pub workspace_merge: Option<crate::commit::merge::Outcome>,
+    /// The ids of all stacks that were conflicting and thus didn't get applied, and tip ref names can be derived from that.
+    pub conflicting_stack_ids: Vec<StackId>,
+}
+
+/// How to treat the workspace merge commit when [unapplying](function::unapply()) it is not technically required anymore.
+///
+/// This happens when the amount of stacks goes from `2` to `1`.
+/// It also happens when a stack is unapplied and the workspace commit only has a single commit merged into it.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WorkspaceMergeCommit {
+    /// Never remove the workspace merge commit. This allows workspaces with 1 stack, or empty workspaces.
+    /// can connect directly with the *one* workspace base.
+    /// This also ensures that there is a workspace merge commit, even if it is none-sensical.
+    #[default]
+    Keep,
+    /// Remove a workspace merge commit by pointing the workspace reference elsewhere, or
+    /// by [deleting](WorkspaceReference) the workspace reference.
+    /// Removal happens if the workspace merge commit would only connect to a commit owned by a single stack,
+    /// or if there is no stack left at all and the workspace is empty.
+    /// Note that workspace commits also don't even have to be present if there are one or more virtual stacks,
+    /// as these don't have commits on their own.
+    // TODO: make this the default when this is the default in apply()
+    RemoveIfPossible,
+}
+
+/// Decide what to do with the workspace reference (typically `gitbutler/workspace`) when it's not needed anymore.
+///
+/// It's not needed anymore when switching away from it to another branch, which may happen only if the workspace commit
+/// isn't needed anymore and is [configured](WorkspaceMergeCommit) to be forgotten in that case.
+/// *Additionally*, it may only happen if it's a managed reference, i.e. in `refs/heads/gitbutler/`, and if there is only
+/// one *named* stack left which then as well may be checked out directly.
+#[derive(Default, Debug, Clone)]
+pub enum WorkspaceReference {
+    /// No matter what, keep the reference for its metadata, *and* keep it checked out.
+    #[default]
+    KeepCheckedOut,
+    /// Keep the reference for its metadata, but allow switching to the last remaining stack.
+    KeepButAllowSwitchingToRemainingStack,
+    /// Delete the workspace metadata and the workspace reference after switching to the last remaining stack.
+    DeleteAfterSwitchingToRemainingStack,
+}
+
+/// Options for [branch::unapply()](function::unapply()).
+#[derive(Default, Debug, Clone)]
+pub struct Options {
+    /// How the branch should be brought into the workspace.
+    pub workspace_merge_commit: WorkspaceMergeCommit,
+    /// Decide how to deal with conflicts when updating the workspace merge commit after removing a stack.
+    ///
+    /// Note that it should be incredibly unlikely, but can we prove it's impossible?
+    pub on_workspace_conflict: OnWorkspaceMergeConflict,
+    /// What to do with the workspace reference after unapplying.
+    pub workspace_reference: WorkspaceReference,
+    /// How the worktree checkout should behave when uncommitted changes are present in the worktree that it would
+    /// want to modify to accommodate the new workspace commit, with the unapplied stack removed.
+    pub uncommitted_changes: UncommitedWorktreeChanges,
+}
+
+pub(crate) mod function {
+    use super::{Options, Outcome};
+    use but_core::RefMetadata;
+    use gix::refs::FullNameRef;
+
+    /// TODO
+    pub fn unapply<'ws>(
+        branch: &FullNameRef,
+        workspace: &'ws but_graph::Workspace,
+        repo: &gix::Repository,
+        meta: &mut impl RefMetadata,
+        opts: Options,
+    ) -> anyhow::Result<Outcome<'ws>> {
+        todo!()
+    }
+}

--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -77,6 +77,8 @@ pub enum WorkspaceDisposition {
     /// no reference that points to a non-base commit, then the reference may already be sufficient
     /// without a merge commit.
     // TODO: make this the default when this is the default in apply().
+    //       WARNING: ANY MUTATION now has to be able to re-merge the workspace commit if they turn a virtual stack
+    //       into a non-virtual one or vice-versa.
     KeepWorkspaceReference,
     /// Remove the workspace merge commit if it is unnecessary, switch to a non-workspace ref , and delete the
     /// managed workspace reference and its metadata.

--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -1,98 +1,988 @@
-use crate::branch::OnWorkspaceMergeConflict;
-use but_core::ref_metadata::StackId;
 use but_core::worktree::checkout::UncommitedWorktreeChanges;
 use std::borrow::Cow;
 
 /// Returned by [unapply()](function::unapply()).
 pub struct Outcome<'workspace> {
-    /// The newly created workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks like now.
+    /// The updated workspace, if owned, or the one that was passed in if borrowed, to show how the workspace looks after unapplying.
     ///
     /// If borrowed, the graph already didn't contain the desired branch and nothing had to be unapplied. Note that metadata changes
     /// might not be included in this case, as they aren't the source of truth.
     pub workspace: Cow<'workspace, but_graph::Workspace>,
-    /// The unapply operation ended in checking out the last remaining stack in the workspace, whose tip name is listed here.
-    /// This will only happen if the commit to check out is named.
+    /// The unapply operation ended by checking out this ref.
     ///
-    /// If a remote tracking branch is given to apply, it will actually apply its local tracking branch, which is created on demand as well.
-    /// Further, if there is no target or if the current branch isn't the target branch, then the current branch and the given one
-    /// will be applied.
+    /// This is set when the operation switches back to the enclosing workspace ref after unapplying the checked-out stack,
+    /// or when [WorkspaceDisposition] allows deleting the workspace reference and switching away from it.
     pub checked_out: Option<gix::refs::FullName>,
-    /// `true` if we created the given workspace ref as it didn't exist yet.
-    pub workspace_ref_created: bool,
-    /// If not `None`, an actual merge was attempted, but depending on [the settings](OnWorkspaceMergeConflict),
-    /// this was persisted or not.
+    /// If not `None`, a non-conflicting workspace merge was materialized while rebuilding the
+    /// workspace merge commit after removing the stack.
+    ///
+    /// Unapply does not return conflicted merge outcomes. If rebuilding the workspace merge commit
+    /// conflicts, `unapply()` fails before refs, metadata, index, or worktree are updated.
     pub workspace_merge: Option<crate::commit::merge::Outcome>,
-    /// The ids of all stacks that were conflicting and thus didn't get applied, and tip ref names can be derived from that.
-    pub conflicting_stack_ids: Vec<StackId>,
 }
 
-/// How to treat the workspace merge commit when [unapplying](function::unapply()) it is not technically required anymore.
+impl<'workspace> Outcome<'workspace> {
+    fn new(ws: Cow<'workspace, but_graph::Workspace>) -> Self {
+        Outcome {
+            workspace: ws,
+            checked_out: None,
+            workspace_merge: None,
+        }
+    }
+}
+
+impl Outcome<'_> {
+    /// Return `true` if a new graph traversal was performed, which always is a sign for an operation which changed the workspace.
+    /// This is `false` if the branch to unapply was already absent from the current workspace.
+    pub fn workspace_changed(&self) -> bool {
+        matches!(self.workspace, Cow::Owned(_))
+    }
+}
+
+impl std::fmt::Debug for Outcome<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Outcome {
+            workspace: _,
+            checked_out,
+            workspace_merge: _,
+        } = self;
+        let checked_out = checked_out.as_ref().map(|rn| rn.to_string());
+        let mut f = f.debug_struct("Outcome");
+        f.field("workspace_changed", &self.workspace_changed())
+            .field("checked_out", &checked_out);
+        f.finish()
+    }
+}
+
+/// How to represent the workspace after unapplying a stack.
 ///
-/// This happens when the amount of stacks goes from `2` to `1`.
-/// It also happens when a stack is unapplied and the workspace commit only has a single commit merged into it.
+/// Unapplying can make the workspace merge commit unnecessary. That happens when the workspace
+/// commit would only connect to a single remaining stack, or if none of the remaining stacks have
+/// their own commits, so all rest on the base and are thus virtual.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum WorkspaceMergeCommit {
-    /// Never remove the workspace merge commit. This allows workspaces with 1 stack, or empty workspaces.
-    /// can connect directly with the *one* workspace base.
-    /// This also ensures that there is a workspace merge commit, even if it is none-sensical.
+pub enum WorkspaceDisposition {
+    /// Keep the workspace merge commit and keep the workspace reference checked out, even if the merge commit is no longer
+    /// required to represent the workspace.
+    ///
+    /// Use this when callers want a stable checked-out workspace ref and do not want unapply to collapse it to a branch,
+    /// target, or workspace base commit. This is the conservative default.
+    // TODO: this is for compatibility with old code and should not be the default or even an option.
     #[default]
-    Keep,
-    /// Remove a workspace merge commit by pointing the workspace reference elsewhere, or
-    /// by [deleting](WorkspaceReference) the workspace reference.
-    /// Removal happens if the workspace merge commit would only connect to a commit owned by a single stack,
-    /// or if there is no stack left at all and the workspace is empty.
-    /// Note that workspace commits also don't even have to be present if there are one or more virtual stacks,
-    /// as these don't have commits on their own.
-    // TODO: make this the default when this is the default in apply()
-    RemoveIfPossible,
+    KeepWorkspaceCommit,
+    /// Remove the workspace merge commit if it is unnecessary, but keep the workspace reference checked out.
+    /// Useful if you want to allow empty workspaces, i.e. prefer to stay in a workspace after it was created.
+    ///
+    /// The workspace reference remains checked out, and set to point directly to the remaining
+    /// stack tip, or workspace base commit of the workspace. If the workspace is purely virtual, i.e. it governs
+    /// no reference that points to a non-base commit, then the reference may already be sufficient
+    /// without a merge commit.
+    // TODO: make this the default when this is the default in apply().
+    KeepWorkspaceReference,
+    /// Remove the workspace merge commit if it is unnecessary, switch to a non-workspace ref , and delete the
+    /// managed workspace reference and its metadata.
+    /// Use this if the workspace should be dissolved as soon as it serves no purpose anymore.
+    ///
+    /// Direct checkout can happen when the future workspace has exactly one named tip, or when it has no tips and the
+    /// workspace target has a local tracking branch to fall back to. If there is no such reference, unapply keeps the
+    /// workspace reference checked out and keeps its metadata.
+    PreventUnnecessaryWorkspaceReferences,
+    /// Like [WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences], but always keep the workspace
+    /// merge commit whenever the workspace reference itself remains.
+    ///
+    /// Use this as a compatibility mode for mutations that do not yet deal gracefully with a
+    /// workspace reference pointing directly to a stack tip, target, or workspace base commit.
+    /// If unapply can remove the whole workspace reference and switch `HEAD` away, it still does so.
+    PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
 }
 
-/// Decide what to do with the workspace reference (typically `gitbutler/workspace`) when it's not needed anymore.
-///
-/// It's not needed anymore when switching away from it to another branch, which may happen only if the workspace commit
-/// isn't needed anymore and is [configured](WorkspaceMergeCommit) to be forgotten in that case.
-/// *Additionally*, it may only happen if it's a managed reference, i.e. in `refs/heads/gitbutler/`, and if there is only
-/// one *named* stack left which then as well may be checked out directly.
-#[derive(Default, Debug, Clone)]
-pub enum WorkspaceReference {
-    /// No matter what, keep the reference for its metadata, *and* keep it checked out.
-    #[default]
-    KeepCheckedOut,
-    /// Keep the reference for its metadata, but allow switching to the last remaining stack.
-    KeepButAllowSwitchingToRemainingStack,
-    /// Delete the workspace metadata and the workspace reference after switching to the last remaining stack.
-    DeleteAfterSwitchingToRemainingStack,
+impl WorkspaceDisposition {
+    fn may_switch_away_from_workspace(self) -> bool {
+        matches!(
+            self,
+            WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences
+                | WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
+        )
+    }
+
+    fn may_delete_workspace_reference(self) -> bool {
+        matches!(
+            self,
+            WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences
+                | WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
+        )
+    }
 }
 
 /// Options for [branch::unapply()](function::unapply()).
 #[derive(Default, Debug, Clone)]
 pub struct Options {
-    /// How the branch should be brought into the workspace.
-    pub workspace_merge_commit: WorkspaceMergeCommit,
-    /// Decide how to deal with conflicts when updating the workspace merge commit after removing a stack.
-    ///
-    /// Note that it should be incredibly unlikely, but can we prove it's impossible?
-    pub on_workspace_conflict: OnWorkspaceMergeConflict,
-    /// What to do with the workspace reference after unapplying.
-    pub workspace_reference: WorkspaceReference,
+    /// How to represent the workspace after the stack has been removed.
+    pub workspace_disposition: WorkspaceDisposition,
     /// How the worktree checkout should behave when uncommitted changes are present in the worktree that it would
     /// want to modify to accommodate the new workspace commit, with the unapplied stack removed.
     pub uncommitted_changes: UncommitedWorktreeChanges,
 }
 
 pub(crate) mod function {
-    use super::{Options, Outcome};
-    use but_core::RefMetadata;
-    use gix::refs::FullNameRef;
+    use super::{Options, Outcome, WorkspaceDisposition};
+    use anyhow::{Context as _, bail, ensure};
+    use std::borrow::Cow;
 
-    /// TODO
+    use but_core::{
+        ObjectStorageExt as _, RefMetadata, RepositoryExt as _,
+        ref_metadata::{ProjectedWorkspaceStack, StackId},
+    };
+    use but_graph::init::Overlay;
+    use gix::{
+        prelude::ObjectIdExt,
+        refs::{
+            FullName, FullNameRef, Target,
+            transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+        },
+    };
+
+    use crate::{WorkspaceCommit, branch::try_find_validated_ref};
+    use crate::{branch::anon_stacks, ref_info::WorkspaceExt};
+
+    /// Remove `branch` from `workspace`, updating `repo` and `meta` so the resulting workspace is the inverse of applying that branch.
+    ///
+    /// Think of it as "remove `branch` from the workspace", somehow, and metadata may be a way to do. This also means
+    /// this function can be applied indiscriminately, and in the worst case, it will do nothing.
+    ///
+    /// `branch` must name a branch to remove from the workspace. If it is already absent from
+    /// `workspace`, this is a no-op and the returned [`Outcome`] borrows `workspace`. Symbolic names such as `HEAD` are
+    /// rejected to avoid ambiguity.
+    ///
+    /// `workspace` is the current projected workspace and is used as the source of truth for which stacks are applied,
+    /// which stack should be removed, and whether the workspace is in a state that can be modified. `repo` supplies the
+    /// Git object database, references, and the *worktree* (which is assumed to belong to the workspace reference that governs `workspace`).
+    /// `meta` is updated to remove the branch from the workspace metadata, persist the resulting stack/workspace metadata,
+    /// and optionally delete workspace metadata when `opts` requests deleting the workspace reference.
+    ///
+    /// `opts` is best looked up via [`Options`].
+    ///
+    /// # Algorithm
+    ///
+    /// - Validate that `branch` is a real, non-symbolic ref and reject stale workspaces with a
+    ///   workspace commit buried in history. Workspaces without a workspace commit are allowed.
+    /// - Early-exit for missing branches, branches outside the workspace, ad-hoc workspaces, and
+    ///   metadata-only no-ops.
+    /// - Remove the branch from workspace metadata.
+    ///      - This removes non-tip virtual segments or entire stacks if the branch to unapply is the tip.
+    /// - Reproject immediately when metadata did not mention the branch, but branch metadata may
+    ///   still disambiguate it in the workspace. This validates whether removing branch metadata
+    ///   was enough and avoids touching refs or the worktree for a metadata-only unapply.
+    /// - Reproject with the updated workspace metadata before touching refs. This gives merge and
+    ///   collapse code the projected future stacks, including anonymous stacks that metadata alone
+    ///   cannot describe.
+    /// - Update the managed workspace ref, rebuilding or collapsing its merge commit, and persist
+    ///   the workspace metadata.
+    /// - Reproject from the updated workspace ref and persisted metadata. This is the canonical
+    ///   post-unapply workspace shape and is used to verify that the branch is gone.
+    /// - If unapplying hid the *checked-out* stack behind the workspace ref, switch `HEAD` back to
+    ///   the workspace ref and reproject again from that entrypoint so the returned workspace
+    ///   matches the actual checkout.
+    /// - If the disposition allows deleting an unnecessary workspace ref, decide from that final
+    ///   projection whether it has one stack, no stacks, or multiple stacks. If deleting it is
+    ///   possible, check out the selected destination, delete the workspace ref plus metadata, and
+    ///   reproject one last time from the new checkout target.
+    /// - If the branch to unapply is the managed workspace ref itself, and the disposition allows switching,
+    ///   the workspace ref is replaced by its target's local branch, or by the named stack with the lowest
+    ///   generation (i.e. the topologically 'newest') if there is no target.
+    #[tracing::instrument(skip(workspace, repo, meta), err(Debug))]
     pub fn unapply<'ws>(
         branch: &FullNameRef,
         workspace: &'ws but_graph::Workspace,
         repo: &gix::Repository,
         meta: &mut impl RefMetadata,
-        opts: Options,
+        Options {
+            workspace_disposition,
+            uncommitted_changes,
+        }: Options,
     ) -> anyhow::Result<Outcome<'ws>> {
-        todo!()
+        let ws = workspace;
+        let branch_ref = try_find_validated_ref(repo, branch, "unapply")?;
+
+        if ws.has_workspace_commit_in_ancestry(repo) {
+            bail!("Refusing to work on workspace whose workspace commit isn't at the top");
+        }
+
+        let workspace_ref_name = ws.ref_name().map(ToOwned::to_owned);
+        if matches!(ws.kind, but_graph::workspace::WorkspaceKind::AdHoc)
+            && branch_ref
+                .as_ref()
+                .zip(workspace_ref_name.as_ref())
+                .is_some_and(|(to_unapply, workspace_ref_name)| {
+                    to_unapply.name() == workspace_ref_name.as_ref()
+                })
+        {
+            bail!(
+                "Cannot unapply branch '{branch}' from an ad-hoc workspace because the workspace cannot be empty",
+                branch = branch.shorten()
+            );
+        }
+
+        if let Some(workspace_ref_name) = workspace_ref_name.as_ref()
+            && workspace_ref_name.as_ref() == branch
+        {
+            return unapply_workspace_reference(
+                ws,
+                repo,
+                meta,
+                workspace_ref_name.as_ref(),
+                workspace_disposition,
+                uncommitted_changes,
+            );
+        }
+
+        let branch_in_ws = ws.find_segment_and_stack_by_refname(branch);
+        if branch_in_ws.is_none() {
+            if branch_ref.is_none() {
+                bail!(
+                    "Cannot unapply non-existing branch '{branch}'",
+                    branch = branch.shorten()
+                );
+            }
+            // The branch exists in Git, but does not in the workspace: Nothing to do.
+            return Ok(Outcome::new(Cow::Borrowed(ws)));
+        }
+        let workspace_tip_was_entrypoint = ws.is_entrypoint();
+
+        let Some(workspace_ref_name) = workspace_ref_name else {
+            // This is an ad-hoc workspace by merit of being unnamed.
+            bail!("Cannot unapply a branch from an ad-hoc detached workspace");
+        };
+        let mut ws_md = meta.workspace(workspace_ref_name.as_ref())?;
+        if ws.kind.has_managed_ref() || ws.has_metadata() {
+            ws_md.reconcile_projected_stacks(
+                ws.stacks.iter().map(|stack| ProjectedWorkspaceStack {
+                    id: stack.id,
+                    branches: stack
+                        .segments
+                        .iter()
+                        .filter_map(|segment| segment.ref_name().map(ToOwned::to_owned))
+                        .collect(),
+                }),
+                |_| StackId::generate(),
+            )?;
+        }
+        let branch_removed_from_ws_meta = ws_md.unapply_branch(branch);
+        if !branch_removed_from_ws_meta {
+            // The branch wasn't in workspace metadata, yet it was present, so also delete its branch metadata
+            // as it could be used to disambiguate the segment.
+            // TODO: this will actually be observable even if it doens't work, unless it's run in a transaction, which right now it's not!
+            //       Should be able to redo the traversal with an overlay that hides branch metadata, but I'd say it's not important enough.
+            meta.remove(branch)?;
+            let graph = ws
+                .graph
+                .redo_traversal_with_overlay(repo, meta, Overlay::default())?;
+            let workspace = graph.into_workspace()?;
+            if workspace.refname_is_segment(branch) {
+                bail!(
+                    "Cannot unapply branch '{branch}' from an ad-hoc workspace because non-tip branches can only disappear if their now removed metadata disambiguated them",
+                    branch = branch.shorten()
+                );
+            }
+            return Ok(Outcome::new(Cow::Owned(workspace)));
+        }
+
+        // Everything past this point is stricly in non-dry-run mode and we may totally end up in intermediate states
+        // if something fails.
+        // Redo the traversal with the changed workspace metadata so code below can rely on the reconciled version.
+        let ws = ws
+            .graph
+            .redo_traversal_with_overlay(
+                repo,
+                meta,
+                Overlay::default().with_workspace_metadata_override(Some((
+                    workspace_ref_name.to_owned(),
+                    ws_md.clone(),
+                ))),
+            )?
+            .into_workspace()?;
+        // Normal unapply first:
+        // - re-merge or collapse the workspace commit
+        // - point workspace to it
+        // - update metadata and workspace
+        let WorkspaceRefUpdateAfterUnapply {
+            entrypoint_id,
+            workspace_merge,
+        } = update_workspace_ref_after_unapply(
+            &ws,
+            repo,
+            workspace_ref_name.as_ref(),
+            &ws_md,
+            workspace_disposition,
+            uncommitted_changes,
+        )?;
+        meta.set_workspace(&ws_md)?;
+        // Update the workspace *only* after a successful workspace commit merge.
+        let overlay = Overlay::default()
+            .with_workspace_metadata_override(Some((workspace_ref_name.to_owned(), ws_md.clone())));
+        let mut ws = ws
+            .graph
+            .redo_traversal_with_overlay(repo, meta, overlay)?
+            .into_workspace()?;
+        let checked_out = if !workspace_tip_was_entrypoint && ws.is_entrypoint() {
+            // The workspace tip never was the entrypoint, meaning something inside
+            // was the entrypoint, and now it's not visible anymore as that stack was unapplied.
+            // Now we checkout the enclosing workspace instead.
+            switch_head_to_workspace_ref(repo, workspace_ref_name.as_ref(), entrypoint_id)?;
+            let overlay = Overlay::default()
+                .with_entrypoint(entrypoint_id, Some(workspace_ref_name.to_owned()));
+            ws = ws
+                .graph
+                .redo_traversal_with_overlay(repo, meta, overlay)?
+                .into_workspace()?;
+            Some(workspace_ref_name.to_owned())
+        } else {
+            None
+        };
+        if ws.refname_is_segment(branch) {
+            bail!(
+                "BUG: branch '{}' is still present in rebuilt workspace after unapply",
+                branch.shorten()
+            );
+        }
+        match ref_to_checkout_after_workspace_deletion(&ws, workspace_disposition)? {
+            Some(ref_to_switch_to) => {
+                // The rebuilt workspace can be discarded entirely, switching to another branch.
+                safe_checkout_ref_to_checkout(
+                    &ws,
+                    repo,
+                    &ref_to_switch_to,
+                    but_core::worktree::checkout::Options {
+                        uncommitted_changes,
+                        // We will be setting the HEAD ourselves.
+                        skip_head_update: true,
+                        ..Default::default()
+                    },
+                )?;
+                switch_head_and_delete_workspace_ref(
+                    repo,
+                    ref_to_switch_to.ref_name.as_ref(),
+                    workspace_ref_name.as_ref(),
+                    ws.tip_commit()
+                        .context("BUG: unborn should be impossible here")?
+                        .id,
+                )?;
+                // Keep the workspace metadata or we lose the target branch.
+                // Currently that's a problem, so deal with it later.
+
+                let overlay = Overlay::default().with_entrypoint(
+                    ref_to_switch_to.commit_id,
+                    Some(ref_to_switch_to.ref_name.clone()),
+                );
+                let ws = ws
+                    .graph
+                    .redo_traversal_with_overlay(repo, meta, overlay)?
+                    .into_workspace()?;
+
+                Ok(Outcome {
+                    workspace: Cow::Owned(ws),
+                    checked_out: Some(ref_to_switch_to.ref_name),
+                    workspace_merge: None,
+                })
+            }
+            None => Ok(Outcome {
+                workspace: Cow::Owned(ws),
+                checked_out,
+                workspace_merge,
+            }),
+        }
+    }
+
+    /// Point `HEAD` back to the managed workspace reference after unapplying the
+    /// branch that was previously checked out directly.
+    /// It is assumed that the worktree and index already match what `HEAD` will
+    /// point to next.
+    ///
+    /// `repo` is the repository whose `HEAD` will become symbolic again.
+    ///
+    /// `workspace_ref_name` is the managed workspace reference to attach `HEAD` to.
+    /// It must already point to the commit checked out into the index and worktree.
+    ///
+    /// `expected_workspace_ref_id` is that checked-out commit. The helper verifies
+    /// the workspace ref points to this id before changing `HEAD`, so the symbolic
+    /// switch cannot silently attach `HEAD` to a different commit than the one the
+    /// index/worktree were updated to.
+    fn switch_head_to_workspace_ref(
+        repo: &gix::Repository,
+        workspace_ref_name: &FullNameRef,
+        expected_workspace_ref_id: gix::ObjectId,
+    ) -> anyhow::Result<()> {
+        let actual_workspace_ref_id = repo
+            .find_reference(workspace_ref_name)?
+            .peel_to_id()?
+            .detach();
+        ensure!(
+            actual_workspace_ref_id == expected_workspace_ref_id,
+            "BUG: workspace ref '{}' points to {actual_workspace_ref_id}, expected {expected_workspace_ref_id}",
+            workspace_ref_name.shorten()
+        );
+        repo.edit_reference(RefEdit {
+            change: Change::Update {
+                log: LogChange {
+                    mode: RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: "GitButler switch to workspace during unapply-branch".into(),
+                },
+                expected: PreviousValue::Any,
+                new: Target::Symbolic(workspace_ref_name.to_owned()),
+            },
+            name: "HEAD".try_into().expect("well-formed root ref"),
+            deref: false,
+        })?;
+        Ok(())
+    }
+
+    /// Update the managed workspace reference after metadata has removed the branch.
+    ///
+    /// If the remaining applied stacks still need a workspace merge commit, this rebuilds it in
+    /// memory first, then safely checks out the resulting tree and moves the workspace ref.
+    /// Workspace merge conflicts are errors and leave refs, metadata, index, and worktree
+    /// untouched.
+    ///
+    /// `ws` is the workspace projection after the branch was removed from workspace metadata.
+    /// `ws_md` is the metadata that produced that projection. `repo` is the repository whose
+    /// workspace ref and worktree may be updated. `workspace_ref_name` is the managed workspace
+    /// ref to move to the new workspace commit. `disposition` controls whether an unnecessary
+    /// workspace merge commit is kept or not. `uncommitted_changes` controls checkout conflict
+    /// handling.
+    fn update_workspace_ref_after_unapply(
+        ws: &but_graph::Workspace,
+        repo: &gix::Repository,
+        workspace_ref_name: &FullNameRef,
+        ws_md: &but_core::ref_metadata::Workspace,
+        disposition: WorkspaceDisposition,
+        uncommitted_changes: but_core::worktree::checkout::UncommitedWorktreeChanges,
+    ) -> anyhow::Result<WorkspaceRefUpdateAfterUnapply> {
+        let prev_head_id = ws
+            .graph
+            .entrypoint()?
+            .commit()
+            .context("BUG: unborn was skipped, why no entrypoint")?
+            .id;
+
+        let future_workspace_tips = future_workspace_tips(ws_md, ws)?;
+        let remaining_tip_count = future_workspace_tips.len();
+        let keep_workspace_commit = match disposition {
+            WorkspaceDisposition::KeepWorkspaceCommit
+            | WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit => {
+                ws.kind.has_managed_commit()
+            }
+            WorkspaceDisposition::KeepWorkspaceReference
+            | WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences => {
+                remaining_tip_count > 1
+            }
+        };
+
+        if !keep_workspace_commit {
+            let new_head_id =
+                commit_to_point_workspace_ref_to_after_unapply(ws, &future_workspace_tips)?;
+            checkout_and_update_workspace_ref(
+                repo,
+                prev_head_id,
+                new_head_id,
+                workspace_ref_name,
+                uncommitted_changes,
+            )?;
+            return Ok(WorkspaceRefUpdateAfterUnapply {
+                entrypoint_id: new_head_id,
+                workspace_merge: None,
+            });
+        }
+
+        let mut in_memory_repo = repo.clone().for_tree_diffing()?.with_object_memory();
+        let merge = merge_workspace_after_unapply(ws, &future_workspace_tips, &in_memory_repo)?;
+
+        // materialize the merged objects.
+        let new_head_id = merge.workspace_commit_id;
+        if let Some(storage) = in_memory_repo.objects.take_object_memory() {
+            storage.persist(repo)?;
+            drop(in_memory_repo);
+        }
+        checkout_and_update_workspace_ref(
+            repo,
+            prev_head_id,
+            new_head_id,
+            workspace_ref_name,
+            uncommitted_changes,
+        )?;
+        Ok(WorkspaceRefUpdateAfterUnapply {
+            entrypoint_id: new_head_id,
+            workspace_merge: merge.workspace_merge,
+        })
+    }
+
+    /// Result of updating a managed workspace ref while keeping the workspace metadata around.
+    struct WorkspaceRefUpdateAfterUnapply {
+        /// Commit to use as the entrypoint when rebuilding the workspace projection.
+        entrypoint_id: gix::ObjectId,
+        /// Merge attempt, present when rebuilding or trying to rebuild the workspace commit.
+        workspace_merge: Option<crate::commit::merge::Outcome>,
+    }
+
+    struct WorkspaceMergeAfterUnapply {
+        /// The commit to materialize as the new workspace ref target.
+        workspace_commit_id: gix::ObjectId,
+        /// The merge attempt callers should receive, if it represents a real workspace merge.
+        ///
+        /// This is `None` for the legacy empty-workspace keep-merge case, where the merge outcome
+        /// is only an implementation detail used to create a managed no-op workspace commit.
+        workspace_merge: Option<crate::commit::merge::Outcome>,
+    }
+
+    fn future_workspace_tips(
+        ws_md: &but_core::ref_metadata::Workspace,
+        ws: &but_graph::Workspace,
+    ) -> anyhow::Result<Vec<crate::commit::merge::Tip>> {
+        let crate::commit::merge::ResolvedTips {
+            tips,
+            missing_stacks,
+        } = WorkspaceCommit::tips_from_metadata(
+            ws_md.stacks.iter(),
+            anon_stacks_to_preserve(ws),
+            &ws.graph,
+        );
+        ensure!(
+            missing_stacks.is_empty(),
+            "Somehow some of the workspace stacks weren't part of the graph: {missing_stacks:#?}"
+        );
+        Ok(tips)
+    }
+
+    /// Unapply the managed workspace reference itself.
+    ///
+    /// - Run before normal branch removal because the workspace ref is a container, not a stack segment.
+    /// - Reject dispositions that keep the workspace ref because unapplying it requires switching away.
+    /// - Pick a named checkout target from the current projection.
+    /// - Reject GitButler-conflicted target commits with a ref-aware error.
+    /// - Safely checkout the target commit, then switch `HEAD` to the target ref.
+    /// - Optionally delete the managed workspace ref and metadata.
+    /// - Retraverse from the target ref so the returned workspace matches the new `HEAD`.
+    fn unapply_workspace_reference<'ws>(
+        ws: &'ws but_graph::Workspace,
+        repo: &gix::Repository,
+        meta: &mut impl RefMetadata,
+        workspace_ref_name: &FullNameRef,
+        disposition: WorkspaceDisposition,
+        uncommitted_changes: but_core::worktree::checkout::UncommitedWorktreeChanges,
+    ) -> anyhow::Result<Outcome<'ws>> {
+        if !disposition.may_switch_away_from_workspace() {
+            bail!(
+                "Cannot unapply workspace reference '{}' without switching away from it",
+                workspace_ref_name.shorten()
+            );
+        }
+
+        let ref_to_checkout = ref_to_checkout_after_workspace_unapply(ws)?;
+        safe_checkout_ref_to_checkout(
+            ws,
+            repo,
+            &ref_to_checkout,
+            but_core::worktree::checkout::Options {
+                uncommitted_changes,
+                skip_head_update: true,
+                ..Default::default()
+            },
+        )?;
+
+        let workspace_ref_expected = ws
+            .tip_commit()
+            .context("BUG: unborn should be impossible here")?
+            .id;
+        switch_head_and_delete_workspace_ref(
+            repo,
+            ref_to_checkout.ref_name.as_ref(),
+            workspace_ref_name,
+            workspace_ref_expected,
+        )?;
+        // Fully remove the workspace, which includes the target branch.
+        // For this we will need more flexibility, on-demand inference or
+        // git-configuration based configuration, so there is always a fallback.
+        meta.remove(workspace_ref_name)?;
+
+        let overlay = Overlay::default().with_entrypoint(
+            ref_to_checkout.commit_id,
+            Some(ref_to_checkout.ref_name.clone()),
+        );
+        let ws = ws
+            .graph
+            .redo_traversal_with_overlay(repo, meta, overlay)?
+            .into_workspace()?;
+        Ok(Outcome {
+            workspace: Cow::Owned(ws),
+            checked_out: Some(ref_to_checkout.ref_name),
+            workspace_merge: None,
+        })
+    }
+
+    /// Rebuild the managed workspace commit after `branch` has been removed from metadata.
+    ///
+    /// The metadata is resolved to tips first so all rebuilds use the lower-level tip merge API.
+    /// If metadata and anonymous workspace inputs resolve to no tips, the legacy keep-merge path
+    /// still needs a managed commit, so we synthesize a single unnamed tip at the post-unapply
+    /// base/checkout commit.
+    fn merge_workspace_after_unapply(
+        ws: &but_graph::Workspace,
+        future_workspace_tips: &[crate::commit::merge::Tip],
+        repo: &gix::Repository,
+    ) -> anyhow::Result<WorkspaceMergeAfterUnapply> {
+        let mut tips = future_workspace_tips.to_vec();
+        let report_workspace_merge = !tips.is_empty();
+        if tips.is_empty() {
+            tips.push(base_tip_after_unapply(ws, future_workspace_tips)?);
+        }
+        let outcome = WorkspaceCommit::from_new_merge_with_tips(tips, &ws.graph, repo, None)?;
+        ensure_workspace_merge_has_no_conflicts(&outcome)?;
+        let workspace_commit_id = outcome.workspace_commit_id;
+        Ok(WorkspaceMergeAfterUnapply {
+            workspace_commit_id,
+            workspace_merge: report_workspace_merge.then_some(outcome),
+        })
+    }
+
+    fn ensure_workspace_merge_has_no_conflicts(
+        outcome: &crate::commit::merge::Outcome,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            !outcome.has_conflicts(),
+            "Failed to unapply branch due to conflicts while rebuilding the workspace merge commit: {}",
+            describe_conflicting_stacks(&outcome.conflicting_stacks)
+        );
+        Ok(())
+    }
+
+    fn describe_conflicting_stacks(
+        conflicting_stacks: &[crate::commit::merge::ConflictingStack],
+    ) -> String {
+        let ref_names = conflicting_stacks
+            .iter()
+            .filter_map(|stack| stack.ref_name.as_ref())
+            .map(|ref_name| ref_name.shorten().to_string())
+            .collect::<Vec<_>>();
+        if ref_names.is_empty() {
+            format!("{} stack(s)", conflicting_stacks.len())
+        } else {
+            ref_names.join(", ")
+        }
+    }
+
+    /// Convert the commit that should remain checked out after unapply into a synthetic merge tip.
+    fn base_tip_after_unapply(
+        ws: &but_graph::Workspace,
+        future_workspace_tips: &[crate::commit::merge::Tip],
+    ) -> anyhow::Result<crate::commit::merge::Tip> {
+        let commit_id = commit_to_point_workspace_ref_to_after_unapply(ws, future_workspace_tips)?;
+        let segment_idx = ws
+            .graph
+            .segment_by_commit_id(commit_id)
+            .with_context(|| {
+                format!("BUG: could not find workspace segment for base commit {commit_id}")
+            })?
+            .id;
+        Ok(crate::commit::merge::Tip {
+            name: None,
+            commit_id,
+            segment_idx,
+        })
+    }
+
+    /// Return anonymous stacks that should be kept while rebuilding the workspace merge commit.
+    ///
+    /// Reprojecting after metadata changes can leave old workspace-commit parents visible as
+    /// anonymous stacks. If such a stack still has a metadata [stack id](but_core::ref_metadata::StackId),
+    /// it is a projected remnant of the old workspace commit rather than independent anonymous work,
+    /// and feeding it back into the merge would preserve the removed stack.
+    fn anon_stacks_to_preserve<'a>(
+        ws: &'a but_graph::Workspace,
+    ) -> impl Iterator<Item = (usize, crate::commit::merge::Tip)> + 'a {
+        anon_stacks(&ws.stacks)
+            .filter(move |(idx, _)| ws.stacks.get(*idx).is_none_or(|stack| stack.id.is_none()))
+    }
+
+    /// Local tracking branch of target ref or the most recent named stack tip.
+    fn ref_to_checkout_after_workspace_unapply(
+        ws: &but_graph::Workspace,
+    ) -> anyhow::Result<RefToCheckout> {
+        if let Some(target) = local_tracking_branch_of_target(ws)? {
+            return Ok(target);
+        }
+        named_stack_with_lowest_generation(ws)?.with_context(
+            || "Cannot unapply workspace reference because no target or named stack could be found",
+        )
+    }
+
+    /// The idea here is to put the user at the topologically most recent stack.
+    /// This is also arbitrary, but *feels* like what one would want.
+    fn named_stack_with_lowest_generation(
+        ws: &but_graph::Workspace,
+    ) -> anyhow::Result<Option<RefToCheckout>> {
+        let mut selected = None;
+        for stack in &ws.stacks {
+            let Some((sidx, ref_info)) = stack
+                .segments
+                .first()
+                .and_then(|s| s.ref_info.as_ref().map(|ri| (s.id, ri)))
+            else {
+                continue;
+            };
+            let generation = ws.graph[sidx].generation;
+            let ref_to_checkout = RefToCheckout::from_segment_ref_info(ws, sidx, ref_info)?;
+            if selected
+                .as_ref()
+                .is_none_or(|(best_generation, _)| generation < *best_generation)
+            {
+                selected = Some((generation, ref_to_checkout));
+            }
+        }
+        Ok(selected.map(|(_, ref_to_checkout)| ref_to_checkout))
+    }
+
+    /// Run `safe_checkout`, but provide better error messages if the commit to checkout
+    /// is conflicted.
+    fn safe_checkout(
+        repo: &gix::Repository,
+        prev_head_id: gix::ObjectId,
+        new_head_id: gix::ObjectId,
+        options: but_core::worktree::checkout::Options,
+    ) -> anyhow::Result<but_core::worktree::checkout::Outcome> {
+        if but_core::Commit::from_id(new_head_id.attach(repo))?.is_conflicted() {
+            bail!("Cannot unapply branch by checking out conflicted commit {new_head_id}");
+        }
+        but_core::worktree::safe_checkout(prev_head_id, new_head_id, repo, options)
+    }
+
+    /// Check out `ref_to_checkout` using the workspace traversal entrypoint as the
+    /// current worktree/index source.
+    ///
+    /// `ws` must be the workspace projection for the currently checked-out `HEAD`.
+    /// Its graph entrypoint is therefore the commit the index and worktree are
+    /// expected to match before checkout. This matters when `HEAD` points at a
+    /// stack segment inside the workspace rather than the workspace tip.
+    ///
+    /// The helper only updates the index/worktree according to `options`; callers
+    /// remain responsible for any subsequent `HEAD`, reference, metadata, and
+    /// projection updates.
+    fn safe_checkout_ref_to_checkout(
+        ws: &but_graph::Workspace,
+        repo: &gix::Repository,
+        ref_to_checkout: &RefToCheckout,
+        options: but_core::worktree::checkout::Options,
+    ) -> anyhow::Result<but_core::worktree::checkout::Outcome> {
+        if but_core::Commit::from_id(ref_to_checkout.commit_id.attach(repo))?.is_conflicted() {
+            bail!(
+                "Cannot unapply workspace reference by checking out conflicted commit at '{}'",
+                ref_to_checkout.ref_name.shorten()
+            );
+        }
+        let prev_head_id = ws
+            .graph
+            .entrypoint()?
+            .commit()
+            .context("BUG: unborn was skipped, why no entrypoint")?
+            .id;
+        safe_checkout(repo, prev_head_id, ref_to_checkout.commit_id, options)
+    }
+
+    /// Return the commit the workspace ref should point to when no workspace merge commit remains.
+    ///
+    /// A single remaining future tip is preferred. Otherwise, an empty workspace falls back to the
+    /// resolved target or the workspace lower bound.
+    fn commit_to_point_workspace_ref_to_after_unapply(
+        ws: &but_graph::Workspace,
+        future_workspace_tips: &[crate::commit::merge::Tip],
+    ) -> anyhow::Result<gix::ObjectId> {
+        if let Some(tip) = future_workspace_tips.first() {
+            return Ok(tip.commit_id);
+        }
+        ws.resolved_target_commit_id()
+            .or(ws.lower_bound)
+            .context("Cannot determine commit for empty workspace after unapply")
+    }
+
+    /// Safely update the worktree and move the managed workspace ref to `new_head_id`.
+    ///
+    /// The checkout runs before the ref update so uncommitted-change conflicts abort without
+    /// changing repository refs. `HEAD` is expected to remain symbolically attached to the workspace
+    /// ref, so the checkout skips its own head update and this function updates only the ref target.
+    fn checkout_and_update_workspace_ref(
+        repo: &gix::Repository,
+        prev_head_id: gix::ObjectId,
+        new_head_id: gix::ObjectId,
+        workspace_ref_name: &FullNameRef,
+        uncommitted_changes: but_core::worktree::checkout::UncommitedWorktreeChanges,
+    ) -> anyhow::Result<()> {
+        safe_checkout(
+            repo,
+            prev_head_id,
+            new_head_id,
+            but_core::worktree::checkout::Options {
+                uncommitted_changes,
+                skip_head_update: true,
+                ..Default::default()
+            },
+        )?;
+        repo.edit_reference(RefEdit {
+            change: Change::Update {
+                log: LogChange {
+                    mode: RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: "GitButler update workspace during unapply-branch".into(),
+                },
+                expected: PreviousValue::Any,
+                new: Target::Object(new_head_id),
+            },
+            name: workspace_ref_name.to_owned(),
+            deref: false,
+        })?;
+        Ok(())
+    }
+
+    /// Determine whether unapply should delete the workspace reference and switch `HEAD` to a regular ref.
+    ///
+    /// `ws` is the current workspace projection after the managed workspace ref was already
+    /// updated and re-projected. It is the source of truth for the resulting stack shape, including
+    /// virtual stacks. `disposition` controls whether deleting the workspace reference is allowed
+    /// at all.
+    ///
+    /// Return the ref to check out after deleting the workspace ref, or `None` if the workspace
+    /// reference must remain checked out.
+    fn ref_to_checkout_after_workspace_deletion(
+        ws: &but_graph::Workspace,
+        disposition: WorkspaceDisposition,
+    ) -> anyhow::Result<Option<RefToCheckout>> {
+        if !disposition.may_delete_workspace_reference() {
+            return Ok(None);
+        }
+
+        match ws.stacks.first() {
+            None => {
+                if let Some(fallback) = local_tracking_branch_of_target(ws)? {
+                    return Ok(Some(fallback));
+                }
+
+                tracing::warn!(
+                    "keeping workspace reference after unapply because no non-stack checkout fallback is available"
+                );
+            }
+            Some(first_stack) if ws.stacks.len() == 1 => {
+                if let Some(ref_to_checkout) = stack_to_checkout(ws, first_stack)? {
+                    return Ok(Some(ref_to_checkout));
+                }
+                tracing::warn!(
+                    "keeping workspace reference after unapply because the remaining stack has no ref to check out"
+                );
+            }
+            _ => {}
+        }
+        Ok(None)
+    }
+
+    fn stack_to_checkout(
+        ws: &but_graph::Workspace,
+        stack: &but_graph::workspace::Stack,
+    ) -> anyhow::Result<Option<RefToCheckout>> {
+        stack
+            .segments
+            .first()
+            .and_then(|segment| {
+                segment
+                    .ref_info
+                    .as_ref()
+                    .map(|ref_info| RefToCheckout::from_segment_ref_info(ws, segment.id, ref_info))
+            })
+            .transpose()
+    }
+
+    /// Return the local branch to check out for the workspace target.
+    ///
+    /// `ws` is the current graph projection with adjusted metadata. The workspace target already
+    /// carries the local tracking branch inferred while building the graph, including the peeled
+    /// commit id to check out.
+    fn local_tracking_branch_of_target(
+        ws: &but_graph::Workspace,
+    ) -> anyhow::Result<Option<RefToCheckout>> {
+        let Some(target_ref) = ws.target_ref.as_ref() else {
+            return Ok(None);
+        };
+        let Some(local_target_ref_sidx) = ws.graph[target_ref.segment_index].sibling_segment_id
+        else {
+            return Ok(None);
+        };
+        let Some(ref_info) = ws.graph[local_target_ref_sidx].ref_info.as_ref() else {
+            return Ok(None);
+        };
+        RefToCheckout::from_segment_ref_info(ws, local_target_ref_sidx, ref_info).map(Some)
+    }
+
+    /// Ref name and peeled commit id selected from the workspace projection for checkout.
+    struct RefToCheckout {
+        ref_name: FullName,
+        // The commit that `ref_name` is pointing to.
+        commit_id: gix::ObjectId,
+    }
+
+    impl RefToCheckout {
+        fn from_segment_ref_info(
+            ws: &but_graph::Workspace,
+            segment_id: but_graph::SegmentIndex,
+            ref_info: &but_graph::RefInfo,
+        ) -> anyhow::Result<Self> {
+            Ok(RefToCheckout {
+                ref_name: ref_info.ref_name.clone(),
+                commit_id: ws
+                    .tip_commit_by_segment_id(segment_id)
+                    .map(|commit| commit.id)
+                    .or(ref_info.commit_id)
+                    .with_context(|| {
+                        format!(
+                            "Cannot check out '{}' because it does not point to a commit",
+                            ref_info.ref_name.shorten()
+                        )
+                    })?,
+            })
+        }
+    }
+
+    /// Delete `workspace_ref_name` and point `HEAD` symbolically at `target_ref`.
+    /// `workspace_ref_commit_id` is the commit that the workspace ref is pointing
+    /// to currently.
+    ///
+    /// This is merely a ref-edit.
+    fn switch_head_and_delete_workspace_ref(
+        repo: &gix::Repository,
+        target_ref: &FullNameRef,
+        workspace_ref_name: &FullNameRef,
+        workspace_ref_commit_id: gix::ObjectId,
+    ) -> anyhow::Result<()> {
+        repo.edit_references([
+            RefEdit {
+                change: Change::Delete {
+                    log: RefLog::AndReference,
+                    expected: PreviousValue::MustExistAndMatch(Target::Object(
+                        workspace_ref_commit_id,
+                    )),
+                },
+                name: workspace_ref_name.to_owned(),
+                deref: false,
+            },
+            RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "GitButler switch away from workspace during unapply-branch"
+                            .into(),
+                    },
+                    expected: PreviousValue::Any,
+                    new: Target::Symbolic(target_ref.to_owned()),
+                },
+                name: "HEAD".try_into().expect("well-formed root ref"),
+                deref: false,
+            },
+        ])?;
+        Ok(())
     }
 }

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -112,6 +112,17 @@ pub mod merge {
         pub segment_idx: SegmentIndex,
     }
 
+    /// Tips resolved from workspace metadata, with references that metadata mentioned but the graph
+    /// couldn't resolve.
+    /// Returned by [WorkspaceCommit::tips_from_metadata()].
+    pub struct ResolvedTips {
+        /// Tips in the order they should appear as workspace commit parents.
+        pub tips: Vec<Tip>,
+        /// Metadata stack tips that couldn't be found in the graph.
+        /// This is usually a problem, as the Graph is expected to contain everything of interest.
+        pub missing_stacks: Vec<gix::refs::FullName>,
+    }
+
     /// A minimal stack for to represent a stack that conflicted.
     #[derive(Clone)]
     pub struct ConflictingStack {
@@ -154,6 +165,76 @@ pub mod merge {
 
     /// Merging - create a merge-commit along with its tree.
     impl WorkspaceCommit<'_> {
+        /// Resolve workspace metadata and anonymous stacks into merge tips.
+        ///
+        /// This preserves metadata ordering, reports missing metadata stacks, and inserts anonymous
+        /// stacks at their projected parent slots while avoiding duplicate commit/segment tips.
+        ///
+        /// `stacks` are the workspace metadata stacks whose top branches should become named
+        /// merge tips unless they are marked outside of the workspace.
+        ///
+        /// `anon_stacks` are unnamed projected tips paired with the parent slot they occupied in
+        /// the workspace projection, used to preserve anonymous parents not represented in metadata.
+        ///
+        /// `graph` resolves metadata branch names to commit and segment ids.
+        pub fn tips_from_metadata<'a>(
+            stacks: impl IntoIterator<Item = &'a but_core::ref_metadata::WorkspaceStack>,
+            anon_stacks: impl IntoIterator<Item = (usize, Tip)>,
+            graph: &but_graph::Graph,
+        ) -> ResolvedTips {
+            let mut missing_stacks = Vec::new();
+            let mut tips_with_metadata_slots: Vec<_> = stacks
+                .into_iter()
+                .filter_map(|s| s.branches.first().map(|b| (b, s.workspacecommit_relation)))
+                .map(|(top_segment, relation)| {
+                    match relation {
+                        WorkspaceCommitRelation::Merged => {}
+                        WorkspaceCommitRelation::MergeFrom { .. } => {
+                            // These need to be part of the parents list, but shouldn't be merged.
+                            // If the caller wants to retry them, they can be passed here as "Merged".
+                            todo!(
+                                "this is a placeholder for where we will have to start handling this UnmergedTree"
+                            )
+                        }
+                        WorkspaceCommitRelation::Outside => return None,
+                    }
+                    let stack_tip_name = top_segment.ref_name.as_ref();
+                    match graph.segment_and_commit_by_ref_name(stack_tip_name) {
+                        None => {
+                            missing_stacks.push(top_segment.ref_name.to_owned());
+                            None
+                        }
+                        Some((segment, commit)) => Some(Tip {
+                            name: Some(stack_tip_name.to_owned()),
+                            commit_id: commit.id,
+                            segment_idx: segment.id,
+                        }),
+                    }
+                })
+                .collect();
+            let named_tips = tips_with_metadata_slots
+                .iter()
+                .flatten()
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut anon_stacks = anon_stacks.into_iter().collect::<Vec<_>>();
+            anon_stacks.sort_by_key(|(idx, _)| *idx);
+            for (idx, anon_tip) in anon_stacks {
+                if named_tips.iter().any(|t| {
+                    t.commit_id == anon_tip.commit_id || t.segment_idx == anon_tip.segment_idx
+                }) {
+                    // prevent duplication of tips, make calling this easier as well.
+                    continue;
+                }
+                tips_with_metadata_slots
+                    .insert(idx.min(tips_with_metadata_slots.len()), Some(anon_tip));
+            }
+            ResolvedTips {
+                tips: tips_with_metadata_slots.into_iter().flatten().collect(),
+                missing_stacks,
+            }
+        }
+
         /// like [`Self::from_new_merge_with_metadata`], but supports tips, which makes it possible to re-merge anything
         /// even if the tip is unnamed.
         /// Note that [`missing_stacks`](Outcome::missing_stacks) is never set.
@@ -403,10 +484,6 @@ pub mod merge {
         /// `repo` is expected to be configured to be suitable for merges, and it *should* be configured to write objects into memory
         /// unless the caller knows that any result of the merge is acceptable.
         ///
-        /// IMPORTANT: This inherently needs the tips to be represented by named branches, so this can't be used to
-        ///            re-merge a workspace with lost or renamed branches. It is, however, good to 'fix' workspaces
-        ///            whose tips were advanced and now are outside the workspace, provide the ref that advanced still exists.
-        ///
         /// ### Shortcoming: inefficient conflict behaviour
         ///
         /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
@@ -425,43 +502,10 @@ pub mod merge {
             repo: &gix::Repository,
             hero_stack: Option<&gix::refs::FullNameRef>,
         ) -> anyhow::Result<Outcome> {
-            let mut missing_stacks = Vec::new();
-            let mut tips: Vec<_> = stacks
-                .into_iter()
-                .filter_map(|s| s.branches.first().map(|b| (b, s.workspacecommit_relation)))
-                .filter_map(|(top_segment, relation)| {
-                    match relation {
-                        WorkspaceCommitRelation::Merged => {}
-                        WorkspaceCommitRelation::MergeFrom { .. } => {
-                            // These need to be part of the parents list, but shouldn't be merged.
-                            // If the caller wants to retry them, they can be passed here as "Merged".
-                            todo!("this is a placeholder for where we will have to start handling this UnmergedTree")
-                        }
-                        WorkspaceCommitRelation::Outside => return None,
-                    }
-                    let stack_tip_name = top_segment.ref_name.as_ref();
-                    match graph.segment_and_commit_by_ref_name(stack_tip_name) {
-                        None => {
-                            missing_stacks.push(top_segment.ref_name.to_owned());
-                            None
-                        }
-                        Some((segment, commit)) => Some(Tip {
-                            name: Some(stack_tip_name.to_owned()),
-                            commit_id: commit.id,
-                            segment_idx: segment.id,
-                        }),
-                    }
-                })
-                .collect();
-            for (idx, anon_tip) in anon_stacks {
-                if tips.iter().any(|t| {
-                    t.commit_id == anon_tip.commit_id || t.segment_idx == anon_tip.segment_idx
-                }) {
-                    // prevent duplication of tips, make calling this easier as well.
-                    continue;
-                }
-                tips.insert(idx, anon_tip)
-            }
+            let ResolvedTips {
+                tips,
+                missing_stacks,
+            } = Self::tips_from_metadata(stacks, anon_stacks, graph);
             let mut out = Self::from_new_merge_with_tips(tips, graph, repo, hero_stack)?;
             out.missing_stacks = missing_stacks;
             Ok(out)

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -212,11 +212,18 @@ impl DerefMut for LocalCommit {
 /// Additional workspace functionality that can't easily be implemented in `but-graph`.
 pub trait WorkspaceExt {
     /// Return `true` if this workspace has a workspace commit that the workspace reference isn't directly pointing to.
+    /// Is always `false` for [managed workspaces](WorkspaceKind::Managed) whose reference is pointing to a managed commit.
+    ///
+    /// Workspaces without any workspace commit return `false`; this only detects a workspace commit
+    /// buried in the workspace history.
     fn has_workspace_commit_in_ancestry(&self, repo: &gix::Repository) -> bool;
 }
 
 impl WorkspaceExt for but_graph::Workspace {
     fn has_workspace_commit_in_ancestry(&self, repo: &Repository) -> bool {
+        if self.kind.has_managed_commit() {
+            return false;
+        }
         find_ancestor_workspace_commit(&self.graph, repo, self.id, self.lower_bound_segment_id)
             .is_some()
     }

--- a/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict-on-main.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict-on-main.sh
@@ -14,7 +14,6 @@ function commit-file() {
 
 ### Description
 # A couple of independent heads where some merge cleanly, and some don't, with `conflict-hero` conflicting with two different branches.
-# A workspace ref is present to make it easier to discover the branches of interest in the graph.
 git init
 commit M
 

--- a/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict-on-main.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/various-heads-for-multi-line-merge-conflict-on-main.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# A copy of various-heads-for-multi-line-merge-conflict.sh but with main checked out
+# and no gitbutler/workspace branch.
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  local content=${2:-$1}
+  echo $content >$name && git add $name && git commit -m "add $content"
+}
+
+### Description
+# A couple of independent heads where some merge cleanly, and some don't, with `conflict-hero` conflicting with two different branches.
+# A workspace ref is present to make it easier to discover the branches of interest in the graph.
+git init
+commit M
+
+for filename in A B C; do
+  git checkout -b clean-$filename main
+    commit-file $filename
+done
+
+git checkout -b conflict-F1 main
+  commit-file F1
+
+git checkout -b conflict-F2 main
+  commit-file F2
+
+git checkout -b conflict-hero main
+  commit-file F1 conflicting-F1
+  commit-file F2 conflicting-F2
+
+git checkout main

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1,3 +1,10 @@
+use crate::{
+    ref_info::with_workspace_commit::utils::{
+        StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
+        named_writable_scenario_with_description_and_graph,
+    },
+    utils::r,
+};
 use bstr::ByteSlice;
 use but_core::{
     RefMetadata, ref_metadata,
@@ -14,14 +21,6 @@ use but_workspace::branch::{
     apply::{WorkspaceMerge, WorkspaceReferenceNaming},
 };
 use gix::refs::Category;
-
-use crate::{
-    ref_info::with_workspace_commit::utils::{
-        StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
-        named_writable_scenario_with_description_and_graph,
-    },
-    utils::r,
-};
 
 #[test]
 fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
@@ -44,16 +43,16 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
             └── ·4979833 (🏘️)
     ");
 
+    let branch_b = r("refs/heads/B");
     let err =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())
-            .unwrap_err();
+        but_workspace::branch::apply(branch_b, &ws, &repo, &mut meta, apply_options()).unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to work on workspace whose workspace commit isn't at the top",
         "cannot apply on a workspace that isn't proper"
     );
 
-    let err = but_workspace::branch::apply(r("HEAD"), &ws, &repo, &mut meta, default_options())
+    let err = but_workspace::branch::apply(r("HEAD"), &ws, &repo, &mut meta, apply_options())
         .unwrap_err();
     assert_eq!(
         err.to_string(),
@@ -82,7 +81,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // Put "B" into the workspace, even though it's the dependent branch of A.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -99,8 +98,8 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // Applying A is always a new stack then.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:B on e5d0542 {1}
     │   └── 📙:2:B
@@ -147,7 +146,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -163,7 +162,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -244,7 +243,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -283,7 +282,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
 
     // Put "A" into the workspace, yielding a single branch.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -301,7 +300,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -363,7 +362,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -391,7 +390,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         but_workspace::branch::apply::Options {
             // Make it appear in place of A, in the center.
             order: Some(1),
-            ..default_options()
+            ..apply_options()
         },
     )?;
     insta::assert_debug_snapshot!(out, @r#"
@@ -440,7 +439,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         &mut meta,
         but_workspace::branch::apply::Options {
             workspace_merge: WorkspaceMerge::AlwaysMerge,
-            ..default_options()
+            ..apply_options()
         },
     )?;
     // A workspace commit was created, even though it does nothing.
@@ -464,7 +463,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         &mut meta,
         but_workspace::branch::apply::Options {
             workspace_merge: WorkspaceMerge::AlwaysMerge,
-            ..default_options()
+            ..apply_options()
         },
     )?;
 
@@ -509,7 +508,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     // Put "A" into the workspace, creating the workspace ref, but never put a branch related to the target in as well,
     // which is currently checked out with `main`.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -529,7 +528,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -551,7 +550,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 
     // Cannot put local tracking branch of target into workspace that has it configured.
     for branch in ["refs/heads/main", "refs/remotes/origin/main"] {
-        let err = but_workspace::branch::apply(r(branch), &ws, &repo, &mut meta, default_options())
+        let err = but_workspace::branch::apply(r(branch), &ws, &repo, &mut meta, apply_options())
             .unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -590,7 +589,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
 
     // Put "A" into the workspace, hence we want "A" and "B" in it.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -643,7 +642,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -679,7 +678,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -739,7 +738,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     ");
 
     assert_eq!(
-        default_options().workspace_merge,
+        apply_options().workspace_merge,
         WorkspaceMerge::MergeIfNeeded
     );
 
@@ -749,7 +748,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -771,7 +770,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     let ws = out.workspace.into_owned();
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/A1"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A1"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -799,7 +798,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         but_workspace::branch::apply::Options {
             // TODO: remove this, use default options.
             on_workspace_conflict: OnWorkspaceMergeConflict::MaterializeAndReportConflictingStacks,
-            ..default_options()
+            ..apply_options()
         },
     )?;
     insta::assert_debug_snapshot!(out, @r#"
@@ -893,7 +892,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())?;
 
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -922,7 +921,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
 
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -962,7 +961,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
         but_workspace::branch::apply::Options {
             // Make 'A' appear at the front.
             order: Some(0),
-            ..default_options()
+            ..apply_options()
         },
     )?;
 
@@ -1025,7 +1024,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
 
     // Apply the dependent branch, to bring in only the dependent branch
     let out =
-        but_workspace::branch::apply(r("refs/heads/E"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/E"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1045,7 +1044,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // Apply the former tip of the stack, to create a new stack. Note how it won't double-list the
     // other stack.
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())?;
     let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
@@ -1071,7 +1070,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // Accepting this behaviour for now as it's quite rare to have such ambiguity, even though I'd love if one day
     // for this to just work as people might intuitively want, even if that means the same commit is used multiple times.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
     let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
@@ -1087,7 +1086,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // This is what happens because we notice that C can't be applied as independent stack due to the graph algorithm,
     // and then it tries it a dependent stack, which should always work.
     let out =
-        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())
+        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())
             .unwrap();
     let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @"
@@ -1126,7 +1125,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     // Apply `A` first.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1151,7 +1150,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     // Apply `B` - the only sane way is to make it its own stack, but allow it to diverge.
     let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())
             .expect("apply actually works");
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -1240,7 +1239,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             &ws,
             &repo,
             &mut meta,
-            default_options(),
+            apply_options(),
         )
         .unwrap_or_else(|err| panic!("{branch_to_apply}: {err}"));
         ws = out.workspace.into_owned();
@@ -1293,7 +1292,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_snapshot!(sanitize_uuids_and_timestamps(format!("{out:#?}")), @r#"
     Outcome {
@@ -1348,7 +1347,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         &mut meta,
         but_workspace::branch::apply::Options {
             on_workspace_conflict: OnWorkspaceMergeConflict::MaterializeAndReportConflictingStacks,
-            ..default_options()
+            ..apply_options()
         },
     )?;
     // It does still report conflicts.
@@ -1523,7 +1522,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -1549,8 +1548,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         └── 👉📙:3:B
     ");
     // Already applied (the HEAD points to it, it literally IS the workspace).
-    let out =
-        but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, default_options())?;
+    let out = but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: false,
@@ -1561,7 +1559,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // To apply A, we just checkout the surrounding workspace, as it's contained there.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1604,7 +1602,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Nothing changed, the desired branch was already applied.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: false,
@@ -1626,7 +1624,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Apply the first branch, it must be independent.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1680,7 +1678,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // Apply the workspace ref itself, it's a no-op
     let ws_ref = r("refs/heads/gitbutler/workspace");
-    let out = but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, default_options())?;
+    let out = but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: false,
@@ -1704,8 +1702,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     ");
 
     // Already applied (the HEAD points to it, it literally IS the workspace).
-    let out =
-        but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, default_options())?;
+    let out = but_workspace::branch::apply(b_ref.as_ref(), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: false,
@@ -1715,7 +1712,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     "#);
 
     let err =
-        but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, default_options()).unwrap_err();
+        but_workspace::branch::apply(ws_ref, &ws, &repo, &mut meta, apply_options()).unwrap_err();
     assert_eq!(
         err.to_string(),
         "Refusing to apply a reference that already is a workspace: 'gitbutler/workspace'",
@@ -1725,7 +1722,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     // To apply, we just checkout the surrounding workspace.
     let out =
-        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -1772,7 +1769,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut *meta,
-        default_options(),
+        apply_options(),
     )
     .unwrap_err();
     assert_eq!(
@@ -1813,7 +1810,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut *meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -1830,7 +1827,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
         &ws,
         &repo,
         &mut *meta,
-        default_options(),
+        apply_options(),
     )?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
@@ -1855,7 +1852,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn default_options() -> but_workspace::branch::apply::Options {
+fn apply_options() -> but_workspace::branch::apply::Options {
     but_workspace::branch::apply::Options {
         workspace_merge: WorkspaceMerge::MergeIfNeeded,
         on_workspace_conflict: OnWorkspaceMergeConflict::AbortAndReportConflictingStacks,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1,7 +1,7 @@
 use crate::{
     ref_info::with_workspace_commit::utils::{
         StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
-        named_writable_scenario_with_description_and_graph,
+        named_writable_scenario, named_writable_scenario_with_description_and_graph,
     },
     utils::r,
 };
@@ -11,16 +11,22 @@ use but_core::{
     ref_metadata::{StackId, WorkspaceCommitRelation::Outside},
     worktree::checkout::UncommitedWorktreeChanges,
 };
-use but_graph::init::{Options, Overlay};
+use but_graph::{
+    Graph,
+    init::{Options, Overlay, Tip},
+};
 use but_testsupport::{
-    InMemoryRefMetadata, git, graph_workspace, id_at, sanitize_uuids_and_timestamps,
-    visualize_commit_graph_all,
+    CommandExt, InMemoryRefMetadata, git, graph_workspace, graph_workspace_determinisitcally,
+    id_at, id_by_rev, sanitize_uuids_and_timestamps, visualize_commit_graph_all,
+    visualize_disk_tree_with_hashes_skip_dot_git,
 };
 use but_workspace::branch::{
     OnWorkspaceMergeConflict,
     apply::{WorkspaceMerge, WorkspaceReferenceNaming},
+    create_reference::{Anchor, Position::Above},
+    unapply::WorkspaceDisposition,
 };
-use gix::refs::Category;
+use gix::refs::{Category, transaction::PreviousValue};
 
 #[test]
 fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
@@ -59,7 +65,146 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
         "Refusing to apply symbolic ref 'HEAD' due to potential ambiguity"
     );
 
-    // TODO: unapply, commit, uncommit
+    let err = but_workspace::branch::unapply(branch_b, &ws, &repo, &mut meta, unapply_options())
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Refusing to work on workspace whose workspace commit isn't at the top",
+        "cannot unapply on a workspace that isn't proper"
+    );
+
+    let err = but_workspace::branch::unapply(r("HEAD"), &ws, &repo, &mut meta, unapply_options())
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Refusing to unapply symbolic ref 'HEAD' due to potential ambiguity"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn unapply_tip_of_ad_hoc_branch_is_an_error() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "fixture starts with a single local main branch", @"
+    * 281da94 (HEAD -> main) 3
+    * 12995d7 2
+    * 3d57fc1 1
+    ");
+
+    let ws = but_graph::Graph::from_head(&repo, &meta, Default::default())?.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "a normal checked-out branch is still an ad-hoc workspace without workspace metadata", @"
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
+
+    let err = but_workspace::branch::unapply(
+        r("refs/heads/main"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )
+    .expect_err("unapplied workspace should be empty, but this one can't be");
+    assert_eq!(
+        err.to_string(),
+        "Cannot unapply branch 'main' from an ad-hoc workspace because the workspace cannot be empty"
+    );
+    Ok(())
+}
+
+#[test]
+fn unapply_branch_from_named_ad_hoc_workspace_affects_metadata() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("single-stack-two-segments")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "fixture starts with a single local main branch", @"
+    * f1889e7 (A2) add A2
+    * 7de99e1 (A1) add A1
+    | * 53ad0c2 (unrelated) add U1
+    |/  
+    * 3183e43 (HEAD -> main, origin/main) M1
+    ");
+
+    let a2_ref = r("refs/heads/A2");
+    let a2_tip = repo.rev_parse_single("A2")?;
+    let ws = but_graph::Graph::from_commit_traversal(
+        a2_tip,
+        a2_ref.to_owned(),
+        &meta,
+        Default::default(),
+    )?
+    .into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "a normal checked-out branch is still an ad-hoc workspace without workspace metadata", @"
+    ⌂:0:A2 <> ✓!
+    └── ≡:0:A2 {1}
+        ├── :0:A2
+        │   └── ·f1889e7
+        ├── :1:A1
+        │   └── ·7de99e1
+        └── :2:main[🌳]
+            └── ·3183e43
+    ");
+
+    let branch = Category::LocalBranch.to_full_name("on-A1")?;
+    let first_id = id_by_rev(&repo, "A1");
+    let ws = but_workspace::branch::create_reference(
+        branch.as_ref(),
+        Anchor::AtCommit {
+            commit_id: first_id.detach(),
+            position: Above,
+        },
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?
+    .into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "creating a branch in the ad-hoc workspace gives unapply a visible segment to reject, it has its own ref-metadata", @"
+    ⌂:0:A2 <> ✓!
+    └── ≡:0:A2 {1}
+        ├── :0:A2
+        │   └── ·f1889e7
+        ├── 📙:1:on-A1
+        │   └── ·7de99e1 ►A1
+        └── :2:main[🌳]
+            └── ·3183e43
+    ");
+
+    let out = but_workspace::branch::unapply(
+        branch.as_ref(),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )
+    .expect("this works because `on-A1` is only present thanks to ref-metadata which we removed");
+
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "on-A1 no longer has a metadata-disambiguated segment", @"
+    ⌂:0:A2 <> ✓!
+    └── ≡:0:A2 {1}
+        ├── :0:A2
+        │   ├── ·f1889e7
+        │   └── ·7de99e1 ►A1, ►on-A1
+        └── :1:main[🌳]
+            └── ·3183e43
+    ");
+
+    let err = but_workspace::branch::unapply(
+        r("refs/heads/main"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )
+    .expect_err("main can't be unapplied, as it's always there in this ad-hoc workspace");
+    assert_eq!(
+        err.to_string(),
+        "Cannot unapply branch 'main' from an ad-hoc workspace because non-tip branches can only disappear if their now removed metadata disambiguated them"
+    );
     Ok(())
 }
 
@@ -99,7 +244,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     // Applying A is always a new stack then.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "the workspace ref still points to the base e5d0542", @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:B on e5d0542 {1}
     │   └── 📙:2:B
@@ -109,7 +254,461 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // It's all virtual.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    let ws = out.workspace.into_owned();
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    "#);
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws),"A was removed with metadata only", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+    └── ≡📙:2:B on e5d0542 {1}
+        └── 📙:2:B
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, "virtual stacks don't cause checkouts.", @r#"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    "#);
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "no stacks are left", @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "no workspace commit is present", @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     Ok(())
+}
+
+mod workspace_disposition {
+    use super::*;
+    use but_meta::VirtualBranchesTomlMetadata;
+    use but_testsupport::gix_testtools::tempfile::TempDir;
+
+    #[test]
+    fn keep_workspace_commit() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = workspace_with_virtual_base()?;
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::KeepWorkspaceCommit),
+        )?;
+        assert!(
+            out.workspace.kind.has_managed_commit(),
+            "KeepWorkspaceCommit must preserve the checked-out managed workspace commit"
+        );
+        assert!(
+            out.workspace_merge.is_some(),
+            "unapply must rebuild the workspace merge instead of collapsing the workspace ref"
+        );
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "A was removed", @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+        ├── ≡📙:4:virtual-base on 85efbe4 {1}
+        │   └── 📙:4:virtual-base
+        └── ≡📙:3:B on 85efbe4 {3}
+            └── 📙:3:B
+                └── ·c813d8d (🏘️)
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the workspace commit is still there with two parents (even though there is no need)", @"
+        * 09d8e52 (A) A
+        | * 3b77768 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        |/| 
+        | * c813d8d (B) B
+        |/  
+        * 85efbe4 (origin/main, virtual-base, main) M
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn keep_workspace_reference() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = workspace_with_virtual_base()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::KeepWorkspaceReference),
+        )?;
+        assert!(
+            out.workspace_merge.is_some(),
+            "KeepWorkspaceReference should keep a workspace commit when a virtual stack remains next to a real stack"
+        );
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "There still is a workspace merge commit, we have two stacks, virtual or not", @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+        ├── ≡📙:4:virtual-base on 85efbe4 {1}
+        │   └── 📙:4:virtual-base
+        └── ≡📙:3:B on 85efbe4 {3}
+            └── 📙:3:B
+                └── ·c813d8d (🏘️)
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the virtual stack counts as real stack and it merges the base to account for it", @"
+        * 09d8e52 (A) A
+        | * 3b77768 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        |/| 
+        | * c813d8d (B) B
+        |/  
+        * 85efbe4 (origin/main, virtual-base, main) M
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn prevent_unnecessary_workspace_reference_checks_out_last_real_stack() -> anyhow::Result<()> {
+        let (_tmp, graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "ws-ref-ws-commit-two-stacks",
+                |meta| {
+                    add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                    add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+                },
+            )?;
+        let ws = graph.into_workspace()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+        )?;
+        insta::assert_debug_snapshot!(&out, "with one real stack left, the workspace ref is deleted and the remaining stack is checked out", @r#"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                "refs/heads/B",
+            ),
+        }
+        "#);
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the workspace ref is deleted and HEAD points to the last real stack", @"
+        * 09d8e52 (A) A
+        | * c813d8d (HEAD -> B) B
+        |/  
+        * 85efbe4 (origin/main, main) M
+        ");
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the projection is the checked-out remaining stack", @"
+        ⌂:0:B[🌳] <> ✓! on 85efbe4
+        └── ≡📙:0:B[🌳] on 85efbe4 {1}
+            └── 📙:0:B[🌳]
+                └── ·c813d8d
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn prevent_unnecessary_workspace_references_keep_workspace_commit_keeps_merge_when_ref_remains()
+    -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = workspace_with_virtual_base()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/virtual-base"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(
+                WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+            ),
+        )?;
+        insta::assert_debug_snapshot!(&out, @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: None,
+        }
+        ");
+        assert!(
+            out.workspace.kind.has_managed_commit(),
+            "compatibility disposition should preserve the managed workspace commit when the workspace ref remains"
+        );
+        assert!(
+            out.workspace_merge.is_some(),
+            "compatibility disposition should rebuild the workspace merge instead of collapsing the ref to the last real stack"
+        );
+        insta::assert_snapshot!(graph_workspace(&out.workspace), @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+        ├── ≡📙:3:A on 85efbe4 {2}
+        │   └── 📙:3:A
+        │       └── ·09d8e52 (🏘️)
+        └── ≡📙:4:B on 85efbe4 {3}
+            └── 📙:4:B
+                └── ·c813d8d (🏘️)
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        *   483c8bd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        |\  
+        | * c813d8d (B) B
+        * | 09d8e52 (A) A
+        |/  
+        * 85efbe4 (origin/main, virtual-base, main) M
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn allow_workspace_reference_deletion() -> anyhow::Result<()> {
+        let (_tmp, _, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "no-ws-ref-no-ws-commit-two-branches",
+                |_meta| {},
+            )?;
+
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        let out = but_workspace::branch::apply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            apply_options(),
+        )?;
+        let ws = out.workspace.into_owned();
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+        └── ≡📙:3:A on e5d0542 {41}
+            └── 📙:3:A
+        ");
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+        )?;
+        insta::assert_debug_snapshot!(&out, "deleting the workspace reference should switch to the local tracking branch of the target", @r#"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                "refs/heads/main",
+            ),
+        }
+        "#);
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "everything is dissolved, there is no gitbutler/workspace ref either", @"
+        ⌂:0:main[🌳] <> ✓!
+        └── ≡:0:main[🌳] {1}
+            └── :0:main[🌳]
+                └── ·e5d0542 ►A, ►B
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn compatibility_mode_deletes_workspace_reference_when_possible() -> anyhow::Result<()> {
+        let (_tmp, _, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "no-ws-ref-no-ws-commit-two-branches",
+                |_meta| {},
+            )?;
+
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        let out = but_workspace::branch::apply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            apply_options(),
+        )?;
+        let ws = out.workspace.into_owned();
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(
+                WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+            ),
+        )?;
+        insta::assert_debug_snapshot!(&out, @r#"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                "refs/heads/main",
+            ),
+        }
+        "#);
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the compatibility mode still removes the whole workspace when it can", @"
+        ⌂:0:main[🌳] <> ✓!
+        └── ≡:0:main[🌳] {1}
+            └── :0:main[🌳]
+                └── ·e5d0542 ►A, ►B
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn unapply_workspace_ref_requires_disposition_that_allows_switching() -> anyhow::Result<()> {
+        let (_tmp, _, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "no-ws-ref-no-ws-commit-two-branches",
+                |_meta| {},
+            )?;
+
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        let out = but_workspace::branch::apply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            apply_options(),
+        )?;
+        let ws = out.workspace.into_owned();
+        insta::assert_snapshot!(graph_workspace(&ws), "the workspace ref is checked out", @"
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+        └── ≡📙:3:A on e5d0542 {41}
+            └── 📙:3:A
+        ");
+
+        let refs_before = visualize_commit_graph_all(&repo)?;
+        let err = but_workspace::branch::unapply(
+            r("refs/heads/gitbutler/workspace"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )
+        .expect_err("unapplying the workspace ref requires checking out another ref");
+        assert_eq!(
+            err.to_string(),
+            "Cannot unapply workspace reference 'gitbutler/workspace' without switching away from it"
+        );
+
+        insta::assert_snapshot!(graph_workspace(&ws), "the workspace is unchanged", @"
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+        └── ≡📙:3:A on e5d0542 {41}
+            └── 📙:3:A
+        ");
+        assert_eq!(
+            visualize_commit_graph_all(&repo)?,
+            refs_before,
+            "failing before checkout must leave refs unchanged"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn keep_workspace_commit_with_last_stack_removed() -> anyhow::Result<()> {
+        let (_tmp, graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "ws-ref-ws-commit-one-stack",
+                |meta| {
+                    add_stack_with_segments(meta, 1, "B", StackState::InWorkspace, &["A"]);
+                },
+            )?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+        * 2076060 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        * d69fe94 (B) B
+        * 09d8e52 (A) A
+        * 85efbe4 (origin/main, main) M
+        ");
+
+        let ws = graph.into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), @"
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+        └── ≡📙:3:B on 85efbe4 {1}
+            ├── 📙:3:B
+            │   └── ·d69fe94 (🏘️)
+            └── 📙:4:A
+                └── ·09d8e52 (🏘️)
+        ");
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/B"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::KeepWorkspaceCommit),
+        )?;
+        assert!(
+            out.workspace_merge.is_none(),
+            "removing the last stack cannot rebuild a workspace merge commit"
+        );
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the workspace is empty", @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the workspace commit is kept as no-op, it's legacy behaviour that will be removed", @"
+        * d69fe94 (B) B
+        * 09d8e52 (A) A
+        | * bde8ed6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+        |/  
+        * 85efbe4 (origin/main, main) M
+        ");
+
+        Ok(())
+    }
+
+    fn workspace_with_virtual_base() -> anyhow::Result<(
+        TempDir,
+        gix::Repository,
+        VirtualBranchesTomlMetadata,
+        but_graph::Workspace,
+    )> {
+        let (tmp, repo, mut meta) = named_writable_scenario("ws-ref-ws-commit-two-stacks")?;
+        let base_id = repo
+            .find_reference("refs/heads/main")?
+            .peel_to_id()?
+            .detach();
+        repo.reference(
+            r("refs/heads/virtual-base"),
+            base_id,
+            PreviousValue::Any,
+            "create a metadata-only virtual stack on the workspace base",
+        )?;
+        add_stack_with_segments(&mut meta, 1, "virtual-base", StackState::InWorkspace, &[]);
+        add_stack_with_segments(&mut meta, 2, "A", StackState::InWorkspace, &[]);
+        add_stack_with_segments(&mut meta, 3, "B", StackState::InWorkspace, &[]);
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        assert!(
+            ws.kind.has_managed_commit(),
+            "fixture starts with a managed workspace commit"
+        );
+
+        let repo_log = visualize_commit_graph_all(&repo)?;
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(repo_log, @r"
+            *   c49e4d8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+            |\  
+            | * 09d8e52 (A) A
+            * | c813d8d (B) B
+            |/  
+            * 85efbe4 (origin/main, virtual-base, main) M
+            ");
+            insta::assert_snapshot!(graph_workspace(&ws), @"
+            📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+            ├── ≡📙:5:virtual-base on 85efbe4 {1}
+            │   └── 📙:5:virtual-base
+            ├── ≡📙:3:A on 85efbe4 {2}
+            │   └── 📙:3:A
+            │       └── ·09d8e52 (🏘️)
+            └── ≡📙:4:B on 85efbe4 {3}
+                └── 📙:4:B
+                    └── ·c813d8d (🏘️)
+            ");
+        }
+        Ok((tmp, repo, meta, ws))
+    }
 }
 
 #[test]
@@ -201,6 +800,75 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     	remote = origin
     	merge = refs/heads/feature
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn unapply_remotely_tracked_tip_of_multi_segment_stack_can_delete_workspace_ref()
+-> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "no-ws-ref-stack-and-dependent-branch",
+            |_meta| {},
+        )?;
+    for branch in ["A", "B", "C"] {
+        let local_name = Category::LocalBranch.to_full_name(branch)?;
+        let remote_name: gix::refs::FullName = format!("refs/remotes/origin/{branch}")
+            .as_str()
+            .try_into()?;
+        let commit_id = repo
+            .find_reference(local_name.as_ref())?
+            .peel_to_id()?
+            .detach();
+        repo.reference(
+            remote_name,
+            commit_id,
+            PreviousValue::Any,
+            "create remote-tracking ref for stack branch",
+        )?;
+    }
+
+    let ws = graph.into_workspace()?;
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:3:B <> origin/B →:5: on 85efbe4 {42}
+        └── 📙:3:B <> origin/B →:5:
+            ├── ❄️f084d61 (🏘️) ►A, ►C
+            └── ❄️7076dee (🏘️) ►D, ►E
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(
+            WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+        ),
+    )?;
+    insta::assert_debug_snapshot!(out, "deleting the workspace ref uses the target fallback instead of the unapplied stack", @r#"
+    Outcome {
+        workspace_changed: true,
+        checked_out: Some(
+            "refs/heads/main",
+        ),
+    }
+    "#);
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the managed workspace ref is deleted and the target's local tracking branch is checked out", @"
+    * f084d61 (origin/C, origin/B, origin/A, C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (HEAD -> main, origin/main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "an ad-hoc workspace remains on the target's local tracking branch", @"
+    ⌂:0:main[🌳] <> ✓! on 85efbe4
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+    ");
     Ok(())
 }
 
@@ -299,8 +967,8 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     // No commit was created, as it's not enabled by default.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
-    let out =
-        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+    let branch_b = r("refs/heads/B");
+    let out = but_workspace::branch::apply(branch_b, &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -310,7 +978,8 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     "#);
     // Note how it will create a new stack (to keep it simple),
     // in theory we could also add B as dependent branch.
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:2:A on e5d0542 {41}
     │   └── 📙:2:A
@@ -321,10 +990,168 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     // Nothing changed visibly, still, it's all in the metadata.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
-    // TODO: create
-    // TODO: commit/uncommit
-    // TODO: unapply
+    let out = but_workspace::branch::unapply(branch_b, &ws, &repo, &mut meta, unapply_options())?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+    └── ≡📙:2:A on e5d0542 {41}
+        └── 📙:2:A
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    Ok(())
+}
+
+#[test]
+fn unapply_natural_stack_with_partial_workspace_metadata() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-two-stacks",
+            |meta| {
+                add_stack_with_segments(meta, 1, "B", StackState::InWorkspace, &["not-in-graph"]);
+            },
+        )?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "A is naturally visible, and B has metadata that matches it with an extra segment in metadata that's not there", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:3:B on 85efbe4 {1}
+    │   └── 📙:3:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡:4:A on 85efbe4
+        └── :4:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "A is removed and B is left", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:3:B on 85efbe4 {1}
+        └── 📙:3:B
+            └── ·c813d8d (🏘️)
+    ");
+
+    let ws_md = out.workspace.metadata.as_ref().expect("present");
+    insta::assert_debug_snapshot!(&ws_md,"the extra segment is still present in metadata to help with stack identities", @r#"
+    Workspace {
+        ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
+        stacks: [
+            WorkspaceStack {
+                id: 00000000-0000-0000-0000-000000000001,
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: "refs/heads/B",
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: "refs/heads/not-in-graph",
+                        archived: false,
+                    },
+                ],
+                workspacecommit_relation: Merged,
+            },
+        ],
+        target_ref: "refs/remotes/origin/main",
+        target_commit_id: Sha1(85efbe4d5a663bff0ed8fb5fbc38a72be0592f55),
+        push_remote: None,
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn unapply_natural_stack_branch_without_workspace_metadata() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack-files",
+            |_meta| {},
+        )?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "a single and multi-branch stack are visible without any workspace metadata", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+    ├── ≡:3:C on 893d602
+    │   ├── :3:C
+    │   │   └── ·356de85 (🏘️)
+    │   └── :5:B
+    │       └── ·f25f65c (🏘️)
+    └── ≡:4:A on 893d602
+        └── :4:A
+            └── ·26e45af (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/C"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+
+    insta::assert_snapshot!(graph_workspace_determinisitcally(&out.workspace), "C was unapplied, and the workspace commit removed", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+    └── ≡📙:3:A on 893d602 {1}
+        └── 📙:3:A
+            └── ·26e45af (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?,"the workspace commit isn't retained due to the workspace disposition", @"
+    * 26e45af (HEAD -> gitbutler/workspace, A) A
+    | * 356de85 (C) C
+    | * f25f65c (B) B
+    |/  
+    * 893d602 (origin/main, main) M
+    ");
+
+    let ws_md = out.workspace.metadata.as_ref().expect("present");
+    insta::assert_snapshot!(sanitize_uuids_and_timestamps(format!("{ws_md:#?}")), "the metadata matches the real workspace now", @r#"
+    Workspace {
+        ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
+        stacks: [
+            WorkspaceStack {
+                id: 1,
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: "refs/heads/C",
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: "refs/heads/B",
+                        archived: false,
+                    },
+                ],
+                workspacecommit_relation: Outside,
+            },
+            WorkspaceStack {
+                id: 2,
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: "refs/heads/A",
+                        archived: false,
+                    },
+                ],
+                workspacecommit_relation: Merged,
+            },
+        ],
+        target_ref: "refs/remotes/origin/main",
+        target_commit_id: Sha1(893d6025c9de29ed75369de967e52a1154bbf0ee),
+        push_remote: None,
+    }
+    "#);
     Ok(())
 }
 
@@ -556,10 +1383,44 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
             err.to_string(),
             format!("Cannot add the target '{branch}' branch to its own workspace")
         );
+
+        let out =
+            but_workspace::branch::unapply(r(branch), &ws, &repo, &mut meta, unapply_options())?;
+        assert!(
+            !out.workspace_changed(),
+            "target refs are never applied, so unapplying them is always fulfilled after the call (i.e. they aren't applied)"
+        );
     }
 
-    // TODO: commit/uncommit
-    // TODO: unapply
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+    └── ≡📙:3:A on e5d0542 {41}
+        └── 📙:3:A
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, origin/main, main, B, A) A");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+    )?;
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "the target's local tracking branch is checked out", @"
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+            └── ·e5d0542 ►A, ►B
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "no workspace ref is present anymore", @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
 
     Ok(())
 }
@@ -612,6 +1473,304 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     Ok(())
+}
+
+mod unapply_checked_out {
+    use but_testsupport::gix_testtools::tempfile::TempDir;
+
+    use super::*;
+
+    type Scenario = (
+        TempDir,
+        gix::Repository,
+        but_meta::VirtualBranchesTomlMetadata,
+        but_graph::Workspace,
+    );
+
+    fn virtual_stack_tip_checked_out() -> anyhow::Result<Scenario> {
+        let (tmp, _graph, repo, meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "ws-ref-no-ws-commit-one-stack-one-branch",
+                |meta| {
+                    add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                    add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+                },
+            )?;
+        let initial_graph = visualize_commit_graph_all(&repo)?;
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(initial_graph, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+        }
+
+        git(&repo).args(["checkout", "B"]).run();
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(graph_workspace(&ws), "B is checked out directly, and its stack is virtual", @"
+            📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+            ├── ≡📙:2:A on e5d0542 {1}
+            │   └── 📙:2:A
+            └── ≡👉📙:3:B[🌳] on e5d0542 {2}
+                └── 👉📙:3:B[🌳]
+            ");
+        }
+
+        Ok((tmp, repo, meta, ws))
+    }
+
+    fn real_stack_tip_checked_out() -> anyhow::Result<Scenario> {
+        let (tmp, graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "detached-with-multiple-branches",
+                |_meta| {},
+            )?;
+        let initial_graph = visualize_commit_graph_all(&repo)?;
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(initial_graph, "the initial checkout is detached, so the workspace has no target ref to fall back to", @"
+            * 49d4b34 (A) A1
+            | * f57c528 (B) B1
+            |/  
+            | * aaa195b (HEAD, C) C1
+            |/  
+            * 3183e43 (main) M1
+            ");
+        }
+        let mut ws = graph.into_workspace()?;
+        for branch_to_apply in ["C", "B"] {
+            let out = but_workspace::branch::apply(
+                Category::LocalBranch
+                    .to_full_name(branch_to_apply)?
+                    .as_ref(),
+                &ws,
+                &repo,
+                &mut meta,
+                apply_options(),
+            )?;
+            ws = out.workspace.into_owned();
+        }
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(graph_workspace(&ws), "C and B are real stacks in the managed workspace", @"
+            📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+            ├── ≡📙:2:C on 3183e43 {43}
+            │   └── 📙:2:C
+            │       └── ·aaa195b (🏘️)
+            └── ≡📙:3:B on 3183e43 {42}
+                └── 📙:3:B
+                    └── ·f57c528 (🏘️)
+            ");
+        }
+
+        git(&repo).args(["checkout", "B"]).run();
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        insta::allow_duplicates! {
+            insta::assert_snapshot!(graph_workspace(&ws), "B is checked out directly, and its stack has a real commit", @"
+            📕🏘️:1:gitbutler/workspace <> ✓! on 3183e43
+            ├── ≡📙:3:C on 3183e43 {43}
+            │   └── 📙:3:C
+            │       └── ·aaa195b (🏘️)
+            └── ≡👉📙:0:B[🌳] on 3183e43 {42}
+                └── 👉📙:0:B[🌳]
+                    └── ·f57c528 (🏘️)
+            ");
+        }
+
+        Ok((tmp, repo, meta, ws))
+    }
+
+    #[test]
+    fn virtual_stack_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = virtual_stack_tip_checked_out()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/B"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )?;
+        insta::assert_debug_snapshot!(out, "the workspace is checked out as the current brnach was unapplied", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                \"refs/heads/gitbutler/workspace\",
+            ),
+        }
+        ");
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace is projected from the managed workspace ref", @"
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+        └── ≡📙:2:A on e5d0542 {1}
+            └── 📙:2:A
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD switches back to the managed workspace when the checked-out branch is unapplied", @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_stack_tip_switches_from_workspace_to_last_stack_when_allowed() -> anyhow::Result<()>
+    {
+        let (_tmp, repo, mut meta, ws) = virtual_stack_tip_checked_out()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/B"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+        )?;
+        insta::assert_debug_snapshot!(out, "the checked-out stack is unapplied, then the remaining stack is checked out directly", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                \"refs/heads/A\",
+            ),
+        }
+        ");
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace is projected from the remaining stack", @"
+        ⌂:0:A[🌳] <> ✓!
+        └── ≡📙:0:A[🌳] {1}
+            └── 📙:0:A[🌳]
+                └── ·e5d0542 ►B, ►main
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD briefly returned to the workspace ref internally, then dissolved it and checked out A (previously virtual)", @"* e5d0542 (HEAD -> A, main, B) A");
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_stack_tip_with_indirect_entrypoint() -> anyhow::Result<()> {
+        let (_tmp, _graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "ws-ref-no-ws-commit-one-stack-one-branch",
+                |meta| {
+                    add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["A"]);
+                },
+            )?;
+
+        git(&repo).args(["checkout", "A"]).run();
+        let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+        insta::assert_snapshot!(graph_workspace(&ws), "A is checked out as a lower segment of the B stack", @"
+        📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+        └── ≡📙:2:B on e5d0542 {2}
+            ├── 📙:2:B
+            └── 👉📙:3:A[🌳]
+        ");
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/B"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )?;
+        insta::assert_debug_snapshot!(out, "the workspace is checked out as the current branch's stack was unapplied", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                \"refs/heads/gitbutler/workspace\",
+            ),
+        }
+        ");
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace is projected from the managed workspace ref", @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD switches back to the managed workspace when the checked-out stack is unapplied", @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+        Ok(())
+    }
+
+    #[test]
+    fn virtual_unrelated_stack_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = virtual_stack_tip_checked_out()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/A"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )?;
+        insta::assert_debug_snapshot!(out, "no change in what's checked out", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: None,
+        }
+        ");
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace preserves the unrelated checked-out entrypoint", @"
+        📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+        └── ≡👉📙:2:B[🌳] on e5d0542 {2}
+            └── 👉📙:2:B[🌳]
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD remains on B while the managed workspace also contains B", @"* e5d0542 (HEAD -> B, main, gitbutler/workspace, A) A");
+        Ok(())
+    }
+
+    #[test]
+    fn real_stack_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = real_stack_tip_checked_out()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/B"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )?;
+        insta::assert_debug_snapshot!(out, "the workspace ref is checked out", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: Some(
+                \"refs/heads/gitbutler/workspace\",
+            ),
+        }
+        ");
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace is projected from the managed workspace ref", @"
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+        └── ≡📙:2:C on 3183e43 {43}
+            └── 📙:2:C
+                └── ·aaa195b (🏘️)
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD switches back to the managed workspace when the checked-out branch is unapplied, without forcing a workspace commit (this is fine, as this is outside of what legacy can do anyway)", @"
+        * 49d4b34 (A) A1
+        | * f57c528 (B) B1
+        |/  
+        | * aaa195b (HEAD -> gitbutler/workspace, C) C1
+        |/  
+        * 3183e43 (main) M1
+        ");
+        Ok(())
+    }
+
+    #[test]
+    fn real_unrelated_stack_tip() -> anyhow::Result<()> {
+        let (_tmp, repo, mut meta, ws) = real_stack_tip_checked_out()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/C"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options(),
+        )?;
+        insta::assert_debug_snapshot!(out, "the checked out branch isn't changed", @"
+        Outcome {
+            workspace_changed: true,
+            checked_out: None,
+        }
+        ");
+
+        insta::assert_snapshot!(graph_workspace(&out.workspace), "the returned workspace preserves the unrelated checked-out entrypoint", @"
+        📕🏘️⚠️:1:gitbutler/workspace <> ✓! on 3183e43
+        └── ≡👉📙:0:B[🌳] on 3183e43 {42}
+            └── 👉📙:0:B[🌳]
+                └── ·f57c528 (🏘️)
+        ");
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "HEAD remains on B while the managed workspace also contains B", @"
+        * 49d4b34 (A) A1
+        | * f57c528 (HEAD -> B, gitbutler/workspace) B1
+        |/  
+        | * aaa195b (C) C1
+        |/  
+        * 3183e43 (main) M1
+        ");
+        Ok(())
+    }
 }
 
 #[test]
@@ -673,13 +1832,8 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     * e31e6ca (origin/main, origin/HEAD) add init
     ");
 
-    let out = but_workspace::branch::apply(
-        r("refs/remotes/origin/B"),
-        &ws,
-        &repo,
-        &mut meta,
-        apply_options(),
-    )?;
+    let branch_b_rt = r("refs/remotes/origin/B");
+    let out = but_workspace::branch::apply(branch_b_rt, &ws, &repo, &mut meta, apply_options())?;
     insta::assert_debug_snapshot!(out, @r#"
     Outcome {
         workspace_changed: true,
@@ -712,6 +1866,171 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     |/  
     * e31e6ca (origin/main, origin/HEAD) add init
     ");
+
+    let out =
+        but_workspace::branch::unapply(branch_b_rt, &ws, &repo, &mut meta, unapply_options())?;
+    insta::assert_debug_snapshot!(out, "remote tracking branches can't be unapplied, as they aren't applied in the first place", @"
+    Outcome {
+        workspace_changed: false,
+        checked_out: None,
+    }
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, "the local tracking branch, howeer, will be unapplied", @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+    ├── ≡📙:1:main on e31e6ca {1a5}
+    │   └── 📙:1:main
+    │       └── ·b1540e5 (🏘️)
+    └── ≡📙:2:A on e31e6ca {41}
+        └── 📙:2:A
+            └── ·bf53300 (🏘️)
+    ");
+    assert!(
+        !repo.workdir_path("B").expect("non-bare").exists(),
+        "unapplying B updates the checked-out workspace tree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.workdir_path("A").expect("non-bare"))?,
+        "A\n"
+    );
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, "A is removed and main is checked out", @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "By default, we keep the workspace, and `main` is in there as a target is missing", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
+    └── ≡📙:1:main {1a5}
+        └── 📙:1:main
+            ├── ·b1540e5 (🏘️)
+            └── ·e31e6ca (🏘️)
+    ");
+    assert!(
+        !repo.workdir_path("A").expect("non-bare").exists(),
+        "unapplying A updates the checked-out workspace tree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.workdir_path("init").expect("non-bare"))?,
+        "init\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> {
+    let (_tmp, mut graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("one-fork", |meta| {
+            meta.data_mut().default_target = None;
+        })?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * bf53300 (A) add A
+    | * b1540e5 (HEAD -> main) M
+    |/  
+    | * 0e391b2 (origin/B) add B
+    |/  
+    * e31e6ca (origin/main, origin/HEAD) add init
+    ");
+    graph.options.extra_target_commit_id = None;
+    let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+            ├── ·b1540e5
+            └── ·e31e6ca
+    ");
+    let out =
+        but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
+    let ws = out.workspace.into_owned();
+    let out = but_workspace::branch::apply(
+        r("refs/remotes/origin/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+    ├── ≡📙:1:main on e31e6ca {1a5}
+    │   └── 📙:1:main
+    │       └── ·b1540e5 (🏘️)
+    ├── ≡📙:2:A on e31e6ca {41}
+    │   └── 📙:2:A
+    │       └── ·bf53300 (🏘️)
+    └── ≡📙:3:B on e31e6ca {42}
+        └── 📙:3:B
+            └── ·0e391b2 (🏘️)
+    ");
+
+    let ws_before = graph_workspace(&ws).to_string();
+    let refs_before = visualize_commit_graph_all(&repo)?;
+    let metadata_before = sanitize_uuids_and_timestamps(format!(
+        "{:#?}",
+        ws.metadata
+            .as_ref()
+            .expect("managed workspace has metadata")
+    ));
+
+    std::fs::write(repo.workdir_path("B").expect("non-bare"), "local edit\n")?;
+    let worktree_before =
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?
+            .to_string();
+    let err =
+        but_workspace::branch::unapply(r("refs/heads/B"), &ws, &repo, &mut meta, unapply_options())
+            .unwrap_err();
+    insta::assert_debug_snapshot!(err, @r#""Worktree changes would be overwritten by checkout: \"B\"""#);
+
+    assert_eq!(
+        visualize_disk_tree_with_hashes_skip_dot_git(repo.workdir().expect("worktree dir"))?
+            .to_string(),
+        worktree_before,
+        "the locally modified file wasn't changed"
+    );
+    assert_eq!(
+        visualize_commit_graph_all(&repo)?,
+        refs_before,
+        "refs must not move when dirty worktree checkout aborts"
+    );
+    let ws_after = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?
+        .into_workspace()?;
+    assert_eq!(graph_workspace(&ws_after).to_string(), ws_before);
+    assert_eq!(
+        sanitize_uuids_and_timestamps(format!(
+            "{:#?}",
+            ws_after
+                .metadata
+                .as_ref()
+                .expect("managed workspace has metadata")
+        )),
+        metadata_before
+    );
     Ok(())
 }
 
@@ -757,7 +2076,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         applied_branches: "[refs/heads/unrelated]",
     }
     "#);
-    // TODO: should this not avoid creating a workspace commit?
+    // TODO: should this not avoid creating a workspace commit? Yes.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f1889e7 (A2) add A2
     * 7de99e1 (A1) add A1
@@ -796,7 +2115,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         &repo,
         &mut meta,
         but_workspace::branch::apply::Options {
-            // TODO: remove this, use default options.
+            // TODO: remove this, use default options when they are the default.
             on_workspace_conflict: OnWorkspaceMergeConflict::MaterializeAndReportConflictingStacks,
             ..apply_options()
         },
@@ -865,6 +2184,164 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         },
     )
     "#);
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A2"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "A2 is removed, along with A1", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    └── ≡📙:3:unrelated on 3183e43 {3c4}
+        └── 📙:3:unrelated
+            └── ·53ad0c2 (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A1"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, "this is a no-op, A1 was removed with A2 prior", @"
+    Outcome {
+        workspace_changed: false,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "nothing changed, this was a no-op" , @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+    └── ≡📙:3:unrelated on 3183e43 {3c4}
+        └── 📙:3:unrelated
+            └── ·53ad0c2 (🏘️)
+    ");
+
+    let opts = unapply_options();
+    assert!(
+        matches!(
+            opts.workspace_disposition,
+            WorkspaceDisposition::KeepWorkspaceReference
+        ),
+        "this should make the workspace commit disappear, but keep the workspace reference"
+    );
+    let out =
+        but_workspace::branch::unapply(r("refs/heads/unrelated"), &ws, &repo, &mut meta, opts)?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43");
+
+    insta::assert_snapshot!(
+        visualize_commit_graph_all(&repo)?, "",
+        @"
+    * f1889e7 (A2) add A2
+    * 7de99e1 (A1) add A1
+    | * 53ad0c2 (unrelated) add U1
+    |/  
+    * 3183e43 (HEAD -> gitbutler/workspace, origin/main, main) M1
+    "
+    );
+    Ok(())
+}
+
+#[test]
+fn unapply_existing_branch_outside_detached_ad_hoc_workspace_is_noop() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "detached-with-multiple-branches",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 49d4b34 (A) A1
+    | * f57c528 (B) B1
+    |/  
+    | * aaa195b (HEAD, C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+    let ws = graph
+        .into_workspace()
+        .expect("detached graph is a workspace");
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:DETACHED <> ✓! on 3183e43
+    └── ≡:0:anon: on 3183e43 {1}
+        └── :0:anon:
+            └── ·aaa195b ►C
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, "it's a noop, the workspace didn't change, the branch was never applied", @"
+    Outcome {
+        workspace_changed: false,
+        checked_out: None,
+    }
+    ");
+    Ok(())
+}
+
+#[test]
+fn unapply_branch_from_detached_ad_hoc_workspace_is_an_error() -> anyhow::Result<()> {
+    let (_tmp, _, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "single-stack-two-segments",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * f1889e7 (A2) add A2
+    * 7de99e1 (A1) add A1
+    | * 53ad0c2 (unrelated) add U1
+    |/  
+    * 3183e43 (HEAD -> main, origin/main) M1
+    ");
+
+    let a2_id = repo.rev_parse_single("A2")?.detach();
+    let ws = Graph::from_commit_traversal_tips(
+        &repo,
+        [Tip::detached_entrypoint(a2_id)],
+        &meta,
+        standard_traversal_options(),
+    )?
+    .into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:DETACHED <> ✓!
+    └── ≡:0:anon: {1}
+        ├── :0:anon:
+        │   └── ·f1889e7 ►A2
+        ├── :1:A1
+        │   └── ·7de99e1
+        └── :2:main[🌳]
+            └── ·3183e43
+    ");
+
+    let unapply_this = r("refs/heads/A1");
+    let err =
+        but_workspace::branch::unapply(unapply_this, &ws, &repo, &mut meta, unapply_options())
+            .expect_err("detached ad-hoc workspaces cannot unapply their contained branch");
+    assert_eq!(
+        err.to_string(),
+        "Cannot unapply a branch from an ad-hoc detached workspace"
+    );
     Ok(())
 }
 
@@ -903,7 +2380,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @"
+    insta::assert_snapshot!(graph_workspace(&ws), "the actual HEAD is ignored, and we only see C (instead of C + HEAD-ref)", @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡📙:2:C on 3183e43 {43}
         └── 📙:2:C
@@ -995,6 +2472,213 @@ fn detached_head_journey() -> anyhow::Result<()> {
     * / 49d4b34 (A) A1
     |/  
     * 3183e43 (main) M1
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "A was removed", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+    ├── ≡📙:2:C on 3183e43 {43}
+    │   └── 📙:2:C
+    │       └── ·aaa195b (🏘️)
+    └── ≡📙:3:B on 3183e43 {42}
+        └── 📙:3:B
+            └── ·f57c528 (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "B was removed", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+    └── ≡📙:2:C on 3183e43 {43}
+        └── 📙:2:C
+            └── ·aaa195b (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/C"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+    )
+    .expect("C can be removed");
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace reference remains checked out and empty because no non-stack fallback exists", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+    ");
+    Ok(())
+}
+
+#[test]
+fn unapply_workspace_ref_without_target_checks_out_named_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "detached-with-multiple-branches",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the initial checkout is detached, so the workspace has no target ref to fall back to", @"
+    * 49d4b34 (A) A1
+    | * f57c528 (B) B1
+    |/  
+    | * aaa195b (HEAD, C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+    let mut ws = graph.into_workspace()?;
+
+    for branch_to_apply in ["C", "B"] {
+        let out = but_workspace::branch::apply(
+            Category::LocalBranch
+                .to_full_name(branch_to_apply)?
+                .as_ref(),
+            &ws,
+            &repo,
+            &mut meta,
+            apply_options(),
+        )?;
+        ws = out.workspace.into_owned();
+    }
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        but_workspace::branch::apply::Options {
+            order: Some(0),
+            ..apply_options()
+        },
+    )?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace has named stacks but no target ref", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+    ├── ≡📙:2:A on 3183e43 {41}
+    │   └── 📙:2:A
+    │       └── ·49d4b34 (🏘️)
+    ├── ≡📙:3:C on 3183e43 {43}
+    │   └── 📙:3:C
+    │       └── ·aaa195b (🏘️)
+    └── ≡📙:4:B on 3183e43 {42}
+        └── 📙:4:B
+            └── ·f57c528 (🏘️)
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/gitbutler/workspace"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+    )
+    .expect("workspace ref can be unapplied by falling back to a named stack");
+    insta::assert_debug_snapshot!(out, "without a target ref, unapplying the workspace ref checks out the named stack with the lowest generation", @r#"
+    Outcome {
+        workspace_changed: true,
+        checked_out: Some(
+            "refs/heads/A",
+        ),
+    }
+    "#);
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the projection shows the checked-out named stack", @"
+    ⌂:0:A[🌳] <> ✓! on 3183e43
+    └── ≡:0:A[🌳] on 3183e43 {1}
+        └── :0:A[🌳]
+            └── ·49d4b34
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the managed workspace ref is deleted and HEAD points to the fallback stack", @r"
+    * 49d4b34 (HEAD -> A) A1
+    | * f57c528 (B) B1
+    |/  
+    | * aaa195b (C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+    Ok(())
+}
+
+#[test]
+fn unapply_workspace_ref_refuses_conflicted_named_stack_checkout() -> anyhow::Result<()> {
+    let (_tmp, _, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("with-conflict", |meta| {
+            meta.data_mut().default_target = None;
+        })?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the fixture starts on a conflicted main commit", @"
+    * 8450331 (HEAD -> main, tag: conflicted) GitButler WIP Commit
+    * a047f81 (tag: normal) init
+    ");
+
+    git(&repo)
+        .args(["branch", "tip-conflicted", "conflicted"])
+        .run();
+    git(&repo).args(["reset", "--hard", "normal"]).run();
+
+    let ws = Graph::from_head(&repo, &meta, standard_traversal_options())?.into_workspace()?;
+    let out = but_workspace::branch::apply(
+        r("refs/heads/tip-conflicted"),
+        &ws,
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the target-less workspace can contain a conflicted named stack", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
+    └── ≡📙:1:tip-conflicted {595}
+        ├── 📙:1:tip-conflicted
+        │   └── ·8450331 (🏘️) ►tags/conflicted
+        └── 📙:2:main
+            └── ·a047f81 (🏘️) ►tags/normal
+    ");
+
+    let err = but_workspace::branch::unapply(
+        r("refs/heads/gitbutler/workspace"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+    )
+    .expect_err("workspace ref unapply must not check out conflicted stack tips");
+    assert_eq!(
+        err.to_string(),
+        "Cannot unapply workspace reference by checking out conflicted commit at 'tip-conflicted'"
+    );
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the failed unapply leaves HEAD and the workspace ref unchanged", @"
+    * 8a0bbba (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8450331 (tag: conflicted, tip-conflicted) GitButler WIP Commit
+    * a047f81 (tag: normal, main) init
     ");
     Ok(())
 }
@@ -1176,7 +2860,275 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     * 85efbe4 (origin/main, main) M
     ");
 
-    // TODO: add all other dependent branches as well.
+    // What follows is a bit wonky, but for now is here to document what happens in a complex scenario.
+    let out =
+        but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, apply_options())
+            .expect("apply actually works");
+    insta::assert_debug_snapshot!(out, "applying C succeeds and updates the workspace metadata", @r#"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+        applied_branches: "[refs/heads/C]",
+    }
+    "#);
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "C is recorded as another segment at the same tip in the B/A stack", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:B on 85efbe4 {41}
+        ├── 📙:4:B
+        ├── 📙:5:C
+        └── 📙:6:A
+            ├── ·f084d61 (🏘️)
+            └── ·7076dee (🏘️) ►D, ►E
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "adding C only changes workspace metadata, not Git refs or objects", @"
+    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/D"), &ws, &repo, &mut meta, apply_options())
+            .expect("apply actually works");
+    insta::assert_debug_snapshot!(out, "applying D succeeds and updates the workspace metadata", @r#"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+        applied_branches: "[refs/heads/D]",
+    }
+    "#);
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "D becomes a lower segment in the same projected stack, leaving E as the remaining alternate ref at that commit", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:5:B on 85efbe4 {41}
+        ├── 📙:5:B
+        ├── 📙:6:C
+        ├── 📙:7:A
+        │   └── ·f084d61 (🏘️)
+        └── 📙:4:D
+            └── ·7076dee (🏘️) ►E
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "adding D also remains metadata-only even though the stack presentation changes", @"
+    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/E"), &ws, &repo, &mut meta, apply_options())
+            .expect("apply actually works");
+    insta::assert_debug_snapshot!(out, "applying E forces the lower same-commit branch pair into its own stack", @r#"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+        applied_branches: "[refs/heads/E]",
+    }
+    "#);
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "applying all ambiguous dependent branches ends with B/C/A and E/D split into two stacks", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:B {41}
+    │   ├── 📙:5:B
+    │   ├── 📙:6:C
+    │   └── 📙:7:A
+    │       └── ·f084d61 (🏘️)
+    └── ≡📙:8:E on 85efbe4 {44}
+        ├── 📙:8:E
+        └── 📙:9:D
+            └── ·7076dee (🏘️)
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "future improvement: it should most definitely not create a merge if both tips have shared in-workspace commits in their ancestry", @r"
+    *   2c125a1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    * | f084d61 (C, B, A) A2
+    |/  
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/E"),
+        &ws,
+        &repo,
+        &mut meta,
+        legacy_unapply_options(),
+    )
+    .expect("unapply actually works");
+    insta::assert_debug_snapshot!(out, "unapplying E removes the E/D stack and keeps the B/C/A stack applied", @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    assert!(
+        out.workspace_merge.is_some(),
+        "legacy mode should rebuild the workspace commit after removing E/D"
+    );
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "after unapplying E, legacy mode keeps a workspace commit", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:B on 85efbe4 {41}
+        ├── 📙:4:B
+        ├── 📙:5:C
+        └── 📙:6:A
+            ├── ·f084d61 (🏘️)
+            └── ·7076dee (🏘️) ►D, ►E
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "after unapplying E, the workspace commit contains only the remaining B/C/A stack", @"
+    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/D"),
+        &ws,
+        &repo,
+        &mut meta,
+        legacy_unapply_options(),
+    )
+    .expect("unapply actually works");
+    insta::assert_debug_snapshot!(out, "unapplying D after E is already gone is a no-op", @"
+    Outcome {
+        workspace_changed: false,
+        checked_out: None,
+    }
+    ");
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the B/C/A stack stays applied after the D no-op", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:B on 85efbe4 {41}
+        ├── 📙:4:B
+        ├── 📙:5:C
+        └── 📙:6:A
+            ├── ·f084d61 (🏘️)
+            └── ·7076dee (🏘️) ►D, ►E
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the Git graph is unchanged after the D no-op", @"
+    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/C"),
+        &ws,
+        &repo,
+        &mut meta,
+        legacy_unapply_options(),
+    )
+    .expect("unapply actually works");
+    insta::assert_debug_snapshot!(out, "unapplying C removes that middle metadata segment from B/C/A", @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "after unapplying C, B/A remains applied with C only as an ambiguous ref on A's tip", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:B on 85efbe4 {41}
+        ├── 📙:4:B
+        └── 📙:5:A
+            ├── ·f084d61 (🏘️) ►C
+            └── ·7076dee (🏘️) ►D, ►E
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the Git graph is unchanged after removing C from metadata", @"
+    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        legacy_unapply_options(),
+    )
+    .expect("unapply actually works");
+    insta::assert_debug_snapshot!(out, "unapplying B removes the remaining B/A applied stack", @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "after unapplying B, no applied stacks remain", @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "after unapplying B, there are no mergeable stacks left so legacy mode keeps an empty workspace commit", @"
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    | * bde8ed6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        legacy_unapply_options(),
+    )
+    .expect("unapply actually works");
+    insta::assert_debug_snapshot!(out, "unapplying A after B removed the remaining stack is a no-op", @"
+    Outcome {
+        workspace_changed: false,
+        checked_out: None,
+    }
+    ");
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace stays empty after the A no-op", @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the Git graph is unchanged after the A no-op", @"
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    | * bde8ed6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/gitbutler/workspace"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options_with(WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences),
+    )
+    .expect("workspace ref can be unapplied by checking out a named target");
+    insta::assert_debug_snapshot!(out, "unapplying the workspace ref switches to the target's local branch when the disposition allows deleting the workspace ref", @r#"
+    Outcome {
+        workspace_changed: true,
+        checked_out: Some(
+            "refs/heads/main",
+        ),
+    }
+    "#);
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the projection is the checked-out target branch", @"
+    ⌂:0:main[🌳] <> ✓! on 85efbe4
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, "the managed workspace ref is deleted and HEAD points to main", @"
+    * f084d61 (C, B, A) A2
+    * 7076dee (E, D) A1
+    * 85efbe4 (HEAD -> main, origin/main) M
+    ");
+
     Ok(())
 }
 
@@ -1204,13 +3156,10 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     * 85efbe4 (main, gitbutler/workspace) M
     ");
 
-    assert!(git(&repo).args(["checkout", "main"]).status()?.success());
-    assert!(
-        git(&repo)
-            .args(["branch", "-d", "gitbutler/workspace"])
-            .status()?
-            .success()
-    );
+    git(&repo).args(["checkout", "main"]).run();
+    git(&repo)
+        .args(["branch", "-d", "gitbutler/workspace"])
+        .run();
     // The fixture helper created `graph` while `HEAD` still pointed to `conflict-hero`.
     // Replaying that graph would correctly keep using `conflict-hero` as the traversal
     // entrypoint, even though the test just checked out `main`. Build the graph from
@@ -1495,6 +3444,101 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
 }
 
 #[test]
+fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repeat_on_unapply()
+-> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "various-heads-for-multi-line-merge-conflict-on-main",
+            |_meta| {},
+        )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * d3cce74 (clean-A) add A
+    | * 115e41b (clean-B) add B
+    |/  
+    | * 34c4591 (clean-C) add C
+    |/  
+    | * bf09eae (conflict-F1) add F1
+    |/  
+    | * f2ce66d (conflict-F2) add F2
+    |/  
+    | * 4bbb93c (conflict-hero) add conflicting-F2
+    | * 98519e9 add conflicting-F1
+    |/  
+    * 85efbe4 (HEAD -> main) M
+    ");
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:main[🌳] <> ✓! on 85efbe4
+    └── ≡:0:main[🌳] {1}
+        └── :0:main[🌳]
+    ");
+    let branches = [
+        "clean-A",
+        "conflict-F1",
+        "clean-B",
+        "conflict-F2",
+        "clean-C",
+        "conflict-hero",
+    ];
+    for branch_to_apply in branches {
+        let out = but_workspace::branch::apply(
+            Category::LocalBranch
+                .to_full_name(branch_to_apply)?
+                .as_ref(),
+            &ws,
+            &repo,
+            &mut meta,
+            but_workspace::branch::apply::Options {
+                on_workspace_conflict:
+                    OnWorkspaceMergeConflict::MaterializeAndReportConflictingStacks,
+                ..apply_options()
+            },
+        )?;
+        ws = out.workspace.into_owned();
+    }
+    insta::assert_snapshot!(graph_workspace(&ws), "all branches are applied", @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+    ├── ≡📙:6:main on 85efbe4 {1a5}
+    │   └── 📙:6:main
+    ├── ≡📙:2:clean-A on 85efbe4 {271}
+    │   └── 📙:2:clean-A
+    │       └── ·d3cce74 (🏘️)
+    ├── ≡📙:3:clean-B on 85efbe4 {272}
+    │   └── 📙:3:clean-B
+    │       └── ·115e41b (🏘️)
+    ├── ≡📙:4:clean-C on 85efbe4 {273}
+    │   └── 📙:4:clean-C
+    │       └── ·34c4591 (🏘️)
+    └── ≡📙:5:conflict-hero on 85efbe4 {52d}
+        └── 📙:5:conflict-hero
+            ├── ·4bbb93c (🏘️)
+            └── ·98519e9 (🏘️)
+    ");
+
+    for branch_to_unapply in branches.into_iter().rev() {
+        let out = but_workspace::branch::unapply(
+            Category::LocalBranch
+                .to_full_name(branch_to_unapply)?
+                .as_ref(),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(WorkspaceDisposition::KeepWorkspaceReference),
+        )?;
+        ws = out.workspace.into_owned();
+    }
+
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace ref remains because the regenerated workspace still has main available", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+    └── ≡📙:2:main on 85efbe4 {1a5}
+        └── 📙:2:main
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
@@ -1593,17 +3637,16 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         standard_traversal_options_with_extra_target(&repo),
     )?
     .into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"
+    insta::assert_snapshot!(graph_workspace(&ws), "V-branch B is checked out", @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡👉📙:2:B on e5d0542 {2}
         ├── 👉📙:2:B
         └── 📙:3:A
     ");
 
-    // Nothing changed, the desired branch was already applied.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, apply_options())?;
-    insta::assert_debug_snapshot!(out, @r#"
+    insta::assert_debug_snapshot!(out, "Nothing changed, the desired branch was already applied", @r#"
     Outcome {
         workspace_changed: false,
         workspace_ref_created: false,
@@ -1620,7 +3663,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     )?
     .into_workspace()?;
     // There is nothing yet.
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws), "metadata defines no branches", @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Apply the first branch, it must be independent.
     let out =
@@ -1639,9 +3682,79 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         └── 📙:2:A
     ");
 
-    // TODO: apply second branch as new stack.
+    // Apply the first branch, it must be independent.
+    let out =
+        but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, apply_options())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        workspace_changed: true,
+        workspace_ref_created: false,
+        applied_branches: "[refs/heads/B]",
+    }
+    "#);
+    insta::assert_snapshot!(graph_workspace(&out.workspace), "B is added as independent stack", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+    ├── ≡📙:2:A on e5d0542 {41}
+    │   └── 📙:2:A
+    └── ≡📙:3:B on e5d0542 {42}
+        └── 📙:3:B
+    ");
 
-    // NOTE: we could also do it as independent branch, but that just adds complexity and it's unclear when this will be used.
+    let (b_id, b_ref) = id_at(&repo, "B");
+    let ws = but_graph::Graph::from_commit_traversal(
+        b_id,
+        b_ref.clone(),
+        &meta,
+        standard_traversal_options_with_extra_target(&repo),
+    )?
+    .into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), "the same result when checked out directly", @"
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
+    ├── ≡📙:2:A on e5d0542 {41}
+    │   └── 📙:2:A
+    └── ≡👉📙:3:B on e5d0542 {42}
+        └── 👉📙:3:B
+    ");
+
+    let ws = out.workspace.into_owned();
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/A"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace is empty again", @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+    └── ≡📙:2:B on e5d0542 {42}
+        └── 📙:2:B
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    let out = but_workspace::branch::unapply(
+        r("refs/heads/B"),
+        &ws,
+        &repo,
+        &mut meta,
+        unapply_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @"
+    Outcome {
+        workspace_changed: true,
+        checked_out: None,
+    }
+    ");
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), "the workspace is empty again", @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     Ok(())
 }
 
@@ -1783,8 +3896,40 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "TBD: needs unapply"]
 fn unapply_nonexisting_branch() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        named_read_only_in_memory_scenario("ws-ref-no-ws-commit-one-stack-one-branch", "")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    meta.data_mut()
+        .default_target
+        .as_mut()
+        .expect("workspace configured")
+        .sha = gix::hash::Kind::Sha1.null();
+    let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
+    └── ≡:1:anon:
+        └── :1:anon:
+            └── ·e5d0542 (🏘️) ►A, ►B, ►main
+    ");
+
+    let err = but_workspace::branch::unapply(
+        r("refs/heads/does-not-exist"),
+        &ws,
+        &repo,
+        &mut *meta,
+        unapply_options(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Cannot unapply non-existing branch 'does-not-exist'"
+    );
+
+    // Nothing should be changed
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     Ok(())
 }
 
@@ -1844,22 +3989,40 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
         └── :0:main[🌳]
     ");
 
-    // TODO: can we reproduce this original error?
-    // assert_eq!(
-    //     err.to_string(),
-    //     "Cannot create reference on unborn branch 'main'"
-    // );
     Ok(())
 }
 
 fn apply_options() -> but_workspace::branch::apply::Options {
     but_workspace::branch::apply::Options {
+        // TODO: make this the Default once it's MergeIfNeeded.
         workspace_merge: WorkspaceMerge::MergeIfNeeded,
         on_workspace_conflict: OnWorkspaceMergeConflict::AbortAndReportConflictingStacks,
         workspace_reference_naming: WorkspaceReferenceNaming::Default,
         uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
         order: None,
         new_stack_id: Some(stack_id_for_name),
+    }
+}
+
+fn unapply_options() -> but_workspace::branch::unapply::Options {
+    but_workspace::branch::unapply::Options {
+        // TODO: make this the Default once it's KeepWorkspaceReference.
+        workspace_disposition: WorkspaceDisposition::KeepWorkspaceReference,
+        uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+    }
+}
+
+/// Legacy because we plan to only have the commits we really need.
+fn legacy_unapply_options() -> but_workspace::branch::unapply::Options {
+    unapply_options_with(WorkspaceDisposition::KeepWorkspaceCommit)
+}
+
+fn unapply_options_with(
+    disposition: WorkspaceDisposition,
+) -> but_workspace::branch::unapply::Options {
+    but_workspace::branch::unapply::Options {
+        workspace_disposition: disposition,
+        ..unapply_options()
     }
 }
 

--- a/crates/but-workspace/tests/workspace/branch/mod.rs
+++ b/crates/but-workspace/tests/workspace/branch/mod.rs
@@ -1,5 +1,5 @@
-/// Various journeys with apply, unapply and commit operations.
-mod apply_unapply_commit_uncommit;
+/// Various journeys with apply and unapply operations.
+mod apply_unapply;
 mod create_reference;
 mod move_branch;
 mod remove_reference;

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -10,9 +10,10 @@ mod uncommit_changes;
 
 mod from_new_merge_with_metadata {
     use bstr::ByteSlice;
+    use but_core::ref_metadata::WorkspaceCommitRelation::Outside;
     use but_graph::init::{Options, Overlay};
     use but_testsupport::{visualize_commit_graph_all, visualize_tree};
-    use but_workspace::WorkspaceCommit;
+    use but_workspace::{WorkspaceCommit, commit::merge::Tip};
     use gix::{prelude::ObjectIdExt, refs::Target};
 
     use crate::ref_info::with_workspace_commit::utils::{
@@ -149,6 +150,62 @@ mod from_new_merge_with_metadata {
         ├── B:100644:223b783 "B\n"
         ├── C:100644:3cc58df "C\n"
         └── D:100644:1784810 "D\n"
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn anonymous_tip_after_removed_parent_slot() -> anyhow::Result<()> {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("various-heads-for-clean-merge", "")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+        * d3cce74 (add-A) add A
+        | * 115e41b (add-B) add B
+        |/  
+        | * 34c4591 (add-C) add C
+        |/  
+        | * 27ab782 (HEAD -> add-D) add D
+        |/  
+        * 85efbe4 (main, gitbutler/workspace) M
+        ");
+        add_stacks(&mut meta, ["add-A", "add-B", "add-C"]);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+
+        let add_c_ref = "refs/heads/add-C".try_into()?;
+        let (segment, commit) = graph
+            .segment_and_commit_by_ref_name(add_c_ref)
+            .expect("add-C is visible in the graph");
+        let anon_c_tip = Tip {
+            name: None,
+            commit_id: commit.id,
+            segment_idx: segment.id,
+        };
+
+        let mut stacks = to_stacks(["add-A", "add-D", "add-B"]);
+        stacks
+            .get_mut(1)
+            .expect("add-D is the skipped metadata slot")
+            .workspacecommit_relation = Outside;
+
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &stacks,
+            [(2, anon_c_tip)],
+            &graph,
+            &repo,
+            None,
+        )?;
+
+        insta::assert_debug_snapshot!(out, "anonymous stacks preserve order after filtered named parents", @r#"
+        Outcome {
+            workspace_commit_id: Sha1(24731387ff4bfbd9c803b388d8f65ca64a9d87b3),
+            stacks: [
+                Stack { tip: d3cce74, name: "add-A" },
+                Stack { tip: 34c4591, name: None },
+                Stack { tip: 115e41b, name: "add-B" },
+            ],
+            missing_stacks: [],
+            conflicting_stacks: [],
+        }
         "#);
         Ok(())
     }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -49,7 +49,7 @@ fn commit_id_works_with_two_or_more_characters() -> anyhow::Result<()> {
     let id1 = id(1);
     let stacks = vec![stack([segment("not-important", [id1], None, [])])];
     let id_map = IdMap::new(stacks, Vec::new())?;
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ no ]
     ");
@@ -118,7 +118,7 @@ fn commit_ids_become_longer_if_ambiguous() -> anyhow::Result<()> {
     let id3 = hex_to_id("21bccccccccccccccccccccccccccccccccccccc");
     let stacks = vec![stack([segment("not-important", [id1, id2, id3], None, [])])];
     let id_map = IdMap::new(stacks, Vec::new())?;
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 3
     branches: [ no ]
     ");
@@ -168,7 +168,7 @@ fn branches_work_with_single_character() -> anyhow::Result<()> {
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ g0 ]
     ");
@@ -206,7 +206,7 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 4
     branches: [ az, g0, h0, i0 ]
     ");
@@ -251,7 +251,7 @@ fn branches_avoid_unassigned_area_id() -> anyhow::Result<()> {
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ za ]
     ");
@@ -276,7 +276,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         segment("0ax", [id(2)], None, []),
     ])];
     let id_map = IdMap::new(stacks, Vec::new())?;
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 2
     branches: [ ax, yz ]
     ");
@@ -319,7 +319,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ ij ]
     uncommitted_files: [ nx, yz ]
@@ -351,7 +351,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 2
     branches: [ g0, up ]
     ");
@@ -397,7 +397,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         hunk_assignment("uncommitted2.txt", None),
     ];
     let id_map = IdMap::new(stacks, hunk_assignments)?;
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
     uncommitted_files: [ kv, ro ]
@@ -561,7 +561,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
             bail!("unexpected IDs {commit_id} {parent_id:?}");
         })
     };
-    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
     uncommitted_files: [ ln ]

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -58,7 +58,7 @@ Hint: you can run `but undo` to undo these changes
     // Change was absorbed
     let repo = env.open_repo()?;
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
-    insta::assert_snapshot!(blob.data.as_bstr(), @r"
+    insta::assert_snapshot!(blob.data.as_bstr(), @"
     firsta
     line
     line
@@ -136,7 +136,7 @@ Hint: you can run `but undo` to undo these changes
     // Change was partially absorbed
     let repo = env.open_repo()?;
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
-    insta::assert_snapshot!(blob.data.as_bstr(), @r"
+    insta::assert_snapshot!(blob.data.as_bstr(), @"
     firsta
     line
     line
@@ -481,7 +481,7 @@ Dry run complete. No changes were made.
     // Verify the file content wasn't actually changed
     let repo = env.open_repo()?;
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
-    insta::assert_snapshot!(blob.data.as_bstr(), @r"
+    insta::assert_snapshot!(blob.data.as_bstr(), @"
     first
     line
     line

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -90,11 +90,11 @@ use crate::command::branch::apply::utils::create_local_branch_with_commit_with_m
 #[test]
 fn local_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -138,11 +138,11 @@ refs/heads/feature-branch
 #[test]
 fn local_branch_with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -207,11 +207,11 @@ fn local_branch_with_json_output() -> anyhow::Result<()> {
 #[test]
 fn remote_branch_creates_local_tracking_branch_automatically() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -251,11 +251,11 @@ Applied remote branch 'origin/remote-feature' to workspace
 #[test]
 fn remote_branch_short_name_resolves_to_unique_remote_tracking_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -296,11 +296,11 @@ Applied remote branch 'origin/remote-feature' to workspace
 fn remote_branch_short_name_requires_disambiguation_across_multiple_remotes() -> anyhow::Result<()>
 {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -417,11 +417,11 @@ Failed to apply branch. The reference 'nonexistent-branch' did not exist
 #[test]
 fn multiple_branches_sequentially() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -5,11 +5,11 @@ use crate::utils::{CommandExt, Sandbox};
 #[test]
 fn outputs_branch_name() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -68,11 +68,11 @@ Error: Could not turn "HEAD-" into a valid reference name
 #[test]
 fn with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -10,11 +10,11 @@ use crate::{
 #[test]
 fn single_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -45,9 +45,9 @@ Unapplied stack with branches 'feature-branch' from workspace
 "#]]);
 
     // Verify the branch is removed from workspace
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * 9f9d5a6 (feature-branch) Add feature
-    | * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
@@ -59,11 +59,11 @@ Unapplied stack with branches 'feature-branch' from workspace
 #[test]
 fn unapply_with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -81,9 +81,9 @@ fn unapply_with_json_output() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * 9f9d5a6 (feature-branch) Add feature
-    | * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
@@ -201,11 +201,11 @@ Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
 #[test]
 fn unapply_remote_tracking_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-");
+    insta::assert_snapshot!(env.git_log()?, @"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
 
     env.setup_metadata(&["A"])?;
 
@@ -242,8 +242,8 @@ Unapplied stack with branches 'remote-feature' from workspace
 "#]]);
 
     // Verify it was removed from workspace
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    insta::assert_snapshot!(env.git_log()?, @"
+    * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
     |/  

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -6,7 +6,7 @@ use crate::utils::Sandbox;
 #[test]
 fn commit_with_message_from_file() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -66,7 +66,7 @@ Caused by:
 #[test]
 fn commit_with_message_flag() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -260,7 +260,7 @@ Hint: run `but help` for all commands
 #[test]
 fn commit_empty_with_before_flag() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -289,7 +289,7 @@ Created blank commit before commit 9477ae7
 #[test]
 fn commit_empty_with_positional_target_defaults_to_before() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -454,7 +454,7 @@ Hint: run `but help` for all commands
 #[test]
 fn commit_empty_with_after_commit() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -6,7 +6,7 @@ use crate::utils::Sandbox;
 #[test]
 fn reword_commit_with_message_flag() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -35,7 +35,7 @@ Updated commit message for [..] (now [..])
 #[test]
 fn reword_commit_with_multiline_message() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -121,7 +121,7 @@ Error: Could not turn "HEAD" into a valid reference name
 #[test]
 fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M
@@ -144,7 +144,7 @@ No changes to commit message - nothing to be done
 #[test]
 fn reword_commit_with_json_flag() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -541,9 +541,9 @@ fn squash_multiple_commits_keeps_squashed_commit_content() -> anyhow::Result<()>
     let second_blob = repo.rev_parse_single(b"A:A-file2.txt")?.object()?;
     let third_blob = repo.rev_parse_single(b"A:A-file3.txt")?.object()?;
 
-    insta::assert_snapshot!(first_blob.data.as_bstr(), @"content for commit 1\n");
-    insta::assert_snapshot!(second_blob.data.as_bstr(), @"content for commit 2\n");
-    insta::assert_snapshot!(third_blob.data.as_bstr(), @"content for commit 3\n");
+    insta::assert_snapshot!(first_blob.data.as_bstr(), @"content for commit 1");
+    insta::assert_snapshot!(second_blob.data.as_bstr(), @"content for commit 2");
+    insta::assert_snapshot!(third_blob.data.as_bstr(), @"content for commit 3");
 
     let log_after = env.git_log()?;
     assert!(
@@ -732,7 +732,7 @@ fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> anyh
 
     let repo = env.open_repo()?;
     let new_file_blob = repo.rev_parse_single(b"B:new-file")?.object()?;
-    insta::assert_snapshot!(new_file_blob.data.as_bstr(), @r"
+    insta::assert_snapshot!(new_file_blob.data.as_bstr(), @"
     1
     2
     3

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -44,7 +44,7 @@ fn worktrees() -> anyhow::Result<()> {
 #[test]
 fn unborn() -> anyhow::Result<()> {
     let env = Sandbox::open_scenario_with_target_and_default_settings("unborn")?;
-    insta::assert_snapshot!(env.git_log()?, @r"");
+    insta::assert_snapshot!(env.git_log()?, @"");
 
     // TODO: make this work
     env.but("status --verbose")

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -7,7 +7,7 @@ use crate::utils::{CommandExt, Sandbox};
 #[test]
 fn single_branch_simple_teardown() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
+    insta::assert_snapshot!(env.git_log()?, @"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
     * 0dc3733 (origin/main, origin/HEAD, main) add M

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -172,7 +172,7 @@ fn from_workspace() -> anyhow::Result<()> {
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main) add M
     ");
-    insta::assert_snapshot!(env.git_status()?, @r"");
+    insta::assert_snapshot!(env.git_status()?, @"");
 
     // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
     env.setup_metadata(&["A", "B"])?;

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -995,6 +995,8 @@ export type ExtraCsp = {
 export type FeatureFlags = {
   /** Turn on the set a v3 version of checkout */
   cv3: boolean;
+  /** Enable the V3 unapply implementation. */
+  unapplyV3: boolean;
   /**
    * Enable undo/redo support.
    *

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -997,6 +997,8 @@ export type FeatureFlags = {
   cv3: boolean;
   /** Enable the V3 unapply implementation. */
   unapplyV3: boolean;
+  /** Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref. */
+  unapplyV3Pgm: boolean;
   /**
    * Enable undo/redo support.
    *


### PR DESCRIPTION
Get `unapply()` going, turning the existing tests into small journeys.

Try to merge this early once it's *basically* working, behind a feature toggle.

Follow-up of #10863.

> [!NOTE]
> While unapply v3 can do more, it's currently configured to have the legacy behaviour which allows empty workspaces. To me this is much like a way of working for those that want workspaces most of the time.

### Notes for the Reviewer

- Testable with the `unapplyV3` feature toggle in `settings.json` (not available in the GUI yet)
    - If you want to try the new "auto-switch to single-branch mode" without breaking mutations, use the `WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences` mode via `unapplyV3Pgm`. **Warning**: While it works there are still some rough'ish edges around metadata, but that can be a follow-up.
- nearly 2k deletions come from a file rename that doesn't get recognized as such anymore. Most added lines are tests, `but-debug` additions and wiring
- You can now 'unapply' the whole workspace to dissolve it.
- Right now it's still *configured* to match the previous implementation's behaviour, so it will keep workspce refs and workspace commits even when not required.
    - other dispositions can be enabled. I implemented two that both have value. One allows to have an empty workspace, the other one will always return to single-branch-mode. Both will remove the workspace commit when there is no need.
- there are special precautions and to my mind useful capabilities even for the times when the user can checkout refs within the workspace directly, *without* losing track of the workspace like it is the case now.

### MVP Tasks

* [x] double-check API and review the unapply tests that are embedded into the apply tests.
* [x] ensure all *needed* or easily implemented options are tested
    - other options should be behind a `todo!` to mark them for future implementation or removal
* [x] but-graph entrypoint API fixes
* [x] double-check reversal/symmetry in existing tests.
* [x] finish initial refackiew
* [x] ideally there are symmetry-tests that validate initial state + apply + unapply == initial state, with various options and initial states.
* [x] there must be a way to unapply `gitbutler/workspace` to dissolve the workspace, and 'clean up' previously empty workspace commits that aren't actually needed
* [x] prohibit unapplying stacks with conflicts in the commit to checkout - should probably be handled by safe-checkout
    - However, stacks with conflicts outside of the tip can still be unapplied, and from there they can easily be pushed.
* [x] Test `WorkspaceDisposition` specifically, may options are untested and maybe even underspecified. Maybe from there it's clear which option we probably don't want. But if anything is unnecessary  it's probably `RemoveWorkspaceMergeCommitAndSwitch`.
* [x] unapply branch that is checked out directly in the current workspace is prohibited
* [x] wire up the new unapply with a hidden feature toggle
* [x] refackiew wiring
* [x] make it work for `but` tests
* [x] make removal logic more independent of workspace metadata
* [x] validate that PGM mode truly switches back to the last remaining stack IRL

### Follow-up

* Rename `WorkspaceMerge` in `unapply` and `apply` to `WorkspaceMergeCommit`
* fix apply bug indicated by last TODO
* follow-up on remaining "all tasks"

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.
    - But that's OK as we don't currently store stashes anyway for a lack of UI support to try to apply them.
* anonymous/unnamed stacks can't be unapplied, which can lave  a workspace 'stuck' unless one can unapply the entire workspace to dissolve it.
* DryRun isn't supported yet, but it would be good to support previews of unapply in future.
* inability to checkout new workspace heads due to lack of stashing, as before.
    - assignments have to be handled as part of standard checkout conflict handling with uncommitted changes as fallback. Besides that, the current handling of creating a 'special' commit before unapplying *might* be desirable, even though I feel it's a surprise and this is better solved as stash.

### All Tasks

General note: this operates under the assumption that anything that refers to a stack to be unapplied handles that it is unapplied automatically, i.e. it reconciles automatically. We do not create snapshots yet.

* [x] read-up on [notion](https://www.notion.so/gitbutler/Thoughts-on-Unapply-2ef5a4bfdeac807eace8c05d3861a5ba) and update analysis.

**The checkboxes and notes were generated based on this branch, and might need validation beyond the ones that are still unticked.**

* [x] API sketch
* [x] unapply non-tips
  - Covered by `apply_multiple_segments_of_stack_in_order_merge_if_needed` and `apply_two_ambiguous_stacks_with_target`, including removing middle metadata segments like `C`.
- [x] unapply a branch in a workspace without workspace commit
  - Covered by `ws_ref_no_ws_commit_two_stacks_on_same_commit` and `ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first`.
- [x] unapply in single-branch mode (anything)
  - Covered in the ad-hoc/single-branch sense by `unapply_tip_of_ad_hoc_branch_is_an_error` and `unapply_branch_from_named_ad_hoc_workspace_affects_metadata`.
- [x] unapply a branch in an enclosing workspace
  - Covered by `unapply_checked_out::virtual_stack_tip`, `unapply_checked_out::real_stack_tip`, and indirect-entrypoint coverage in `unapply_checked_out::virtual_stack_tip_with_indirect_entrypoint`.
- [ ] unapply of unapplied branch, but one that has metadata (also check the metadata)
  - There are no-op cases for already-unapplied branches, but I did not find a test that also asserts the metadata remains correct afterward.
- [ ] unapply a branch whose tip advanced outside of the workspace
  - `workspace_with_out_of_ws_ref_and_anon_stack` covers projection/apply around an advanced outside ref, but not unapply.
- [ ] unapply a branch whose tip is 'recessed', i.e. it's commit is not merged in the workspace commit, but a descendant is. This is an anon-stack technically, and we specify the segment below the tip.
- [x] unapply from 3 to 2 may remove the workspace commit if the remaining stacks are virtual
  - Covered by `workspace_disposition::keep_workspace_reference`; it removes the workspace commit when only one real stack remains alongside a virtual stack.
- [x] should unapply from 2 to 1 always drop the WS-commit? Make it configurable
  - Covered by `workspace_disposition::keep_workspace_commit` and `workspace_disposition::keep_workspace_reference`.
    - [x] ensure it won't checkout the stack reference if there is conflicts in the remaining stack
      - Covered by `unapply_workspace_ref_refuses_conflicted_named_stack_checkout`; lower-level checkout rejection is also covered by `conflicted_commits_cannot_be_checked_out`.
    - [x] ensure it won't checkout the stack reference if there is commits on top of the workspace commit
      - Covered indirectly by `operation_denied_on_improper_workspace`, which refuses unapply when the workspace commit is not at the top.
    - [ ] ensure it won't checkout the stack if it is not named.
- [x] go from 2 -> 1 stacks
  - Covered by `workspace_disposition::*`, `detached_head_journey`, and `unapply_checked_out::*`.
    - [x] with without loosing the WS commit
      - Covered by `workspace_disposition::keep_workspace_commit` versus `workspace_disposition::keep_workspace_reference`.
    - [x] with and without checkout out the last remaining stack (SBR or not)
      - Covered by `unapply_checked_out::real_stack_tip`, `detached_head_journey`, and `unapply_workspace_ref_without_target_checks_out_named_stack`.
    - [x] be sure this fails if worktree changes would conflict (lacking auto-snapshot targets)
      - Covered by `unapply_dirty_worktree_abort_keeps_refs_and_metadata`.
 - [x] go from 1 -> 0 stacks - this can't change branches
    - Covered for the keep-workspace-ref behavior by `ws_ref_no_ws_commit_two_stacks_on_same_commit` and `apply_multiple_segments_of_stack_in_order_merge_if_needed`.
    - Note: `PreventUnnecessaryWorkspaceReferences` tests intentionally can switch away/delete the workspace ref, e.g. `workspace_disposition::allow_workspace_reference_deletion`.
    - [x] with or without loosing the WS commit
      - Covered by `workspace_disposition::allow_workspace_reference_deletion`, `no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target`, and keep-ref cases above.
- [x] all `WorkspaceMergeCommit` variants are tested
  - The current API collapsed/renamed this into `WorkspaceDisposition`; `KeepWorkspaceCommit` and remove-if-possible behavior are both covered in `workspace_disposition`.
- [x] all `WorkspaceReference` variants are tested
  - For the current `WorkspaceDisposition` replacement, keep ref and delete/switch behavior are covered. The old `KeepButAllowSwitchingToRemainingStack` shape no longer exists as a separate variant.
* [x] make use of new `unapply()` behind new feature toggle
  - Implementation is wired via `feature_flags.unapply_v3`, but I did not find a test exercising the feature-toggle path through `but-api`.

### Future Tasks (too old to be applicable I presume)

- [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost
- [ ] make `archived` more sturdy in the light of applying/unapplying, to *consider* keeping the original copy of the now integrated part of the stack.
- [x] **proper worktree checkout handling** - we must not checkout branches that are already checked out in any worktree (see `gix` code somewhere)
- [ ] unapply takes care of assignments by creating snapshots (move away from bare WIP commits). Snapshots solve a lot of problems around 'stashing' otherwise conflicting changes.
- Permutations: base position - shouldn't be needed as unapply doesn't affect any base (it's all computed)


### Notes

#### Kiril's thoughts

> yeah, possibly the "tricky" part is that bit about going to a single branch mode (if it's going from 2 branches in the workspace to 1). And I am curious what this new world means when a user wants to go from a 1 branch (single branch mode) to zero... is that a valid operation? Does it mean checking out orgin master? And maybe one final question in my mind - what if there are commits on top of the workspace commit (i.e. user did something outside of the app) - how unapply deals with that

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
    - **BUT**: we can enforce this, and have single-branch and zero-branch workspaces.
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.
    - the actual implementation actually fails if there are conflicts *I think*.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


<details><summary>Research</summary>
<p>

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.

</p>
</details> 





