### PR TITLE
feat: persist file list mode and defaults

### DIFF
--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -30,6 +30,7 @@
 		ancestorMostConflictedCommitId?: string;
 		ontoggle?: (collapsed: boolean) => void;
 		allowUnselect?: boolean;
+		persistId?: string;
 	};
 
 	const {
@@ -48,7 +49,8 @@
 		autoselect,
 		ancestorMostConflictedCommitId,
 		ontoggle,
-		allowUnselect = true
+		allowUnselect = true,
+		persistId = 'default'
 	}: Props = $props();
 
 	const idSelection = inject(FILE_SELECTION_MANAGER);
@@ -88,7 +90,7 @@
 		</div>
 	{/snippet}
 	{#snippet actions()}
-		<FileListMode bind:mode={listMode} persist="committed" />
+		<FileListMode bind:mode={listMode} persistId={`changed-files-${persistId}`} />
 	{/snippet}
 
 	<div class="filelist-wrapper" class:bottom-border={bottomBorder}>

--- a/apps/desktop/src/components/FileListMode.svelte
+++ b/apps/desktop/src/components/FileListMode.svelte
@@ -1,28 +1,30 @@
 <script lang="ts">
+	import { SETTINGS } from '$lib/settings/userSettings';
+	import { inject } from '@gitbutler/core/context';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { Segment, SegmentControl, TestId } from '@gitbutler/ui';
 
 	type Mode = 'tree' | 'list';
 	type Props = {
 		mode: Mode;
-		persist: 'uncommitted' | 'committed';
+		persistId: string;
 	};
 
-	let { persist, mode = $bindable() }: Props = $props();
+	let { persistId, mode = $bindable() }: Props = $props();
 
-	let saved = persisted<Mode | undefined>(undefined, persist);
+	const userSettings = inject(SETTINGS);
+	let saved = persisted<Mode | undefined>(undefined, `file-list-mode-${persistId}`);
 
+	// Initialize mode from saved value or default setting (runs once on mount)
 	$effect(() => {
-		if ($saved !== undefined && $saved !== mode) {
-			mode = $saved;
-		}
+		mode = $saved ?? $userSettings.defaultFileListMode;
 	});
 </script>
 
 <SegmentControl
 	defaultIndex={mode === 'list' ? 0 : 1}
 	onselect={(id) => {
-		// TODO: Refactor SegmentControl.
+		// Update saved preference; the effect will sync mode
 		$saved = id as Mode;
 	}}
 	size="small"

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -392,6 +392,7 @@
 				selectionId={createCommitSelection({ commitId, stackId: stackId })}
 				noshrink={!!previewKey}
 				grow={!previewKey}
+				persistId={`commit-${commitId}`}
 				changes={changes.changes.filter(
 					(change) => !(change.path in (changes.conflictEntries?.entries ?? {}))
 				)}
@@ -431,6 +432,7 @@
 				selectionId={createBranchSelection({ stackId: stackId, branchName, remote: undefined })}
 				noshrink={!!previewKey}
 				grow={!previewKey}
+				persistId={`branch-${branchName}`}
 				changes={changes.changes}
 				stats={changes.stats}
 				resizer={previewKey

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -110,6 +110,7 @@
 					autoselect
 					grow
 					{selectionId}
+					persistId={`unapplied-branch-${branchName}`}
 					changes={changes.changes}
 					stats={changes.stats}
 					allowUnselect={false}

--- a/apps/desktop/src/components/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/UnappliedCommitView.svelte
@@ -45,6 +45,7 @@
 					grow
 					{projectId}
 					selectionId={createCommitSelection({ commitId })}
+					persistId={`unapplied-commit-${commitId}`}
 					changes={changes.changes}
 					allowUnselect={false}
 				/>

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -49,6 +49,9 @@
 		onscrollexists
 	}: Props = $props();
 
+	// Create a unique persist ID based on stackId and mode (both are static props)
+	const persistId = stackId ? `worktree-${mode}-${stackId}` : `worktree-${mode}`;
+
 	const stackService = inject(STACK_SERVICE);
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
@@ -144,7 +147,7 @@
 					</div>
 				</div>
 				{#if changes.current.length > 0}
-					<FileListMode bind:mode={listMode} persist="uncommitted" />
+					<FileListMode bind:mode={listMode} {persistId} />
 				{/if}
 			</div>
 		{/if}

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -58,6 +58,38 @@
 	{/snippet}
 	<ThemeSelector {userSettings} />
 </SectionCard>
+
+<SectionCard orientation="row" centerAlign>
+	{#snippet title()}
+		Default file list mode
+	{/snippet}
+	{#snippet caption()}
+		Set the default file list view (can be changed per location).
+	{/snippet}
+	{#snippet actions()}
+		<Select
+			maxWidth={120}
+			value={$userSettings.defaultFileListMode}
+			options={[
+				{ label: 'List view', value: 'list' },
+				{ label: 'Tree view', value: 'tree' }
+			]}
+			onselect={(value) => {
+				userSettings.update((s) => ({
+					...s,
+					defaultFileListMode: value as 'tree' | 'list'
+				}));
+			}}
+		>
+			{#snippet itemSnippet({ item, highlighted })}
+				<SelectItem selected={item.value === $userSettings.defaultFileListMode} {highlighted}>
+					{item.label}
+				</SelectItem>
+			{/snippet}
+		</Select>
+	{/snippet}
+</SectionCard>
+
 <div class="stack-v">
 	<SectionCard centerAlign roundedBottom={false}>
 		{#snippet title()}

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -31,6 +31,7 @@ export interface Settings {
 	diffContrast: 'light' | 'medium' | 'strong';
 	colorBlindFriendly: boolean;
 	defaultCodeEditor: CodeEditorSettings;
+	defaultFileListMode: 'tree' | 'list';
 }
 
 const defaults: Settings = {
@@ -52,7 +53,8 @@ const defaults: Settings = {
 	inlineUnifiedDiffs: false,
 	diffContrast: 'light',
 	colorBlindFriendly: false,
-	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' }
+	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' },
+	defaultFileListMode: 'list'
 };
 
 export function loadUserSettings(): Writable<Settings> {


### PR DESCRIPTION
## Motivation

Current behavior of switching between tree and list modes is not persisted across different components.
Each component should remember the user's choice independently.
In order to create a default value for the file list mode, we need to add it to the user settings.ts file.
Also, we need to change the persist prop to persistId prop in all components using FileListMode component.

Before:

https://github.com/user-attachments/assets/8127f21d-6e1e-4f5f-8dff-2e0957a2bce6

After:

https://github.com/user-attachments/assets/c9b06241-169b-42a2-9447-9407f6922d5b

