### PR TITLE
ui-fixes

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -83,6 +83,7 @@
 		numberOfUpstreamCommits: number;
 		numberOfBranchesInStack: number;
 		hasCodegenRow?: boolean;
+		baseCommit?: string;
 		onclick: () => void;
 		menu?: Snippet<[{ rightClickTrigger: HTMLElement }]>;
 		buttons?: Snippet;
@@ -129,6 +130,11 @@
 	const selection = $derived(laneState ? laneState.selection.current : undefined);
 	const selected = $derived(selection?.branchName === branchName);
 	const isPushed = $derived(!!(args.type === 'draft-branch' ? undefined : args.trackingBranch));
+	const isCommitTarget = $derived(
+		exclusiveAction?.type === 'commit' &&
+			(exclusiveAction.branchName === branchName ||
+				(exclusiveAction.branchName === undefined && args.type === 'draft-branch'))
+	);
 
 	// Consolidated rounded bottom logic from both BranchCard and BranchHeader
 	const isRoundedBottom = $derived.by(() => {
@@ -226,6 +232,17 @@
 				draft={false}
 				{lineColor}
 				isCommitting={args.isCommitting}
+				{isCommitTarget}
+				commitId={args.baseCommit}
+				onCommitGoesHereClick={() => {
+					if (!args.stackId) return;
+					projectState.exclusiveAction.set({
+						type: 'commit',
+						stackId: args.stackId,
+						branchName,
+						parentCommitId: args.baseCommit
+					});
+				}}
 				iconName={args.iconName}
 				{updateBranchName}
 				isUpdatingName={nameUpdate.current.isLoading}
@@ -373,6 +390,8 @@
 			selected
 			draft
 			{lineColor}
+			isCommitting={args.isCommitting}
+			{isCommitTarget}
 			iconName="branch-local"
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -10,7 +10,6 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import UpstreamCommitsAction from '$components/UpstreamCommitsAction.svelte';
 	import { isLocalAndRemoteCommit, isUpstreamCommit } from '$components/lib';
-	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { commitStatusLabel } from '$lib/commits/commit';
 	import {
 		AmendCommitWithChangeDzHandler,
@@ -74,7 +73,6 @@
 	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
-	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const hooksService = inject(HOOKS_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
@@ -98,10 +96,6 @@
 	const upstreamOnlyCommits = $derived(
 		stackService.upstreamCommits(projectId, stackId, branchName)
 	);
-
-	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
-	const base = $derived(baseBranchQuery.response);
-	const baseSha = $derived(base?.baseSha);
 
 	let integrationModal = $state<Modal>();
 
@@ -226,23 +220,6 @@
 	{#snippet children([upstreamOnlyCommits, localAndRemoteCommits], { stackId })}
 		{@const hasRemoteCommits = upstreamOnlyCommits.length > 0}
 		{@const hasCommits = localAndRemoteCommits.length > 0}
-
-		{#if !hasCommits && isCommitting}
-			<CommitGoesHere
-				commitId={baseSha}
-				last
-				draft
-				selected={branchName === commitAction?.branchName}
-				onclick={() => {
-					projectState.exclusiveAction.set({
-						type: 'commit',
-						stackId,
-						branchName,
-						parentCommitId: branchDetails.baseCommit
-					});
-				}}
-			/>
-		{/if}
 
 		{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
 

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -418,7 +418,8 @@
 							{first}
 							{last}
 							selected={exclusiveAction?.type === 'commit' &&
-								exclusiveAction.parentCommitId === branchDetails.baseCommit}
+								exclusiveAction.parentCommitId === branchDetails.baseCommit &&
+								commitAction?.branchName === branchName}
 							onclick={() => {
 								projectState.exclusiveAction.set({
 									type: 'commit',

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -83,6 +83,7 @@
 	let active = $state(false);
 
 	const actionsVisible = $derived(!draft && !isCommitting && (buttons || menu));
+	const showCommitGoesHere = $derived(draft || (isEmpty && isCommitting));
 
 	const draggableBranchConfig = $derived.by<DraggableConfig>(() => {
 		if (!dragArgs) {
@@ -102,7 +103,7 @@
 
 <div
 	class="header-wrapper"
-	class:rounded={(actionsVisible && roundedBottom) || draft}
+	class:rounded={roundedBottom}
 	use:focusable={{
 		onAction: () => onclick?.(),
 		onActive: (value) => (active = value),
@@ -117,7 +118,6 @@
 		class="branch-header"
 		class:selected
 		class:active
-		class:draft
 		class:commiting={isCommitting}
 		{onclick}
 		onkeypress={onclick}
@@ -166,7 +166,7 @@
 		</div>
 	</div>
 
-	{#if draft}
+	{#if showCommitGoesHere}
 		<CommitGoesHere commitId={undefined} selected draft />
 	{/if}
 

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -33,6 +33,9 @@
 		readonly: boolean;
 		draft: boolean;
 		isCommitting?: boolean;
+		isCommitTarget?: boolean;
+		commitId?: string;
+		onCommitGoesHereClick?: () => void;
 		isPushed: boolean;
 		lineColor: string;
 		conflicts?: boolean;
@@ -57,6 +60,9 @@
 		selected,
 		draft,
 		isCommitting,
+		isCommitTarget = false,
+		commitId,
+		onCommitGoesHereClick,
 		isUpdatingName,
 		failedMisserablyToUpdateBranchName,
 		readonly,
@@ -83,7 +89,13 @@
 	let active = $state(false);
 
 	const actionsVisible = $derived(!draft && !isCommitting && (buttons || menu));
-	const showCommitGoesHere = $derived(draft || (isEmpty && isCommitting));
+	// Show CommitGoesHere in header for:
+	// 1. Draft branches (always when committing)
+	// 2. Empty branches with click handler (so you can select them)
+	// Branches with commits show it between commits in BranchCommitList instead
+	const showCommitGoesHere = $derived(
+		isCommitting && (draft || (isEmpty && onCommitGoesHereClick))
+	);
 
 	const draggableBranchConfig = $derived.by<DraggableConfig>(() => {
 		if (!dragArgs) {
@@ -167,7 +179,13 @@
 	</div>
 
 	{#if showCommitGoesHere}
-		<CommitGoesHere commitId={undefined} selected draft />
+		<CommitGoesHere
+			{commitId}
+			selected={isCommitTarget}
+			draft={draft || isEmpty}
+			last={isEmpty && !draft}
+			onclick={onCommitGoesHereClick}
+		/>
 	{/if}
 
 	{#if actionsVisible && !showPrCreation}

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -237,6 +237,7 @@
 					numberOfCommits={localAndRemoteCommits.length}
 					numberOfUpstreamCommits={upstreamOnlyCommits.length}
 					numberOfBranchesInStack={branches.length}
+					baseCommit={branchDetails.baseCommit}
 					dropzones={[stackingReorderDropzoneManager.top(branchName)]}
 					trackingBranch={branch.remoteTrackingBranch ?? undefined}
 					readonly={!!branch.remoteTrackingBranch}

--- a/apps/desktop/src/components/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/CommitGoesHere.svelte
@@ -83,7 +83,6 @@
 		width: 42px;
 		height: 8px;
 	}
-
 	.pin__circle {
 		position: relative;
 		width: 8px;
@@ -117,7 +116,7 @@
 		margin-top: -10px;
 		margin-bottom: -10px;
 		opacity: 0;
-		transition: height var(--transition-fast);
+		transition: height var(--transition-medium);
 
 		&:hover {
 			opacity: 1;

--- a/apps/desktop/src/components/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/CommitGoesHere.svelte
@@ -115,6 +115,7 @@
 		height: 20px;
 		margin-top: -10px;
 		margin-bottom: -10px;
+		background-color: var(--clr-bg-1);
 		opacity: 0;
 		transition: height var(--transition-medium);
 

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -51,6 +51,7 @@
 							type="draft-branch"
 							{projectId}
 							{branchName}
+							isCommitting
 							readonly={false}
 							lineColor="var(--clr-commit-local)"
 						/>


### PR DESCRIPTION
This pull request refactors how empty branches and draft branches display the "Commit Goes Here" indicator, consolidating logic for when and where this UI element appears. It also improves the selection and click handling for commit targets, and streamlines the passing of commit-related props between components. The changes ensure a more consistent user experience and cleaner code by centralizing and clarifying the conditions under which commit actions can be performed.

**Commit action and UI logic improvements:**

* Consolidated the logic for showing rounded bottoms and the "Commit Goes Here" indicator for branches, moving it into a derived variable `isRoundedBottom` in `BranchCard.svelte` and using it in both `BranchCard` and `BranchHeader` components for consistency. [[1]](diffhunk://#diff-4719bea7c284e3942fab655243a6b3e5eb3d6fb01756da229ad02097ab89fe43R133-R166) [[2]](diffhunk://#diff-4719bea7c284e3942fab655243a6b3e5eb3d6fb01756da229ad02097ab89fe43R235-R250) [[3]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495R92-R98) [[4]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495L105-R118)
* Refactored the handling of commit targets by introducing `isCommitTarget`, `commitId`, and `onCommitGoesHereClick` props, allowing more precise selection and click handling for commit actions. [[1]](diffhunk://#diff-4719bea7c284e3942fab655243a6b3e5eb3d6fb01756da229ad02097ab89fe43R235-R250) [[2]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495R36-R38) [[3]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495R63-R65) [[4]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495L169-R188)

**Component prop and data flow updates:**

* Added `baseCommit` as a prop to `BranchCard` and ensured it is passed down from `BranchList` and other parent components, improving data flow for commit actions. [[1]](diffhunk://#diff-4719bea7c284e3942fab655243a6b3e5eb3d6fb01756da229ad02097ab89fe43R86) [[2]](diffhunk://#diff-1ad580da2436dcbcce1c2ae53082aaa7b0e9d9efef5a964beed3ee454d75aa3cR240)
* Updated `StackDraft` to explicitly set `isCommitting` when rendering draft branches, ensuring correct UI state.

**Code cleanup and UI tweaks:**

* Removed unused base branch logic from `BranchCommitList.svelte`, simplifying the code and removing unnecessary queries. [[1]](diffhunk://#diff-149974f0265cdf94b6eee58ae93dd3014bed081d9fa151bb16d9db73669ca820L13) [[2]](diffhunk://#diff-149974f0265cdf94b6eee58ae93dd3014bed081d9fa151bb16d9db73669ca820L77) [[3]](diffhunk://#diff-149974f0265cdf94b6eee58ae93dd3014bed081d9fa151bb16d9db73669ca820L102-L105)
* Improved the selection logic for commit actions in `BranchCommitList.svelte` to ensure the correct branch and commit are targeted.
* Updated styles for the `CommitGoesHere` component to use a background color and smoother transition for better visual feedback.

These changes work together to make the commit workflow more intuitive and visually consistent for users.