### PR TITLE
fix(Gitlab): remove unnecessary characters from draft prefix

### DIFF
--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -131,7 +131,7 @@ function injectEndpoints(api: GitLabApi) {
 						const upstreamProject = await api.Projects.show(upstreamProjectId);
 
 						// GitLab uses title prefix to mark drafts: "Draft:", "[Draft]", or "(Draft)"
-						const finalTitle = draft ? `[Draft]: ${title}` : title;
+						const finalTitle = draft ? `[Draft] ${title}` : title;
 
 						const mr = await api.MergeRequests.create(forkProjectId, head, base, finalTitle, {
 							description: body,


### PR DESCRIPTION
## 🧢 Changes
Remove `:` from added prefix

## ☕️ Reasoning

GitLab uses title prefix to mark drafts: "Draft:", "[Draft]", or "(Draft)". If add `[Draft]: ` to the title and then switch MR to ready to merge, GitLab will only remove the `[Draft]` prefix, leaving the `: ` intact.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
