### PR TITLE
Gerrit use refs/notes/review for auto detect

### DIFF
--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -330,7 +330,7 @@ pub fn is_gerrit_remote(repo: &gix::Repository) -> anyhow::Result<bool> {
     use gix::{bstr::ByteSlice, remote::Direction};
 
     // Magic refspec that we use to determine if the remote is a Gerrit remote
-    let gerrit_notes_ref = "refs/meta/config";
+    let gerrit_notes_ref = "refs/notes/review";
 
     let remote_name = repo
         .remote_default_name(Direction::Fetch)


### PR DESCRIPTION
It seems like `refs/meta/config` is used for other things by Azure 
DevOps forge

This should resolve the issue first observed here https://github.com/gitbutlerapp/gitbutler/issues/10899

NB: It appears that this will possibly create a significant number of false negatives. [Discord conversation](https://discord.com/channels/1060193121130000425/1073202153163857920/1433508933158309968)

Gonna merge this as a temporary solution (since false positives are worse). 
But we need to revisit this auto detection