### PR TITLE
Fix codegen file mention bug that deletes rest of line

### DIFF
--- a/packages/ui/src/lib/richText/plugins/FilePlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/FilePlugin.svelte
@@ -80,13 +80,23 @@
 			if (!isTextNode(anchorNode)) return;
 
 			const offset = anchor.offset;
-			const text = anchorNode.getTextContent().slice(0, offset);
+			const fullText = anchorNode.getTextContent();
+			const textBeforeCursor = fullText.slice(0, offset);
+			const textAfterCursor = fullText.slice(offset);
 			const match = '@' + fileStart;
-			if (text.includes(match)) {
-				const newText = text.replace(match, '`' + path + '`');
+			const matchIndex = textBeforeCursor.lastIndexOf(match);
+			if (matchIndex !== -1) {
+				const replacement = '`' + path + '`';
+				const newTextBefore =
+					textBeforeCursor.slice(0, matchIndex) +
+					replacement +
+					textBeforeCursor.slice(matchIndex + match.length);
+				const newText = newTextBefore + textAfterCursor;
 				const newNode = new TextNode(newText);
+				const selectionStart = matchIndex;
+				const selectionEnd = matchIndex + replacement.length;
 				anchorNode.replace(newNode);
-				newNode.selectEnd();
+				newNode.select(selectionStart, selectionEnd);
 			}
 		});
 


### PR DESCRIPTION
<img width="649" height="128" alt="image" src="https://github.com/user-attachments/assets/29313026-f085-4515-989f-39537d3bb7c9" />

- Select inserted text
- Do not truncate the rest of the line
- Handle multiple occurrences of file trigger
- Improve cursor placement after inserting file path
- Default to no-op when the expected file match is absent