### PR TITLE
Avoid 'apply' conflict handling when applying a segment that is on top of an already applied one

### DIFF
--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -33,7 +33,7 @@ pub struct Workspace<'graph> {
     pub id: SegmentIndex,
     /// Specify what kind of workspace this is.
     pub kind: WorkspaceKind,
-    /// One or more stacks that live in the workspace.
+    /// One or more stacks that live in the workspace, in order of parents of the workspace commit if there are more than one.
     pub stacks: Vec<Stack>,
     /// The bound can be imagined as the commit from which all other commits in the workspace originate.
     /// It can also be imagined to be the delimiter at the bottom beyond which nothing belongs to the workspace,

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -709,8 +709,9 @@ pub(crate) mod function {
     ) -> Vec<StackId> {
         conflicts
             .iter()
-            .filter_map(|cs| {
-                ws.find_stack_with_branch(cs.ref_name.as_ref(), AppliedAndUnapplied)
+            .filter_map(|cs| cs.ref_name.as_ref())
+            .filter_map(|ref_name| {
+                ws.find_stack_with_branch(ref_name.as_ref(), AppliedAndUnapplied)
                     .map(|stack| stack.id)
             })
             .collect()

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -63,7 +63,7 @@ impl std::fmt::Debug for Outcome<'_> {
 }
 
 /// How the newly applied branch should be merged into the workspace commit.
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WorkspaceMerge {
     /// Do nothing but to merge it into the workspace commit, *even* if it's not needed as the workspace reference
     /// can connect directly with the *one* workspace base.
@@ -110,9 +110,12 @@ pub struct Options {
 pub(crate) mod function {
     use std::borrow::Cow;
 
+    use super::{Options, Outcome, WorkspaceMerge, WorkspaceReferenceNaming};
+    use crate::commit::merge::Tip;
+    use crate::{WorkspaceCommit, branch::checkout, ext::ObjectStorageExt, ref_info::WorkspaceExt};
     use anyhow::{Context, bail};
     use but_core::{
-        RefMetadata, RepositoryExt, extract_remote_name,
+        RefMetadata, RepositoryExt, extract_remote_name, ref_metadata,
         ref_metadata::{
             StackId,
             StackKind::AppliedAndUnapplied,
@@ -120,7 +123,8 @@ pub(crate) mod function {
             WorkspaceCommitRelation::{Merged, Outside},
         },
     };
-    use but_graph::{init::Overlay, projection::WorkspaceKind};
+    use but_graph::petgraph::Direction;
+    use but_graph::{SegmentIndex, init::Overlay, projection::WorkspaceKind};
     use gitbutler_oxidize::GixRepositoryExt;
     use gix::{
         prelude::ObjectIdExt,
@@ -131,9 +135,6 @@ pub(crate) mod function {
         },
     };
     use tracing::instrument;
-
-    use super::{Options, Outcome, WorkspaceMerge, WorkspaceReferenceNaming};
-    use crate::{WorkspaceCommit, branch::checkout, ext::ObjectStorageExt, ref_info::WorkspaceExt};
 
     /// Apply `branch` to the given `workspace`, and possibly create the workspace reference in `repo`
     /// along with its `meta`-data if it doesn't exist yet.
@@ -434,18 +435,27 @@ pub(crate) mod function {
             );
         }
 
+        let existing_stacks_superseded_by_branch = find_superseded_stacks(branch, &workspace);
         // At this point, the workspace-metadata already knows the new branch(es), but the workspace itself
         // doesn't see one or more of to-be-applied branches (to become stacks).
         // These are, however, part of the graph by now, and we want to try to create a workspace
         // merge.
         let mut in_memory_repo = repo.clone().for_tree_diffing()?.with_object_memory();
         let mut merge_result = WorkspaceCommit::from_new_merge_with_metadata(
-            ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
-            workspace.graph,
+            filter_superseded_metadata_stacks(
+                ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
+                &existing_stacks_superseded_by_branch,
+            ),
+            filter_superseded_anon_stacks(
+                anon_stacks(&workspace.stacks),
+                &existing_stacks_superseded_by_branch,
+            ),
+            &graph,
             &in_memory_repo,
             Some(branch),
         )?;
         ensure_no_missing_stacks(&merge_result)?;
+        drop(existing_stacks_superseded_by_branch);
 
         if merge_result.has_conflicts() && on_workspace_conflict.should_abort() {
             let conflicting_stack_ids =
@@ -547,9 +557,17 @@ pub(crate) mod function {
 
             // Redo the merge, with the different stack configuration.
             // Note that this is the exception, typically using stacks will be fine.
+            let existing_stacks_superseded_by_branch = find_superseded_stacks(branch, &workspace);
             merge_result = WorkspaceCommit::from_new_merge_with_metadata(
-                ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
-                workspace.graph,
+                filter_superseded_metadata_stacks(
+                    ws_md.stacks.iter().filter(|s| s.is_in_workspace()),
+                    &existing_stacks_superseded_by_branch,
+                ),
+                filter_superseded_anon_stacks(
+                    anon_stacks(&workspace.stacks),
+                    &existing_stacks_superseded_by_branch,
+                ),
+                &graph,
                 &in_memory_repo,
                 Some(branch),
             )?;
@@ -630,6 +648,117 @@ pub(crate) mod function {
             conflicting_stack_ids,
             applied_branches,
         })
+    }
+
+    fn anon_stacks(stacks: &[but_graph::projection::Stack]) -> impl Iterator<Item = (usize, Tip)> {
+        stacks.iter().enumerate().filter_map(|(idx, s)| {
+            if s.ref_name().is_none() {
+                s.tip_skip_empty().and_then(|cid| {
+                    s.segments.first().map(|s| {
+                        (
+                            idx,
+                            Tip {
+                                name: None,
+                                commit_id: cid,
+                                segment_idx: s.id,
+                            },
+                        )
+                    })
+                })
+            } else {
+                None
+            }
+        })
+    }
+
+    fn filter_superseded_metadata_stacks<'a>(
+        stack_iter: impl Iterator<Item = &'a ref_metadata::WorkspaceStack>,
+        existing_stacks_superseded_by_branch: &[(
+            SegmentIndex,
+            Option<gix::refs::FullName>,
+            Option<gix::ObjectId>,
+        )],
+    ) -> impl Iterator<Item = &'a ref_metadata::WorkspaceStack> {
+        stack_iter.into_iter().filter(|ws_stack| {
+            !existing_stacks_superseded_by_branch
+                .iter()
+                .any(|(_sidx, ref_name, _cid)| ws_stack.ref_name() == ref_name.as_ref())
+        })
+    }
+
+    fn filter_superseded_anon_stacks(
+        tips_iter: impl Iterator<Item = (usize, Tip)>,
+        existing_stacks_superseded_by_branch: &[(
+            SegmentIndex,
+            Option<gix::refs::FullName>,
+            Option<gix::ObjectId>,
+        )],
+    ) -> impl Iterator<Item = (usize, Tip)> {
+        tips_iter.filter(|(_parent_idx, anon_tip)| {
+            !existing_stacks_superseded_by_branch
+                .iter()
+                .any(|(sidx, _ref_name, cid)| {
+                    anon_tip.segment_idx == *sidx
+                        || cid.is_some_and(|cid| cid == anon_tip.commit_id)
+                })
+        })
+    }
+
+    /// If the branch to be applied already flows into the workspace, find the stacks it *whose tips* it flows
+    /// into, and remove these.
+    /// Note that we don't do that if it doesn't include the entire segment.
+    /// This check is lenient, and we allow the branch to be applied to not be in the graph yet for any known (or unknown) reason.
+    /// We keep enough information to identify these superseded stacks and recognise them by
+    ///
+    /// `branch` is the branch to find in `workspace` and start the traversal from, whereas the existing `workspace` stacks
+    /// will be used as candidates for being superseded by it.
+    fn find_superseded_stacks(
+        branch: &FullNameRef,
+        workspace: &but_graph::projection::Workspace,
+    ) -> Vec<(
+        SegmentIndex,
+        Option<gix::refs::FullName>,
+        Option<gix::ObjectId>,
+    )> {
+        let graph = workspace.graph;
+        if let Some(branch_segment) = graph.named_segment_by_ref_name(branch) {
+            // At this stage we know first segment isn't in the workspace, so exclude it.
+            let _tip_commit_ids_and_sidx: Vec<_> = workspace
+                .stacks
+                .iter()
+                .filter_map(|stack| {
+                    stack
+                        .segments
+                        .first()
+                        .and_then(|s| s.commits.first().map(|c| (c.id, s.id)))
+                })
+                .collect();
+            let mut superseded = Vec::new();
+            graph.visit_all_segments_excluding_start_until(
+                branch_segment.id,
+                Direction::Outgoing,
+                |segment| {
+                    let prune = _tip_commit_ids_and_sidx.iter().any(|(cid, sidx)| {
+                        segment.id == *sidx || segment.commits.first().is_some_and(|c| c.id == *cid)
+                    });
+                    if prune {
+                        superseded.push((
+                            segment.id,
+                            segment.ref_name.clone(),
+                            segment.commits.first().map(|c| c.id),
+                        ));
+                    }
+                    prune
+                },
+            );
+            superseded
+        } else {
+            tracing::warn!(
+                ?branch,
+                "Didn't find branch in graph to do the 'reaches into workspace' check"
+            );
+            Vec::new()
+        }
     }
 
     /// Setup `local_tracking_ref` to track `remote_tracking_ref` using the typical pattern, and prepare the configuration file

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -38,7 +38,7 @@ impl std::fmt::Debug for Stack {
 /// Structures related to creating a merge-commit along with the respective tree.
 pub mod merge {
     use anyhow::{Context, bail};
-    use but_core::ref_metadata::WorkspaceCommitRelation;
+    use but_core::ref_metadata::{MaybeDebug, WorkspaceCommitRelation};
     use but_graph::SegmentIndex;
     use gitbutler_oxidize::GixRepositoryExt;
     use gix::prelude::ObjectIdExt;
@@ -47,13 +47,35 @@ pub mod merge {
     use super::Stack;
     use crate::WorkspaceCommit;
 
-    /// A minimal stack for to represent a stack that conflicted.
+    /// A optionally named tip that can be merged.
     #[derive(Debug, Clone)]
+    pub struct Tip {
+        /// The name of the reference that points to `commit_id`, or `None` if there is no such reference.
+        /// The name is for use in the generated workspace commit message.
+        pub name: Option<gix::refs::FullName>,
+        /// The commit that should be merged into the workspace commit.
+        pub commit_id: gix::ObjectId,
+        /// The index to the top-most segment of the stack in the graph for use in merge-base computation.
+        pub segment_idx: SegmentIndex,
+    }
+
+    /// A minimal stack for to represent a stack that conflicted.
+    #[derive(Clone)]
     pub struct ConflictingStack {
         /// The tip that could not be merged in.
         pub tip: gix::ObjectId,
         /// The name of the references to be merged, it pointed to `tip`.
-        pub ref_name: gix::refs::FullName,
+        pub ref_name: Option<gix::refs::FullName>,
+    }
+
+    impl std::fmt::Debug for ConflictingStack {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let ConflictingStack { ref_name, tip } = self;
+            f.debug_struct("ConflictingStack")
+                .field("tip", tip)
+                .field("ref_name", &MaybeDebug(ref_name))
+                .finish()
+        }
     }
 
     /// The outcome of a workspace-merge operation via [WorkspaceCommit::from_new_merge_with_metadata()].
@@ -79,27 +101,11 @@ pub mod merge {
 
     /// Merging - create a merge-commit along with its tree.
     impl WorkspaceCommit<'_> {
-        /// Using the names of the `stacks` stored in [workspace metadata](but_core::ref_metadata::Workspace),
-        /// create a new workspace commit with their tips extracted from `graph`. Note that stacks that don't exist in `graph` aren't fatal.
-        ///
-        /// Use `hero_stack` to highlight a stack that you definitely want merged in, and would rather not merge other stacks for it.
-        /// This can lead to a situation where only the hero stack is applied.
-        /// If there is only one stack, it just uses the tree of that stack. It's an error if `stacks` is empty.
-        /// `repo` is expected to be configured to be suitable for merges, and it *should* be configured to write objects into memory
-        /// unless the caller knows that any result of the merge is acceptable.
-        ///
-        /// IMPORTANT: This inherently needs the tips to be represented by named branches, so this can't be used to
-        ///            re-merge a workspace with lost or renamed branches. It is, however, good to 'fix' workspaces
-        ///            whose tips were advanced and now are outside the workspace.
-        ///
-        /// ### Shortcoming: inefficient conflict behaviour
-        ///
-        /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
-        /// One could be better and only repeat what didn't change, to avoid repeating unnecessarily.
-        /// But that shouldn't usually matter unless in the biggest repositories with tree-merge times past a 500ms or so.
-        #[instrument(name = "re-merge workspace commit", level = tracing::Level::DEBUG, skip(stacks, graph, repo), err(Debug))]
-        pub fn from_new_merge_with_metadata<'a>(
-            stacks: impl IntoIterator<Item = &'a but_core::ref_metadata::WorkspaceStack>,
+        /// like [`Self::from_new_merge_with_metadata`], but supports tips, which makes it possible to re-merge anything
+        /// even if the tip is unnamed.
+        /// Note that [`missing_stacks`](Outcome::missing_stacks) is never set.
+        pub fn from_new_merge_with_tips<'a>(
+            tips: impl IntoIterator<Item = Tip>,
             graph: &but_graph::Graph,
             repo: &gix::Repository,
             hero_stack: Option<&gix::refs::FullNameRef>,
@@ -123,32 +129,8 @@ pub mod merge {
                     }
                 }
             }
-            let mut missing_stacks = Vec::new();
-            let mut tips: Vec<_> = stacks
-                .into_iter()
-                .filter_map(|s| s.branches.first().map(|b| (b, s.workspacecommit_relation)))
-                .filter_map(|(top_segment, relation)| {
-                    match relation {
-                        WorkspaceCommitRelation::Merged => {}
-                        WorkspaceCommitRelation::UnmergedTree => {
-                            // These need to be part of the parents list, but shouldn't be merged.
-                            // If the caller wants to retry them, they can be passed here as "Merged".
-                            todo!("this is a placeholder for where we will have to start handling this UnmergedTree")
-                        }
-                        WorkspaceCommitRelation::Outside => return None,
-                    }
-                    let stack_tip_name = top_segment.ref_name.as_ref();
-                    match graph.segment_and_commit_by_ref_name(stack_tip_name) {
-                        None => {
-                            missing_stacks.push(top_segment.ref_name.to_owned());
-                            None
-                        }
-                        Some((segment, commit)) => {
-                            Some((I::Merge, stack_tip_name, commit.id, segment.id))
-                        }
-                    }
-                })
-                .collect();
+            let mut tips: Vec<(Instruction, Tip)> =
+                tips.into_iter().map(|t| (I::Merge, t)).collect();
 
             let mut ran_merge_trials_loop_safety = false;
             #[allow(clippy::indexing_slicing)]
@@ -159,7 +141,14 @@ pub mod merge {
                 let (merge_options, conflict_kind) = repo.merge_options_fail_fast()?;
                 let labels_uninteresting_as_no_conflict_allowed = repo.default_merge_labels();
                 'tips_loop: for tip_idx in 0..tips.len() {
-                    let (mode, ref_name, commit_id, sidx) = &mut tips[tip_idx];
+                    let (
+                        mode,
+                        Tip {
+                            name: ref_name,
+                            commit_id,
+                            segment_idx: sidx,
+                        },
+                    ) = &mut tips[tip_idx];
                     let sidx = *sidx;
                     if mode.should_skip() {
                         continue;
@@ -182,18 +171,20 @@ pub mod merge {
                             labels_uninteresting_as_no_conflict_allowed,
                             merge_options.clone(),
                         )?;
-                        let is_hero = hero_stack.is_some_and(|hero| hero == *ref_name);
+                        let is_hero = hero_stack.is_some_and(|hero| {
+                            Some(hero) == ref_name.as_ref().map(|rn| rn.as_ref())
+                        });
                         if merge.has_unresolved_conflicts(conflict_kind) {
                             if matches!(mode, I::MergeTrial { .. }) {
                                 bail!(
-                                    "BUG: Found {ref_name} in merge-trial, even though these shouldn't fail without the hero merged in"
+                                    "BUG: Found {ref_name:?} in merge-trial, even though these shouldn't fail without the hero merged in"
                                 );
                             }
                             if is_hero {
                                 // We definitely want this one, so must restart the whole operation
                                 // while disallowing the most recent allowed tip.
                                 let err_msg = format!(
-                                    "BUG: if there was no allowed stack in front of {ref_name}, then we aren't here as no merge can be done with just one branch"
+                                    "BUG: if there was no allowed stack in front of {ref_name:?}, then we aren't here as no merge can be done with just one branch"
                                 );
                                 let presumed_conflicting_tip = tips[..tip_idx]
                                     .iter_mut()
@@ -222,7 +213,7 @@ pub mod merge {
                             // First, mark the first X as conflict as we know it for sure.
                             let mut saw_first_certain_conflict = false;
                             let mut has_merge_trials = false;
-                            for (mode, _, _, _) in &mut tips[..tip_idx] {
+                            for (mode, _) in &mut tips[..tip_idx] {
                                 match mode {
                                     I::Merge => continue,
                                     I::MergeTrial { .. } => bail!(
@@ -290,16 +281,24 @@ pub mod merge {
 
                 let (stacks, conflicting_stacks) = tips.iter().fold(
                     (Vec::new(), Vec::new()),
-                    |(mut stacks, mut conflicting_stacks), (mode, ref_name, commit_id, _sidx)| {
+                    |(mut stacks, mut conflicting_stacks),
+                     (
+                        mode,
+                        Tip {
+                            name: ref_name,
+                            commit_id,
+                            ..
+                        },
+                    )| {
                         if mode.should_skip() {
                             conflicting_stacks.push(ConflictingStack {
                                 tip: *commit_id,
-                                ref_name: (*ref_name).to_owned(),
+                                ref_name: ref_name.clone(),
                             });
                         } else {
                             stacks.push(Stack {
                                 tip: *commit_id,
-                                name: Some(ref_name.shorten().to_owned()),
+                                name: ref_name.as_ref().map(|rn| rn.shorten().to_owned()),
                             });
                         }
                         (stacks, conflicting_stacks)
@@ -308,7 +307,7 @@ pub mod merge {
 
                 if stacks.is_empty() {
                     bail!(
-                        "BUG: Cannot merge nothing, no tips ended up in the graph: `missing_stacks` = {missing_stacks:?}, `conflicting_stacks` = {conflicting_stacks:?}, `tips` = : {tips:?}"
+                        "BUG: Cannot merge nothing, no tips ended up in the graph: `conflicting_stacks` = {conflicting_stacks:?}, `tips` = : {tips:?}"
                     )
                 }
 
@@ -329,10 +328,66 @@ pub mod merge {
                 return Ok(Outcome {
                     workspace_commit_id,
                     stacks,
-                    missing_stacks,
+                    missing_stacks: vec![], /* this is never set here as all tips are already resolved */
                     conflicting_stacks,
                 });
             }
+        }
+
+        /// Using the names of the `stacks` stored in [workspace metadata](but_core::ref_metadata::Workspace),
+        /// create a new workspace commit with their tips extracted from `graph`. Note that stacks that don't exist in `graph` aren't fatal.
+        /// Also, this will create a workspace commit as it's desired, but not as it is, and the caller should assure that all branches are present.
+        ///
+        /// Use `hero_stack` to highlight a stack that you definitely want merged in, and would rather not merge other stacks for it.
+        /// This can lead to a situation where only the hero stack is applied.
+        /// If there is only one stack, it just uses the tree of that stack. It's an error if `stacks` is empty.
+        /// `repo` is expected to be configured to be suitable for merges, and it *should* be configured to write objects into memory
+        /// unless the caller knows that any result of the merge is acceptable.
+        ///
+        /// IMPORTANT: This inherently needs the tips to be represented by named branches, so this can't be used to
+        ///            re-merge a workspace with lost or renamed branches. It is, however, good to 'fix' workspaces
+        ///            whose tips were advanced and now are outside the workspace, provide the ref that advanced still exists.
+        ///
+        /// ### Shortcoming: inefficient conflict behaviour
+        ///
+        /// In order to find out exactly which branches conflicts, we repeat the whole operations with different configuration.
+        /// One could be better and only repeat what didn't change, to avoid repeating unnecessarily.
+        /// But that shouldn't usually matter unless in the biggest repositories with tree-merge times past a 500ms or so.
+        #[instrument(name = "re-merge workspace commit", level = tracing::Level::DEBUG, skip(stacks, graph, repo), err(Debug))]
+        pub fn from_new_merge_with_metadata<'a>(
+            stacks: impl IntoIterator<Item = &'a but_core::ref_metadata::WorkspaceStack>,
+            graph: &but_graph::Graph,
+            repo: &gix::Repository,
+            hero_stack: Option<&gix::refs::FullNameRef>,
+        ) -> anyhow::Result<Outcome> {
+            let mut missing_stacks = Vec::new();
+            let tips = stacks
+                .into_iter()
+                .filter_map(|s| s.branches.first().map(|b| (b, s.workspacecommit_relation)))
+                .filter_map(|(top_segment, relation)| {
+                    match relation {
+                        WorkspaceCommitRelation::Merged => {}
+                        WorkspaceCommitRelation::UnmergedTree => {
+                            // These need to be part of the parents list, but shouldn't be merged.
+                            // If the caller wants to retry them, they can be passed here as "Merged".
+                            todo!("this is a placeholder for where we will have to start handling this UnmergedTree")
+                        }
+                        WorkspaceCommitRelation::Outside => return None,
+                    }
+                    let stack_tip_name = top_segment.ref_name.as_ref();
+                    match graph.segment_and_commit_by_ref_name(stack_tip_name) {
+                        None => {
+                            missing_stacks.push(top_segment.ref_name.to_owned());
+                            None
+                        }
+                        Some((segment, commit)) => {
+                            Some(Tip {name: Some(stack_tip_name.to_owned()), commit_id: commit.id, segment_idx: segment.id})
+                        }
+                    }
+                });
+            let mut out = Self::from_new_merge_with_tips(tips, graph, repo, hero_stack)?;
+            out.missing_stacks = missing_stacks;
+            Ok(out)
         }
     }
 

--- a/crates/but-workspace/tests/fixtures/scenario/advanced-stack-and-unnamed-stack-in-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/advanced-stack-and-unnamed-stack-in-workspace.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+echo "A workspace with an advanced stack whose ref exists, and another whose ref doesn't exist anymore" >.git/description
+
+commit M1
+setup_target_to_match_main
+git checkout -b outside
+  commit advanced-inside
+git checkout -b soon-missing main
+  commit missing-name
+create_workspace_commit_once outside soon-missing
+git checkout -b feature main
+  commit F1
+
+git checkout outside
+  commit advanced-outside
+git branch -D soon-missing
+git checkout gitbutler/workspace

--- a/crates/but-workspace/tests/fixtures/scenario/shared.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/shared.sh
@@ -113,6 +113,12 @@ function commit() {
   git commit -m "$message" --allow-empty
 }
 
+function commit-file() {
+  local name="${1:?First argument is the filename}"
+  local content=${2:-$1}
+  echo $content >$name && git add $name && git commit -m "add $content"
+}
+
 function add_change_id_to_given_commit() {
   local a="00000000-0000-0000-0000-000000000000"
   local b="${1:?first argument is the single-digit number of the change-id}"

--- a/crates/but-workspace/tests/fixtures/scenario/single-stack-two-segments.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/single-stack-two-segments.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+echo "a stack with two segments, one commit each" >.git/description
+
+commit M1
+setup_target_to_match_main
+git checkout -b A1
+  commit-file file A1
+git checkout -b A2
+  commit-file file A2
+git checkout -b unrelated main
+  commit-file unrelated U1
+git checkout main

--- a/crates/but-workspace/tests/workspace/commit.rs
+++ b/crates/but-workspace/tests/workspace/commit.rs
@@ -27,8 +27,13 @@ mod from_new_merge_with_metadata {
         let stacks = ["add-A"];
         add_stacks(&mut meta, stacks);
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-        let out =
-            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            None,
+            &graph,
+            &repo,
+            None,
+        )?;
         let commit = out.workspace_commit_id.attach(&repo).object()?;
         // This commit is never signed.
         insta::assert_snapshot!(commit.data.as_bstr(), @r"
@@ -74,6 +79,7 @@ mod from_new_merge_with_metadata {
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
         let out = WorkspaceCommit::from_new_merge_with_metadata(
             &to_stacks(stacks),
+            None,
             &graph,
             &repo,
             Some("refs/heads/has-no-effect-outside-conflicts".try_into()?),
@@ -171,6 +177,7 @@ mod from_new_merge_with_metadata {
 
         let out = WorkspaceCommit::from_new_merge_with_metadata(
             &to_stacks(stacks),
+            None,
             &graph,
             &repo,
             Some("refs/heads/conflict-hero".try_into()?),
@@ -213,8 +220,13 @@ mod from_new_merge_with_metadata {
         "#);
 
         // Just for show, see what happens if there is no hero.
-        let out =
-            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            None,
+            &graph,
+            &repo,
+            None,
+        )?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
             workspace_commit_id: Sha1(e444bfa38570217271f5df56c3fe26ed57a7e023),
@@ -282,8 +294,13 @@ mod from_new_merge_with_metadata {
             ]),
         )?;
 
-        let out =
-            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            None,
+            &graph,
+            &repo,
+            None,
+        )?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
             workspace_commit_id: Sha1(e25b36b3a4192701e5e91a00d1c2fe07b9888338),
@@ -328,8 +345,13 @@ mod from_new_merge_with_metadata {
         add_stacks(&mut meta, stacks);
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
 
-        let out =
-            WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), &graph, &repo, None)?;
+        let out = WorkspaceCommit::from_new_merge_with_metadata(
+            &to_stacks(stacks),
+            None,
+            &graph,
+            &repo,
+            None,
+        )?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
             workspace_commit_id: Sha1(4aede0de89327f3afde3db1ed9f83f368f67d501),
@@ -389,6 +411,7 @@ mod from_new_merge_with_metadata {
 
         let out = WorkspaceCommit::from_new_merge_with_metadata(
             &to_stacks(stacks),
+            None,
             &graph,
             &repo,
             Some("refs/heads/conflict-C2".try_into()?),
@@ -452,6 +475,7 @@ mod from_new_merge_with_metadata {
 
         let out = WorkspaceCommit::from_new_merge_with_metadata(
             &to_stacks(["conflict-C2", "conflict-C2", "conflict-C1", "clean-A"]),
+            None,
             &graph,
             &repo,
             Some("refs/heads/conflict-C1".try_into()?),


### PR DESCRIPTION
### Tasks

* [x] test
* [x] make `apply()` work with advanced branches and unnamed branches
* [x] fix
* [x] refactor

### Future Improvements

* [ ] per stack base so we can show only what's needed, but on a per-stack level.
    - important when a local tracking branch from the past is put into the workspace, without rebase
