### PR TITLE
Upstream integration: Remove the `force_integrated_branches` option

### DIFF
--- a/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
+++ b/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
@@ -86,22 +86,19 @@ describe('Upstream Integration', () => {
 				{
 					stackId: 'stack-a-id',
 					approach: { type: 'rebase' },
-					deleteIntegratedBranches: true,
-					forceIntegratedBranches: []
+					deleteIntegratedBranches: true
 				},
 				{
 					stackId: 'stack-b-id',
 					approach: { type: 'delete' },
-					deleteIntegratedBranches: false,
-					forceIntegratedBranches: []
+					deleteIntegratedBranches: false
 				},
 				{
 					stackId: 'stack-c-id',
 					approach: {
 						type: 'delete'
 					},
-					deleteIntegratedBranches: true,
-					forceIntegratedBranches: []
+					deleteIntegratedBranches: true
 				}
 			],
 			baseBranchResolution: undefined

--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -98,19 +98,13 @@
 		// Side effect, refresh results
 		results.clear();
 		for (const status of statusesTmp) {
-			const mergedAssociatedReviews = filteredReviews.filter(
-				(r) => status.stack.heads.some((h) => h.name === r.sourceBranch) && r.mergedAt !== undefined
-			);
-			const forceIntegratedBranches = mergedAssociatedReviews.map((r) => r.sourceBranch);
-
 			if (status.stack.id) {
 				const dontDelete = someBranchesShouldNotBeDeleted(status.stack.heads.map((b) => b.name));
 
 				results.set(status.stack.id, {
 					stackId: status.stack.id,
 					approach: getResolutionApproachV3(status),
-					deleteIntegratedBranches: !dontDelete,
-					forceIntegratedBranches
+					deleteIntegratedBranches: !dontDelete
 				});
 			}
 		}

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -52,7 +52,6 @@ export type Resolution = {
 	stackId: string;
 	approach: ResolutionApproach;
 	deleteIntegratedBranches: boolean;
-	forceIntegratedBranches: string[];
 };
 
 export type BaseBranchResolutionApproach = 'rebase' | 'merge' | 'hardReset';

--- a/crates/but/src/base.rs
+++ b/crates/but/src/base.rs
@@ -161,7 +161,6 @@ pub fn handle(cmd: Subcommands, project: &LegacyProject, json: bool) -> anyhow::
                                 stack_id,
                                 approach,
                                 delete_integrated_branches: true,
-                                force_integrated_branches: vec![],
                             };
                             resolutions.push(resolution);
                         }

--- a/crates/gitbutler-cli/src/command/mod.rs
+++ b/crates/gitbutler-cli/src/command/mod.rs
@@ -29,7 +29,6 @@ pub mod workspace {
                 stack_id: id,
                 approach,
                 delete_integrated_branches: false,
-                force_integrated_branches: vec![],
             })
             .collect();
         gitbutler_branch_actions::integrate_upstream(&ctx, &resolutions, None)?;


### PR DESCRIPTION
We don’t use it anymore, and we probably will rethink the way we handle this states in a nicer way