### PR TITLE
Remember tool call expanded state in codegen chat

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenClaudeMessage.svelte
@@ -17,9 +17,12 @@
 			decision: PermissionDecision,
 			useWildcard: boolean
 		) => Promise<void>;
-		toolCallsExpandedState?: Map<string, boolean>;
+		toolCallExpandedState?: {
+			groups: Map<string, boolean>;
+			individual: Map<string, boolean>;
+		};
 	};
-	const { projectId, message, onPermissionDecision, toolCallsExpandedState }: Props = $props();
+	const { projectId, message, onPermissionDecision, toolCallExpandedState }: Props = $props();
 
 	let expanded = $state(false);
 </script>
@@ -39,7 +42,7 @@
 			{projectId}
 			toolCalls={message.toolCalls}
 			messageId={message.createdAt}
-			{toolCallsExpandedState}
+			{toolCallExpandedState}
 		/>
 		{#if message.toolCallsPendingApproval.length > 0}
 			{#each message.toolCallsPendingApproval as toolCall}

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -112,7 +112,10 @@
 	let inputRef = $state<CodegenInput>();
 
 	// Track expanded state for tool calls by message createdAt timestamp
-	const toolCallsExpandedState = new Map<string, boolean>();
+	const toolCallExpandedState = {
+		groups: new Map<string, boolean>(),
+		individual: new Map<string, boolean>()
+	};
 
 	const modelOptions: { label: string; value: ModelType }[] = [
 		{ label: 'Haiku', value: 'haiku' },
@@ -582,7 +585,7 @@
 									{projectId}
 									{message}
 									{onPermissionDecision}
-									{toolCallsExpandedState}
+									{toolCallExpandedState}
 								/>
 							{/each}
 						{/snippet}

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -9,8 +9,26 @@
 		style?: 'nested' | 'standalone';
 		toolCall: ToolCall;
 		fullWidth?: boolean;
+		toolCallKey?: string;
+		toolCallExpandedState?: {
+			groups: Map<string, boolean>;
+			individual: Map<string, boolean>;
+		};
 	};
-	const { toolCall, style, fullWidth }: Props = $props();
+	const { toolCall, style, fullWidth, toolCallKey, toolCallExpandedState }: Props = $props();
+
+	// Initialize expanded state from map, default to false (collapsed)
+	const initialExpanded =
+		toolCallKey && toolCallExpandedState
+			? (toolCallExpandedState.individual.get(toolCallKey) ?? false)
+			: false;
+
+	function handleToggle(newExpanded: boolean) {
+		// Persist to map if available
+		if (toolCallKey && toolCallExpandedState) {
+			toolCallExpandedState.individual.set(toolCallKey, newExpanded);
+		}
+	}
 </script>
 
 <div class="tool-call {style}" class:full-width={fullWidth}>
@@ -18,6 +36,8 @@
 		label={toolCall.name}
 		icon={getToolIcon(toolCall.name)}
 		loading={toolCallLoading(toolCall)}
+		expanded={initialExpanded}
+		onToggle={handleToggle}
 	>
 		{#snippet summary()}
 			<span class="summary truncate">{formatToolCall(toolCall)}</span>

--- a/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
@@ -9,9 +9,12 @@
 		projectId: string;
 		toolCalls: ToolCall[];
 		messageId: string;
-		toolCallsExpandedState?: Map<string, boolean>;
+		toolCallExpandedState?: {
+			groups: Map<string, boolean>;
+			individual: Map<string, boolean>;
+		};
 	};
-	const { projectId, toolCalls, messageId, toolCallsExpandedState }: Props = $props();
+	const { projectId, toolCalls, messageId, toolCallExpandedState }: Props = $props();
 
 	const filteredCalls = $derived(toolCalls.filter((tc) => tc.name !== 'TodoWrite'));
 
@@ -24,13 +27,13 @@
 	});
 
 	// Initialize from map, default to true
-	let expanded = $state(toolCallsExpandedState?.get(messageId) ?? true);
+	let expanded = $state(toolCallExpandedState?.groups.get(messageId) ?? true);
 
 	function handleToggle(newExpanded: boolean) {
 		expanded = newExpanded;
 		// Persist to map if available
-		if (toolCallsExpandedState) {
-			toolCallsExpandedState.set(messageId, newExpanded);
+		if (toolCallExpandedState) {
+			toolCallExpandedState.groups.set(messageId, newExpanded);
 		}
 	}
 </script>
@@ -38,7 +41,13 @@
 {#if filteredCalls.length > 0}
 	{#if filteredCalls.length === 1}
 		<!-- Only one tool call: show expanded directly, no container -->
-		<CodegenToolCall {projectId} toolCall={toolCalls[0]!} style="standalone" />
+		<CodegenToolCall
+			{projectId}
+			toolCall={toolCalls[0]!}
+			style="standalone"
+			toolCallKey="{messageId}-0"
+			{toolCallExpandedState}
+		/>
 	{:else}
 		<div class="tool-calls-wrapper">
 			<div
@@ -77,8 +86,14 @@
 					{#snippet content()}
 						<div class="tool-calls-expanded">
 							<div class="tool-calls-expanded__list">
-								{#each filteredCalls as toolCall}
-									<CodegenToolCall {projectId} fullWidth {toolCall} />
+								{#each filteredCalls as toolCall, index}
+									<CodegenToolCall
+										{projectId}
+										fullWidth
+										{toolCall}
+										toolCallKey="{messageId}-{index}"
+										{toolCallExpandedState}
+									/>
 								{/each}
 							</div>
 						</div>


### PR DESCRIPTION
Replace the previous Map-based toolCallsExpandedState with a unified
toolCallExpandedState object that separates group and individual
expansion maps. This standardizes how expanded/collapsed state is 
tracked across messages and tool calls.