### PR TITLE
Add inline code node and plugin for rich text

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -16,7 +16,14 @@
 	import { FILE_SERVICE } from '$lib/files/fileService';
 	import { showError } from '$lib/notifications/toasts';
 	import { inject } from '@gitbutler/core/context';
-	import { Tooltip, AsyncButton, RichTextEditor, FilePlugin, UpDownPlugin } from '@gitbutler/ui';
+	import {
+		Tooltip,
+		AsyncButton,
+		RichTextEditor,
+		FilePlugin,
+		UpDownPlugin,
+		InlineCodePlugin
+	} from '@gitbutler/ui';
 	import { tick, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import type { FileSuggestionUpdate } from '@gitbutler/ui/richText/plugins/FilePlugin.svelte';
@@ -286,6 +293,7 @@
 							}
 						}}
 					/>
+					<InlineCodePlugin />
 				{/snippet}
 			</RichTextEditor>
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -143,6 +143,7 @@ export { default as Formatter } from '$lib/richText/plugins/Formatter.svelte';
 export { default as GhostTextPlugin } from '$lib/richText/plugins/GhostText.svelte';
 export { default as HardWrapPlugin } from '$lib/richText/plugins/HardWrapPlugin.svelte';
 export { default as FilePlugin } from '$lib/richText/plugins/FilePlugin.svelte';
+export { default as InlineCodePlugin } from '$lib/richText/plugins/InlineCodePlugin.svelte';
 export { default as UpDownPlugin } from '$lib/richText/plugins/UpDownPlugin.svelte';
 export {
 	default as Mention,

--- a/packages/ui/src/lib/richText/config/config.ts
+++ b/packages/ui/src/lib/richText/config/config.ts
@@ -1,5 +1,6 @@
 import { EmojiNode } from '$lib/richText/node/emoji';
 import { GhostText } from '$lib/richText/node/ghostText';
+import { InlineCodeNode } from '$lib/richText/node/inlineCode';
 import { MentionNode } from '$lib/richText/node/mention';
 import {
 	HeadingNode,
@@ -91,6 +92,7 @@ export function standardConfig(args: {
 			CodeHighlightNode,
 			EmojiNode,
 			KeywordNode,
+			InlineCodeNode,
 			MentionNode,
 			GhostText
 		]

--- a/packages/ui/src/lib/richText/css/component.css
+++ b/packages/ui/src/lib/richText/css/component.css
@@ -260,6 +260,19 @@
 	color: var(--clr-theme-pop-on-soft);
 }
 
+.inline-code {
+	padding: 2px 4px;
+	border-radius: var(--radius-s);
+	background: var(--clr-bg-2);
+	font-size: 0.9em;
+	font-family: var(--font-mono);
+}
+
+.inline-code:focus {
+	outline: none;
+	box-shadow: rgb(180 213 255) 0px 0px 0px 2px;
+}
+
 .filepath {
 	border-radius: var(--radius-s);
 	background: var(--clr-theme-scale-pop-80);

--- a/packages/ui/src/lib/richText/getText.ts
+++ b/packages/ui/src/lib/richText/getText.ts
@@ -1,5 +1,37 @@
 import { getMarkdownString } from '$lib/richText/markdown';
-import { $getRoot as getRoot } from 'lexical';
+import { isInlineCodeNode } from '$lib/richText/node/inlineCode';
+import {
+	$getRoot as getRoot,
+	$isTextNode as isTextNode,
+	$isElementNode as isElementNode,
+	type LexicalNode
+} from 'lexical';
+
+/**
+ * Gets text content with inline code nodes wrapped in backticks
+ */
+function getTextContentWithInlineCode(): string {
+	const root = getRoot();
+	const parts: string[] = [];
+
+	root.getChildren().forEach((child) => {
+		if (!isElementNode(child)) return;
+
+		child.getChildren().forEach((node: LexicalNode) => {
+			if (isInlineCodeNode(node)) {
+				parts.push(`\`${node.getTextContent()}\``);
+			} else if (isTextNode(node)) {
+				parts.push(node.getTextContent());
+			} else {
+				parts.push(node.getTextContent());
+			}
+		});
+		parts.push('\n');
+	});
+
+	// Remove trailing newline
+	return parts.join('').replace(/\n$/, '');
+}
 
 /**
  * Should only be called inside of an editor scope.
@@ -9,5 +41,5 @@ import { $getRoot as getRoot } from 'lexical';
 export function getCurrentText(markdown: boolean, maxLength?: number) {
 	// If WYSIWYG is enabled, we need to transform the content to markdown strings
 	if (markdown) return getMarkdownString(maxLength);
-	return getRoot().getTextContent();
+	return getTextContentWithInlineCode();
 }

--- a/packages/ui/src/lib/richText/node/inlineCode.ts
+++ b/packages/ui/src/lib/richText/node/inlineCode.ts
@@ -1,0 +1,170 @@
+import {
+	TextNode,
+	type BaseSelection,
+	type EditorConfig,
+	type LexicalNode,
+	type NodeKey,
+	type SerializedTextNode,
+	type Spread,
+	$isRangeSelection as isRangeSelection,
+	$isTextNode as isTextNode,
+	$createTextNode as createTextNode
+} from 'lexical';
+
+const BACKTICK_REGEX = /(^|\s)(`([^`]+)`)$/;
+
+export type InlineCodeMatch = {
+	end: number;
+	start: number;
+	code: string;
+};
+
+/**
+ * Return information about the inline code match in the text, if there's any
+ */
+export function getInlineCodeMatch(text: string): InlineCodeMatch | null {
+	const matchArr = BACKTICK_REGEX.exec(text);
+	if (matchArr === null) {
+		return null;
+	}
+
+	const codeLength = matchArr[2].length;
+	const startOffset = matchArr.index + matchArr[1].length;
+	const endOffset = startOffset + codeLength;
+	const code = matchArr[3];
+
+	return {
+		end: endOffset,
+		start: startOffset,
+		code
+	};
+}
+
+export type SerializedInlineCodeNode = Spread<
+	{
+		type: 'inline-code';
+		code: string;
+	},
+	SerializedTextNode
+>;
+
+export class InlineCodeNode extends TextNode {
+	__code: string;
+
+	static getType(): string {
+		return 'inline-code';
+	}
+
+	static clone(node: InlineCodeNode): InlineCodeNode {
+		return new InlineCodeNode(node.__code, node.__key);
+	}
+
+	constructor(code: string, key?: NodeKey) {
+		super(code, key);
+		this.__code = code;
+	}
+
+	createDOM(config: EditorConfig): HTMLElement {
+		const dom = document.createElement('code');
+		const inner = super.createDOM(config);
+		dom.className = 'inline-code';
+		inner.className = 'inline-code-inner';
+		dom.appendChild(inner);
+		return dom;
+	}
+
+	static importJSON(serializedNode: SerializedInlineCodeNode): InlineCodeNode {
+		const node = createInlineCodeNode(serializedNode.code);
+		node.setFormat(serializedNode.format);
+		node.setDetail(serializedNode.detail);
+		node.setMode(serializedNode.mode);
+		node.setStyle(serializedNode.style);
+		return node;
+	}
+
+	exportJSON(): SerializedInlineCodeNode {
+		return {
+			...super.exportJSON(),
+			type: 'inline-code',
+			code: this.__code
+		};
+	}
+
+	updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
+		const inner = dom.firstChild;
+		if (inner === null) {
+			return true;
+		}
+		super.updateDOM(prevNode, inner as HTMLElement, config);
+		return false;
+	}
+
+	canInsertTextBefore(): boolean {
+		return false;
+	}
+
+	canInsertTextAfter(): boolean {
+		return false;
+	}
+
+	isTextEntity(): boolean {
+		return false;
+	}
+
+	getTextContent(): string {
+		return this.__code;
+	}
+
+	setTextContent(text: string): this {
+		const writable = this.getWritable();
+		writable.__code = text;
+		writable.__text = text;
+		return writable;
+	}
+}
+
+export function createInlineCodeNode(code: string): InlineCodeNode {
+	return new InlineCodeNode(code);
+}
+
+export function isInlineCodeNode(node: LexicalNode): node is InlineCodeNode {
+	return node instanceof InlineCodeNode;
+}
+
+function getTextSurroundingCode(text: string, start: number, end: number): [string, string] {
+	const before = text.slice(0, start);
+	let after = text.slice(end);
+	after = after.startsWith(' ') ? after : ' ' + after;
+
+	return [before, after];
+}
+
+interface InlineCodeInsertionParams {
+	selection: BaseSelection | null;
+	start: number;
+	end: number;
+	code: string;
+}
+
+export function insertInlineCode(params: InlineCodeInsertionParams) {
+	const { selection, start, end, code } = params;
+	if (!isRangeSelection(selection)) return;
+
+	const nodes = selection.getNodes();
+
+	// Has to be the last node of the selection since we are replacing the
+	// last thing the user typed.
+	const lastNode = nodes[nodes.length - 1];
+	if (!isTextNode(lastNode)) return;
+
+	const text = lastNode.getTextContent();
+	const [before, after] = getTextSurroundingCode(text, start, end);
+
+	lastNode.setTextContent(before);
+
+	const inlineCode = createInlineCodeNode(code);
+
+	lastNode.insertAfter(inlineCode);
+	const suffix = inlineCode.insertAfter(createTextNode(after));
+	suffix.selectEnd();
+}

--- a/packages/ui/src/lib/richText/plugins/InlineCodePlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/InlineCodePlugin.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { getEditor } from '$lib/richText/context';
+	import { createInlineCodeNode, isInlineCodeNode } from '$lib/richText/node/inlineCode';
+	import {
+		$getSelection as getSelection,
+		$isRangeSelection as isRangeSelection,
+		$isTextNode as isTextNode,
+		$createTextNode as createTextNode,
+		type TextNode
+	} from 'lexical';
+
+	const editor = getEditor();
+
+	/**
+	 * Parse a text node's content and split it into text and inline code nodes
+	 */
+	function parseAndReplaceTextNode(node: TextNode) {
+		const text = node.getTextContent();
+		const backtickRegex = /`([^`]+)`/g;
+		const matches: Array<{ start: number; end: number; code: string }> = [];
+		let match;
+
+		// Find all backtick matches
+		while ((match = backtickRegex.exec(text)) !== null) {
+			matches.push({
+				start: match.index,
+				end: backtickRegex.lastIndex,
+				code: match[1]
+			});
+		}
+
+		// If no matches, nothing to do
+		if (matches.length === 0) {
+			return;
+		}
+
+		// Build array of nodes to replace the current text node
+		const newNodes: Array<TextNode> = [];
+		let lastIndex = 0;
+
+		for (const match of matches) {
+			// Add text before the match
+			if (match.start > lastIndex) {
+				const beforeText = text.slice(lastIndex, match.start);
+				newNodes.push(createTextNode(beforeText));
+			}
+
+			// Add inline code node
+			newNodes.push(createInlineCodeNode(match.code));
+
+			lastIndex = match.end;
+		}
+
+		// Add remaining text after the last match
+		if (lastIndex < text.length) {
+			const remainingText = text.slice(lastIndex);
+			newNodes.push(createTextNode(remainingText));
+		}
+
+		// Replace the node with the new nodes
+		if (newNodes.length > 0) {
+			const firstNode = newNodes[0];
+			node.replace(firstNode);
+
+			// Insert the rest of the nodes after the first one
+			let prevNode = firstNode;
+			for (let i = 1; i < newNodes.length; i++) {
+				prevNode.insertAfter(newNodes[i]);
+				prevNode = newNodes[i];
+			}
+
+			// Restore selection - always select the end of the last node
+			const lastNode = newNodes[newNodes.length - 1];
+			lastNode.selectEnd();
+		}
+	}
+
+	$effect(() => {
+		return editor.registerUpdateListener(({ editorState, dirtyLeaves, tags }) => {
+			if (tags.has('history-merge') || dirtyLeaves.size === 0) {
+				return;
+			}
+
+			editorState.read(() => {
+				const selection = getSelection();
+				if (!isRangeSelection(selection)) {
+					return;
+				}
+
+				const anchorNode = selection.anchor.getNode();
+				if (!isTextNode(anchorNode) || isInlineCodeNode(anchorNode)) {
+					return;
+				}
+
+				// Only process if the text contains backticks
+				const text = anchorNode.getTextContent();
+				if (!text.includes('`')) {
+					return;
+				}
+
+				// Check if we have complete backtick pairs
+				const backtickCount = (text.match(/`/g) || []).length;
+				if (backtickCount < 2 || backtickCount % 2 !== 0) {
+					// Incomplete pairs, don't process yet
+					return;
+				}
+
+				// Parse and replace the text node
+				editor.update(() => {
+					parseAndReplaceTextNode(anchorNode);
+				});
+			});
+		});
+	});
+</script>

--- a/packages/ui/src/lib/richText/selection.ts
+++ b/packages/ui/src/lib/richText/selection.ts
@@ -1,3 +1,4 @@
+import { createInlineCodeNode } from '$lib/richText/node/inlineCode';
 import {
 	$isRangeSelection,
 	$getSelection,
@@ -217,6 +218,43 @@ export function insertTextAtCaret(editor: LexicalEditor, text: string) {
 	});
 }
 
+/**
+ * Parse a line of text and create nodes, converting backtick-wrapped text to InlineCodeNodes
+ */
+function parseLineToNodes(line: string): TextNode[] {
+	const nodes: TextNode[] = [];
+	const backtickRegex = /`([^`]+)`/g;
+	let lastIndex = 0;
+	let match;
+
+	while ((match = backtickRegex.exec(line)) !== null) {
+		// Add text before the backtick match
+		if (match.index > lastIndex) {
+			const beforeText = line.slice(lastIndex, match.index);
+			nodes.push($createTextNode(beforeText));
+		}
+
+		// Add inline code node
+		const code = match[1];
+		nodes.push(createInlineCodeNode(code));
+
+		lastIndex = backtickRegex.lastIndex;
+	}
+
+	// Add remaining text after the last match
+	if (lastIndex < line.length) {
+		const remainingText = line.slice(lastIndex);
+		nodes.push($createTextNode(remainingText));
+	}
+
+	// If no matches were found, return a single text node with the whole line
+	if (nodes.length === 0) {
+		nodes.push($createTextNode(line));
+	}
+
+	return nodes;
+}
+
 export function setEditorText(editor: LexicalEditor, text: string) {
 	editor.update(() => {
 		const root = $getRoot();
@@ -224,8 +262,8 @@ export function setEditorText(editor: LexicalEditor, text: string) {
 		const paragraphNode = $createParagraphNode();
 		const lines = text.split('\n');
 		for (let i = 0; i < lines.length; i++) {
-			const textNode = $createTextNode(lines[i]);
-			paragraphNode.append(textNode);
+			const lineNodes = parseLineToNodes(lines[i]);
+			lineNodes.forEach((node) => paragraphNode.append(node));
 			// Only add line break if it's not the last line
 			if (i < lines.length - 1) {
 				paragraphNode.append($createLineBreakNode());

--- a/packages/ui/src/stories/components/RichTextEditor.stories.svelte
+++ b/packages/ui/src/stories/components/RichTextEditor.stories.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
 	import RichTextEditor from '$lib/richText/RichTextEditor.svelte';
 	import Formatter from '$lib/richText/plugins/Formatter.svelte';
+	import InlineCodePlugin from '$lib/richText/plugins/InlineCodePlugin.svelte';
 	import UpDownPlugin from '$lib/richText/plugins/UpDownPlugin.svelte';
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
@@ -35,6 +36,7 @@
 				>
 					{#snippet plugins()}
 						<Formatter bind:this={formatter} />
+						<InlineCodePlugin />
 						<UpDownPlugin historyLookup={async (offset) => `offset ${offset}`} />
 					{/snippet}
 				</RichTextEditor>


### PR DESCRIPTION
Using a new `InlineCodeNode` extension to the lexical editor.