### PR TITLE
but: Forge forget handles ambiguity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "cli-prompts",
  "colored",
  "command-group",
  "crossterm 0.29.0",
@@ -1713,6 +1714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cli-prompts"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b683c917349f99b2e634c2d46f571401ce2bd167969c702446e37d38561bec15"
+dependencies = [
+ "crossterm 0.23.2",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,13 +2050,29 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.10.0",
  "crossterm_winapi",
- "mio",
+ "mio 1.1.0",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -2064,7 +2090,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more 2.0.1",
  "document-features",
- "mio",
+ "mio 1.1.0",
  "parking_lot",
  "rustix 1.1.2",
  "signal-hook",
@@ -6727,6 +6753,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
@@ -6899,7 +6937,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 1.1.0",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -9396,7 +9434,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.1.0",
  "signal-hook",
 ]
 
@@ -10537,7 +10576,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/cli-docs/but-forge.mdx
+++ b/cli-docs/but-forge.mdx
@@ -41,7 +41,7 @@ but forge forget <USERNAME>
 
 #### Arguments
 
-- `<USERNAME>` - The username of the forge account to forget (required)
+- `[USERNAME]` - The username of the forge account to forget (optional). If not provided, you'll be prompted to select which account(s) to forget. If only one account exists, it will be forgotten automatically.
 
 ## Examples
 

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -74,6 +74,7 @@ tracing-forest.workspace = true
 ratatui = "0.29.0"
 crossterm = "0.29.0"
 atty = "0.2.0"
+cli-prompts = "0.1.0"
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
Handle the ambiguity of deleting a forge account by interactively letting the user pick which account(s) to forget.

closes: https://github.com/gitbutlerapp/gitbutler/issues/11146