### PR TITLE
applyv3: tracking-branch usability

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -128,6 +128,12 @@ impl Options {
         self.commits_limit_recharge_location.extend(commits);
         self
     }
+
+    /// Set the extra-target which should be included in the workspace.
+    pub fn with_extra_target_commit_id(mut self, id: impl Into<gix::ObjectId>) -> Self {
+        self.extra_target_commit_id = Some(id.into());
+        self
+    }
 }
 
 /// Lifecycle

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -70,7 +70,7 @@ impl Stack {
         }
         if let Some((last_segment, last_aggregated_sidx)) = segments.last_mut().and_then(|s| {
             let sidx = s.commits_by_segment.last().map(|t| t.0)?;
-            (s, sidx).into()
+            Some((s, sidx))
         }) {
             let first_parent_sidx = graph
                 .neighbors_directed(last_aggregated_sidx, Direction::Outgoing)

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -205,6 +205,65 @@ git init special-branches
 
 mkdir ws
 (cd ws
+  git init remote-and-integrated-tracking-linear
+  (cd remote-and-integrated-tracking-linear
+     commit M1
+     commit M-base
+     git branch A
+     git checkout -b soon-origin-A main
+       commit A-remote
+     git checkout main
+       commit M-advanced
+       setup_target_to_match_main
+
+     git checkout A
+     create_workspace_commit_once A
+     setup_remote_tracking soon-origin-A A "move"
+  )
+
+  git init remote-and-integrated-tracking
+  (cd remote-and-integrated-tracking
+     commit M1
+     commit M2
+     git checkout -b tmp1
+      commit X
+     git checkout main
+     commit Y
+     git merge --no-ff tmp1 -m "M-base"
+     git branch A
+     git checkout -b soon-origin-A main
+       commit A-remote
+     git checkout main
+       commit M-advanced
+       setup_target_to_match_main
+
+     git checkout A
+     create_workspace_commit_once A
+     setup_remote_tracking soon-origin-A A "move"
+  )
+
+  git init remote-and-integrated-tracking-extra-commit
+  (cd remote-and-integrated-tracking-extra-commit
+     commit M1
+     commit M2
+     git checkout -b tmp1
+      commit X
+     git checkout main
+     commit Y
+     git merge --no-ff tmp1 -m "M-base"
+     git checkout -b A
+       commit A-local
+     git checkout -b soon-origin-A main
+       commit A-remote
+     git checkout main
+       commit M-advanced
+       setup_target_to_match_main
+
+     git checkout A
+     create_workspace_commit_once A
+     setup_remote_tracking soon-origin-A A "move"
+  )
+
   git init single-stack-ambiguous
   (cd single-stack-ambiguous
      commit init

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -5243,16 +5243,11 @@ fn remote_and_integrated_tracking_branch_on_merge() -> anyhow::Result<()> {
         standard_options().with_extra_target_commit_id(repo.rev_parse_single("origin/main")?),
     )?
     .validated()?;
-    // TODO: this shouldn't move past the base on 1ee1e34!
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
-    └── ≡📙:3:A <> origin/A →:4:⇣1 {1}
+    └── ≡📙:3:A <> origin/A →:4:⇣1 on 1ee1e34 {1}
         └── 📙:3:A <> origin/A →:4:⇣1
-            ├── 🟣2181501
-            ├── ❄️1ee1e34 (🏘️|✓)
-            ├── ❄️c822d66 (🏘️|✓)
-            ├── ❄️bce0c5e (🏘️|✓)
-            └── ❄️3183e43 (🏘️|✓)
+            └── 🟣2181501
     ");
 
     Ok(())
@@ -5279,15 +5274,11 @@ fn remote_and_integrated_tracking_branch_on_linear_segment() -> anyhow::Result<(
         standard_options().with_extra_target_commit_id(repo.rev_parse_single("origin/main")?),
     )?
     .validated()?;
-    // TODO: Can we arbitrarily split the segment below the low base of all stacks to prevent
-    //       it from going all the way down?
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 081bae9
-    └── ≡📙:3:A <> origin/A →:4:⇣1 {1}
+    └── ≡📙:3:A <> origin/A →:4:⇣1 on 081bae9 {1}
         └── 📙:3:A <> origin/A →:4:⇣1
-            ├── 🟣197ddce
-            ├── ❄️081bae9 (🏘️|✓)
-            └── ❄️3183e43 (🏘️|✓)
+            └── 🟣197ddce
     ");
 
     Ok(())

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -5219,6 +5219,118 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
 }
 
 #[test]
+fn remote_and_integrated_tracking_branch_on_merge() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/remote-and-integrated-tracking")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * d018f71 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * c1e26b0 (origin/main, main) M-advanced
+    |/  
+    | * 2181501 (origin/A) A-remote
+    |/  
+    *   1ee1e34 (A) M-base
+    |\  
+    | * efc3b77 (tmp1) X
+    * | c822d66 Y
+    |/  
+    * bce0c5e M2
+    * 3183e43 M1
+    ");
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        standard_options().with_extra_target_commit_id(repo.rev_parse_single("origin/main")?),
+    )?
+    .validated()?;
+    // TODO: this shouldn't move past the base on 1ee1e34!
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+    └── ≡📙:3:A <> origin/A →:4:⇣1 {1}
+        └── 📙:3:A <> origin/A →:4:⇣1
+            ├── 🟣2181501
+            ├── ❄️1ee1e34 (🏘️|✓)
+            ├── ❄️c822d66 (🏘️|✓)
+            ├── ❄️bce0c5e (🏘️|✓)
+            └── ❄️3183e43 (🏘️|✓)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn remote_and_integrated_tracking_branch_on_linear_segment() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("ws/remote-and-integrated-tracking-linear")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 21e584f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 8dc508f (origin/main, main) M-advanced
+    |/  
+    | * 197ddce (origin/A) A-remote
+    |/  
+    * 081bae9 (A) M-base
+    * 3183e43 M1
+    ");
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        standard_options().with_extra_target_commit_id(repo.rev_parse_single("origin/main")?),
+    )?
+    .validated()?;
+    // TODO: Can we arbitrarily split the segment below the low base of all stacks to prevent
+    //       it from going all the way down?
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 081bae9
+    └── ≡📙:3:A <> origin/A →:4:⇣1 {1}
+        └── 📙:3:A <> origin/A →:4:⇣1
+            ├── 🟣197ddce
+            ├── ❄️081bae9 (🏘️|✓)
+            └── ❄️3183e43 (🏘️|✓)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn remote_and_integrated_tracking_branch_on_merge_extra_target() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("ws/remote-and-integrated-tracking-extra-commit")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 5f2810f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9f47a25 (A) A-local
+    | * c1e26b0 (origin/main, main) M-advanced
+    |/  
+    | * 2181501 (origin/A) A-remote
+    |/  
+    *   1ee1e34 M-base
+    |\  
+    | * efc3b77 (tmp1) X
+    * | c822d66 Y
+    |/  
+    * bce0c5e M2
+    * 3183e43 M1
+    ");
+    add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &[]);
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        standard_options().with_extra_target_commit_id(repo.rev_parse_single("origin/main")?),
+    )?
+    .validated()?;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+    └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 1ee1e34 {1}
+        └── 📙:3:A <> origin/A →:4:⇡1⇣1
+            ├── 🟣2181501
+            └── ·9f47a25 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn unapplied_branch_on_base() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/unapplied-branch-on-base")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -202,7 +202,7 @@ impl Project {
         let mut projects = crate::dangerously_list_projects_without_migration()?;
         // Sort projects by longest pathname to shortest.
         // We need to do this because users might have one gitbutler project
-        // nexted insided of another via a gitignored folder.
+        // nexted inside another via a gitignored folder.
         // We want to match on the longest project path.
         projects.sort_by(|a, b| {
             a.worktree_dir


### PR DESCRIPTION
What does it take to make apply usable today, particularly when applying a remote tracking branch for which a local tracking branch was created.

### Tasks

* [x] reproduce the problem
* [x] fix it by splitting the segment at the base, so the base commit isn't owned by anything we will pick up


### Research

#### Good

```
Workspace(📕🏘:0:gitbutler/workspace <> ✓refs/remotes/origin/master⇣173 on 2cc5b1e) {
    id: 0,
    kind: Managed {
        ref_name: FullName(
            "refs/heads/gitbutler/workspace",
        ),
    },
    stacks: [
        Stack(≡📙:3:mg-branch-16 <> origin/mg-branch-16 →:4:⇡1⇣3 on 2cc5b1e {ab834ec9f4148be92e2fabfc335ecb}) {
            segments: [
                StackSegment(📙:3:mg-branch-16 <> origin/mg-branch-16 →:4:⇡1⇣3) {
                    commits: [
                        "·5e1ce11 (🏘\u{fe0f})",
                    ],
                    commits_on_remote: [
                        "·0fe89d8",
                        "·dd55200",
                        "·2417a02",
                    ],
                },
            ],
            id: ab8340ec-9f41-48be-92e2-f0abfc335ecb,
        },
    ],
    metadata: Some(
        Workspace {
            ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
            stacks: [
                WorkspaceStack {
                    id: ab8340ec-9f41-48be-92e2-f0abfc335ecb,
                    branches: [
                        WorkspaceStackBranch {
                            ref_name: "refs/heads/mg-branch-16",
                            archived: false,
                        },
                    ],
                    workspacecommit_relation: Merged,
                },
            ],
            target_ref: "refs/remotes/origin/master",
            push_remote: "origin",
        },
    ),
    target: Some(
        Target {
            ref_name: FullName(
                "refs/remotes/origin/master",
            ),
            segment_index: NodeIndex(1),
            commits_ahead: 173,
        },
    ),
    extra_target: Some(
        NodeIndex(2),
    ),
}
```

![debug-graph-01](https://github.com/user-attachments/assets/fa01ba8d-c2a7-41de-9024-ee4be6f8397f)


#### Bad

```
Workspace(📕🏘:0:gitbutler/workspace <> ✓refs/remotes/origin/master⇣173 on 2cc5b1e) {
    id: 0,
    kind: Managed {
        ref_name: FullName(
            "refs/heads/gitbutler/workspace",
        ),
    },
    stacks: [
        Stack(≡📙:3:mg-branch-16 <> origin/mg-branch-16 →:4:⇣3 {ab834ec9f4148be92e2fabfc335ecb}) {
            segments: [
                StackSegment(📙:3:mg-branch-16 <> origin/mg-branch-16 →:4:⇣3) {
                    commits: [
                        "❄\u{fe0f}2cc5b1e (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1626",
                        "❄\u{fe0f}2e90546 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}c03c432 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}df6cc3d (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1625",
                        "❄\u{fe0f}677191d (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}b2d1da6 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}a5010be (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}02ee544 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}00fadef (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}bf1eb24 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}b4c88a3 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}defdbb0 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}8ebbc1d (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1624",
                        "❄\u{fe0f}90bd046 (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1622",
                        "❄\u{fe0f}d7a8693 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}d92fd18 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}2b18bea (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}d7d9180 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}b31580d (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1621",
                        "❄\u{fe0f}2fb9df5 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}5b01e90 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}1ba063f (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}f70ef7b (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}d2f70be (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}516af4e (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}547d277 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}36dda9a (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}f41be8e (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}01fa5ed (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}27477c3 (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1617",
                        "❄\u{fe0f}807ce3b (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}5de7284 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}01644f7 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}6de1448 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}3c2f016 (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1616",
                        "❄\u{fe0f}99fb1d0 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}3e84af4 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}0f2e291 (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1615",
                        "❄\u{fe0f}cca4707 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}8a2be54 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}07fd7d0 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}d3aa27f (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}e3f4588 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}07cbbee (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}877e8a3 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}e6d5ab7 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}9a0a589 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}e455e35 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}0809aa6 (🏘\u{fe0f}|✓)",
                        "❄\u{fe0f}c81819f (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1614",
                        "❄\u{fe0f}8aa06de (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1613",
                        "❄\u{fe0f}c769bc3 (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1611, ►tags/nightly/0.5.1612",
                        "✂\u{fe0f}❄\u{fe0f}393c46d (🏘\u{fe0f}|✓) ►tags/nightly/0.5.1610",
                    ],
                    commits_on_remote: [
                        "·0fe89d8",
                        "·dd55200",
                        "·2417a02",
                    ],
                },
            ],
            id: ab8340ec-9f41-48be-92e2-f0abfc335ecb,
        },
    ],
    metadata: Some(
        Workspace {
            ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
            stacks: [
                WorkspaceStack {
                    id: ab8340ec-9f41-48be-92e2-f0abfc335ecb,
                    branches: [
                        WorkspaceStackBranch {
                            ref_name: "refs/heads/mg-branch-16",
                            archived: false,
                        },
                    ],
                    workspacecommit_relation: Merged,
                },
            ],
            target_ref: "refs/remotes/origin/master",
            push_remote: "origin",
        },
    ),
    target: Some(
        Target {
            ref_name: FullName(
                "refs/remotes/origin/master",
            ),
            segment_index: NodeIndex(1),
            commits_ahead: 173,
        },
    ),
    extra_target: None,
}
```

![debug-graph-00](https://github.com/user-attachments/assets/a7c2f6f2-5ce4-4de4-8552-ee26ad05065e)



