### PR TITLE
Branch selection: If the branch is not part of the listing, remove it

### DIFF
--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -191,7 +191,7 @@ export function initDependencies(args: {
 
 	const gitService = new GitService(backend, clientState.backendApi);
 	const baseBranchService = new BaseBranchService(clientState.backendApi);
-	const branchService = new BranchService(clientState['backendApi']);
+	const branchService = new BranchService(clientState['backendApi'], uiState);
 	const cherryApplyService = new CherryApplyService(clientState.backendApi);
 	const remotesService = new RemotesService(backend);
 	const hooksService = new HooksService(clientState.backendApi);

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -528,7 +528,7 @@ export function updateStalePrSelection(uiState: UiState, projectId: string, prs:
 	}
 }
 
-export function updateStaleStackSelectionInBranchesView(
+export function updateStaleBranchSelectionInBranchesView(
 	uiState: UiState,
 	projectId: string,
 	deletedBranches: string[]
@@ -536,6 +536,18 @@ export function updateStaleStackSelectionInBranchesView(
 	const projectState = uiState.project(projectId);
 	const selection = projectState.branchesSelection.current;
 	if (selection.branchName && deletedBranches.includes(selection.branchName)) {
+		projectState.branchesSelection.set({});
+	}
+}
+
+export function retainBranchSelectionInBranchesView(
+	uiState: UiState,
+	projectId: string,
+	branches: string[]
+) {
+	const projectState = uiState.project(projectId);
+	const selection = projectState.branchesSelection.current;
+	if (selection.branchName && !branches.includes(selection.branchName)) {
 		projectState.branchesSelection.set({});
 	}
 }

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -1,5 +1,5 @@
 import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
-import { updateStaleStackSelectionInBranchesView, type UiState } from '$lib/state/uiState.svelte';
+import { updateStaleBranchSelectionInBranchesView, type UiState } from '$lib/state/uiState.svelte';
 import { InjectionToken } from '@gitbutler/core/context';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import type { StackService } from '$lib/stacks/stackService.svelte';
@@ -103,7 +103,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 					invalidatesList(ReduxTag.BranchListing)
 				],
 				transformResponse: (response: IntegrationOutcome, _, { projectId }) => {
-					updateStaleStackSelectionInBranchesView(uiState, projectId, response.deletedBranches);
+					updateStaleBranchSelectionInBranchesView(uiState, projectId, response.deletedBranches);
 					return response;
 				}
 			}),


### PR DESCRIPTION
If the selected branch is not part of the response for the branch listings API, then assume it doesn’t exist and unselect it