### PR TITLE
chore: bump design-core and simplify button CSS

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
 	},
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
-		"@gitbutler/design-core": "^1.2.6",
+		"@gitbutler/design-core": "^1.3.2",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@gitbutler/design-core": "^1.2.6",
+		"@gitbutler/design-core": "^1.3.2",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "^1.2.6",
+		"@gitbutler/design-core": "^1.3.2",
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.56.1",

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -299,7 +299,6 @@
 		/* Theme Variables - All themes use the same pattern */
 		:where(&.neutral) {
 			--theme-outline-text: var(--clr-btn-ntrl-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-ntrl-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-ntrl-outline-bg);
 			--theme-outline-border: var(--clr-btn-ntrl-outline);
 			--theme-solid-text: var(--clr-theme-ntrl-on-element);
@@ -309,7 +308,6 @@
 
 		:where(&.pop) {
 			--theme-outline-text: var(--clr-btn-pop-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-pop-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-pop-outline-bg);
 			--theme-outline-border: var(--clr-btn-pop-outline);
 			--theme-solid-text: var(--clr-theme-pop-on-element);
@@ -319,7 +317,6 @@
 
 		:where(&.success) {
 			--theme-outline-text: var(--clr-btn-succ-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-succ-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-succ-outline-bg);
 			--theme-outline-border: var(--clr-btn-succ-outline);
 			--theme-solid-text: var(--clr-theme-succ-on-element);
@@ -329,7 +326,6 @@
 
 		:where(&.error) {
 			--theme-outline-text: var(--clr-btn-err-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-err-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-err-outline-bg);
 			--theme-outline-border: var(--clr-btn-err-outline);
 			--theme-solid-text: var(--clr-theme-err-on-element);
@@ -339,7 +335,6 @@
 
 		:where(&.warning) {
 			--theme-outline-text: var(--clr-btn-warn-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-warn-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-warn-outline-bg);
 			--theme-outline-border: var(--clr-btn-warn-outline);
 			--theme-solid-text: var(--clr-theme-warn-on-element);
@@ -349,7 +344,6 @@
 
 		:where(&.purple) {
 			--theme-outline-text: var(--clr-btn-purp-outline-text);
-			--theme-outline-text-hover: var(--clr-btn-purp-outline-text-hover);
 			--theme-outline-bg: var(--clr-btn-purp-outline-bg);
 			--theme-outline-border: var(--clr-btn-purp-outline);
 			--theme-solid-text: var(--clr-theme-purp-on-element);
@@ -364,12 +358,7 @@
 			--btn-bg: var(--theme-outline-bg);
 		}
 
-		:where(&.outline:not(:disabled):hover),
-		:where(&.ghost:not(:disabled):hover),
-		:where(&.outline.activated),
-		:where(&.ghost.activated) {
-			--label-clr: var(--theme-outline-text-hover);
-		}
+		/* Hover and activated states maintain the same text color as default state */
 
 		:where(&.outline) {
 			--btn-border-clr: var(--theme-outline-border);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: ^1.2.6
-        version: 1.2.6
+        specifier: ^1.3.2
+        version: 1.3.2
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -389,8 +389,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: ^1.2.6
-        version: 1.2.6
+        specifier: ^1.3.2
+        version: 1.3.2
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -786,8 +786,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: ^1.2.6
-        version: 1.2.6
+        specifier: ^1.3.2
+        version: 1.3.2
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1661,8 +1661,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.2.6':
-    resolution: {integrity: sha512-SSI0QX1wOpvg4FvoAhETCB8KOdBKZI7jPngXdCtLfzcJNCJ6QypPhFjs64z4dJfnIre7DYpTqqB1PLOetkGDKQ==}
+  '@gitbutler/design-core@1.3.2':
+    resolution: {integrity: sha512-8LS6kZP/YHlvoTahS+/hKhfy2wE/CfbooOnGP89BW1Xa8EzlehJVDvb4AT8QYiDaQfqy1TayV7gYKsQ/ZHQj3A==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8962,7 +8962,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.2.6': {}
+  '@gitbutler/design-core@1.3.2': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -11114,6 +11114,27 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@3.2.4(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.56.1)(vite@6.4.1(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.18.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(vite@6.4.1(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@14.12.3)(jsdom@26.1.0)(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.56.1
+      webdriverio: 9.18.4
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.2
@@ -11158,6 +11179,16 @@ snapshots:
       msw: 2.7.0(@types/node@24.3.0)(typescript@5.9.2)
       vite: 6.3.5(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1)
 
+  '@vitest/mocker@3.2.4(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(vite@6.4.1(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.0(@types/node@24.3.0)(typescript@5.9.2)
+      vite: 6.4.1(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1)
+    optional: true
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -11197,7 +11228,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@14.12.3)(jsdom@26.1.0)(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@14.12.3)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.17.0)(typescript@5.9.2))(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -16533,7 +16564,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.56.1)(vite@6.3.5(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.18.4)
+      '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.56.1)(vite@6.4.1(@types/node@24.3.0)(sass-embedded@1.82.0)(tsx@4.19.3)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.18.4)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 14.12.3
       jsdom: 26.1.0


### PR DESCRIPTION
Update dependency versions 1.3.1,
remove redundant hover variables, and keep
outline text color consistent on hover.