### PR TITLE
codegen-fixes

### DIFF
--- a/apps/desktop/src/components/CommitDetails.svelte
+++ b/apps/desktop/src/components/CommitDetails.svelte
@@ -98,7 +98,11 @@
 				{abbreviated}
 			{/if}
 			{#if isAbbrev}
-				<button onclick={() => (expanded = !expanded)} type="button" class="readmore text-bold">
+				<button
+					onclick={() => (expanded = !expanded)}
+					type="button"
+					class="readmore underline-dotted text-bold"
+				>
 					{#if expanded}
 						less
 					{:else}
@@ -134,7 +138,7 @@
 		display: flex;
 		align-items: center;
 		gap: 2px;
-		text-decoration: underline dotted;
+		font-family: var(--font-mono);
 	}
 
 	.description {
@@ -147,6 +151,5 @@
 	.readmore {
 		display: inline;
 		position: relative;
-		text-decoration: underline dotted;
 	}
 </style>

--- a/apps/desktop/src/components/codegen/CodegenGitButlerMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenGitButlerMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CommitDetails from '$components/CommitDetails.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
+	import ExpandableSection from '$components/codegen/ExpandableSection.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { Icon } from '@gitbutler/ui';
@@ -14,58 +15,41 @@
 	let { projectId, message }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
-
-	let expanded = $state(false);
 </script>
 
 {#if message.type === 'commitCreated'}
 	<div class="system-message">
-		<button
-			type="button"
-			class="tool-btn"
-			class:expanded
-			onclick={() => {
-				expanded = !expanded;
-			}}
-		>
-			<div class="tool-btn__arrow" class:expanded>
-				<Icon name="chevron-right" />
-			</div>
-
-			<span class="tool-btn__label text-13 text-semibold m-r-2">
-				New commit{message.commitIds.length > 1 ? 's' : ''} created
-			</span>
-
-			{#if !expanded}
+		<ExpandableSection root label="New commit{message.commitIds.length > 1 ? 's' : ''} created">
+			{#snippet summary()}
 				{#each message.commitIds as commitId}
 					<div class="commit-hash">
 						<Icon name="commit" color="var(--clr-text-3)" />
 						<span>{commitId.slice(0, 7)}</span>
 					</div>
 				{/each}
-			{/if}
-		</button>
+			{/snippet}
 
-		{#if expanded}
-			{#each message.commitIds as commitId}
-				{@const commit = stackService.commitDetails(projectId, commitId)}
-				<div class="stack-v gap-8">
-					<ReduxResult {projectId} result={commit.result}>
-						{#snippet children(commit)}
-							<div class="commit-bubble">
-								<CommitDetails {commit} />
-							</div>
-						{/snippet}
-						{#snippet empty()}
-							<div class="commit-not-found text-12">
-								<Icon name="error-small" color="var(--clr-text-2)" />
-								<span>Commit {commitId.slice(0, 7)} not found</span>
-							</div>
-						{/snippet}
-					</ReduxResult>
-				</div>
-			{/each}
-		{/if}
+			{#snippet content()}
+				{#each message.commitIds as commitId}
+					{@const commit = stackService.commitDetails(projectId, commitId)}
+					<div class="stack-v gap-8">
+						<ReduxResult {projectId} result={commit.result}>
+							{#snippet children(commit)}
+								<div class="commit-bubble">
+									<CommitDetails {commit} />
+								</div>
+							{/snippet}
+							{#snippet empty()}
+								<div class="commit-not-found text-12">
+									<Icon name="error-small" color="var(--clr-text-2)" />
+									<span>Commit {commitId.slice(0, 7)} not found</span>
+								</div>
+							{/snippet}
+						</ReduxResult>
+					</div>
+				{/each}
+			{/snippet}
+		</ExpandableSection>
 	</div>
 {/if}
 
@@ -94,35 +78,6 @@
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-2);
 		color: var(--clr-text-2);
-	}
-
-	.tool-btn {
-		display: flex;
-		align-items: center;
-		width: fit-content;
-		gap: 6px;
-		user-select: none;
-
-		&:hover {
-			.tool-btn__arrow {
-				color: var(--clr-text-2);
-			}
-		}
-	}
-
-	.tool-btn__arrow {
-		display: flex;
-		margin-left: -2px;
-		color: var(--clr-text-3);
-		transition: transform var(--transition-medium);
-
-		&.expanded {
-			transform: rotate(90deg);
-		}
-	}
-
-	.tool-btn__label {
-		white-space: nowrap;
 	}
 
 	.commit-hash {

--- a/apps/desktop/src/components/codegen/CodegenGitButlerMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenGitButlerMessage.svelte
@@ -3,6 +3,7 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { inject } from '@gitbutler/core/context';
+	import { Icon } from '@gitbutler/ui';
 	import type { GitButlerUpdate } from '$lib/codegen/types';
 
 	interface Props {
@@ -13,24 +14,58 @@
 	let { projectId, message }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
+
+	let expanded = $state(false);
 </script>
 
 {#if message.type === 'commitCreated'}
-	<div class="system-message text-13">
-		<p>New commit{message.commitIds.length > 1 ? 's' : ''} created!</p>
-		{#each message.commitIds as commitId}
-			{@const commit = stackService.commitDetails(projectId, commitId)}
-			<ReduxResult {projectId} result={commit.result}>
-				{#snippet children(commit)}
-					<div class="commit-bubble">
-						<CommitDetails {commit} />
+	<div class="system-message">
+		<button
+			type="button"
+			class="tool-btn"
+			class:expanded
+			onclick={() => {
+				expanded = !expanded;
+			}}
+		>
+			<div class="tool-btn__arrow" class:expanded>
+				<Icon name="chevron-right" />
+			</div>
+
+			<span class="tool-btn__label text-13 text-semibold m-r-2">
+				New commit{message.commitIds.length > 1 ? 's' : ''} created
+			</span>
+
+			{#if !expanded}
+				{#each message.commitIds as commitId}
+					<div class="commit-hash">
+						<Icon name="commit" color="var(--clr-text-3)" />
+						<span>{commitId.slice(0, 7)}</span>
 					</div>
-				{/snippet}
-				{#snippet empty()}
-					Commit {commitId.slice(0, 7)} not found
-				{/snippet}
-			</ReduxResult>
-		{/each}
+				{/each}
+			{/if}
+		</button>
+
+		{#if expanded}
+			{#each message.commitIds as commitId}
+				{@const commit = stackService.commitDetails(projectId, commitId)}
+				<div class="stack-v gap-8">
+					<ReduxResult {projectId} result={commit.result}>
+						{#snippet children(commit)}
+							<div class="commit-bubble">
+								<CommitDetails {commit} />
+							</div>
+						{/snippet}
+						{#snippet empty()}
+							<div class="commit-not-found text-12">
+								<Icon name="error-small" color="var(--clr-text-2)" />
+								<span>Commit {commitId.slice(0, 7)} not found</span>
+							</div>
+						{/snippet}
+					</ReduxResult>
+				</div>
+			{/each}
+		{/if}
 	</div>
 {/if}
 
@@ -44,9 +79,59 @@
 	}
 
 	.commit-bubble {
-		max-width: var(--message-max-width);
+		max-width: 520px;
 		overflow: hidden;
-		border-radius: var(--radius-ml);
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.commit-not-found {
+		display: flex;
+		align-items: center;
+		width: fit-content;
+		padding: 12px;
+		gap: 6px;
+		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-2);
+		color: var(--clr-text-2);
+	}
+
+	.tool-btn {
+		display: flex;
+		align-items: center;
+		width: fit-content;
+		gap: 6px;
+		user-select: none;
+
+		&:hover {
+			.tool-btn__arrow {
+				color: var(--clr-text-2);
+			}
+		}
+	}
+
+	.tool-btn__arrow {
+		display: flex;
+		margin-left: -2px;
+		color: var(--clr-text-3);
+		transition: transform var(--transition-medium);
+
+		&.expanded {
+			transform: rotate(90deg);
+		}
+	}
+
+	.tool-btn__label {
+		white-space: nowrap;
+	}
+
+	.commit-hash {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		color: var(--clr-text-2);
+		font-size: 0.78rem;
+		line-height: 1;
+		font-family: var(--font-mono);
 	}
 </style>

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -26,7 +26,7 @@
 		{#snippet content()}
 			{#if toolCall.result}
 				<div class="stack-v gap-6 m-b-8">
-					<Codeblock label="Tool Call Input:" content={formatToolCall(toolCall)} />
+					<Codeblock label="Tool call input:" content={formatToolCall(toolCall)} />
 					<Codeblock content={toolCall.result.slice(0, 65536)} />
 				</div>
 			{/if}

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -24,16 +24,19 @@
 			expanded = !expanded;
 		}}
 	>
-		<div class="tool-call-header__arrow">
-			<Icon name="chevron-right" />
-		</div>
-		{#if toolCallLoading(toolCall)}
-			<Icon name="spinner" />
-		{:else}
-			<Icon name={getToolIcon(toolCall.name)} color="var(--clr-text-3)" />
-		{/if}
+		<div class="flex items-center gap-6">
+			<div class="tool-call-header__arrow">
+				<Icon name="chevron-right" />
+			</div>
+			{#if toolCallLoading(toolCall)}
+				<Icon name="spinner" />
+			{:else}
+				<Icon name={getToolIcon(toolCall.name)} color="var(--clr-text-3)" />
+			{/if}
 
-		<span class="tool-name">{toolCall.name}</span>
+			<span class="tool-name">{toolCall.name}</span>
+		</div>
+
 		<span class="summary truncate">{formatToolCall(toolCall)}</span>
 	</button>
 

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import Codeblock from '$components/codegen/Codeblock.svelte';
+	import ExpandableSection from '$components/codegen/ExpandableSection.svelte';
 	import { toolCallLoading, type ToolCall } from '$lib/codegen/messages';
 	import { formatToolCall, getToolIcon } from '$lib/utils/codegenTools';
-	import { Icon } from '@gitbutler/ui';
 
 	type Props = {
 		projectId: string;
@@ -11,52 +11,31 @@
 		fullWidth?: boolean;
 	};
 	const { toolCall, style, fullWidth }: Props = $props();
-
-	let expanded = $state(false);
 </script>
 
 <div class="tool-call {style}" class:full-width={fullWidth}>
-	<button
-		type="button"
-		class="tool-details text-13"
-		class:expanded
-		onclick={() => {
-			expanded = !expanded;
-		}}
+	<ExpandableSection
+		label={toolCall.name}
+		icon={getToolIcon(toolCall.name)}
+		loading={toolCallLoading(toolCall)}
 	>
-		<div class="flex items-center gap-6">
-			<div class="tool-call-header__arrow">
-				<Icon name="chevron-right" />
-			</div>
-			{#if toolCallLoading(toolCall)}
-				<Icon name="spinner" />
-			{:else}
-				<Icon name={getToolIcon(toolCall.name)} color="var(--clr-text-3)" />
+		{#snippet summary()}
+			<span class="summary truncate">{formatToolCall(toolCall)}</span>
+		{/snippet}
+
+		{#snippet content()}
+			{#if toolCall.result}
+				<div class="stack-v gap-6 m-b-8">
+					<Codeblock label="Tool Call Input:" content={formatToolCall(toolCall)} />
+					<Codeblock content={toolCall.result.slice(0, 65536)} />
+				</div>
 			{/if}
-
-			<span class="tool-name">{toolCall.name}</span>
-		</div>
-
-		<span class="summary truncate">{formatToolCall(toolCall)}</span>
-	</button>
-
-	{#if expanded && toolCall.result}
-		<div class="stack-v gap-6 m-b-8">
-			<Codeblock label="Tool Call Input:" content={formatToolCall(toolCall)} />
-			<Codeblock content={toolCall.result.slice(0, 65536)} />
-		</div>
-	{/if}
+		{/snippet}
+	</ExpandableSection>
 </div>
 
 <style lang="postcss">
 	.tool-call {
-		display: flex;
-		flex-direction: column;
-		max-width: 100%;
-		overflow: hidden;
-		gap: 12px;
-		user-select: text;
-
 		&:not(.full-width) {
 			max-width: var(--message-max-width);
 		}
@@ -67,57 +46,6 @@
 		&.standalone {
 			padding: 12px 0;
 		}
-	}
-
-	.tool-details {
-		display: flex;
-		position: relative;
-		align-items: center;
-		gap: 8px;
-
-		&:hover {
-			.tool-call-header__arrow {
-				color: var(--clr-text-2);
-			}
-		}
-	}
-
-	.tool-call-header__arrow {
-		display: flex;
-		margin-left: -2px;
-		color: var(--clr-text-3);
-		transition:
-			background-color var(--transition-fast),
-			transform var(--transition-medium);
-	}
-
-	.expanded .tool-call-header__arrow {
-		transform: rotate(90deg);
-	}
-
-	.tool-call-wrapper {
-		max-height: 20lh;
-		margin-bottom: 12px;
-		overflow: auto;
-		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-2);
-
-		&.border {
-			border: 1px solid var(--clr-border-3);
-		}
-	}
-
-	.tool-call-content {
-		padding: 10px 14px;
-		font-family: var(--font-mono);
-		white-space: pre-line;
-	}
-
-	.tool-call-content :global(pre) {
-	}
-
-	.tool-name {
-		white-space: nowrap;
 	}
 
 	.summary {

--- a/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CodegenToolCall from '$components/codegen/CodegenToolCall.svelte';
+	import ExpandableSection from '$components/codegen/ExpandableSection.svelte';
 	import { toolCallLoading, type ToolCall } from '$lib/codegen/messages';
 	import { getToolIcon } from '$lib/utils/codegenTools';
 	import { Icon } from '@gitbutler/ui';
@@ -25,11 +26,11 @@
 	// Initialize from map, default to true
 	let expanded = $state(toolCallsExpandedState?.get(messageId) ?? true);
 
-	function toggleExpanded() {
-		expanded = !expanded;
+	function handleToggle(newExpanded: boolean) {
+		expanded = newExpanded;
 		// Persist to map if available
 		if (toolCallsExpandedState) {
-			toolCallsExpandedState.set(messageId, expanded);
+			toolCallsExpandedState.set(messageId, newExpanded);
 		}
 	}
 </script>
@@ -42,24 +43,15 @@
 		<div class="tool-calls-wrapper">
 			<div
 				class="tool-calls-container"
-				class:expanded
 				style="--initial-tool-items: {toolCalls.length - toolDisplayLimit}"
 			>
-				<!-- Header for multiple tool calls -->
-				<button
-					type="button"
-					class="text-13 tool-calls-header"
-					onclick={toggleExpanded}
-					class:expanded
+				<ExpandableSection
+					root
+					label="{filteredCalls.length} tool calls"
+					bind:expanded
+					onToggle={handleToggle}
 				>
-					<div class="flex gap-6 items-center">
-						<div class="tool-calls-header__arrow">
-							<Icon name="chevron-right" />
-						</div>
-						<span class="text-semibold">{filteredCalls.length} tool calls</span>
-					</div>
-
-					{#if !expanded}
+					{#snippet summary()}
 						{#each toolsToDisplay as toolCall}
 							<div
 								class="tool-calls-collapsed__item"
@@ -80,19 +72,18 @@
 							<span class="separator">•</span>
 							<p class="clr-text-2">+<span class="tool-calls-amount"></span> more</p>
 						{/if}
-					{/if}
-				</button>
+					{/snippet}
 
-				<!-- Content -->
-				{#if expanded}
-					<div class="tool-calls-expanded">
-						<div class="tool-calls-expanded__list">
-							{#each filteredCalls as toolCall}
-								<CodegenToolCall {projectId} fullWidth {toolCall} />
-							{/each}
+					{#snippet content()}
+						<div class="tool-calls-expanded">
+							<div class="tool-calls-expanded__list">
+								{#each filteredCalls as toolCall}
+									<CodegenToolCall {projectId} fullWidth {toolCall} />
+								{/each}
+							</div>
 						</div>
-					</div>
-				{/if}
+					{/snippet}
+				</ExpandableSection>
 			</div>
 		</div>
 	{/if}
@@ -110,7 +101,6 @@
 		width: 100%;
 		max-width: var(--message-max-width);
 		overflow: hidden;
-		/* background-color: red; */
 	}
 
 	/* Hide items in collapsed mode based on container width */
@@ -133,32 +123,6 @@
 		}
 	}
 
-	.tool-calls-header {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		cursor: pointer;
-
-		&:hover {
-			.tool-calls-header__arrow {
-				color: var(--clr-text-2);
-			}
-		}
-	}
-
-	.tool-calls-header__arrow {
-		display: flex;
-		margin-left: -2px;
-		color: var(--clr-text-3);
-		transition:
-			background-color var(--transition-fast),
-			transform var(--transition-medium);
-	}
-
-	.expanded .tool-calls-header__arrow {
-		transform: rotate(90deg);
-	}
-
 	.tool-calls-collapsed__item {
 		display: contents;
 	}
@@ -170,7 +134,6 @@
 
 	.tool-calls-expanded {
 		display: flex;
-		margin-top: 12px;
 		gap: 10px;
 	}
 

--- a/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
@@ -47,14 +47,8 @@
 		/* make code blocks visible */
 		:global(.markdown pre) {
 			max-height: 400px;
-			margin: 0 -12px;
-			padding: 0;
-			padding: 6px 12px;
 			overflow-y: auto;
-			border: none;
-			border-radius: 0;
-			background-color: var(--clr-scale-ntrl-20);
-			color: white;
+			background-color: var(--clr-bg-1);
 		}
 	}
 </style>

--- a/apps/desktop/src/components/codegen/ExpandableSection.svelte
+++ b/apps/desktop/src/components/codegen/ExpandableSection.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import { Icon, type IconName } from '@gitbutler/ui';
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		label: string;
+		icon?: IconName;
+		loading?: boolean;
+		summary?: Snippet;
+		content?: Snippet;
+		expanded?: boolean;
+		onToggle?: (expanded: boolean) => void;
+		root?: boolean;
+	};
+
+	let {
+		label,
+		icon,
+		loading = false,
+		summary,
+		content,
+		expanded = $bindable(false),
+		onToggle,
+		root = false
+	}: Props = $props();
+</script>
+
+<div class="expandable-section">
+	<button
+		type="button"
+		class="section-header text-13"
+		class:expanded
+		onclick={() => {
+			expanded = !expanded;
+			onToggle?.(expanded);
+		}}
+	>
+		<div class="flex items-center gap-6">
+			<div class="section-header__arrow">
+				<Icon name="chevron-right" />
+			</div>
+			{#if loading}
+				<Icon name="spinner" />
+			{:else if icon}
+				<Icon name={icon} color="var(--clr-text-3)" />
+			{/if}
+
+			<span class="section-label" class:text-semibold={root}>{label}</span>
+		</div>
+
+		{#if summary && !(root && expanded)}
+			<div class="section-summary">
+				{@render summary()}
+			</div>
+		{/if}
+	</button>
+
+	{#if expanded && content}
+		<div class="section-content">
+			{@render content()}
+		</div>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.expandable-section {
+		display: flex;
+		flex-direction: column;
+		max-width: 100%;
+		overflow: hidden;
+		gap: 12px;
+		user-select: text;
+	}
+
+	.section-header {
+		display: flex;
+		position: relative;
+		align-items: center;
+		width: fit-content;
+		gap: 8px;
+		user-select: none;
+
+		&:hover {
+			.section-header__arrow {
+				color: var(--clr-text-2);
+			}
+		}
+	}
+
+	.section-header__arrow {
+		display: flex;
+		margin-left: -2px;
+		color: var(--clr-text-3);
+		transition:
+			background-color var(--transition-fast),
+			transform var(--transition-medium);
+	}
+
+	.expanded .section-header__arrow {
+		transform: rotate(90deg);
+	}
+
+	.section-label {
+		white-space: nowrap;
+	}
+
+	.section-summary {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.section-content {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+</style>


### PR DESCRIPTION

https://github.com/user-attachments/assets/1f34f242-b377-40a1-8693-38a877b9c203

---

This pull request refactors the commit and tool call UI components to use a new reusable `ExpandableSection` component for displaying expandable/collapsible sections. It also updates the visual styling and improves code readability and maintainability. The most important changes are grouped below.

### Component Refactoring and Reusability

* Introduced a new reusable `ExpandableSection` component (`apps/desktop/src/components/codegen/ExpandableSection.svelte`) to handle expandable/collapsible UI sections with label, icon, loading state, summary, and content slots. This replaces custom expand/collapse logic in other components.
* Refactored `CodegenGitButlerMessage.svelte` and `CodegenToolCall.svelte` to use the new `ExpandableSection` for commit and tool call display, simplifying their code and improving consistency. [[1]](diffhunk://#diff-4fe068b5dc82ce9b6baf3c98847414993155a182b4ae008f3064554889c6082bR4-R7) [[2]](diffhunk://#diff-4fe068b5dc82ce9b6baf3c98847414993155a182b4ae008f3064554889c6082bL19-R52) [[3]](diffhunk://#diff-48daedd4a54886864ac6faafac6190ce0e248e4ff9dbdea2dab3c60c85df078cR3-L5) [[4]](diffhunk://#diff-48daedd4a54886864ac6faafac6190ce0e248e4ff9dbdea2dab3c60c85df078cL14-L56)

### Visual and Styling Improvements

* Updated the styling of commit bubbles, commit hash, and "commit not found" messages for better readability and clearer separation, including use of icons and improved color contrast.
* Improved code block appearance in user messages for better visibility and consistency, changing the background color and removing excess margins and borders.

### Minor UI/UX Adjustments

* Adjusted styling and behavior of the "read more" button in `CommitDetails.svelte` to use a dotted underline and improved font settings, enhancing its discoverability and appearance. [[1]](diffhunk://#diff-c47b3e636eb996fd193f170dafe5631e033ac09bd70657a85e534ea27c8414c7L101-R105) [[2]](diffhunk://#diff-c47b3e636eb996fd193f170dafe5631e033ac09bd70657a85e534ea27c8414c7L137-R141) [[3]](diffhunk://#diff-c47b3e636eb996fd193f170dafe5631e033ac09bd70657a85e534ea27c8414c7L150)
* Removed redundant or obsolete CSS and markup related to previous expand/collapse logic in `CodegenToolCall.svelte`, cleaning up the codebase.
