### PR TITLE
fix(ui): Incorrect file path display in file names

### DIFF
--- a/packages/ui/src/lib/components/file/FileName.svelte
+++ b/packages/ui/src/lib/components/file/FileName.svelte
@@ -89,6 +89,5 @@
 	}
 	.file-name__path--first {
 		flex: 1;
-		direction: rtl;
 	}
 </style>


### PR DESCRIPTION
Test path `.github/actions/run-frontend-tests/file.svelte` 👇

Before:
<img width="330" height="56" alt="image" src="https://github.com/user-attachments/assets/31c4634a-513e-412d-a623-b89bac4b7251" />


After:
<img width="327" height="61" alt="image" src="https://github.com/user-attachments/assets/48d9e24a-3665-47e7-bce1-091d8b7e3bef" />
