### PR TITLE
Show upstream target branch state in `but status`

### DIFF
--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -9,9 +9,12 @@ use but_project::Project;
 use but_workspace::ui::StackDetails;
 use colored::{ColoredString, Colorize};
 use gitbutler_command_context::CommandContext;
+use gix::date::time::CustomFormat;
 use serde::Serialize;
 
 use crate::CLI_DATE;
+
+const DATE_ONLY: CustomFormat = CustomFormat::new("%Y-%m-%d");
 
 pub(crate) mod assignment;
 
@@ -35,6 +38,7 @@ struct UpstreamState {
     latest_commit: String,
     message: String,
     commit_date: String,
+    last_fetched_ms: Option<u128>,
 }
 
 #[derive(Serialize)]
@@ -116,7 +120,7 @@ pub(crate) async fn worktree(
         .chars()
         .take(50)
         .collect::<String>();
-    let formatted_date = base_commit.committer().time()?.format_or_unix(CLI_DATE);
+    let formatted_date = base_commit.committer().time()?.format_or_unix(DATE_ONLY);
     let common_merge_base_data = CommonMergeBase {
         target_name: target_name.clone(),
         common_merge_base: target.sha.to_string()[..7].to_string(),
@@ -125,40 +129,45 @@ pub(crate) async fn worktree(
     };
 
     // Get cached upstream state information (without fetching)
-    let upstream_state = but_api::virtual_branches::get_base_branch_data(project.id)
-        .ok()
-        .flatten()
-        .and_then(|base_branch| {
-            if base_branch.behind > 0 {
-                // Get the latest commit on the upstream branch (current_sha is the tip of the remote branch)
-                let commit_id = base_branch.current_sha;
-                repo.find_commit(commit_id.to_gix())
-                    .ok()
-                    .and_then(|commit_obj| {
-                        let commit = commit_obj.decode().ok()?;
-                        let commit_message = commit
-                            .message
-                            .to_string()
-                            .replace('\n', " ")
-                            .chars()
-                            .take(50)
-                            .collect::<String>();
+    let (upstream_state, last_fetched_ms) =
+        but_api::virtual_branches::get_base_branch_data(project.id)
+            .ok()
+            .flatten()
+            .map(|base_branch| {
+                let last_fetched = base_branch.last_fetched_ms;
+                let state = if base_branch.behind > 0 {
+                    // Get the latest commit on the upstream branch (current_sha is the tip of the remote branch)
+                    let commit_id = base_branch.current_sha;
+                    repo.find_commit(commit_id.to_gix())
+                        .ok()
+                        .and_then(|commit_obj| {
+                            let commit = commit_obj.decode().ok()?;
+                            let commit_message = commit
+                                .message
+                                .to_string()
+                                .replace('\n', " ")
+                                .chars()
+                                .take(50)
+                                .collect::<String>();
 
-                        let formatted_date =
-                            commit.committer().time().ok()?.format_or_unix(CLI_DATE);
+                            let formatted_date =
+                                commit.committer().time().ok()?.format_or_unix(DATE_ONLY);
 
-                        Some(UpstreamState {
-                            target_name: base_branch.branch_name.clone(),
-                            behind_count: base_branch.behind,
-                            latest_commit: commit_id.to_string()[..7].to_string(),
-                            message: commit_message,
-                            commit_date: formatted_date,
+                            Some(UpstreamState {
+                                target_name: base_branch.branch_name.clone(),
+                                behind_count: base_branch.behind,
+                                latest_commit: commit_id.to_string()[..7].to_string(),
+                                message: commit_message,
+                                commit_date: formatted_date,
+                                last_fetched_ms: last_fetched,
+                            })
                         })
-                    })
-            } else {
-                None
-            }
-        });
+                } else {
+                    None
+                };
+                (state, last_fetched)
+            })
+            .unwrap_or((None, None));
 
     if json {
         let worktree_status = WorktreeStatus {
@@ -196,44 +205,76 @@ pub(crate) async fn worktree(
             &review_map,
         )?;
     }
+    // Format the last fetched time as relative time
+    let last_checked_text = last_fetched_ms
+        .map(|ms| {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
+            let elapsed_ms = now_ms.saturating_sub(ms);
+            let elapsed_secs = elapsed_ms / 1000;
+
+            let relative_time = if elapsed_secs < 60 {
+                format!("{} seconds ago", elapsed_secs)
+            } else if elapsed_secs < 3600 {
+                let minutes = elapsed_secs / 60;
+                format!(
+                    "{} {} ago",
+                    minutes,
+                    if minutes == 1 { "minute" } else { "minutes" }
+                )
+            } else if elapsed_secs < 86400 {
+                let hours = elapsed_secs / 3600;
+                format!(
+                    "{} {} ago",
+                    hours,
+                    if hours == 1 { "hour" } else { "hours" }
+                )
+            } else {
+                let days = elapsed_secs / 86400;
+                format!("{} {} ago", days, if days == 1 { "day" } else { "days" })
+            };
+
+            format!(" (checked {})", relative_time)
+        })
+        .unwrap_or_default();
+
     // Display upstream state if there are new commits
     if let Some(upstream) = &upstream_state {
         let dot = "●".yellow();
+
         writeln!(
             stdout,
-            "┊{dot} {} (upstream) ⏫ {} new commits {} {}",
+            "┊{dot} {} (upstream) ⏫ {} new commits {} {}{}",
             upstream.latest_commit.dimmed(),
             upstream.behind_count,
             upstream.commit_date.dimmed(),
-            upstream.message
-        )
-        .ok();
-        writeln!(
-            stdout,
-            "{} {} (common base) [{}] {} {}",
-            if upstream_state.is_some() {
-                "├╯"
-            } else {
-                "┊"
-            },
-            common_merge_base_data.common_merge_base.dimmed(),
-            common_merge_base_data.target_name.green().bold(),
-            common_merge_base_data.commit_date.dimmed(),
-            common_merge_base_data.message
-        )
-        .ok();
-    } else {
-        writeln!(
-            stdout,
-            "{}┴ {} (common base) [{}] {} {}",
-            if upstream_state.is_some() { "┊" } else { "" },
-            common_merge_base_data.common_merge_base.dimmed(),
-            common_merge_base_data.target_name.green().bold(),
-            common_merge_base_data.commit_date.dimmed(),
-            common_merge_base_data.message
+            upstream.message,
+            last_checked_text.dimmed()
         )
         .ok();
     }
+
+    writeln!(
+        stdout,
+        "{} {} (common base) [{}] {} {}{}",
+        if upstream_state.is_some() {
+            "├╯"
+        } else {
+            "┴"
+        },
+        common_merge_base_data.common_merge_base.dimmed(),
+        common_merge_base_data.target_name.green().bold(),
+        common_merge_base_data.commit_date.dimmed(),
+        common_merge_base_data.message,
+        if upstream_state.is_none() {
+            last_checked_text.dimmed().to_string()
+        } else {
+            String::new()
+        }
+    )
+    .ok();
     Ok(())
 }
 

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -3,7 +3,6 @@
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-green { fill: #00AA00 }
-    .fg-magenta { fill: #AA00AA }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -45,7 +44,7 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> add M </tspan>
+    <tspan x="10px" y="244px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -3,7 +3,6 @@
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-green { fill: #00AA00 }
-    .fg-magenta { fill: #AA00AA }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -41,7 +40,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> add M </tspan>
+    <tspan x="10px" y="208px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -3,7 +3,6 @@
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-green { fill: #00AA00 }
-    .fg-magenta { fill: #AA00AA }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -50,7 +49,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="280px"><tspan>┴ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>

--- a/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -3,7 +3,6 @@
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
     .fg-green { fill: #00AA00 }
-    .fg-magenta { fill: #AA00AA }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -44,7 +43,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-magenta">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="226px"><tspan>┴ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/crates/but/tests/but/status.rs
+++ b/crates/but/tests/but/status.rs
@@ -217,8 +217,9 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
     "target_name": "origin/main",
     "common_merge_base": "0dc3733",
     "message": "add M ",
-    "commit_date": "2000-01-02 00:00:00 +0000"
-  }
+    "commit_date": "2000-01-02"
+  },
+  "upstream_state": null
 }
 
 "#]]);


### PR DESCRIPTION
Display the last-known state of the upstream target branch in the `but status` output (and include it in JSON output) so users can see if their branch is behind the remote.

With upstream commits:

<img width="2202" height="420" alt="CleanShot 2025-11-11 at 13 53 47@2x" src="https://github.com/user-attachments/assets/9d46fe11-2e55-4fd8-bf01-5b7d096bb799" />


Without upstream commits:

<img width="2210" height="668" alt="CleanShot 2025-11-11 at 13 54 06@2x" src="https://github.com/user-attachments/assets/0522b103-fdf4-4c2a-af2a-5de99df5ec1b" />


