### PR TITLE
Single-branch support for `but status`

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -112,6 +112,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - run: cargo fmt --check --all
       - run: cargo check --workspace --all-targets
+      - run: |
+          # should work without any features
+          cargo check -p but-project
+        name: Special `cargo check` runs
       - name: cargo clippy
         run: |
           rustup component add clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
+ "but-project",
  "but-rules",
  "but-secret",
  "but-settings",
@@ -959,10 +960,12 @@ dependencies = [
  "bstr",
  "but-testsupport",
  "chardetng",
+ "fslock",
  "gitbutler-error",
  "gitbutler-serde",
  "gix",
  "insta",
+ "parking_lot",
  "serde",
  "serde_json",
  "toml 0.9.8",
@@ -1141,6 +1144,19 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
+]
+
+[[package]]
+name = "but-project"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "but-core",
+ "but-graph",
+ "but-settings",
+ "gitbutler-command-context",
+ "gitbutler-project",
+ "gix",
 ]
 
 [[package]]
@@ -3673,7 +3689,6 @@ dependencies = [
  "anyhow",
  "but-core",
  "but-path",
- "fslock",
  "git2",
  "gitbutler-error",
  "gitbutler-forge",
@@ -3683,7 +3698,6 @@ dependencies = [
  "gitbutler-testsupport",
  "gix",
  "insta",
- "parking_lot",
  "resolve-path",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ but = { path = "crates/but" }
 but-testsupport = { path = "crates/but-testsupport" }
 but-rebase = { path = "crates/but-rebase" }
 but-core = { path = "crates/but-core" }
+but-project = { path = "crates/but-project" }
 but-workspace = { path = "crates/but-workspace" }
 but-hunk-assignment = { path = "crates/but-hunk-assignment" }
 but-hunk-dependency = { path = "crates/but-hunk-dependency" }

--- a/crates/but-action/src/generate.rs
+++ b/crates/but-action/src/generate.rs
@@ -46,7 +46,22 @@ pub async fn commit_message(
     let system_message =
         "You are a version control assistant that helps with Git branch committing.".to_string();
     let user_message = format!(
-        "Extract the git commit data from the prompt, summary and diff output. Return the commit message. Determine from this AI prompt, summary and diff output what the git commit data should be.\n\n{DEFAULT_COMMIT_MESSAGE_INSTRUCTIONS}\n\nHere is the data:\n\nPrompt: {external_prompt}\n\nSummary: {external_summary}\n\nDiff:\n```\n{diff}\n```\n\n"
+        r#"Extract the git commit data from the prompt, summary and diff output.
+Return the commit message. Determine from this AI prompt, summary and diff output what the git commit data should be.
+
+{DEFAULT_COMMIT_MESSAGE_INSTRUCTIONS}
+
+Here is the data:
+
+Prompt: {external_prompt}
+
+Summary: {external_summary}
+
+unified diff:
+```patch
+{diff}
+```
+"#
     );
 
     let schema = schema_for!(StructuredOutput);

--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -33,7 +33,9 @@ pub async fn rename_branch(
         .flat_map(|s| s.heads.iter().map(|h| h.name.clone().to_string()))
         .collect::<Vec<_>>();
     let changes = but_core::diff::ui::commit_changes_by_worktree_dir(repo, commit_id)?;
-    let diff = changes.try_as_unidiff_string(repo, ctx.app_settings().context_lines)?;
+    let diff = changes
+        .try_to_unidiff(repo, ctx.app_settings().context_lines)?
+        .to_string();
     let diffs = vec![diff];
 
     let commit_messages = vec![commit_message];

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -30,7 +30,9 @@ pub async fn commit(
     )?;
     let repo = &ctx.gix_repo_for_merging_non_persisting()?;
     let changes = but_core::diff::ui::commit_changes_by_worktree_dir(repo, event.commit_id)?;
-    let diff = changes.try_as_unidiff_string(repo, ctx.app_settings().context_lines)?;
+    let diff = changes
+        .try_to_unidiff(repo, ctx.app_settings().context_lines)?
+        .to_string();
     let message = crate::generate::commit_message(
         client,
         &event.external_summary,

--- a/crates/but-api/src/commands/diff.rs
+++ b/crates/but-api/src/commands/diff.rs
@@ -28,12 +28,12 @@ use crate::{error::Error, hex_hash::HexHash};
 pub fn tree_change_diffs(
     project_id: ProjectId,
     change: TreeChange,
-) -> anyhow::Result<Option<but_core::UnifiedDiff>, Error> {
+) -> anyhow::Result<Option<but_core::UnifiedPatch>, Error> {
     let change: but_core::TreeChange = change.into();
     let project = gitbutler_project::get(project_id)?;
     let app_settings = AppSettings::load_from_default_path_creating()?;
     let repo = project.open()?;
-    Ok(change.unified_diff(&repo, app_settings.context_lines)?)
+    Ok(change.unified_patch(&repo, app_settings.context_lines)?)
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -31,6 +31,10 @@ uuid.workspace = true
 toml.workspace = true
 chardetng = "0.1.17"
 
+# for locking
+fslock = "0.2.1"
+parking_lot = { workspace = true, features = ["arc_lock"] }
+
 [dev-dependencies]
 but-testsupport.workspace = true
 gix = { workspace = true, features = ["revision"] }

--- a/crates/but-core/src/diff/tree_changes.rs
+++ b/crates/but-core/src/diff/tree_changes.rs
@@ -26,7 +26,7 @@ fn id_to_tree(repo: &gix::Repository, id: gix::ObjectId) -> anyhow::Result<gix::
 /// They are sorted by their current path.
 ///
 /// Additionally, line-stats aggregated for all changes will be computed, which incurs a considerable fraction of the cost
-/// of asking for [UnifiedDiffs](TreeChange::unified_diff()).
+/// of asking for [UnifiedDiffs](TreeChange::unified_patch()).
 pub fn tree_changes(
     repo: &gix::Repository,
     lhs: Option<gix::ObjectId>,

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -86,6 +86,9 @@ pub use repo_ext::RepositoryExt;
 pub mod ref_metadata;
 use crate::ref_metadata::ValueInfo;
 
+/// Utilities to sync project access.
+pub mod sync;
+
 /// A utility to extra the name of the remote from a remote tracking ref with `ref_name`.
 /// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,
 /// `None` is returned.

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -190,7 +190,7 @@ pub struct Commit<'repo> {
 /// or how it previously looked like in case of a deletion.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", content = "subject")]
-pub enum UnifiedDiff {
+pub enum UnifiedPatch {
     /// The resource was a binary and couldn't be diffed.
     Binary,
     /// The file was too large and couldn't be diffed.

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, bail};
+use parking_lot::{ArcRwLockReadGuard, ArcRwLockWriteGuard, RawRwLock};
+use std::path::Path;
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+
+/// Try to obtain the exclusive inter-process lock on the entire project that stores its application data in `project_data`,
+/// preventing other GitButler instances to operate on it entirely.
+/// This lock should be obtained and held for as long as a user interface is observing the project.
+///
+/// Note that the lock is automatically released on `Drop`, or when the process quits for any reason,
+/// so it can't go stale.
+pub fn try_exclusive_inter_process_access(
+    project_data: impl AsRef<Path>,
+) -> anyhow::Result<LockFile> {
+    let project_data = project_data.as_ref();
+    let mut lock = LockFile::open(project_data.join("project.lock").as_os_str())?;
+    let got_lock = lock
+        .try_lock()
+        .context("Failed to check if lock is taken")?;
+    if !got_lock {
+        bail!(
+            "Project at '{}' is already opened for writing",
+            project_data.display()
+        );
+    }
+    Ok(lock)
+}
+
+/// Return a guard for exclusive (read+write) worktree access for the project at `git_dir`,
+/// blocking while waiting for someone else, in the same process only, to release it, or for all readers to disappear.
+/// Locking is fair.
+///
+/// Note that this **in-process** locking works only under the assumption that no two instances of
+/// GitButler are able to read or write the same repository.
+pub fn exclusive_worktree_access(git_dir: impl Into<PathBuf>) -> WorkspaceWriteGuard {
+    let mut map = WORKTREE_LOCKS.lock();
+    let git_dir = git_dir.into();
+    WorkspaceWriteGuard {
+        inner: map.entry(git_dir).or_default().write_arc().into(),
+        perm: WorktreeWritePermission(()),
+    }
+}
+
+/// Return a guard for shared (read) worktree access for the project at `git_dir`,
+/// and block while waiting for writers to disappear.
+/// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
+/// thus block readers to prevent writer starvation.
+pub fn shared_worktree_access(git_dir: impl Into<PathBuf>) -> WorkspaceReadGuard {
+    let mut map = WORKTREE_LOCKS.lock();
+    let git_dir = git_dir.into();
+    WorkspaceReadGuard(Some(map.entry(git_dir).or_default().read_arc()))
+}
+
+/// A utility that drops an exclusive lock on drop.
+pub struct WorkspaceWriteGuard {
+    inner: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
+    perm: WorktreeWritePermission,
+}
+
+impl Drop for WorkspaceWriteGuard {
+    fn drop(&mut self) {
+        let lock = self
+            .inner
+            .take()
+            .expect("it's always set, and only taken once when dropping");
+        ArcRwLockWriteGuard::unlock_fair(lock);
+    }
+}
+
+impl Drop for WorkspaceReadGuard {
+    fn drop(&mut self) {
+        let lock = self
+            .0
+            .take()
+            .expect("it's always set, and only taken once when dropping");
+        ArcRwLockReadGuard::unlock_fair(lock)
+    }
+}
+
+impl WorkspaceWriteGuard {
+    /// Signal that a write-permission is available - useful as API-marker to assure these
+    /// can only be called when the respective protection/permission is present.
+    pub fn write_permission(&mut self) -> &mut WorktreeWritePermission {
+        &mut self.perm
+    }
+
+    /// Signal that a read-permission is available - useful as API-marker to assure these
+    /// can only be called when the respective protection/permission is present.
+    pub fn read_permission(&self) -> &WorktreeReadPermission {
+        self.perm.read_permission()
+    }
+}
+
+/// A utility that drops a shared lock on drop.
+pub struct WorkspaceReadGuard(Option<parking_lot::ArcRwLockReadGuard<RawRwLock, ()>>);
+
+impl WorkspaceReadGuard {
+    /// Signal that a read-permission is available - useful as API-marker to assure these
+    /// can only be called when the respective protection/permission is present.
+    pub fn read_permission(&self) -> &WorktreeReadPermission {
+        static READ: WorktreeReadPermission = WorktreeReadPermission(());
+        &READ
+    }
+}
+
+/// A token to indicate read-only access was granted to the worktree, assuring there are no writers
+/// *within this process*.
+pub struct WorktreeReadPermission(());
+
+/// A token to indicate exclusive access was granted to the worktree, assuring there are no readers or other writers
+/// *within this process*.
+pub struct WorktreeWritePermission(());
+
+impl WorktreeWritePermission {
+    /// Signal that a read-permission is available - useful as API-marker to assure these
+    /// can only be called when the respective protection/permission is present.
+    pub fn read_permission(&self) -> &WorktreeReadPermission {
+        static READ: WorktreeReadPermission = WorktreeReadPermission(());
+        &READ
+    }
+}
+
+static WORKTREE_LOCKS: parking_lot::Mutex<BTreeMap<PathBuf, Arc<parking_lot::RwLock<()>>>> =
+    parking_lot::Mutex::new(BTreeMap::new());
+
+/// A file-based lock that can indicate exclusive access.
+///
+/// As opposed to its actual implementation, it will ignore failures due to lack of filesystem support.
+pub struct LockFile {
+    /// The actual lock implementation.
+    inner: fslock::LockFile,
+    /// The path which was originally locked, for error reporting.
+    path: PathBuf,
+}
+
+/// Lifecycle and operations
+impl LockFile {
+    /// Open the file at `path`, possibly creating it, for the purpose of using it for file-based locking.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, fslock::Error> {
+        let path = path.into();
+        Ok(Self {
+            inner: fslock::LockFile::open(path.as_path())?,
+            path,
+        })
+    }
+
+    /// Try to lock the resource, or pretend it was locked if the underlying filesystem didn't support it.
+    pub fn try_lock(&mut self) -> Result<bool, fslock::Error> {
+        self.inner.try_lock().or_else(|err| {
+            if err.kind() == std::io::ErrorKind::Unsupported {
+                tracing::warn!(
+                "Filesystem hosting '{}' doesn't support file locking - pretending to own lock to avoid failure",
+                self.path.display()
+            );
+                Ok(true)
+            } else {
+                Err(err)
+            }
+        })
+    }
+
+    /// Drop the lock on this file, or do nothing if we don't own the lock.
+    pub fn unlock(&mut self) -> Result<(), fslock::Error> {
+        if !self.inner.owns_lock() {
+            return Ok(());
+        }
+        self.inner.unlock()
+    }
+}

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -6,9 +6,9 @@ use gix::diff::blob::{
 };
 use serde::Serialize;
 
-use super::{ChangeState, UnifiedDiff};
+use super::{ChangeState, UnifiedPatch};
 
-/// A hunk as used in a [UnifiedDiff], which also contains all added and removed lines.
+/// A hunk as used in a [UnifiedPatch], which also contains all added and removed lines.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffHunk {
@@ -50,7 +50,7 @@ impl std::fmt::Debug for DiffHunk {
     }
 }
 
-impl UnifiedDiff {
+impl UnifiedPatch {
     /// Determine how resources are converted to their form used for diffing.
     ///
     /// `ToGit` means that we want to see manifests of `git-lfs` for instance, or generally the result of 'clean' filters.
@@ -201,7 +201,7 @@ impl UnifiedDiff {
                 );
                 let hunks = gix::diff::blob::diff(algorithm, &input, uni_diff)?.hunks;
                 let (lines_added, lines_removed) = compute_line_changes(&hunks);
-                UnifiedDiff::Patch {
+                UnifiedPatch::Patch {
                     is_result_of_binary_to_text_conversion: prep.old_or_new_is_derived,
                     hunks,
                     lines_added,
@@ -229,11 +229,11 @@ impl UnifiedDiff {
                     .expect("BUG: one of the resources must have been binary/too big");
                 let big_file_size = repo.big_file_threshold()?;
                 if size > big_file_size {
-                    UnifiedDiff::TooLarge {
+                    UnifiedPatch::TooLarge {
                         size_in_bytes: size,
                     }
                 } else {
-                    UnifiedDiff::Binary
+                    UnifiedPatch::Binary
                 }
             }
         }))

--- a/crates/but-core/tests/core/diff/commit_changes.rs
+++ b/crates/but-core/tests/core/diff/commit_changes.rs
@@ -1,6 +1,7 @@
+use crate::diff::unified_diffs;
 use crate::{
     commit::conflict_repo,
-    diff::{ui::repo, unified_diffs},
+    diff::{ui::repo, unified_patches},
 };
 
 #[test]
@@ -95,7 +96,28 @@ fn many_changes() -> anyhow::Result<()> {
     )
     "#);
 
-    insta::assert_debug_snapshot!(unified_diffs(changes.0, &repo)?, @r#"
+    insta::assert_snapshot!(unified_diffs(&changes.0, &repo)?, @r"
+    rename from aa-renamed-old-name
+    rename to aa-renamed-new-name
+
+    --- a/executable-bit-added
+    +++ b/executable-bit-added
+
+    --- a/file-to-link
+    +++ b/file-to-link
+    @@ -1,0 +1,1 @@
+    +link-target
+
+    --- a/modified
+    +++ b/modified
+    @@ -1,0 +1,1 @@
+    +change
+
+    +++ a/removed
+    --- /dev/null
+    ");
+
+    insta::assert_debug_snapshot!(unified_patches(&changes.0, &repo)?, @r#"
     [
         Patch {
             hunks: [],
@@ -226,7 +248,28 @@ fn many_changes() -> anyhow::Result<()> {
     )
     "#);
 
-    insta::assert_debug_snapshot!(unified_diffs(changes.0, &repo)?, @r#"
+    insta::assert_snapshot!(unified_diffs(&changes.0, &repo)?, @r"
+    rename from aa-renamed-new-name
+    rename to aa-renamed-old-name
+
+    --- a/executable-bit-added
+    +++ b/executable-bit-added
+
+    --- a/file-to-link
+    +++ b/file-to-link
+    @@ -1,1 +1,0 @@
+    -link-target
+
+    --- a/modified
+    +++ b/modified
+    @@ -1,1 +1,0 @@
+    -change
+
+    --- /dev/null
+    +++ b/removed
+    ");
+
+    insta::assert_debug_snapshot!(unified_patches(&changes.0, &repo)?, @r#"
     [
         Patch {
             hunks: [],
@@ -305,7 +348,7 @@ fn many_changes_without_symlink_support() -> anyhow::Result<()> {
     }
     "#);
     // It can do it as long as the symlink isn't on disk.
-    insta::assert_debug_snapshot!(change.unified_diff(&repo, 3)?, @r#"
+    insta::assert_debug_snapshot!(change.unified_patch(&repo, 3)?, @r#"
     Some(
         Patch {
             hunks: [

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -580,7 +580,7 @@ fn worktree_changes_unified_diffs_json_example() -> anyhow::Result<()> {
     let diffs: Vec<_> = but_core::diff::worktree_changes(&repo)?
         .changes
         .iter()
-        .map(|tree_change| tree_change.unified_diff(&repo, 3))
+        .map(|tree_change| tree_change.unified_patch(&repo, 3))
         .collect::<std::result::Result<Vec<_>, _>>()?
         .into_iter()
         .flatten()

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use but_core::{UnifiedDiff, WorktreeChanges, diff};
+use but_core::{UnifiedPatch, WorktreeChanges, diff};
 use but_testsupport::gix_testtools;
 
 #[test]
@@ -48,7 +48,7 @@ fn executable_bit_added_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -89,7 +89,7 @@ fn executable_bit_removed_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -130,7 +130,7 @@ fn executable_bit_removed_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -171,7 +171,7 @@ fn executable_bit_added_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -205,7 +205,7 @@ fn untracked_in_unborn() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -239,7 +239,7 @@ fn added_in_unborn() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -295,7 +295,7 @@ fn submodule_added_in_unborn() -> Result<()> {
     }
     "#);
     assert_eq!(
-        unified_diffs(actual, &repo).unwrap_err().to_string(),
+        unified_patches(actual, &repo).unwrap_err().to_string(),
         "Can only diff blobs and links, not Commit"
     );
     Ok(())
@@ -368,7 +368,7 @@ fn submodule_changed_head() -> Result<()> {
     }
     "#);
     assert_eq!(
-        unified_diffs(actual, &repo).unwrap_err().to_string(),
+        unified_patches(actual, &repo).unwrap_err().to_string(),
         "Can only diff blobs and links, not Commit"
     );
     Ok(())
@@ -404,7 +404,7 @@ fn case_folding_worktree_changes() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -452,7 +452,7 @@ fn case_folding_worktree_and_index_changes() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -499,7 +499,7 @@ fn file_to_dir_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [],
@@ -552,7 +552,7 @@ fn file_to_dir_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [],
@@ -605,7 +605,7 @@ fn dir_to_file_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -658,7 +658,7 @@ fn dir_to_file_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -709,7 +709,7 @@ fn file_to_symlink_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -773,7 +773,7 @@ fn file_to_symlink_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -819,7 +819,7 @@ fn symlink_to_file_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -865,7 +865,7 @@ fn symlink_to_file_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -932,7 +932,7 @@ fn added_modified_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [],
@@ -988,7 +988,7 @@ fn non_utf8_decoding() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -1030,7 +1030,7 @@ fn modified_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -1068,7 +1068,7 @@ fn deleted_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -1105,7 +1105,7 @@ fn deleted_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r#"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r#"
     [
         Patch {
             hunks: [
@@ -1148,7 +1148,7 @@ fn renamed_in_index() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -1187,7 +1187,7 @@ fn renamed_in_index_with_executable_bit() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -1226,7 +1226,7 @@ fn renamed_in_worktree() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -1265,7 +1265,7 @@ fn renamed_in_worktree_with_executable_bit() -> Result<()> {
         ignored_changes: [],
     }
     "#);
-    insta::assert_debug_snapshot!(unified_diffs(actual, &repo)?, @r"
+    insta::assert_debug_snapshot!(unified_patches(actual, &repo)?, @r"
     [
         Patch {
             hunks: [],
@@ -1309,7 +1309,7 @@ fn modified_in_index_and_worktree_mod_mod() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1366,7 +1366,7 @@ fn modified_in_index_and_worktree_mod_mod_symlink() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1419,7 +1419,7 @@ fn modified_in_index_and_worktree_add_mod() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1456,7 +1456,7 @@ fn modified_in_index_and_worktree_add_del() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1497,7 +1497,7 @@ fn modified_in_index_and_worktree_del_add() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1547,7 +1547,7 @@ fn modified_in_index_and_worktree_mod_del() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     // newlines at the end should work.
@@ -1591,7 +1591,7 @@ fn modified_in_index_and_worktree_rename_mod() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1634,7 +1634,7 @@ fn modified_in_index_and_worktree_rename_rename() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     assert_eq!(
@@ -1671,7 +1671,7 @@ fn modified_in_index_and_worktree_rename_del() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1713,7 +1713,7 @@ fn modified_in_index_and_worktree_mod_rename() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     insta::assert_snapshot!(hunks[0].diff, @r"
@@ -1767,13 +1767,13 @@ fn modified_in_index_and_worktree_rename_add() -> Result<()> {
     "#);
 
     let [
-        UnifiedDiff::Patch {
+        UnifiedPatch::Patch {
             hunks: ref hunks1, ..
         },
-        UnifiedDiff::Patch {
+        UnifiedPatch::Patch {
             hunks: ref hunks2, ..
         },
-    ] = unified_diffs(actual, &repo)?[..]
+    ] = unified_patches(actual, &repo)?[..]
     else {
         unreachable!("need hunks")
     };
@@ -1821,7 +1821,7 @@ fn modified_in_index_and_worktree_add_rename() -> Result<()> {
     }
     "#);
 
-    let [UnifiedDiff::Patch { ref hunks, .. }] = unified_diffs(actual, &repo)?[..] else {
+    let [UnifiedPatch::Patch { ref hunks, .. }] = unified_patches(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
     assert_eq!(
@@ -1832,11 +1832,11 @@ fn modified_in_index_and_worktree_add_rename() -> Result<()> {
     Ok(())
 }
 
-fn unified_diffs(
+fn unified_patches(
     worktree: WorktreeChanges,
     repo: &gix::Repository,
-) -> anyhow::Result<Vec<UnifiedDiff>> {
-    super::unified_diffs(worktree.changes, repo)
+) -> anyhow::Result<Vec<UnifiedPatch>> {
+    super::unified_patches(&worktree.changes, repo)
 }
 
 pub fn repo_in(fixture_name: &str, name: &str) -> anyhow::Result<gix::Repository> {

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -128,7 +128,7 @@
 mod input;
 
 use anyhow::Context;
-use but_core::{TreeChange, UnifiedDiff};
+use but_core::{TreeChange, UnifiedPatch};
 use gitbutler_oxidize::ObjectIdExt;
 use gix::{prelude::ObjectIdExt as _, trace};
 pub use input::{InputCommit, InputDiffHunk, InputFile, InputStack};
@@ -185,8 +185,8 @@ pub fn tree_changes_to_input_files(
 ) -> anyhow::Result<Vec<InputFile>> {
     let mut files = Vec::new();
     for change in changes {
-        let diff = change.unified_diff(repo, 0)?;
-        let Some(UnifiedDiff::Patch { hunks, .. }) = diff else {
+        let diff = change.unified_patch(repo, 0)?;
+        let Some(UnifiedPatch::Patch { hunks, .. }) = diff else {
             trace::warn!(
                 "Skipping change at '{}' as it doesn't have hunks to calculate dependencies for (binary/too large)",
                 change.path

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use but_core::{UnifiedDiff, unified_diff::DiffHunk};
+use but_core::{UnifiedPatch, unified_diff::DiffHunk};
 use gitbutler_command_context::{CommandContext, gix_repo_for_merging};
 use gitbutler_oxidize::OidExt;
 use gitbutler_stack::StackId;
@@ -62,8 +62,8 @@ impl HunkDependencies {
     ) -> anyhow::Result<HunkDependencies> {
         let mut diffs = Vec::<(String, DiffHunk, Vec<HunkLock>)>::new();
         for change in worktree_changes {
-            let unidiff = change.unified_diff(repo, 0 /* zero context lines */)?;
-            let Some(UnifiedDiff::Patch { hunks, .. }) = unidiff else {
+            let unidiff = change.unified_patch(repo, 0 /* zero context lines */)?;
+            let Some(UnifiedPatch::Patch { hunks, .. }) = unidiff else {
                 continue;
             };
             for hunk in hunks {

--- a/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
@@ -13,8 +13,8 @@ fn intersect_workspace_ranges(
     let mut intersections_by_path = Vec::new();
     let mut missed_hunks = Vec::new();
     for change in worktree_changes {
-        let unidiff = change.unified_diff(repo, 0)?;
-        let Some(but_core::UnifiedDiff::Patch { hunks, .. }) = unidiff else {
+        let unidiff = change.unified_patch(repo, 0)?;
+        let Some(but_core::UnifiedPatch::Patch { hunks, .. }) = unidiff else {
             continue;
         };
         let mut intersections = Vec::new();

--- a/crates/but-project/Cargo.toml
+++ b/crates/but-project/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "but-project"
+version = "0.0.0"
+edition = "2024"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+description = "A project implementation to act as 'context'"
+rust-version = "1.89"
+
+[lib]
+doctest = false
+test = false
+
+[features]
+# Support for a built-in legacy project.
+legacy = ["dep:gitbutler-project", "dep:gitbutler-command-context"]
+
+[dependencies]
+gitbutler-project = { workspace = true, optional = true }
+gitbutler-command-context = { workspace = true, optional = true }
+
+but-core.workspace = true
+but-settings.workspace = true
+but-graph.workspace = true
+anyhow.workspace = true
+gix.workspace = true
+

--- a/crates/but-project/src/lib.rs
+++ b/crates/but-project/src/lib.rs
@@ -1,0 +1,121 @@
+//! A crate to host a `Project` type, suitable to provide all context *applications* need to operate
+//! on it.
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+use but_settings::AppSettings;
+#[cfg(feature = "legacy")]
+use gitbutler_command_context::CommandContext;
+use std::path::{Path, PathBuf};
+
+/// Project specific information, *not* thread-safe, and cheap to clone.
+/// That way it may own per-thread caches.
+#[derive(Debug, Clone)]
+pub struct Project {
+    /// The application context, here for convenience and as feature toggles and flags are needed.
+    pub settings: AppSettings,
+    /// The legacy implementation, for all the old code.
+    #[cfg(feature = "legacy")]
+    pub legacy: gitbutler_project::Project,
+    /// The repository of the project, which also provides access to the `git_dir`.
+    pub repo: gix::Repository,
+}
+
+/// Legacy - none of this should be kept.
+// TODO: make this an extension implemented elsewhere.
+#[cfg(feature = "legacy")]
+impl Project {
+    /// Return a context for calling into `gitbutler-` functions.
+    pub fn legacy_ctx(&self) -> anyhow::Result<CommandContext> {
+        CommandContext::open(&self.legacy, self.settings.clone())
+    }
+
+    /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
+    /// to read data.
+    /// This is helping to prevent races with mutable instances.
+    // TODO: remove _read_only as we don't need it anymore with a DB based implementation as long as the instances
+    //       starts a transaction to isolate reads.
+    //       For a correct implementation, this would also have to hold on to `_read_only`.
+    pub fn legacy_meta(
+        &self,
+        _read_only: &but_core::sync::WorktreeReadPermission,
+    ) -> anyhow::Result<but_graph::VirtualBranchesTomlMetadata> {
+        but_graph::VirtualBranchesTomlMetadata::from_path(
+            self.legacy.gb_dir().join("virtual_branches.toml"),
+        )
+    }
+}
+
+/// Locking utilities to protect against concurrency on the same project.
+impl Project {
+    /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for someone else,
+    /// in the same process only, to release it, or for all readers to disappear.
+    /// Locking is fair.
+    ///
+    /// Note that this in-process locking works only under the assumption that no two instances of
+    /// GitButler are able to read or write the same repository.
+    pub fn exclusive_worktree_access(&self) -> but_core::sync::WorkspaceWriteGuard {
+        but_core::sync::exclusive_worktree_access(self.git_dir())
+    }
+
+    /// Return a guard for shared (read) worktree access, and block while waiting for writers to disappear.
+    /// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
+    /// thus block readers to prevent writer starvation.
+    pub fn shared_worktree_access(&self) -> but_core::sync::WorkspaceReadGuard {
+        but_core::sync::shared_worktree_access(self.git_dir())
+    }
+}
+
+/// Utilities for calling into plumbing functions.
+impl Project {
+    /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
+    /// to read data.
+    /// This is helping to prevent races with mutable instances.
+    // TODO: remove _read_only as we don't need it anymore with a DB based implementation as long as the instances
+    //       starts a transaction to isolate reads.
+    //       For a correct implementation, this would also have to hold on to `_read_only`.
+    pub fn meta(
+        &self,
+        _read_only: &but_core::sync::WorktreeReadPermission,
+    ) -> anyhow::Result<impl but_core::RefMetadata> {
+        but_graph::VirtualBranchesTomlMetadata::from_path(
+            self.data_dir().join("virtual_branches.toml"),
+        )
+    }
+}
+
+/// Repository helpers.
+impl Project {
+    /// Open an isolated repository, one that didn't read options beyond `.git/config` and
+    /// knows no environment variables.
+    ///
+    /// Use it for fastest-possible access, when incomplete configuration is acceptable.
+    pub fn open_isolated_repo(&self) -> anyhow::Result<gix::Repository> {
+        Ok(gix::open_opts(
+            self.git_dir(),
+            gix::open::Options::isolated(),
+        )?)
+    }
+
+    /// Open a standard Git repository at the project directory, just like a real user would.
+    ///
+    /// This repository is good for standard tasks, like checking refs and traversing the commit graph,
+    /// and for reading objects as well.
+    ///
+    /// Diffing and merging is better done with [`Self::open_repo_for_merging()`].
+    pub fn open_repo(&self) -> anyhow::Result<gix::Repository> {
+        Ok(gix::open(self.git_dir())?)
+    }
+
+    /// Calls [`but_core::open_repo_for_merging()`]
+    pub fn open_repo_for_merging(&self) -> anyhow::Result<gix::Repository> {
+        but_core::open_repo_for_merging(self.git_dir())
+    }
+
+    fn git_dir(&self) -> &Path {
+        self.repo.git_dir()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        self.git_dir().join("gitbutler")
+    }
+}

--- a/crates/but-testing/src/command/diff.rs
+++ b/crates/but-testing/src/command/diff.rs
@@ -117,12 +117,12 @@ fn unified_diff_for_changes(
     repo: &gix::Repository,
     changes: Vec<but_core::TreeChange>,
     context_lines: u32,
-) -> anyhow::Result<Vec<(but_core::TreeChange, but_core::UnifiedDiff)>> {
+) -> anyhow::Result<Vec<(but_core::TreeChange, but_core::UnifiedPatch)>> {
     changes
         .into_iter()
         .map(|tree_change| {
             tree_change
-                .unified_diff(repo, context_lines)
+                .unified_patch(repo, context_lines)
                 .map(|diff| (tree_change, diff.expect("no submodule")))
         })
         .collect::<Result<Vec<_>, _>>()
@@ -136,8 +136,8 @@ fn intersect_workspace_ranges(
     let mut intersections_by_path = Vec::new();
     let mut missed_hunks = Vec::new();
     for change in worktree_changes {
-        let unidiff = change.unified_diff(repo, 0)?;
-        let Some(but_core::UnifiedDiff::Patch { hunks, .. }) = unidiff else {
+        let unidiff = change.unified_patch(repo, 0)?;
+        let Some(but_core::UnifiedPatch::Patch { hunks, .. }) = unidiff else {
             continue;
         };
         let mut intersections = Vec::new();

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, mem::ManuallyDrop, path::Path};
 
 use anyhow::{Context, anyhow, bail};
-use but_core::{UnifiedDiff, ref_metadata::StackId};
+use but_core::{UnifiedPatch, ref_metadata::StackId};
 use but_db::poll::ItemKind;
 use but_graph::VirtualBranchesTomlMetadata;
 use but_settings::AppSettings;
@@ -698,8 +698,8 @@ fn indices_or_headers_to_hunk_headers(
                     change.path == *path
                         && change.previous_path() == previous_path.as_ref().map(|p| p.as_bstr())
                 }).with_context(|| format!("Couldn't find worktree change for file at '{path}' (previous-path: {previous_path:?}"))?;
-            let Some(UnifiedDiff::Patch { hunks, .. }) =
-                worktree_changes.unified_diff(repo, UI_CONTEXT_LINES)?
+            let Some(UnifiedPatch::Patch { hunks, .. }) =
+                worktree_changes.unified_patch(repo, UI_CONTEXT_LINES)?
             else {
                 bail!("No hunks available for given '{path}'")
             };

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::Context;
 use bstr::BString;
-use but_core::{TreeChange, UnifiedDiff};
+use but_core::{TreeChange, UnifiedPatch};
 use but_graph::VirtualBranchesTomlMetadata;
 use but_workspace::{CommmitSplitOutcome, StackId, ui::StackEntryNoOpt};
 use gitbutler_branch_actions::{BranchManagerExt, update_workspace_commit};
@@ -1857,13 +1857,13 @@ fn entries_to_simple_stacks(
 }
 
 fn get_file_changes(
-    changes: &[(TreeChange, UnifiedDiff)],
+    changes: &[(TreeChange, UnifiedPatch)],
     assingments: Vec<but_hunk_assignment::HunkAssignment>,
 ) -> Vec<FileChange> {
     let mut file_changes = vec![];
     for (change, unified_diff) in changes.iter() {
         match unified_diff {
-            but_core::UnifiedDiff::Patch { hunks, .. } => {
+            but_core::UnifiedPatch::Patch { hunks, .. } => {
                 let path = change.path.to_string();
                 let status = match &change.status {
                     but_core::TreeStatus::Addition { .. } => "added".to_string(),
@@ -1918,12 +1918,12 @@ fn unified_diff_for_changes(
     repo: &gix::Repository,
     changes: Vec<but_core::TreeChange>,
     context_lines: u32,
-) -> anyhow::Result<Vec<(but_core::TreeChange, but_core::UnifiedDiff)>> {
+) -> anyhow::Result<Vec<(but_core::TreeChange, but_core::UnifiedPatch)>> {
     changes
         .into_iter()
         .map(|tree_change| {
             tree_change
-                .unified_diff(repo, context_lines)
+                .unified_patch(repo, context_lines)
                 .map(|diff| (tree_change, diff.expect("no submodule")))
         })
         .collect::<Result<Vec<_>, _>>()

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -548,7 +548,7 @@ mod file {
 mod hunk {
     use anyhow::bail;
     use bstr::ByteSlice;
-    use but_core::{ChangeState, TreeChange, UnifiedDiff};
+    use but_core::{ChangeState, TreeChange, UnifiedPatch};
     use gix::{
         filter::plumbing::{
             driver::apply::{Delay, MaybeDelayed},
@@ -592,12 +592,12 @@ mod hunk {
         let mut diff_filter = but_core::unified_diff::filter_from_state(
             repo,
             Some(state_in_worktree),
-            UnifiedDiff::CONVERSION_MODE,
+            UnifiedPatch::CONVERSION_MODE,
         )?;
-        let Some(UnifiedDiff::Patch {
+        let Some(UnifiedPatch::Patch {
             hunks: hunks_in_worktree,
             ..
-        }) = wt_change.unified_diff_with_filter(repo, context_lines, &mut diff_filter)?
+        }) = wt_change.unified_patch_with_filter(repo, context_lines, &mut diff_filter)?
         else {
             bail!("Couldn't obtain diff for worktree changes.")
         };

--- a/crates/but-workspace/src/tree_manipulation/utils.rs
+++ b/crates/but-workspace/src/tree_manipulation/utils.rs
@@ -167,7 +167,7 @@ pub fn create_tree_without_diff(
                         );
                     };
 
-                    let diff = but_core::UnifiedDiff::compute(
+                    let diff = but_core::UnifiedPatch::compute(
                         repository,
                         change.path.as_bstr(),
                         Some(before_path.as_bstr()),
@@ -185,7 +185,7 @@ pub fn create_tree_without_diff(
                         "Cannot diff submodules - if this is encountered we should look into it",
                     )?;
 
-                    let but_core::UnifiedDiff::Patch {
+                    let but_core::UnifiedPatch::Patch {
                         hunks: diff_hunks, ..
                     } = diff
                     else {

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -1291,12 +1291,12 @@ const UI_CONTEXT_LINES: u32 = 3;
 
 mod utils {
     use bstr::BString;
-    use but_core::UnifiedDiff;
+    use but_core::UnifiedPatch;
 
     pub fn worktree_change_diffs(
         repo: &gix::Repository,
         context_lines: u32,
-    ) -> anyhow::Result<Vec<(Option<BString>, BString, UnifiedDiff)>> {
+    ) -> anyhow::Result<Vec<(Option<BString>, BString, UnifiedPatch)>> {
         Ok(but_core::diff::worktree_changes(repo)?
             .changes
             .iter()
@@ -1304,7 +1304,7 @@ mod utils {
                 (
                     c.previous_path().map(ToOwned::to_owned),
                     c.path.clone(),
-                    c.unified_diff(repo, context_lines).unwrap().unwrap(),
+                    c.unified_patch(repo, context_lines).unwrap().unwrap(),
                 )
             })
             .collect())

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -1,5 +1,5 @@
 use bstr::{BString, ByteSlice};
-use but_core::UnifiedDiff;
+use but_core::UnifiedPatch;
 use but_testsupport::{git_status, visualize_disk_tree_skip_dot_git};
 use but_workspace::{DiffSpec, HunkHeader, discard_workspace_changes};
 
@@ -125,8 +125,8 @@ fn from_end() -> anyhow::Result<()> {
         17
         18
         "));
-        let Some(UnifiedDiff::Patch { mut hunks, .. }) =
-            change.unified_diff(&repo, CONTEXT_LINES)?
+        let Some(UnifiedPatch::Patch { mut hunks, .. }) =
+            change.unified_patch(&repo, CONTEXT_LINES)?
         else {
             unreachable!("We know there are hunks")
         };
@@ -199,8 +199,8 @@ fn from_beginning() -> anyhow::Result<()> {
         .into_iter()
         .find(|change| change.path == filename)
     {
-        let Some(UnifiedDiff::Patch { mut hunks, .. }) =
-            change.unified_diff(&repo, CONTEXT_LINES)?
+        let Some(UnifiedPatch::Patch { mut hunks, .. }) =
+            change.unified_patch(&repo, CONTEXT_LINES)?
         else {
             unreachable!("We know there are hunks")
         };
@@ -823,7 +823,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
 
 mod util {
     use bstr::BString;
-    use but_core::{TreeChange, UnifiedDiff, unified_diff::DiffHunk};
+    use but_core::{TreeChange, UnifiedPatch, unified_diff::DiffHunk};
     use gix::prelude::ObjectIdExt;
 
     pub fn previous_change_text(
@@ -854,7 +854,7 @@ mod util {
             .find(|change| change.path == filename)
             .expect("well-known fixture");
 
-        let Some(UnifiedDiff::Patch { hunks, .. }) = change.unified_diff(repo, context_lines)?
+        let Some(UnifiedPatch::Patch { hunks, .. }) = change.unified_patch(repo, context_lines)?
         else {
             unreachable!("We know there are hunks")
         };

--- a/crates/but-workspace/tests/workspace/utils.rs
+++ b/crates/but-workspace/tests/workspace/utils.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use bstr::ByteSlice;
-use but_core::{TreeChange, TreeStatus, UnifiedDiff, unified_diff::DiffHunk};
+use but_core::{TreeChange, TreeStatus, UnifiedPatch, unified_diff::DiffHunk};
 use but_testsupport::{
     gix_testtools,
     gix_testtools::{Creation, tempfile},
@@ -183,8 +183,8 @@ pub fn to_change_specs_all_hunks_with_context_lines(
                 ..Default::default()
             },
             _ => {
-                match change.unified_diff(repo, context_lines)? {
-                    Some(but_core::UnifiedDiff::Patch { hunks, .. }) => DiffSpec {
+                match change.unified_patch(repo, context_lines)? {
+                    Some(but_core::UnifiedPatch::Patch { hunks, .. }) => DiffSpec {
                         previous_path: change.previous_path().map(ToOwned::to_owned),
                         path: change.path,
                         hunk_headers: hunks.into_iter().map(Into::into).collect(),
@@ -307,9 +307,9 @@ pub fn worktree_changes_with_diffs(
         .into_iter()
         .map(|tree_change| {
             let diff = tree_change
-                .unified_diff(repo, 0 /* context_lines */)
+                .unified_patch(repo, 0 /* context_lines */)
                 .expect("diffs can always be generated");
-            let Some(UnifiedDiff::Patch { hunks, .. }) = diff else {
+            let Some(UnifiedPatch::Patch { hunks, .. }) = diff else {
                 unreachable!("don't use this with binary files or large files or submodules")
             };
             (tree_change, hunks.into_iter().map(LeanDiffHunk).collect())

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -33,6 +33,7 @@ command-group = { version = "5.0.1", features = ["with-tokio"] }
 gitbutler-project.workspace = true
 gix.workspace = true
 but-core.workspace = true
+but-project = { workspace = true, features = ["legacy"] }
 but-api.workspace = true
 but-action.workspace = true
 but-graph.workspace = true

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -106,7 +106,7 @@ impl CommandContext {
     /// Also note that there are plenty of other places where repositories are opened ad-hoc, and
     /// there is no need to use this type there at all - opening a repo is very cheap still.
     pub fn gix_repo(&self) -> Result<gix::Repository> {
-        Ok(gix::open(self.repo().path())?)
+        self.project.open()
     }
 
     /// Create a new Graph traversal from the current HEAD, using (and returning) the given `repo` (configured by the caller),
@@ -131,6 +131,7 @@ impl CommandContext {
     /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
     /// to read data.
     /// This is helping to prevent races with mutable instances.
+    // NOTE: this
     pub fn meta(&self, _read_only: &WorktreeReadPermission) -> Result<VirtualBranchesTomlMetadata> {
         self.meta_inner().map(VirtualBranchesTomlMetadata)
     }

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-parking_lot = { workspace = true, features = ["arc_lock"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 gitbutler-error.workspace = true
@@ -31,9 +30,6 @@ gix = { workspace = true, features = [
 strum = { version = "0.27", features = ["derive"] }
 tracing.workspace = true
 resolve-path = "0.1.0"
-
-# for locking
-fslock = "0.2.1"
 
 [dev-dependencies]
 gitbutler-testsupport.workspace = true

--- a/crates/gitbutler-project/src/access.rs
+++ b/crates/gitbutler-project/src/access.rs
@@ -1,9 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
-
-use anyhow::{Context, bail};
-use parking_lot::{ArcRwLockReadGuard, ArcRwLockWriteGuard, RawRwLock};
-
-use crate::{Project, ProjectId};
+use crate::Project;
 
 /// Access Control
 impl Project {
@@ -13,22 +8,8 @@ impl Project {
     ///
     /// Note that the lock is automatically released on `Drop`, or when the process quits for any reason,
     /// so it can't go stale.
-    pub fn try_exclusive_access(&self) -> anyhow::Result<LockFile> {
-        // MIGRATION: bluntly remove old lock files, which are now more generally named to also fit
-        //            the CLI.
-        std::fs::remove_file(self.gb_dir().join("window.lock").as_os_str()).ok();
-
-        let mut lock = LockFile::open(self.gb_dir().join("project.lock").as_os_str())?;
-        let got_lock = lock
-            .try_lock()
-            .context("Failed to check if lock is taken")?;
-        if !got_lock {
-            bail!(
-                "Project '{}' is already opened in another window",
-                self.title
-            );
-        }
-        Ok(lock)
+    pub fn try_exclusive_access(&self) -> anyhow::Result<but_core::sync::LockFile> {
+        but_core::sync::try_exclusive_inter_process_access(self.git_dir())
     }
 
     /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for someone else,
@@ -37,134 +18,19 @@ impl Project {
     ///
     /// Note that this in-process locking works only under the assumption that no two instances of
     /// GitButler are able to read or write the same repository.
-    pub fn exclusive_worktree_access(&self) -> WriteWorkspaceGuard {
-        let mut map = WORKTREE_LOCKS.lock();
-        WriteWorkspaceGuard {
-            inner: map.entry(self.id).or_default().write_arc().into(),
-            perm: WorktreeWritePermission(()),
-        }
+    pub fn exclusive_worktree_access(&self) -> WorkspaceWriteGuard {
+        but_core::sync::exclusive_worktree_access(self.git_dir())
     }
 
     /// Return a guard for shared (read) worktree access, and block while waiting for writers to disappear.
     /// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
     /// thus block readers to prevent writer starvation.
     pub fn shared_worktree_access(&self) -> WorkspaceReadGuard {
-        let mut map = WORKTREE_LOCKS.lock();
-        WorkspaceReadGuard(Some(map.entry(self.id).or_default().read_arc()))
+        but_core::sync::shared_worktree_access(self.git_dir())
     }
 }
 
-pub struct WriteWorkspaceGuard {
-    inner: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
-    perm: WorktreeWritePermission,
-}
-
-impl Drop for WriteWorkspaceGuard {
-    fn drop(&mut self) {
-        let lock = self
-            .inner
-            .take()
-            .expect("it's always set, and only taken once when dropping");
-        ArcRwLockWriteGuard::unlock_fair(lock);
-    }
-}
-
-impl Drop for WorkspaceReadGuard {
-    fn drop(&mut self) {
-        let lock = self
-            .0
-            .take()
-            .expect("it's always set, and only taken once when dropping");
-        ArcRwLockReadGuard::unlock_fair(lock)
-    }
-}
-
-impl WriteWorkspaceGuard {
-    /// Signal that a write-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
-    pub fn write_permission(&mut self) -> &mut WorktreeWritePermission {
-        &mut self.perm
-    }
-
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
-    pub fn read_permission(&self) -> &WorktreeReadPermission {
-        self.perm.read_permission()
-    }
-}
-
-pub struct WorkspaceReadGuard(Option<parking_lot::ArcRwLockReadGuard<RawRwLock, ()>>);
-
-impl WorkspaceReadGuard {
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
-    pub fn read_permission(&self) -> &WorktreeReadPermission {
-        static READ: WorktreeReadPermission = WorktreeReadPermission(());
-        &READ
-    }
-}
-
-/// A token to indicate read-only access was granted to the worktree, assuring there are no writers
-/// *within this process*.
-pub struct WorktreeReadPermission(());
-
-/// A token to indicate exclusive access was granted to the worktree, assuring there are no readers or other writers
-/// *within this process*.
-pub struct WorktreeWritePermission(());
-
-impl WorktreeWritePermission {
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
-    pub fn read_permission(&self) -> &WorktreeReadPermission {
-        static READ: WorktreeReadPermission = WorktreeReadPermission(());
-        &READ
-    }
-}
-
-static WORKTREE_LOCKS: parking_lot::Mutex<BTreeMap<ProjectId, Arc<parking_lot::RwLock<()>>>> =
-    parking_lot::Mutex::new(BTreeMap::new());
-
-/// A file-based lock that can indicate exclusive access.
-///
-/// As opposed to its actual implementation, it will ignore failures due to lack of filesystem support.
-pub struct LockFile {
-    /// The actual lock implementation.
-    inner: fslock::LockFile,
-    /// The path which was originally locked, for error reporting.
-    path: PathBuf,
-}
-
-/// Lifecycle and operations
-impl LockFile {
-    /// Open the file at `path`, possibly creating it, for the purpose of using it for file-based locking.
-    pub fn open(path: impl Into<PathBuf>) -> Result<Self, fslock::Error> {
-        let path = path.into();
-        Ok(Self {
-            inner: fslock::LockFile::open(path.as_path())?,
-            path,
-        })
-    }
-
-    /// Try to lock the resource, or pretend it was locked if the underlying filesystem didn't support it.
-    pub fn try_lock(&mut self) -> Result<bool, fslock::Error> {
-        self.inner.try_lock().or_else(|err| {
-            if err.kind() == std::io::ErrorKind::Unsupported {
-                tracing::warn!(
-                    "Filesystem hosting '{}' doesn't support file locking - pretending to own lock to avoid failure",
-                    self.path.display()
-                );
-                Ok(true)
-            } else {
-                Err(err)
-            }
-        })
-    }
-
-    /// Drop the lock on this file, or do nothing if we don't own the lock.
-    pub fn unlock(&mut self) -> Result<(), fslock::Error> {
-        if !self.inner.owns_lock() {
-            return Ok(());
-        }
-        self.inner.unlock()
-    }
-}
+pub use but_core::sync::{
+    LockFile, WorkspaceReadGuard, WorkspaceWriteGuard, WorktreeReadPermission,
+    WorktreeWritePermission,
+};

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -102,7 +102,7 @@ pub(crate) mod state {
         watcher: gitbutler_watcher::WatcherHandle,
         /// An active lock to signal that the entire project is locked for the Window this state belongs to.
         /// Let's make it optional while it's only in our own way, while aiming for making that reasonably well working.
-        exclusive_access: Option<gitbutler_project::access::LockFile>,
+        exclusive_access: Option<but_core::sync::LockFile>,
         // Database watcher handle.
         #[expect(dead_code)]
         db_watcher: but_db::poll::DBWatcherHandle,


### PR DESCRIPTION
This is to help AI to use newer APIs, maybe, and to show that it can already be done.

### Tasks

* [x] refactors
* [x] API proposal

### Next PR 

* [ ] put `gitbutler-` dependencies behind `legacy` feature toggle.
* [ ] status uses `but_workspace::ref_info()`
