### PR TITLE
Upstream Integration: Handle forge merging

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -550,13 +550,33 @@ pub fn find_commit(
     gitbutler_branch_actions::find_commit(&ctx, commit_id).map_err(Into::into)
 }
 
-#[api_cmd]
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
-pub fn upstream_integration_statuses(
+pub async fn upstream_integration_statuses(
     project_id: ProjectId,
     target_commit_id: Option<String>,
 ) -> Result<StackStatuses, Error> {
+    upstream_integration_statuses_cmd(UpstreamIntegrationStatuses {
+        project_id,
+        target_commit_id,
+    })
+    .await
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpstreamIntegrationStatuses {
+    pub project_id: ProjectId,
+    pub target_commit_id: Option<String>,
+}
+
+pub async fn upstream_integration_statuses_cmd(
+    params: UpstreamIntegrationStatuses,
+) -> Result<StackStatuses, Error> {
+    let UpstreamIntegrationStatuses {
+        project_id,
+        target_commit_id,
+    } = params;
     let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let commit_id = target_commit_id
@@ -567,14 +587,37 @@ pub fn upstream_integration_statuses(
     )?)
 }
 
-#[api_cmd]
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
-pub fn integrate_upstream(
+pub async fn integrate_upstream(
     project_id: ProjectId,
     resolutions: Vec<Resolution>,
     base_branch_resolution: Option<BaseBranchResolution>,
 ) -> Result<IntegrationOutcome, Error> {
+    integrate_upstream_cmd(IntegrateUpstreamParams {
+        project_id,
+        resolutions,
+        base_branch_resolution,
+    })
+    .await
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntegrateUpstreamParams {
+    pub project_id: ProjectId,
+    pub resolutions: Vec<Resolution>,
+    pub base_branch_resolution: Option<BaseBranchResolution>,
+}
+
+pub async fn integrate_upstream_cmd(
+    params: IntegrateUpstreamParams,
+) -> Result<IntegrationOutcome, Error> {
+    let IntegrateUpstreamParams {
+        project_id,
+        resolutions,
+        base_branch_resolution,
+    } = params;
     let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let outcome =

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result, anyhow};
 use but_api_macros::api_cmd;
 use but_core::DiffSpec;
@@ -556,7 +558,7 @@ pub async fn upstream_integration_statuses(
     project_id: ProjectId,
     target_commit_id: Option<String>,
 ) -> Result<StackStatuses, Error> {
-    upstream_integration_statuses_cmd(UpstreamIntegrationStatuses {
+    upstream_integration_statuses_cmd(UpstreamIntegrationStatusesParams {
         project_id,
         target_commit_id,
     })
@@ -565,15 +567,15 @@ pub async fn upstream_integration_statuses(
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UpstreamIntegrationStatuses {
+pub struct UpstreamIntegrationStatusesParams {
     pub project_id: ProjectId,
     pub target_commit_id: Option<String>,
 }
 
 pub async fn upstream_integration_statuses_cmd(
-    params: UpstreamIntegrationStatuses,
+    params: UpstreamIntegrationStatusesParams,
 ) -> Result<StackStatuses, Error> {
-    let UpstreamIntegrationStatuses {
+    let UpstreamIntegrationStatusesParams {
         project_id,
         target_commit_id,
     } = params;
@@ -582,8 +584,15 @@ pub async fn upstream_integration_statuses_cmd(
     let commit_id = target_commit_id
         .map(|commit_id| git2::Oid::from_str(&commit_id).map_err(|e| anyhow!(e)))
         .transpose()?;
+
+    // Get all the actively applied reviews
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+    let resolved_reviews = resolve_review_map(project, &base_branch).await?;
+
     Ok(gitbutler_branch_actions::upstream_integration_statuses(
-        &ctx, commit_id,
+        &ctx,
+        commit_id,
+        &resolved_reviews,
     )?)
 }
 
@@ -620,24 +629,96 @@ pub async fn integrate_upstream_cmd(
     } = params;
     let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
-    let outcome =
-        gitbutler_branch_actions::integrate_upstream(&ctx, &resolutions, base_branch_resolution)?;
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+    let resolved_reviews = resolve_review_map(project, &base_branch).await?;
+    let outcome = gitbutler_branch_actions::integrate_upstream(
+        &ctx,
+        &resolutions,
+        base_branch_resolution,
+        &resolved_reviews,
+    )?;
 
     Ok(outcome)
 }
 
-#[api_cmd]
 #[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
-pub fn resolve_upstream_integration(
+pub async fn resolve_upstream_integration(
     project_id: ProjectId,
     resolution_approach: BaseBranchResolutionApproach,
 ) -> Result<String, Error> {
+    resolve_upstream_integration_cmd(ResolveUpstreamIntegrationParams {
+        project_id,
+        resolution_approach,
+    })
+    .await
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveUpstreamIntegrationParams {
+    pub project_id: ProjectId,
+    pub resolution_approach: BaseBranchResolutionApproach,
+}
+
+pub async fn resolve_upstream_integration_cmd(
+    params: ResolveUpstreamIntegrationParams,
+) -> Result<String, Error> {
+    let ResolveUpstreamIntegrationParams {
+        project_id,
+        resolution_approach,
+    } = params;
     let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
 
-    let new_target_id =
-        gitbutler_branch_actions::resolve_upstream_integration(&ctx, resolution_approach)?;
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+    let resolved_reviews = resolve_review_map(project, &base_branch).await?;
+    let new_target_id = gitbutler_branch_actions::resolve_upstream_integration(
+        &ctx,
+        resolution_approach,
+        &resolved_reviews,
+    )?;
     let commit_id = git2::Oid::to_string(&new_target_id);
     Ok(commit_id)
+}
+
+/// Resolve all actively applied reviews for the given project and command context
+/// TODO: This should be moved somewhere else more appropriate.
+async fn resolve_review_map(
+    project: gitbutler_project::Project,
+    base_branch: &BaseBranch,
+) -> Result<HashMap<String, but_forge::ForgeReview>, Error> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let Some(forge_repo_info) = base_branch.forge_repo_info.as_ref() else {
+        // No forge? No problem!
+        // If there's no forge associated with the base branch, there can't be any reviews.
+        // Return an empty map.
+        return Ok(HashMap::new());
+    };
+
+    let filter = Some(BranchListingFilter {
+        local: None,
+        applied: Some(true),
+    });
+    let branches = list_branches(project.id, filter)?;
+    let mut reviews = branches.iter().fold(HashMap::new(), |mut acc, branch| {
+        if let Some(stack_ref) = &branch.stack {
+            acc.extend(stack_ref.pull_requests.iter().map(|(k, v)| (k.clone(), *v)));
+        }
+        acc
+    });
+    let mut resolved_reviews = HashMap::new();
+    for (key, pr_number) in reviews.drain() {
+        if let Ok(resolved) = but_forge::get_forge_review(
+            &project.preferred_forge_user,
+            forge_repo_info,
+            pr_number,
+            &storage,
+        )
+        .await
+        {
+            resolved_reviews.insert(key, resolved);
+        }
+    }
+    Ok(resolved_reviews)
 }

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::forge::{ForgeName, ForgeRepoInfo, ForgeUser, deserialize_preferre
 mod review;
 pub use review::{
     CreateForgeReviewParams, ForgeReview, ReviewTemplateFunctions, available_review_templates,
-    create_forge_review, get_review_template_functions, list_forge_reviews,
+    create_forge_review, get_forge_review, get_review_template_functions, list_forge_reviews,
 };
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -274,6 +274,18 @@ pub struct ForgeReview {
     pub unit_symbol: String,
 }
 
+impl ForgeReview {
+    /// Whether the review is still open (not merged or closed)
+    pub fn is_open(&self) -> bool {
+        self.merged_at.is_none() && self.closed_at.is_none()
+    }
+
+    /// Whether the review has been merged
+    pub fn is_merged(&self) -> bool {
+        self.merged_at.is_some()
+    }
+}
+
 impl From<but_github::PullRequest> for ForgeReview {
     fn from(pr: but_github::PullRequest) -> Self {
         ForgeReview {
@@ -321,6 +333,30 @@ pub async fn list_forge_reviews(
         }
         _ => Err(Error::msg(format!(
             "Listing reviews for forge {:?} is not implemented yet.",
+            forge,
+        ))),
+    }
+}
+
+/// Get a specific review (e.g. pull request) for a given forge repository
+pub async fn get_forge_review(
+    preferred_forge_user: &Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    pr_number: usize,
+    storage: &but_forge_storage::Controller,
+) -> Result<ForgeReview> {
+    let crate::forge::ForgeRepoInfo {
+        forge, owner, repo, ..
+    } = forge_repo_info;
+    match forge {
+        ForgeName::GitHub => {
+            let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
+            let pr =
+                but_github::pr::get(preferred_account, owner, repo, pr_number, storage).await?;
+            Ok(ForgeReview::from(pr))
+        }
+        _ => Err(Error::msg(format!(
+            "Getting reviews for forge {:?} is not implemented yet.",
             forge,
         ))),
     }

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -284,6 +284,11 @@ impl ForgeReview {
     pub fn is_merged(&self) -> bool {
         self.merged_at.is_some()
     }
+
+    /// Whether the review points to the given commit ID and has been merged
+    pub fn is_merged_at_commit(&self, commit_id: &str) -> bool {
+        self.is_merged() && self.sha == commit_id
+    }
 }
 
 impl From<but_github::PullRequest> for ForgeReview {

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -107,6 +107,23 @@ impl GitHubClient {
 
         Ok(pr.into())
     }
+
+    pub async fn get_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: i64,
+    ) -> Result<PullRequest> {
+        let pr = self
+            .github
+            .pulls()
+            .get(owner, repo, pr_number)
+            .await
+            .map(|response| response.body)
+            .map_err(anyhow::Error::from)?;
+
+        Ok(pr.into())
+    }
 }
 
 pub struct CreatePullRequestParams<'a> {

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -331,7 +331,15 @@ async fn handle_command(
             }
         }
         "resolve_upstream_integration" => {
-            legacy::virtual_branches::resolve_upstream_integration_cmd(request.params)
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result =
+                        legacy::virtual_branches::resolve_upstream_integration_cmd(params).await;
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
         }
         // Operating modes commands
         "operating_mode" => legacy::modes::operating_mode_cmd(request.params),

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -310,9 +310,26 @@ async fn handle_command(
         }
         "find_commit" => legacy::virtual_branches::find_commit_cmd(request.params),
         "upstream_integration_statuses" => {
-            legacy::virtual_branches::upstream_integration_statuses_cmd(request.params)
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result =
+                        legacy::virtual_branches::upstream_integration_statuses_cmd(params).await;
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
         }
-        "integrate_upstream" => legacy::virtual_branches::integrate_upstream_cmd(request.params),
+        "integrate_upstream" => {
+            let params = serde_json::from_value(request.params).to_error();
+            match params {
+                Ok(params) => {
+                    let result = legacy::virtual_branches::integrate_upstream_cmd(params).await;
+                    result.map(|r| json!(r))
+                }
+                Err(e) => Err(e),
+            }
+        }
         "resolve_upstream_integration" => {
             legacy::virtual_branches::resolve_upstream_integration_cmd(request.params)
         }

--- a/crates/but/src/base.rs
+++ b/crates/but/src/base.rs
@@ -20,7 +20,7 @@ pub enum Subcommands {
     Update,
 }
 
-pub fn handle(
+pub async fn handle(
     cmd: Subcommands,
     project: &LegacyProject,
     out: &mut OutputChannel,
@@ -64,7 +64,8 @@ pub fn handle(
 
                 let status = but_api::legacy::virtual_branches::upstream_integration_statuses(
                     project.id, None,
-                )?;
+                )
+                .await?;
 
                 match status {
                     UpToDate => {
@@ -124,7 +125,8 @@ pub fn handle(
         }
         Subcommands::Update => {
             let status =
-                but_api::legacy::virtual_branches::upstream_integration_statuses(project.id, None)?;
+                but_api::legacy::virtual_branches::upstream_integration_statuses(project.id, None)
+                    .await?;
             let resolutions = match status {
                 UpToDate => {
                     if let Some(out) = out.for_human() {
@@ -186,7 +188,8 @@ pub fn handle(
                     project.id,
                     resolutions,
                     None,
-                )?;
+                )
+                .await?;
             }
             Ok(())
         }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -244,7 +244,9 @@ async fn match_subcommand(
         },
         Subcommands::Base(base::Platform { cmd }) => {
             let project = get_or_init_legacy_non_bare_project(&args)?;
-            base::handle(cmd, &project, out).emit_metrics(metrics_ctx)
+            base::handle(cmd, &project, out)
+                .await
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Branch(branch::Platform { cmd }) => {
             let ctx = get_or_init_context_with_legacy_support(&args)?;

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -538,6 +538,7 @@ pub fn get_uncommited_files(ctx: &CommandContext) -> Result<Vec<RemoteBranchFile
 pub fn upstream_integration_statuses(
     ctx: &CommandContext,
     target_commit_oid: Option<git2::Oid>,
+    review_map: &std::collections::HashMap<String, but_forge::ForgeReview>,
 ) -> Result<StackStatuses> {
     let mut guard = ctx.project().exclusive_worktree_access();
 
@@ -547,6 +548,7 @@ pub fn upstream_integration_statuses(
         target_commit_oid,
         guard.write_permission(),
         &gix_repo,
+        review_map,
     )?;
 
     upstream_integration::upstream_integration_statuses(&context)
@@ -556,6 +558,7 @@ pub fn integrate_upstream(
     ctx: &CommandContext,
     resolutions: &[Resolution],
     base_branch_resolution: Option<BaseBranchResolution>,
+    review_map: &std::collections::HashMap<String, but_forge::ForgeReview>,
 ) -> Result<IntegrationOutcome> {
     let mut guard = ctx.project().exclusive_worktree_access();
 
@@ -568,6 +571,7 @@ pub fn integrate_upstream(
         ctx,
         resolutions,
         base_branch_resolution,
+        review_map,
         guard.write_permission(),
     )
 }
@@ -575,12 +579,14 @@ pub fn integrate_upstream(
 pub fn resolve_upstream_integration(
     ctx: &CommandContext,
     resolution_approach: BaseBranchResolutionApproach,
+    review_map: &std::collections::HashMap<String, but_forge::ForgeReview>,
 ) -> Result<git2::Oid> {
     let mut guard = ctx.project().exclusive_worktree_access();
 
     upstream_integration::resolve_upstream_integration(
         ctx,
         resolution_approach,
+        review_map,
         guard.write_permission(),
     )
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -69,7 +69,7 @@ fn rebase_commit() {
 
     {
         // fetch remote
-        gitbutler_branch_actions::integrate_upstream(ctx, &[], None).unwrap();
+        gitbutler_branch_actions::integrate_upstream(ctx, &[], None, &Default::default()).unwrap();
 
         // branch is stil unapplied
         let stacks = stack_details(ctx);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
+use but_forge::ForgeReview;
 use gitbutler_branch::BranchCreateRequest;
+use gitbutler_branch_actions::upstream_integration::{BranchStatus, StackStatuses, TreeStatus};
 use gitbutler_reference::Refname;
 use gitbutler_testsupport::stack_details;
 
@@ -113,5 +117,427 @@ fn rebase_commit() {
             fs::read_to_string(repo.path().join("file.txt")).unwrap(),
             "two"
         );
+    }
+}
+
+#[test]
+fn upstream_integration_status_without_review_map() {
+    let Test { repo, ctx, .. } = &Test::default();
+
+    // Setup: Create a remote branch with commits
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first_commit_oid = repo.commit_all("initial commit");
+        fs::write(repo.path().join("file.txt"), "second").unwrap();
+        repo.commit_all("second commit");
+        repo.push();
+        repo.reset_hard(Some(first_commit_oid));
+    }
+
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        ctx.project().exclusive_worktree_access().write_permission(),
+    )
+    .unwrap();
+
+    // Create a virtual branch with a commit
+    let stack_id = {
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("feature-branch".to_string()),
+                ..Default::default()
+            },
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("feature-file.txt"), "feature work").unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "feature commit", None)
+            .unwrap();
+
+        stack_entry.id
+    };
+
+    let empty_review_map = HashMap::new();
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &empty_review_map)
+            .unwrap();
+
+    match statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts,
+        } => {
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].0, Some(stack_id));
+            assert_eq!(statuses[0].1.tree_status, TreeStatus::Empty);
+            assert_eq!(statuses[0].1.branch_statuses.len(), 1);
+            assert_eq!(statuses[0].1.branch_statuses[0].name, "feature-branch");
+            assert_eq!(
+                statuses[0].1.branch_statuses[0].status,
+                BranchStatus::SaflyUpdatable
+            );
+            assert!(worktree_conflicts.is_empty());
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
+    }
+}
+
+#[test]
+fn upstream_integration_status_with_merged_pr() {
+    let Test { repo, ctx, .. } = &Test::default();
+
+    // Setup: Create a remote branch with commits
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first_commit_oid = repo.commit_all("initial commit");
+        fs::write(repo.path().join("file.txt"), "second").unwrap();
+        repo.commit_all("second commit");
+        repo.push();
+        repo.reset_hard(Some(first_commit_oid));
+    }
+
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        ctx.project().exclusive_worktree_access().write_permission(),
+    )
+    .unwrap();
+
+    // Create a virtual branch with a commit
+    let (stack_id, commit_id) = {
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("feature-branch".to_string()),
+                ..Default::default()
+            },
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("feature-file.txt"), "feature work").unwrap();
+        let commit_id =
+            gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "feature commit", None)
+                .unwrap();
+
+        (stack_entry.id, commit_id)
+    };
+
+    let mut review_map = HashMap::new();
+    review_map.insert(
+        "feature-branch".to_string(),
+        ForgeReview {
+            html_url: "https://github.com/test/repo/pull/1".to_string(),
+            number: 1,
+            title: "Feature PR".to_string(),
+            body: Some("Description".to_string()),
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "feature-branch".to_string(),
+            target_branch: "master".to_string(),
+            sha: commit_id.to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            modified_at: Some("2024-01-02T00:00:00Z".to_string()),
+            merged_at: Some("2024-01-03T00:00:00Z".to_string()),
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            reviewers: vec![],
+            unit_symbol: "#".to_string(),
+        },
+    );
+
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &review_map).unwrap();
+
+    match statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts,
+        } => {
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].0, Some(stack_id));
+            assert_eq!(statuses[0].1.tree_status, TreeStatus::Empty);
+            assert_eq!(statuses[0].1.branch_statuses.len(), 1);
+            assert_eq!(statuses[0].1.branch_statuses[0].name, "feature-branch");
+            assert_eq!(
+                statuses[0].1.branch_statuses[0].status,
+                BranchStatus::Integrated
+            );
+            assert!(worktree_conflicts.is_empty());
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
+    }
+}
+
+#[test]
+fn upstream_integration_status_with_merged_pr_mismatched_head() {
+    let Test { repo, ctx, .. } = &Test::default();
+
+    // Setup: Create a remote branch with commits
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first_commit_oid = repo.commit_all("initial commit");
+        fs::write(repo.path().join("file.txt"), "second").unwrap();
+        repo.commit_all("second commit");
+        repo.push();
+        repo.reset_hard(Some(first_commit_oid));
+    }
+
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        ctx.project().exclusive_worktree_access().write_permission(),
+    )
+    .unwrap();
+
+    // Create a virtual branch with a commit
+    let stack_id = {
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("feature-branch".to_string()),
+                ..Default::default()
+            },
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("feature-file.txt"), "feature work").unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "feature commit", None)
+            .unwrap();
+
+        stack_entry.id
+    };
+
+    let mut review_map = HashMap::new();
+    review_map.insert(
+        "feature-branch".to_string(),
+        ForgeReview {
+            html_url: "https://github.com/test/repo/pull/1".to_string(),
+            number: 1,
+            title: "Feature PR".to_string(),
+            body: Some("Description".to_string()),
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "feature-branch".to_string(),
+            target_branch: "master".to_string(),
+            sha: "some-other-sha".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            modified_at: Some("2024-01-02T00:00:00Z".to_string()),
+            merged_at: Some("2024-01-03T00:00:00Z".to_string()),
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            reviewers: vec![],
+            unit_symbol: "#".to_string(),
+        },
+    );
+
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &review_map).unwrap();
+
+    match statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts,
+        } => {
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].0, Some(stack_id));
+            assert_eq!(statuses[0].1.tree_status, TreeStatus::Empty);
+            assert_eq!(statuses[0].1.branch_statuses.len(), 1);
+            assert_eq!(statuses[0].1.branch_statuses[0].name, "feature-branch");
+            assert_eq!(
+                statuses[0].1.branch_statuses[0].status,
+                BranchStatus::SaflyUpdatable
+            );
+            assert!(worktree_conflicts.is_empty());
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
+    }
+}
+
+#[test]
+fn upstream_integration_status_with_closed_but_not_merged_pr() {
+    let Test { repo, ctx, .. } = &Test::default();
+
+    // Setup: Create a remote branch with commits
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first_commit_oid = repo.commit_all("initial commit");
+        fs::write(repo.path().join("file.txt"), "second").unwrap();
+        repo.commit_all("second commit");
+        repo.push();
+        repo.reset_hard(Some(first_commit_oid));
+    }
+
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        ctx.project().exclusive_worktree_access().write_permission(),
+    )
+    .unwrap();
+
+    // Create a virtual branch with a commit
+    let stack_id = {
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("feature-branch".to_string()),
+                ..Default::default()
+            },
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("feature-file.txt"), "feature work").unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "feature commit", None)
+            .unwrap();
+
+        stack_entry.id
+    };
+
+    let mut review_map = HashMap::new();
+    review_map.insert(
+        "feature-branch".to_string(),
+        ForgeReview {
+            html_url: "https://github.com/test/repo/pull/1".to_string(),
+            number: 1,
+            title: "Feature PR".to_string(),
+            body: Some("Description".to_string()),
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "feature-branch".to_string(),
+            target_branch: "master".to_string(),
+            sha: "abc123".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            modified_at: Some("2024-01-02T00:00:00Z".to_string()),
+            merged_at: None,
+            closed_at: Some("2024-01-03T00:00:00Z".to_string()),
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            reviewers: vec![],
+            unit_symbol: "#".to_string(),
+        },
+    );
+
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &review_map).unwrap();
+
+    match statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts,
+        } => {
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].0, Some(stack_id));
+            assert_eq!(statuses[0].1.tree_status, TreeStatus::Empty);
+            assert_eq!(statuses[0].1.branch_statuses.len(), 1);
+            assert_eq!(statuses[0].1.branch_statuses[0].name, "feature-branch");
+            assert_eq!(
+                statuses[0].1.branch_statuses[0].status,
+                BranchStatus::SaflyUpdatable
+            );
+            assert!(worktree_conflicts.is_empty());
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
+    }
+}
+
+#[test]
+fn upstream_integration_status_with_different_branch_pr() {
+    let Test { repo, ctx, .. } = &Test::default();
+
+    // Setup: Create a remote branch with commits
+    {
+        fs::write(repo.path().join("file.txt"), "initial").unwrap();
+        let first_commit_oid = repo.commit_all("initial commit");
+        fs::write(repo.path().join("file.txt"), "second").unwrap();
+        repo.commit_all("second commit");
+        repo.push();
+        repo.reset_hard(Some(first_commit_oid));
+    }
+
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        ctx.project().exclusive_worktree_access().write_permission(),
+    )
+    .unwrap();
+
+    // Create a virtual branch with a commit
+    let stack_id = {
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
+            ctx,
+            &BranchCreateRequest {
+                name: Some("feature-branch".to_string()),
+                ..Default::default()
+            },
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )
+        .unwrap();
+
+        fs::write(repo.path().join("feature-file.txt"), "feature work").unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "feature commit", None)
+            .unwrap();
+
+        stack_entry.id
+    };
+
+    let mut review_map = HashMap::new();
+    review_map.insert(
+        "different-branch".to_string(),
+        ForgeReview {
+            html_url: "https://github.com/test/repo/pull/2".to_string(),
+            number: 2,
+            title: "Different PR".to_string(),
+            body: None,
+            author: None,
+            labels: vec![],
+            draft: false,
+            source_branch: "different-branch".to_string(),
+            target_branch: "master".to_string(),
+            sha: "def456".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            modified_at: Some("2024-01-02T00:00:00Z".to_string()),
+            merged_at: Some("2024-01-03T00:00:00Z".to_string()),
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            reviewers: vec![],
+            unit_symbol: "#".to_string(),
+        },
+    );
+
+    let statuses =
+        gitbutler_branch_actions::upstream_integration_statuses(ctx, None, &review_map).unwrap();
+
+    match statuses {
+        StackStatuses::UpdatesRequired {
+            statuses,
+            worktree_conflicts,
+        } => {
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].0, Some(stack_id));
+            assert_eq!(statuses[0].1.tree_status, TreeStatus::Empty);
+            assert_eq!(statuses[0].1.branch_statuses.len(), 1);
+            assert_eq!(statuses[0].1.branch_statuses[0].name, "feature-branch");
+            assert_eq!(
+                statuses[0].1.branch_statuses[0].status,
+                BranchStatus::SaflyUpdatable
+            );
+            assert!(worktree_conflicts.is_empty());
+        }
+        StackStatuses::UpToDate => panic!("Expected UpdatesRequired status"),
     }
 }

--- a/crates/gitbutler-cli/src/command/mod.rs
+++ b/crates/gitbutler-cli/src/command/mod.rs
@@ -31,7 +31,12 @@ pub mod workspace {
                 delete_integrated_branches: false,
             })
             .collect();
-        gitbutler_branch_actions::integrate_upstream(&ctx, &resolutions, None)?;
+        gitbutler_branch_actions::integrate_upstream(
+            &ctx,
+            &resolutions,
+            None,
+            &Default::default(),
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Correctly handle branches being merged from a forge.

- If the branch has been merged from the forge, then consider it integrated
- If the branch has local changes but the previously-associated review has been closed, dissociate it