### PR TITLE
Worktree information in but-status

### DIFF
--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -214,7 +214,6 @@ mkdir ws
 (cd ws
   git init ambiguous-worktrees
   (cd ambiguous-worktrees
-    set -x
     commit M1
     commit M-base
 

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -86,6 +86,7 @@ pub fn branch_details(
 
     Ok(ui::BranchDetails {
         name: branch_name.into(),
+        linked_worktree_id: None, /* not implemented in legacy mode */
         remote_tracking_branch: upstream
             .as_ref()
             .and_then(|upstream| upstream.get().name())
@@ -228,6 +229,7 @@ pub fn branch_details_v3(
 
     Ok(ui::BranchDetails {
         name: name.as_bstr().into(),
+        linked_worktree_id: None, /* probably not needed here */
         remote_tracking_branch: remote_tracking_branch.map(|b| b.name().as_bstr().to_owned()),
         description: meta.description.clone(),
         pr_number: meta.review.pull_request,

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -362,6 +362,10 @@ pub struct BranchDetails {
     /// The name of the branch.
     #[serde(with = "gitbutler_serde::bstring_lossy")]
     pub name: BString,
+    /// The id of the linked worktree that has the reference of `name` checked out.
+    /// Note that we don't list the main worktree here.
+    #[serde(with = "gitbutler_serde::bstring_opt_lossy")]
+    pub linked_worktree_id: Option<BString>,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
     #[serde(with = "gitbutler_serde::bstring_opt_lossy")]
     pub remote_tracking_branch: Option<BString>,

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -41,6 +41,7 @@ mod with_workspace {
             @r#"
         BranchDetails {
             name: "refs/heads/A",
+            linked_worktree_id: None,
             remote_tracking_branch: None,
             description: Some(
                 "A: description",
@@ -89,6 +90,7 @@ mod with_workspace {
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
             name: "refs/heads/A",
+            linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",
             ),
@@ -141,6 +143,7 @@ mod with_workspace {
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
             name: "refs/heads/A",
+            linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",
             ),
@@ -178,6 +181,7 @@ mod with_workspace {
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("origin/A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
             name: "refs/remotes/origin/A",
+            linked_worktree_id: None,
             remote_tracking_branch: None,
             description: None,
             pr_number: None,
@@ -220,6 +224,7 @@ mod with_workspace {
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
             name: "refs/heads/A",
+            linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",
             ),

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -82,6 +82,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -232,6 +233,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -348,6 +350,7 @@ fn single_branch() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -537,6 +540,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -557,6 +561,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "nine",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -579,6 +584,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "six",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -601,6 +607,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "three",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,
@@ -622,6 +629,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "one",
+                linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
                 pr_number: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
@@ -15,6 +15,7 @@ fn disjoint() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(actual, @r#"
     BranchDetails {
         name: "refs/heads/disjoint",
+        linked_worktree_id: None,
         remote_tracking_branch: None,
         description: None,
         pr_number: None,
@@ -40,6 +41,7 @@ fn disjoint() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(actual, @r#"
     BranchDetails {
         name: "refs/heads/main",
+        linked_worktree_id: None,
         remote_tracking_branch: None,
         description: None,
         pr_number: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -169,6 +169,7 @@ mod stacks {
             branch_details: [
                 BranchDetails {
                     name: "C-on-A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
                     pr_number: None,
@@ -191,6 +192,7 @@ mod stacks {
                 },
                 BranchDetails {
                     name: "A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",
                     ),
@@ -283,6 +285,7 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "dependant",
+                    linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
                     pr_number: None,
@@ -301,6 +304,7 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "advanced-lane",
+                    linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/advanced-lane",
                     ),
@@ -356,6 +360,7 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "B-on-A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
                     pr_number: None,
@@ -378,6 +383,7 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",
                     ),
@@ -413,6 +419,7 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "C-on-A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
                     pr_number: None,
@@ -435,6 +442,7 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "A",
+                    linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",
                     ),

--- a/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,0 +1,59 @@
+<svg width="740px" height="308px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>┊│     A-remote </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>┊│     A </tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>┊│     B </tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> M-advanced </tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,0 +1,53 @@
+<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> A-remote    </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A    </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B    </tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> M-advanced </tspan>
+</tspan>
+    <tspan x="10px" y="244px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/fixtures/scenario/two-worktrees.sh
+++ b/crates/but/tests/fixtures/scenario/two-worktrees.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside, each with their own commit.
+git init
+commit M1
+commit M-base
+
+git checkout -b A
+  commit A
+
+git checkout -b soon-origin-A main
+  commit A-remote
+
+git checkout -b B main
+  commit B
+
+git checkout main
+  commit M-advanced
+  setup_target_to_match_main
+
+git checkout A
+create_workspace_commit_once A B
+setup_remote_tracking soon-origin-A A "move"
+
+git worktree add .git/gitbutler/worktrees/A A
+git worktree add .git/gitbutler/worktrees/B B
+


### PR DESCRIPTION

### Tasks

* [x] Legacy data structures (like StackDetails) provide worktree information
* [x] the CLI exposes worktrees in the status

- Related to #11073
- Related to #10677 
- Prerequisite for the worktree-checkout part of #10986
