### PR TITLE
but: Review template

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/projects.ts
+++ b/apps/desktop/cypress/e2e/support/mock/projects.ts
@@ -16,7 +16,8 @@ export const MOCK_PROJECT_A: Project = {
 	is_open: false,
 	forge_override: undefined,
 	preferred_forge_user: null,
-	gerrit_mode: false
+	gerrit_mode: false,
+	forge_review_template_path: null
 };
 
 export function createMockProject(id: string, title: string, path: string): Project {

--- a/apps/desktop/src/lib/config/gitConfigService.ts
+++ b/apps/desktop/src/lib/config/gitConfigService.ts
@@ -53,6 +53,10 @@ export class GitConfigService {
 		return await this.setGbConfig(projectId, { gitbutlerGerritMode: gerritMode });
 	}
 
+	async setForgeReviewTemplatePath(projectId: string, path: string | null) {
+		return await this.setGbConfig(projectId, { gitbutlerForgeReviewTemplatePath: path });
+	}
+
 	async checkGitFetch(projectId: string, remoteName: string | null | undefined) {
 		if (!remoteName) return;
 		const resp = await this.backend.invoke<string>('git_test_fetch', {
@@ -88,6 +92,7 @@ export class GitConfigService {
 export class GbConfig {
 	signCommits?: boolean | undefined;
 	gitbutlerGerritMode?: boolean | undefined;
+	gitbutlerForgeReviewTemplatePath?: string | null;
 	signingKey?: string | undefined;
 	signingFormat?: string | undefined;
 	gpgProgram?: string | undefined;

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -39,6 +39,10 @@ export type Project = {
 	preferred_forge_user: ForgeUserIdentifier | null;
 	// Gerrit mode enabled for this project, derived from git configuration
 	gerrit_mode: boolean;
+	/**
+	 * The path to the forge review template, if set in git configuration.
+	 */
+	forge_review_template_path: string | null;
 };
 
 export function vscodePath(path: string) {

--- a/cli-docs/but-review.mdx
+++ b/cli-docs/but-review.mdx
@@ -59,6 +59,26 @@ If the review contains only a single commit, the commit message will be used for
 - **Type:** Flag (boolean)
 - **Default:** `false`
 
+### template
+
+Configure the template to use for review descriptions.
+This will list all available templates found in the repository and allow you to select one.
+
+```
+but review template [OPTIONS] [TEMPLATE_PATH]
+```
+
+#### Arguments
+
+- `template_path`
+
+Path to the review template file within the repository.
+
+- **Type:** String
+- **Required:** Optional
+
+This command will validate the provided relative path and ensure the template file exists in the repository.
+
 ## Examples
 
 Publish all active branches:
@@ -81,4 +101,8 @@ but review publish --run-hooks=false
 
 ```
 but review publish --default
+```
+
+```
+but review template .gitbutler/review_templates/feature_template.md
 ```

--- a/crates/but-core/tests/core/settings.rs
+++ b/crates/but-core/tests/core/settings.rs
@@ -22,6 +22,7 @@ mod git {
         let expected = GitConfigSettings {
             gitbutler_sign_commits: Some(true),
             gitbutler_gerrit_mode: Some(false),
+            gitbutler_forge_review_template_path: None,
             signing_key: Some("signing key".into()),
             signing_format: Some("signing format".into()),
             gpg_program: Some("gpg program".into()),

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -277,6 +277,7 @@ pub enum CommandName {
     ForgeListUsers,
     ForgeForget,
     PublishReview,
+    ReviewTemplate,
     Completions,
     #[default]
     Unknown,

--- a/crates/but/src/forge/auth.rs
+++ b/crates/but/src/forge/auth.rs
@@ -25,7 +25,7 @@ impl From<AuthMethod> for String {
 /// Authenticate with GitHub
 pub async fn auth_github() -> anyhow::Result<()> {
     let auth_method_prompt = cli_prompts::prompts::Selection::new(
-        "Select an authentication method:",
+        "Select an authentication method",
         vec![
             AuthMethod::DeviceFlow,
             AuthMethod::Pat,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -424,6 +424,18 @@ async fn match_subcommand(
                 .ok();
                 result
             }
+            forge::review::Subcommands::Template { template_path } => {
+                let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
+                let result = forge::review::set_review_template(&project, template_path, args.json)
+                    .context("Failed to set review template.");
+                metrics_if_configured(
+                    app_settings,
+                    CommandName::ReviewTemplate,
+                    props(start, &result),
+                )
+                .ok();
+                result
+            }
         },
         Subcommands::Completions { shell } => completions::generate_completions(shell),
     }

--- a/crates/but/src/metrics.rs
+++ b/crates/but/src/metrics.rs
@@ -97,6 +97,7 @@ impl From<CommandName> for EventKind {
             CommandName::ForgeListUsers => EventKind::Cli(Command::ForgeListUsers),
             CommandName::ForgeForget => EventKind::Cli(Command::ForgeForget),
             CommandName::PublishReview => EventKind::Cli(Command::PublishReview),
+            CommandName::ReviewTemplate => EventKind::Cli(Command::PublishReview),
             CommandName::Completions => EventKind::Cli(Command::Completions),
             CommandName::Absorb => EventKind::Cli(Command::Absorb),
             CommandName::Unknown => EventKind::Cli(Command::Unknown),

--- a/crates/gitbutler-project/src/api.rs
+++ b/crates/gitbutler-project/src/api.rs
@@ -10,6 +10,8 @@ pub struct Project {
     /// Gerrit mode enabled for this project, derived from git configuration
     #[serde(default)]
     pub gerrit_mode: bool,
+    /// Path to the forge review template, if set in git configuration.
+    pub forge_review_template_path: Option<String>,
 }
 
 impl From<crate::Project> for Project {
@@ -23,9 +25,19 @@ impl From<crate::Project> for Project {
             Err(_) => false,
         };
 
+        let forge_review_template_path = match project.open_isolated() {
+            Ok(repo) => repo
+                .git_settings()
+                .ok()
+                .and_then(|s| s.gitbutler_forge_review_template_path)
+                .map(|bstring| bstring.to_string()),
+            Err(_) => None,
+        };
+
         Self {
             inner: project,
             gerrit_mode,
+            forge_review_template_path,
         }
     }
 }


### PR DESCRIPTION
- Store the preferred template path in the git config, and propagate it into the project
- but review uses the PR template if needed
- but allows the user to select the PR template

closes: https://github.com/gitbutlerapp/gitbutler/issues/11165

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:


Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/


-->