### PR TITLE
Actually use the GitHub host base URL

### DIFF
--- a/apps/desktop/src/lib/forge/github/githubClient.ts
+++ b/apps/desktop/src/lib/forge/github/githubClient.ts
@@ -57,7 +57,7 @@ export class GitHubClient implements ApiClient {
 
 	get octokit(): Octokit {
 		if (!this._client) {
-			this._client = newClient(this._token);
+			this._client = newClient(this._token, this._host);
 		}
 		return this._client;
 	}


### PR DESCRIPTION
Pass the host for the GItHub Enterprise account correctly to the GitHub client