### PR TITLE
add gitbutler cli man-pages

### DIFF
--- a/cli-docs/README.md
+++ b/cli-docs/README.md
@@ -1,0 +1,46 @@
+# GitButler CLI Documentation
+
+This directory contains "man-page" style documentation for all `but` CLI commands in MDX format.
+
+These files are copied to the `gitbutler-docs` project and rendered on https://docs.gitbutler.com/ for reference.
+
+If you update a CLI command, please submit the changes with appropriate changes to the corresponding MDX doc.
+
+## Documentation Structure
+
+Each command has its own MDX file following the naming convention `but-<command>.mdx`. For example:
+
+- `but-status.mdx` - Documentation for the `but status` command
+- `but-commit.mdx` - Documentation for the `but commit` command
+- `but-branch.mdx` - Documentation for the `but branch` command with subcommands
+
+## File Format
+
+All documentation files use MDX (Markdown with JSX) format, which allows for:
+
+- Standard markdown formatting
+- Code syntax highlighting
+- Potential for interactive components
+- Easy conversion to various documentation platforms
+
+## Documentation Contents
+
+Each command documentation file can include:
+
+1. **Command name and description** - A brief overview of what the command does
+2. **Usage** - The basic command syntax
+3. **Arguments** - Required and optional positional arguments with types
+4. **Options** - Flags and options with:
+   - Type (Flag, String, etc.)
+   - Default values
+   - Whether required or optional
+5. **Examples** - Practical usage examples
+6. **Related commands** - Links to related command documentation (where applicable)
+
+## Source Code Reference
+
+The CLI command definitions can be found in:
+
+- `crates/but/src/args.rs` - Main argument parsing and command structure
+- `crates/but/src/main.rs` - Command dispatch and execution
+- `crates/but/src/<command>/mod.rs` - Individual command implementations

--- a/cli-docs/but-base.mdx
+++ b/cli-docs/but-base.mdx
@@ -1,0 +1,51 @@
+---
+title: 'but base'
+description: 'Commands for managing the base branch'
+---
+
+## Usage
+
+```
+but base <SUBCOMMAND>
+```
+
+## Subcommands
+
+### check
+
+Fetches remotes from the remote and checks the mergeability of the branches in the workspace.
+
+```
+but base check
+```
+
+Shows the status of the base branch including:
+
+- Base branch name
+- Number of upstream commits
+- Recent commits
+- Status of active branches (updatable, integrated, conflicted, etc.)
+
+### update
+
+Updates the workspace (with all applied branches) to include the latest changes from the base branch.
+
+```
+but base update
+```
+
+Integrates upstream changes into your workspace branches, rebasing or deleting branches as appropriate.
+
+## Examples
+
+Check base branch status:
+
+```
+but base check
+```
+
+Update workspace with base branch changes:
+
+```
+but base update
+```

--- a/cli-docs/but-branch.mdx
+++ b/cli-docs/but-branch.mdx
@@ -1,0 +1,124 @@
+---
+title: 'but branch'
+description: 'Commands for managing branches'
+---
+
+## Usage
+
+```
+but branch <SUBCOMMAND>
+```
+
+## Subcommands
+
+### new
+
+Creates a new branch in the workspace.
+
+```
+but branch new [OPTIONS] [BRANCH_NAME]
+```
+
+#### Arguments
+
+- `[BRANCH_NAME]` - Name of the new branch (optional, auto-generated if not provided)
+
+#### Options
+
+- `-a, --anchor <ANCHOR>` - Anchor point - either a commit ID or branch name to create the new branch from
+
+### delete
+
+Deletes a branch from the workspace.
+
+```
+but branch delete [OPTIONS] <BRANCH_NAME>
+```
+
+Alias: `-d`
+
+#### Arguments
+
+- `<BRANCH_NAME>` - Name of the branch to delete (required)
+
+#### Options
+
+- `-f, --force` - Force deletion without confirmation
+
+### list
+
+List the branches in the repository.
+
+```
+but branch list [OPTIONS]
+```
+
+#### Options
+
+- `-l, --local` - Show only local branches
+
+### unapply
+
+Unapply a branch from the workspace.
+
+```
+but branch unapply [OPTIONS] <BRANCH_NAME>
+```
+
+#### Arguments
+
+- `<BRANCH_NAME>` - Name of the branch to unapply (required)
+
+#### Options
+
+- `-f, --force` - Force unapply without confirmation
+
+## Examples
+
+Create a new branch with auto-generated name:
+
+```
+but branch new
+```
+
+Create a new branch with a specific name:
+
+```
+but branch new my-feature
+```
+
+Create a new branch from a specific commit:
+
+```
+but branch new my-feature --anchor abc123
+```
+
+Delete a branch with confirmation:
+
+```
+but branch delete my-feature
+```
+
+Force delete a branch without confirmation:
+
+```
+but branch delete my-feature --force
+```
+
+List all branches:
+
+```
+but branch list
+```
+
+List only local branches:
+
+```
+but branch list --local
+```
+
+Unapply a branch from the workspace:
+
+```
+but branch unapply my-feature
+```

--- a/cli-docs/but-commit.mdx
+++ b/cli-docs/but-commit.mdx
@@ -1,0 +1,53 @@
+---
+title: 'but commit'
+description: 'Commit changes to a stack'
+---
+
+## Usage
+
+```
+but commit [OPTIONS]
+```
+
+## Options
+
+### `-m, --message <MESSAGE>`
+
+Commit message.
+
+- **Type:** String
+- **Required:** Optional
+
+### `--branch <BRANCH>`
+
+Branch CLI ID or name to derive the stack to commit to.
+
+- **Type:** String
+- **Required:** Optional
+
+### `-o, --only`
+
+Only commit assigned files, not unassigned files.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Commit with a message:
+
+```
+but commit -m "Add new feature"
+```
+
+Commit to a specific branch:
+
+```
+but commit -m "Fix bug" --branch my-feature-branch
+```
+
+Commit only assigned files:
+
+```
+but commit -m "Update docs" --only
+```

--- a/cli-docs/but-describe.mdx
+++ b/cli-docs/but-describe.mdx
@@ -1,0 +1,41 @@
+---
+title: 'but describe'
+description: 'Edit the commit message of a specified commit'
+---
+
+## Usage
+
+```
+but describe <TARGET>
+```
+
+## Alias
+
+This command can also be invoked using the shorter alias `desc`:
+
+```
+but desc <TARGET>
+```
+
+## Arguments
+
+### `<TARGET>`
+
+Commit ID to edit the message for, or branch ID to rename.
+
+- **Type:** String
+- **Required:** Yes
+
+## Examples
+
+Edit a commit message:
+
+```
+but describe abc123
+```
+
+Rename a branch:
+
+```
+but describe my-feature-branch
+```

--- a/cli-docs/but-forge.mdx
+++ b/cli-docs/but-forge.mdx
@@ -1,0 +1,64 @@
+---
+title: 'but forge'
+description: 'Commands for interacting with forges like GitHub, GitLab, etc.'
+---
+
+## Usage
+
+```
+but forge <SUBCOMMAND>
+```
+
+## Subcommands
+
+### auth
+
+Authenticate with your forge provider (at the moment, only GitHub is supported).
+
+```
+but forge auth
+```
+
+Initiates a device OAuth flow to authenticate with GitHub. You'll be provided with a code and URL to complete the authentication process.
+
+### list-users
+
+List authenticated forge accounts known to GitButler.
+
+```
+but forge list-users
+```
+
+Displays a list of all GitHub usernames that have been authenticated with GitButler.
+
+### forget
+
+Forget a previously authenticated forge account.
+
+```
+but forge forget <USERNAME>
+```
+
+#### Arguments
+
+- `<USERNAME>` - The username of the forge account to forget (required)
+
+## Examples
+
+Authenticate with GitHub:
+
+```
+but forge auth
+```
+
+List authenticated users:
+
+```
+but forge list-users
+```
+
+Forget a GitHub account:
+
+```
+but forge forget octocat
+```

--- a/cli-docs/but-init.mdx
+++ b/cli-docs/but-init.mdx
@@ -1,0 +1,33 @@
+---
+title: 'but init'
+description: 'Initialize a GitButler project from a git repository'
+---
+
+## Usage
+
+```
+but init [OPTIONS]
+```
+
+## Options
+
+### `-r, --repo`
+
+Also initializes a git repository in the current directory if one does not exist.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Initialize GitButler in an existing git repository:
+
+```
+but init
+```
+
+Initialize both git and GitButler:
+
+```
+but init --repo
+```

--- a/cli-docs/but-mark.mdx
+++ b/cli-docs/but-mark.mdx
@@ -1,0 +1,46 @@
+---
+title: 'but mark'
+description: 'Create or remove a rule for auto-assigning or auto-committing'
+---
+
+## Usage
+
+```
+but mark [OPTIONS] <TARGET>
+```
+
+## Arguments
+
+### `<TARGET>`
+
+The target entity that will be marked.
+
+- **Type:** String
+- **Required:** Yes
+
+## Options
+
+### `-d, --delete`
+
+Deletes a mark.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Create a mark:
+
+```
+but mark my-feature-branch
+```
+
+Delete a mark:
+
+```
+but mark my-feature-branch --delete
+```
+
+## Related Commands
+
+- [`but unmark`](but-unmark) - Removes all marks from the workspace

--- a/cli-docs/but-mcp.mdx
+++ b/cli-docs/but-mcp.mdx
@@ -1,0 +1,38 @@
+---
+title: 'but mcp'
+description: 'Start up the MCP server'
+---
+
+## Usage
+
+```
+but mcp [OPTIONS]
+```
+
+## Description
+
+Starts the Model Context Protocol (MCP) server for GitButler, enabling integration with AI assistants and other tools that support the MCP protocol.
+
+## Options
+
+### `-i, --internal`
+
+Starts the internal MCP server which has more granular tools.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+- **Note:** This option is hidden from standard help output
+
+## Examples
+
+Start the standard MCP server:
+
+```
+but mcp
+```
+
+Start the internal MCP server with more granular tools:
+
+```
+but mcp --internal
+```

--- a/cli-docs/but-new.mdx
+++ b/cli-docs/but-new.mdx
@@ -1,0 +1,33 @@
+---
+title: 'but new'
+description: 'Insert a blank commit before a specified commit or at the top of a stack'
+---
+
+## Usage
+
+```
+but new <TARGET>
+```
+
+## Arguments
+
+### `<TARGET>`
+
+Commit ID to insert before, or branch ID to insert at top of stack.
+
+- **Type:** String
+- **Required:** Yes
+
+## Examples
+
+Insert a blank commit before a specific commit:
+
+```
+but new abc123
+```
+
+Insert a blank commit at the top of a branch's stack:
+
+```
+but new my-feature-branch
+```

--- a/cli-docs/but-oplog.mdx
+++ b/cli-docs/but-oplog.mdx
@@ -1,0 +1,43 @@
+---
+title: 'but oplog'
+description: 'Show operation history'
+---
+
+## Usage
+
+```
+but oplog [OPTIONS]
+```
+
+## Description
+
+Displays the operation log (oplog) which tracks all operations performed in your GitButler workspace. This is useful for understanding what changes have been made and for potentially undoing or restoring to previous states.
+
+## Options
+
+### `--since <SHA>`
+
+Start from this oplog SHA instead of the head.
+
+- **Type:** String
+- **Required:** Optional
+
+## Examples
+
+Show recent operation history:
+
+```
+but oplog
+```
+
+Show operation history from a specific point:
+
+```
+but oplog --since abc123def456
+```
+
+## Related Commands
+
+- [`but undo`](but-undo) - Undo the last operation
+- [`but restore`](but-restore) - Restore to a specific oplog snapshot
+- [`but snapshot`](but-snapshot) - Create an on-demand snapshot

--- a/cli-docs/but-publish.mdx
+++ b/cli-docs/but-publish.mdx
@@ -1,0 +1,64 @@
+---
+title: 'but publish'
+description: 'Publish review requests for active branches in your workspace'
+---
+
+## Usage
+
+```
+but publish [OPTIONS]
+```
+
+## Description
+
+By default, publishes reviews for all active branches in your workspace. You can optionally specify a single branch to publish.
+
+## Options
+
+### `-b, --branch <BRANCH>`
+
+Publish reviews only for the specified branch.
+
+- **Type:** String
+- **Required:** Optional
+
+### `-f, --with-force`
+
+Force push even if it's not fast-forward.
+
+- **Type:** Flag (boolean)
+- **Default:** `true`
+
+### `-s, --skip-force-push-protection`
+
+Skip force push protection checks.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-r, --run-hooks`
+
+Run pre-push hooks.
+
+- **Type:** Flag (boolean)
+- **Default:** `true`
+
+## Examples
+
+Publish all active branches:
+
+```
+but publish
+```
+
+Publish a specific branch:
+
+```
+but publish --branch my-feature
+```
+
+Publish without running hooks:
+
+```
+but publish --run-hooks=false
+```

--- a/cli-docs/but-push.mdx
+++ b/cli-docs/but-push.mdx
@@ -1,0 +1,115 @@
+---
+title: 'but push'
+description: 'Push a branch/stack to remote'
+---
+
+## Usage
+
+```
+but push [OPTIONS] <BRANCH_ID>
+```
+
+## Arguments
+
+### `<BRANCH_ID>`
+
+Branch name or CLI ID to push.
+
+- **Type:** String
+- **Required:** Yes
+
+## Options
+
+### `-f, --with-force`
+
+Force push even if it's not fast-forward.
+
+- **Type:** Flag (boolean)
+- **Default:** `true`
+
+### `-s, --skip-force-push-protection`
+
+Skip force push protection checks.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-r, --run-hooks`
+
+Run pre-push hooks.
+
+- **Type:** Flag (boolean)
+- **Default:** `true`
+
+## Gerrit Options
+
+The following options are only available when Gerrit mode is enabled for your repository:
+
+### `-w, --wip`
+
+Mark change as work-in-progress (Gerrit). Mutually exclusive with `--ready`.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-y, --ready`
+
+Mark change as ready for review (Gerrit). This is the default state. Mutually exclusive with `--wip`.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-a, --hashtag, --tag <TAG>`
+
+Add hashtag(s) to change (Gerrit). Can be used multiple times.
+
+- **Type:** String (repeatable)
+- **Required:** Optional
+
+### `-t, --topic <TOPIC>`
+
+Add custom topic to change (Gerrit). At most one topic can be set. Mutually exclusive with `--topic-from-branch`.
+
+- **Type:** String
+- **Required:** Optional
+
+### `--tb, --topic-from-branch`
+
+Use branch name as topic (Gerrit). Mutually exclusive with `--topic`.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-p, --private`
+
+Mark change as private (Gerrit).
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Push a branch:
+
+```
+but push my-feature-branch
+```
+
+Force push without running hooks:
+
+```
+but push my-feature-branch --with-force --run-hooks=false
+```
+
+Push with Gerrit flags (when Gerrit mode is enabled):
+
+```
+but push my-feature-branch --ready --hashtag bug-fix --hashtag security
+```
+
+## Notes
+
+- Gerrit push flags (`--wip`, `--ready`, `--hashtag/--tag`, `--topic`, `--topic-from-branch`, `--private`) can only be used when gerrit_mode is enabled for the repository
+- `--wip` and `--ready` are mutually exclusive. Ready is the default state.
+- `--topic` and `--topic-from-branch` are mutually exclusive. At most one topic can be set.
+- Multiple hashtags can be specified by using `--hashtag` (or `--tag`) multiple times.

--- a/cli-docs/but-restore.mdx
+++ b/cli-docs/but-restore.mdx
@@ -1,0 +1,48 @@
+---
+title: 'but restore'
+description: 'Restore to a specific oplog snapshot'
+---
+
+## Usage
+
+```
+but restore [OPTIONS] <OPLOG_SHA>
+```
+
+## Arguments
+
+### `<OPLOG_SHA>`
+
+Oplog SHA to restore to.
+
+- **Type:** String
+- **Required:** Yes
+
+## Options
+
+### `-f, --force`
+
+Skip confirmation prompt.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Restore to a specific snapshot (with confirmation):
+
+```
+but restore abc123def456
+```
+
+Restore without confirmation prompt:
+
+```
+but restore abc123def456 --force
+```
+
+## Related Commands
+
+- [`but oplog`](but-oplog) - Show operation history
+- [`but undo`](but-undo) - Undo the last operation
+- [`but snapshot`](but-snapshot) - Create an on-demand snapshot

--- a/cli-docs/but-rub.mdx
+++ b/cli-docs/but-rub.mdx
@@ -1,0 +1,67 @@
+---
+title: 'but rub'
+description: 'Combine two entities together to perform an operation'
+---
+
+## Usage
+
+```
+but rub <SOURCE> <TARGET>
+```
+
+## Description
+
+The `rub` command is a versatile operation that combines two entities together to perform various operations depending on the types of entities provided.
+
+### Supported Operations
+
+| Source | Target | Operation |
+| ------ | ------ | --------- |
+| File   | Commit | Amend     |
+| Branch | Commit | Amend     |
+| Commit | Commit | Squash    |
+| File   | Branch | Assign    |
+| Branch | Branch | Assign    |
+| Commit | Branch | Move      |
+
+## Arguments
+
+### `<SOURCE>`
+
+The source entity to combine.
+
+- **Type:** String
+- **Required:** Yes
+
+### `<TARGET>`
+
+The target entity to combine with the source.
+
+- **Type:** String
+- **Required:** Yes
+
+## Examples
+
+Amend a file to a commit:
+
+```
+but rub path/to/file.txt abc123
+```
+
+Squash two commits:
+
+```
+but rub abc123 def456
+```
+
+Assign a file to a branch:
+
+```
+but rub path/to/file.txt my-feature-branch
+```
+
+Move a commit to a different branch:
+
+```
+but rub abc123 my-other-branch
+```

--- a/cli-docs/but-snapshot.mdx
+++ b/cli-docs/but-snapshot.mdx
@@ -1,0 +1,43 @@
+---
+title: 'but snapshot'
+description: 'Create an on-demand snapshot with optional message'
+---
+
+## Usage
+
+```
+but snapshot [OPTIONS]
+```
+
+## Description
+
+Creates a snapshot of the current workspace state in the operation log. This is useful for creating manual checkpoints before making significant changes.
+
+## Options
+
+### `-m, --message <MESSAGE>`
+
+Message to include with the snapshot.
+
+- **Type:** String
+- **Required:** Optional
+
+## Examples
+
+Create a snapshot without a message:
+
+```
+but snapshot
+```
+
+Create a snapshot with a descriptive message:
+
+```
+but snapshot -m "Before refactoring authentication module"
+```
+
+## Related Commands
+
+- [`but oplog`](but-oplog) - Show operation history
+- [`but undo`](but-undo) - Undo the last operation
+- [`but restore`](but-restore) - Restore to a specific oplog snapshot

--- a/cli-docs/but-status.mdx
+++ b/cli-docs/but-status.mdx
@@ -1,0 +1,61 @@
+---
+title: 'but status'
+description: 'Overview of the uncommitted changes in the repository'
+---
+
+## Usage
+
+```
+but status [OPTIONS]
+```
+
+## Alias
+
+This command can also be invoked using the shorter alias `st`:
+
+```
+but st [OPTIONS]
+```
+
+## Options
+
+### `-f, --files`
+
+Determines whether the committed files should be shown as well.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-v, --verbose`
+
+Show verbose output with commit author and timestamp.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+### `-r, --review`
+
+Show the forge review information.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
+## Examples
+
+Show basic status:
+
+```
+but status
+```
+
+Show status with files:
+
+```
+but status --files
+```
+
+Show verbose status with review information:
+
+```
+but status -v -r
+```

--- a/cli-docs/but-undo.mdx
+++ b/cli-docs/but-undo.mdx
@@ -1,0 +1,32 @@
+---
+title: 'but undo'
+description: 'Undo the last operation by reverting to the previous snapshot'
+---
+
+## Usage
+
+```
+but undo
+```
+
+## Description
+
+Reverts the workspace to the state it was in before the last operation. This uses the operation log (oplog) to roll back changes.
+
+## Options
+
+This command takes no specific options.
+
+## Examples
+
+Undo the last operation:
+
+```
+but undo
+```
+
+## Related Commands
+
+- [`but oplog`](but-oplog) - Show operation history
+- [`but restore`](but-restore) - Restore to a specific oplog snapshot
+- [`but snapshot`](but-snapshot) - Create an on-demand snapshot

--- a/cli-docs/but-unmark.mdx
+++ b/cli-docs/but-unmark.mdx
@@ -1,0 +1,30 @@
+---
+title: 'but unmark'
+description: 'Remove all marks from the workspace'
+---
+
+## Usage
+
+```
+but unmark
+```
+
+## Description
+
+This command removes all auto-assign and auto-commit rules (marks) from the workspace.
+
+## Options
+
+This command takes no specific options.
+
+## Examples
+
+Remove all marks:
+
+```
+but unmark
+```
+
+## Related Commands
+
+- [`but mark`](but-mark) - Creates or removes a rule for auto-assigning or auto-committing


### PR DESCRIPTION
I added man-page like mdx files for each of the commands we currently have. 

It would be nice to keep this up to date - submit changes to these files if the commands themselves change. I will work on fleshing them out a bit, but this way docs and code can be submitted together and I have a script in `gitbutler-docs` to copy them in and group them.