### PR TITLE
Forge detection: Widen the net when detecting GitHub repositories

### DIFF
--- a/crates/gitbutler-forge/src/lib.rs
+++ b/crates/gitbutler-forge/src/lib.rs
@@ -7,7 +7,7 @@ pub mod forge;
 pub mod review;
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
-    if host.contains("github.com") {
+    if host.contains("github.com") || host.starts_with("github.") {
         Some(ForgeName::GitHub)
     } else if host.contains("gitlab.com") || host.starts_with("gitlab.") {
         Some(ForgeName::GitLab)


### PR DESCRIPTION
Make it a bit easier to spot GitHub repositories. Especially Enterprise ones