### PR TITLE
Always provide permission mode

### DIFF
--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -433,7 +433,9 @@ async fn spawn_command(
         ]);
         // Set permission mode based on interaction mode
         match user_params.permission_mode {
-            PermissionMode::Default => {}
+            PermissionMode::Default => {
+                command.args(["--permission-mode", "default"]);
+            }
             PermissionMode::Plan => {
                 command.args(["--permission-mode", "plan"]);
             }


### PR DESCRIPTION
If you don’t provide a permission mode, it uses the one defined in the settings (if it exists), where as passing “default” is the CC’s original “default” behaviour.