### PR TITLE
Emit new commit system message in codegen chat after stop hook

### DIFF
--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -25,6 +25,7 @@
 		children: Snippet<[A, Env<B, C>]>;
 		loading?: Snippet<[A | undefined]>;
 		error?: Snippet<[unknown]>;
+		empty?: Snippet<[]>;
 		onerror?: (err: unknown) => void;
 	} & StackEnv<B> &
 		ProjectEnv<C>;
@@ -99,6 +100,10 @@
 	{@render props.children(display.result.data, display.env)}
 {:else if display.result?.status === 'pending' || display.result?.status === 'uninitialized'}
 	{@render loadingComponent(display.result.data, display.result.status)}
+{:else if display.result?.status === 'fulfilled'}
+	{@render props.empty?.()}
+{:else}
+	what
 {/if}
 
 <style>

--- a/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CodegenAssistantMessage from '$components/codegen/CodegenAssistantMessage.svelte';
 	import CodegenServiceMessage from '$components/codegen/CodegenServiceMessage.svelte';
+	import CodegenSystemMessage from '$components/codegen/CodegenSystemMessage.svelte';
 	import CodegenToolCall from '$components/codegen/CodegenToolCall.svelte';
 	import CodegenToolCalls from '$components/codegen/CodegenToolCalls.svelte';
 	import CodegenUserMessage from '$components/codegen/CodegenUserMessage.svelte';
@@ -19,12 +20,12 @@
 	let expanded = $state(false);
 </script>
 
-{#if message.type === 'user'}
+{#if message.source === 'user'}
 	<div class="timestamp text-12 text-bold text-right">
 		<Timestamp date={message.createdAt} />
 	</div>
 	<CodegenUserMessage content={message.message} attachments={message.attachments} />
-{:else if message.type === 'claude'}
+{:else if message.source === 'claude'}
 	<div class="timestamp text-12 text-bold">
 		<Timestamp date={message.createdAt} />
 	</div>
@@ -56,6 +57,11 @@
 			{/each}
 		{/if}
 	{/if}
+{:else if message.source === 'system'}
+	<div class="timestamp text-12 text-bold">
+		<Timestamp date={message.createdAt} />
+	</div>
+	<CodegenSystemMessage {projectId} {message} />
 {/if}
 
 {#snippet compactionSummary(summary: string)}

--- a/apps/desktop/src/components/codegen/CodegenSystemMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenSystemMessage.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import CommitDetails from '$components/CommitDetails.svelte';
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
+	import { inject } from '@gitbutler/core/context';
+	import type { SystemMessage } from '$lib/codegen/types';
+
+	interface Props {
+		projectId: string;
+		message: SystemMessage;
+	}
+
+	let { projectId, message }: Props = $props();
+
+	const stackService = inject(STACK_SERVICE);
+</script>
+
+{#if message.type === 'commitCreated'}
+	<div class="system-message text-13">
+		<p>New commit{message.commitIds.length > 1 ? 's' : ''} created!</p>
+		{#each message.commitIds as commitId}
+			{@const { stackId } = message}
+			{@const commit = stackService.commitById(projectId, stackId, commitId)}
+			<ReduxResult {projectId} {stackId} result={commit.result}>
+				{#snippet children(commit)}
+					<div class="commit-bubble">
+						<CommitDetails {commit} />
+					</div>
+				{/snippet}
+				{#snippet empty()}
+					Commit {commitId.slice(0, 7)} not found
+				{/snippet}
+			</ReduxResult>
+		{/each}
+	</div>
+{/if}
+
+<style lang="postcss">
+	.system-message {
+		display: flex;
+		flex-direction: column;
+		padding: 12px 0;
+		gap: 12px;
+	}
+
+	.commit-bubble {
+		overflow: hidden;
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-2);
+	}
+</style>

--- a/apps/desktop/src/lib/codegen/claude.ts
+++ b/apps/desktop/src/lib/codegen/claude.ts
@@ -184,9 +184,14 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					const unsubscribe = listen<ClaudeMessage>(
 						`project://${arg.projectId}/claude/${arg.stackId}/message_recieved`,
 						async (event) => {
-							const message = event.payload;
+							const { payload } = event.payload;
+							if (payload.source === 'system' && payload.type === 'commitCreated') {
+								lifecycleApi.dispatch(
+									api.util.invalidateTags([invalidatesItem(ReduxTag.StackDetails, arg.stackId)])
+								);
+							}
 							lifecycleApi.updateCachedData((events) => {
-								events.push(message);
+								events.push(event.payload);
 							});
 
 							api.util.invalidateTags([invalidatesList(ReduxTag.ClaudeStackActive)]);

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -155,6 +155,12 @@ export type SystemMessage =
 	| {
 			type: 'compactFinished';
 			summary: string;
+	  }
+	| {
+			type: 'commitCreated';
+			stackId: string;
+			branchName: string;
+			commitIds: string[];
 	  };
 
 /**

--- a/apps/desktop/src/lib/soup/codegenAnalytics.ts
+++ b/apps/desktop/src/lib/soup/codegenAnalytics.ts
@@ -72,7 +72,7 @@ export class CodegenAnalytics {
 	}
 
 	private countUserMessages(formattedMessages: Message[]): number {
-		return formattedMessages.filter((message) => message.type === 'user').length;
+		return formattedMessages.filter((message) => message.source === 'user').length;
 	}
 }
 

--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -18,7 +18,7 @@ pub async fn rename_branch(
     client: &Client<OpenAIConfig>,
     parameters: RenameBranchParams,
     trigger_id: uuid::Uuid,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<String> {
     let RenameBranchParams {
         commit_id,
         commit_message,
@@ -59,7 +59,7 @@ pub async fn rename_branch(
         workflow::Kind::RenameBranch(workflow::RenameBranchOutcome {
             stack_id,
             old_branch_name: current_branch_name,
-            new_branch_name: normalized_branch_name,
+            new_branch_name: normalized_branch_name.clone(),
         }),
         workflow::Trigger::Snapshot(trigger_id),
         status,
@@ -70,5 +70,5 @@ pub async fn rename_branch(
     .persist(ctx)
     .ok();
 
-    Ok(())
+    Ok(normalized_branch_name)
 }

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -147,6 +147,18 @@ pub struct UserInput {
     pub attachments: Option<Vec<PromptAttachment>>,
 }
 
+/// Details about commits created by Claude.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitCreatedDetails {
+    #[serde(default)]
+    pub stack_id: Option<String>,
+    #[serde(default)]
+    pub branch_name: Option<String>,
+    #[serde(default)]
+    pub commit_ids: Option<Vec<String>>,
+}
+
 /// System messages from GitButler about the Claude session state.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", tag = "type")]
@@ -167,6 +179,8 @@ pub enum SystemMessage {
     CompactFinished {
         summary: String,
     },
+    /// Commits were created by Claude.
+    CommitCreated(CommitCreatedDetails),
 }
 
 /// Details about a Claude session, extracted from the Claude transcript.

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -425,6 +425,7 @@
 		visibleRowElements = viewport.getElementsByClassName('list-row');
 		itemObserver = new ResizeObserver((entries) =>
 			untrack(() => {
+				let shouldRecalculate = false;
 				for (const entry of entries) {
 					const { target } = entry;
 					if (!target.isConnected) continue;
@@ -452,7 +453,7 @@
 						}
 					}
 					if (index !== undefined) {
-						recalculateVisibleRange();
+						shouldRecalculate = true;
 					}
 				}
 
@@ -462,6 +463,9 @@
 					if (hasGrown) {
 						scrollToBottom();
 					}
+				}
+				if (shouldRecalculate) {
+					recalculateVisibleRange();
 				}
 			})
 		);


### PR DESCRIPTION
This is an experiment with adding a commit confirmation to codegen. It could be as simple as a message saying something has been committed, or as this poc shows, using the existing `CommitDetails` component inline in the chat.

<img width="899" height="561" alt="image" src="https://github.com/user-attachments/assets/82c73b64-a2cc-419a-a5df-b8c124c43483" />

