### PR TITLE
Link fix: By default, the links open on another window

### DIFF
--- a/apps/desktop/src/components/AnalyticsSettings.svelte
+++ b/apps/desktop/src/components/AnalyticsSettings.svelte
@@ -12,19 +12,13 @@
 <div class="analytics-settings__content">
 	<p class="text-13 text-body analytics-settings__text">
 		GitButler uses telemetry strictly to help us improve the client. We do not collect any personal
-		information, unless explicitly allowed below. <Link
-			target="_blank"
-			rel="noreferrer"
-			href="https://gitbutler.com/privacy"
-		>
+		information, unless explicitly allowed below. <Link href="https://gitbutler.com/privacy">
 			Privacy policy
 		</Link>
 	</p>
 	<p class="text-13 text-body analytics-settings__text">
 		We kindly ask you to consider keeping these settings enabled as it helps us catch issues more
 		quickly. If you choose to disable them, please feel free to share your feedback on our <Link
-			target="_blank"
-			rel="noreferrer"
 			href="https://discord.gg/MmFkmaJ42D"
 		>
 			Discord

--- a/apps/desktop/src/components/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/CreateBranchModal.svelte
@@ -230,8 +230,6 @@
 		<div class="footer">
 			<span class="text-12 text-body footer-text"
 				>See more: <Link
-					target="_blank"
-					rel="noreferrer"
 					href="https://docs.gitbutler.com/features/branch-management/stacked-branches"
 					>Stacked vs. Dependent</Link
 				></span

--- a/apps/desktop/src/components/Feed.svelte
+++ b/apps/desktop/src/components/Feed.svelte
@@ -162,7 +162,6 @@
 								</p>
 								<Link
 									href="https://docs.gitbutler.com/features/ai-integration/ai-overview"
-									target="_blank"
 									class="clr-text-2">Learn more</Link
 								>
 							</li>

--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -181,13 +181,7 @@
 						{#snippet caption()}
 							{#if selectedType === 'gitCredentialsHelper'}
 								GitButler will use the system's git credentials helper.
-								<Link
-									target="_blank"
-									rel="noreferrer"
-									href="https://git-scm.com/doc/credential-helpers"
-								>
-									Learn more
-								</Link>
+								<Link href="https://git-scm.com/doc/credential-helpers">Learn more</Link>
 							{/if}
 						{/snippet}
 

--- a/apps/desktop/src/components/PRBranchView.svelte
+++ b/apps/desktop/src/components/PRBranchView.svelte
@@ -61,9 +61,7 @@
 							<span>No remote</span>
 
 							<span class="pr-request-data__divider">•</span>
-							<Link target="_blank" rel="noopener noreferrer" href={pr.htmlUrl}>
-								Open in browser
-							</Link>
+							<Link href={pr.htmlUrl}>Open in browser</Link>
 						</div>
 					</div>
 				</div>

--- a/apps/desktop/src/components/profileSettings/GitSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GitSettings.svelte
@@ -56,8 +56,6 @@
 		By default, everything in the GitButler client is free to use. You can opt in to crediting us as
 		the committer in your virtual branch commits to help spread the word.
 		<Link
-			target="_blank"
-			rel="noreferrer"
 			href="https://github.com/gitbutlerapp/gitbutler-docs/blob/d81a23779302c55f8b20c75bf7842082815b4702/content/docs/features/virtual-branches/committer-mark.mdx"
 		>
 			Learn more

--- a/apps/desktop/src/components/v3/ClaudeCheck.svelte
+++ b/apps/desktop/src/components/v3/ClaudeCheck.svelte
@@ -90,13 +90,10 @@
 	<Icon name="docs" color="info" />
 	<p class="text-13 text-body">
 		{#if recheckedAvailability === 'recheck-failed'}
-			If you haven't installed Claude Code, check our <Link target="_blank" href={DOCS_URL}
-				>installation guide</Link
+			If you haven't installed Claude Code, check our <Link href={DOCS_URL}>installation guide</Link
 			>
 		{:else}
-			Get the full guide to Agents in GitButler in <Link target="_blank" href={DOCS_URL}
-				>our documentation</Link
-			>
+			Get the full guide to Agents in GitButler in <Link href={DOCS_URL}>our documentation</Link>
 		{/if}
 	</p>
 </div>

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
@@ -262,8 +262,7 @@
 						</Factoid>
 						{#if branch.forgeUrl}
 							<Factoid label="PR"
-								><Link href={branch.forgeUrl} target="_blank"
-									>{branch.forgeDescription || '#unknown'}</Link
+								><Link href={branch.forgeUrl}>{branch.forgeDescription || '#unknown'}</Link
 								></Factoid
 							>
 						{/if}

--- a/packages/ui/src/lib/components/Link.svelte
+++ b/packages/ui/src/lib/components/Link.svelte
@@ -5,11 +5,14 @@
 		href: string;
 		children: Snippet;
 		class?: string;
-		target?: '_blank' | '_self' | '_parent' | '_top' | undefined;
-		rel?: string | undefined;
+		/**
+		 * Open link inside the current window.
+		 * Most times this is not what you  want. For that use `goto()` instead.
+		 */
+		insideWindow?: boolean;
 	}
 
-	const { href, target = undefined, class: classes, rel = undefined, children }: Props = $props();
+	const { href, class: classes, children, insideWindow = false }: Props = $props();
 
 	let element = $state<HTMLAnchorElement>();
 
@@ -20,6 +23,8 @@
 	});
 
 	const isExternal = $derived(href?.startsWith('http'));
+	const target = $derived(isExternal && !insideWindow ? '_blank' : '_self');
+	const rel = $derived(isExternal && !insideWindow ? 'noopener noreferrer' : undefined);
 </script>
 
 <a {href} {target} {rel} class="link {classes}" bind:this={element}>

--- a/packages/ui/src/lib/components/markdown/markdownRenderers/Link.svelte
+++ b/packages/ui/src/lib/components/markdown/markdownRenderers/Link.svelte
@@ -6,6 +6,6 @@
 	const { href, children }: Props = $props();
 </script>
 
-<Link {href} target="_blank" rel="noopener noreferrer">
+<Link {href}>
 	{@render children()}
 </Link>


### PR DESCRIPTION
This makes it so that we don’t need to remember to make all links external links.
Ensuring we don’t open links on the application window

fixes: #10971 