### PR TITLE
Single-branch support for `but branch apply`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9227,6 +9227,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -51,8 +51,13 @@ pub fn git_at_dir(dir: impl AsRef<Path>) -> std::process::Command {
 /// Run the given `script` in bash, with the `cwd` set to the `repo` worktree.
 /// Panic if the script fails.
 pub fn invoke_bash(script: &str, repo: &gix::Repository) {
+    invoke_bash_at_dir(script, repo.workdir().unwrap_or(repo.git_dir()))
+}
+/// Run the given `script` in bash, with the `cwd` set to `dir`.
+/// Panic if the script fails.
+pub fn invoke_bash_at_dir(script: &str, dir: &Path) {
     let mut cmd = std::process::Command::new("bash");
-    cmd.current_dir(repo.workdir().unwrap_or(repo.git_dir()));
+    cmd.current_dir(dir);
     isolate_env_std_cmd(&mut cmd);
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -80,6 +80,7 @@ cli-prompts = "0.1.0"
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 but-testsupport = { workspace = true, features = ["snapbox"] }
 snapbox = { workspace = true, features = ["term-svg", "regex"] }
 shell-words = "1.1.0"

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -1,6 +1,6 @@
+use crate::forge::review;
+use crate::{base, branch, forge};
 use std::path::PathBuf;
-
-use crate::forge;
 
 #[derive(Debug, clap::Parser)]
 #[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("GIX_VERSION"))]
@@ -89,9 +89,9 @@ For examples see `but rub --help`."
         repo: bool,
     },
     /// Commands for managing the base.
-    Base(crate::base::Platform),
+    Base(base::Platform),
     /// Commands for managing branches.
-    Branch(crate::branch::Platform),
+    Branch(branch::Platform),
     /// Commands for managing worktrees.
     #[clap(hide = true)]
     Worktree(crate::worktree::Platform),
@@ -203,47 +203,82 @@ For examples see `but rub --help`."
     },
 }
 
-/// How to format the output.
-#[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
-pub enum OutputFormat {
-    /// Produce verbose output for human consumption.
-    #[default]
-    Human,
-    /// The output is optimised for variable assignment in shells.
-    Shell,
-    /// Output detailed information as JSON for tool consumption.
-    Json,
+impl Subcommands {
+    pub fn to_metrics_command(&self) -> CommandName {
+        use CommandName::*;
+        match self {
+            Subcommands::Log => Log,
+            Subcommands::Status { .. } => Status,
+            Subcommands::Stf { .. } => Stf,
+            Subcommands::Rub { .. } => Rub,
+            Subcommands::Base(base::Platform { cmd }) => match cmd {
+                base::Subcommands::Update => BaseUpdate,
+                base::Subcommands::Check => BaseCheck,
+            },
+            Subcommands::Branch(branch::Platform { cmd }) => match cmd {
+                None | Some(branch::Subcommands::List { .. }) => BranchList,
+                Some(branch::Subcommands::New { .. }) => BranchNew,
+                Some(branch::Subcommands::Delete { .. }) => BranchDelete,
+                Some(branch::Subcommands::Unapply { .. }) => BranchUnapply,
+                Some(branch::Subcommands::Apply { .. }) => BranchApply,
+            },
+            Subcommands::Worktree(crate::worktree::Platform { cmd: _ }) => Worktree,
+            Subcommands::Mark { .. } => Mark,
+            Subcommands::Unmark => Unmark,
+            Subcommands::Gui => Gui,
+            Subcommands::Commit { .. } => Commit,
+            Subcommands::Push(_) => Push,
+            Subcommands::New { .. } => New,
+            Subcommands::Describe { .. } => Describe,
+            Subcommands::Oplog { .. } => Oplog,
+            Subcommands::Restore { .. } => Restore,
+            Subcommands::Undo => Undo,
+            Subcommands::Snapshot { .. } => Snapshot,
+            Subcommands::Claude(claude::Platform { cmd }) => match cmd {
+                claude::Subcommands::PreTool => ClaudePreTool,
+                claude::Subcommands::PostTool => ClaudePostTool,
+                claude::Subcommands::Stop => ClaudeStop,
+                claude::Subcommands::Last { .. }
+                | claude::Subcommands::PermissionPromptMcp { .. } => Unknown,
+            },
+            Subcommands::Cursor(cursor::Platform { cmd }) => match cmd {
+                cursor::Subcommands::AfterEdit => CursorAfterEdit,
+                cursor::Subcommands::Stop { .. } => CursorStop,
+            },
+            Subcommands::Forge(forge::integration::Platform { cmd }) => match cmd {
+                forge::integration::Subcommands::Auth => ForgeAuth,
+                forge::integration::Subcommands::Forget { .. } => ForgeForget,
+                forge::integration::Subcommands::ListUsers => ForgeListUsers,
+            },
+            Subcommands::Review(review::Platform { cmd }) => match cmd {
+                review::Subcommands::Publish { .. } => PublishReview,
+                review::Subcommands::Template { .. } => ReviewTemplate,
+            },
+            Subcommands::Completions { .. } => Completions,
+            Subcommands::Absorb { .. } => Absorb,
+            Subcommands::Metrics { .. }
+            | Subcommands::Actions(_)
+            | Subcommands::Mcp { .. }
+            | Subcommands::Init { .. } => Unknown,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
 pub enum CommandName {
-    #[clap(alias = "log")]
     Log,
-    #[clap(alias = "absorb")]
     Absorb,
-    #[clap(alias = "st")]
     Status,
-    #[clap(alias = "stf", hide = true)]
     Stf,
-    #[clap(alias = "rub")]
     Rub,
-    #[clap(alias = "commit")]
     Commit,
-    #[clap(alias = "push")]
     Push,
-    #[clap(alias = "new")]
     New,
-    #[clap(alias = "describe")]
     Describe,
-    #[clap(alias = "oplog")]
     Oplog,
-    #[clap(alias = "restore")]
     Restore,
-    #[clap(alias = "undo")]
     Undo,
-    #[clap(alias = "snapshot")]
     Snapshot,
-    #[clap(alias = "gui")]
     Gui,
     BaseCheck,
     BaseUpdate,
@@ -252,40 +287,10 @@ pub enum CommandName {
     BranchList,
     BranchUnapply,
     BranchApply,
-    #[clap(
-        alias = "claude-pre-tool",
-        alias = "claudepretool",
-        alias = "claudePreTool",
-        alias = "ClaudePreTool"
-    )]
     ClaudePreTool,
-    #[clap(
-        alias = "claude-post-tool",
-        alias = "claudeposttool",
-        alias = "claudePostTool",
-        alias = "ClaudePostTool"
-    )]
     ClaudePostTool,
-    #[clap(
-        alias = "claude-stop",
-        alias = "claudestop",
-        alias = "claudeStop",
-        alias = "ClaudeStop"
-    )]
     ClaudeStop,
-    #[clap(
-        alias = "cursor-after-edit",
-        alias = "cursorafteredit",
-        alias = "cursorAfterEdit",
-        alias = "CursorAfterEdit"
-    )]
     CursorAfterEdit,
-    #[clap(
-        alias = "cursor-stop",
-        alias = "cursorstop",
-        alias = "cursorStop",
-        alias = "CursorStop"
-    )]
     CursorStop,
     Worktree,
     Mark,
@@ -298,6 +303,18 @@ pub enum CommandName {
     Completions,
     #[default]
     Unknown,
+}
+
+/// How to format the output.
+#[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
+pub enum OutputFormat {
+    /// Produce verbose output for human consumption.
+    #[default]
+    Human,
+    /// The output is optimised for variable assignment in shells.
+    Shell,
+    /// Output detailed information as JSON for tool consumption.
+    Json,
 }
 
 pub mod actions {

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -11,6 +11,11 @@ pub struct Args {
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]
     pub current_dir: PathBuf,
+    /// Explicitly control how output should be formatted.
+    ///
+    /// If unset and from a terminal, it defaults to human output, when redirected it's for shells.
+    #[clap(long, short = 'f', env = "BUT_OUTPUT_FORMAT", conflicts_with = "json")]
+    pub format: Option<OutputFormat>,
     /// Whether to use JSON output format.
     #[clap(long, short = 'j', global = true)]
     pub json: bool,
@@ -196,6 +201,18 @@ For examples see `but rub --help`."
         /// If not provided, everything that is uncommitted will be absorbed
         source: Option<String>,
     },
+}
+
+/// How to format the output.
+#[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
+pub enum OutputFormat {
+    /// Produce verbose output for human consumption.
+    #[default]
+    Human,
+    /// The output is optimised for variable assignment in shells.
+    Shell,
+    /// Output detailed information as JSON for tool consumption.
+    Json,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]

--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::we_need_proper_json_output_here;
+use crate::utils::we_need_proper_json_output_here;
 use colored::Colorize;
 use gitbutler_branch_actions::BranchListingFilter;
 use gitbutler_project::Project;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -3,6 +3,7 @@ use std::{ffi::OsString, io::Write, path::Path};
 use anyhow::{Context, Result};
 
 mod args;
+use crate::utils::{Output, OutputFormat, OutputTarget, ResultExt, print_grouped_help, props};
 use args::{Args, CommandName, Subcommands, actions, claude, cursor};
 use but_claude::hooks::OutputAsJson;
 use but_settings::AppSettings;
@@ -48,7 +49,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         return Ok(());
     }
 
-    // The but push --help output is different if gerrit mode is enabled, hence the special handling
+    // The `but push --help` output is different if gerrit mode is enabled, hence the special handling
     let args_vec: Vec<String> = std::env::args().collect();
     if args_vec.iter().any(|arg| arg == "push")
         && args_vec.iter().any(|arg| arg == "--help" || arg == "-h")
@@ -59,6 +60,24 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 
     let mut args: Args = clap::Parser::parse_from(args);
     let app_settings = AppSettings::load_from_default_path_creating()?;
+    let output_target = if args.json {
+        OutputTarget::Blackhole
+    } else {
+        match args.format.unwrap_or_default() {
+            args::OutputFormat::Human | args::OutputFormat::Shell => OutputTarget::Stdout,
+            args::OutputFormat::Json => {
+                // Our code likes to check this flag instead, as convenience also for the caller.
+                args.json = true;
+                OutputTarget::Blackhole
+            }
+        }
+    };
+    let output_format = args.format.and_then(|fmt| match fmt {
+        args::OutputFormat::Human => Some(OutputFormat::Human),
+        args::OutputFormat::Shell => Some(OutputFormat::Shell),
+        args::OutputFormat::Json => None,
+    });
+    let out = Output::new(output_target, output_format);
 
     if args.trace > 0 {
         trace::init(args.trace)?;
@@ -84,14 +103,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             let result =
                 rub::handle(&project, args.json, source, target).context("Rubbed the wrong way.");
             if let Err(e) = &result {
-                let mut stderr = std::io::stderr();
-                writeln!(stderr, "{} {}", e, e.root_cause()).ok();
+                writeln!(std::io::stderr(), "{} {}", e, e.root_cause()).ok();
             }
             metrics_if_configured(app_settings, CommandName::Rub, props(start, &result)).ok();
             result
         }
         None if args.source_or_path.is_some() && args.target.is_none() => {
-            // If only one arguments is provided without a subcommand, check if this is a valid path.
+            // If only one argument is provided without a subcommand, check if this is a valid path.
             let maybe_path = args
                 .source_or_path
                 .as_ref()
@@ -105,7 +123,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             print_grouped_help().ok();
             Ok(())
         }
-        Some(cmd) => match_subcommand(cmd, args, app_settings, start).await,
+        Some(cmd) => match_subcommand(cmd, args, app_settings, start, out).await,
     }
 }
 
@@ -114,6 +132,7 @@ async fn match_subcommand(
     args: Args,
     app_settings: AppSettings,
     start: std::time::Instant,
+    mut out: Output,
 ) -> Result<()> {
     match cmd {
         Subcommands::Mcp { internal } => {
@@ -260,8 +279,9 @@ async fn match_subcommand(
                 Some(branch::Subcommands::Apply { .. }) => CommandName::BranchApply,
             };
             // TODO: print JSON result here, based on args
-            // TODO: add stdout abstraction to deal with dev/null + for_humans.
-            let result = branch::handle(cmd, &ctx, args.json).await;
+            let result = branch::handle(cmd, &ctx, &mut out)
+                .await
+                .output_json(args.json);
             metrics_if_configured(app_settings, metrics_command, props(start, &result)).ok();
             result.map(|_| ())
         }
@@ -517,196 +537,7 @@ pub fn get_context_with_legacy_support(
     })
 }
 
-fn we_need_proper_json_output_here() -> serde_json::Value {
-    serde_json::Value::Null
-}
-
-/// Convert anything into a json value, **or panic**.
-/// I think this should never fail at runtime, but I am not sure.
-fn into_json_value(value: impl serde::Serialize) -> serde_json::Value {
-    serde_json::to_value(&value)
-        .expect("BUG: Failed to serialize JSON value, we should know that at compile time")
-}
-
-pub(crate) fn props<E, T, R>(start: std::time::Instant, result: R) -> Props
-where
-    R: std::ops::Deref<Target = Result<T, E>>,
-    E: std::fmt::Display,
-{
-    let error = result.as_ref().err().map(|e| e.to_string());
-    let mut props = Props::new();
-    props.insert("durationMs", start.elapsed().as_millis());
-    props.insert("error", error);
-    props
-}
-
-fn print_grouped_help() -> std::io::Result<()> {
-    use std::collections::HashSet;
-
-    use clap::CommandFactory;
-    use terminal_size::{Width, terminal_size};
-
-    let mut stdout = std::io::stdout();
-
-    // Get terminal width, default to 80 if detection fails
-    let terminal_width = if let Some((Width(w), _)) = terminal_size() {
-        w as usize
-    } else {
-        80
-    };
-
-    // Helper function to truncate text to fit within available width
-    let truncate_text = |text: &str, available_width: usize| -> String {
-        const ELLIPSIS_LEN: usize = 1;
-        if text.len() <= available_width {
-            text.to_string()
-        } else if available_width > ELLIPSIS_LEN {
-            format!("{}…", &text[..available_width.saturating_sub(ELLIPSIS_LEN)])
-        } else {
-            text.chars().take(available_width).collect()
-        }
-    };
-
-    let cmd = Args::command();
-    let subcommands: Vec<_> = cmd.get_subcommands().collect();
-
-    // Define command groupings and their order (excluding MISC)
-    let groups = [
-        ("Inspection".yellow(), vec!["status"]),
-        (
-            "Branching and Committing".yellow(),
-            vec!["commit", "new", "branch", "base", "mark", "unmark"],
-        ),
-        (
-            "Server Interactions".yellow(),
-            vec!["push", "review", "forge"],
-        ),
-        (
-            "Editing Commits".yellow(),
-            vec!["rub", "describe", "absorb"],
-        ),
-        (
-            "Operation History".yellow(),
-            vec!["oplog", "undo", "restore", "snapshot"],
-        ),
-    ];
-
-    writeln!(
-        stdout,
-        "{}",
-        "The GitButler CLI change control system".red()
-    )?;
-    writeln!(stdout)?;
-    writeln!(stdout, "Usage: but [OPTIONS] <COMMAND>")?;
-    writeln!(stdout, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
-    writeln!(stdout)?;
-    writeln!(
-        stdout,
-        "The GitButler CLI can be used to do nearly anything the desktop client can do (and more)."
-    )?;
-    writeln!(
-        stdout,
-        "It is a drop in replacement for most of the Git commands you would normally use, but Git"
-    )?;
-    writeln!(
-        stdout,
-        "commands (blame, log, etc) can also be used, as GitButler is fully Git compatible."
-    )?;
-    writeln!(stdout)?;
-    writeln!(
-        stdout,
-        "Checkout the full docs here: https://docs.gitbutler.com/cli-overview"
-    )?;
-    writeln!(stdout)?;
-
-    // Keep track of which commands we've already printed
-    let mut printed_commands = HashSet::new();
-    const LONGEST_COMMAND_LEN: usize = 13;
-    const LONGEST_COMMAND_LEN_AND_ELLIPSIS: usize = LONGEST_COMMAND_LEN + 3;
-
-    // Print grouped commands
-    for (group_name, command_names) in &groups {
-        writeln!(stdout, "{group_name}:")?;
-        for cmd_name in command_names {
-            if let Some(subcmd) = subcommands.iter().find(|c| c.get_name() == *cmd_name) {
-                let about = subcmd.get_about().unwrap_or_default().to_string();
-                // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
-                let available_width =
-                    terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
-                let truncated_about = truncate_text(&about, available_width);
-                writeln!(
-                    stdout,
-                    "  {:<LONGEST_COMMAND_LEN$}{}",
-                    cmd_name.green(),
-                    truncated_about,
-                )?;
-                printed_commands.insert(cmd_name.to_string());
-            }
-        }
-        writeln!(stdout)?;
-    }
-
-    // Collect any remaining commands not in the explicit groups
-    let misc_commands: Vec<_> = subcommands
-        .iter()
-        .filter(|subcmd| !printed_commands.contains(subcmd.get_name()) && !subcmd.is_hide_set())
-        .collect();
-
-    // Print MISC section if there are any ungrouped commands
-    if !misc_commands.is_empty() {
-        writeln!(stdout, "{}:", "Other Commands".yellow())?;
-        for subcmd in misc_commands {
-            let about = subcmd.get_about().unwrap_or_default().to_string();
-            // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
-            let available_width = terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
-            let truncated_about = truncate_text(&about, available_width);
-            writeln!(
-                stdout,
-                "  {:<LONGEST_COMMAND_LEN$}{}",
-                subcmd.get_name().green(),
-                truncated_about
-            )?;
-        }
-        writeln!(stdout)?;
-    }
-
-    // Add command completion instructions
-    writeln!(
-        stdout,
-        "To add command completion, add this to your shell rc: (for example ~/.zshrc)"
-    )?;
-    writeln!(stdout, "  eval \"$(but completions zsh)\"")?;
-    writeln!(stdout)?;
-
-    writeln!(
-        stdout,
-        "To use the GitButler CLI with coding agents (Claude Code hooks, Cursor hooks, MCP), see:"
-    )?;
-    writeln!(
-        stdout,
-        "  https://docs.gitbutler.com/features/ai-integration/ai-overview"
-    )?;
-    writeln!(stdout)?;
-
-    writeln!(stdout, "{}:", "Options".yellow())?;
-    // Truncate long option descriptions if needed
-    let option_descriptions = [
-        (
-            "  -C, --current-dir <PATH>",
-            "Run as if but was started in PATH instead of the current working directory [default: .]",
-        ),
-        ("  -j, --json", "Whether to use JSON output format"),
-        ("  -h, --help", "Print help"),
-    ];
-
-    for (flag, desc) in option_descriptions {
-        let available_width = terminal_width.saturating_sub(flag.len() + 2);
-        let truncated_desc = truncate_text(desc, available_width);
-        writeln!(stdout, "{}  {}", flag, truncated_desc)?;
-    }
-
-    Ok(())
-}
+mod utils;
 
 mod trace {
     use tracing::metadata::LevelFilter;

--- a/crates/but/src/metrics.rs
+++ b/crates/but/src/metrics.rs
@@ -116,6 +116,18 @@ impl Props {
         }
     }
 
+    pub fn from_result<E, T, R>(start: std::time::Instant, result: R) -> Props
+    where
+        R: std::ops::Deref<Target = anyhow::Result<T, E>>,
+        E: std::fmt::Display,
+    {
+        let error = result.as_ref().err().map(|e| e.to_string());
+        let mut props = Props::new();
+        props.insert("durationMs", start.elapsed().as_millis());
+        props.insert("error", error);
+        props
+    }
+
     pub fn insert<K: Into<String>, V: Serialize>(&mut self, key: K, value: V) {
         if let Ok(value) = serde_json::to_value(value) {
             self.values.insert(key.into(), value);

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -1,0 +1,278 @@
+use crate::args::Args;
+use crate::metrics::Props;
+use colored::Colorize;
+use std::io::Write;
+
+/// How we should format anything written to [`std::io::stdout()`].
+#[derive(Debug, Copy, Clone)]
+pub enum OutputFormat {
+    /// The output to write is supposed to be for human consumption, and can be more verbose.
+    Human,
+    /// The output should be suitable for shells, and assigning the major result to variables so that it can be re-used
+    /// in subsequent CLI invocations.
+    Shell,
+}
+
+/// Where to write
+pub enum OutputTarget {
+    Stdout,
+    Blackhole,
+}
+
+/// A utility `std::io::Write` implementation that can always be used to generate output for humans or for scripts.
+pub struct Output {
+    /// How to print the output, one should match on it.
+    pub format: OutputFormat,
+    /// The actual writer.
+    inner: Box<dyn std::io::Write>,
+}
+
+impl Write for Output {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Lifecycle
+impl Output {
+    /// Create a new instance to output to `target`.
+    pub fn new(target: OutputTarget, format: Option<OutputFormat>) -> Self {
+        Output {
+            format: match target {
+                OutputTarget::Stdout => format.unwrap_or_else(|| {
+                    if atty::is(atty::Stream::Stdout) {
+                        OutputFormat::Human
+                    } else {
+                        OutputFormat::Shell
+                    }
+                }),
+                OutputTarget::Blackhole => {
+                    // Most likely implemented, and it doesn't matter
+                    OutputFormat::Human
+                }
+            },
+            inner: match target {
+                OutputTarget::Stdout => Box::new(std::io::stdout()),
+                OutputTarget::Blackhole => Box::new(std::io::sink()),
+            },
+        }
+    }
+}
+
+/// Utilities attached to `anyhow::Result<impl serde::Serialize>`.
+pub trait ResultExt {
+    /// Write this value as pretty `JSON` to stdout if `json` is `true`.
+    fn output_json(self, json: bool) -> Self;
+}
+
+impl<T> ResultExt for anyhow::Result<T>
+where
+    T: serde::Serialize,
+{
+    fn output_json(self, json: bool) -> Self {
+        if json && let Ok(value) = &self {
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            serde_json::to_writer_pretty(&mut stdout, value)
+                .expect("This is to indicate that the write failed, leading to invalid JSON");
+            stdout.write_all(b"\n").ok();
+        }
+        self
+    }
+}
+
+/// A placeholder, which should be substituted for the actual return value.
+pub fn we_need_proper_json_output_here() -> serde_json::Value {
+    serde_json::Value::Null
+}
+
+/// Convert anything into a json value, **or panic**.
+/// I think this should never fail at runtime, but I am not sure.
+pub fn into_json_value(value: impl serde::Serialize) -> serde_json::Value {
+    serde_json::to_value(&value)
+        .expect("BUG: Failed to serialize JSON value, we should know that at compile time")
+}
+
+pub fn props<E, T, R>(start: std::time::Instant, result: R) -> Props
+where
+    R: std::ops::Deref<Target = anyhow::Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let error = result.as_ref().err().map(|e| e.to_string());
+    let mut props = Props::new();
+    props.insert("durationMs", start.elapsed().as_millis());
+    props.insert("error", error);
+    props
+}
+
+pub fn print_grouped_help() -> std::io::Result<()> {
+    use std::collections::HashSet;
+
+    use clap::CommandFactory;
+    use terminal_size::{Width, terminal_size};
+
+    let mut stdout = std::io::stdout();
+
+    // Get terminal width, default to 80 if detection fails
+    let terminal_width = if let Some((Width(w), _)) = terminal_size() {
+        w as usize
+    } else {
+        80
+    };
+
+    // Helper function to truncate text to fit within available width
+    let truncate_text = |text: &str, available_width: usize| -> String {
+        const ELLIPSIS_LEN: usize = 1;
+        if text.len() <= available_width {
+            text.to_string()
+        } else if available_width > ELLIPSIS_LEN {
+            format!("{}…", &text[..available_width.saturating_sub(ELLIPSIS_LEN)])
+        } else {
+            text.chars().take(available_width).collect()
+        }
+    };
+
+    let cmd = Args::command();
+    let subcommands: Vec<_> = cmd.get_subcommands().collect();
+
+    // Define command groupings and their order (excluding MISC)
+    let groups = [
+        ("Inspection".yellow(), vec!["status"]),
+        (
+            "Branching and Committing".yellow(),
+            vec!["commit", "new", "branch", "base", "mark", "unmark"],
+        ),
+        (
+            "Server Interactions".yellow(),
+            vec!["push", "review", "forge"],
+        ),
+        (
+            "Editing Commits".yellow(),
+            vec!["rub", "describe", "absorb"],
+        ),
+        (
+            "Operation History".yellow(),
+            vec!["oplog", "undo", "restore", "snapshot"],
+        ),
+    ];
+
+    writeln!(
+        stdout,
+        "{}",
+        "The GitButler CLI change control system".red()
+    )?;
+    writeln!(stdout)?;
+    writeln!(stdout, "Usage: but [OPTIONS] <COMMAND>")?;
+    writeln!(stdout, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
+    writeln!(stdout)?;
+    writeln!(
+        stdout,
+        "The GitButler CLI can be used to do nearly anything the desktop client can do (and more)."
+    )?;
+    writeln!(
+        stdout,
+        "It is a drop in replacement for most of the Git commands you would normally use, but Git"
+    )?;
+    writeln!(
+        stdout,
+        "commands (blame, log, etc) can also be used, as GitButler is fully Git compatible."
+    )?;
+    writeln!(stdout)?;
+    writeln!(
+        stdout,
+        "Checkout the full docs here: https://docs.gitbutler.com/cli-overview"
+    )?;
+    writeln!(stdout)?;
+
+    // Keep track of which commands we've already printed
+    let mut printed_commands = HashSet::new();
+    const LONGEST_COMMAND_LEN: usize = 13;
+    const LONGEST_COMMAND_LEN_AND_ELLIPSIS: usize = LONGEST_COMMAND_LEN + 3;
+
+    // Print grouped commands
+    for (group_name, command_names) in &groups {
+        writeln!(stdout, "{group_name}:")?;
+        for cmd_name in command_names {
+            if let Some(subcmd) = subcommands.iter().find(|c| c.get_name() == *cmd_name) {
+                let about = subcmd.get_about().unwrap_or_default().to_string();
+                // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
+                let available_width =
+                    terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
+                let truncated_about = truncate_text(&about, available_width);
+                writeln!(
+                    stdout,
+                    "  {:<LONGEST_COMMAND_LEN$}{}",
+                    cmd_name.green(),
+                    truncated_about,
+                )?;
+                printed_commands.insert(cmd_name.to_string());
+            }
+        }
+        writeln!(stdout)?;
+    }
+
+    // Collect any remaining commands not in the explicit groups
+    let misc_commands: Vec<_> = subcommands
+        .iter()
+        .filter(|subcmd| !printed_commands.contains(subcmd.get_name()) && !subcmd.is_hide_set())
+        .collect();
+
+    // Print MISC section if there are any ungrouped commands
+    if !misc_commands.is_empty() {
+        writeln!(stdout, "{}:", "Other Commands".yellow())?;
+        for subcmd in misc_commands {
+            let about = subcmd.get_about().unwrap_or_default().to_string();
+            // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
+            let available_width = terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
+            let truncated_about = truncate_text(&about, available_width);
+            writeln!(
+                stdout,
+                "  {:<LONGEST_COMMAND_LEN$}{}",
+                subcmd.get_name().green(),
+                truncated_about
+            )?;
+        }
+        writeln!(stdout)?;
+    }
+
+    // Add command completion instructions
+    writeln!(
+        stdout,
+        "To add command completion, add this to your shell rc: (for example ~/.zshrc)"
+    )?;
+    writeln!(stdout, "  eval \"$(but completions zsh)\"")?;
+    writeln!(stdout)?;
+
+    writeln!(
+        stdout,
+        "To use the GitButler CLI with coding agents (Claude Code hooks, Cursor hooks, MCP), see:"
+    )?;
+    writeln!(
+        stdout,
+        "  https://docs.gitbutler.com/features/ai-integration/ai-overview"
+    )?;
+    writeln!(stdout)?;
+
+    writeln!(stdout, "{}:", "Options".yellow())?;
+    // Truncate long option descriptions if needed
+    let option_descriptions = [
+        (
+            "  -C, --current-dir <PATH>",
+            "Run as if but was started in PATH instead of the current working directory [default: .]",
+        ),
+        ("  -j, --json", "Whether to use JSON output format"),
+        ("  -h, --help", "Print help"),
+    ];
+
+    for (flag, desc) in option_descriptions {
+        let available_width = terminal_width.saturating_sub(flag.len() + 2);
+        let truncated_desc = truncate_text(desc, available_width);
+        writeln!(stdout, "{}  {}", flag, truncated_desc)?;
+    }
+
+    Ok(())
+}

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -178,6 +178,7 @@ fn json_flag_can_be_placed_before_or_after_subcommand() -> anyhow::Result<()> {
     // Test with actual commands that need a repo (they'll fail but should accept the flag)
     // Before subcommand
     env.but("--json status")
+        .env_remove("BUT_OUTPUT_FORMAT")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
@@ -187,6 +188,7 @@ Error: Could not find a git repository in '.' or in any of its parents
 
     // After subcommand
     env.but("status --json")
+        .env_remove("BUT_OUTPUT_FORMAT")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
@@ -196,13 +198,21 @@ Error: Could not find a git repository in '.' or in any of its parents
 
     // Test with log command as well
     // Before subcommand
-    env.but("--json log").assert().failure().stderr_eq(str![[r#"
+    env.but("--json log")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
 Error: Could not find a git repository in '.' or in any of its parents
 
 "#]]);
 
     // After subcommand
-    env.but("log --json").assert().failure().stderr_eq(str![[r#"
+    env.but("log --json")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
 Error: Could not find a git repository in '.' or in any of its parents
 
 "#]]);

--- a/crates/but/tests/but/status.rs
+++ b/crates/but/tests/but/status.rs
@@ -88,6 +88,7 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
 
     env
         .but("--json status")
+        .env_remove("BUT_OUTPUT_FORMAT")
         .with_assert(env.assert_with_uuid_and_timestamp_redactions())
         .assert()
         .success()

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -255,7 +255,9 @@ impl Sandbox {
             cmd = cmd
                 .args(shell_words::split(args).expect("statically known args must split correctly"))
         }
-        self.with_updated_env(cmd).env("GITBUTLER_CHANGE_ID", "42")
+        self.with_updated_env(cmd)
+            .env("GITBUTLER_CHANGE_ID", "42")
+            .env("BUT_OUTPUT_FORMAT", "human")
     }
 
     /// Invoke an isolated `git` with the given `args`, which will be split automatically.
@@ -265,6 +267,12 @@ impl Sandbox {
             .args(shell_words::split(args).expect("statically known args must split correctly"))
             .assert()
             .success();
+        self
+    }
+
+    /// Invoke the given `script` in `bash` in this sandbox
+    pub fn invoke_bash(&self, script: &str) -> &Self {
+        but_testsupport::invoke_bash_at_dir(script, self.projects_root());
         self
     }
 }


### PR DESCRIPTION
This is to help AI to use newer APIs, maybe, and to show that it can already be done.

For that reason, some refactoring is needed, making it very clear (also to AI) that legacy
should be avoided.

Ideally, `but-apply` can be rewritten by AI to use newer APIs.

### Tasks

* [x] output formalisation
* [x] Result extension for metrics and json printing.

### Next PR 

* [ ] alter `Output` to also deal with JSON so it's not a return value anymore.
* [ ] `but apply` uses recent API and has at least one test. Should be a good case for usable mutating API as well.
* [ ] `but status` uses `but_workspace::ref_info()`


Follow-up of #11210

