### PR TITLE
Worktree information in workspace info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.74.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-actor 0.35.6 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.28.1",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-date 0.10.7 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.28.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-glob 0.22.1",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-path 0.10.21 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4177,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.47.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.31.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.7"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "itoa",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.54.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-attributes 0.28.1",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-discover 0.42.0",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "dunce",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.44.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "faster-hex",
  "gix-features 0.44.1",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-hash 0.20.1",
  "hashbrown 0.16.0",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-glob 0.22.1",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.42.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "19.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-tempfile 19.0.1",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-actor 0.35.6 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.30.1",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.51.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-actor 0.35.6 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.71.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.7 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.61.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "clru",
  "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4750,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.21"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.54.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-actor 0.35.6 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.44.1",
@@ -4876,9 +4876,10 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
+ "gix-glob 0.22.1",
  "gix-hash 0.20.1",
  "gix-revision",
  "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4889,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.36.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4922,7 +4923,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "gix-commitgraph 0.30.1",
  "gix-date 0.10.7 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4948,7 +4949,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "gix-path 0.10.21 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4960,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-hash 0.20.1",
@@ -4972,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.21.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "filetime",
@@ -4994,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5023,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "19.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "dashmap",
  "gix-fs 0.17.0",
@@ -5065,7 +5066,7 @@ checksum = "1d3f59a8de2934f6391b6b3a1a7654eae18961fcb9f9c843533fed34ad0f3457"
 [[package]]
 name = "gix-trace"
 version = "0.1.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "tracing-core",
 ]
@@ -5073,7 +5074,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5109,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.30.1",
@@ -5125,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-features 0.44.1",
@@ -5149,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5169,7 +5170,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "thiserror 2.0.17",
@@ -5197,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-attributes 0.28.1",
@@ -5216,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c400dd34e29ae3be922e55a282645e9767d36a22"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#2f14246f01029ceee4c39fd9aedffe1fb938ba42"
 dependencies = [
  "bstr",
  "gix-features 0.44.1",
@@ -5748,7 +5749,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -7479,7 +7480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8165,7 +8166,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.34",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8202,7 +8203,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11660,7 +11661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -135,10 +135,10 @@ pub fn create_branch(
                 {
                     let segment = stack.segments.first().context("BUG: no empty stacks")?;
                     segment
-                    .ref_name
+                    .ref_info
                     .as_ref()
-                    .map(|rn| but_workspace::branch::create_reference::Anchor::AtSegment {
-                        ref_name: Cow::Borrowed(rn.as_ref()),
+                    .map(|ri| but_workspace::branch::create_reference::Anchor::AtSegment {
+                        ref_name: Cow::Borrowed(ri.ref_name.as_ref()),
                         position: Above,
                     })
                     .or_else(|| {

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -133,13 +133,13 @@ impl Graph {
         name: &gix::refs::FullNameRef,
     ) -> Option<(&Segment, &Commit)> {
         self.inner.node_weights().find_map(|s| {
-            if s.ref_name.as_ref().is_some_and(|rn| rn.as_ref() == name) {
+            if s.ref_name().is_some_and(|rn| rn == name) {
                 self.tip_skip_empty(s.id).map(|c| (s, c))
             } else {
                 s.commits.iter().find_map(|c| {
                     c.refs
                         .iter()
-                        .any(|rn| rn.as_ref() == name)
+                        .any(|ri| ri.ref_name.as_ref() == name)
                         .then_some((s, c))
                 })
             }
@@ -156,7 +156,7 @@ impl Graph {
     pub fn named_segment_by_ref_name(&self, name: &gix::refs::FullNameRef) -> Option<&Segment> {
         self.inner
             .node_weights()
-            .find(|s| s.ref_name.as_ref().is_some_and(|rn| rn.as_ref() == name))
+            .find(|s| s.ref_name().is_some_and(|rn| rn == name))
     }
 
     /// Starting a `segment`, ignore all segments that have no commit and return the first commit

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -182,6 +182,10 @@ impl<'repo> OverlayRepo<'repo> {
         self.inner
     }
 
+    pub fn for_worktree_only(&self) -> &'repo gix::Repository {
+        self.inner
+    }
+
     pub fn remote_names(&self) -> gix::remote::Names<'repo> {
         self.inner.remote_names()
     }

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -201,7 +201,7 @@
 mod segment;
 /// Use this for basic types like [`petgraph::Direction`], and graph algorithms.
 pub use petgraph;
-pub use segment::{Commit, CommitFlags, Segment, SegmentMetadata};
+pub use segment::{Commit, CommitFlags, RefInfo, Segment, SegmentMetadata, Worktree};
 
 mod api;
 /// Produce a graph from a Git repository.

--- a/crates/but-graph/src/statistics.rs
+++ b/crates/but-graph/src/statistics.rs
@@ -40,7 +40,7 @@ impl Graph {
             .map(|s| {
                 let s = &self[s];
                 (
-                    s.ref_name.clone(),
+                    s.ref_info.clone().map(|ri| ri.ref_name),
                     s.id,
                     s.non_empty_flags_of_first_commit(),
                 )
@@ -86,7 +86,7 @@ impl Graph {
         for n in self.inner.node_indices().map(|n| &self[n]) {
             *commits += n.commits.len();
 
-            if n.ref_name.is_none() {
+            if n.ref_info.is_none() {
                 *segments_unnamed += 1;
             }
             if n.remote_tracking_ref_name.is_some() {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -120,6 +120,13 @@ git init multi-root
   git checkout main && git merge --allow-unrelated-histories C
 )
 
+git init ambiguous-worktrees
+(cd ambiguous-worktrees
+  commit M
+  git worktree add ../wt-outside-ambiguous-worktree
+  git worktree add wt-inside-ambiguous-worktree
+)
+
 # A single root that splits up into 4 branches and merges again
 git init four-diamond
 (cd four-diamond
@@ -205,6 +212,32 @@ git init special-branches
 
 mkdir ws
 (cd ws
+  git init ambiguous-worktrees
+  (cd ambiguous-worktrees
+    set -x
+    commit M1
+    commit M-base
+
+    git branch A
+    git worktree add -b A-inside wt-A-inside
+    git worktree add -b A-outside ../wt-A-outside
+
+    git checkout -b soon-origin-A main
+      commit A-remote
+    git checkout main
+      commit M-advanced
+      setup_target_to_match_main
+
+    git checkout -b B A
+      commit B
+    git checkout A
+    git worktree add wt-B-inside B
+
+    create_workspace_commit_once A B
+    setup_remote_tracking soon-origin-A A "move"
+    git worktree add wt-origin-A-inside origin/A
+  )
+
   git init remote-and-integrated-tracking-linear
   (cd remote-and-integrated-tracking-linear
      commit M1

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -6,7 +6,7 @@ fn unborn() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("unborn")?;
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
-    insta::assert_snapshot!(graph_tree(&graph), @"└── 👉►:0[0]:main");
+    insta::assert_snapshot!(graph_tree(&graph), @"└── 👉►:0[0]:main[🌳]");
     insta::assert_debug_snapshot!(graph, @r#"
     Graph {
         inner: StableGraph {
@@ -17,7 +17,7 @@ fn unborn() -> anyhow::Result<()> {
                 0: StackSegment {
                     id: NodeIndex(0),
                     generation: 0,
-                    ref_name: "refs/heads/main",
+                    ref_name: "►main[🌳]",
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [],
@@ -49,9 +49,9 @@ fn unborn() -> anyhow::Result<()> {
     "#);
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
     ");
     Ok(())
 }
@@ -103,7 +103,7 @@ fn detached() -> anyhow::Result<()> {
                 1: StackSegment {
                     id: NodeIndex(1),
                     generation: 1,
-                    ref_name: "refs/heads/other",
+                    ref_name: "►other",
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [
@@ -173,7 +173,7 @@ fn multi_root() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:main
+    └── 👉►:0[0]:main[🌳]
         └── ·c6c8c05 (⌂|1)
             ├── ►:1[1]:anon:
             │   └── ·76fc5c4 (⌂|1)
@@ -199,9 +199,9 @@ fn multi_root() -> anyhow::Result<()> {
         "there are 4 orphaned bases"
     );
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             ├── ·c6c8c05
             ├── ·76fc5c4
             └── ·e5d0542
@@ -231,7 +231,7 @@ fn four_diamond() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:merged
+    └── 👉►:0[0]:merged[🌳]
         └── ·8a6c109 (⌂|1)
             ├── ►:1[1]:A
             │   └── ·62b409a (⌂|1)
@@ -265,9 +265,9 @@ fn four_diamond() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:merged <> ✓!
-    └── ≡:0:merged
-        ├── :0:merged
+    ⌂:0:merged[🌳] <> ✓!
+    └── ≡:0:merged[🌳]
+        ├── :0:merged[🌳]
         │   └── ·8a6c109
         ├── :1:A
         │   ├── ·62b409a
@@ -294,7 +294,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0[0]:B <> origin/B →:1:
+    ├── 👉►:0[0]:B[🌳] <> origin/B →:1:
     │   └── ·312f819 (⌂|1)
     │       └── ►:2[1]:A <> origin/A →:3:
     │           └── ·e255adc (⌂|101)
@@ -309,9 +309,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
 
     // 'main' is frozen because it connects to a 'foreign' remote, the commit was pushed.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:B <> ✓!
-    └── ≡:0:B <> origin/B →:1:⇡1⇣1
-        ├── :0:B <> origin/B →:1:⇡1⇣1
+    ⌂:0:B[🌳] <> ✓!
+    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1
+        ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
         │   ├── 🟣682be32
         │   └── ·312f819
         ├── :2:A <> origin/A →:3:⇡1⇣1
@@ -325,7 +325,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(7))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0[0]:B <> origin/B →:1:
+    ├── 👉►:0[0]:B[🌳] <> origin/B →:1:
     │   └── ·312f819 (⌂|1)
     │       └── ►:2[1]:A <> origin/A →:3:
     │           └── ·e255adc (⌂|101)
@@ -337,9 +337,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ");
     // As the remotes don't connect, they are entirely unknown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:B <> ✓!
-    └── ≡:0:B <> origin/B →:1:⇡1⇣1
-        ├── :0:B <> origin/B →:1:⇡1⇣1
+    ⌂:0:B[🌳] <> ✓!
+    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1
+        ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
         │   ├── 🟣682be32
         │   └── ·312f819
         ├── :2:A <> origin/A →:3:⇡1
@@ -351,7 +351,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     // Everything we encounter is checked for remotes (no limit)
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0[0]:B <> origin/B →:1:
+    ├── 👉►:0[0]:B[🌳] <> origin/B →:1:
     │   └── ·312f819 (⌂|1)
     │       └── ►:2[1]:A <> origin/A →:3:
     │           └── ·e255adc (⌂|101)
@@ -415,7 +415,7 @@ fn with_limits() -> anyhow::Result<()> {
     // Without limits
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:1[1]:anon:
             │   ├── ·6861158 (⌂|1)
@@ -440,9 +440,9 @@ fn with_limits() -> anyhow::Result<()> {
     ");
     // No limits list the first parent everywhere.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        ├── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        ├── :0:C[🌳]
         │   ├── ·2a95729
         │   ├── ·6861158
         │   ├── ·4f1f248
@@ -460,14 +460,14 @@ fn with_limits() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ✂·2a95729 (⌂|1)
     ");
     // The cut by limit is also represented here.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        └── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        └── :0:C[🌳]
             └── ✂️·2a95729
     ");
 
@@ -475,7 +475,7 @@ fn with_limits() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:1[1]:anon:
             │   └── ✂·6861158 (⌂|1)
@@ -485,9 +485,9 @@ fn with_limits() -> anyhow::Result<()> {
                 └── ✂·9908c99 (⌂|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        └── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        └── :0:C[🌳]
             ├── ·2a95729
             └── ✂️·6861158
     ");
@@ -496,7 +496,7 @@ fn with_limits() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(2))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:1[1]:anon:
             │   ├── ·6861158 (⌂|1)
@@ -509,9 +509,9 @@ fn with_limits() -> anyhow::Result<()> {
                 └── ✂·60d9a56 (⌂|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        └── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
             └── ✂️·4f1f248
@@ -528,7 +528,7 @@ fn with_limits() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:1[1]:anon:
             │   ├── ·6861158 (⌂|1)
@@ -542,9 +542,9 @@ fn with_limits() -> anyhow::Result<()> {
                 └── ✂·60d9a56 (⌂|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        └── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
             └── ✂️·4f1f248
@@ -561,7 +561,7 @@ fn with_limits() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:1[1]:anon:
             │   ├── ·6861158 (⌂|1)
@@ -580,9 +580,9 @@ fn with_limits() -> anyhow::Result<()> {
                 └── ✂·9d171ff (⌂|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        └── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
             ├── ·4f1f248
@@ -647,7 +647,7 @@ fn with_limits() -> anyhow::Result<()> {
 
     // This limits the reach of the stack naturally.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:C
+    └── 👉►:0[0]:C[🌳]
         └── ·2a95729 (⌂|1)
             ├── ►:2[1]:anon:
             │   ├── ·6861158 (⌂|1)
@@ -674,9 +674,9 @@ fn with_limits() -> anyhow::Result<()> {
     //       integrated-by-workspace and the extra target to be able to decide that
     //       integrated portions (see below) shouldn't be shown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C <> ✓!
-    └── ≡:0:C
-        ├── :0:C
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳]
+        ├── :0:C[🌳]
         │   ├── ·2a95729
         │   ├── ·6861158
         │   ├── ·4f1f248
@@ -703,7 +703,7 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // Standard handling after travrsal and post-processing.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:main
+    └── 👉►:0[0]:main[🌳]
         └── ·3686017 (⌂|1)
             └── ►:1[1]:gitbutler/edit
                 └── ·9725482 (⌂|1)
@@ -713,12 +713,32 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
 
     // But special handling for workspace views.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             ├── ·3686017
             ├── ·9725482
             └── ·fafd9d0
+    ");
+    Ok(())
+}
+
+#[test]
+fn ambiguous_worktrees() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("ambiguous-worktrees")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 85efbe4 (HEAD -> main, wt-outside-ambiguous-worktree, wt-inside-ambiguous-worktree) M");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    └── 👉►:0[0]:main[🌳]
+        └── ·85efbe4 (⌂|1) ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
+            └── ·85efbe4 ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
     ");
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -30,7 +30,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘|1)
     │       └── ►:3[1]:B <> origin/B →:4:
     │           ├── ·70e9a36 (⌂|🏘|101)
@@ -46,7 +46,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
 
     // All non-integrated segments are visible.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B <> origin/B →:4:⇡3 on fafd9d0
         └── :3:B <> origin/B →:4:⇡3
             ├── ·70e9a36 (🏘️)
@@ -62,7 +62,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         .validated()?;
     // See how tags ARE allowed to name a segment, at least when used as entrypoint.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘)
     │       └── ►:4[1]:B <> origin/B →:5:
     │           └── ·70e9a36 (⌂|🏘|100)
@@ -81,7 +81,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     // Now `HEAD` is outside a workspace, which goes to single-branch mode. But it knows it's in a workspace
     // and shows the surrounding parts, while marking the segment as entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
@@ -95,7 +95,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(without_ref_id, None, &*meta, standard_options())?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘)
     │       └── ►:4[1]:B <> origin/B →:5:
     │           └── ·70e9a36 (⌂|🏘|100)
@@ -114,7 +114,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
 
     // Entrypoint is now unnamed (as no ref-name was provided for traversal)
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
@@ -129,7 +129,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(b_id_1, None, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘)
     │       └── ►:4[1]:B <> origin/B →:5:
     │           ├── ·70e9a36 (⌂|🏘|100)
@@ -148,7 +148,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
 
     // Doing this is very much like edit mode, and there is always a segment starting at the entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -162,7 +162,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(b_id_1, tag_ref_name, &*meta, standard_options())?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘)
     │       └── ►:4[1]:B <> origin/B →:5:
     │           ├── ·70e9a36 (⌂|🏘|100)
@@ -180,7 +180,7 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -223,7 +223,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘|1)
     │       └── 📙►:4[1]:B <> origin/B →:6:
     │           ├── ·70e9a36 (⌂|🏘|101)
@@ -244,7 +244,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
 
     // We pickup empty segments.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:4:B <> origin/B →:6:⇡2 on fafd9d0 {0}
         ├── 📙:4:B <> origin/B →:6:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -272,7 +272,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘|1)
     │       └── 📙►:4[1]:B <> origin/B →:6:
     │           ├── ·70e9a36 (⌂|🏘|101)
@@ -292,7 +292,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         └── →:7: (A-empty-03)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:4:B <> origin/B →:6:⇡2 on fafd9d0 {0}
         ├── 📙:4:B <> origin/B →:6:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -315,7 +315,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     let (id, ref_name) = id_at(&repo, "A-empty-01");
     let graph = Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·20de6ee (⌂|🏘)
     │       └── 📙►:5[1]:B <> origin/B →:6:
     │           ├── ·70e9a36 (⌂|🏘|100)
@@ -333,7 +333,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         └── →:7: (A)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:B <> origin/B →:6:⇡2 on fafd9d0 {1}
         ├── 📙:5:B <> origin/B →:6:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -354,7 +354,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     // We can also summon new empty stacks from branches resting on the base, and set them
     // as entrypoint, to have two more stacks.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:new-B on fafd9d0 {3}
     │   └── 📙:8:new-B
     ├── ≡👉📙:7:new-A on fafd9d0 {2}
@@ -388,7 +388,7 @@ fn single_stack() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·2c12d75 (⌂|🏘|1)
     │       └── ►:3[1]:B
     │           └── ·320e105 (⌂|🏘|1)
@@ -402,7 +402,7 @@ fn single_stack() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B on fafd9d0
         ├── :3:B
         │   └── ·320e105 (🏘️)
@@ -425,7 +425,7 @@ fn single_stack() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·2c12d75 (⌂|🏘|1)
     │       ├── 📙►:3[1]:B
     │       │   └── ·320e105 (⌂|🏘|1)
@@ -441,7 +441,7 @@ fn single_stack() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:6:new-A on fafd9d0 {1}
     │   └── 📙:6:new-A
     └── ≡📙:3:B on fafd9d0 {0}
@@ -475,7 +475,7 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
 
     // By default, everything with metadata on the branch will show up, even if on the base.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0cc5a6f
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
     └── ≡📙:3:C on 0cc5a6f {0}
         ├── 📙:3:C
         │   └── ·c6d714c (🏘️)
@@ -495,7 +495,7 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
 
     let graph = graph.redo_traversal_with_overlay(&repo, &*meta, Default::default())?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0cc5a6f
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
     └── ≡📙:3:C {0}
         └── 📙:3:C
             └── ·c6d714c (🏘️)
@@ -507,7 +507,7 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0cc5a6f
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
     ├── ≡📙:7:merge on 0cc5a6f {1}
     │   └── 📙:7:merge
     └── ≡📙:3:C on 0cc5a6f {0}
@@ -521,7 +521,7 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0cc5a6f
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
     ├── ≡📙:3:C on 0cc5a6f {1}
     │   └── 📙:3:C
     │       └── ·c6d714c (🏘️)
@@ -552,7 +552,7 @@ fn minimal_merge_no_refs() -> anyhow::Result<()> {
     // Without hints.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉►:0[0]:gitbutler/workspace
+    └── 👉►:0[0]:gitbutler/workspace[🌳]
         └── ·47e1cf1 (⌂|1)
             └── ►:1[1]:anon:
                 └── ·f40fb16 (⌂|1)
@@ -575,9 +575,9 @@ fn minimal_merge_no_refs() -> anyhow::Result<()> {
     // This a very untypical setup, but it's not forbidden. Code might want to check
     // if the workspace commit is actually managed before proceeding.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:gitbutler/workspace <> ✓!
-    └── ≡:0:gitbutler/workspace
-        └── :0:gitbutler/workspace
+    ⌂:0:gitbutler/workspace[🌳] <> ✓!
+    └── ≡:0:gitbutler/workspace[🌳]
+        └── :0:gitbutler/workspace[🌳]
             ├── ·47e1cf1
             ├── ·f40fb16
             ├── ·450c58a
@@ -616,7 +616,7 @@ fn segment_on_each_incoming_connection() -> anyhow::Result<()> {
     │       └── ►:3[2]:anon:
     │           ├── ·b688f2d (⌂|🏘|1)
     │           └── ·fafd9d0 (⌂|🏘|1)
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         └── ·b6917c7 (⌂|🏘)
             └── ►:2[1]:main
                 └── ·f7fe830 (⌂|🏘)
@@ -657,7 +657,7 @@ fn minimal_merge() -> anyhow::Result<()> {
     // Without hints, and no workspace data, the branch is normal!
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0[0]:gitbutler/workspace
+    ├── 👉►:0[0]:gitbutler/workspace[🌳]
     │   └── ·47e1cf1 (⌂|1)
     │       └── ►:1[1]:merge-2
     │           └── ·f40fb16 (⌂|1)
@@ -681,9 +681,9 @@ fn minimal_merge() -> anyhow::Result<()> {
 
     // Without workspace data this becomes a single-branch workspace, with `main` as normal segment.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:gitbutler/workspace <> ✓!
-    └── ≡:0:gitbutler/workspace
-        ├── :0:gitbutler/workspace
+    ⌂:0:gitbutler/workspace[🌳] <> ✓!
+    └── ≡:0:gitbutler/workspace[🌳]
+        ├── :0:gitbutler/workspace[🌳]
         │   └── ·47e1cf1
         ├── :1:merge-2
         │   └── ·f40fb16
@@ -707,7 +707,7 @@ fn minimal_merge() -> anyhow::Result<()> {
     );
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·47e1cf1 (⌂|🏘|1)
     │       └── ►:6[1]:merge-2
     │           └── ·f40fb16 (⌂|🏘|1)
@@ -731,7 +731,7 @@ fn minimal_merge() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:6:merge-2 on fafd9d0 {0}
         ├── :6:merge-2
         │   └── ·f40fb16 (🏘️)
@@ -758,7 +758,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     let extra_target_options = standard_options_with_extra_target(&repo, "main");
     let graph = Graph::from_head(&repo, &*meta, extra_target_options.clone())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         ├── 📙►:2[1]:A
         │   └── ►:1[2]:anon:
         │       └── ·fafd9d0 (⌂|🏘|1) ►main
@@ -766,7 +766,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
             └── →:1:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on fafd9d0
     ├── ≡📙:3:B on fafd9d0 {2}
     │   └── 📙:3:B
     └── ≡📙:2:A on fafd9d0 {1}
@@ -778,7 +778,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
         Graph::from_commit_traversal(id, ref_name.clone(), &*meta, extra_target_options.clone())?
             .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         ├── 📙►:2[1]:A
         │   └── ►:0[2]:anon:
         │       └── ·fafd9d0 (⌂|🏘|1) ►main
@@ -786,7 +786,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
             └── →:0:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on fafd9d0
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on fafd9d0
     ├── ≡👉📙:3:B on fafd9d0 {2}
     │   └── 👉📙:3:B
     └── ≡📙:2:A on fafd9d0 {1}
@@ -797,7 +797,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, extra_target_options)?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         ├── 👉📙►:2[1]:A
         │   └── ►:0[2]:anon:
         │       └── ·fafd9d0 (⌂|🏘|1) ►main
@@ -805,7 +805,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
             └── →:0:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on fafd9d0
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on fafd9d0
     ├── ≡📙:3:B on fafd9d0 {2}
     │   └── 📙:3:B
     └── ≡👉📙:2:A on fafd9d0 {1}
@@ -827,18 +827,18 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1[0]:gitbutler/workspace
-    │   └── 👉►:0[1]:main <> origin/main →:2:
+    │   └── 👉►:0[1]:main[🌳] <> origin/main →:2:
     │       └── ·fafd9d0 (⌂|🏘|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
     └── ►:2[0]:origin/main →:0:
-        └── →:0: (main →:2:)
+        └── →:0: (main[🌳] →:2:)
     ");
 
     // There is no workspace as `main` is the base of the workspace, so it's shown directly,
     // outside the workspace.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main <> origin/main →:2:
-        └── :0:main <> origin/main →:2:
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳] <> origin/main →:2:
+        └── :0:main[🌳] <> origin/main →:2:
             └── ❄️fafd9d0 (🏘️|✓) ►A, ►B, ►C, ►D, ►E, ►F
     ");
 
@@ -847,10 +847,10 @@ fn just_init_with_branches() -> anyhow::Result<()> {
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0[0]:gitbutler/workspace
-    │   └── ►:2[1]:main <> origin/main →:1:
+    │   └── ►:2[1]:main[🌳] <> origin/main →:1:
     │       └── ·fafd9d0 (⌂|🏘|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
     └── ►:1[0]:origin/main →:2:
-        └── →:2: (main →:1:)
+        └── →:2: (main[🌳] →:1:)
     ");
 
     // However, when the workspace is checked out, it's at least empty.
@@ -867,21 +867,21 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     │   ├── 📙►:3[1]:C
     │   │   └── 📙►:4[2]:B
     │   │       └── 📙►:5[3]:A
-    │   │           └── 👉►:0[4]:main <> origin/main →:2:
+    │   │           └── 👉►:0[4]:main[🌳] <> origin/main →:2:
     │   │               └── ·fafd9d0 (⌂|🏘|✓|1)
     │   └── 📙►:6[1]:D
     │       └── 📙►:7[2]:E
     │           └── 📙►:8[3]:F
-    │               └── →:0: (main →:2:)
+    │               └── →:0: (main[🌳] →:2:)
     └── ►:2[0]:origin/main →:0:
-        └── →:0: (main →:2:)
+        └── →:0: (main[🌳] →:2:)
     ");
 
     // ~~There is no segmentation outside the workspace.~~ workspace segmentation always happens so the view is consistent.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main <> origin/main →:2:
-        └── :0:main <> origin/main →:2:
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳] <> origin/main →:2:
+        └── :0:main[🌳] <> origin/main →:2:
             └── ❄️fafd9d0 (🏘️|✓)
     ");
 
@@ -894,14 +894,14 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     │   ├── 📙►:3[1]:C
     │   │   └── 📙►:4[2]:B
     │   │       └── 📙►:5[3]:A
-    │   │           └── ►:2[4]:main <> origin/main →:1:
+    │   │           └── ►:2[4]:main[🌳] <> origin/main →:1:
     │   │               └── ·fafd9d0 (⌂|🏘|✓|1)
     │   └── 📙►:6[1]:D
     │       └── 📙►:7[2]:E
     │           └── 📙►:8[3]:F
-    │               └── →:2: (main →:1:)
+    │               └── →:2: (main[🌳] →:1:)
     └── ►:1[0]:origin/main →:2:
-        └── →:2: (main →:1:)
+        └── →:2: (main[🌳] →:1:)
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -943,7 +943,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0[0]:gitbutler/workspace
     │   └── ►:2[0]:anon:
-    │       └── ·fafd9d0 (⌂|🏘|✓|1) ►A, ►B, ►C, ►D, ►E, ►F, ►main, ►origin/main
+    │       └── ·fafd9d0 (⌂|🏘|✓|1) ►A, ►B, ►C, ►D, ►E, ►F, ►main[🌳], ►origin/main
     └── ►:1[0]:origin/main
         └── →:2:
     ");
@@ -1018,7 +1018,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // Without any information it looks quite barren.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·298d938 (⌂|🏘|1)
     │       └── ►:3[1]:anon:
     │           ├── ·16f132b (⌂|🏘|1) ►F, ►G, ►S1
@@ -1031,7 +1031,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
 
     // With no workspace at all as the workspace segment isn't split.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:anon: on fafd9d0
         └── :3:anon:
             ├── ·16f132b (🏘️) ►F, ►G, ►S1
@@ -1043,7 +1043,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         .validated()?;
     // The S1 starting position is a split, so there is more.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·298d938 (⌂|🏘)
     │       └── 👉►:0[1]:S1
     │           ├── ·16f132b (⌂|🏘|1) ►F, ►G
@@ -1054,7 +1054,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡👉:0:S1 on fafd9d0
         └── 👉:0:S1
             ├── ·16f132b (🏘️) ►F, ►G
@@ -1070,7 +1070,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     // We see that all segments are used: S1 C B A E D G F
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·298d938 (⌂|🏘|1)
     │       ├── 📙►:5[1]:C
     │       │   └── 📙►:6[2]:B
@@ -1091,7 +1091,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:S1 on fafd9d0 {3}
     │   ├── 📙:8:S1
     │   ├── 📙:9:G
@@ -1111,7 +1111,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         .validated()?;
     // This should look the same as before, despite the starting position.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·298d938 (⌂|🏘)
     │       ├── 📙►:5[1]:C
     │       │   └── 📙►:6[2]:B
@@ -1131,7 +1131,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡👉📙:8:S1 on fafd9d0 {3}
     │   ├── 👉📙:8:S1
     │   ├── 📙:9:G
@@ -1166,17 +1166,17 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     ├── 👉📕►►►:0[0]:gitbutler/workspace
     │   ├── 📙►:3[1]:C
     │   │   └── 📙►:4[2]:B
-    │   │       └── ►:2[3]:main <> origin/main →:1:
+    │   │       └── ►:2[3]:main[🌳] <> origin/main →:1:
     │   │           └── ·fafd9d0 (⌂|🏘|✓|1)
     │   ├── 📙►:5[1]:A
-    │   │   └── →:2: (main →:1:)
+    │   │   └── →:2: (main[🌳] →:1:)
     │   ├── 📙►:6[1]:D
     │   │   └── 📙►:7[2]:E
-    │   │       └── →:2: (main →:1:)
+    │   │       └── →:2: (main[🌳] →:1:)
     │   └── 📙►:8[1]:F
-    │       └── →:2: (main →:1:)
+    │       └── →:2: (main[🌳] →:1:)
     └── ►:1[0]:origin/main →:2:
-        └── →:2: (main →:1:)
+        └── →:2: (main[🌳] →:1:)
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -1202,17 +1202,17 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     ├── 📕►►►:1[0]:gitbutler/workspace
     │   ├── 👉📙►:3[1]:C
     │   │   └── 📙►:4[2]:B
-    │   │       └── ►:0[3]:main <> origin/main →:2:
+    │   │       └── ►:0[3]:main[🌳] <> origin/main →:2:
     │   │           └── ·fafd9d0 (⌂|🏘|✓|1)
     │   ├── 📙►:5[1]:A
-    │   │   └── →:0: (main →:2:)
+    │   │   └── →:0: (main[🌳] →:2:)
     │   ├── 📙►:6[1]:D
     │   │   └── 📙►:7[2]:E
-    │   │       └── →:0: (main →:2:)
+    │   │       └── →:0: (main[🌳] →:2:)
     │   └── 📙►:8[1]:F
-    │       └── →:0: (main →:2:)
+    │       └── →:0: (main[🌳] →:2:)
     └── ►:2[0]:origin/main →:0:
-        └── →:0: (main →:2:)
+        └── →:0: (main[🌳] →:2:)
     ");
 
     // We should see the same stacks as we did before, just with a different entrypoint.
@@ -1248,7 +1248,7 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·9bcd3af (⌂|🏘|1)
     │       └── ►:2[1]:main <> origin/main →:1:
     │           ├── ·998eae6 (⌂|🏘|✓|11)
@@ -1260,14 +1260,14 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     ");
 
     // Everything in the workspace is integrated, thus it's empty.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣2 on 998eae6");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 998eae6");
 
     let (id, ref_name) = id_at(&repo, "main");
     // The integration branch can be in the workspace and be checked out.
     let graph = Graph::from_commit_traversal(id, Some(ref_name), &*meta, standard_options())?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·9bcd3af (⌂|🏘)
     │       └── 👉►:0[1]:main <> origin/main →:2:
     │           ├── ·998eae6 (⌂|🏘|✓|1)
@@ -1313,7 +1313,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·8b39ce4 (⌂|🏘|1)
     │       └── ►:1[1]:A <> origin/A →:2:
     │           ├── ·9d34471 (⌂|🏘|11)
@@ -1335,7 +1335,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     // There is no target branch, so nothing is integrated, and `main` shows up.
     // It's not special.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:A <> origin/A →:2:⇡2⇣4
         ├── :1:A <> origin/A →:2:⇡2⇣4
         │   ├── 🟣3ea1a8f
@@ -1352,7 +1352,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     let id = id_by_rev(&repo, ":/init");
     let graph = Graph::from_commit_traversal(id, None, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·8b39ce4 (⌂|🏘)
     │       └── ►:2[1]:A <> origin/A →:3:
     │           ├── ·9d34471 (⌂|🏘|10)
@@ -1374,7 +1374,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     // The whole workspace is visible, but it's clear where the entrypoint is.
     // As there is no target ref, `main` shows up.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓!
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡:2:A <> origin/A →:3:⇡2⇣4
         ├── :2:A <> origin/A →:3:⇡2⇣4
         │   ├── 🟣3ea1a8f
@@ -1396,7 +1396,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
         .push_remote_name = Some("push-remote".into());
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·8b39ce4 (⌂|🏘|1)
     │       └── ►:1[1]:A <> push-remote/A →:2:
     │           ├── ·9d34471 (⌂|🏘|11)
@@ -1417,7 +1417,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:A <> push-remote/A →:2:⇡2⇣4
         ├── :1:A <> push-remote/A →:2:⇡2⇣4
         │   ├── 🟣3ea1a8f
@@ -1451,7 +1451,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·7786959 (⌂|🏘|1)
     │       └── ►:3[1]:B <> origin/B →:4:
     │           └── ·312f819 (⌂|🏘|101)
@@ -1471,7 +1471,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     // directly owned by another remote segment.
     // they have to be considered as something relevant to the branch history.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B <> origin/B →:4:⇡1⇣1 on fafd9d0
         ├── :3:B <> origin/B →:4:⇡1⇣1
         │   ├── 🟣682be32
@@ -1485,7 +1485,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let (id, name) = id_at(&repo, "A");
     let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·7786959 (⌂|🏘)
     │       └── ►:5[1]:B <> origin/B →:6:
     │           └── ·312f819 (⌂|🏘|1000)
@@ -1502,7 +1502,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
                     └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:5:B <> origin/B →:6:⇡1⇣1 on fafd9d0
         ├── :5:B <> origin/B →:6:⇡1⇣1
         │   ├── 🟣682be32
@@ -1595,7 +1595,7 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ·dd0cca8 (⌂|🏘|1)
             └── 📙►:2[1]:A
                 └── ·e255adc (⌂|🏘|11) ►main
@@ -1605,7 +1605,7 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
 
     // The main branch is not present, as it's the target.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:2:A on fafd9d0 {1}
         └── 📙:2:A
             └── ·e255adc (🏘️) ►main
@@ -1615,7 +1615,7 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "A", StackState::InWorkspace, &["main"]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:A on fafd9d0 {1}
         ├── 📙:3:A
         └── 📙:4:main <> origin/main →:1:⇡1
@@ -1626,7 +1626,7 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "main", StackState::InWorkspace, &["A"]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:main <> origin/main →:1: on fafd9d0 {1}
         ├── 📙:3:main <> origin/main →:1:
         └── 📙:4:A
@@ -1660,7 +1660,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     // it steals the commit from `main`. This should be fine.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·e30f90c (⌂|🏘|1)
     │       └── ►:6[1]:anon:
     │           └── ·2173153 (⌂|🏘|101) ►C, ►ambiguous-C
@@ -1684,7 +1684,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     ");
     // An anonymous segment to start with is alright, and can always happen for other situations as well.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:6:anon: on fafd9d0
         ├── :6:anon:
         │   └── ·2173153 (🏘️) ►C, ►ambiguous-C
@@ -1705,7 +1705,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 0, "C", StackState::InWorkspace, &[]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·e30f90c (⌂|🏘|1)
     │       └── 📙►:3[1]:C <> origin/C →:4:
     │           └── ·2173153 (⌂|🏘|101) ►ambiguous-C
@@ -1729,7 +1729,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     ");
     // And because `C` is in the workspace data, its data is denoted.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:C <> origin/C →:4: on fafd9d0 {0}
         ├── 📙:3:C <> origin/C →:4:
         │   └── ❄️2173153 (🏘️) ►ambiguous-C
@@ -1779,7 +1779,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     assert_eq!(graph.partial_segments().count(), 1);
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
     │       └── ►:2[1]:B
     │           ├── ·6b1a13b (⌂|🏘|1)
@@ -1802,7 +1802,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // It's true that `A` is fully integrated so it isn't displayed. so from a workspace-perspective
     // it's the right answer.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡:2:B on 79bbb29
         └── :2:B
             ├── ·6b1a13b (🏘️)
@@ -1816,7 +1816,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // We see more though as we add workspace segments immediately.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
     │       └── 📙►:2[1]:B
     │           ├── ·6b1a13b (⌂|🏘|1)
@@ -1845,7 +1845,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     ");
     // `A` is integrated, hence it's not shown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡📙:2:B on 79bbb29 {0}
         └── 📙:2:B
             ├── ·6b1a13b (🏘️)
@@ -1857,7 +1857,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
     │       └── 📙►:2[1]:B
     │           ├── ·6b1a13b (⌂|🏘|1)
@@ -1885,7 +1885,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                     └── →:3: (A)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡📙:2:B on 79bbb29 {0}
         └── 📙:2:B
             ├── ·6b1a13b (🏘️)
@@ -1902,7 +1902,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, standard_options())?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘)
     │       └── ►:3[1]:B
     │           ├── ·6b1a13b (⌂|🏘)
@@ -1955,7 +1955,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // It's still getting quite far despite the limit due to other heads searching for their goals,
     // but also ends traversal early.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘)
     │       └── ►:3[1]:B
     │           ├── ·6b1a13b (⌂|🏘)
@@ -2007,7 +2007,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // It keeps the tip-settings of the workspace it setup by itself, and doesn't override this
     // with the extra-target settings.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘)
     │       └── ►:3[1]:B
     │           ├── ·6b1a13b (⌂|🏘)
@@ -2051,7 +2051,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // Thanks to the limit-transplant we get to discover more of the workspace.
     // TODO(extra-target): make it work so they limit single branches even.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘)
     │       └── ►:3[1]:B
     │           ├── ·6b1a13b (⌂|🏘|✓)
@@ -2118,7 +2118,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     // Thanks to the remote `main` is searched for by the entrypoint.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
     │       └── ►:3[1]:B
     │           ├── ·6b1a13b (⌂|🏘|1)
@@ -2151,7 +2151,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
 
     // This search discovers the whole workspace, without the integrated one.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 79bbb29
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 79bbb29
     └── ≡:3:B on 79bbb29
         └── :3:B
             ├── ·6b1a13b (🏘️)
@@ -2166,7 +2166,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
     └── ≡:3:B on 4b3e5a8
         ├── :3:B
         │   ├── ·6b1a13b (🏘️)
@@ -2186,7 +2186,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, standard_options())?
         .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘)
     │       └── ►:4[1]:B
     │           ├── ·6b1a13b (⌂|🏘)
@@ -2247,7 +2247,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
     └── ≡:4:B on 4b3e5a8
         ├── :4:B
         │   ├── ·6b1a13b (🏘️)
@@ -2325,17 +2325,17 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
     // Main is a normal branch, and its remote is known.
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1[0]:gitbutler/workspace
-    │   └── 👉📙►:0[1]:main <> origin/main →:2:
+    │   └── 👉📙►:0[1]:main[🌳] <> origin/main →:2:
     │       └── ·3183e43 (⌂|🏘|1)
     └── 📙►:2[0]:origin/main →:0:
         └── ·956a3de (⌂)
-            └── →:0: (main →:2:)
+            └── →:0: (main[🌳] →:2:)
     ");
     // The workspace shows the remote commit, there is nothing special about the target.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-    └── ≡👉📙:0:main <> origin/main →:2:⇡1 {0}
-        └── 👉📙:0:main <> origin/main →:2:⇡1
+    └── ≡👉📙:0:main[🌳] <> origin/main →:2:⇡1 {0}
+        └── 👉📙:0:main[🌳] <> origin/main →:2:⇡1
             └── ·3183e43 (🏘️)
     ");
 
@@ -2346,17 +2346,17 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
     let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1[0]:gitbutler/workspace
-    │   └── 👉📙►:0[1]:main <> origin/main →:2:
+    │   └── 👉📙►:0[1]:main[🌳] <> origin/main →:2:
     │       └── ·3183e43 (⌂|🏘|1)
     └── 📙►:2[0]:origin/main →:0:
         └── ·956a3de (⌂)
-            └── →:0: (main →:2:)
+            └── →:0: (main[🌳] →:2:)
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-    └── ≡👉📙:0:main <> origin/main →:2:⇡1 {0}
-        └── 👉📙:0:main <> origin/main →:2:⇡1
+    └── ≡👉📙:0:main[🌳] <> origin/main →:2:⇡1 {0}
+        └── 👉📙:0:main[🌳] <> origin/main →:2:⇡1
             └── ·3183e43 (🏘️)
     ");
     Ok(())
@@ -2398,12 +2398,12 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ✂·4077353 (⌂|🏘|1)
     ");
     // The commit in the workspace branch is always ignored and is expected to be the workspace merge commit.
     // So nothing to show here.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓!");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓!");
 
     meta.data_mut().branches.clear();
     add_workspace(&mut meta);
@@ -2417,7 +2417,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
     │       └── ►:2[1]:B
     │           ├── ·6b1a13b (⌂|🏘|1)
@@ -2438,7 +2438,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡:2:B on 79bbb29
         └── :2:B
             ├── ·6b1a13b (🏘️)
@@ -2463,7 +2463,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·f8f33a7 (⌂|🏘|1)
     │       └── ►:4[1]:advanced-lane <> origin/advanced-lane →:3:
     │           └── ·cbc6713 (⌂|🏘|101) ►dependant, ►on-top-of-dependant
@@ -2477,7 +2477,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
 
     // By default, the advanced lane is simply frozen as its remote contains the commit.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:advanced-lane <> origin/advanced-lane →:3: on fafd9d0
         └── :4:advanced-lane <> origin/advanced-lane →:3:
             └── ❄️cbc6713 (🏘️) ►dependant, ►on-top-of-dependant
@@ -2494,7 +2494,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
     // Lanes are properly ordered
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·f8f33a7 (⌂|🏘|1)
     │       └── 📙►:5[1]:dependant
     │           └── 📙►:6[2]:advanced-lane <> origin/advanced-lane →:4:
@@ -2509,7 +2509,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
 
     // When putting the dependent branch on top as empty segment, the frozen state is retained.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:dependant on fafd9d0 {1}
         ├── 📙:5:dependant
         └── 📙:6:advanced-lane <> origin/advanced-lane →:4:
@@ -2534,7 +2534,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     // It sees the entire history as it had to find `main`.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ►:1[1]:origin/main →:2:
             ├── ·2cde30a (⌂|🏘|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
             ├── ·1c938f4 (⌂|🏘|✓|1)
@@ -2545,13 +2545,13 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
                     └── ·2be54cd (⌂|🏘|✓|11)
     ");
     // Workspace is empty as everything is integrated.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a");
 
     add_stack_with_segments(&mut meta, 0, "C", StackState::InWorkspace, &["B", "A"]);
     add_stack_with_segments(&mut meta, 1, "D", StackState::InWorkspace, &["E", "F"]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         ├── 📙►:3[1]:C
         │   └── 📙►:4[2]:B
         │       └── 📙►:5[3]:A
@@ -2571,7 +2571,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
 
     // Empty stack segments on top of integrated portions will show, and nothing integrated shows.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a
     ├── ≡📙:6:D on 2cde30a {1}
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -2592,7 +2592,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2be54cd
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2be54cd
     ├── ≡📙:6:D on 2be54cd {1}
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -2665,7 +2665,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
         Graph::from_commit_traversal(main_id, main_ref_name.clone(), &*meta, standard_options())?
             .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘)
     │       └── ►:3[2]:workspace
     │           └── ·9730cbf (⌂|🏘|✓)
@@ -2736,7 +2736,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘)
     │       └── ►:3[2]:workspace
     │           └── ·9730cbf (⌂|🏘|✓)
@@ -2790,7 +2790,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // However, we wait for the target to be fully reconciled to get the proper workspace configuration.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘|1)
     │       └── ►:2[2]:workspace
     │           └── ·9730cbf (⌂|🏘|✓|1)
@@ -2831,7 +2831,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     ");
 
     // Everything is integrated, nothing to see here.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣11 on 9730cbf");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣11 on 9730cbf");
     Ok(())
 }
 
@@ -2867,7 +2867,7 @@ fn remote_far_in_ancestry() -> anyhow::Result<()> {
     // or else the remote part will go on forever create a lot of issues for those who want to display
     // all these incorrectly labeled commits.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·9412ebd (⌂|🏘|1)
     │       └── ►:3[1]:A <> origin/A →:4:
     │           ├── ·8407093 (⌂|🏘|101)
@@ -2896,7 +2896,7 @@ fn remote_far_in_ancestry() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 685d644
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 685d644
     └── ≡:3:A <> origin/A →:4:⇡3⇣2 on 685d644
         └── :3:A <> origin/A →:4:⇡3⇣2
             ├── 🟣975754f
@@ -2952,7 +2952,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·f514495 (⌂|🏘)
     │       └── ►:3[3]:workspace
     │           └── ·c9120f1 (⌂|🏘|✓)
@@ -3005,7 +3005,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     // We wait for targets to fully reconcile as well.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·f514495 (⌂|🏘|1)
     │       └── ►:2[3]:workspace
     │           └── ·c9120f1 (⌂|🏘|✓|1)
@@ -3046,7 +3046,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
                             └── →:3: (main-to-workspace)
     ");
     // Everything is integrated.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣17 on c9120f1");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on c9120f1");
     Ok(())
 }
 
@@ -3087,7 +3087,7 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·2b30d94 (⌂|🏘|1)
     │       ├── ►:3[1]:D
     │       │   └── ·9895054 (⌂|🏘|1)
@@ -3117,7 +3117,7 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     // A is still shown despite it being fully integrated, as it's still enclosed by the
     // workspace tip and the fork-point, at least when we provide the previous known location of the target.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:5:B on 3183e43
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
@@ -3149,7 +3149,7 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     // If we do not, integrated portions are removed.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on d4f537e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on d4f537e
     ├── ≡:5:B on d4f537e
     │   └── :5:B
     │       ├── ·acdc49a (🏘️)
@@ -3195,7 +3195,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·2b30d94 (⌂|🏘|1)
     │       ├── ►:2[1]:D
     │       │   └── ·9895054 (⌂|🏘|1)
@@ -3223,7 +3223,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
 
     // Segments can definitely repeat
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:4:B on 3183e43
     │   ├── :4:B
     │   │   ├── ·acdc49a (🏘️)
@@ -3257,7 +3257,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
         .validated()?;
     // Checking out anything inside the workspace yields the same result.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:5:B on 3183e43
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
@@ -3311,7 +3311,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·335d6f2 (⌂|🏘|1)
     │       ├── ►:2[3]:main <> origin/main →:1:
     │       │   └── ·fafd9d0 (⌂|🏘|✓|111) ►lane
@@ -3327,7 +3327,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
 
     // The dependant branch is empty and on top of the one with the remote
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:dependant on fafd9d0 {1}
         ├── 📙:5:dependant
         └── 📙:6:advanced-lane <> origin/advanced-lane →:4:
@@ -3345,7 +3345,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·335d6f2 (⌂|🏘|1)
     │       ├── ►:2[3]:main <> origin/main →:1:
     │       │   └── ·fafd9d0 (⌂|🏘|✓|111) ►lane
@@ -3364,7 +3364,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     // It's probably OK to leave it like this for now, and instead allow users to reorder
     // these more easily.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
         ├── 📙:5:advanced-lane <> origin/advanced-lane →:4:
         └── 📙:6:dependant
@@ -3375,7 +3375,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡👉📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
         ├── 👉📙:5:advanced-lane <> origin/advanced-lane →:4:
         └── 📙:6:dependant
@@ -3386,7 +3386,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
         ├── 📙:5:advanced-lane <> origin/advanced-lane →:4:
         └── 👉📙:6:dependant
@@ -3415,7 +3415,7 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·e982e8a (⌂|🏘|1)
     │       ├── 📙►:3[1]:C-on-A
     │       │   └── ·4f1bb32 (⌂|🏘|1)
@@ -3434,7 +3434,7 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡:6:B-on-A on fafd9d0
     │   ├── :6:B-on-A
     │   │   └── ·aff8449 (🏘️)
@@ -3472,7 +3472,7 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·873d056 (⌂|🏘|1)
     │       ├── 📙►:2[1]:advanced-lane
     │       │   └── ·cbc6713 (⌂|🏘|1)
@@ -3488,7 +3488,7 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     // However, as nothing is integrated, it really is another name for `main` now,
     // `main` is nothing special.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:4:lane on fafd9d0 {1}
     │   └── 📙:4:lane
     └── ≡📙:2:advanced-lane on fafd9d0 {0}
@@ -3502,7 +3502,7 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     }
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·873d056 (⌂|🏘|1)
     │       ├── 📙►:4[1]:lane
     │       │   └── ►:2[2]:anon: →:4:
@@ -3515,7 +3515,7 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:3:advanced-lane on fafd9d0 {1}
     │   └── 📙:3:advanced-lane
     │       └── ·cbc6713 (🏘️)
@@ -3551,7 +3551,7 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·a221221 (⌂|🏘|1)
     │       └── 📙►:3[1]:A <> origin/A →:4:
     │           └── ·aadad9d (⌂|🏘|101)
@@ -3570,7 +3570,7 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     // Remote tracking branches we just want to aggregate, just like anonymous segments,
     // but only when another target is provided (the old position, `main`).
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on fafd9d0 {1}
         ├── 📙:3:A <> origin/A →:4:⇡1⇣1
         │   ├── 🟣2b1808c
@@ -3585,7 +3585,7 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     // but it's skipped because it's actually part of an integrated otherwise ignored segment.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 96a2408
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 96a2408
     └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 96a2408 {1}
         └── 📙:3:A <> origin/A →:4:⇡1⇣1
             ├── 🟣2b1808c
@@ -3622,7 +3622,7 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4f08b8d (⌂|🏘|1)
     │       └── 📙►:3[1]:B <> origin/B →:5:
     │           └── ·da597e8 (⌂|🏘|101)
@@ -3645,7 +3645,7 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
     // Note how there is no expensive computation to see if remote commits are the same,
     // it's all ID-based.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 281456a
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
     └── ≡📙:3:B <> origin/B →:5:⇡1⇣1 on 281456a {0}
         ├── 📙:3:B <> origin/B →:5:⇡1⇣1
         │   ├── 🟣e0bd0a7
@@ -3663,7 +3663,7 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
     .validated()?;
     // Pretending we are rebased onto A still shows the same remote commits.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1818c17
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1818c17
     └── ≡📙:4:B <> origin/B →:6:⇡1⇣1 on 1818c17 {0}
         └── 📙:4:B <> origin/B →:6:⇡1⇣1
             ├── 🟣e0bd0a7
@@ -3696,7 +3696,7 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·1109eb2 (⌂|🏘|1)
     │       └── 📙►:3[1]:D <> origin/D →:4:
     │           └── ·624e118 (⌂|🏘|101)
@@ -3717,7 +3717,7 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -
     // as we are in this situation because these ambiguous remotes don't actually matter as their
     // local tracking branches aren't present anymore.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0b6b861
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
     └── ≡📙:3:D <> origin/D →:4:⇡1⇣1 on 0b6b861 {0}
         └── 📙:3:D <> origin/D →:4:⇡1⇣1
             ├── 🟣3045ea6
@@ -3753,7 +3753,7 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·deeae50 (⌂|🏘|1)
     │       └── 📙►:3[1]:D <> origin/D →:4:
     │           ├── ·353471f (⌂|🏘|101)
@@ -3779,7 +3779,7 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
     // We let each remote on the path down own a commit so we only see one remote commit here,
     // the one belonging to the last remaining associated remote tracking branch of D.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0b6b861
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
     └── ≡📙:3:D <> origin/D →:4:⇡3⇣1 on 0b6b861 {0}
         └── 📙:3:D <> origin/D →:4:⇡3⇣1
             ├── 🟣bbd4ff6
@@ -3803,7 +3803,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ►:1[1]:A
             ├── ·a62b0de (⌂|🏘|1)
             └── ·120a217 (⌂|🏘|1)
@@ -3811,7 +3811,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
                     └── ·fafd9d0 (⌂|🏘|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:A
         ├── :1:A
         │   ├── ·a62b0de (🏘️)
@@ -3824,7 +3824,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         └── 👉►:0[1]:A
             ├── ·a62b0de (⌂|🏘|1)
             └── ·120a217 (⌂|🏘|1)
@@ -3834,7 +3834,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
 
     // Main can be a normal segment if there is no target ref.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:0:A
         ├── 👉:0:A
         │   ├── ·a62b0de (🏘️)
@@ -3860,7 +3860,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     // Without disambiguation, there is no segment name.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ►:1[1]:anon:
             ├── ·a62b0de (⌂|🏘|1) ►A, ►B
             └── ·120a217 (⌂|🏘|1)
@@ -3868,7 +3868,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
                     └── ·fafd9d0 (⌂|🏘|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
         ├── :1:anon:
         │   ├── ·a62b0de (🏘️) ►A, ►B
@@ -3885,7 +3885,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, a_ref.clone(), &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         └── 👉►:3[1]:A
             └── 📙►:0[2]:B
                 ├── ·a62b0de (⌂|🏘|1)
@@ -3896,7 +3896,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
 
     // Main can be a normal segment if there is no target ref.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:3:A {1}
         ├── 👉:3:A
         ├── 📙:0:B
@@ -3909,7 +3909,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     // Finally, show the normal version with just disambiguated 'B".
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── 📙►:1[1]:B
             ├── ·a62b0de (⌂|🏘|1) ►A
             └── ·120a217 (⌂|🏘|1)
@@ -3918,7 +3918,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:1:B {1}
         ├── 📙:1:B
         │   ├── ·a62b0de (🏘️) ►A
@@ -3931,7 +3931,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &["A"]);
     let graph = Graph::from_commit_traversal(id, a_ref, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:3:B {1}
         ├── 📙:3:B
         ├── 👉📙:4:A
@@ -3958,7 +3958,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     // Without disambiguation, there is no segment name.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ►:1[1]:anon:
     │       ├── ·a62b0de (⌂|🏘|1) ►A, ►B
     │       └── ·120a217 (⌂|🏘|1)
@@ -3970,7 +3970,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         └── →:1:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
         ├── :1:anon:
         │   ├── ·a62b0de (🏘️) ►A, ►B
@@ -3984,7 +3984,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     let graph =
         Graph::from_commit_traversal(id, a_ref.clone(), &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── 👉►:0[1]:A <> origin/A →:2:
     │       ├── ·a62b0de (⌂|🏘|1) ►B
     │       └── ·120a217 (⌂|🏘|1)
@@ -3996,7 +3996,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         └── →:0: (A →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:0:A <> origin/A →:2:
         ├── 👉:0:A <> origin/A →:2:
         │   ├── ❄️a62b0de (🏘️) ►B
@@ -4009,7 +4009,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     let (id, b_ref) = id_at(&repo, "B");
     let graph = Graph::from_commit_traversal(id, b_ref, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:0:B <> origin/B →:3:
         ├── 👉:0:B <> origin/B →:3:
         │   ├── ❄️a62b0de (🏘️) ►A
@@ -4031,7 +4031,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     //       reach the right segment, just through one more indirection. Empty segments are 'looked through'
     //       as well by all algorithms for exactly that reason.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── 👉►:5[1]:A <> origin/A →:2:
     │       └── 📙►:0[2]:B <> origin/B →:3:
     │           ├── ·a62b0de (⌂|🏘|1)
@@ -4044,7 +4044,7 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         └── →:0: (B →:3:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:5:A <> origin/A →:2: {1}
         ├── 👉:5:A <> origin/A →:2:
         ├── 📙:0:B <> origin/B →:3:
@@ -4072,7 +4072,7 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     // The commit is ambiguous, so there is just the entrypoint to split the segment.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ·3ea2742 (⌂|🏘|1)
             └── ►:1[1]:A
                 ├── ·a62b0de (⌂|🏘|1)
@@ -4082,7 +4082,7 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     ");
     // TODO: add more stacks.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:A
         ├── :1:A
         │   ├── ·a62b0de (🏘️)
@@ -4095,7 +4095,7 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 📕►►►:1[0]:gitbutler/workspace
+    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
         └── ·3ea2742 (⌂|🏘)
             └── 👉►:0[1]:A
                 ├── ·a62b0de (⌂|🏘|1)
@@ -4105,7 +4105,7 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓!
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
     └── ≡👉:0:A
         ├── 👉:0:A
         │   ├── ·a62b0de (🏘️)
@@ -4130,7 +4130,7 @@ fn workspace_commit_pushed_to_target() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     └── ►:1[0]:origin/main
-        └── 👉📕►►►:0[1]:gitbutler/workspace
+        └── 👉📕►►►:0[1]:gitbutler/workspace[🌳]
             └── ·8ee08de (⌂|🏘|✓|1)
                 └── ►:2[2]:A
                     └── ·120a217 (⌂|🏘|✓|1)
@@ -4138,7 +4138,7 @@ fn workspace_commit_pushed_to_target() -> anyhow::Result<()> {
                             └── ·fafd9d0 (⌂|🏘|✓|1)
     ");
     // Everything is integrated, so nothing is shown.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 120a217");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 120a217");
     Ok(())
 }
 
@@ -4155,7 +4155,7 @@ fn no_workspace_no_target_commit_under_managed_ref() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ►:1[1]:anon:
             └── ·dca94a4 (⌂|🏘|1)
                 └── ►:2[2]:A
@@ -4167,7 +4167,7 @@ fn no_workspace_no_target_commit_under_managed_ref() -> anyhow::Result<()> {
     // It's notable how hard the workspace ref tries to not own the commit
     // it's under unless it's a managed commit.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
         ├── :1:anon:
         │   └── ·dca94a4 (🏘️)
@@ -4207,7 +4207,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // Notably we also pick up 'lane' which sits on the base.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   ├── 📙►:3[1]:lane
     │   │   └── ·cbc6713 (⌂|🏘|1)
     │   │       └── 📙►:7[2]:lane-segment-01
@@ -4222,7 +4222,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:4:lane-2 on fafd9d0 {1}
     │   ├── 📙:4:lane-2
     │   ├── 📙:5:lane-2-segment-01
@@ -4254,7 +4254,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // the order is maintained as provided in the workspace.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   ├── 📙►:4[1]:lane-2
     │   │   └── 📙►:5[2]:lane-2-segment-01
     │   │       └── 📙►:6[3]:lane-2-segment-02
@@ -4269,7 +4269,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:3:lane on fafd9d0 {1}
     │   ├── 📙:3:lane
     │   │   └── ·cbc6713 (🏘️)
@@ -4299,7 +4299,7 @@ fn two_dependent_branches_first_merged_by_rebase() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4f08b8d (⌂|🏘|1)
     │       └── ►:3[1]:B
     │           └── ·da597e8 (⌂|🏘|1)
@@ -4314,7 +4314,7 @@ fn two_dependent_branches_first_merged_by_rebase() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 281456a
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
     └── ≡:3:B on 281456a
         ├── :3:B
         │   └── ·da597e8 (🏘️)
@@ -4339,7 +4339,7 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // Standard handling after traversal and post-processing.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ·8926b15 (⌂|🏘|1)
             └── ►:1[1]:main
                 └── ·3686017 (⌂|🏘|1)
@@ -4351,7 +4351,7 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
 
     // But special handling for workspace views.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:main
         └── :1:main
             ├── ·3686017 (🏘️)
@@ -4382,7 +4382,7 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
     .validated()?;
     // Standard handling after traversal and post-processing.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·270738b (⌂|🏘|1)
     │       └── ►:4[1]:A
     │           └── ·c59457b (⌂|🏘|1)
@@ -4400,7 +4400,7 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
     // But special handling for workspace views. Note how we don't overshoot
     // and stop exactly where we have to, magically even.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on ce09734
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
     └── ≡:4:A on ce09734
         ├── :4:A
         │   ├── ·c59457b (🏘️)
@@ -4465,7 +4465,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·fe6ba62 (⌂|🏘|1)
     │       ├── ►:5[3]:anon:
     │       │   ├── ·a62b0de (⌂|🏘|✓|11)
@@ -4499,7 +4499,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     // nothing special happens.
     // The branches that are outside the workspace don't exist and segments are flattened.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣2 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
     ├── ≡:8:new-name-for-D on fafd9d0
     │   └── :8:new-name-for-D
     │       └── ·ed36e3b (🏘️)
@@ -4531,7 +4531,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·fe6ba62 (⌂|🏘|1)
     │       ├── ►:19[3]:anon: →:4:
     │       │   └── ·a62b0de (⌂|🏘|✓|11)
@@ -4596,7 +4596,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     // - except: if the segment with a known named segment in its future has a (new) name,
     //   we leave it and don't attempt to reconstruct the original (out-of-workspace) reference
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣2 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
     ├── ≡:18:new-name-for-D on fafd9d0
     │   └── :18:new-name-for-D
     │       └── ·ed36e3b (🏘️)
@@ -4654,7 +4654,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 📕►►►:1[0]:gitbutler/workspace
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·873d056 (⌂|🏘)
     │       ├── 👉📙►:4[1]:lane
     │       │   └── ►:0[2]:anon: →:4:
@@ -4666,7 +4666,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
         └── 🟣da83717 (✓)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:3:advanced-lane on fafd9d0 {1}
     │   └── 📙:3:advanced-lane
     │       └── ·cbc6713 (🏘️)
@@ -4681,7 +4681,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·873d056 (⌂|🏘|1)
     │       ├── 📙►:4[1]:lane
     │       │   └── ►:2[2]:anon: →:4:
@@ -4694,7 +4694,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:3:advanced-lane on fafd9d0 {1}
     │   └── 📙:3:advanced-lane
     │       └── ·cbc6713 (🏘️)
@@ -4704,7 +4704,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·873d056 (⌂|🏘|1)
     │       ├── 📙►:4[1]:lane
     │       │   └── ►:2[2]:anon: →:4:
@@ -4717,7 +4717,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:3:advanced-lane on fafd9d0 {1}
     │   └── 📙:3:advanced-lane
     │       └── ·cbc6713 (🏘️)
@@ -4752,7 +4752,7 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ►:5[1]:anon:
     │       └── ·a7131b1 (⌂|🏘|1)
     │           └── ►:6[2]:intermediate-ref
@@ -4782,7 +4782,7 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
     // it contains the workspace commit 619d548.
     // It's up to the caller to deal with this situation as the workspace now is marked differently.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡:5:anon: on bce0c5e {1}
         ├── :5:anon:
         │   └── ·a7131b1 (🏘️)
@@ -4803,7 +4803,7 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
     .validated()?;
     // The extra-target as would happen in the typical case would change nothing though.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ►:5[1]:anon:
     │       └── ·a7131b1 (⌂|🏘|1)
     │           └── ►:6[2]:intermediate-ref
@@ -4830,7 +4830,7 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡:5:anon: on bce0c5e {1}
         ├── :5:anon:
         │   └── ·a7131b1 (🏘️)
@@ -4867,7 +4867,7 @@ fn advanced_workspace_ref_single_stack() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ►:4[1]:anon:
     │       └── ·da912a8 (⌂|🏘|1)
     │           └── ►:5[2]:intermediate-ref
@@ -4892,7 +4892,7 @@ fn advanced_workspace_ref_single_stack() -> anyhow::Result<()> {
     // Here we'd show what happens if the workspace commit is somewhere in the middle
     // of the segment. This is relevant for code trying to find it, which isn't done here.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡:4:anon: on bce0c5e {0}
         ├── :4:anon:
         │   └── ·da912a8 (🏘️)
@@ -4928,7 +4928,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     meta.data_mut().default_target = None;
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         └── ·e82dfab (⌂|🏘|1)
             ├── ►:1[1]:B
             │   ├── ·78b1b59 (⌂|🏘|1)
@@ -4943,7 +4943,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
 
     // The base is automatically set to the lowest one that includes both branches, despite the target.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
     ├── ≡:2:A on bce0c5e
     │   └── :2:A
     │       └── ·6fdab32 (🏘️)
@@ -4959,7 +4959,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     // The same is true if stacks are known in workspace metadata.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·e82dfab (⌂|🏘|1)
     │       ├── 📙►:3[1]:A
     │       │   └── ·6fdab32 (⌂|🏘|1)
@@ -4977,7 +4977,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
                 └── →:5:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
     ├── ≡📙:4:B on bce0c5e {1}
     │   └── 📙:4:B
     │       ├── ·78b1b59 (🏘️)
@@ -4995,7 +4995,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·e82dfab (⌂|🏘|1)
     │       ├── 📙►:4[1]:A
     │       │   └── ·6fdab32 (⌂|🏘|1)
@@ -5016,7 +5016,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     // The base is still adjusted so it matches the actual stacks.
     // Note how it shows more of the base of `B` due to `A` having a lower base with the target branch.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
     ├── ≡📙:5:B on bce0c5e {1}
     │   └── 📙:5:B
     │       ├── ·78b1b59 (🏘️)
@@ -5047,7 +5047,7 @@ fn applied_stack_above_explicit_lower_bound() -> anyhow::Result<()> {
     meta.data_mut().default_target = None;
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·c5587c9 (⌂|🏘|1)
     │       ├── ►:1[1]:B
     │       │   └── ·ce25240 (⌂|🏘|1)
@@ -5066,7 +5066,7 @@ fn applied_stack_above_explicit_lower_bound() -> anyhow::Result<()> {
     // The base is automatically set to the lowest one that includes both branches, despite the target.
     // Interestingly, A now gets to see integrated parts of the target branch.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
     ├── ≡:2:A on bce0c5e
     │   ├── :2:A
     │   │   └── ·de6d39c (🏘️)
@@ -5127,7 +5127,7 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·a0385a8 (⌂|🏘|1)
     │       ├── 📙►:3[1]:A
     │       │   └── ·49d4b34 (⌂|🏘|1)
@@ -5157,7 +5157,7 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
 
     // Both stacks will look the same, with the dependent branch inserted at the very bottom.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:11:C on 3183e43 {3}
     │   ├── 📙:11:C
     │   ├── 📙:12:C2-1
@@ -5194,7 +5194,7 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
     // Note that the segments are incorrectly assigned to A, which is related to it using the metadata
     // and relying on it to be valid. Acceptable for now, what matters is as long as the stack-id is associated.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:11:C on 3183e43 {3}
     │   ├── 📙:11:C
     │   ├── 📙:12:C2-1
@@ -5244,7 +5244,7 @@ fn remote_and_integrated_tracking_branch_on_merge() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
     └── ≡📙:3:A <> origin/A →:4:⇣1 on 1ee1e34 {1}
         └── 📙:3:A <> origin/A →:4:⇣1
             └── 🟣2181501
@@ -5275,7 +5275,7 @@ fn remote_and_integrated_tracking_branch_on_linear_segment() -> anyhow::Result<(
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 081bae9
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
     └── ≡📙:3:A <> origin/A →:4:⇣1 on 081bae9 {1}
         └── 📙:3:A <> origin/A →:4:⇣1
             └── 🟣197ddce
@@ -5311,7 +5311,7 @@ fn remote_and_integrated_tracking_branch_on_merge_extra_target() -> anyhow::Resu
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
     └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 1ee1e34 {1}
         └── 📙:3:A <> origin/A →:4:⇡1⇣1
             ├── 🟣2181501
@@ -5332,7 +5332,7 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·a26ae77 (⌂|🏘|1)
     │       └── ►:2[1]:main <> origin/main →:1:
     │           └── ·fafd9d0 (⌂|🏘|✓|11) ►unapplied
@@ -5341,13 +5341,13 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
     ");
 
     // if the branch was never seen, it's not visible as one would expect.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0");
 
     // An applied branch would be present, but has no commit.
     add_stack_with_segments(&mut meta, 1, "unapplied", StackState::InWorkspace, &[]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:unapplied on fafd9d0 {1}
         └── 📙:3:unapplied
     ");
@@ -5358,7 +5358,7 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
     // This will be an empty workspace.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0");
 
     Ok(())
 }
@@ -5375,7 +5375,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·a26ae77 (⌂|🏘|1)
     │       └── ►:2[1]:main <> origin/main →:1:
     │           └── ·fafd9d0 (⌂|🏘|11) ►unapplied
@@ -5385,7 +5385,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 
     // the main branch is disambiguated by its remote reference.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:2:main <> origin/main →:1:
         └── :2:main <> origin/main →:1:
             └── ❄️fafd9d0 (🏘️) ►unapplied
@@ -5397,7 +5397,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·a26ae77 (⌂|🏘|1)
     │       ├── 📙►:3[1]:unapplied
     │       │   └── ►:2[2]:anon:
@@ -5409,7 +5409,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:4:main <> origin/main →:1: on fafd9d0 {2}
     │   └── 📙:4:main <> origin/main →:1:
     └── ≡📙:3:unapplied on fafd9d0 {1}
@@ -5423,7 +5423,7 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 
     // Now only `main` shows up.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:main <> origin/main →:1: on fafd9d0 {2}
         └── 📙:3:main <> origin/main →:1:
     ");
@@ -5444,7 +5444,7 @@ fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0[0]:gitbutler/workspace
+    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         ├── 📙►:2[1]:main
         │   └── ►:1[2]:anon: →:3:
         │       ├── ·bce0c5e (⌂|🏘|1) ►B
@@ -5453,11 +5453,60 @@ fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
             └── →:1:
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on bce0c5e
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
     ├── ≡📙:3:A on bce0c5e {1}
     │   └── 📙:3:A
     └── ≡📙:2:main on bce0c5e {0}
         └── 📙:2:main
+    ");
+    Ok(())
+}
+
+#[test]
+fn ambiguous_worktrees() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/ambiguous-worktrees")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   a5f94a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 3e01e28 (B) B
+    |/  
+    | * 8dc508f (origin/main, main) M-advanced
+    |/  
+    | * 197ddce (origin/A) A-remote
+    |/  
+    * 081bae9 (A-outside, A-inside, A) M-base
+    * 3183e43 M1
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·a5f94a2 (⌂|🏘|1)
+    │       ├── ►:5[1]:B[📁wt-B-inside]
+    │       │   └── ·3e01e28 (⌂|🏘|1)
+    │       │       └── ►:3[2]:anon: →:6:
+    │       │           ├── ·081bae9 (⌂|🏘|✓|1111) ►A-inside[📁wt-A-inside], ►A-outside[📁wt-A-outside]
+    │       │           └── ·3183e43 (⌂|🏘|✓|1111)
+    │       └── 📙►:6[1]:A <> origin/A →:4:
+    │           └── →:3:
+    ├── ►:1[0]:origin/main →:2:
+    │   └── ►:2[1]:main <> origin/main →:1:
+    │       └── ·8dc508f (⌂|✓|10)
+    │           └── →:3:
+    └── ►:4[0]:origin/A →:6:
+        └── 🟣197ddce (0x0|1000)
+            └── →:3:
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+    ├── ≡📙:6:A <> origin/A →:4:⇣1 on 081bae9 {0}
+    │   └── 📙:6:A <> origin/A →:4:⇣1
+    │       └── 🟣197ddce
+    └── ≡:5:B[📁wt-B-inside] on 081bae9
+        └── :5:B[📁wt-B-inside]
+            └── ·3e01e28 (🏘️)
     ");
     Ok(())
 }
@@ -5481,7 +5530,7 @@ mod edit_commit {
         add_workspace(&mut meta);
         let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
         insta::assert_snapshot!(graph_tree(&graph), @r"
-        ├── 👉📕►►►:0[0]:gitbutler/workspace
+        ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
         │   └── ·3ea2742 (⌂|🏘|1)
         │       └── ►:3[1]:A
         │           └── ·a62b0de (⌂|🏘|1)
@@ -5495,7 +5544,7 @@ mod edit_commit {
 
         // special branch names are skipped by default and entirely invisible.
         insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
         └── ≡:3:A on fafd9d0
             └── :3:A
                 ├── ·a62b0de (🏘️)
@@ -5507,7 +5556,7 @@ mod edit_commit {
         let graph =
             Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
         insta::assert_snapshot!(graph_tree(&graph), @r"
-        ├── 📕►►►:1[0]:gitbutler/workspace
+        ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
         │   └── ·3ea2742 (⌂|🏘)
         │       └── ►:4[1]:A
         │           └── ·a62b0de (⌂|🏘)
@@ -5520,7 +5569,7 @@ mod edit_commit {
         ");
         // …then the segment becomes visible.
         insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-        📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+        📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
         └── ≡:4:A on fafd9d0
             ├── :4:A
             │   └── ·a62b0de (🏘️)

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -3,7 +3,7 @@
 use std::str::FromStr;
 
 use but_core::ref_metadata;
-use but_graph::{Commit, CommitFlags, Graph, Segment, SegmentIndex, SegmentMetadata};
+use but_graph::{Commit, CommitFlags, Graph, RefInfo, Segment, SegmentIndex, SegmentMetadata};
 use but_testsupport::graph_tree;
 use gix::ObjectId;
 
@@ -18,7 +18,10 @@ fn post_graph_traversal() -> anyhow::Result<()> {
     // these are in the segments above it.
     let local_target = Segment {
         id: 0.into(),
-        ref_name: Some("refs/heads/main".try_into()?),
+        ref_info: Some(RefInfo {
+            ref_name: "refs/heads/main".try_into()?,
+            worktree: None,
+        }),
         remote_tracking_ref_name: Some("refs/remotes/origin/main".try_into()?),
         metadata: Some(SegmentMetadata::Workspace(ref_metadata::Workspace {
             ref_info: Default::default(),
@@ -36,7 +39,10 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         // A newly created branch which appears at the workspace base.
         Segment {
             id: 1.into(),
-            ref_name: Some("refs/heads/new-stack".try_into()?),
+            ref_info: Some(RefInfo {
+                ref_name: "refs/heads/new-stack".try_into()?,
+                worktree: None,
+            }),
             ..Default::default()
         },
         0,
@@ -45,7 +51,10 @@ fn post_graph_traversal() -> anyhow::Result<()> {
 
     let remote_to_local_target = Segment {
         id: 2.into(),
-        ref_name: Some("refs/remotes/origin/main".try_into()?),
+        ref_info: Some(RefInfo {
+            ref_name: "refs/remotes/origin/main".try_into()?,
+            worktree: None,
+        }),
         commits: vec![commit(id("c"), Some(init_commit_id), CommitFlags::empty())],
         ..Default::default()
     };
@@ -54,7 +63,10 @@ fn post_graph_traversal() -> anyhow::Result<()> {
     let branch = Segment {
         id: 3.into(),
         generation: 2,
-        ref_name: Some("refs/heads/A".try_into()?),
+        ref_info: Some(RefInfo {
+            ref_name: "refs/heads/A".try_into()?,
+            worktree: None,
+        }),
         remote_tracking_ref_name: Some("refs/remotes/origin/A".try_into()?),
         sibling_segment_id: Some(SegmentIndex::from(1)),
         commits: vec![
@@ -67,7 +79,10 @@ fn post_graph_traversal() -> anyhow::Result<()> {
 
     let remote_to_root_branch = Segment {
         id: 4.into(),
-        ref_name: Some("refs/remotes/origin/A".try_into()?),
+        ref_info: Some(RefInfo {
+            ref_name: "refs/remotes/origin/A".try_into()?,
+            worktree: None,
+        }),
         commits: vec![
             commit(id("b"), Some(init_commit_id), CommitFlags::empty()),
             // Note that the initial commit was assigned to the base segment already,

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -79,7 +79,7 @@ pub fn graph_tree(graph: &Graph) -> StringTree {
 }
 
 fn no_first_commit_on_named_segments(mut ep: EntryPoint<'_>) -> EntryPoint<'_> {
-    if ep.segment.ref_name.is_some() && ep.commit_index == Some(0) {
+    if ep.segment.ref_info.is_some() && ep.commit_index == Some(0) {
         ep.commit_index = None;
     }
     ep
@@ -104,11 +104,11 @@ fn recurse_segment(
             "→:{sidx}:{name}",
             sidx = sidx.index(),
             name = graph[sidx]
-                .ref_name
+                .ref_info
                 .as_ref()
-                .map(|n| format!(
+                .map(|ri| format!(
                     " ({}{maybe_sibling})",
-                    Graph::ref_debug_string(n),
+                    Graph::ref_debug_string(ri.ref_name.as_ref(), ri.worktree.as_ref()),
                     maybe_sibling = segment
                         .sibling_segment_id
                         .map_or_else(String::new, |sid| format!(" →:{}:", sid.index()))
@@ -123,7 +123,7 @@ fn recurse_segment(
     let mut show_segment_entrypoint = segment_is_entrypoint;
     if segment_is_entrypoint {
         // Reduce noise by preferring ref-based entry-points.
-        if segment.ref_name.is_none() && ep.commit_index.is_some() {
+        if segment.ref_info.is_none() && ep.commit_index.is_some() {
             show_segment_entrypoint = false;
         }
     }
@@ -166,7 +166,7 @@ fn recurse_segment(
             ""
         },
         ref_name_and_remote = Graph::ref_and_remote_debug_string(
-            segment.ref_name.as_ref(),
+            segment.ref_info.as_ref(),
             segment.remote_tracking_ref_name.as_ref(),
             segment.sibling_segment_id
         ),

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -452,17 +452,15 @@ pub(super) mod function {
             .rev()
             .find_map(|seg_idx| {
                 let s = &stack.segments[seg_idx];
-                s.ref_name
-                    .as_ref()
-                    .map(|rn| (rn.as_ref(), Below))
+                s.ref_name()
+                    .map(|rn| (rn, Below))
                     .filter(|_| s.metadata.is_some())
             })
             .or_else(|| {
                 (anchor_seg_idx + 1..stack.segments.len()).find_map(|seg_idx| {
                     let s = &stack.segments[seg_idx];
-                    s.ref_name
-                        .as_ref()
-                        .map(|rn| (rn.as_ref(), Above))
+                    s.ref_name()
+                        .map(|rn| (rn, Above))
                         .filter(|_| s.metadata.is_some())
                 })
             })

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -453,7 +453,7 @@ impl Stack {
     pub fn ref_name(&self) -> Option<&gix::refs::FullName> {
         self.segments
             .first()
-            .and_then(|name| name.ref_name.as_ref())
+            .and_then(|name| name.ref_info.as_ref().map(|ri| &ri.ref_name))
     }
 }
 

--- a/crates/but-workspace/src/branch/remove_reference.rs
+++ b/crates/but-workspace/src/branch/remove_reference.rs
@@ -52,7 +52,7 @@ pub(crate) mod function {
                 && stack
                     .segments
                     .iter()
-                    .filter(|s| s.ref_name.is_some())
+                    .filter(|s| s.ref_info.is_some())
                     .count()
                     < 2)
         {
@@ -99,13 +99,13 @@ pub(crate) mod function {
                 && let Some(commit) = stack
                     .segments
                     .first()
-                    .and_then(|s| s.commits.first().filter(|_| s.ref_name.is_none()))
+                    .and_then(|s| s.commits.first().filter(|_| s.ref_info.is_none()))
             {
                 let (name_of_segment_below, target_id) = stack
                     .segments
                     .iter()
                     .find_map(|s| {
-                        let rn = s.ref_name.as_ref()?;
+                        let rn = s.ref_name()?;
                         workspace.graph.tip_skip_empty(s.id).map(|c| (rn, c.id))
                     })
                     .with_context(|| {
@@ -114,7 +114,7 @@ pub(crate) mod function {
                     })?;
 
                 repo.reference(
-                    name_of_segment_below.as_ref(),
+                    name_of_segment_below,
                     commit.id,
                     PreviousValue::MustExistAndMatch(gix::refs::Target::Object(target_id)),
                     "move segment reference up to avoid anonymous stack",

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -172,8 +172,8 @@ impl HunkHeader {
 #[derive(Debug, Clone)]
 pub struct RefInfo {
     /// The name of the ref that points to a workspace commit,
-    /// *or* the name of the first stack segment.
-    pub workspace_ref_name: Option<gix::refs::FullName>,
+    /// *or* the name of the first stack segment, along with worktree information.
+    pub workspace_ref_info: Option<but_graph::RefInfo>,
     /// The stacks visible in the current workspace.
     ///
     /// This is an empty array if the `HEAD` is unborn.

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -168,7 +168,7 @@ impl inner::RefInfo {
     /// The `repo` is used just to get ref-names, for convenience.
     pub fn for_ui(
         crate::RefInfo {
-            workspace_ref_name,
+            workspace_ref_info,
             stacks,
             target,
             extra_target: _,
@@ -186,7 +186,7 @@ impl inner::RefInfo {
             .map(|stack| Stack::for_ui(stack, &remote_names))
             .collect::<Result<_, _>>()?;
         Ok(inner::RefInfo {
-            workspace_ref: workspace_ref_name.map(Into::into),
+            workspace_ref: workspace_ref_info.map(|ri| ri.ref_name.into()),
             stacks,
             target: target
                 .map(|t| Target::for_ui(t, &remote_names))
@@ -286,7 +286,7 @@ pub struct Segment {
 impl Segment {
     fn for_ui(
         crate::ref_info::Segment {
-            ref_name,
+            ref_info,
             id: _,
             remote_tracking_ref_name,
             commits,
@@ -300,7 +300,7 @@ impl Segment {
         names: &gix::remote::Names,
     ) -> anyhow::Result<Self> {
         Ok(Segment {
-            ref_name: ref_name.map(Into::into),
+            ref_name: ref_info.map(|ri| ri.ref_name.into()),
             remote_tracking_ref_name: remote_tracking_ref_name
                 .map(|r| RemoteTrackingReference::for_ui(r, names))
                 .transpose()?,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -37,7 +37,7 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
     ");
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡:2:anon: on 3183e43
         └── :2:anon:
             ├── ·0d01196 (🏘️)
@@ -78,7 +78,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
 
     // We know a stack, but nothing is actually in the workspace.
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Put "B" into the workspace, even though it's the dependent branch of A.
     let out =
@@ -93,7 +93,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:B on e5d0542 {1}
         └── 📙:2:B
     ");
@@ -102,7 +102,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
     └── ≡📙:2:B on e5d0542 {1}
@@ -137,9 +137,9 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     let ws = graph.to_workspace()?;
     // note how the remote isn't interesting as we have no target configured, nor an extra target.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·3183e43
     ");
 
@@ -182,8 +182,8 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     ├── ≡📙:2:feature on 3183e43 {2ec}
     │   └── 📙:2:feature
     │       └── ·6b40b15 (🏘️)
-    └── ≡📙:3:main on 3183e43 {1a5}
-        └── 📙:3:main
+    └── ≡📙:3:main[🌳] on 3183e43 {1a5}
+        └── 📙:3:main[🌳]
     ");
 
     // the new local tracking ref actually exists, and is in the right spot.
@@ -231,7 +231,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:5:outside →:3: on 3183e43 {1}
     │   └── 📙:5:outside →:3:
     │       ├── ·5121eb9*
@@ -257,7 +257,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     "#);
 
     insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:feature on 3183e43 {2ec}
     │   └── 📙:4:feature
     │       └── ·d03b217 (🏘️)
@@ -281,7 +281,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
         )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Put "A" into the workspace, yielding a single branch.
     let out =
@@ -295,7 +295,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     "#);
     let graph = out.graph;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
     ");
@@ -314,7 +314,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     // Note how it will create a new stack (to keep it simple),
     // in theory we could also add B as dependent branch.
     insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {42}
     │   └── 📙:3:B
     └── ≡📙:2:A on e5d0542 {41}
@@ -356,9 +356,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·e5d0542 ►A, ►B
     ");
 
@@ -379,8 +379,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
-    └── ≡📙:2:main on e5d0542 {1a5}
-        └── 📙:2:main
+    └── ≡📙:2:main[🌳] on e5d0542 {1a5}
+        └── 📙:2:main[🌳]
     ");
 
     // No commit was created, as it's not enabled by default, but a ws-ref was created, and it's checked out.
@@ -407,7 +407,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:4:A on e5d0542 {41}
     │   └── 📙:4:A
     ├── ≡📙:3:B on e5d0542 {42}
@@ -429,7 +429,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon: {41}
         └── :1:anon:
             └── ·e5d0542 (🏘️) ►A, ►B, ►main
@@ -453,7 +453,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:2:A {41}
         └── 📙:2:A
             └── ·e5d0542 (🏘️) ►B, ►main
@@ -479,7 +479,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
     └── ≡📙:2:B on e5d0542 {42}
@@ -502,9 +502,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·e5d0542 ►A, ►B
     ");
 
@@ -542,7 +542,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     ├── ≡📙:4:B on e5d0542 {42}
     │   └── 📙:4:B
     └── ≡📙:3:A on e5d0542 {41}
@@ -577,7 +577,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
         )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     // The default workspace, it's empty as target is set to `main`.
-    insta::assert_snapshot!(graph_workspace(&ws_graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws_graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Pretend "B" is checked out (it's at the right state independently of that)
     let (b_id, b_ref) = id_at(&repo, "B");
@@ -605,7 +605,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     let ws = out.graph.to_workspace()?;
     // This apply brings both branches into the existing workspace, and it's where HEAD points to.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
     └── ≡📙:2:B on e5d0542 {42}
@@ -635,9 +635,9 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·3183e43
     ");
 
@@ -687,7 +687,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A1 on 3183e43 {72}
     │   └── 📙:4:A1
     │       └── ·7de99e1 (🏘️)
@@ -718,7 +718,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A2 on 3183e43 {73}
     │   ├── 📙:4:A2
     │   │   └── ·f1889e7 (🏘️)
@@ -854,7 +854,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:3:B on 3183e43 {42}
     │   └── 📙:3:B
     │       └── ·f57c528 (🏘️)
@@ -885,7 +885,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:B on 3183e43 {42}
     │   └── 📙:4:B
     │       └── ·f57c528 (🏘️)
@@ -928,9 +928,9 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·85efbe4
     ");
 
@@ -961,7 +961,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {43}
     │   └── 📙:5:C
     │       └── ·f084d61 (🏘️) ►A, ►B
@@ -988,7 +988,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:6:B on 7076dee {2}
     │   └── 📙:6:B
     │       └── ·f084d61 (🏘️) ►A, ►C
@@ -1006,7 +1006,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {2}
     │   ├── 📙:5:C
     │   └── 📙:6:B
@@ -1034,9 +1034,9 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
             └── ·85efbe4
     ");
 
@@ -1081,7 +1081,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     let graph = out.graph;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:B on 85efbe4 {41}
         ├── 📙:4:B
         └── 📙:5:A
@@ -1155,7 +1155,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:clean-C on 85efbe4 {273}
     │   └── 📙:6:clean-C
     │       └── ·34c4591 (🏘️)
@@ -1219,7 +1219,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     let ws = graph.to_workspace()?;
     // By default, it fails and just reports the conflicting stacks, so it's the same as it was before.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:clean-C on 85efbe4 {273}
     │   └── 📙:6:clean-C
     │       └── ·34c4591 (🏘️)
@@ -1278,7 +1278,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     let graph = out.graph.into_owned();
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓! on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:5:conflict-hero on 85efbe4 {52d}
     │   └── 📙:5:conflict-hero
     │       ├── ·4bbb93c (🏘️)
@@ -1420,7 +1420,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
     │   └── 📙:3:B
     └── ≡📙:2:A on e5d0542 {1}
@@ -1452,7 +1452,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡👉📙:3:B on e5d0542 {2}
     │   └── 👉📙:3:B
     └── ≡📙:2:A on e5d0542 {1}
@@ -1483,7 +1483,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     // Now the workspace ref itself is checked out.
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
     │   └── 📙:3:B
     └── ≡📙:2:A on e5d0542 {1}
@@ -1505,7 +1505,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     )?;
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡👉📙:2:B on e5d0542 {2}
         ├── 👉📙:2:B
         └── 📙:3:A
@@ -1530,7 +1530,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         standard_traversal_options_with_extra_target(&repo),
     )?;
     // There is nothing yet.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Apply the first branch, it must be independent.
     let ws = graph.to_workspace()?;
@@ -1545,7 +1545,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     "#);
     let graph = out.graph;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
     ");
@@ -1578,7 +1578,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
     │       └── ·c813d8d (🏘️)
@@ -1603,7 +1603,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
         but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡👉📙:0:B on 85efbe4 {2}
     │   └── 👉📙:0:B
     │       └── ·c813d8d (🏘️)
@@ -1645,7 +1645,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
 
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 85efbe4
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
     │       └── ·c813d8d (🏘️)
@@ -1665,7 +1665,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
         └── :1:anon:
             └── ·e5d0542 (🏘️) ►A, ►B, ►main
@@ -1706,9 +1706,9 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
     ");
 
     // Idempotency in ad-hoc workspace
@@ -1746,9 +1746,9 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
 
     let ws = out.graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
     ");
 
     // TODO: can we reproduce this original error?

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -53,17 +53,17 @@ mod with_workspace {
 
         // And even though setting an extra-target works like it should, i.e a simulated target
         // which we can store in absence of a selected target branch…
-        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43");
+        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
         // …we chose to work with an open-ended workspace just to struggle more.
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-            📕🏘️⚠️:0:gitbutler/workspace <> ✓!
-            └── ≡:1:main
-                └── :1:main
-                    └── ·3183e43 (🏘️)
-            ");
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
+        └── ≡:1:main
+            └── :1:main
+                └── ·3183e43 (🏘️)
+        ");
 
         let new_name = rc("refs/heads/A");
         let err = but_workspace::branch::create_reference(
@@ -95,7 +95,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.to_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43");
+        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43");
 
         let a_ref = r("refs/heads/A");
         let graph = but_workspace::branch::create_reference(
@@ -109,7 +109,7 @@ mod with_workspace {
         .expect("it updates the workspace metadata legitimate the new ref at base");
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {41}
             └── 📙:3:A
         ");
@@ -131,7 +131,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
         │   └── 📙:4:B
         └── ≡📙:3:A on 3183e43 {41}
@@ -149,7 +149,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
         │   └── 📙:4:B
         └── ≡📙:3:A on 3183e43 {41}
@@ -170,7 +170,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   └── 📙:5:B
         └── ≡📙:3:above-A on 3183e43 {41}
@@ -192,7 +192,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   ├── 📙:5:B
         │   └── 📙:6:below-B
@@ -208,7 +208,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   ├── 📙:5:B
         │   └── 📙:6:below-B
@@ -237,12 +237,12 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-            📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
-            └── ≡:3:A on bce0c5e
-                └── :3:A
-                    ├── ·43f9472 (🏘️)
-                    └── ·6fdab32 (🏘️)
-            ");
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+        └── ≡:3:A on bce0c5e
+            └── :3:A
+                ├── ·43f9472 (🏘️)
+                └── ·6fdab32 (🏘️)
+        ");
 
         let above_bottom_ref = r("refs/heads/above-bottom");
         let bottom_id = id_by_rev(&repo, ":/A1");
@@ -261,7 +261,7 @@ mod with_workspace {
         // It handles this special case, by creating the necessary workspace metadata
         // if for some reason (like manual building) it's not set.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:4:A on bce0c5e {4cf}
             ├── :4:A
             │   └── ·43f9472 (🏘️)
@@ -284,7 +284,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:4:A on bce0c5e {4cf}
             ├── :4:A
             │   └── ·43f9472 (🏘️)
@@ -312,7 +312,7 @@ mod with_workspace {
         // And as there are now two references on one commit, and one has metadata, the other one doesn't,
         // 'A' is moved to the background.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:3:above-A-commit on bce0c5e {4cf}
             ├── 📙:3:above-A-commit
             │   └── ·43f9472 (🏘️) ►A
@@ -338,7 +338,7 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
         // And 'A' is back, with the desired order correctly restored.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
             ├── 📙:6:A
@@ -365,7 +365,7 @@ mod with_workspace {
         // *Above a segment means what one would expect though.
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
             ├── 📙:6:above-A
@@ -391,7 +391,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
             ├── 📙:6:above-A
@@ -417,7 +417,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
             ├── 📙:6:above-A
@@ -442,7 +442,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:B on bce0c5e {42}
         │   └── 📙:5:B
         └── ≡📙:6:above-A-commit on bce0c5e {4cf}
@@ -472,7 +472,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
         │   └── 📙:6:B
@@ -505,7 +505,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
         │   ├── 📙:6:B
@@ -529,7 +529,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
         │   ├── 📙:6:B
@@ -572,7 +572,7 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
                 ├── ·c2878fb (🏘️)
@@ -594,7 +594,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:4:A on 3183e43 {0}
             ├── 📙:4:A
             │   └── ·c2878fb (🏘️)
@@ -619,7 +619,7 @@ mod with_workspace {
         // We can create branches that would be on the base.
         // There are
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:4:A on 3183e43 {0}
             ├── 📙:4:A
             │   └── ·c2878fb (🏘️)
@@ -645,7 +645,7 @@ mod with_workspace {
         // Note how 'Above' *a commit* means directly above, not on top of everything.
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:A on 3183e43 {0}
             ├── 📙:5:A
             ├── 📙:6:above-A-commit
@@ -672,7 +672,7 @@ mod with_workspace {
         // *Above a segment means what one would expect though.
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
             ├── 📙:6:A
@@ -700,7 +700,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
             ├── 📙:6:A
@@ -726,7 +726,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
             ├── 📙:6:A
@@ -752,7 +752,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
             ├── 📙:6:A
@@ -777,7 +777,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   └── 📙:5:B
         └── ≡📙:6:above-A on 3183e43 {0}
@@ -807,7 +807,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
         │   └── 📙:6:B
@@ -840,7 +840,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
         │   ├── 📙:6:B
@@ -864,7 +864,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
         │   ├── 📙:6:B
@@ -905,7 +905,7 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
                 ├── ·c2878fb (🏘️)
@@ -928,7 +928,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             ├── 📙:3:A
             │   ├── ·c2878fb (🏘️)
@@ -957,7 +957,7 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   └── 📙:4:B
         │       └── ·f57c528 (🏘️)
@@ -981,7 +981,7 @@ mod with_workspace {
         )?;
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   └── 📙:4:B
         │       └── ·f57c528 (🏘️)
@@ -1007,7 +1007,7 @@ mod with_workspace {
 
         let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   ├── 📙:4:B
         │   │   └── ·f57c528 (🏘️)
@@ -1034,7 +1034,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
         let ws = graph.to_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on bce0c5e");
+        insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e");
 
         let (ws_id, ws_ref_name) = id_at(&repo, "gitbutler/workspace");
         let main_remote_id = id_by_rev(&repo, "@~1");
@@ -1094,7 +1094,7 @@ mod with_workspace {
         let ws = graph.to_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
-        📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+        📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
                 ├── ·c2878fb (🏘️)
@@ -1221,9 +1221,9 @@ fn errors() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main <> ✓!
-    └── ≡:0:main
-        └── :0:main
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
     ");
 
     // Below first in history
@@ -1254,11 +1254,11 @@ fn errors() -> anyhow::Result<()> {
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            └── :0:main
-                └── ·c166d42
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
+            └── ·c166d42
+    ");
 
     let (id, ref_name) = id_at(&repo, "main");
     for anchor in [
@@ -1351,14 +1351,14 @@ fn errors() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_commit_traversal(a_id, a_ref, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:A <> ✓!
-        └── ≡:0:A
-            ├── :0:A
-            │   ├── ·89cc2d3
-            │   └── ·d79bba9
-            └── :1:main
-                └── ·c166d42
-        ");
+    ⌂:0:A <> ✓!
+    └── ≡:0:A
+        ├── :0:A
+        │   ├── ·89cc2d3
+        │   └── ·d79bba9
+        └── :1:main[🌳]
+            └── ·c166d42
+    ");
 
     // Create the same ref at a different location
     let a_ref = r("refs/heads/A");
@@ -1451,13 +1451,13 @@ fn journey_with_commits() -> anyhow::Result<()> {
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            └── :0:main
-                ├── ·281da94
-                ├── ·12995d7
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        └── :0:main[🌳]
+            ├── ·281da94
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
 
     let (main_id, main_ref) = id_at(&repo, "main");
     let new_name = r("refs/heads/below-main");
@@ -1473,14 +1473,14 @@ fn journey_with_commits() -> anyhow::Result<()> {
 
     // We always add metadata to new branches.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            ├── :0:main
-            │   └── ·281da94
-            └── 📙:1:below-main
-                ├── ·12995d7
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        ├── :0:main[🌳]
+        │   └── ·281da94
+        └── 📙:1:below-main
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
     let md = meta.branch(new_name)?;
     assert!(!md.is_default(), "It should have set the date at least");
     assert!(md.ref_info.updated_at.is_some());
@@ -1505,14 +1505,14 @@ fn journey_with_commits() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            ├── :0:main
-            │   └── ·281da94
-            └── 📙:1:below-main
-                ├── ·12995d7
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        ├── :0:main[🌳]
+        │   └── ·281da94
+        └── 📙:1:below-main
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
 
     // the last possible branch without a workspace.
     let graph = but_workspace::branch::create_reference(
@@ -1525,15 +1525,15 @@ fn journey_with_commits() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            ├── :0:main
-            │   └── ·281da94
-            ├── 📙:1:below-main
-            │   └── ·12995d7
-            └── 📙:2:two-below-main
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        ├── :0:main[🌳]
+        │   └── ·281da94
+        ├── 📙:1:below-main
+        │   └── ·12995d7
+        └── 📙:2:two-below-main
+            └── ·3d57fc1
+    ");
 
     // Now no new segment can be created anymore, each commit can only have one.
     // the last possible branch without a workspace.
@@ -1568,15 +1568,15 @@ fn journey_with_commits() -> anyhow::Result<()> {
             There should be no benefit doing that."
     );
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-        ⌂:0:main <> ✓!
-        └── ≡:0:main
-            ├── :0:main
-            │   └── ·281da94
-            ├── 📙:1:below-main
-            │   └── ·12995d7
-            └── 📙:2:two-below-main
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡:0:main[🌳]
+        ├── :0:main[🌳]
+        │   └── ·281da94
+        ├── 📙:1:below-main
+        │   └── ·12995d7
+        └── 📙:2:two-below-main
+            └── ·3d57fc1
+    ");
 
     // However, creating a dependent branch creates metadata as well.
     let graph = but_workspace::branch::create_reference(
@@ -1597,15 +1597,15 @@ fn journey_with_commits() -> anyhow::Result<()> {
             which is a way to make segments appear if there were not visible before due to ambiguity."
         );
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-        ⌂:0:main <> ✓!
-        └── ≡📙:0:main
-            ├── 📙:0:main
-            │   └── ·281da94
-            ├── 📙:1:below-main
-            │   └── ·12995d7
-            └── 📙:2:two-below-main
-                └── ·3d57fc1
-        ");
+    ⌂:0:main[🌳] <> ✓!
+    └── ≡📙:0:main[🌳]
+        ├── 📙:0:main[🌳]
+        │   └── ·281da94
+        ├── 📙:1:below-main
+        │   └── ·12995d7
+        └── 📙:2:two-below-main
+            └── ·3d57fc1
+    ");
 
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -25,7 +25,7 @@ fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, B, A) M1");
     let ws = graph.to_workspace()?;
     // the workspace is empty.
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
     for name in ["A", "B", "gitbutler/workspace", "main", "nonexisting"] {
         assert!(
@@ -60,7 +60,7 @@ fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
     // repo and workspace should still look like before.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, B, A) M1");
     let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
     Ok(())
 }
@@ -83,7 +83,7 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let mut ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡📙:3:A on 3183e43 {0}
         ├── 📙:3:A
         │   └── ·c2878fb (🏘️) ►A2
@@ -112,7 +112,7 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡:3:anon: on 3183e43
         └── :3:anon:
             ├── ·c2878fb (🏘️)
@@ -148,7 +148,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     ");
     let mut ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:5:A on bce0c5e {0}
         ├── 📙:5:A
         ├── 📙:6:A2-3
@@ -180,7 +180,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
         ws = graph.to_workspace()?;
     }
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:3:A1-1 on bce0c5e {0}
         ├── 📙:3:A1-1
         │   └── ·43f9472 (🏘️)
@@ -207,7 +207,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     }
     // Just one segment left.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:3:A1-3 on bce0c5e {0}
         └── 📙:3:A1-3
             ├── ·43f9472 (🏘️)
@@ -250,7 +250,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
     │   ├── 📙:5:D
     │   └── 📙:6:E
@@ -275,7 +275,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
     │   ├── 📙:4:D
     │   └── 📙:5:E
@@ -294,7 +294,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
     │   ├── 📙:5:D
     │   └── 📙:6:E
@@ -321,7 +321,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
 
     let mut ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
     │   ├── 📙:4:D
     │   └── 📙:5:E
@@ -369,7 +369,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, A) M1");
     let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
     // The workspace is completely empty.
-    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
     assert_eq!(
         meta.iter().count(),

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -13,10 +13,15 @@ fn unborn_untracked() -> anyhow::Result<()> {
     // in absence of a target ref.
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/main",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -25,7 +30,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
+                        ref_name: "►main[🌳]",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -106,7 +111,7 @@ fn detached() -> anyhow::Result<()> {
     // We do know that `main` is pointing at the local commit though, despite the unnamed segment owning it.
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
-        workspace_ref_name: None,
+        workspace_ref_info: None,
         stacks: [
             Stack {
                 id: None,
@@ -157,10 +162,15 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
     // The conflict is detected in the local commit.
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/main",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -169,7 +179,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
+                        ref_name: "►main[🌳]",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(💥8450331, "GitButler WIP Commit\n\n\n", local),
@@ -261,10 +271,15 @@ fn single_branch() -> anyhow::Result<()> {
     );
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/main",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -273,7 +288,7 @@ fn single_branch() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
+                        ref_name: "►main[🌳]",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(b5743a3, "10\n", local),
@@ -374,10 +389,15 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/main",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -386,7 +406,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
+                        ref_name: "►main[🌳]",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(b5743a3, "10\n", local, ►above-10),
@@ -399,7 +419,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(1),
-                        ref_name: "refs/heads/nine",
+                        ref_name: "►nine",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(344e320, "9\n", local),
@@ -414,7 +434,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(2),
-                        ref_name: "refs/heads/six",
+                        ref_name: "►six",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(c4f2a35, "6\n", local),
@@ -429,7 +449,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/three",
+                        ref_name: "►three",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(281da94, "3\n", local),
@@ -443,7 +463,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/one",
+                        ref_name: "►one",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(3d57fc1, "1\n", local),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -23,10 +23,15 @@ fn j01_unborn() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/main",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/main",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -35,7 +40,7 @@ fn j01_unborn() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(0),
-                            ref_name: "refs/heads/main",
+                            ref_name: "►main[🌳]",
                             remote_tracking_ref_name: "None",
                             commits: [],
                             commits_on_remote: [],
@@ -70,10 +75,15 @@ fn j02_first_commit() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/main",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/main",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -82,7 +92,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(0),
-                            ref_name: "refs/heads/main",
+                            ref_name: "►main[🌳]",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(fafd9d0, "init\n", local),
@@ -123,10 +133,15 @@ However, without an official workspace it still won't be acting as a target.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/main",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/main",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -135,7 +150,7 @@ However, without an official workspace it still won't be acting as a target.
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(0),
-                            ref_name: "refs/heads/main",
+                            ref_name: "►main[🌳]",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(fafd9d0, "init\n", local),
@@ -170,10 +185,15 @@ However, without an official workspace it still won't be acting as a target.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/main",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/main",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -182,7 +202,7 @@ However, without an official workspace it still won't be acting as a target.
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(0),
-                            ref_name: "refs/heads/main",
+                            ref_name: "►main[🌳]",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(fafd9d0, "init\n", integrated(fafd9d0)),
@@ -226,10 +246,15 @@ fn j04_create_workspace() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [],
             target: Some(
@@ -271,10 +296,15 @@ fn j05_empty_stack() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -287,7 +317,7 @@ fn j05_empty_stack() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "None",
                             commits: [],
                             commits_on_remote: [],
@@ -337,10 +367,15 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -351,7 +386,7 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(ba16348, "one\n", local),
@@ -391,10 +426,15 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -407,7 +447,7 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(ba16348, "one\n", local),
@@ -459,10 +499,15 @@ fn j07_push_commit() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -475,7 +520,7 @@ fn j07_push_commit() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(ba16348, "one\n", local/remote(identity)),
@@ -532,10 +577,15 @@ Create a new local commit right after the previous pushed one
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -548,7 +598,7 @@ Create a new local commit right after the previous pushed one
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(9f4d478, "two\n", local),
@@ -604,10 +654,15 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -620,7 +675,7 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(314cacb, "two\n", local/remote(9a2fcdf)),
@@ -683,10 +738,15 @@ The remote squash-merges S1 *and* changes the 'file' so it looks entirely differ
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -699,7 +759,7 @@ The remote squash-merges S1 *and* changes the 'file' so it looks entirely differ
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(314cacb, "two\n", integrated(d110262)),
@@ -772,10 +832,15 @@ The remote was re-used and merged once more with more changes.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -788,7 +853,7 @@ The remote was re-used and merged once more with more changes.
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(314cacb, "two\n", integrated(d110262)),
@@ -869,10 +934,15 @@ A new multi-segment stack is created without remote and squash merged locally.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -885,7 +955,7 @@ A new multi-segment stack is created without remote and squash merged locally.
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/S1",
+                            ref_name: "►S1",
                             remote_tracking_ref_name: "refs/remotes/origin/S1",
                             commits: [
                                 LocalCommit(314cacb, "two\n", integrated(d110262)),
@@ -910,7 +980,7 @@ A new multi-segment stack is created without remote and squash merged locally.
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(5),
-                            ref_name: "refs/heads/local",
+                            ref_name: "►local",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(1af5d57, "new local file\n", integrated(ca783a4)),
@@ -923,7 +993,7 @@ A new multi-segment stack is created without remote and squash merged locally.
                         },
                         ref_info::ui::Segment {
                             id: NodeIndex(6),
-                            ref_name: "refs/heads/local-bottom",
+                            ref_name: "►local-bottom",
                             remote_tracking_ref_name: "None",
                             commits: [
                                 LocalCommit(de02b20, "new local-bottom file\n", integrated(ca783a4)),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -31,10 +31,15 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -45,7 +50,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(f9c2b14, "A2\n", local),
@@ -102,10 +107,15 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -116,7 +126,7 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(f9c2b14, "A2\n", local),
@@ -175,10 +185,15 @@ fn remote_diverged() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -189,7 +204,7 @@ fn remote_diverged() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(a62b0de, "A2\n", local),
@@ -258,10 +273,15 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -272,7 +292,7 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(5),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(a62b0de, "A2\n", local),
@@ -327,10 +347,15 @@ fn remote_behind() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -341,7 +366,7 @@ fn remote_behind() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(a62b0de, "A2\n", local),
@@ -403,10 +428,15 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -417,7 +447,7 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(5),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(a62b0de, "A2\n", local),
@@ -473,10 +503,15 @@ fn remote_ahead() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -487,7 +522,7 @@ fn remote_ahead() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(120a217, "A1\n", local/remote(identity)),
@@ -546,10 +581,15 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -560,7 +600,7 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(4),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(120a217, "A1\n", integrated(120a217)),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -32,10 +32,15 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -46,7 +51,7 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(f9c2b14, "A2\n", integrated(36c87e5)),
@@ -110,10 +115,15 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -124,7 +134,7 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(5039218, "A2\n", local/remote(identity)),
@@ -185,10 +195,15 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -199,7 +214,7 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(e9c9d74, "A2\n", local/remote(ad92cce)),
@@ -263,10 +278,15 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
-            workspace_ref_name: Some(
-                FullName(
-                    "refs/heads/gitbutler/workspace",
-                ),
+            workspace_ref_info: Some(
+                RefInfo {
+                    ref_name: FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                    worktree: Some(
+                        Main,
+                    ),
+                },
             ),
             stacks: [
                 Stack {
@@ -277,7 +297,7 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
                     segments: [
                         ref_info::ui::Segment {
                             id: NodeIndex(3),
-                            ref_name: "refs/heads/A",
+                            ref_name: "►A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(f9c2b14, "A2\n", integrated(85063c1)),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -42,10 +42,15 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -58,7 +63,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -101,10 +106,15 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     // Information doesn't change just because the starting point is different.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -117,7 +127,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -164,10 +174,15 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     let info = ref_info(at, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -180,7 +195,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -240,10 +255,15 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -256,7 +276,7 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
                             LocalCommit(3ba6995, "change in B\n", local/remote(ec39463)),
@@ -269,7 +289,7 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(f504e38, "change after push\n", local),
@@ -331,10 +351,15 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -347,7 +372,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
                             LocalCommit(3ba6995, "change in B\n", local/remote(ec39463)),
@@ -360,7 +385,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(f504e38, "change after push\n", local),
@@ -373,7 +398,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/base-of-A",
+                        ref_name: "►base-of-A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(807f596, "change in A\n", local/remote(identity)),
@@ -433,10 +458,15 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -449,7 +479,7 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
                             LocalCommit(de11c03, "change in B\n", local/remote(identity)),
@@ -462,7 +492,7 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(0ee3a9e, "change in A\n", integrated(0ee3a9e)),
@@ -531,10 +561,15 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -547,7 +582,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
                             LocalCommit(de11c03, "change in B\n", local/remote(identity)),
@@ -592,10 +627,15 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -608,7 +648,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
                             LocalCommit(de11c03, "change in B\n", local/remote(identity)),
@@ -621,7 +661,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(0ee3a9e, "change in A\n", integrated(0ee3a9e)),
@@ -680,10 +720,15 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -694,7 +739,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B",
+                        ref_name: "►B",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(da597e8, "B\n", local),
@@ -707,7 +752,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(1818c17, "A\n", integrated(0b6b861)),
@@ -750,10 +795,15 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
     // branch up to the workspace base, which we should consider.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -764,7 +814,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/B",
+                        ref_name: "►B",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(da597e8, "B\n", local),
@@ -777,7 +827,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(1818c17, "A\n", integrated(0b6b861)),
@@ -838,10 +888,15 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
     let info = ref_info(repo.find_reference("A")?, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -854,7 +909,7 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d5d3a92, "unique local tip\n", local),
@@ -921,10 +976,15 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -937,7 +997,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -958,7 +1018,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane-2",
+                        ref_name: "►advanced-lane-2",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(93d7eac, "change 2\n", local),
@@ -981,7 +1041,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -1050,10 +1110,15 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
     let info = ref_info(repo.find_reference("lane")?, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1066,7 +1131,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -1079,7 +1144,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(7),
-                        ref_name: "refs/heads/lane-segment-01",
+                        ref_name: "►lane-segment-01",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1090,7 +1155,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(8),
-                        ref_name: "refs/heads/lane-segment-02",
+                        ref_name: "►lane-segment-02",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1111,7 +1176,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane-2",
+                        ref_name: "►lane-2",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1122,7 +1187,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/lane-2-segment-01",
+                        ref_name: "►lane-2-segment-01",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1133,7 +1198,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/lane-2-segment-02",
+                        ref_name: "►lane-2-segment-02",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1188,10 +1253,15 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
     let info = ref_info(repo.find_reference("lane")?, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1204,7 +1274,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane-2",
+                        ref_name: "►lane-2",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1215,7 +1285,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/lane-2-segment-01",
+                        ref_name: "►lane-2-segment-01",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1226,7 +1296,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/lane-2-segment-02",
+                        ref_name: "►lane-2-segment-02",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1247,7 +1317,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -1260,7 +1330,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(7),
-                        ref_name: "refs/heads/lane-segment-01",
+                        ref_name: "►lane-segment-01",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1271,7 +1341,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(8),
-                        ref_name: "refs/heads/lane-segment-02",
+                        ref_name: "►lane-segment-02",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1327,10 +1397,15 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1343,7 +1418,7 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -1366,7 +1441,7 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1421,10 +1496,15 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1435,7 +1515,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1498,10 +1578,15 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1514,7 +1599,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/dependant",
+                        ref_name: "►dependant",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1525,7 +1610,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1575,10 +1660,15 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1591,7 +1681,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
                         commits: [],
                         commits_on_remote: [],
@@ -1602,7 +1692,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/dependant",
+                        ref_name: "►dependant",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1663,10 +1753,15 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1679,7 +1774,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/on-top-of-dependant",
+                        ref_name: "►on-top-of-dependant",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1690,7 +1785,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/dependant",
+                        ref_name: "►dependant",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1701,7 +1796,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(7),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1749,10 +1844,15 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1765,7 +1865,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/dependant",
+                        ref_name: "►dependant",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1776,7 +1876,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/on-top-of-dependant",
+                        ref_name: "►on-top-of-dependant",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -1787,7 +1887,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(7),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1848,10 +1948,15 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1864,7 +1969,7 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/on-top-of-lane",
+                        ref_name: "►on-top-of-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/on-top-of-lane",
                         commits: [
                             LocalCommit(788ad06, "change on top\n", local/remote(identity)),
@@ -1877,7 +1982,7 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "refs/remotes/origin/lane",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),
@@ -1938,10 +2043,15 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -1954,7 +2064,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(aadad9d, "shared by name\n", local/remote(2b1808c)),
@@ -1968,7 +2078,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/integrated",
+                        ref_name: "►integrated",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(f15ca75, "other integrated\n", integrated(f15ca75)),
@@ -2025,10 +2135,15 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     // It's fine to have no managed commit, but we have to deal with it - see flag is_managed.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2041,7 +2156,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2064,7 +2179,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2101,10 +2216,15 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     let info = ref_info(repo.find_reference("advanced-lane")?, &meta, opts).unwrap();
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2117,7 +2237,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2140,7 +2260,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2200,10 +2320,15 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     let info = head_info(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2216,7 +2341,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2237,7 +2362,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2277,10 +2402,15 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     let info = ref_info(repo.find_reference("advanced-lane")?, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2293,7 +2423,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2314,7 +2444,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2353,10 +2483,15 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     let info = ref_info(repo.find_reference("lane")?, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2369,7 +2504,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2390,7 +2525,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2435,10 +2570,15 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     let info = head_info(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2451,7 +2591,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/advanced-lane",
+                        ref_name: "►advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(cbc6713, "change\n", local),
@@ -2474,7 +2614,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/lane",
+                        ref_name: "►lane",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -2526,10 +2666,15 @@ fn disjoint() -> anyhow::Result<()> {
     // We see the commit in the branch as there is no base to hide it.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/disjoint",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/disjoint",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2538,7 +2683,7 @@ fn disjoint() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/disjoint",
+                        ref_name: "►disjoint[🌳]",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(32791d2, "disjoint init\n", local),
@@ -2590,10 +2735,15 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     // Stack A isn't listed, so it has no stack id.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2606,7 +2756,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/C-on-A",
+                        ref_name: "►C-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
@@ -2619,7 +2769,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2642,7 +2792,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(4e5484a, "add new file in B-on-A\n", local),
@@ -2655,7 +2805,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2698,10 +2848,15 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     // A partial workspace is provided, but the entire workspace is known.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2714,7 +2869,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/C-on-A",
+                        ref_name: "►C-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
@@ -2727,7 +2882,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2750,7 +2905,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(4e5484a, "add new file in B-on-A\n", local),
@@ -2763,7 +2918,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2806,10 +2961,15 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     // It's like the stack is part of the workspace, the result is the same, with entrypoints changed.
     insta::assert_debug_snapshot!(b_info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2822,7 +2982,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/C-on-A",
+                        ref_name: "►C-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
@@ -2835,7 +2995,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2858,7 +3018,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(4e5484a, "add new file in B-on-A\n", local),
@@ -2871,7 +3031,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2915,10 +3075,15 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     // It's notable how there are two entrypoints, so the UI has to assure both are visible.
     insta::assert_debug_snapshot!(a_info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -2931,7 +3096,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
-                        ref_name: "refs/heads/C-on-A",
+                        ref_name: "►C-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
@@ -2944,7 +3109,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -2967,7 +3132,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(6),
-                        ref_name: "refs/heads/B-on-A",
+                        ref_name: "►B-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(4e5484a, "add new file in B-on-A\n", local),
@@ -2980,7 +3145,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                     },
                     👉ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/A",
+                        ref_name: "►A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -3036,10 +3201,15 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
     // not any other branch that happens to point at that commit.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -3052,7 +3222,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/unrelated",
+                        ref_name: "►unrelated",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -3090,10 +3260,15 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
     // It can be checked out with the same effect, the parent workspace is still known.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [
             Stack {
@@ -3106,7 +3281,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 segments: [
                     👉ref_info::ui::Segment {
                         id: NodeIndex(3),
-                        ref_name: "refs/heads/unrelated",
+                        ref_name: "►unrelated",
                         remote_tracking_ref_name: "None",
                         commits: [],
                         commits_on_remote: [],
@@ -3147,10 +3322,15 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
     // Now there should be no stack, it's an empty workspace.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+                worktree: Some(
+                    Main,
+                ),
+            },
         ),
         stacks: [],
         target: Some(
@@ -3180,10 +3360,13 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
     let info = ref_info(repo.find_reference("unrelated")?, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/unrelated",
-            ),
+        workspace_ref_info: Some(
+            RefInfo {
+                ref_name: FullName(
+                    "refs/heads/unrelated",
+                ),
+                worktree: None,
+            },
         ),
         stacks: [
             Stack {
@@ -3192,7 +3375,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
-                        ref_name: "refs/heads/unrelated",
+                        ref_name: "►unrelated",
                         remote_tracking_ref_name: "None",
                         commits: [
                             LocalCommit(c166d42, "init-integration\n", integrated(c166d42), ►main),

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -24,13 +24,7 @@ pub fn worktree_new(
 
     let (repo, _, graph) = ctx.graph_and_meta(repo, perm)?;
     let ws = graph.to_workspace()?;
-    let mut ws_segment_names = ws
-        .stacks
-        .into_iter()
-        .flat_map(|s| s.segments)
-        .filter_map(|s| s.ref_name);
-
-    if !ws_segment_names.any(|n| n.as_ref() == refname) {
+    if ws.find_segment_and_stack_by_refname(refname).is_none() {
         bail!("Branch not found in workspace");
     }
 

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -424,7 +424,7 @@ impl GitButlerStack {
                 .segments
                 .iter()
                 .map(|s| GitbutlerStackSegment {
-                    tip: s.ref_name.clone().unwrap_or_else(|| {
+                    tip: s.ref_info.clone().map(|ri| ri.ref_name).unwrap_or_else(|| {
                         gix::refs::FullName::try_from(
                             "refs/heads/unnamed-ref-and-we-fake-a-name-fix-me",
                         )


### PR DESCRIPTION
Make it possible to know which worktree is affected by changes to a named segment in the graph.

### Tasks

* [x] Graph collects worktree information per named segment
    - [x] workspace project inherits worktree data
    - [x] adjust tests
* [ ] Legacy data structures (like StackDetails) provide worktree information
* [ ] the CLI exposes worktrees in the status

- Related to #11073
- Related to #10677 
- Prerequisite for the worktree-checkout part of #10986
