### PR TITLE
Handle network errors when fetching GitHub user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ name = "but-github"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-error",
  "but-forge-storage",
  "but-secret",
  "but-settings",

--- a/apps/desktop/src/lib/forge/github/hooks.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/hooks.svelte.ts
@@ -57,6 +57,8 @@ type GitHubAccess = {
 	host: Reactive<string | undefined>;
 	accessToken: Reactive<string | undefined>;
 	isLoading: Reactive<boolean>;
+	error: Reactive<{ code: string; message: string } | undefined>;
+	isError: Reactive<boolean>;
 };
 
 /**
@@ -79,6 +81,10 @@ export function useGitHubAccessToken(projectId: Reactive<string>): GitHubAccess 
 	return {
 		host: reactive(() => host),
 		accessToken: reactive(() => aceessToken),
-		isLoading: reactive(() => ghUserResponse?.result.isLoading ?? false)
+		isLoading: reactive(() => ghUserResponse?.result.isLoading ?? false),
+		error: reactive(
+			() => ghUserResponse?.result.error as { code: string; message: string } | undefined
+		),
+		isError: reactive(() => ghUserResponse?.result.isError ?? false)
 	};
 }

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -124,6 +124,7 @@
 			baseBranch: baseBranchName,
 			githubAuthenticated: !!githubAccessToken.accessToken.current,
 			githubIsLoading: githubAccessToken.isLoading.current,
+			githubError: githubAccessToken.error.current,
 			gitlabAuthenticated: !!$gitlabConfigured,
 			detectedForgeProvider: baseBranch?.forgeRepoInfo?.forge ?? undefined,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -139,6 +139,7 @@ pub enum Code {
     SecretKeychainNotFound,
     MissingLoginKeychain,
     GitForcePushProtection,
+    NetworkError,
 }
 
 impl std::fmt::Display for Code {
@@ -157,6 +158,7 @@ impl std::fmt::Display for Code {
             Code::SecretKeychainNotFound => "errors.secret.keychain_notfound",
             Code::MissingLoginKeychain => "errors.secret.missing_login_keychain",
             Code::GitForcePushProtection => "errors.git.force_push_protection",
+            Code::NetworkError => "errors.network",
         };
         f.write_str(code)
     }

--- a/crates/but-github/Cargo.toml
+++ b/crates/but-github/Cargo.toml
@@ -18,8 +18,13 @@ serde.workspace = true
 but-settings.workspace = true
 but-secret.workspace = true
 but-forge-storage.workspace = true
+but-error.workspace = true
 anyhow.workspace = true
 gitbutler-user.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 octorust = { version = "0.10.0", default-features = false }
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["blocking"] }
+http = "1"

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -28,7 +28,7 @@ impl GitHubClient {
         Ok(Self { github })
     }
 
-    pub async fn get_authenticated(&self) -> Result<AuthenticatedUser> {
+    pub async fn get_authenticated(&self) -> Result<AuthenticatedUser, octorust::ClientError> {
         self.github
             .users()
             .get_authenticated()
@@ -57,7 +57,6 @@ impl GitHubClient {
                     }
                 }
             })
-            .map_err(Into::into)
     }
 
     pub async fn list_open_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PullRequest>> {


### PR DESCRIPTION
Detect and surface network connectivity problems when calling the GitHub
API from get_gh_user.

Expose the GitHub error object through the forge factory and related 
hooks so the frontend can react to network or API errors.

Prevents showing the integration setup prompt on network errors.