### PR TITLE
safer `Project::git_dir()` usage and migration on startup.

### DIFF
--- a/crates/but-api/src/commands/projects.rs
+++ b/crates/but-api/src/commands/projects.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn update_project(project: projects::UpdateRequest) -> Result<projects::api::Project, Error> {
-    Ok(gitbutler_project::update(&project)?.into())
+    Ok(gitbutler_project::update(project)?.into())
 }
 
 /// Adds an existing git repository as a GitButler project.

--- a/crates/but-api/src/commands/virtual_branches.rs
+++ b/crates/but-api/src/commands/virtual_branches.rs
@@ -452,7 +452,7 @@ pub fn fetch_from_remotes(
     // Updates the project controller with the last fetched timestamp
     //
     // TODO: This cross dependency likely indicates that last_fetched is stored in the wrong place - value is coupled with virtual branches state
-    gitbutler_project::update(&gitbutler_project::UpdateRequest {
+    gitbutler_project::update(gitbutler_project::UpdateRequest {
         id: project.id,
         project_data_last_fetched: Some(project_data_last_fetched.clone()),
         ..Default::default()

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -175,9 +175,12 @@ pub enum Subcommands {
     },
     /// Returns a segmented graph starting from `HEAD`.
     Graph {
-        /// Debug-print the whole graph.
+        /// Debug-print the whole graph, and ignore all other dot-related flags
         #[clap(long, short = 'd')]
         debug: bool,
+        /// Print graph statistics at the very beginning, to get a grasp of huge graphs.
+        #[clap(long, short = 's')]
+        stats: bool,
         /// The rev-spec of the extra target to provide for traversal.
         #[clap(long)]
         extra_target: Option<String>,
@@ -186,9 +189,9 @@ pub enum Subcommands {
         /// If too large, it takes a long time or runs out of memory.
         #[clap(long)]
         no_debug_workspace: bool,
-        /// Do not output the dot-file to stdout.
-        #[clap(long, conflicts_with = "no_open")]
-        no_dot: bool,
+        /// Output the dot-file to stdout.
+        #[clap(long, conflicts_with = "dot_show")]
+        dot: bool,
         /// The maximum number of commits to traverse.
         ///
         /// Use only as safety net to prevent runaways.
@@ -202,9 +205,9 @@ pub enum Subcommands {
         /// Refill the limit when running over these hashes, provided as short or long hash.
         #[clap(long, short = 'e')]
         limit_extension: Vec<String>,
-        /// Avoid opening the resulting dot-file and instead write it to standard output.
+        /// Open the dot-file as SVG instead of writing it to stdout.
         #[clap(long)]
-        no_open: bool,
+        dot_show: bool,
         /// The name of the ref to start the graph traversal at.
         ref_name: Option<String>,
     },

--- a/crates/but-testing/src/command/graph.rs
+++ b/crates/but-testing/src/command/graph.rs
@@ -1,0 +1,104 @@
+use crate::command::{RepositoryOpenMode, meta_from_maybe_project, repo_and_maybe_project};
+use gix::odb::store::RefreshMode;
+use std::io::{Write, stdout};
+
+pub enum Dot {
+    Print,
+    OpenAsSVG,
+    Debug,
+}
+
+#[expect(clippy::too_many_arguments)]
+pub fn doit(
+    args: &crate::Args,
+    ref_name: Option<&str>,
+    dot: Option<Dot>,
+    limit: Option<usize>,
+    limit_extension: Vec<String>,
+    extra_target_spec: Option<&str>,
+    hard_limit: Option<usize>,
+    no_debug_workspace: bool,
+    stats: bool,
+) -> anyhow::Result<()> {
+    let (mut repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
+    repo.objects.refresh = RefreshMode::Never;
+    let extra_target = extra_target_spec
+        .map(|rev_spec| repo.rev_parse_single(rev_spec))
+        .transpose()?
+        .map(|id| id.detach());
+    let opts = but_graph::init::Options {
+        extra_target_commit_id: extra_target,
+        collect_tags: true,
+        hard_limit,
+        commits_limit_hint: limit,
+        commits_limit_recharge_location: limit_extension
+            .into_iter()
+            .map(|short_hash| {
+                repo.objects
+                    .lookup_prefix(
+                        gix::hash::Prefix::from_hex(&short_hash).expect("valid hex prefix"),
+                        None,
+                    )
+                    .unwrap()
+                    .expect("object for prefix exists")
+                    .expect("the prefix is unambiguous")
+            })
+            .collect(),
+        dangerously_skip_postprocessing_for_debugging: false,
+    };
+
+    // Never drop - this is read-only.
+    let meta = meta_from_maybe_project(project.as_ref())?;
+    let graph = match ref_name {
+        None => but_graph::Graph::from_head(&repo, &*meta, opts),
+        Some(ref_name) => {
+            let mut reference = repo.find_reference(ref_name)?;
+            let id = reference.peel_to_id()?;
+            but_graph::Graph::from_commit_traversal(id, reference.name().to_owned(), &*meta, opts)
+        }
+    }?;
+
+    let errors = graph.validation_errors();
+    if !errors.is_empty() {
+        eprintln!("VALIDATION FAILED: {errors:?}");
+    }
+    if stats {
+        eprintln!("{:#?}", graph.statistics());
+    }
+
+    let workspace = graph.to_workspace()?;
+    if no_debug_workspace {
+        eprintln!(
+            "Workspace with {} stacks and {} segments across all stacks with {} commits total",
+            workspace.stacks.len(),
+            workspace
+                .stacks
+                .iter()
+                .map(|s| s.segments.len())
+                .sum::<usize>(),
+            workspace
+                .stacks
+                .iter()
+                .flat_map(|s| s.segments.iter().map(|s| s.commits.len()))
+                .sum::<usize>(),
+        );
+    } else {
+        eprintln!("{workspace:#?}");
+    }
+
+    match dot {
+        Some(Dot::Print) => {
+            stdout().write_all(graph.dot_graph().as_bytes())?;
+        }
+        Some(Dot::OpenAsSVG) => {
+            #[cfg(unix)]
+            graph.open_as_svg();
+        }
+        Some(Dot::Debug) => {
+            eprintln!("{graph:#?}");
+        }
+        None => {}
+    }
+
+    Ok(())
+}

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -9,6 +9,7 @@ use gix::bstr::BString;
 mod args;
 use args::Args;
 
+use crate::command::graph::Dot;
 use crate::{
     args::Subcommands,
     command::{RepositoryOpenMode, repo_and_maybe_project},
@@ -152,26 +153,34 @@ async fn main() -> Result<()> {
             expensive,
         } => command::ref_info(&args, ref_name.as_deref(), *expensive),
         args::Subcommands::Graph {
+            dot_show,
+            stats,
             ref_name,
-            no_open,
             limit,
             limit_extension,
             hard_limit,
             debug,
             extra_target,
             no_debug_workspace,
-            no_dot,
-        } => command::graph(
+            dot,
+        } => command::graph::doit(
             &args,
             ref_name.as_deref(),
-            *no_open,
+            if *debug {
+                Dot::Debug.into()
+            } else if *dot_show {
+                Dot::OpenAsSVG.into()
+            } else if *dot {
+                Dot::Print.into()
+            } else {
+                None
+            },
             limit.flatten(),
             limit_extension.clone(),
             extra_target.as_deref(),
             *hard_limit,
-            *debug,
             *no_debug_workspace,
-            *no_dot,
+            *stats,
         ),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -19,7 +19,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
 
     gitbutler_project::update_with_path(
         data_dir.as_ref().unwrap(),
-        &projects::UpdateRequest {
+        projects::UpdateRequest {
             id: *project_id,
             ..Default::default()
         },
@@ -35,7 +35,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
 
     gitbutler_project::update_with_path(
         data_dir.as_ref().unwrap(),
-        &projects::UpdateRequest {
+        projects::UpdateRequest {
             id: *project_id,
             ..Default::default()
         },

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -151,7 +151,7 @@ fn forcepush_allowed() {
 
     gitbutler_project::update_with_path(
         data_dir.as_ref().unwrap(),
-        &projects::UpdateRequest {
+        projects::UpdateRequest {
             id: *project_id,
             ..Default::default()
         },

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -148,7 +148,8 @@ impl Controller {
         Ok(AddProjectOutcome::Added(project))
     }
 
-    pub(crate) fn update(&self, project: &UpdateRequest) -> Result<Project> {
+    #[cfg_attr(not(windows), allow(unused_mut))]
+    pub(crate) fn update(&self, mut project: UpdateRequest) -> Result<Project> {
         #[cfg(not(windows))]
         if let Some(AuthKey::Local {
             private_key_path, ..
@@ -173,14 +174,9 @@ impl Controller {
         }
 
         #[cfg(windows)]
-        let project_owned = {
-            let mut project = project.clone();
+        {
             project.preferred_key = Some(AuthKey::SystemExecutable);
-            project
-        };
-
-        #[cfg(windows)]
-        let project = &project_owned;
+        }
 
         self.projects_storage.update(project)
     }

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -50,7 +50,7 @@ pub fn get_raw(id: ProjectId) -> anyhow::Result<Project> {
     controller.get_raw(id)
 }
 
-pub fn update(project: &UpdateRequest) -> anyhow::Result<Project> {
+pub fn update(project: UpdateRequest) -> anyhow::Result<Project> {
     let controller = Controller::from_path(but_path::app_data_dir()?);
     controller.update(project)
 }
@@ -58,7 +58,7 @@ pub fn update(project: &UpdateRequest) -> anyhow::Result<Project> {
 /// Testing purpose only.
 pub fn update_with_path<P: AsRef<Path>>(
     data_dir: P,
-    project: &UpdateRequest,
+    project: UpdateRequest,
 ) -> anyhow::Result<Project> {
     let controller = Controller::from_path(data_dir.as_ref());
     controller.update(project)

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -234,7 +234,7 @@ impl Project {
     /// Use it for fastest-possible access, when incomplete configuration is acceptable.
     pub fn open_isolated(&self) -> anyhow::Result<gix::Repository> {
         Ok(gix::open_opts(
-            &self.git_dir,
+            self.git_dir(),
             gix::open::Options::isolated(),
         )?)
     }
@@ -246,18 +246,18 @@ impl Project {
     ///
     /// Diffing and merging is better done with [`Self::open_for_merging()`].
     pub fn open(&self) -> anyhow::Result<gix::Repository> {
-        Ok(gix::open(&self.git_dir)?)
+        Ok(gix::open(self.git_dir())?)
     }
 
     /// Calls [`but_core::open_repo_for_merging()`]
     pub fn open_for_merging(&self) -> anyhow::Result<gix::Repository> {
-        but_core::open_repo_for_merging(&self.git_dir)
+        but_core::open_repo_for_merging(self.git_dir())
     }
 
     /// Open a git2 repository.
     /// Deprecated, but still in use.
     pub fn open_git2(&self) -> anyhow::Result<git2::Repository> {
-        Ok(git2::Repository::open(&self.git_dir)?)
+        Ok(git2::Repository::open(self.git_dir())?)
     }
 }
 
@@ -292,7 +292,7 @@ impl Project {
     ///
     /// Normally this is `.git/gitbutler` in the project's repository.
     pub fn gb_dir(&self) -> PathBuf {
-        self.git_dir.join("gitbutler")
+        self.git_dir().join("gitbutler")
     }
 
     pub fn snapshot_lines_threshold(&self) -> usize {
@@ -316,6 +316,10 @@ impl Project {
 
     /// Return the path to the directory that holds the repository data and that is associated with the current worktree.
     pub fn git_dir(&self) -> &Path {
+        assert!(
+            !self.git_dir.as_os_str().is_empty(),
+            "BUG: must call `project.migrated()` before using the git_dir to have it initialised."
+        );
         &self.git_dir
     }
 

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -157,9 +157,10 @@ impl Project {
 }
 
 impl Project {
-    pub(crate) fn migrate(&mut self) -> anyhow::Result<()> {
+    /// Return `true` if the project was migrated, and thus is changed, or `false` otherwise.
+    pub fn migrate(&mut self) -> anyhow::Result<bool> {
         if !self.git_dir.as_os_str().is_empty() {
-            return Ok(());
+            return Ok(false);
         }
         let repo = gix::open_opts(&self.worktree_dir, gix::open::Options::isolated())
             .context("BUG: worktree is supposed to be valid here for migration")?;
@@ -167,7 +168,7 @@ impl Project {
         // NOTE: we set the worktree so the frontend is happier until this usage can be reviewed,
         // probably for supporting bare repositories.
         self.worktree_dir = repo.workdir().context("BUG: we currently only support non-bare repos, yet this one didn't have a worktree dir")?.to_owned();
-        Ok(())
+        Ok(true)
     }
 
     pub(crate) fn worktree_dir_but_should_use_git_dir(&self) -> &Path {

--- a/crates/gitbutler-sync/src/cloud.rs
+++ b/crates/gitbutler-sync/src/cloud.rs
@@ -180,7 +180,7 @@ fn push_all_refs(
     Ok(())
 }
 fn update_project(project_id: Id<projects::Project>, id: git2::Oid) -> Result<()> {
-    gitbutler_project::update(&projects::UpdateRequest {
+    gitbutler_project::update(projects::UpdateRequest {
         id: project_id,
         gitbutler_code_push_state: Some(CodePushState {
             id,


### PR DESCRIPTION
### Tasks

* [x] make `.git_dir()` safer by assertion. We want it to blow up instead of failing silently under circumstances.
* [x] migrate all projects on application startup, infallibly.
