### PR TITLE
ui-fixes-and-gerrit-mode

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenTodoAccordion.svelte
+++ b/apps/desktop/src/components/codegen/CodegenTodoAccordion.svelte
@@ -25,7 +25,7 @@
 		</div>
 		{#if displayTodo && !expanded}
 			<CodegenStatusIcon status={displayTodo.status} />
-			<span class="text-12 clr-text-2">
+			<span class="text-12 clr-text-2 truncate">
 				{completedCount}/{totalCount}.
 				{displayTodo.content}
 			</span>

--- a/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCalls.svelte
@@ -66,8 +66,6 @@
 								class="tool-calls-collapsed__item"
 								class:hidable={filteredCalls.length > toolDisplayLimit}
 							>
-								<span class="separator">•</span>
-
 								{#if toolCallLoading(toolCall)}
 									<Icon name="spinner" />
 								{:else}
@@ -78,7 +76,6 @@
 						{/each}
 
 						{#if filteredCalls.length > toolDisplayLimit}
-							<span class="separator">•</span>
 							<p class="clr-text-2">+<span class="tool-calls-amount"></span> more</p>
 						{/if}
 					{/snippet}

--- a/apps/desktop/src/components/codegen/ExpandableSection.svelte
+++ b/apps/desktop/src/components/codegen/ExpandableSection.svelte
@@ -77,6 +77,8 @@
 		position: relative;
 		align-items: center;
 		width: fit-content;
+		width: 100%;
+		overflow: hidden;
 		gap: 10px;
 		user-select: none;
 
@@ -107,6 +109,7 @@
 	.section-summary {
 		display: flex;
 		align-items: center;
+		overflow: hidden;
 		gap: 8px;
 	}
 

--- a/apps/desktop/src/components/codegen/ExpandableSection.svelte
+++ b/apps/desktop/src/components/codegen/ExpandableSection.svelte
@@ -77,7 +77,7 @@
 		position: relative;
 		align-items: center;
 		width: fit-content;
-		gap: 8px;
+		gap: 10px;
 		user-select: none;
 
 		&:hover {
@@ -107,7 +107,7 @@
 	.section-summary {
 		display: flex;
 		align-items: center;
-		gap: 6px;
+		gap: 8px;
 	}
 
 	.section-content {

--- a/packages/ui/src/lib/components/TagInput.svelte
+++ b/packages/ui/src/lib/components/TagInput.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	import Icon from '$components/Icon.svelte';
+	import { focusable } from '$lib/focus/focusable';
+	import { pxToRem } from '$lib/utils/pxToRem';
+	import type { BaseInputProps, InputStylingProps } from '$components/inputTypes';
+
+	export interface Tag {
+		id: string;
+		label: string;
+	}
+
+	interface Props extends BaseInputProps, InputStylingProps {
+		tags?: Tag[];
+		value?: string;
+		maxTags?: number;
+		onAddTag?: (tag: Tag) => void;
+		onRemoveTag?: (tagId: string) => void;
+		onTagsChange?: (tags: Tag[]) => void;
+	}
+
+	let {
+		id,
+		testId,
+		label,
+		tags = $bindable([]),
+		value = $bindable(''),
+		placeholder = 'Add tags (split by space/comma)',
+		disabled = false,
+		readonly = false,
+		autofocus: _autofocus = false,
+		error,
+		helperText,
+		wide = false,
+		width,
+		maxTags,
+		onAddTag,
+		onRemoveTag,
+		onTagsChange
+	}: Props = $props();
+
+	let inputEl: HTMLInputElement;
+	let hasError = $derived(!!error);
+
+	function generateId(): string {
+		return `tag-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+	}
+
+	function addTag(label: string) {
+		const trimmedLabel = label.trim();
+
+		if (!trimmedLabel) return;
+		if (maxTags && tags.length >= maxTags) return;
+		if (tags.some((t) => t.label === trimmedLabel)) return;
+
+		const newTag: Tag = {
+			id: generateId(),
+			label: trimmedLabel
+		};
+
+		tags = [...tags, newTag];
+		value = '';
+
+		onAddTag?.(newTag);
+		onTagsChange?.(tags);
+	}
+
+	function removeTag(tagId: string) {
+		tags = tags.filter((t) => t.id !== tagId);
+		onRemoveTag?.(tagId);
+		onTagsChange?.(tags);
+		inputEl?.focus();
+	}
+
+	function handleKeyDown(e: KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement }) {
+		// Add tag on comma or space
+		if (e.key === ',' || e.key === ' ') {
+			e.preventDefault();
+			addTag(value);
+		} else if (e.key === 'Backspace' && !value && tags.length > 0) {
+			// Remove last tag on backspace when input is empty
+			removeTag(tags[tags.length - 1].id);
+		}
+	}
+
+	function handleBlur() {
+		// Optionally add tag on blur if there's content
+		if (value.trim()) {
+			addTag(value);
+		}
+	}
+
+	export function focus() {
+		inputEl?.focus();
+	}
+</script>
+
+<div
+	class="tag-input-wrapper"
+	class:wide
+	class:error={hasError}
+	style:width={width ? `${pxToRem(width)}rem` : undefined}
+>
+	{#if label}
+		<label class="tag-input-label text-13 text-semibold" for={id}>
+			{label}
+		</label>
+	{/if}
+
+	<div
+		class="tag-input-container text-input"
+		class:disabled
+		class:readonly
+		class:error={hasError}
+		role="button"
+		tabindex="-1"
+		onclick={() => !disabled && !readonly && inputEl?.focus()}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				inputEl?.focus();
+			}
+		}}
+	>
+		<div class="tag-list">
+			{#each tags as tag (tag.id)}
+				<div class="tag">
+					<span class="tag-label text-12">{tag.label}</span>
+					{#if !disabled && !readonly}
+						<button
+							type="button"
+							class="tag-remove focus-state"
+							onclick={(e) => {
+								e.stopPropagation();
+								removeTag(tag.id);
+							}}
+							aria-label="Remove tag"
+						>
+							<Icon name="cross-small" />
+						</button>
+					{/if}
+				</div>
+			{/each}
+
+			<input
+				bind:this={inputEl}
+				use:focusable={{ button: true }}
+				{id}
+				data-testid={testId}
+				type="text"
+				class="tag-input text-13"
+				class:disabled
+				class:readonly
+				{placeholder}
+				{disabled}
+				{readonly}
+				bind:value
+				onkeydown={handleKeyDown}
+				onblur={handleBlur}
+			/>
+		</div>
+	</div>
+
+	{#if error}
+		<p class="text-11 text-body tag-input-error">{error}</p>
+	{:else if helperText}
+		<p class="text-11 text-body tag-input-helper">{helperText}</p>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.tag-input-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+
+		&.wide {
+			flex: 1;
+			width: 100%;
+		}
+	}
+
+	.tag-input-container {
+		min-height: var(--size-cta);
+		padding: 4px;
+		cursor: text;
+
+		&:focus-within {
+			border-color: var(--clr-border-1);
+		}
+
+		&.disabled {
+			cursor: default;
+		}
+
+		&.readonly {
+			cursor: default;
+		}
+	}
+
+	.tag-list {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 2px;
+	}
+
+	.tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 4px 2px 8px;
+		gap: 2px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: 100px;
+		background-color: var(--clr-bg-2);
+		color: var(--clr-text-1);
+		transition: background-color var(--transition-fast);
+
+		&:hover {
+			background-color: var(--clr-bg-1-muted);
+		}
+	}
+
+	.tag-label {
+		max-width: 200px;
+		overflow: hidden;
+		line-height: 1;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		user-select: none;
+	}
+
+	.tag-remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 100px;
+		color: var(--clr-text-3);
+		transition: color var(--transition-fast);
+
+		&:hover {
+			color: var(--clr-text-2);
+		}
+	}
+
+	.tag-input {
+		flex: 1;
+		min-width: 120px;
+		padding: 4px 6px;
+		border: none;
+		outline: none;
+		background: transparent;
+		color: var(--clr-text-1);
+
+		&::placeholder {
+			color: var(--clr-text-3);
+		}
+
+		&:disabled,
+		&.disabled {
+			cursor: default;
+		}
+
+		&.readonly {
+			cursor: default;
+		}
+	}
+
+	.tag-input-label {
+		color: var(--clr-scale-ntrl-50);
+	}
+
+	.tag-input-helper {
+		color: var(--clr-scale-ntrl-50);
+	}
+
+	.tag-input-error {
+		color: var(--clr-theme-err-element);
+	}
+</style>

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -215,26 +215,12 @@
 	.textarea {
 		overflow-x: hidden;
 		overflow-y: auto; /* Enable scrolling when max height is reached */
-		font-family: var(--font-default);
-		cursor: text;
 		resize: none;
-
-		transition:
-			border-color var(--transition-fast),
-			background-color var(--transition-fast);
 
 		&.hide-scrollbar {
 			&::-webkit-scrollbar {
 				display: none;
 			}
-		}
-
-		&:disabled {
-			cursor: default;
-		}
-
-		&::placeholder {
-			color: var(--clr-text-3);
 		}
 	}
 

--- a/packages/ui/src/lib/components/Textbox.svelte
+++ b/packages/ui/src/lib/components/Textbox.svelte
@@ -276,12 +276,6 @@
 			& .textbox__icon {
 				color: var(--clr-scale-ntrl-60);
 			}
-
-			& .textbox__input {
-				border: 1px solid var(--clr-border-3);
-				background-color: var(--clr-bg-1-muted);
-				color: var(--clr-text-2);
-			}
 		}
 	}
 
@@ -289,16 +283,6 @@
 		position: relative;
 		flex-grow: 1;
 		width: 100%;
-
-		&.readonly {
-			border-color: var(--clr-border-2);
-			background-color: var(--clr-bg-1-muted);
-		}
-
-		&.error {
-			border-color: var(--clr-theme-err-element);
-			background-color: var(--clr-theme-err-bg);
-		}
 
 		&.size-default {
 			height: var(--size-cta);

--- a/packages/ui/src/lib/components/inputTypes.ts
+++ b/packages/ui/src/lib/components/inputTypes.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared types for input components (Textbox, Textarea, TagInput)
+ */
+
+export interface BaseInputProps {
+	id?: string;
+	testId?: string;
+	label?: string;
+	placeholder?: string;
+	disabled?: boolean;
+	readonly?: boolean;
+	autofocus?: boolean;
+	error?: string;
+	helperText?: string;
+}
+
+export interface InputStylingProps {
+	wide?: boolean;
+	width?: number;
+}
+
+export interface InputStateCallbacks {
+	oninput?: (val: string) => void;
+	onchange?: (val: string) => void;
+	onblur?: (e: FocusEvent) => void;
+	onfocus?: (e: FocusEvent) => void;
+}

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -43,6 +43,7 @@ export { default as SeriesLabelsRow } from '$components/SeriesLabelsRow.svelte';
 export { default as SidebarEntry } from '$components/SidebarEntry.svelte';
 export { default as SimpleCommitRow } from '$components/SimpleCommitRow.svelte';
 export { default as Spacer } from '$components/Spacer.svelte';
+export { default as TagInput, type Tag } from '$components/TagInput.svelte';
 export { default as Textarea } from '$components/Textarea.svelte';
 export { default as Textbox } from '$components/Textbox.svelte';
 export { default as EmailTextbox } from '$components/EmailTextbox.svelte';
@@ -152,3 +153,10 @@ export {
 export { default as FormattingBar } from '$lib/richText/tools/FormattingBar.svelte';
 export { default as FormattingButton } from '$lib/richText/tools/FormattingButton.svelte';
 export * from '$lib/utils/testIds';
+
+// Shared types
+export type {
+	BaseInputProps,
+	InputStylingProps,
+	InputStateCallbacks
+} from '$components/inputTypes';

--- a/packages/ui/src/stories/components/TagInput.stories.svelte
+++ b/packages/ui/src/stories/components/TagInput.stories.svelte
@@ -1,0 +1,60 @@
+<script module lang="ts">
+	import TagInput from '$components/TagInput.svelte';
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import type { Tag } from '$components/TagInput.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Inputs / TagInput',
+		component: TagInput,
+		args: {
+			placeholder: 'Add tags…',
+			disabled: false,
+			readonly: false,
+			autofocus: false,
+			wide: false,
+			label: '',
+			helperText: 'Press comma or space to add a tag',
+			error: '',
+			maxTags: undefined,
+			width: undefined
+		},
+		argTypes: {
+			maxTags: {
+				control: { type: 'number' }
+			},
+			width: {
+				control: { type: 'number' }
+			}
+		}
+	});
+</script>
+
+<script lang="ts">
+	let basicTags = $state<Tag[]>([]);
+</script>
+
+<Story name="Default">
+	{#snippet template(args)}
+		<div class="wrap">
+			<TagInput
+				bind:tags={basicTags}
+				placeholder={args.placeholder}
+				disabled={args.disabled}
+				readonly={args.readonly}
+				wide={args.wide}
+				label={args.label}
+				helperText={args.helperText}
+				error={args.error}
+				maxTags={args.maxTags}
+				width={args.width}
+			/>
+		</div>
+	{/snippet}
+</Story>
+
+<style>
+	.wrap {
+		max-width: 400px;
+		padding: 16px;
+	}
+</style>

--- a/packages/ui/src/styles/components/text-input.css
+++ b/packages/ui/src/styles/components/text-input.css
@@ -5,8 +5,11 @@
 		border-radius: var(--radius-s);
 		background-color: var(--clr-bg-1);
 		color: var(--clr-text-1);
+		font-family: var(--font-default);
 		cursor: text;
-		transition: border-color var(--transition-fast);
+		transition:
+			border-color var(--transition-fast),
+			background-color var(--transition-fast);
 
 		&::placeholder {
 			color: var(--clr-text-3);
@@ -23,15 +26,26 @@
 		}
 
 		&:invalid,
-		&.invalid {
+		&.invalid,
+		&.error {
 			border-color: var(--clr-theme-err-element);
+		}
+
+		&.error {
+			background-color: var(--clr-theme-err-bg);
 		}
 
 		&:disabled,
 		&.disabled {
-			border-color: var(--clr-scale-ntrl-70);
+			border-color: var(--clr-border-3);
 			background-color: var(--clr-bg-1-muted);
 			color: var(--clr-text-2);
+			cursor: default;
+		}
+
+		&.readonly {
+			border-color: var(--clr-border-2);
+			background-color: var(--clr-bg-1-muted);
 		}
 	}
 }


### PR DESCRIPTION
Gerrit modal changes.

Before:

<img width="731" height="555" alt="image" src="https://github.com/user-attachments/assets/c9aea874-53d1-489a-b617-7a7b2100bb60" />


After:

<img width="505" height="442" alt="image" src="https://github.com/user-attachments/assets/be089645-e5ac-40b0-b6f8-a805a38b7377" />


---

This pull request introduces a new reusable `TagInput` component to the UI library and refactors the Gerrit push modal to use it, improving tag entry UX and code maintainability. It also includes minor UI tweaks for other components and consolidates shared input types.

**UI Component Improvements**

* Added a new `TagInput` component (`TagInput.svelte`) to the UI library, supporting tag entry, removal, keyboard navigation, and accessibility, with customizable props and styling. 
* Refactored the Gerrit push modal (`GerritPushModal.svelte`) to replace the previous manual tag entry logic with the new `TagInput` component, simplifying state management and improving user experience. 
* Added Storybook stories for `TagInput` to demonstrate usage and support UI documentation and testing.
**Shared Types and Exports**

* Added shared input prop types (`inputTypes.ts`) for consistent API across input components and exported them from the UI library index.
* Exported `TagInput` and its `Tag` type from the UI library index for use throughout the app. 

**Minor UI Tweaks**

* Improved text truncation and layout in codegen and expandable section components for better readability. 
* Adjusted styles for text input components to ensure consistent appearance and transitions. 
* Cleaned up unused or redundant styles in `Textarea` and `Textbox` components.