### PR TITLE
ui-fixes-branches-page

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -364,7 +364,7 @@
 						{/if}
 
 						{#if isNonLocalPr && current.prNumber}
-							<div class="commits" use:focusable={{ vertical: true }}>
+							<div class="commits with-padding" use:focusable={{ vertical: true }}>
 								<BranchesViewPr
 									bind:this={prBranch}
 									{projectId}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -149,6 +149,8 @@
 
 <style lang="postcss">
 	.branch-commits {
-		border-top: 1px solid var(--clr-border-2);
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: 0 0 var(--radius-ml) var(--radius-ml);
 	}
 </style>

--- a/apps/desktop/src/components/PRBranchView.svelte
+++ b/apps/desktop/src/components/PRBranchView.svelte
@@ -21,7 +21,11 @@
 
 <ReduxResult result={prQuery?.result} {projectId} {onerror}>
 	{#snippet children(pr)}
-		<Drawer testId={TestId.PRBranchDrawer} persistId="pr-branch-drawer-{projectId}-{pr.number}">
+		<Drawer
+			testId={TestId.PRBranchDrawer}
+			persistId="pr-branch-drawer-{projectId}-{pr.number}"
+			bottomBorder
+		>
 			{#snippet header()}
 				<h3 class="text-14 text-semibold">
 					<span class="clr-text-2">PR {unitSymbol}{pr.number}:</span>
@@ -65,7 +69,7 @@
 				</div>
 
 				{#if pr.body}
-					<div class="pr-body text-13">
+					<div class="pr-body text-13 text-body">
 						<Markdown content={pr.body} />
 					</div>
 				{/if}
@@ -78,13 +82,13 @@
 	.pr-content {
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
 	}
 
 	.pr-request-data {
 		display: flex;
 		flex-direction: row;
 		width: 100%;
+		padding: 16px;
 		gap: 10px;
 	}
 
@@ -117,7 +121,7 @@
 	}
 
 	.pr-body {
-		padding-top: 16px;
+		padding: 16px;
 		border-top: 1px solid var(--clr-border-2);
 	}
 </style>

--- a/apps/desktop/src/components/PRBranchView.svelte
+++ b/apps/desktop/src/components/PRBranchView.svelte
@@ -27,7 +27,7 @@
 			bottomBorder
 		>
 			{#snippet header()}
-				<h3 class="text-14 text-semibold">
+				<h3 class="text-14 text-semibold truncate">
 					<span class="clr-text-2">PR {unitSymbol}{pr.number}:</span>
 					<span> {pr.title}</span>
 				</h3>


### PR DESCRIPTION
Fix borderless commit lists:

Before:
<img width="375" height="838" alt="Screenshot 2025-10-29 at 15 31 01" src="https://github.com/user-attachments/assets/55afee14-c509-4cbf-b028-ed80abca3b1a" />

After:
<img width="364" height="815" alt="Screenshot 2025-10-29 at 15 41 24" src="https://github.com/user-attachments/assets/75cb7f21-fc7d-4aab-9811-30d2f5ef4b9b" />

---

Fix PR paddings:

Before:
<img width="1320" height="574" alt="Screenshot 2025-10-29 at 15 42 26" src="https://github.com/user-attachments/assets/0b49bb48-9df4-4d6a-a6e3-6d28db3086fe" />

After:
<img width="1314" height="551" alt="Screenshot 2025-10-29 at 15 48 11" src="https://github.com/user-attachments/assets/55ff9cab-4bb4-4559-879e-ef9866093038" />

---

Truncate long PR names