### PR TITLE
Single-branch support for `but branch apply`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "but-secret",
  "but-settings",
  "gitbutler-user",
+ "http 1.3.1",
  "octorust",
  "reqwest 0.12.24",
  "serde",

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -574,12 +574,12 @@ impl Drop for ClearLocksGuard<'_> {
 }
 
 pub trait OutputAsJson {
-    fn out_json(&self);
+    fn output_claude_json(self) -> Self;
 }
 
 impl OutputAsJson for Result<ClaudeHookOutput> {
-    fn out_json(&self) {
-        match self {
+    fn output_claude_json(self) -> Self {
+        match &self {
             Ok(output) => println!("{}", serde_json::to_string(output).unwrap_or_default()),
             Err(e) => eprintln!(
                 "{}",
@@ -591,6 +591,7 @@ impl OutputAsJson for Result<ClaudeHookOutput> {
                 .unwrap_or_default()
             ),
         }
+        self
     }
 }
 

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -1,4 +1,5 @@
 use crate::forge::review;
+use crate::utils::OutputFormat;
 use crate::{base, branch, forge};
 use std::path::PathBuf;
 
@@ -303,18 +304,6 @@ pub enum CommandName {
     Completions,
     #[default]
     Unknown,
-}
-
-/// How to format the output.
-#[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
-pub enum OutputFormat {
-    /// Produce verbose output for human consumption.
-    #[default]
-    Human,
-    /// The output is optimised for variable assignment in shells.
-    Shell,
-    /// Output detailed information as JSON for tool consumption.
-    Json,
 }
 
 pub mod actions {

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -1,4 +1,3 @@
-use crate::forge::review;
 use crate::utils::OutputFormat;
 use crate::{base, branch, forge};
 use std::path::PathBuf;
@@ -204,70 +203,10 @@ For examples see `but rub --help`."
     },
 }
 
-impl Subcommands {
-    pub fn to_metrics_command(&self) -> CommandName {
-        use CommandName::*;
-        match self {
-            Subcommands::Log => Log,
-            Subcommands::Status { .. } => Status,
-            Subcommands::Stf { .. } => Stf,
-            Subcommands::Rub { .. } => Rub,
-            Subcommands::Base(base::Platform { cmd }) => match cmd {
-                base::Subcommands::Update => BaseUpdate,
-                base::Subcommands::Check => BaseCheck,
-            },
-            Subcommands::Branch(branch::Platform { cmd }) => match cmd {
-                None | Some(branch::Subcommands::List { .. }) => BranchList,
-                Some(branch::Subcommands::New { .. }) => BranchNew,
-                Some(branch::Subcommands::Delete { .. }) => BranchDelete,
-                Some(branch::Subcommands::Unapply { .. }) => BranchUnapply,
-                Some(branch::Subcommands::Apply { .. }) => BranchApply,
-            },
-            Subcommands::Worktree(crate::worktree::Platform { cmd: _ }) => Worktree,
-            Subcommands::Mark { .. } => Mark,
-            Subcommands::Unmark => Unmark,
-            Subcommands::Gui => Gui,
-            Subcommands::Commit { .. } => Commit,
-            Subcommands::Push(_) => Push,
-            Subcommands::New { .. } => New,
-            Subcommands::Describe { .. } => Describe,
-            Subcommands::Oplog { .. } => Oplog,
-            Subcommands::Restore { .. } => Restore,
-            Subcommands::Undo => Undo,
-            Subcommands::Snapshot { .. } => Snapshot,
-            Subcommands::Claude(claude::Platform { cmd }) => match cmd {
-                claude::Subcommands::PreTool => ClaudePreTool,
-                claude::Subcommands::PostTool => ClaudePostTool,
-                claude::Subcommands::Stop => ClaudeStop,
-                claude::Subcommands::Last { .. }
-                | claude::Subcommands::PermissionPromptMcp { .. } => Unknown,
-            },
-            Subcommands::Cursor(cursor::Platform { cmd }) => match cmd {
-                cursor::Subcommands::AfterEdit => CursorAfterEdit,
-                cursor::Subcommands::Stop { .. } => CursorStop,
-            },
-            Subcommands::Forge(forge::integration::Platform { cmd }) => match cmd {
-                forge::integration::Subcommands::Auth => ForgeAuth,
-                forge::integration::Subcommands::Forget { .. } => ForgeForget,
-                forge::integration::Subcommands::ListUsers => ForgeListUsers,
-            },
-            Subcommands::Review(review::Platform { cmd }) => match cmd {
-                review::Subcommands::Publish { .. } => PublishReview,
-                review::Subcommands::Template { .. } => ReviewTemplate,
-            },
-            Subcommands::Completions { .. } => Completions,
-            Subcommands::Absorb { .. } => Absorb,
-            Subcommands::Metrics { .. }
-            | Subcommands::Actions(_)
-            | Subcommands::Mcp { .. }
-            | Subcommands::Init { .. } => Unknown,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
 pub enum CommandName {
     Log,
+    Init,
     Absorb,
     Status,
     Stf,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -124,6 +124,7 @@ async fn match_subcommand(
     start: std::time::Instant,
     mut out: Output,
 ) -> Result<()> {
+    let out = &mut out;
     let metrics_cmd = cmd.to_metrics_command();
 
     match cmd {
@@ -259,7 +260,7 @@ async fn match_subcommand(
         }
         Subcommands::Branch(branch::Platform { cmd }) => {
             let ctx = get_or_init_context_with_legacy_support(&args.current_dir)?;
-            branch::handle(cmd, &ctx, &mut out)
+            branch::handle(cmd, &ctx, out)
                 .await
                 .output_json(args.json)
                 .emit_metrics(app_settings, metrics_cmd, start)
@@ -283,15 +284,15 @@ async fn match_subcommand(
             review,
         } => {
             let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
-            let result = status::worktree(&project, args.json, show_files, verbose, review).await;
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            status::worktree(&project, out, show_files, verbose, review)
+                .await
+                .emit_metrics(app_settings, metrics_cmd, start)
         }
         Subcommands::Stf { verbose, review } => {
             let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
-            let result = status::worktree(&project, args.json, true, verbose, review).await;
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            status::worktree(&project, out, true, verbose, review)
+                .await
+                .emit_metrics(app_settings, metrics_cmd, start)
         }
         Subcommands::Rub { source, target } => {
             let mut stderr = std::io::stderr();

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -3,15 +3,17 @@ use std::{ffi::OsString, io::Write, path::Path};
 use anyhow::{Context, Result};
 
 mod args;
+use crate::args::CommandName;
+use crate::metrics::MetricsContext;
 use crate::utils::{
-    Output, OutputFormat, ResultJsonExt, ResultMetricsExt, print_grouped_help, props,
+    Output, OutputFormat, ResultErrorExt, ResultJsonExt, ResultMetricsExt, print_grouped_help,
 };
 use args::{Args, Subcommands, actions, claude, cursor};
 use but_claude::hooks::OutputAsJson;
 use but_settings::AppSettings;
 use colored::Colorize;
 use gix::date::time::CustomFormat;
-use metrics::{Event, Metrics, Props, metrics_if_configured};
+use metrics::{Event, Metrics, Props};
 
 mod absorb;
 mod base;
@@ -75,7 +77,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
 
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);
-    let start = std::time::Instant::now();
 
     // If no subcommand is provided but we have source and target, default to rub
     match args.cmd.take() {
@@ -90,13 +91,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
                 .as_ref()
                 .expect("target is checked to be Some in match guard");
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result =
-                rub::handle(&project, args.json, source, target).context("Rubbed the wrong way.");
-            if let Err(e) = &result {
-                writeln!(std::io::stderr(), "{} {}", e, e.root_cause()).ok();
-            }
-            metrics_if_configured(app_settings, args::CommandName::Rub, props(start, &result)).ok();
-            result
+            rub::handle(&project, args.json, source, target)
+                .context("Rubbed the wrong way.")
+                .emit_metrics(MetricsContext::new_if_enabled(
+                    &app_settings,
+                    CommandName::Rub,
+                ))
+                .show_root_cause_error_then_exit()
         }
         None if args.source_or_path.is_some() && args.target.is_none() => {
             // If only one argument is provided without a subcommand, check if this is a valid path.
@@ -113,7 +114,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
             print_grouped_help().ok();
             Ok(())
         }
-        Some(cmd) => match_subcommand(cmd, args, app_settings, start, out).await,
+        Some(cmd) => match_subcommand(cmd, args, app_settings, out).await,
     }
 }
 
@@ -121,11 +122,10 @@ async fn match_subcommand(
     cmd: Subcommands,
     args: Args,
     app_settings: AppSettings,
-    start: std::time::Instant,
     mut out: Output,
 ) -> Result<()> {
     let out = &mut out;
-    let metrics_cmd = cmd.to_metrics_command();
+    let metrics_ctx = cmd.to_metrics_context(&app_settings);
 
     match cmd {
         Subcommands::Mcp { internal } => {
@@ -160,27 +160,16 @@ async fn match_subcommand(
             Ok(())
         }
         Subcommands::Claude(claude::Platform { cmd }) => match cmd {
-            claude::Subcommands::PreTool => {
-                let result = but_claude::hooks::handle_pre_tool_call();
-                let p = props(start, &result);
-                result.out_json();
-                metrics_if_configured(app_settings, metrics_cmd, p).ok();
-                Ok(())
-            }
-            claude::Subcommands::PostTool => {
-                let result = but_claude::hooks::handle_post_tool_call();
-                let p = props(start, &result);
-                result.out_json();
-                metrics_if_configured(app_settings, metrics_cmd, p).ok();
-                Ok(())
-            }
-            claude::Subcommands::Stop => {
-                let result = but_claude::hooks::handle_stop().await;
-                let p = props(start, &result);
-                result.out_json();
-                metrics_if_configured(app_settings, metrics_cmd, p).ok();
-                Ok(())
-            }
+            claude::Subcommands::PreTool => but_claude::hooks::handle_pre_tool_call()
+                .output_claude_json()
+                .emit_metrics(metrics_ctx),
+            claude::Subcommands::PostTool => but_claude::hooks::handle_post_tool_call()
+                .output_claude_json()
+                .emit_metrics(metrics_ctx),
+            claude::Subcommands::Stop => but_claude::hooks::handle_stop()
+                .await
+                .output_claude_json()
+                .emit_metrics(metrics_ctx),
             claude::Subcommands::PermissionPromptMcp { session_id } => {
                 but_claude::mcp::start(&args.current_dir, &session_id).await
             }
@@ -235,48 +224,33 @@ async fn match_subcommand(
             }
         },
         Subcommands::Cursor(cursor::Platform { cmd }) => match cmd {
-            cursor::Subcommands::AfterEdit => {
-                let mut stdout = std::io::stdout();
-                let result = but_cursor::handle_after_edit().await;
-                let p = props(start, &result);
-                writeln!(stdout, "{}", serde_json::to_string(&result?)?).ok();
-                metrics_if_configured(app_settings, metrics_cmd, p).ok();
-                Ok(())
-            }
-            cursor::Subcommands::Stop { nightly } => {
-                let mut stdout = std::io::stdout();
-                let result = but_cursor::handle_stop(nightly).await;
-                let p = props(start, &result);
-                writeln!(stdout, "{}", serde_json::to_string(&result?)?).ok();
-                metrics_if_configured(app_settings, metrics_cmd, p).ok();
-                Ok(())
-            }
+            cursor::Subcommands::AfterEdit => but_cursor::handle_after_edit()
+                .await
+                .output_json(true)
+                .emit_metrics(metrics_ctx),
+            cursor::Subcommands::Stop { nightly } => but_cursor::handle_stop(nightly)
+                .await
+                .output_json(true)
+                .emit_metrics(metrics_ctx),
         },
         Subcommands::Base(base::Platform { cmd }) => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = base::handle(cmd, &project, args.json);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            Ok(())
+            base::handle(cmd, &project, args.json).emit_metrics(metrics_ctx)
         }
         Subcommands::Branch(branch::Platform { cmd }) => {
             let ctx = get_or_init_context_with_legacy_support(&args.current_dir)?;
             branch::handle(cmd, &ctx, out)
                 .await
                 .output_json(args.json)
-                .emit_metrics(app_settings, metrics_cmd, start)
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Worktree(worktree::Platform { cmd }) => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = worktree::handle(cmd, &project, args.json);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            worktree::handle(cmd, &project, args.json).emit_metrics(metrics_ctx)
         }
         Subcommands::Log => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = log::commit_graph(&project, args.json);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result?;
-            Ok(())
+            log::commit_graph(&project, args.json).emit_metrics(metrics_ctx)
         }
         Subcommands::Status {
             show_files,
@@ -286,52 +260,36 @@ async fn match_subcommand(
             let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
             status::worktree(&project, out, show_files, verbose, review)
                 .await
-                .emit_metrics(app_settings, metrics_cmd, start)
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Stf { verbose, review } => {
             let project = get_or_init_context_with_legacy_support(&args.current_dir)?;
             status::worktree(&project, out, true, verbose, review)
                 .await
-                .emit_metrics(app_settings, metrics_cmd, start)
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Rub { source, target } => {
-            let mut stderr = std::io::stderr();
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result =
-                rub::handle(&project, args.json, &source, &target).context("Rubbed the wrong way.");
-            if let Err(e) = &result {
-                writeln!(stderr, "{} {}", e, e.root_cause()).ok();
-            }
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            rub::handle(&project, args.json, &source, &target)
+                .context("Rubbed the wrong way.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit()
         }
         Subcommands::Mark { target, delete } => {
-            let mut stderr = std::io::stderr();
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = mark::handle(&project, args.json, &target, delete)
-                .context("Can't mark this. Taaaa-na-na-na. Can't mark this.");
-            if let Err(e) = &result {
-                writeln!(stderr, "{} {}", e, e.root_cause()).ok();
-            }
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            mark::handle(&project, args.json, &target, delete)
+                .context("Can't mark this. Taaaa-na-na-na. Can't mark this.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit()
         }
         Subcommands::Unmark => {
-            let mut stderr = std::io::stderr();
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = mark::unmark(&project, args.json)
-                .context("Can't unmark this. Taaaa-na-na-na. Can't unmark this.");
-            if let Err(e) = &result {
-                writeln!(stderr, "{} {}", e, e.root_cause()).ok();
-            }
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            mark::unmark(&project, args.json)
+                .context("Can't unmark this. Taaaa-na-na-na. Can't unmark this.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit()
         }
-        Subcommands::Gui => {
-            let result = gui::open(&args.current_dir);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
-        }
+        Subcommands::Gui => gui::open(&args.current_dir).emit_metrics(metrics_ctx),
         Subcommands::Commit {
             message,
             branch,
@@ -339,72 +297,56 @@ async fn match_subcommand(
             only,
         } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = commit::commit(
+            commit::commit(
                 &project,
                 args.json,
                 message.as_deref(),
                 branch.as_deref(),
                 only,
                 create,
-            );
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            )
+            .emit_metrics(metrics_ctx)
         }
         Subcommands::Push(push_args) => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = push::handle(push_args, &project, args.json);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            push::handle(push_args, &project, args.json).emit_metrics(metrics_ctx)
         }
         Subcommands::New { target } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = commit::insert_blank_commit(&project, args.json, &target);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            commit::insert_blank_commit(&project, args.json, &target).emit_metrics(metrics_ctx)
         }
         Subcommands::Describe { target } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = describe::describe_target(&project, args.json, &target);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            describe::describe_target(&project, args.json, &target).emit_metrics(metrics_ctx)
         }
         Subcommands::Oplog { since } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = oplog::show_oplog(&project, args.json, since.as_deref());
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            oplog::show_oplog(&project, args.json, since.as_deref()).emit_metrics(metrics_ctx)
         }
         Subcommands::Restore { oplog_sha, force } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = oplog::restore_to_oplog(&project, args.json, &oplog_sha, force);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            oplog::restore_to_oplog(&project, args.json, &oplog_sha, force)
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Undo => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = oplog::undo_last_operation(&project, args.json);
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            oplog::undo_last_operation(&project, args.json).emit_metrics(metrics_ctx)
         }
         Subcommands::Snapshot { message } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = oplog::create_snapshot(&project, args.json, message.as_deref());
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            oplog::create_snapshot(&project, args.json, message.as_deref())
+                .emit_metrics(metrics_ctx)
         }
         Subcommands::Absorb { source } => {
             let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-            let result = absorb::handle(&project, args.json, source.as_deref());
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
+            absorb::handle(&project, args.json, source.as_deref()).emit_metrics(metrics_ctx)
         }
         Subcommands::Init { repo } => init::repo(&args.current_dir, args.json, repo)
-            .context("Failed to initialize GitButler project."),
-        Subcommands::Forge(forge::integration::Platform { cmd }) => {
-            let result = forge::integration::handle(cmd).await;
-            metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-            result
-        }
+            .context("Failed to initialize GitButler project.")
+            .emit_metrics(metrics_ctx),
+        Subcommands::Forge(forge::integration::Platform { cmd }) => forge::integration::handle(cmd)
+            .await
+            .emit_metrics(metrics_ctx),
         Subcommands::Review(forge::review::Platform { cmd }) => match cmd {
             forge::review::Subcommands::Publish {
                 branch,
@@ -414,7 +356,7 @@ async fn match_subcommand(
                 default,
             } => {
                 let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-                let result = forge::review::publish_reviews(
+                forge::review::publish_reviews(
                     &project,
                     branch,
                     skip_force_push_protection,
@@ -424,19 +366,19 @@ async fn match_subcommand(
                     args.json,
                 )
                 .await
-                .context("Failed to publish reviews for branches.");
-                metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-                result
+                .context("Failed to publish reviews for branches.")
+                .emit_metrics(metrics_ctx)
             }
             forge::review::Subcommands::Template { template_path } => {
                 let project = get_or_init_legacy_non_bare_project(&args.current_dir)?;
-                let result = forge::review::set_review_template(&project, template_path, args.json)
-                    .context("Failed to set review template.");
-                metrics_if_configured(app_settings, metrics_cmd, props(start, &result)).ok();
-                result
+                forge::review::set_review_template(&project, template_path, args.json)
+                    .context("Failed to set review template.")
+                    .emit_metrics(metrics_ctx)
             }
         },
-        Subcommands::Completions { shell } => completions::generate_completions(shell),
+        Subcommands::Completions { shell } => {
+            completions::generate_completions(shell).emit_metrics(metrics_ctx)
+        }
     }
 }
 

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -19,6 +19,7 @@ const DATE_ONLY: CustomFormat = CustomFormat::new("%Y-%m-%d");
 pub(crate) mod assignment;
 
 use crate::id::CliId;
+use crate::utils::Output;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -172,7 +173,7 @@ struct WorktreeStatus {
 
 pub(crate) async fn worktree(
     ctx: &Context,
-    json: bool,
+    out: &mut Output,
     show_files: bool,
     verbose: bool,
     review: bool,
@@ -291,14 +292,13 @@ pub(crate) async fn worktree(
             })
             .unwrap_or((None, None));
 
-    if json {
+    if let Some(out) = out.for_json() {
         let worktree_status = WorktreeStatus {
             stacks: stack_details,
             common_merge_base: common_merge_base_data,
             upstream_state: upstream_state.clone(),
         };
-        let json_output = serde_json::to_string_pretty(&worktree_status)?;
-        writeln!(stdout, "{json_output}")?;
+        out.write_value(worktree_status)?;
         return Ok(());
     }
 

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -43,6 +43,8 @@ impl Output {
 /// JSON utilities
 impl Output {
     /// Write `value` as pretty JSON to the output.
+    ///
+    /// Note that it's owned to avoid double-printing with [ResultJsonExt::output_json]
     pub fn write_value(&mut self, value: impl serde::Serialize) -> std::io::Result<()> {
         json_pretty_to_stdout(&value)
     }

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -4,29 +4,62 @@ use colored::Colorize;
 use std::io::Write;
 
 /// How we should format anything written to [`std::io::stdout()`].
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum, Default)]
 pub enum OutputFormat {
     /// The output to write is supposed to be for human consumption, and can be more verbose.
+    #[default]
     Human,
     /// The output should be suitable for shells, and assigning the major result to variables so that it can be re-used
     /// in subsequent CLI invocations.
     Shell,
-}
-
-/// Where to write
-pub enum OutputTarget {
-    Stdout,
-    Blackhole,
+    /// Output detailed information as JSON for tool consumption.
+    Json,
 }
 
 /// A utility `std::io::Write` implementation that can always be used to generate output for humans or for scripts.
 pub struct Output {
-    /// How to print the output, one should match on it.
-    pub format: OutputFormat,
+    /// How to print the output, one should match on it. Match on this if you prefer this style.
+    format: OutputFormat,
     /// The actual writer.
     inner: Box<dyn std::io::Write>,
 }
 
+/// Conversions
+impl Output {
+    /// Provide a write implementation for humans, if the format setting permits.
+    pub fn for_human(&mut self) -> Option<&mut (dyn std::io::Write + 'static)> {
+        matches!(self.format, OutputFormat::Human).then(|| self.inner.as_mut())
+    }
+    /// Provide a write implementation for Shwll output, if the format setting permits.
+    pub fn for_shell(&mut self) -> Option<&mut (dyn std::io::Write + 'static)> {
+        matches!(self.format, OutputFormat::Shell).then(|| self.inner.as_mut())
+    }
+    /// Provide a handle to receive a serde-serializable value to write to stdout.
+    pub fn for_json(&mut self) -> Option<&mut Self> {
+        matches!(self.format, OutputFormat::Json).then_some(self)
+    }
+}
+
+/// JSON utilities
+impl Output {
+    /// Write `value` as pretty JSON to the output.
+    pub fn write_value(&mut self, value: impl serde::Serialize) -> std::io::Result<()> {
+        json_pretty_to_stdout(&value)
+    }
+}
+
+fn json_pretty_to_stdout(value: &impl serde::Serialize) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let value = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
+    if value != "null" {
+        stdout.write_all(value.as_bytes())?;
+        stdout.write_all(b"\n").ok();
+    }
+    Ok(())
+}
+
+/// We allow writing directly, knowing that JSON output will be a blackhole anyway.
 impl Write for Output {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.inner.write(buf)
@@ -39,35 +72,29 @@ impl Write for Output {
 
 /// Lifecycle
 impl Output {
-    /// Create a new instance to output to `target`.
-    pub fn new(target: OutputTarget, format: Option<OutputFormat>) -> Self {
+    /// Create a new instance to output with `format` (advisory), which affects where it prints to.
+    pub fn new(format: OutputFormat) -> Self {
         Output {
-            format: match target {
-                OutputTarget::Stdout => format.unwrap_or_else(|| {
-                    if atty::is(atty::Stream::Stdout) {
-                        OutputFormat::Human
-                    } else {
-                        OutputFormat::Shell
-                    }
-                }),
-                OutputTarget::Blackhole => {
-                    // Most likely implemented, and it doesn't matter
-                    OutputFormat::Human
-                }
-            },
-            inner: match target {
-                OutputTarget::Stdout => Box::new(std::io::stdout()),
-                OutputTarget::Blackhole => Box::new(std::io::sink()),
+            format,
+            inner: match format {
+                OutputFormat::Human | OutputFormat::Shell => Box::new(std::io::stdout()),
+                OutputFormat::Json => Box::new(std::io::sink()),
             },
         }
     }
 }
 
 /// Utilities attached to `anyhow::Result<impl serde::Serialize>`.
-pub trait ResultExt {
+pub trait ResultJsonExt {
     /// Write this value as pretty `JSON` to stdout if `json` is `true`.
+    ///
+    /// This style is great if you don't want to forget that JSON must be implemented.
+    /// Note that "null" isn't printed and silently dropped.
     fn output_json(self, json: bool) -> anyhow::Result<()>;
+}
 
+/// Utilities attached to `anyhow::Result<T>`.
+pub trait ResultMetricsExt {
     fn emit_metrics(
         self,
         app_settings: but_settings::AppSettings,
@@ -76,21 +103,19 @@ pub trait ResultExt {
     ) -> anyhow::Result<()>;
 }
 
-impl<T> ResultExt for anyhow::Result<T>
+impl<T> ResultJsonExt for anyhow::Result<T>
 where
     T: serde::Serialize,
 {
     fn output_json(self, json: bool) -> anyhow::Result<()> {
         if json && let Ok(value) = &self {
-            let stdout = std::io::stdout();
-            let mut stdout = stdout.lock();
-            serde_json::to_writer_pretty(&mut stdout, value)
-                .expect("This is to indicate that the write failed, leading to invalid JSON");
-            stdout.write_all(b"\n").ok();
+            json_pretty_to_stdout(value)?;
         }
         self.map(|_| ())
     }
+}
 
+impl<T> ResultMetricsExt for anyhow::Result<T> {
     fn emit_metrics(
         self,
         app_settings: but_settings::AppSettings,

--- a/crates/but/tests/but/rub.rs
+++ b/crates/but/tests/but/rub.rs
@@ -16,10 +16,6 @@ fn shorthand_without_subcommand() -> anyhow::Result<()> {
         .failure()
         .stderr_eq(str![[r#"
 Rubbed the wrong way. Source 'nonexistent1' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
-Error: Rubbed the wrong way.
-
-Caused by:
-    Source 'nonexistent1' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state.
 
 "#]]);
 


### PR DESCRIPTION
This is to help AI to use newer APIs, maybe, and to show that it can already be done.

For that reason, some refactoring is needed, making it very clear (also to AI) that legacy
should be avoided.

Ideally, `but-apply` can be rewritten by AI to use newer APIs.

### Tasks

* [x] alter `Output` to also deal with JSON so it's not a return value anymore (this is still possible, but there is an alternative)
* [x] `but status` uses the new-style `but` utilities 

### Next PR 

* [x] #11250 
* [x] #11251
* [x] #11253 
* [x] #11281
* [x] #11297
* [x] #11332
* [x] #11333 
* [x] ~~deal with `--help` and make `json` output docs work at least in principle.~~ - not now, catchup with Scott to see what's the state of affairs.
* [ ] #11371 
* [x] ~~`but status` uses `but_workspace::ref_info()`~~ - will hand it over.

### Bonus

- move reconcliation logic into `but-meta` where it fixes up its head references.

Follow-up of #11232

