### PR TITLE
Remove 'log' command and related code

### DIFF
--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -27,8 +27,6 @@ pub struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
-    /// Show commits on active branches in your workspace.
-    Log,
     /// Overview of the uncommitted changes in the repository.
     #[clap(alias = "st")]
     Status {
@@ -196,8 +194,6 @@ For examples see `but rub --help`."
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
 pub enum CommandName {
-    #[clap(alias = "log")]
-    Log,
     #[clap(alias = "st")]
     Status,
     #[clap(alias = "stf", hide = true)]

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -22,7 +22,6 @@ mod forge;
 mod gui;
 mod id;
 mod init;
-mod log;
 mod mark;
 mod mcp;
 mod mcp_internal;
@@ -203,13 +202,6 @@ async fn match_subcommand(
             let result = worktree::handle(cmd, &project, args.json);
             metrics_if_configured(app_settings, CommandName::Worktree, props(start, &result)).ok();
             result
-        }
-        Subcommands::Log => {
-            let project = get_or_init_project(&args.current_dir)?;
-            let result = log::commit_graph(&project, args.json);
-            metrics_if_configured(app_settings, CommandName::Log, props(start, &result)).ok();
-            result?;
-            Ok(())
         }
         Subcommands::Status {
             show_files,
@@ -435,7 +427,7 @@ fn print_grouped_help() {
 
     // Define command groupings and their order (excluding MISC)
     let groups = [
-        ("Inspection".yellow(), vec!["status", "log"]),
+        ("Inspection".yellow(), vec!["status"]),
         (
             "Branching and Committing".yellow(),
             vec!["commit", "push", "new", "branch", "base", "mark", "unmark"],


### PR DESCRIPTION
The 'log' subcommand and its CommandName variant were removed along with the module and handling in lib.rs because the project no longer supports or needs a separate 'but log' command. This cleans up the CLI enum, command dispatch, module imports, and help groupings to reflect that 'status' is now the sole inspection command.