### PR TITLE
Spike: Linux ARM publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,6 +98,8 @@ jobs:
             target: x86_64-apple-darwin
           - platform: ubuntu-24.04 # [linux, x64]
             target: ''
+          - platform: ubuntu-24.04-arm # [linux, ARM64]
+            target: ''
           - platform: windows-latest # [windows, x64]
             target: ''
 
@@ -346,6 +348,8 @@ jobs:
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
           - platform: ubuntu-24.04 # [linux, x64]
+            target: ''
+          - platform: ubuntu-24.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # IMPORTANT: This should match CI so it won't download the toolchain all the time.
-channel = "1.90"
+channel = "1.91"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
Triggered by @nshcr, let's see if we can build on ARM Linux, and see if it can be uploaded to somewhere.

For now, it's not expected that the website picks this up.

### Tasks

* [x] try publish: https://github.com/gitbutlerapp/gitbutler/actions/runs/18997804055 
* [x] set rustc version
