### PR TITLE
Filter for system messages when broadcasting after claude stop hook

### DIFF
--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -284,14 +284,14 @@ impl Claudes {
         )
         .await?;
 
-        // Broadcast any messages created during this Claude session
-        // (e.g., commit notifications from the Stop hook)
+        // Broadcast system any messages created during this Claude session
+        // (e.g., commit created notification from the Stop hook)
         {
             let mut ctx_guard = ctx.lock().await;
             if let Ok(all_messages) = db::list_messages_by_session(&mut ctx_guard, session_id) {
-                // Find messages created after session started
                 let new_messages: Vec<_> = all_messages
                     .into_iter()
+                    .filter(|msg| matches!(msg.payload, MessagePayload::System(_)))
                     .filter(|msg| msg.created_at > session_start_time)
                     .collect();
 


### PR DESCRIPTION
New claude messages are recorded into the db during execution, by the
app itself. The but binary on the other hand handles the stop hook, in
which we currently write a system message.

To prevent duplication messages we look only for system messages here, 
but in the future we likely want a better way to filter here.