### PR TITLE
Branch header context menu: Bring back the unapply option

### DIFF
--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -353,6 +353,20 @@
 					{#snippet error()}{/snippet}
 				</ReduxResult>
 			{/if}
+
+			{#if stackId && first}
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Unapply Stack"
+						icon="eject"
+						disabled={isReadOnly}
+						onclick={async () => {
+							await stackService.unapply({ projectId, stackId });
+							close();
+						}}
+					/>
+				</ContextMenuSection>
+			{/if}
 		{/snippet}
 	</KebabButton>
 {/if}


### PR DESCRIPTION
Bring back the unapply option in the branch header context menu temporarily, while blind people like me find the new stack-kebab menu