### PR TITLE
Single-branch support for `but branch apply`

### DIFF
--- a/crates/but-ctx/Cargo.toml
+++ b/crates/but-ctx/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
-description = "A context implementation specific for a repository"
+description = "A context implementation specific to a repository"
 rust-version = "1.89"
 
 [lib]

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -1,5 +1,4 @@
-//! A crate to host a `Context` type, suitable to provide the context *applications* need to operate
-//! on it.
+//! A crate to host a `Context` type, suitable to provide the context *applications* need to operate on a Git repository.
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 use std::path::{Path, PathBuf};
@@ -8,8 +7,10 @@ use but_settings::AppSettings;
 #[cfg(feature = "legacy")]
 use gitbutler_command_context::CommandContext;
 
-/// A context specific to a repository(project) specific information, *not* thread-safe, and cheap to clone.
-/// That way it may own per-thread caches.
+/// A context specific to a repository, along with commonly used information to make higher-level functions
+/// more convenient to implement.
+/// This type is *not* thread-safe, and cheap to clone. That way it may own per-thread caches.
+/// It's fine for it to one day receive thread-safe shared state, as needed, similar to [`gix::Repository`].
 #[derive(Debug, Clone)]
 pub struct Context {
     /// The application context, here for convenience and as feature toggles and flags are needed.
@@ -22,7 +23,6 @@ pub struct Context {
 }
 
 /// Legacy - none of this should be kept.
-// TODO: make this an extension implemented elsewhere.
 #[cfg(feature = "legacy")]
 impl Context {
     /// Return a context for calling into `gitbutler-` functions.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -271,13 +271,13 @@ async fn match_subcommand(
             verbose,
             review,
         } => {
-            let project = get_project_with_legacy_support(&args.current_dir)?;
+            let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
             let result = status::worktree(&project, args.json, show_files, verbose, review).await;
             metrics_if_configured(app_settings, CommandName::Status, props(start, &result)).ok();
             result
         }
         Subcommands::Stf { verbose, review } => {
-            let project = get_project_with_legacy_support(&args.current_dir)?;
+            let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
             let result = status::worktree(&project, args.json, true, verbose, review).await;
             metrics_if_configured(app_settings, CommandName::Stf, props(start, &result)).ok();
             result
@@ -467,7 +467,7 @@ fn get_or_init_legacy_non_bare_project(
 /// Legacy - none of this should be kept.
 /// Turn this instance into a project, which knows about the Git repository discovered from `directory`
 /// and which can derive all other information from there.
-pub fn get_or_init_project_with_legacy_support(
+pub fn get_or_init_context_with_legacy_support(
     directory: impl AsRef<Path>,
 ) -> anyhow::Result<but_ctx::Context> {
     let directory = directory.as_ref();
@@ -489,7 +489,7 @@ pub fn get_or_init_project_with_legacy_support(
 }
 
 /// Discover the Git repository in `directory` and return it,
-pub fn get_project_with_legacy_support(
+pub fn get_context_with_legacy_support(
     directory: impl AsRef<Path>,
 ) -> anyhow::Result<but_ctx::Context> {
     let directory = directory.as_ref();

--- a/crates/but/tests/but/branch.rs
+++ b/crates/but/tests/but/branch.rs
@@ -4,7 +4,7 @@ use crate::utils::{Sandbox, setup_metadata};
 
 #[test]
 fn new_outputs_branch_name() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
@@ -35,7 +35,7 @@ my-anchored-feature
 
 #[test]
 fn new_with_json_output() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A

--- a/crates/but/tests/but/commit.rs
+++ b/crates/but/tests/but/commit.rs
@@ -4,7 +4,7 @@ use crate::utils::{Sandbox, setup_metadata};
 
 #[test]
 fn commit_with_message_flag() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("one-stack")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9477ae7 (A) add A
@@ -34,7 +34,7 @@ Created commit [..] on branch A
 
 #[test]
 fn commit_with_branch_hint() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
@@ -66,7 +66,7 @@ Created commit [..] on branch B
 
 #[test]
 fn commit_with_nonexistent_branch_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
@@ -93,7 +93,7 @@ Error: Branch 'nonexistent' not found
 
 #[test]
 fn commit_with_create_flag_creates_new_branch() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -125,7 +125,7 @@ Error: workspace at refs/heads/main is missing a base
 
 #[test]
 fn from_workspace() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  

--- a/crates/but/tests/but/rub.rs
+++ b/crates/but/tests/but/rub.rs
@@ -4,7 +4,7 @@ use crate::utils::{Sandbox, setup_metadata};
 
 #[test]
 fn shorthand_without_subcommand() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target("two-stacks")?;
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
     // Must set metadata to match the scenario
     setup_metadata(&env, &["A", "B"])?;

--- a/crates/but/tests/fixtures/scenario/first-commit.sh
+++ b/crates/but/tests/fixtures/scenario/first-commit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A repository with a single commit
+git init
+commit M

--- a/crates/but/tests/fixtures/scenario/unborn.sh
+++ b/crates/but/tests/fixtures/scenario/unborn.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+### General Description
+
+# Just an initialised repository, nothing else.
+git init


### PR DESCRIPTION
This is to help AI to use newer APIs, maybe, and to show that it can already be done.

For that reason, some refactoring is needed, making it very clear (also to AI) that legacy
should be avoided.

Ideally, `but-apply` can be rewritten by AI to use newer APIs.

### Tasks

* [x] what happens without initialised repo in `but status`?
* [ ] `but apply` uses recent API and has at least one test. Should be a good case for usable mutating API as well.

### Next PR 

* [ ] `but status` uses `but_workspace::ref_info()`


Follow-up of #11189
