### PR TITLE
feat(ui,desktop,stories): adjust Badge layout, line and story args

### DIFF
--- a/apps/desktop/src/components/BranchBadge.svelte
+++ b/apps/desktop/src/components/BranchBadge.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <span
-	class={[!unstyled && 'text-10 text-bold branch-badge', 'truncate']}
+	class={[!unstyled && 'text-11 text-bold branch-badge', 'truncate']}
 	style:--b-bg-color={bgColor}
 >
 	{label}

--- a/apps/desktop/src/components/BranchExplorer.svelte
+++ b/apps/desktop/src/components/BranchExplorer.svelte
@@ -260,7 +260,6 @@
 		justify-content: flex-end;
 		width: 100%;
 		height: 32px;
-
 		margin-bottom: 8px;
 	}
 
@@ -270,7 +269,7 @@
 		top: 50%;
 		left: 0;
 		align-items: center;
-		gap: 4px;
+		gap: 6px;
 		transform: translateY(-50%);
 
 		transition:

--- a/apps/desktop/src/components/CommitRow.svelte
+++ b/apps/desktop/src/components/CommitRow.svelte
@@ -180,7 +180,7 @@
 						onclick={openGerritReview}
 						title="Open Gerrit review #{reviewId}"
 					>
-						<span class="text-10 text-semibold">{reviewId}</span>
+						<span class="text-11 text-semibold">{reviewId}</span>
 					</div>
 				{/if}
 			{/if}

--- a/packages/ui/src/lib/components/Badge.svelte
+++ b/packages/ui/src/lib/components/Badge.svelte
@@ -12,10 +12,10 @@
 		size?: 'icon' | 'tag';
 		class?: string;
 		icon?: keyof typeof iconsJson | undefined;
-		reversedDirection?: boolean;
 		tooltip?: string;
 		children?: Snippet;
 		onclick?: (e: MouseEvent) => void;
+		reversedDirection?: boolean;
 	}
 
 	const {
@@ -25,10 +25,10 @@
 		size = 'icon',
 		class: className = '',
 		icon,
-		reversedDirection,
 		tooltip,
 		children,
-		onclick
+		onclick,
+		reversedDirection = false
 	}: Props = $props();
 </script>
 
@@ -39,13 +39,11 @@
 	<div
 		data-testid={testId}
 		class="badge {style} {kind} {size}-size {className}"
-		class:reversedDirection
+		class:reversed={reversedDirection}
 		{onclick}
 	>
 		{#if children}
-			<span class="badge__label {size === 'icon' ? 'text-10' : 'text-11'} text-semibold"
-				>{@render children()}</span
-			>
+			<span class="badge__label text-11 text-semibold">{@render children()}</span>
 		{/if}
 		{#if icon}
 			<i class="badge__icon">
@@ -163,37 +161,36 @@
 			}
 		}
 
-		/* REVERSED DIRECTION */
-		&.reversedDirection {
+		&.reversed {
 			flex-direction: row-reverse;
 
-			&.icon-size .badge__label {
-				padding: 0 5px 0 2px;
+			&.icon-size {
+				& .badge__label {
+					padding: 0 5px 0 2px;
+				}
+
+				& .badge__icon {
+					padding-right: 0;
+					padding-left: 2px;
+				}
 			}
 
-			&.tag-size .badge__label {
-				padding: 0 8px 0 2px;
-			}
+			&.tag-size {
+				& .badge__label {
+					padding: 0 8px 0 2px;
+				}
 
-			&.tag-size .badge__icon {
-				padding-right: 0;
-				padding-left: 4px;
-			}
-
-			/* When reversed and no icon, padding stays equal */
-			&.icon-size:not(:has(.badge__icon)) .badge__label {
-				padding: 0 5px;
-			}
-
-			&.tag-size:not(:has(.badge__icon)) .badge__label {
-				padding: 0 8px;
+				& .badge__icon {
+					padding-right: 0;
+					padding-left: 4px;
+				}
 			}
 		}
 	}
 
 	.badge__label {
 		display: flex;
-		line-height: 1;
+		line-height: var(--size-icon);
 		white-space: nowrap;
 	}
 

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -166,8 +166,7 @@
 			<span
 				class="btn-label text-semibold truncate"
 				class:text-12={size === 'button' || size === 'cta'}
-				class:text-11={size === 'tag'}
-				class:text-10={size === 'icon'}
+				class:text-11={size === 'tag' || size === 'icon'}
 			>
 				{@render children()}
 

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -64,7 +64,7 @@
 			{/if}
 		</div>
 
-		<span class="text-10 text-semibold review-badge-text">
+		<span class="text-11 text-semibold review-badge-text">
 			{#if status === 'draft'}
 				Draft
 			{:else}

--- a/packages/ui/src/stories/components/Badge.stories.svelte
+++ b/packages/ui/src/stories/components/Badge.stories.svelte
@@ -5,17 +5,16 @@
 
 	const { Story } = defineMeta({
 		title: 'Basic / Badge',
-		component: Badge,
+		component: Badge as any,
 		args: {
-			children,
+			text: 'Badge',
 			style: 'neutral',
 			kind: 'solid',
 			size: 'icon',
-			icon: undefined,
-			reversedDirection: false
+			icon: undefined
 		},
 		argTypes: {
-			children: {
+			text: {
 				control: { type: 'text' }
 			},
 			style: {
@@ -38,20 +37,11 @@
 	});
 </script>
 
-{#snippet children()}
-	Badge
-{/snippet}
-
 <Story name="default">
 	{#snippet template(args)}
-		<Badge
-			style={args.style}
-			kind={args.kind}
-			icon={args.icon}
-			size={args.size}
-			reversedDirection={args.reversedDirection}
-			children={args.children}
-		></Badge>
+		<Badge style={args.style} kind={args.kind} icon={args.icon} size={args.size}>
+			{args.text}
+		</Badge>
 	{/snippet}
 </Story>
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `Badge` component in the UI package, along with minor style adjustments to the `BranchExplorer` component. The main focus is on simplifying the badge label rendering, refining reversed direction styling, and updating the Badge stories for clarity and consistency.

**Badge component improvements:**

* Simplified the rendering logic for the badge label by removing conditional text size classes and always using `text-11 text-semibold` for the label.
* Refactored and clarified the CSS for reversed direction badges, consolidating padding rules and separating the flex direction styling for better maintainability. [[1]](diffhunk://#diff-ac04917671203e45f25d09f2c6187c494847f3054de015b9fda932a546e7c64fR142-R150) [[2]](diffhunk://#diff-ac04917671203e45f25d09f2c6187c494847f3054de015b9fda932a546e7c64fL164-R195)

**Badge stories refactor:**

* Updated `Badge.stories.svelte` to use a `text` prop instead of `children`, and adjusted the story template to pass the label as a child element, improving story clarity and usage. [[1]](diffhunk://#diff-53480a112d27b689df0936ba77b2dd929bfe84414b1ce91c018e93c8b27e867dL8-R18) [[2]](diffhunk://#diff-53480a112d27b689df0936ba77b2dd929bfe84414b1ce91c018e93c8b27e867dL41-L44) [[3]](diffhunk://#diff-53480a112d27b689df0936ba77b2dd929bfe84414b1ce91c018e93c8b27e867dL53-R51)

**BranchExplorer style tweaks:**

* Increased the gap between items in the `BranchExplorer` component from 4px to 6px for improved spacing.