### PR TITLE
Remove the on-add gerrit-check for now. (#10927)

### DIFF
--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -1,7 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
-use but_core::{GitConfigSettings, RepositoryExt};
 use gitbutler_error::error;
 
 use super::{Project, ProjectId, storage, storage::UpdateRequest};
@@ -144,15 +143,6 @@ impl Controller {
         // Create a .git/gitbutler directory for app data
         if let Err(error) = std::fs::create_dir_all(project.gb_dir()) {
             tracing::error!(project_id = %project.id, ?error, "failed to create {:?} on project add", project.gb_dir());
-        }
-
-        // Check if the remote is a Gerrit remote and set config accordingly
-        if let Ok(true) = is_gerrit_remote(&repo) {
-            let gerrit_config = GitConfigSettings {
-                gitbutler_gerrit_mode: Some(true),
-                ..Default::default()
-            };
-            repo.set_git_settings(&gerrit_config).ok();
         }
 
         Ok(AddProjectOutcome::Added(project))
@@ -324,26 +314,4 @@ fn delete_gitbutler_references(repo: &gix::Repository) -> Result<()> {
     }
 
     Ok(())
-}
-
-pub fn is_gerrit_remote(repo: &gix::Repository) -> anyhow::Result<bool> {
-    use gix::{bstr::ByteSlice, remote::Direction};
-
-    // Magic refspec that we use to determine if the remote is a Gerrit remote
-    let gerrit_notes_ref = "refs/notes/review";
-
-    let remote_name = repo
-        .remote_default_name(Direction::Push)
-        .ok_or_else(|| anyhow::anyhow!("No push remotes found"))?;
-
-    let mut remote = repo.find_remote(remote_name.as_bstr())?;
-    // Need to set fetch specs as ref-map requests always use fetch specs (it's not used when pushing)
-    remote.replace_refspecs(vec![gerrit_notes_ref], Direction::Fetch)?;
-
-    let (map, _) = remote
-        .with_fetch_tags(gix::remote::fetch::Tags::None)
-        .connect(Direction::Push)?
-        .ref_map(gix::progress::Discard, Default::default())?;
-
-    Ok(!map.remote_refs.is_empty())
 }

--- a/crates/gitbutler-project/src/gerrit.rs
+++ b/crates/gitbutler-project/src/gerrit.rs
@@ -1,0 +1,22 @@
+/// Check if the default remote of the repository is using Gerrit.
+pub fn is_used_by_default_remote(repo: &gix::Repository) -> anyhow::Result<bool> {
+    use gix::{bstr::ByteSlice, remote::Direction};
+
+    // Magic refspec that we use to determine if the remote is a Gerrit remote
+    let gerrit_notes_ref = "refs/notes/review";
+
+    let remote_name = repo
+        .remote_default_name(Direction::Push)
+        .ok_or_else(|| anyhow::anyhow!("No push remotes found"))?;
+
+    let mut remote = repo.find_remote(remote_name.as_bstr())?;
+    // Need to set fetch specs as ref-map requests always use fetch specs (it's not used when pushing)
+    remote.replace_refspecs(vec![gerrit_notes_ref], Direction::Fetch)?;
+
+    let (map, _) = remote
+        .with_fetch_tags(gix::remote::fetch::Tags::None)
+        .connect(Direction::Push)?
+        .ref_map(gix::progress::Discard, Default::default())?;
+
+    Ok(!map.remote_refs.is_empty())
+}

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -2,6 +2,7 @@ pub mod access;
 pub mod api;
 mod controller;
 mod default_true;
+pub mod gerrit;
 mod project;
 mod storage;
 


### PR DESCRIPTION
There are two known occasions where it misdetects its presence, which leads to change-ids being added on each commit GB creates.

And it can create a lot of commits during rebase.

Note that this commit doesn't add a UI way of changing the gerrit mode yet, and I imagine that the auto-detection could be a suggestion in future.
