### PR TITLE
but status: Display the associated PR number

### DIFF
--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -28,15 +28,21 @@ pub async fn list(project: &Project, local: bool) -> Result<(), anyhow::Error> {
             continue;
         }
 
-        let reviews =
-            crate::forge::review::get_review_numbers(&branch.name.to_string(), &branch_review_map);
+        let reviews = crate::forge::review::get_review_numbers(
+            &branch.name.to_string(),
+            &None,
+            &branch_review_map,
+        );
 
         println!("{}{}", branch.name, reviews);
     }
 
     for branch in remote_only_branches {
-        let reviews =
-            crate::forge::review::get_review_numbers(&branch.name.to_string(), &branch_review_map);
+        let reviews = crate::forge::review::get_review_numbers(
+            &branch.name.to_string(),
+            &None,
+            &branch_review_map,
+        );
         println!("{} {}{}", "(remote)".dimmed(), branch.name, reviews);
     }
     Ok(())
@@ -58,6 +64,7 @@ fn print_applied_branches(
                 let branch_entry = format!("* {}", branch.name);
                 let reviews = crate::forge::review::get_review_numbers(
                     &branch.name.to_string(),
+                    &None,
                     branch_review_map,
                 );
                 println!("{}{}", branch_entry.green(), reviews);
@@ -82,6 +89,7 @@ fn print_applied_branches(
 
             let reviews = crate::forge::review::get_review_numbers(
                 &branch.name.to_string(),
+                &None,
                 branch_review_map,
             );
 

--- a/crates/but/src/forge/review.rs
+++ b/crates/but/src/forge/review.rs
@@ -513,6 +513,7 @@ pub async fn get_review_map(
 
 pub fn get_review_numbers(
     branch_name: &str,
+    associated_review_number: &Option<usize>,
     branch_review_map: &std::collections::HashMap<
         String,
         Vec<gitbutler_forge::review::ForgeReview>,
@@ -526,6 +527,8 @@ pub fn get_review_numbers(
             .join(", ");
 
         format!(" ({})", review_numbers).blue()
+    } else if let Some(pr_number) = associated_review_number {
+        format!(" (#{})", pr_number).blue()
     } else {
         "".to_string().normal()
     }

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -218,8 +218,11 @@ pub fn print_group(
             .dimmed()
             .italic();
 
-            let reviews =
-                crate::forge::review::get_review_numbers(&branch.name.to_string(), review_map);
+            let reviews = crate::forge::review::get_review_numbers(
+                &branch.name.to_string(),
+                &branch.pr_number,
+                review_map,
+            );
 
             println!(
                 "┊{}┄{} [{}]{} {} {}",


### PR DESCRIPTION
Display the PR number associated with the branch, regardless of whether the Network call was made or not

closes: https://github.com/gitbutlerapp/gitbutler/issues/11029