### PR TITLE
Refactor text editor

### DIFF
--- a/apps/desktop/src/components/Feed.svelte
+++ b/apps/desktop/src/components/Feed.svelte
@@ -249,7 +249,7 @@
 					<RichTextEditor
 						bind:this={editor}
 						namespace="feed"
-						markdown={false}
+						plaintext={true}
 						styleContext="chat-input"
 						placeholder="Tab tab tab"
 						disabled={botting.current.isLoading}

--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -246,7 +246,7 @@
 				bind:this={editorRef}
 				bind:value
 				namespace="codegen-input"
-				markdown={false}
+				plaintext={true}
 				styleContext="chat-input"
 				placeholder="{randomPlaceholder} Use @ to reference files…"
 				minHeight="4rem"

--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -329,7 +329,7 @@
 					namespace="CommitMessageEditor"
 					{placeholder}
 					bind:this={composer}
-					markdown={false}
+					plaintext={true}
 					onError={(e) => console.warn('Editor error', e)}
 					initialText={initialValue}
 					onChange={handleChange}

--- a/apps/web/src/lib/components/chat/ChatInput.svelte
+++ b/apps/web/src/lib/components/chat/ChatInput.svelte
@@ -276,7 +276,7 @@
 				styleContext="chat-input"
 				placeholder="Write your message"
 				bind:this={richText.richTextEditor}
-				markdown={false}
+				plaintext={true}
 				namespace="ChatInput"
 				onError={console.error}
 				onInput={(text) => messageHandler.update(text)}

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
@@ -283,7 +283,7 @@
 							<div class="summary-wrapper">
 								<RichTextEditor
 									namespace="review-description"
-									markdown={false}
+									plaintext={true}
 									onError={console.error}
 									styleContext="chat-input"
 									initialText={branch.description}

--- a/packages/ui/src/lib/richText/css/standard-theme.css
+++ b/packages/ui/src/lib/richText/css/standard-theme.css
@@ -44,6 +44,11 @@
 	text-wrap: var(--lexical-input-client-text-wrap, normal);
 }
 
+/* Remove paragraph margins in plain-text mode */
+.lexical-container.plain-text .StandardTheme__paragraph {
+	margin-bottom: 0;
+}
+
 .StandardTheme__quote {
 	position: relative;
 	margin-bottom: var(--markdown-generic-bottom-margin);
@@ -155,10 +160,10 @@
 .StandardTheme__code {
 	display: block;
 	position: relative;
-	margin-top: 8px;
-	margin-bottom: var(--markdown-generic-bottom-margin);
-	padding: 12px;
-	overflow-x: auto;
+	max-height: 400px;
+	margin: 8px 0;
+	padding: 8px 12px;
+	overflow: auto;
 	border: 1px solid var(--clr-border-2);
 	border-radius: var(--radius-m);
 	background-color: var(--clr-bg-1);

--- a/packages/ui/src/lib/richText/customTransforers.ts
+++ b/packages/ui/src/lib/richText/customTransforers.ts
@@ -3,17 +3,18 @@ import { $isParagraphNode, ParagraphNode } from 'lexical';
 import type { ElementTransformer, Transformer } from '@lexical/markdown';
 
 /**
- * A transformer used for exporting to markdown, and having paragraphs
- * separated by `\n\n` instead of just a single newline.
+ * A transformer used for exporting to markdown, where each paragraph
+ * becomes its own line separated by `\n`.
  */
-export const ParagraphMarkdownTransformer: ElementTransformer = {
+export const PARAGRAPH_TRANSFORMER: ElementTransformer = {
 	dependencies: [ParagraphNode],
 	export: (node, traverseChildren) => {
 		if ($isParagraphNode(node)) {
 			const nextSibling = node.getNextSibling();
 			const text = traverseChildren(node);
+			// Each paragraph becomes a line, separated by a single newline
 			if (nextSibling !== null) {
-				return `${text}\n`;
+				return `${text}`;
 			}
 			return text;
 		}

--- a/packages/ui/src/lib/richText/markdown.ts
+++ b/packages/ui/src/lib/richText/markdown.ts
@@ -1,4 +1,4 @@
-import { ParagraphMarkdownTransformer } from '$lib/richText/customTransforers';
+import { PARAGRAPH_TRANSFORMER } from '$lib/richText/customTransforers';
 import { isWrappingExempt, parseBullet, parseIndent, wrapLine } from '$lib/richText/linewrap';
 import {
 	$convertFromMarkdownString as convertFromMarkdownString,
@@ -8,8 +8,7 @@ import {
 	$getRoot as getRoot,
 	type LexicalEditor,
 	$createParagraphNode as createParagraphNode,
-	$createTextNode as createTextNode,
-	$createLineBreakNode as createLineBreakNode
+	$createTextNode as createTextNode
 } from 'lexical';
 import { ALL_TRANSFORMERS } from 'svelte-lexical';
 
@@ -25,7 +24,7 @@ export function updateEditorToRichText(editor: LexicalEditor | undefined) {
  */
 export function getMarkdownString(maxLength?: number): string {
 	const markdown = convertToMarkdownString(
-		[ParagraphMarkdownTransformer, ...ALL_TRANSFORMERS],
+		[PARAGRAPH_TRANSFORMER, ...ALL_TRANSFORMERS],
 		undefined,
 		true
 	);
@@ -121,11 +120,11 @@ export function updateEditorToPlaintext(editor: LexicalEditor | undefined, maxLe
 		const root = getRoot();
 		root.clear();
 
-		const paragraph = createParagraphNode();
+		// Create a separate paragraph for each line
 		for (const line of text.split('\n')) {
+			const paragraph = createParagraphNode();
 			paragraph.append(createTextNode(line));
-			paragraph.append(createLineBreakNode());
+			root.append(paragraph);
 		}
-		root.append(paragraph);
 	});
 }

--- a/packages/ui/src/lib/richText/plugins/FilePlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/FilePlugin.svelte
@@ -72,37 +72,40 @@
 		const fileStart = fileMatch;
 
 		// Replace the search text with the selected file path
-		editor.update(() => {
-			const selection = getSelection();
-			if (!isRangeSelection(selection)) return;
+		editor.update(
+			() => {
+				const selection = getSelection();
+				if (!isRangeSelection(selection)) return;
 
-			const anchor = selection.anchor;
-			const anchorNode = anchor.getNode();
-			if (!isTextNode(anchorNode)) return;
+				const anchor = selection.anchor;
+				const anchorNode = anchor.getNode();
+				if (!isTextNode(anchorNode)) return;
 
-			const offset = anchor.offset;
-			const fullText = anchorNode.getTextContent();
-			const textBeforeCursor = fullText.slice(0, offset);
-			const textAfterCursor = fullText.slice(offset);
-			const match = '@' + fileStart;
-			const matchIndex = textBeforeCursor.lastIndexOf(match);
-			if (matchIndex !== -1) {
-				const replacement = '`' + path + '`';
-				const textBefore = textBeforeCursor.slice(0, matchIndex);
+				const offset = anchor.offset;
+				const fullText = anchorNode.getTextContent();
+				const textBeforeCursor = fullText.slice(0, offset);
+				const textAfterCursor = fullText.slice(offset);
+				const match = '@' + fileStart;
+				const matchIndex = textBeforeCursor.lastIndexOf(match);
+				if (matchIndex !== -1) {
+					const replacement = '`' + path + '`';
+					const textBefore = textBeforeCursor.slice(0, matchIndex);
 
-				// Split the text node and insert inline code node
-				const beforeNode = new TextNode(textBefore);
-				const inlineCodeNode = createInlineCodeNode(replacement);
-				const afterNode = new TextNode(textAfterCursor);
+					// Split the text node and insert inline code node
+					const beforeNode = new TextNode(textBefore);
+					const inlineCodeNode = createInlineCodeNode(replacement);
+					const afterNode = new TextNode(textAfterCursor);
 
-				anchorNode.replace(beforeNode);
-				beforeNode.insertAfter(inlineCodeNode);
-				inlineCodeNode.insertAfter(afterNode);
+					anchorNode.replace(beforeNode);
+					beforeNode.insertAfter(inlineCodeNode);
+					inlineCodeNode.insertAfter(afterNode);
 
-				// Position cursor after the inline code
-				afterNode.selectStart();
-			}
-		});
+					// Position cursor after the inline code
+					afterNode.selectStart();
+				}
+			},
+			{ discrete: true }
+		);
 
 		exit();
 	}

--- a/packages/ui/src/lib/richText/plugins/Formatter.svelte
+++ b/packages/ui/src/lib/richText/plugins/Formatter.svelte
@@ -62,10 +62,13 @@
 	};
 
 	function formatBlock(type: keyof typeof blockMap) {
-		editor.update(() => {
-			const selection = getSelection();
-			setBlocksType(selection, () => blockMap[type]());
-		});
+		editor.update(
+			() => {
+				const selection = getSelection();
+				setBlocksType(selection, () => blockMap[type]());
+			},
+			{ tag: 'history-merge' }
+		);
 	}
 
 	function nonZeroRange() {

--- a/packages/ui/src/lib/richText/plugins/HardWrapPlugin.test.ts
+++ b/packages/ui/src/lib/richText/plugins/HardWrapPlugin.test.ts
@@ -1,0 +1,452 @@
+import { wrapIfNecssary } from '$lib/richText/linewrap';
+import { createEditor, type LexicalEditor } from 'lexical';
+import {
+	$createParagraphNode as createParagraphNode,
+	$createTextNode as createTextNode,
+	$getRoot as getRoot,
+	$getNodeByKey as getNodeByKey,
+	$getSelection as getSelection,
+	$isRangeSelection as isRangeSelection,
+	type TextNode
+} from 'lexical';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('HardWrapPlugin with multi-paragraph structure', () => {
+	let editor: LexicalEditor;
+
+	beforeEach(() => {
+		editor = createEditor({
+			namespace: 'test',
+			onError: (error) => {
+				throw error;
+			}
+		});
+	});
+
+	it('should wrap a single long line into multiple paragraphs', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode('This is a very long line that exceeds the maximum length');
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			// Trigger wrapping with maxLength of 20
+			wrapIfNecssary({ node: textNode, maxLength: 20 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// Should have created multiple paragraphs
+			expect(children.length).toBeGreaterThan(1);
+		});
+	});
+
+	it('should handle wrapping text with indentation', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode('  This is an indented line that is very long');
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			wrapIfNecssary({ node: textNode, maxLength: 20 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// Check that indentation is preserved
+			if (children.length > 1) {
+				const secondPara = children[1];
+				const text = secondPara.getTextContent();
+				expect(text.startsWith('  ')).toBe(true);
+			}
+		});
+	});
+
+	it('should handle wrapping bullet points', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode(
+				'- This is a bullet point that is very long and needs wrapping'
+			);
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			wrapIfNecssary({ node: textNode, maxLength: 25 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// First line should have bullet
+			expect(children[0].getTextContent()).toContain('-');
+
+			// Subsequent lines should be indented
+			if (children.length > 1) {
+				const secondPara = children[1];
+				const text = secondPara.getTextContent();
+				expect(text.startsWith('  ')).toBe(true);
+			}
+		});
+	});
+
+	it('should not wrap lines that are exempt (code blocks)', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode('```typescript');
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			wrapIfNecssary({ node: textNode, maxLength: 10 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// Should not have wrapped
+			expect(children.length).toBe(1);
+			expect(children[0].getTextContent()).toBe('```typescript');
+		});
+	});
+
+	it('should not wrap lines shorter than maxLength', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode('Short line');
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			wrapIfNecssary({ node: textNode, maxLength: 50 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// Should not have wrapped
+			expect(children.length).toBe(1);
+			expect(children[0].getTextContent()).toBe('Short line');
+		});
+	});
+
+	it('should handle text without spaces', () => {
+		editor.update(() => {
+			const root = getRoot();
+			const paragraph = createParagraphNode();
+			const textNode = createTextNode('verylongtextwithoutspaces');
+			paragraph.append(textNode);
+			root.append(paragraph);
+
+			wrapIfNecssary({ node: textNode, maxLength: 10 });
+		});
+
+		editor.read(() => {
+			const root = getRoot();
+			const children = root.getChildren();
+
+			// Should not wrap text without spaces
+			expect(children.length).toBe(1);
+		});
+	});
+
+	describe('cursor positioning', () => {
+		it('should maintain cursor position when editing at the start', () => {
+			let textNodeKey = '';
+
+			editor.update(() => {
+				const root = getRoot();
+				const paragraph = createParagraphNode();
+				const textNode = createTextNode('This is a very long line that needs wrapping');
+				paragraph.append(textNode);
+				root.append(paragraph);
+				textNodeKey = textNode.getKey();
+
+				// Set cursor at position 5 (after "This ")
+				textNode.select(5, 5);
+			});
+
+			editor.update(() => {
+				const node = getNodeByKey(textNodeKey) as TextNode;
+				wrapIfNecssary({ node, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const selection = getSelection();
+				if (isRangeSelection(selection)) {
+					const anchorNode = selection.anchor.getNode();
+					const offset = selection.anchor.offset;
+
+					// Cursor should still be in the first paragraph
+					expect(anchorNode.getTextContent()).toContain('This is a very long');
+					expect(offset).toBe(5);
+				}
+			});
+		});
+
+		it('should move cursor to next paragraph when editing near wrap point', () => {
+			let textNodeKey = '';
+
+			editor.update(() => {
+				const root = getRoot();
+				const paragraph = createParagraphNode();
+				const textNode = createTextNode('Short text that will become long text after edit');
+				paragraph.append(textNode);
+				root.append(paragraph);
+				textNodeKey = textNode.getKey();
+
+				// Set cursor at position 35 (towards the end)
+				textNode.select(35, 35);
+			});
+
+			editor.update(() => {
+				const node = getNodeByKey(textNodeKey) as TextNode;
+				wrapIfNecssary({ node, maxLength: 25 });
+			});
+
+			editor.read(() => {
+				const selection = getSelection();
+				const root = getRoot();
+				const children = root.getChildren();
+
+				if (isRangeSelection(selection)) {
+					// Cursor should have moved to a subsequent paragraph
+					// since position 35 is past the first wrap point
+					expect(children.length).toBeGreaterThan(1);
+				}
+			});
+		});
+
+		it('should handle cursor at the very end of wrapped text', () => {
+			let textNodeKey = '';
+
+			editor.update(() => {
+				const root = getRoot();
+				const paragraph = createParagraphNode();
+				const textNode = createTextNode('This is a very long line that definitely needs wrapping');
+				paragraph.append(textNode);
+				root.append(paragraph);
+				textNodeKey = textNode.getKey();
+
+				// Set cursor at the end
+				const length = textNode.getTextContentSize();
+				textNode.select(length, length);
+			});
+
+			editor.update(() => {
+				const node = getNodeByKey(textNodeKey) as TextNode;
+				wrapIfNecssary({ node, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const selection = getSelection();
+				const root = getRoot();
+				const children = root.getChildren();
+
+				if (isRangeSelection(selection)) {
+					const anchorNode = selection.anchor.getNode();
+
+					// Cursor should be in the last paragraph
+					const lastPara = children[children.length - 1];
+					expect(anchorNode.getParent()?.getKey()).toBe(lastPara.getKey());
+				}
+			});
+		});
+	});
+
+	describe('rewrapping paragraphs', () => {
+		it('should rewrap multiple related paragraphs when editing the first one', () => {
+			editor.update(() => {
+				const root = getRoot();
+
+				// Create multiple paragraphs that look like they were previously wrapped
+				const para1 = createParagraphNode();
+				para1.append(createTextNode('This is the first'));
+				root.append(para1);
+
+				const para2 = createParagraphNode();
+				para2.append(createTextNode('line of a long'));
+				root.append(para2);
+
+				const para3 = createParagraphNode();
+				para3.append(createTextNode('paragraph text'));
+				root.append(para3);
+
+				// Now edit the first paragraph to make it longer
+				const textNode = para1.getFirstChild() as TextNode;
+				textNode.setTextContent('This is the first line that has been made much longer');
+
+				// Trigger rewrap
+				wrapIfNecssary({ node: textNode, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const root = getRoot();
+				const children = root.getChildren();
+
+				// Should have rewrapped all related paragraphs
+				expect(children.length).toBeGreaterThan(1);
+
+				// Each paragraph should respect the maxLength
+				children.forEach((child) => {
+					const text = child.getTextContent();
+					// Allow some tolerance for word boundaries
+					expect(text.length).toBeLessThanOrEqual(25);
+				});
+			});
+		});
+
+		it('should handle editing in the middle of a long unwrapped line', () => {
+			let textNodeKey = '';
+
+			editor.update(() => {
+				const root = getRoot();
+				const paragraph = createParagraphNode();
+				const textNode = createTextNode(
+					'This is a very long line that has not been wrapped yet and needs to be wrapped'
+				);
+				paragraph.append(textNode);
+				root.append(paragraph);
+				textNodeKey = textNode.getKey();
+
+				// Set cursor towards the end (position 60)
+				textNode.select(60, 60);
+			});
+
+			editor.update(() => {
+				const node = getNodeByKey(textNodeKey) as TextNode;
+				// Simulate adding text by modifying the content
+				node.setTextContent(
+					'This is a very long line that has not been wrapped yet and definitely needs to be wrapped now'
+				);
+
+				wrapIfNecssary({ node, maxLength: 25 });
+			});
+
+			editor.read(() => {
+				const selection = getSelection();
+				const root = getRoot();
+				const children = root.getChildren();
+
+				// Should have created multiple paragraphs
+				expect(children.length).toBeGreaterThan(2);
+
+				if (isRangeSelection(selection)) {
+					const anchorNode = selection.anchor.getNode();
+
+					// Cursor should be in one of the later paragraphs since edit was at position 60
+					const anchorParent = anchorNode.getParent();
+					const parentIndex = children.findIndex(
+						(child) => child.getKey() === anchorParent?.getKey()
+					);
+
+					// Should be in the last few paragraphs
+					expect(parentIndex).toBeGreaterThan(0);
+				}
+			});
+		});
+
+		it('should not rewrap paragraphs with different indentation', () => {
+			editor.update(() => {
+				const root = getRoot();
+
+				// First paragraph with no indentation
+				const para1 = createParagraphNode();
+				para1.append(createTextNode('This is a long line that needs wrapping and has no indent'));
+				root.append(para1);
+
+				// Second paragraph with indentation (should not be considered related)
+				const para2 = createParagraphNode();
+				para2.append(createTextNode('  This line has indent'));
+				root.append(para2);
+
+				// Trigger wrap on first paragraph
+				const textNode = para1.getFirstChild() as TextNode;
+				wrapIfNecssary({ node: textNode, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const root = getRoot();
+				const children = root.getChildren();
+
+				// Should have wrapped the first paragraph but not touched the indented one
+				const lastPara = children[children.length - 1];
+				expect(lastPara.getTextContent()).toBe('  This line has indent');
+			});
+		});
+
+		it('should stop rewrapping at bullet points', () => {
+			editor.update(() => {
+				const root = getRoot();
+
+				// First paragraph
+				const para1 = createParagraphNode();
+				para1.append(
+					createTextNode('This is a long line that needs wrapping before the bullet point')
+				);
+				root.append(para1);
+
+				// Second paragraph with a bullet (should not be rewrapped)
+				const para2 = createParagraphNode();
+				para2.append(createTextNode('- This is a bullet point'));
+				root.append(para2);
+
+				// Trigger wrap on first paragraph
+				const textNode = para1.getFirstChild() as TextNode;
+				wrapIfNecssary({ node: textNode, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const root = getRoot();
+				const children = root.getChildren();
+
+				// Should have wrapped the first paragraph but kept bullet separate
+				const lastPara = children[children.length - 1];
+				expect(lastPara.getTextContent()).toBe('- This is a bullet point');
+			});
+		});
+
+		it('should preserve empty paragraphs as boundaries', () => {
+			editor.update(() => {
+				const root = getRoot();
+
+				// First paragraph
+				const para1 = createParagraphNode();
+				para1.append(createTextNode('This is a long line that needs to be wrapped properly'));
+				root.append(para1);
+
+				// Empty paragraph (paragraph break)
+				const emptyPara = createParagraphNode();
+				emptyPara.append(createTextNode(''));
+				root.append(emptyPara);
+
+				// Third paragraph (should not be touched)
+				const para3 = createParagraphNode();
+				para3.append(createTextNode('Another paragraph'));
+				root.append(para3);
+
+				// Trigger wrap on first paragraph
+				const textNode = para1.getFirstChild() as TextNode;
+				wrapIfNecssary({ node: textNode, maxLength: 20 });
+			});
+
+			editor.read(() => {
+				const root = getRoot();
+				const children = root.getChildren();
+
+				// The last paragraph should still be "Another paragraph"
+				const lastPara = children[children.length - 1];
+				expect(lastPara.getTextContent()).toBe('Another paragraph');
+			});
+		});
+	});
+});

--- a/packages/ui/src/lib/richText/plugins/Mention.svelte
+++ b/packages/ui/src/lib/richText/plugins/Mention.svelte
@@ -46,16 +46,19 @@
 		const mentionEnd = mentionMatch.end;
 
 		// Replace the search text with the selected mention
-		editor.update(() => {
-			const selection = getSelection();
-			insertMention({
-				selection,
-				start: mentionStart,
-				end: mentionEnd,
-				id: suggestion.id,
-				label: suggestion.label
-			});
-		});
+		editor.update(
+			() => {
+				const selection = getSelection();
+				insertMention({
+					selection,
+					start: mentionStart,
+					end: mentionEnd,
+					id: suggestion.id,
+					label: suggestion.label
+				});
+			},
+			{ tag: 'history-merge' }
+		);
 
 		exit();
 	}

--- a/packages/ui/src/lib/richText/plugins/PlainTextIndentPlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/PlainTextIndentPlugin.svelte
@@ -1,17 +1,18 @@
 <!--
 @component
 This component overrides enter key command, in order to customize the behavior
-of the Enter key.
+of the Enter key in plain-text mode to create new paragraphs.
 -->
 <script lang="ts">
 	import { parseIndent, parseBullet } from '$lib/richText/linewrap';
 
 	import {
-		TextNode,
-		LineBreakNode,
+		$createTextNode as createTextNode,
+		$createParagraphNode as createParagraphNode,
 		$getSelection as getSelection,
 		$isRangeSelection as isRangeSelection,
-		$insertNodes as insertNodes,
+		$isParagraphNode as isParagraphNode,
+		$isTextNode as isTextNode,
 		COMMAND_PRIORITY_HIGH,
 		INSERT_PARAGRAPH_COMMAND
 	} from 'lexical';
@@ -24,9 +25,12 @@ of the Enter key.
 		if (!isRangeSelection(selection)) return false;
 
 		const anchor = selection.anchor;
-		const node = anchor.getNode(); // Current line.
+		const node = anchor.getNode();
+		const paragraph = node.getParent();
 
-		const text = node.getTextContent();
+		if (!isParagraphNode(paragraph)) return false;
+
+		const text = paragraph.getTextContent();
 		const indent = parseIndent(text);
 		const bullet = parseBullet(text);
 
@@ -39,9 +43,30 @@ of the Enter key.
 		}
 
 		if (bullet && text.length === bullet.prefix.length) {
-			node.remove();
+			// Empty bullet line - remove it
+			paragraph.remove();
 		} else {
-			insertNodes([new LineBreakNode(), new TextNode(newIndent)]);
+			// Split the current paragraph at cursor position
+			const offset = anchor.offset;
+
+			// Only handle if we're in a text node
+			if (!isTextNode(node)) return false;
+
+			const textContent = node.getTextContent();
+			const beforeText = textContent.substring(0, offset);
+			const afterText = textContent.substring(offset);
+
+			// Update current node with text before cursor
+			node.setTextContent(beforeText);
+
+			// Create new paragraph with indentation and remaining text
+			const newParagraph = createParagraphNode();
+			const newTextNode = createTextNode(newIndent + afterText);
+			newParagraph.append(newTextNode);
+			paragraph.insertAfter(newParagraph);
+
+			// Move cursor to start of new paragraph (after indent)
+			newTextNode.select(newIndent.length, newIndent.length);
 		}
 
 		return true;

--- a/packages/ui/src/lib/richText/selection.ts
+++ b/packages/ui/src/lib/richText/selection.ts
@@ -129,37 +129,40 @@ export function getSelectionPosition(windowScrollY?: number) {
  * offset are passed.
  */
 export function insertFilePath(editor: LexicalEditor, path: string, count: number) {
-	editor.update(() => {
-		const selection = $getSelection();
-		if (!$isRangeSelection(selection)) {
-			return;
-		}
+	editor.update(
+		() => {
+			const selection = $getSelection();
+			if (!$isRangeSelection(selection)) {
+				return;
+			}
 
-		const pathNode = new TextNode(path);
+			const pathNode = new TextNode(path);
 
-		const node = selection.getNodes().at(0);
+			const node = selection.getNodes().at(0);
 
-		if (!(node instanceof TextNode)) {
-			selection.insertNodes([pathNode]);
-			return;
-		}
+			if (!(node instanceof TextNode)) {
+				selection.insertNodes([pathNode]);
+				return;
+			}
 
-		const offset = selection.anchor.offset;
-		let target: TextNode | undefined;
+			const offset = selection.anchor.offset;
+			let target: TextNode | undefined;
 
-		if (offset === count) {
-			[target] = node.splitText(count);
-		} else {
-			[, target] = node.splitText(offset - count, offset);
-		}
+			if (offset === count) {
+				[target] = node.splitText(count);
+			} else {
+				[, target] = node.splitText(offset - count, offset);
+			}
 
-		if (!target) {
-			throw new Error('Expected target');
-		}
+			if (!target) {
+				throw new Error('Expected target');
+			}
 
-		target.replace(pathNode, false);
-		pathNode.selectEnd();
-	});
+			target.replace(pathNode, false);
+			pathNode.selectEnd();
+		},
+		{ tag: 'history-merge' }
+	);
 }
 
 /**
@@ -200,24 +203,30 @@ export function insertImageAtCaret(
 }
 
 export function insertTextAtCaret(editor: LexicalEditor, text: string) {
-	editor.update(() => {
-		const selection = $getSelection();
-		if (!$isRangeSelection(selection)) {
-			return;
-		}
-		const node = selection.getNodes().at(0);
+	editor.update(
+		() => {
+			const selection = $getSelection();
+			if (!$isRangeSelection(selection)) {
+				return;
+			}
+			const node = selection.getNodes().at(0);
 
-		if (!(node instanceof TextNode)) {
-			selection.insertText(text);
-			return;
-		}
-		const offset = selection.anchor.offset;
-		node.spliceText(offset, 0, text);
-	});
+			if (!(node instanceof TextNode)) {
+				selection.insertText(text);
+				return;
+			}
+			const offset = selection.anchor.offset;
+			node.spliceText(offset, 0, text);
+		},
+		{ tag: 'history-merge' }
+	);
 }
 
 export function setEditorText(editor: LexicalEditor, text: string) {
-	editor.update(() => {
-		$convertFromMarkdownString(text, [INLINE_CODE_TRANSFORMER, CODE]);
-	});
+	editor.update(
+		() => {
+			$convertFromMarkdownString(text, [INLINE_CODE_TRANSFORMER, CODE]);
+		},
+		{ discrete: true }
+	);
 }

--- a/packages/ui/src/stories/components/RichTextEditor.stories.svelte
+++ b/packages/ui/src/stories/components/RichTextEditor.stories.svelte
@@ -10,7 +10,7 @@
 		args: {
 			styleContext: 'client-editor',
 			namespace: 'commit-message',
-			markdown: false,
+			plaintext: true,
 			onError: (error: unknown) => console.error(error),
 			placeholder: 'Type your message here…'
 		}
@@ -27,7 +27,7 @@
 			<div class="text-input">
 				<RichTextEditor
 					namespace={args.namespace || 'commit-message'}
-					markdown={args.markdown || false}
+					plaintext={args.plaintext ?? true}
 					onError={args.onError || console.error}
 					styleContext={args.styleContext || 'client-editor'}
 					placeholder={args.placeholder || 'Type your message here…'}


### PR DESCRIPTION
Fixes a shortcoming where in plaintext mode we don't allow paragraphs. 

While that made sense, it makes dealing with newlines more difficult. 

Going forward we'll be preferring paragraphs without margins instead of 

text nodes separated by line breaks.