### PR TITLE
Fix but-log format which fails even the infallible function `format_or_raw()`.

### DIFF
--- a/crates/but/src/oplog.rs
+++ b/crates/but/src/oplog.rs
@@ -116,7 +116,10 @@ pub(crate) fn show_oplog(project: &Project, json: bool, since: Option<&str>) -> 
 }
 
 fn snapshot_time_string(snapshot: &Snapshot) -> String {
-    snapshot.created_at.to_gix().format_or_raw(ISO8601_NO_TZ)
+    let time = snapshot.created_at.to_gix();
+    // TODO: use `format_or_unix`.
+    time.format(ISO8601_NO_TZ)
+        .unwrap_or_else(|_| time.seconds.to_string())
 }
 
 pub(crate) fn restore_to_oplog(

--- a/crates/gitbutler-oxidize/src/lib.rs
+++ b/crates/gitbutler-oxidize/src/lib.rs
@@ -9,7 +9,7 @@ mod ext;
 pub use ext::GixRepositoryExt;
 
 pub fn gix_time_to_git2(time: gix::date::Time) -> git2::Time {
-    git2::Time::new(time.seconds, time.offset)
+    git2::Time::new(time.seconds, time.offset / 60)
 }
 
 pub fn git2_to_gix_object_id(id: git2::Oid) -> gix::ObjectId {


### PR DESCRIPTION
The question really is how `git2` gets to parse commits with seconds as minutes.
