### PR TITLE
Add UpDownPlugin and wire up user input recall

### DIFF
--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -97,7 +97,7 @@ export type ClaudeSession = {
 /**
  * Represents a message in a Claude session, referencing the stable session ID.
  */
-export type ClaudeMessage = {
+export type ClaudeMessage<T extends MessagePayload = MessagePayload> = {
 	/** Message identifier */
 	id: string;
 	/** The stable session ID that this message belongs to. */
@@ -105,7 +105,7 @@ export type ClaudeMessage = {
 	/** The timestamp when the message was created. */
 	createdAt: string;
 	/** The payload of the message from different sources. */
-	payload: MessagePayload;
+	payload: T;
 };
 
 /**

--- a/crates/but-claude/src/db.rs
+++ b/crates/but-claude/src/db.rs
@@ -173,7 +173,7 @@ pub fn get_user_message(
     let message = ctx
         .db()?
         .claude_messages()
-        .get_message_of_type(MessagePayloadDbType::UserInput.to_string(), offset)?;
+        .get_message_of_type(MessagePayloadDbType::User.to_string(), offset)?;
 
     match message {
         Some(m) => Ok(Some(m.try_into()?)),

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -540,6 +540,7 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
+        "claude_get_user_message" => claude::claude_get_user_message_cmd(request.params),
         "claude_list_permission_requests" => {
             claude::claude_list_permission_requests_cmd(request.params)
         }

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -143,6 +143,7 @@ export { default as Formatter } from '$lib/richText/plugins/Formatter.svelte';
 export { default as GhostTextPlugin } from '$lib/richText/plugins/GhostText.svelte';
 export { default as HardWrapPlugin } from '$lib/richText/plugins/HardWrapPlugin.svelte';
 export { default as FilePlugin } from '$lib/richText/plugins/FilePlugin.svelte';
+export { default as UpDownPlugin } from '$lib/richText/plugins/UpDownPlugin.svelte';
 export {
 	default as Mention,
 	type MentionSuggestion,

--- a/packages/ui/src/lib/richText/plugins/UpDownPlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/UpDownPlugin.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { setEditorText } from '$lib/richText/selection';
+	import { mergeUnlisten } from '$lib/utils/mergeUnlisten';
+	import {
+		$getRoot as getRoot,
+		$getSelection as getSelection,
+		COMMAND_PRIORITY_NORMAL,
+		$isRangeSelection as isRangeSelection,
+		KEY_DOWN_COMMAND
+	} from 'lexical';
+	import { getEditor } from 'svelte-lexical';
+
+	type Props = { historyLookup: (offset: number) => Promise<string | undefined> };
+
+	const { historyLookup }: Props = $props();
+
+	const editor = getEditor();
+	let offset = $state(0);
+	let active = $state(false);
+
+	async function applyFromHistory(offset: number) {
+		const entry = await historyLookup(offset);
+		if (entry) {
+			setEditorText(editor, entry);
+			return true;
+		}
+		return false;
+	}
+
+	function canActivate() {
+		const selection = getSelection();
+		if (!isRangeSelection(selection)) return false;
+		if (!selection.isCollapsed()) return false;
+		if (selection.anchor.getNode().getPreviousSibling()) return false;
+		if (selection.anchor.offset > 0) return false;
+
+		const contentSize = getRoot().getTextContentSize();
+		if (contentSize !== 0) return false;
+		return true;
+	}
+
+	function handleKeyboardEvent(e: KeyboardEvent): boolean {
+		if (active && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+			active = false;
+			offset = 0;
+			return false;
+		}
+
+		if (active || canActivate()) {
+			active = true;
+			e.preventDefault();
+			switch (e.key) {
+				case 'ArrowUp': {
+					applyFromHistory(offset++);
+					return true;
+				}
+				case 'ArrowDown': {
+					if (offset === 0) {
+						setEditorText(editor, '');
+						return false;
+					}
+					applyFromHistory(--offset);
+					return true;
+				}
+			}
+		}
+		offset = 0;
+		return false;
+	}
+
+	$effect(() => {
+		return mergeUnlisten(
+			editor.registerCommand(KEY_DOWN_COMMAND, handleKeyboardEvent, COMMAND_PRIORITY_NORMAL)
+		);
+	});
+</script>

--- a/packages/ui/src/stories/components/RichTextEditor.stories.svelte
+++ b/packages/ui/src/stories/components/RichTextEditor.stories.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
 	import RichTextEditor from '$lib/richText/RichTextEditor.svelte';
 	import Formatter from '$lib/richText/plugins/Formatter.svelte';
+	import UpDownPlugin from '$lib/richText/plugins/UpDownPlugin.svelte';
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	const { Story } = defineMeta({
@@ -34,6 +35,7 @@
 				>
 					{#snippet plugins()}
 						<Formatter bind:this={formatter} />
+						<UpDownPlugin historyLookup={async (offset) => `offset ${offset}`} />
 					{/snippet}
 				</RichTextEditor>
 			</div>


### PR DESCRIPTION
Introduce a new UpDownPlugin for rich text editors to allow navigating
history entries and inserting prior user messages. Export the plugin
from the UI library and include it in the RichTextEditor story so it
appears in Storybook.

Wire backend support and command routing for retrieving user messages:
add a "claude_get_user_message" handler in the server command map and
call the new backend method from the desktop CodegenInput component.
When a historical user message contains attachments, add them to the
attachment service so they are available in the editor.

Fix a typo in the Claude DB accessor: request user messages by the
MessagePayloadDbType::User tag (previously used UserInput) so lookups
correctly return stored user messages.