### PR TITLE
but: Review takes the commit as a default message

### DIFF
--- a/cli-docs/but-review.mdx
+++ b/cli-docs/but-review.mdx
@@ -53,7 +53,8 @@ Run pre-push hooks.
 
 ### `-t, --default`
 
-Use just the branch name as the review title, without opening an editor.
+Use the default content for the review title and description, skipping any prompts.
+If the review contains only a single commit, the commit message will be used for the review title and description.
 
 - **Type:** Flag (boolean)
 - **Default:** `false`


### PR DESCRIPTION
The but review publish command will take the title and description from the commit in the
branch about to be published, if there's only one commit.

This is one part of https://github.com/gitbutlerapp/gitbutler/issues/11165