### PR TITLE
Also provide the names of the stacks that conflicted, so they can be shown.

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -623,6 +623,7 @@ export default class MockBackend {
 
 		// Do nothing for now
 		return {
+			unappliedStacksShortNames: [],
 			stackId: 'something',
 			unappliedStacks: []
 		};

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -7,14 +7,43 @@ import type iconsJson from '@gitbutler/ui/data/icons.json';
 export type CreateBranchFromBranchOutcome = {
 	stackId: string;
 	unappliedStacks: string[];
+	unappliedStacksShortNames: string[];
 };
+
+function stackCount(numStacks: number): string {
+	if (numStacks === 1) {
+		return 'one stack';
+	} else {
+		return 'some stacks';
+	}
+}
+
+function prettyNamedListIfPossible(expectedNames: number, names: string[]): string {
+	// It could happen that not all stacks had names, for now we don't deal with that.
+	// Also, the old codepath doesn't produce names.
+	if (expectedNames !== names.length) {
+		return stackCount(expectedNames);
+	}
+	if (names.length === 0) {
+		return '';
+	} else if (names.length === 1) {
+		return `stack ${names[0]}`;
+	} else if (names.length === 2) {
+		return `stack ${names[0]} and stack ${names[1]}`;
+	}
+
+	const allButLast = names.slice(0, -1);
+	const last = names[names.length - 1];
+
+	return `${allButLast.map((n) => `stack ${n}`).join(', ')}, and stack ${last}`;
+}
 
 export function handleCreateBranchFromBranchOutcome(outcome: CreateBranchFromBranchOutcome) {
 	if (outcome.unappliedStacks.length > 0) {
 		showToast({
 			testId: TestId.StacksUnappliedToast,
-			title: 'Heads up: We had to unapply some stacks to apply this one',
-			message: `There were some conflicts detected when applying this branch into your workspace, so we automatically unapplied ${outcome.unappliedStacks.length} ${outcome.unappliedStacks.length === 1 ? 'stack' : 'stacks'}.
+			title: `Heads up: We had to unapply ${stackCount(outcome.unappliedStacks.length)} to apply this one`,
+			message: `There were some conflicts detected when applying this branch into your workspace, so we automatically unapplied ${prettyNamedListIfPossible(outcome.unappliedStacks.length, outcome.unappliedStacksShortNames)}.
 You can always re-apply them later from the branches page.`
 		});
 	}

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -282,7 +282,7 @@ pub mod stacks {
             let ref_name = Refname::from_str(&format!("refs/remotes/{remote_name}/{name}"))?;
             let remote_ref_name = RemoteRefname::new(remote_name, name);
 
-            let (stack_id, _) = gitbutler_branch_actions::create_virtual_branch_from_branch(
+            let (stack_id, _, _) = gitbutler_branch_actions::create_virtual_branch_from_branch(
                 ctx,
                 &ref_name,
                 Some(remote_ref_name),

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1410,7 +1410,7 @@ pub fn split_branch(
     let refname = Refname::Local(LocalRefname::new(&params.new_branch_name, None));
     let branch_manager = ctx.branch_manager();
 
-    let (stack_id, _) = branch_manager.create_virtual_branch_from_branch(
+    let (stack_id, _, _) = branch_manager.create_virtual_branch_from_branch(
         &refname,
         None,
         None,

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -516,7 +516,7 @@ pub fn create_virtual_branch_from_branch(
     branch: &Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
-) -> Result<(StackId, Vec<StackId>)> {
+) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     ensure_open_workspace_mode(ctx)

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -34,13 +34,21 @@ use crate::{
 pub struct CreateBranchFromBranchOutcome {
     pub stack_id: StackId,
     pub unapplied_stacks: Vec<StackId>,
+    pub unapplied_stacks_short_names: Vec<String>,
 }
 
-impl From<(StackId, Vec<StackId>)> for CreateBranchFromBranchOutcome {
-    fn from((stack_id, unapplied_stacks): (StackId, Vec<StackId>)) -> Self {
+impl From<(StackId, Vec<StackId>, Vec<String>)> for CreateBranchFromBranchOutcome {
+    fn from(
+        (stack_id, unapplied_stacks, unapplied_stacks_short_names): (
+            StackId,
+            Vec<StackId>,
+            Vec<String>,
+        ),
+    ) -> Self {
         Self {
             stack_id,
             unapplied_stacks,
+            unapplied_stacks_short_names,
         }
     }
 }
@@ -145,7 +153,7 @@ impl BranchManager<'_> {
         upstream_branch: Option<RemoteRefname>,
         pr_number: Option<usize>,
         perm: &mut WorktreeWritePermission,
-    ) -> Result<(StackId, Vec<StackId>)> {
+    ) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
         let branch_name = target
             .branch()
             .expect("always a branch reference")
@@ -183,7 +191,21 @@ impl BranchManager<'_> {
                 .0
                 .id
                 .context("BUG: newly applied stacks should always have a stack id")?;
-            return Ok((applied_branch_stack_id, out.conflicting_stack_ids));
+            let conflicted_stack_short_names_for_display = ws
+                .stacks
+                .iter()
+                .filter_map(|s| {
+                    out.conflicting_stack_ids
+                        .contains(&s.id?)
+                        .then(|| s.ref_name().map(|rn| rn.shorten().to_string()))
+                        .flatten()
+                })
+                .collect();
+            return Ok((
+                applied_branch_stack_id,
+                out.conflicting_stack_ids,
+                conflicted_stack_short_names_for_display,
+            ));
         }
         let old_cwd = (!self.ctx.app_settings().feature_flags.cv3)
             .then(|| self.ctx.repo().create_wd_tree(0).map(|tree| tree.id()))
@@ -312,14 +334,14 @@ impl BranchManager<'_> {
         self.ctx.add_branch_reference(&branch)?;
 
         match self.apply_branch(branch.id, perm, old_workspace, old_cwd) {
-            Ok((_, unapplied_stacks)) => Ok((branch.id, unapplied_stacks)),
+            Ok((_, unapplied_stacks)) => Ok((branch.id, unapplied_stacks, vec![])),
             Err(err)
                 if err
                     .downcast_ref()
                     .is_some_and(|marker: &Marker| *marker == Marker::ProjectConflict) =>
             {
                 // if branch conflicts with the workspace, it's ok. keep it unapplied
-                Ok((branch.id, vec![]))
+                Ok((branch.id, vec![], vec![]))
             }
             Err(err) => Err(err).context("failed to apply"),
         }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -192,15 +192,20 @@ impl BranchManager<'_> {
                 .id
                 .context("BUG: newly applied stacks should always have a stack id")?;
             let conflicted_stack_short_names_for_display = ws
-                .stacks
-                .iter()
-                .filter_map(|s| {
-                    out.conflicting_stack_ids
-                        .contains(&s.id?)
-                        .then(|| s.ref_name().map(|rn| rn.shorten().to_string()))
-                        .flatten()
+                .metadata
+                .as_ref()
+                .map(|md| {
+                    md.stacks
+                        .iter()
+                        .filter_map(|s| {
+                            out.conflicting_stack_ids
+                                .contains(&s.id)
+                                .then(|| s.ref_name().map(|rn| rn.shorten().to_string()))
+                                .flatten()
+                        })
+                        .collect::<Vec<_>>()
                 })
-                .collect();
+                .unwrap_or_default();
             return Ok((
                 applied_branch_stack_id,
                 out.conflicting_stack_ids,

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -133,12 +133,13 @@ pub(crate) fn tear_off_branch(
         .context("failed to update gitbutler workspace")?;
 
     let branch_manager = ctx.branch_manager();
-    let (_, unapplied_stacks) = branch_manager.create_virtual_branch_from_branch(
-        &Refname::Local(LocalRefname::new(subject_branch_name, None)),
-        None,
-        None,
-        perm,
-    )?;
+    let (_, unapplied_stacks, _unapplied_stack_shortnames) = branch_manager
+        .create_virtual_branch_from_branch(
+            &Refname::Local(LocalRefname::new(subject_branch_name, None)),
+            None,
+            None,
+            perm,
+        )?;
 
     Ok(MoveBranchResult {
         deleted_stacks,


### PR DESCRIPTION
The motivation here is that this is a quick change that will live disproportionally better
for users, and gives us some time to rethink the workflow more thoroughly.

### Tasks

* [x] backend also sends names
* [x] frontend uses them
