### PR TITLE
feat(diff/syntax-highlight): support 12 more languages

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -52,7 +52,7 @@
 		"@codemirror/lang-xml": "^6.1.0",
 		"@codemirror/lang-yaml": "^6.1.2",
 		"@codemirror/language": "^6.11.2",
-		"@codemirror/legacy-modes": "^6.5.1",
+		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^1.0.15",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
 		"@codemirror/lang-vue": "^0.1.3",
 		"@codemirror/lang-wast": "^6.0.2",
 		"@codemirror/lang-xml": "^6.1.0",
+		"@codemirror/lang-yaml": "^6.1.2",
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.1",
 		"@csstools/postcss-bundler": "^2.0.8",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
 	"devDependencies": {
 		"@codemirror/lang-cpp": "^6.0.3",
 		"@codemirror/lang-css": "^6.3.1",
+		"@codemirror/lang-go": "^6.0.1",
 		"@codemirror/lang-html": "^6.4.9",
 		"@codemirror/lang-java": "^6.0.2",
 		"@codemirror/lang-javascript": "^6.2.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,6 +51,7 @@
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.56.1",
+		"@replit/codemirror-lang-nix": "^6.0.1",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@storybook/addon-docs": "^10.0.2",
 		"@storybook/addon-links": "^10.0.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,7 @@
 		"@codemirror/lang-xml": "^6.1.0",
 		"@codemirror/lang-yaml": "^6.1.2",
 		"@codemirror/language": "^6.11.2",
-		"@codemirror/legacy-modes": "^6.5.1",
+		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
 		"@gitbutler/design-core": "^1.2.6",
 		"@lezer/common": "^1.2.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,6 +65,7 @@
 		"@types/postcss-pxtorem": "^6.1.0",
 		"@vitest/browser": "catalog:",
 		"autoprefixer": "^10.4.21",
+		"codemirror-lang-elixir": "^4.0.0",
 		"codemirror-lang-hcl": "^0.1.0",
 		"cpy-cli": "^5.0.0",
 		"cssnano": "^7.1.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,6 +64,7 @@
 		"@types/postcss-pxtorem": "^6.1.0",
 		"@vitest/browser": "catalog:",
 		"autoprefixer": "^10.4.21",
+		"codemirror-lang-hcl": "^0.1.0",
 		"cpy-cli": "^5.0.0",
 		"cssnano": "^7.1.0",
 		"dayjs": "^1.11.13",

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -17,6 +17,7 @@ import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { kotlin } from '@codemirror/legacy-modes/mode/clike';
 import { commonLisp } from '@codemirror/legacy-modes/mode/commonlisp';
+import { jinja2 } from '@codemirror/legacy-modes/mode/jinja2';
 import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
@@ -278,6 +279,11 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'java':
 			return java().language.parser;
+
+		case 'j2':
+		case 'jinja':
+		case 'jinja2':
+			return StreamLanguage.define(jinja2).parser;
 
 		case 'kt':
 		case 'kts':

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -29,6 +29,7 @@ import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
 import { tags, highlightTree } from '@lezer/highlight';
 import { nix } from '@replit/codemirror-lang-nix';
+import { elixir } from 'codemirror-lang-elixir';
 import { hcl } from 'codemirror-lang-hcl';
 import diff_match_patch from 'diff-match-patch';
 import type { BrandedId } from '$lib/utils/branding';
@@ -276,6 +277,10 @@ export function parserFromExtension(extension: string): Parser | undefined {
 		case 'hpp':
 		case 'h++':
 			return cpp().language.parser;
+
+		case 'ex':
+		case 'exs':
+			return elixir().language.parser;
 
 		case 'go':
 			return go().language.parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -28,6 +28,7 @@ import { swift } from '@codemirror/legacy-modes/mode/swift';
 import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
 import { tags, highlightTree } from '@lezer/highlight';
+import { nix } from '@replit/codemirror-lang-nix';
 import { hcl } from 'codemirror-lang-hcl';
 import diff_match_patch from 'diff-match-patch';
 import type { BrandedId } from '$lib/utils/branding';
@@ -322,6 +323,9 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'md':
 			return markdown().language.parser;
+
+		case 'nix':
+			return nix().language.parser;
 
 		// case 'text/x-coffeescript':
 		//     return new LanguageSupport(await CodeMirror.coffeescript());

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -28,6 +28,7 @@ import { swift } from '@codemirror/legacy-modes/mode/swift';
 import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
 import { tags, highlightTree } from '@lezer/highlight';
+import { hcl } from 'codemirror-lang-hcl';
 import diff_match_patch from 'diff-match-patch';
 import type { BrandedId } from '$lib/utils/branding';
 
@@ -277,6 +278,13 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'go':
 			return go().language.parser;
+
+		case 'hcl':
+		case 'hcl2':
+		case 'nomad':
+		case 'tf':
+		case 'tfvars':
+			return hcl().language.parser;
 
 		case 'java':
 			return java().language.parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -16,6 +16,7 @@ import { xml } from '@codemirror/lang-xml';
 import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { kotlin } from '@codemirror/legacy-modes/mode/clike';
+import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
 import { ruby } from '@codemirror/legacy-modes/mode/ruby';
@@ -281,6 +282,9 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'json':
 			return json().language.parser;
+
+		case 'lua':
+			return StreamLanguage.define(lua).parser;
 
 		case 'php':
 			return php().language.parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -17,6 +17,7 @@ import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { kotlin } from '@codemirror/legacy-modes/mode/clike';
 import { commonLisp } from '@codemirror/legacy-modes/mode/commonlisp';
+import { dockerFile } from '@codemirror/legacy-modes/mode/dockerfile';
 import { jinja2 } from '@codemirror/legacy-modes/mode/jinja2';
 import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
@@ -375,7 +376,14 @@ export function parserFromExtension(extension: string): Parser | undefined {
 }
 
 export function parserFromFilename(filename: string): Parser | undefined {
-	const ext = filename.split('.').pop();
+	const basename = filename.split('/').pop() || '';
+	const ext = basename.split('.').pop()?.toLowerCase();
+
+	// Handle Dockerfiles (with common variations).
+	if (basename === 'Dockerfile' || basename.startsWith('Dockerfile.') || ext === 'dockerfile') {
+		return StreamLanguage.define(dockerFile).parser;
+	}
+
 	if (!ext) return undefined;
 	return parserFromExtension(ext);
 }

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -16,6 +16,7 @@ import { xml } from '@codemirror/lang-xml';
 import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { kotlin } from '@codemirror/legacy-modes/mode/clike';
+import { commonLisp } from '@codemirror/legacy-modes/mode/commonlisp';
 import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
@@ -282,6 +283,12 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'json':
 			return json().language.parser;
+
+		case 'lisp':
+		case 'lsp':
+		case 'cl': // Common Lisp
+		case 'el': // Emacs Lisp
+			return StreamLanguage.define(commonLisp).parser;
 
 		case 'lua':
 			return StreamLanguage.define(lua).parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -21,6 +21,7 @@ import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
 import { ruby } from '@codemirror/legacy-modes/mode/ruby';
+import { shell } from '@codemirror/legacy-modes/mode/shell';
 import { swift } from '@codemirror/legacy-modes/mode/swift';
 import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
@@ -307,9 +308,6 @@ export function parserFromExtension(extension: string): Parser | undefined {
 		case 'md':
 			return markdown().language.parser;
 
-		// case 'text/x-sh':
-		//     return new LanguageSupport(await CodeMirror.shell());
-
 		// case 'text/x-coffeescript':
 		//     return new LanguageSupport(await CodeMirror.coffeescript());
 
@@ -340,6 +338,11 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 			// highlighting svelte with js + jsx works much better than the above
 			return javascript({ typescript: true, jsx: true }).language.parser;
+
+		case 'sh':
+		case 'bash':
+		case 'zsh':
+			return StreamLanguage.define(shell).parser;
 
 		case 'swift':
 			return StreamLanguage.define(swift).parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -21,6 +21,7 @@ import { lua } from '@codemirror/legacy-modes/mode/lua';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
 import { ruby } from '@codemirror/legacy-modes/mode/ruby';
+import { swift } from '@codemirror/legacy-modes/mode/swift';
 import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
 import { tags, highlightTree } from '@lezer/highlight';
@@ -339,6 +340,9 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 			// highlighting svelte with js + jsx works much better than the above
 			return javascript({ typescript: true, jsx: true }).language.parser;
+
+		case 'swift':
+			return StreamLanguage.define(swift).parser;
 
 		case 'vue':
 			return vue().language.parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -19,6 +19,7 @@ import { kotlin } from '@codemirror/legacy-modes/mode/clike';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
 import { protobuf } from '@codemirror/legacy-modes/mode/protobuf';
 import { ruby } from '@codemirror/legacy-modes/mode/ruby';
+import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { NodeType, Tree, Parser } from '@lezer/common';
 import { tags, highlightTree } from '@lezer/highlight';
 import diff_match_patch from 'diff-match-patch';
@@ -336,6 +337,9 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'rb':
 			return StreamLanguage.define(ruby).parser;
+
+		case 'toml':
+			return StreamLanguage.define(toml).parser;
 
 		case 'yml':
 		case 'yaml':

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -1,5 +1,6 @@
 import { cpp } from '@codemirror/lang-cpp';
 import { css } from '@codemirror/lang-css';
+import { go } from '@codemirror/lang-go';
 import { html } from '@codemirror/lang-html';
 import { java } from '@codemirror/lang-java';
 import { javascript } from '@codemirror/lang-javascript';
@@ -266,8 +267,8 @@ export function parserFromExtension(extension: string): Parser | undefined {
 		case 'h++':
 			return cpp().language.parser;
 
-		// case 'text/x-go':
-		//     return new LanguageSupport(await CodeMirror.go());
+		case 'go':
+			return go().language.parser;
 
 		case 'java':
 			return java().language.parser;

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -13,6 +13,7 @@ import { rust } from '@codemirror/lang-rust';
 import { vue } from '@codemirror/lang-vue';
 import { wast } from '@codemirror/lang-wast';
 import { xml } from '@codemirror/lang-xml';
+import { yaml } from '@codemirror/lang-yaml';
 import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { kotlin } from '@codemirror/legacy-modes/mode/clike';
 import { powerShell } from '@codemirror/legacy-modes/mode/powershell';
@@ -335,6 +336,10 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'rb':
 			return StreamLanguage.define(ruby).parser;
+
+		case 'yml':
+		case 'yaml':
+			return yaml().language.parser;
 
 		default:
 			return undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,6 +839,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      codemirror-lang-elixir:
+        specifier: ^4.0.0
+        version: 4.0.0
       codemirror-lang-hcl:
         specifier: ^0.1.0
         version: 0.1.0
@@ -3982,6 +3985,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  codemirror-lang-elixir@4.0.0:
+    resolution: {integrity: sha512-mzFesxo/t6KOxwnkqVd34R/q7yk+sMtHh6vUKGAvjwHmpL7bERHB+vQAsmU/nqrndkwVeJEHWGw/z/ybfdiudA==}
+
   codemirror-lang-hcl@0.1.0:
     resolution: {integrity: sha512-duwKEaQDhkJWad4YQ9pv4282BS6hCdR+gS/qTAj3f9bypXNNZ42bIN43h9WK3DjyZRENtVlUQdrQM1sA44wHmA==}
 
@@ -5678,6 +5684,9 @@ packages:
 
   lexical@0.27.1:
     resolution: {integrity: sha512-EXlRE/NQO9quKFuz4Z2pu5f48oF8LZOAw0YpN0RmGQx2CbqmEi7SIgO+d+NUKVx9Qs1vX0DL5S7GJpvpZBOE3w==}
+
+  lezer-elixir@1.1.2:
+    resolution: {integrity: sha512-K3yPMJcNhqCL6ugr5NkgOC1g37rcOM38XZezO9lBXy0LwWFd8zdWXfmRbY829vZVk0OGCQoI02yDWp9FF2OWZA==}
 
   lib0@0.2.114:
     resolution: {integrity: sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==}
@@ -11918,6 +11927,11 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  codemirror-lang-elixir@4.0.0:
+    dependencies:
+      '@codemirror/language': 6.11.2
+      lezer-elixir: 1.1.2
+
   codemirror-lang-hcl@0.1.0:
     dependencies:
       '@codemirror/language': 6.11.2
@@ -13970,6 +13984,11 @@ snapshots:
       type-check: 0.4.0
 
   lexical@0.27.1: {}
+
+  lezer-elixir@1.1.2:
+    dependencies:
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
 
   lib0@0.2.114:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,8 +591,8 @@ importers:
         specifier: ^6.11.2
         version: 6.11.2
       '@codemirror/legacy-modes':
-        specifier: ^6.5.1
-        version: 6.5.1
+        specifier: ^6.5.2
+        version: 6.5.2
       '@csstools/postcss-bundler':
         specifier: ^1.0.15
         version: 1.0.15(postcss@8.5.6)
@@ -780,8 +780,8 @@ importers:
         specifier: ^6.11.2
         version: 6.11.2
       '@codemirror/legacy-modes':
-        specifier: ^6.5.1
-        version: 6.5.1
+        specifier: ^6.5.2
+        version: 6.5.2
       '@csstools/postcss-bundler':
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
@@ -1047,8 +1047,8 @@ packages:
   '@codemirror/language@6.11.2':
     resolution: {integrity: sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==}
 
-  '@codemirror/legacy-modes@6.5.1':
-    resolution: {integrity: sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==}
+  '@codemirror/legacy-modes@6.5.2':
+    resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
 
   '@codemirror/lint@6.8.5':
     resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
@@ -8435,7 +8435,7 @@ snapshots:
       '@lezer/lr': 1.4.2
       style-mod: 4.1.2
 
-  '@codemirror/legacy-modes@6.5.1':
+  '@codemirror/legacy-modes@6.5.2':
     dependencies:
       '@codemirror/language': 6.11.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,9 @@ importers:
       '@codemirror/lang-css':
         specifier: ^6.3.1
         version: 6.3.1
+      '@codemirror/lang-go':
+        specifier: ^6.0.1
+        version: 6.0.1
       '@codemirror/lang-html':
         specifier: ^6.4.9
         version: 6.4.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -797,6 +797,9 @@ importers:
       '@playwright/experimental-ct-svelte':
         specifier: ^1.56.1
         version: 1.56.1(@types/node@24.3.0)(sass-embedded@1.82.0)(svelte@5.38.0)(tsx@4.19.3)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))(yaml@2.8.1)
+      '@replit/codemirror-lang-nix':
+        specifier: ^6.0.1
+        version: 6.0.1(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/lr@1.4.2)
       '@replit/codemirror-lang-svelte':
         specifier: ^6.0.0
         version: 6.0.0(@codemirror/autocomplete@6.18.6)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.4)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/javascript@1.5.1)(@lezer/lr@1.4.2)
@@ -2321,6 +2324,17 @@ packages:
         optional: true
       react-redux:
         optional: true
+
+  '@replit/codemirror-lang-nix@6.0.1':
+    resolution: {integrity: sha512-lvzjoYn9nfJzBD5qdm3Ut6G3+Or2wEacYIDJ49h9+19WSChVnxv4ojf+rNmQ78ncuxIt/bfbMvDLMeMP0xze6g==}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
+      '@lezer/highlight': ^1.0.0
+      '@lezer/lr': ^1.0.0
 
   '@replit/codemirror-lang-svelte@6.0.0':
     resolution: {integrity: sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==}
@@ -9866,6 +9880,16 @@ snapshots:
       reselect: 5.1.1
     optionalDependencies:
       react: 19.1.1
+
+  '@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/lr@1.4.2)':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/language': 6.11.2
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.1
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
 
   '@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.18.6)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.4)(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/javascript@1.5.1)(@lezer/lr@1.4.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,6 +773,9 @@ importers:
       '@codemirror/lang-xml':
         specifier: ^6.1.0
         version: 6.1.0
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.2
+        version: 6.1.2
       '@codemirror/language':
         specifier: ^6.11.2
         version: 6.11.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      codemirror-lang-hcl:
+        specifier: ^0.1.0
+        version: 0.1.0
       cpy-cli:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3964,6 +3967,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codemirror-lang-hcl@0.1.0:
+    resolution: {integrity: sha512-duwKEaQDhkJWad4YQ9pv4282BS6hCdR+gS/qTAj3f9bypXNNZ42bIN43h9WK3DjyZRENtVlUQdrQM1sA44wHmA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -11887,6 +11893,12 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
+
+  codemirror-lang-hcl@0.1.0:
+    dependencies:
+      '@codemirror/language': 6.11.2
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## 🧢 Changes

This is a semi-repeat of my earlier PR #7915. Those changes did not survive the transition from the v2 to the v3 UI however.

This PR syntax highlighting in diff views for 12 new languages:

- Dockerfile
- Elixir
- Go
- HCL/Terraform
- Jinja2
- Lisp
- Lua
- Nix
- shell script
- Swift
- TOML
- YAML

Go and YAML support is done via official CodeMirror packages:

- `@codemirror/lang-go`
- `@codemirror/lang-yaml`

TOML, Lua, Lisp, Swift, shell script, Jinja2, and Dockerfile support was added via the `@codemirror/legacy-modes`. But I did upgrade it from 6.5.1 to 6.5.2 as it contained a fix for TOML.

Additionally, I chose to keep using the jinja2 parser from legacy package, as the new official CodeMirror 6 package seems very lacking by comparison.

HCL, Nix and Elixir however uses [community packages](https://codemirror.net/docs/community/#language):

- `@replit/codemirror-lang-nix`
- `codemirror-lang-elixir`
- `codemirror-lang-hcl`

I'm more than happy to remove the community package provided languages if there's any hesitation around pulling in non-official parsers. Each language was added in a separate commit, so it's easy to rip things out if needed.

## ☕️ Reasoning

I wanted syntax highlighting again in diffs like I had before the v3 UI took over. I frequently use all these languages except Switch and Elixir.

## 🎆 Screenshots

<details>
  <summary>Dockerfile</summary>

<img width="602" height="230" alt="Screen-Capture-2025-11-07-00-54-38" src="https://github.com/user-attachments/assets/0cef0544-441e-40fa-8b81-a7cc7c585037" />

</details>

<details>
  <summary>Elixir</summary>

<img width="567" height="286" alt="Screen-Capture-2025-11-07-01-19-50" src="https://github.com/user-attachments/assets/7dc95442-82da-4ab3-83bd-d042dce48702" />

</details>

<details>
  <summary>Go</summary>

<img width="479" height="382" alt="Screen-Capture-2025-11-07-00-16-41" src="https://github.com/user-attachments/assets/178339a8-d797-4c89-a51c-d78d673302b0" />

</details>

<details>
  <summary>HCL/Terraform</summary>

<img width="603" height="949" alt="Screen-Capture-2025-11-07-01-00-30" src="https://github.com/user-attachments/assets/d20f9d2d-a8c6-413b-b49f-218a5c224569" />

</details>

<details>
  <summary>Jinja2</summary>

<img width="600" height="197" alt="Screen-Capture-2025-11-07-00-51-31" src="https://github.com/user-attachments/assets/d763d4c5-a51b-4242-bba6-1a56946e887a" />

</details>

<details>
  <summary>Lisp</summary>

<img width="602" height="372" alt="Screen-Capture-2025-11-07-00-32-56" src="https://github.com/user-attachments/assets/673655a9-3d68-47f7-a12b-45995755fcf1" />

</details>

<details>
  <summary>Lua</summary>

<img width="600" height="230" alt="Screen-Capture-2025-11-07-00-25-25" src="https://github.com/user-attachments/assets/3ec5c764-9465-4ecf-81fc-cd1e3b12f98c" />

</details>

<details>
  <summary>Nix</summary>

<img width="869" height="1080" alt="Screen-Capture-2025-11-07-01-08-42" src="https://github.com/user-attachments/assets/d72a2f2f-243b-47ec-9861-90b9ab7599ed" />

</details>

<details>
  <summary>shell script</summary>

<img width="602" height="214" alt="Screen-Capture-2025-11-07-00-47-52" src="https://github.com/user-attachments/assets/d375307e-4721-42f7-aab8-0973aba1842c" />

</details>

<details>
  <summary>Swift</summary>

<img width="601" height="231" alt="Screen-Capture-2025-11-07-00-43-32" src="https://github.com/user-attachments/assets/47d3f061-852d-4aef-bd3c-67125e412b4a" />

</details>

<details>
  <summary>TOML</summary>

<img width="476" height="142" alt="Screen-Capture-2025-11-07-00-17-14" src="https://github.com/user-attachments/assets/bfefa363-2782-4207-9205-75f6c425d093" />

</details>

<details>
  <summary>YAML</summary>

<img width="599" height="934" alt="Screen-Capture-2025-11-07-00-44-34" src="https://github.com/user-attachments/assets/db6cb468-722b-43f6-b889-4c3c653d31a1" />

</details>