### PR TITLE
fix(cli): escape spaces in cli path when building MCP config

### DIFF
--- a/crates/but-claude/src/claude_mcp.rs
+++ b/crates/but-claude/src/claude_mcp.rs
@@ -116,7 +116,7 @@ impl ClaudeMcpConfig {
 
     pub fn mcp_servers_with_security(&self) -> McpConfig {
         let cli_path = get_cli_path()
-            .map(|p| p.to_string_lossy().into_owned())
+            .map(|p| p.to_string_lossy().replace(' ', "\\ "))
             .unwrap_or("but".into());
         let mut out = self.mcp_servers();
         out.mcp_servers.insert(


### PR DESCRIPTION
Should fix https://github.com/gitbutlerapp/gitbutler/issues/10901