### PR TITLE
Auto-focus codegen input

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -330,6 +330,17 @@
 								onclick={async () => {
 									if (!stackId) return;
 									laneState?.selection.set({ branchName, codegen: true, previewOpen: true });
+									setTimeout(() => {
+										// This is a hacky way, but we need the job done until we
+										// can figure out a good way of autofocusing text inputs,
+										// without too many of them firing at the wrong times.
+										const element = document.querySelector(
+											`[data-id="${stackId}"] .ContentEditable__root`
+										);
+										if (element instanceof HTMLElement) {
+											element?.focus();
+										}
+									}, 100);
 								}}
 							/>
 						{/if}


### PR DESCRIPTION
This is a hacky way, but we need the job done until we can figure out a 
good way of autofocusing text inputs, without too many of them firing
at the wrong times.