### PR TITLE
Single-branch support for `but branch apply`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ name = "but-api"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bstr",
  "but-action",
  "but-api-macros",
  "but-broadcaster",
@@ -852,6 +853,7 @@ dependencies = [
  "gitbutler-user",
  "gix",
  "open",
+ "schemars 1.1.0",
  "serde",
  "serde-error",
  "serde_json",

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -14,7 +14,12 @@ rust-version = "1.89"
 doctest = false
 
 [features]
+default = []
+## Provide Tauri commands automatically where possible, to avoid duplication.
 tauri = ["dep:tauri"]
+## When paths are turned into strings they are lossy. Also provide a `_bytes` variant of such fields with the original value
+## for lossless use.
+path-bytes = ["dep:bstr"]
 
 [dependencies]
 but-settings.workspace = true
@@ -60,6 +65,8 @@ gitbutler-forge.workspace = true
 
 tauri = { version = "^2.9.2", features = ["unstable"], optional = true } # For the #[tauri::command(async)] macro only
 
+bstr = { workspace = true, optional = true }
+schemars.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }
 anyhow.workspace = true

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -26,3 +26,77 @@ pub struct App {
 
 #[derive(Deserialize)]
 pub struct NoParams {}
+
+/// Types meant to be serialised to JSON, without degenerating information despite the need to be UTF-8 encodable.
+/// EXPERIMENTAL
+pub mod json {
+    use gix::refs::Target;
+    use schemars;
+    use serde::Serialize;
+
+    /// To make bstring work with schemars.
+    #[cfg(feature = "path-bytes")]
+    fn bstring_schema(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // TODO: implement this. How to get description and what not?
+        generate.root_schema_for::<String>()
+    }
+
+    /// The full name of a Git reference.
+    #[derive(Debug, Clone, schemars::JsonSchema, Serialize)]
+    pub struct FullRefName {
+        /// The full name, like `refs/heads/main` or `refs/remotes/origin/foo`.
+        /// Note that it might be degenerated if it can't be represented in Unicode.
+        pub full: String,
+        /// `full` without degeneration, as plain bytes.
+        #[cfg(feature = "path-bytes")]
+        #[schemars(schema_with = "bstring_schema")]
+        pub full_bytes: bstr::BString,
+    }
+
+    impl From<gix::refs::FullName> for FullRefName {
+        fn from(value: gix::refs::FullName) -> Self {
+            FullRefName {
+                full: value.as_bstr().to_string(),
+                #[cfg(feature = "path-bytes")]
+                full_bytes: value.as_bstr().into(),
+            }
+        }
+    }
+
+    /// A Git reference identified by its full reference name, along with the information Git stores about it.
+    // TODO: make this work with schemars
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Reference {
+        /// The full name, like `refs/heads/main` or `refs/remotes/origin/foo`.
+        /// Note that it might be degenerated if it can't be represented in Unicode.
+        pub name: FullRefName,
+        /// Set if the reference points to an object id. This is the common case.
+        #[serde(with = "but_serde::object_id_opt", default)]
+        pub target_id: Option<gix::ObjectId>,
+        /// Set if the reference points to the name of another reference. This happens if the reference is symbolic.
+        #[serde(default)]
+        pub target_ref: Option<FullRefName>,
+    }
+
+    impl From<gix::refs::Reference> for Reference {
+        fn from(
+            gix::refs::Reference {
+                name,
+                target,
+                peeled: _ignored,
+            }: gix::refs::Reference,
+        ) -> Self {
+            Reference {
+                name: name.into(),
+                target_id: match &target {
+                    Target::Object(id) => Some(*id),
+                    Target::Symbolic(_) => None,
+                },
+                target_ref: match target {
+                    Target::Object(_) => None,
+                    Target::Symbolic(rn) => Some(rn.into()),
+                },
+            }
+        }
+    }
+}

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -31,7 +31,7 @@ anyhow.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 
-but-api.workspace = true
+but-api = { workspace = true, features = ["path-bytes"] }
 but-broadcaster.workspace = true
 but-db.workspace = true
 but-path.workspace = true

--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -1,10 +1,11 @@
 use std::io::Write;
 
+use crate::we_need_proper_json_output_here;
 use colored::Colorize;
 use gitbutler_branch_actions::BranchListingFilter;
 use gitbutler_project::Project;
 
-pub async fn list(project: &Project, local: bool) -> Result<(), anyhow::Error> {
+pub async fn list(project: &Project, local: bool) -> Result<serde_json::Value, anyhow::Error> {
     let mut stdout = std::io::stdout();
     let filter = if local {
         Some(BranchListingFilter {
@@ -50,7 +51,7 @@ pub async fn list(project: &Project, local: bool) -> Result<(), anyhow::Error> {
         );
         writeln!(stdout, "{} {}{}", "(remote)".dimmed(), branch.name, reviews).ok();
     }
-    Ok(())
+    Ok(we_need_proper_json_output_here())
 }
 
 fn print_applied_branches(

--- a/crates/but/tests/but/branch.rs
+++ b/crates/but/tests/but/branch.rs
@@ -222,12 +222,12 @@ fn apply_nonexistent_branch() -> anyhow::Result<()> {
     // Try to apply a branch that doesn't exist
     env.but("branch apply nonexistent-branch")
         .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-Could not find branch 'nonexistent-branch' in local repository
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Could not find branch 'nonexistent-branch' in local repository
 
-"#]]);
+"#]])
+        .stdout_eq(str![""]);
 
     Ok(())
 }
@@ -239,8 +239,11 @@ fn apply_nonexistent_branch_with_json() -> anyhow::Result<()> {
     // Try to apply a branch that doesn't exist with JSON output
     env.but("--json branch apply nonexistent-branch")
         .assert()
-        .success()
-        .stderr_eq(str![]);
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Could not find branch 'nonexistent-branch' in local repository
+
+"#]]);
     // Note: Currently the apply function doesn't output anything with JSON when branch not found
     // This might be improved to output an error in JSON format
 

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -31,7 +31,7 @@ but-meta = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
 but-action.workspace = true
 but-bot.workspace = true
-but-api = { workspace = true, features = ["tauri"] }
+but-api = { workspace = true, features = ["tauri", "path-bytes"] }
 but-claude.workspace = true
 but-github.workspace = true
 


### PR DESCRIPTION
This is to help AI to use newer APIs, maybe, and to show that it can already be done.

For that reason, some refactoring is needed, making it very clear (also to AI) that legacy
should be avoided.

Ideally, `but-apply` can be rewritten by AI to use newer APIs.

### Tasks

* [x] `json` sketch in `but-api` with `path-bytes` toggle
* [ ] `but apply` uses recent API and has at least one test. Should be a good case for usable mutating API as well.

### Next PR 

* [ ] `but status` uses `but_workspace::ref_info()`


Follow-up of #11207

