### PR TITLE
fix: Correctly create the GitHub client depending on the account type

### DIFF
--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -223,8 +223,9 @@ pub async fn get_gh_user(
     storage: &but_forge_storage::controller::Controller,
 ) -> Result<Option<AuthenticatedUser>> {
     if let Some(access_token) = token::get_gh_access_token(account, storage)? {
-        let gh =
-            client::GitHubClient::new(&access_token).context("Failed to create GitHub client")?;
+        let gh = account
+            .client(&access_token)
+            .context("Failed to create GitHub client")?;
         let user = gh
             .get_authenticated()
             .await

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -8,7 +8,8 @@ pub async fn list(
 ) -> Result<Vec<crate::client::PullRequest>> {
     let account_id = resolve_account(preferred_account, storage)?;
     if let Some(access_token) = crate::token::get_gh_access_token(&account_id, storage)? {
-        let gh = crate::client::GitHubClient::new(&access_token)
+        let gh = account_id
+            .client(&access_token)
             .context("Failed to create GitHub client")?;
         let pulls = gh
             .list_open_pulls(owner, repo)
@@ -27,7 +28,8 @@ pub async fn create(
 ) -> Result<crate::client::PullRequest> {
     let account_id = resolve_account(preferred_account, storage)?;
     if let Some(access_token) = crate::token::get_gh_access_token(&account_id, storage)? {
-        let gh = crate::client::GitHubClient::new(&access_token)
+        let gh = account_id
+            .client(&access_token)
             .context("Failed to create GitHub client")?;
         let pr = gh
             .create_pull_request(&params)

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 use but_secret::{Sensitive, secret};
 use serde::{Deserialize, Serialize};
 
+use crate::client::GitHubClient;
+
 /// Persist GitHub account access tokens securely.
 pub fn persist_gh_access_token(
     account_id: &GithubAccountIdentifier,
@@ -84,6 +86,16 @@ impl GithubAccountIdentifier {
             GithubAccountIdentifier::OAuthUsername { username } => username,
             GithubAccountIdentifier::PatUsername { username } => username,
             GithubAccountIdentifier::Enterprise { username, .. } => username,
+        }
+    }
+
+    pub fn client(&self, access_token: &Sensitive<String>) -> Result<GitHubClient> {
+        match self {
+            GithubAccountIdentifier::OAuthUsername { .. }
+            | GithubAccountIdentifier::PatUsername { .. } => GitHubClient::new(access_token),
+            GithubAccountIdentifier::Enterprise { host, .. } => {
+                GitHubClient::new_with_host_override(access_token, host)
+            }
         }
     }
 }


### PR DESCRIPTION
If the account is an Enterprise GH account, create a client with the host override

fixes: https://github.com/gitbutlerapp/gitbutler/issues/10945