### PR TITLE
but review: Default flag

### DIFF
--- a/cli-docs/but-review.mdx
+++ b/cli-docs/but-review.mdx
@@ -51,6 +51,13 @@ Run pre-push hooks.
 - **Type:** Flag (boolean)
 - **Default:** `true`
 
+### `-t, --default`
+
+Use just the branch name as the review title, without opening an editor.
+
+- **Type:** Flag (boolean)
+- **Default:** `false`
+
 ## Examples
 
 Publish all active branches:
@@ -69,4 +76,8 @@ Publish without running hooks:
 
 ```
 but review publish --run-hooks=false
+```
+
+```
+but review publish --default
 ```

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -299,6 +299,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
                 skip_force_push_protection,
                 with_force,
                 run_hooks,
+                default,
             } => {
                 let project = get_or_init_project(&args.current_dir)?;
                 let result = forge::review::publish_reviews(
@@ -307,6 +308,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
                     *skip_force_push_protection,
                     *with_force,
                     *run_hooks,
+                    *default,
                     args.json,
                 )
                 .await


### PR DESCRIPTION
Add a flag for a creating reviews with the default values.
Currently, that means that the branch name will be used as the review title and the description will be left empty