### PR TITLE
Turn `WorkspaceCommitRelation::UnmergedTree` into `::MergeFrom { commit }` to cover more cases.

### DIFF
--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -363,7 +363,7 @@ pub mod merge {
                 .filter_map(|(top_segment, relation)| {
                     match relation {
                         WorkspaceCommitRelation::Merged => {}
-                        WorkspaceCommitRelation::UnmergedTree => {
+                        WorkspaceCommitRelation::MergeFrom {..} => {
                             // These need to be part of the parents list, but shouldn't be merged.
                             // If the caller wants to retry them, they can be passed here as "Merged".
                             todo!("this is a placeholder for where we will have to start handling this UnmergedTree")


### PR DESCRIPTION
That way, we can indicate that the stack is unmuted from a certain point in the stack.

Related to #11089
 
