### PR TITLE
fix(ui): vertical text via writing

### DIFF
--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -69,7 +69,6 @@
 		margin-top: 10px;
 		overflow: hidden;
 		gap: 10px;
-		transform: rotate(180deg);
 		text-orientation: mixed;
 		pointer-events: none;
 		writing-mode: vertical-lr;

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -255,8 +255,7 @@
 	.unassigned-folded__text {
 		display: flex;
 		align-items: center;
-		margin-right: 2px;
-		transform: rotate(-90deg);
+		writing-mode: vertical-lr;
 	}
 
 	.unassigned__files {


### PR DESCRIPTION
More logical actually to have one read direction instead of two.

<img width="1206" height="824" alt="image" src="https://github.com/user-attachments/assets/0e6667a1-7846-4fff-afee-a559dbec0b4a" />
