### PR TITLE
Use C++ parser for CC files (#11140)

### DIFF
--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -272,10 +272,12 @@ export function parserFromExtension(extension: string): Parser | undefined {
 
 		case 'c':
 		case 'h':
+		case 'cc':
 		case 'cpp':
 		case 'c++':
 		case 'hpp':
 		case 'h++':
+		case 'hxx':
 			return cpp().language.parser;
 
 		case 'ex':


### PR DESCRIPTION
The .cc file extension is traditionally used for C++ source code files. Therefore, .cc files should be parsed by a C++ parser, not a C parser.

Fixes #11140 
