### PR TITLE
Intermezzo: use `Output` everywhere in `but`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,17 +446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +695,6 @@ name = "but"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "atty",
  "bstr",
  "but-action",
  "but-api",
@@ -5602,15 +5590,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -7972,7 +7951,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.1.2",
  "windows-sys 0.61.2",

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use anyhow::Context;
 use but_error::Code;
 use gix::prelude::ObjectIdExt;
@@ -129,6 +127,7 @@ impl RepositoryExt for gix::Repository {
     }
 
     fn write_local_common_config(&self, local_config: &gix::config::File) -> anyhow::Result<()> {
+        use std::io::Write;
         // Note: we don't use a lock file here to not risk changing the mode, and it's what Git does.
         //       But we lock the file so there is no raciness.
         let local_config_path = self.common_dir().join("config");

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -75,7 +75,6 @@ tracing-subscriber = { workspace = true, features = [
 tracing-forest.workspace = true
 ratatui = "0.29.0"
 crossterm = "0.29.0"
-atty = "0.2.0"
 cli-prompts = "0.1.0"
 minus = { version = "5.6.1", default-features = false, features = ["static_output", "search"] }
 

--- a/crates/but/agents.md
+++ b/crates/but/agents.md
@@ -3,16 +3,12 @@
 * Avoid using code from `gitbutler-`-prefixed crates, and prefer code from `but-` prefixed crates as long as it's not in the `legacy` module.
 
 ### Output
-* Usable output goes to `stdout` with `writeln!(stdout, …).ok()`.
-    - Obtain `stdout` once per function using `let mut stdout = std::io::stdout();`
-    - Use `stdout` when writing: `writeln!(stdout, "…").ok();`
-    - Use `atty::is` to print human output, otherwise print output optimised for use in bash scripts, when single values are returned.
-    - **But** when writing `json`, always use `writeln!(stdout, "{json_pretty}")?`
-* Error or side-channel information goes to `stderr` with `writeln!(stderr, …).ok()`.
-    - Obtain `stderr` once per function using `let mut stderr = std::io::stderr();`
-    - Use `stderr` when writing: `writeln!(stderr, "…").ok();`
-* The `.ok()` at the end ignores write errors gracefully (e.g., broken pipe) instead of panicking.
-* `--json` only outputs the happy path, there are no JSON errors.
+
+Usable output goes to `out: &mut OutputChannel`
+
+- For humans, use `if let Some(out) = out.for_human() { writeln!(out, “{…}")?; }`
+- For shell, use `if let Some(out) = out.for_shell() { writeln!(out, “{…}")?; }`
+- For JSON, use `if let Some(out) = out.for_json() { out.write_value(json)?; }`
 
 ### Testing
 

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -14,8 +14,14 @@ pub struct Args {
     /// Explicitly control how output should be formatted.
     ///
     /// If unset and from a terminal, it defaults to human output, when redirected it's for shells.
-    #[clap(long, short = 'f', env = "BUT_OUTPUT_FORMAT", conflicts_with = "json")]
-    pub format: Option<OutputFormat>,
+    #[clap(
+        long,
+        short = 'f',
+        env = "BUT_OUTPUT_FORMAT",
+        conflicts_with = "json",
+        default_value = "human"
+    )]
+    pub format: OutputFormat,
     /// Whether to use JSON output format.
     #[clap(long, short = 'j', global = true)]
     pub json: bool,

--- a/crates/but/src/branch/apply.rs
+++ b/crates/but/src/branch/apply.rs
@@ -1,4 +1,4 @@
-use crate::utils::Output;
+use crate::utils::OutputChannel;
 use anyhow::bail;
 use bstr::ByteSlice;
 use gitbutler_reference::RemoteRefname;
@@ -11,7 +11,7 @@ use std::{ops::Deref, str::FromStr};
 pub fn apply(
     ctx: &but_ctx::Context,
     branch_name: &str,
-    out: &mut Output,
+    out: &mut OutputChannel,
 ) -> anyhow::Result<but_api::json::Reference> {
     let legacy_project = &ctx.legacy_project;
     let ctx = ctx.legacy_ctx()?;
@@ -62,8 +62,7 @@ pub fn apply(
             writeln!(out, "Applied remote branch '{short_name}' to workspace")
         } else {
             writeln!(out, "Applied branch '{short_name}' to workspace")
-        }
-        .ok();
+        }?;
     } else if let Some(out) = out.for_shell() {
         writeln!(out, "{reference_name}", reference_name = reference.name())?;
     }

--- a/crates/but/src/forge/auth.rs
+++ b/crates/but/src/forge/auth.rs
@@ -1,9 +1,10 @@
+use crate::utils::OutputChannel;
+use anyhow::bail;
 use but_api::{
     NoParams,
     github::{AuthStatusResponseSensitive, StoreGitHubPatParams},
 };
 use cli_prompts::DisplayPrompt;
-use std::io::Write;
 
 #[derive(Debug, Clone)]
 enum AuthMethod {
@@ -23,7 +24,10 @@ impl From<AuthMethod> for String {
 }
 
 /// Authenticate with GitHub
-pub async fn auth_github() -> anyhow::Result<()> {
+pub async fn auth_github(out: &mut OutputChannel) -> anyhow::Result<()> {
+    let Some(out) = out.for_human() else {
+        bail!("Human input required - run this in a terminal")
+    };
     let auth_method_prompt = cli_prompts::prompts::Selection::new(
         "Select an authentication method",
         vec![
@@ -39,136 +43,117 @@ pub async fn auth_github() -> anyhow::Result<()> {
         .map_err(|_| anyhow::anyhow!("Could not determine authentication method"))?;
 
     match selected_method {
-        AuthMethod::Pat => github_pat().await,
-        AuthMethod::Enterprise => github_enterprise().await,
-        AuthMethod::DeviceFlow => github_oauth().await,
+        AuthMethod::Pat => github_pat(out).await,
+        AuthMethod::Enterprise => github_enterprise(out).await,
+        AuthMethod::DeviceFlow => github_oauth(out).await,
     }
 }
 
 /// Authenticate with GitHub using a Personal Access Token (PAT)
-async fn github_pat() -> anyhow::Result<()> {
-    let mut stdout = std::io::stdout();
+async fn github_pat(out_for_humans: &mut dyn std::fmt::Write) -> anyhow::Result<()> {
     writeln!(
-        stdout,
+        out_for_humans,
         "Please enter your GitHub Personal Access Token (PAT) and hit enter:"
-    )
-    .ok();
+    )?;
 
     let mut input = String::new();
     std::io::stdin().read_line(&mut input)?;
 
     if input.trim().is_empty() {
-        writeln!(stdout, "No PAT provided. Aborting authentication.").ok();
-        return Ok(());
+        bail!("No PAT provided. Aborting authentication.");
     }
 
     let pat = input.trim().to_string();
-    match but_api::github::strore_github_pat(StoreGitHubPatParams { access_token: pat }).await {
-        Ok(AuthStatusResponseSensitive { login, .. }) => {
-            writeln!(stdout, "Authentication successful! Welcome, {}.", login).ok();
-        }
-        Err(e) => {
-            writeln!(stdout, "Authentication failed: {}", anyhow::format_err!(e)).ok();
-        }
-    }
+    let AuthStatusResponseSensitive { login, .. } =
+        but_api::github::strore_github_pat(StoreGitHubPatParams { access_token: pat })
+            .await
+            .map_err(|err| anyhow::Error::from(err).context("Authentication failed"))?;
+
+    writeln!(
+        out_for_humans,
+        "Authentication successful! Welcome, {}.",
+        login
+    )?;
 
     Ok(())
 }
 
 /// Authenticate with GitHub Enterprise
-async fn github_enterprise() -> anyhow::Result<()> {
-    let mut stdout = std::io::stdout();
+async fn github_enterprise(out_for_humans: &mut dyn std::fmt::Write) -> anyhow::Result<()> {
     writeln!(
-        stdout,
+        out_for_humans,
         "Please enter your GitHub Enterprise API base URL (e.g., https://github.mycompany.com/api/v3) and hit enter:"
-    )
-    .ok();
+    )?;
 
     let mut input = String::new();
     std::io::stdin().read_line(&mut input)?;
 
     let base_url = input.trim().to_string();
     if base_url.is_empty() {
-        writeln!(stdout, "No host provided. Aborting authentication.").ok();
-        return Ok(());
+        bail!("No host provided. Aborting authentication.")
     }
 
     writeln!(
-        stdout,
+        out_for_humans,
         "Now, please enter your GitHub Enterprise Personal Access Token (PAT) and hit enter:"
-    )
-    .ok();
+    )?;
 
     input.clear();
     std::io::stdin().read_line(&mut input)?;
     let pat = input.trim().to_string();
     if pat.is_empty() {
-        writeln!(stdout, "No PAT provided. Aborting authentication.").ok();
-        return Ok(());
+        bail!("No PAT provided. Aborting authentication.");
     }
 
-    match but_api::github::store_github_enterprise_pat(
+    let AuthStatusResponseSensitive { login, .. } = but_api::github::store_github_enterprise_pat(
         but_api::github::StoreGitHubEnterprisePatParams {
             access_token: pat,
             host: base_url,
         },
     )
     .await
-    {
-        Ok(AuthStatusResponseSensitive { login, .. }) => {
-            writeln!(stdout, "Authentication successful! Welcome, {}.", login).ok();
-        }
-        Err(e) => {
-            writeln!(stdout, "Authentication failed: {}", anyhow::format_err!(e)).ok();
-        }
-    }
+    .map_err(|err| anyhow::Error::from(err).context("Authentication failed"))?;
+
+    writeln!(
+        out_for_humans,
+        "Authentication successful! Welcome, {}.",
+        login
+    )?;
 
     Ok(())
 }
 
 /// Authenticate with GitHub usgin the device OAuth flow
-async fn github_oauth() -> anyhow::Result<()> {
+async fn github_oauth(out_for_humans: &mut dyn std::fmt::Write) -> anyhow::Result<()> {
     let code = but_api::github::init_device_oauth(NoParams {}).await?;
-    let mut stdout = std::io::stdout();
     writeln!(
-        stdout,
+        out_for_humans,
         "Device authorization initiated. Please visit the following URL and enter the code:\n\nhttps://github.com/login/device\n\nCode: {}\n\n",
         code.user_code
-    ).ok();
+    )?;
 
     writeln!(
-        stdout,
+        out_for_humans,
         "Type 'y' and press Enter after you have successfully authorized the device:"
-    )
-    .ok();
+    )?;
     let mut input = String::new();
     std::io::stdin().read_line(&mut input)?;
 
     if input.trim().to_lowercase() != "y" {
-        writeln!(stdout, "Authorization process aborted by user.").ok();
-        return Ok(());
+        bail!("Authorization process aborted by user.")
     }
 
-    let auth_outcome = but_api::github::check_auth_status(but_github::CheckAuthStatusParams {
+    let status = but_api::github::check_auth_status(but_github::CheckAuthStatusParams {
         device_code: code.device_code,
     })
-    .await;
+    .await
+    .map_err(|err| anyhow::Error::from(err).context("Authentication failed"))?;
 
-    let mut stdout = std::io::stdout();
-    let mut stderr = std::io::stderr();
-    match auth_outcome {
-        Ok(status) => {
-            writeln!(
-                stdout,
-                "Authentication successful! Welcome, {}.",
-                status.login
-            )
-            .ok();
-        }
-        Err(e) => {
-            writeln!(stderr, "Authentication failed: {}", anyhow::format_err!(e)).ok();
-        }
-    }
+    writeln!(
+        out_for_humans,
+        "Authentication successful! Welcome, {}.",
+        status.login
+    )?;
 
     Ok(())
 }

--- a/crates/but/src/forge/integration.rs
+++ b/crates/but/src/forge/integration.rs
@@ -1,8 +1,9 @@
+use anyhow::bail;
 use cli_prompts::DisplayPrompt;
 use colored::Colorize;
-use std::io::Write;
 
 use crate::forge::auth::auth_github;
+use crate::utils::OutputChannel;
 
 #[derive(Debug, clap::Parser)]
 pub struct Platform {
@@ -23,18 +24,19 @@ pub enum Subcommands {
     },
 }
 
-pub async fn handle(cmd: Subcommands) -> anyhow::Result<()> {
+pub async fn handle(cmd: Subcommands, out: &mut OutputChannel) -> anyhow::Result<()> {
     match cmd {
-        Subcommands::Auth => auth_github().await,
-        Subcommands::ListUsers => list_github_users().await,
-        Subcommands::Forget { username } => forget_github_username(username).await,
+        Subcommands::Auth => auth_github(out).await,
+        Subcommands::ListUsers => list_github_users(out).await,
+        Subcommands::Forget { username } => forget_github_username(username, out).await,
     }
 }
 
-async fn forget_github_username(username: Option<String>) -> anyhow::Result<()> {
+async fn forget_github_username(
+    username: Option<String>,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     let known_accounts = but_api::github::list_known_github_accounts().await?;
-    let mut stdout = std::io::stdout();
-
     let accounts_to_delete: Vec<_> = if let Some(username) = &username {
         known_accounts
             .into_iter()
@@ -46,13 +48,8 @@ async fn forget_github_username(username: Option<String>) -> anyhow::Result<()> 
 
     // Handle case where no matching account was found
     if accounts_to_delete.is_empty() {
-        if let Some(username) = &username {
-            writeln!(
-                stdout,
-                "No known GitHub account with username '{}'",
-                username
-            )
-            .ok();
+        if let Some((username, out)) = username.zip(out.for_human()) {
+            writeln!(out, "No known GitHub account with username '{username}'")?;
         }
         return Ok(());
     }
@@ -62,28 +59,34 @@ async fn forget_github_username(username: Option<String>) -> anyhow::Result<()> 
         [single_account] => {
             // Single account: delete automatically
             but_api::github::forget_github_account(single_account.clone())?;
-            writeln!(stdout, "Forgot GitHub account '{}'", single_account).ok();
+            if let Some(out) = out.for_human() {
+                writeln!(out, "Forgot GitHub account '{}'", single_account)?;
+            }
         }
         _ => {
             // Multiple accounts: prompt user to select
-            let account_prompt = cli_prompts::prompts::Multiselect::new_transformed(
-                "Which of the following accounts do you want to forget?",
-                accounts_to_delete.into_iter(),
-                |acc| acc.to_string(),
-            );
+            if let Some(out) = out.for_human() {
+                let account_prompt = cli_prompts::prompts::Multiselect::new_transformed(
+                    "Which of the following accounts do you want to forget?",
+                    accounts_to_delete.into_iter(),
+                    |acc| acc.to_string(),
+                );
 
-            let selected_accounts = account_prompt
-                .display()
-                .map_err(|_| anyhow::anyhow!("Could not determine which accounts to delete"))?;
+                let selected_accounts = account_prompt
+                    .display()
+                    .map_err(|_| anyhow::anyhow!("Could not determine which accounts to delete"))?;
 
-            if selected_accounts.is_empty() {
-                writeln!(stdout, "No accounts were selected to forget.").ok();
-                return Ok(());
-            }
+                if selected_accounts.is_empty() {
+                    writeln!(out, "No accounts were selected to forget.")?;
+                    return Ok(());
+                }
 
-            for account in selected_accounts {
-                but_api::github::forget_github_account(account.clone())?;
-                writeln!(stdout, "Forgot GitHub account '{}'", account).ok();
+                for account in selected_accounts {
+                    but_api::github::forget_github_account(account.clone())?;
+                    writeln!(out, "Forgot GitHub account '{}'", account)?;
+                }
+            } else {
+                bail!("Username ambiguous, got {accounts_to_delete:?}");
             }
         }
     }
@@ -91,39 +94,45 @@ async fn forget_github_username(username: Option<String>) -> anyhow::Result<()> 
     Ok(())
 }
 
-async fn list_github_users() -> anyhow::Result<()> {
+async fn list_github_users(out: &mut OutputChannel) -> anyhow::Result<()> {
     let known_accounts = but_api::github::list_known_github_accounts().await?;
-    let mut stdout = std::io::stdout();
-    writeln!(stdout, "Known GitHub usernames:").ok();
-    let mut some_accounts_invalid = false;
-    for account in known_accounts {
-        let account_status = but_api::github::check_github_credentials(&account)
-            .await
-            .ok();
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Known GitHub usernames:")?;
+        let mut some_accounts_invalid = false;
+        for account in known_accounts {
+            let account_status = but_api::github::check_github_credentials(&account)
+                .await
+                .ok();
 
-        let message = match account_status {
-            Some(but_github::CredentialCheckResult::Valid) => "(valid credentials)".green().bold(),
-            Some(but_github::CredentialCheckResult::Invalid) => {
-                some_accounts_invalid = true;
-                "(invalid credentials)".bold().yellow()
-            }
-            Some(but_github::CredentialCheckResult::NoCredentials) => {
-                some_accounts_invalid = true;
-                "(no credentials)".bold().yellow()
-            }
-            None => " (unknown status)".bold().red(),
-        };
+            let message = match account_status {
+                Some(but_github::CredentialCheckResult::Valid) => {
+                    "(valid credentials)".green().bold()
+                }
+                Some(but_github::CredentialCheckResult::Invalid) => {
+                    some_accounts_invalid = true;
+                    "(invalid credentials)".bold().yellow()
+                }
+                Some(but_github::CredentialCheckResult::NoCredentials) => {
+                    some_accounts_invalid = true;
+                    "(no credentials)".bold().yellow()
+                }
+                None => " (unknown status)".bold().red(),
+            };
 
-        writeln!(stdout, "- {} {}", account, message).ok();
+            writeln!(out, "- {} {}", account, message)?;
+        }
+
+        if some_accounts_invalid {
+            writeln!(
+                out,
+                "\nSome accounts have invalid or missing credentials.\nYou may want to re-authenticate with those accounts using the '{}' command.",
+                "but forge auth".bold()
+            )?;
+        }
+    } else if let Some(out) = out.for_shell() {
+        for account in known_accounts {
+            writeln!(out, "{}", account.username())?;
+        }
     }
-
-    if some_accounts_invalid {
-        writeln!(
-            stdout,
-            "\nSome accounts have invalid or missing credentials.\nYou may want to re-authenticate with those accounts using the '{}' command.",
-            "but forge auth".bold()
-        ).ok();
-    }
-
     Ok(())
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -71,16 +71,9 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let output_format = if args.json {
         OutputFormat::Json
     } else {
-        args.format.unwrap_or_else(|| {
-            if atty::is(atty::Stream::Stdout) {
-                OutputFormat::Human
-            } else {
-                OutputFormat::Shell
-            }
-        })
+        args.format
     };
     // Set it so code past this point can assume it's set.;
-    args.format = Some(output_format);
     let mut out = OutputChannel::new_with_pager(output_format);
 
     if args.trace > 0 {
@@ -405,7 +398,7 @@ fn get_or_init_legacy_non_bare_project(args: &Args) -> anyhow::Result<LegacyProj
             Err(_e) => {
                 init::repo(
                     path,
-                    &mut OutputChannel::new_without_pager_non_json(args.format.unwrap()),
+                    &mut OutputChannel::new_without_pager_non_json(args.format),
                     false,
                 )?;
                 LegacyProject::find_by_worktree_dir(path)
@@ -431,7 +424,7 @@ pub fn get_or_init_context_with_legacy_support(args: &Args) -> anyhow::Result<bu
         .unwrap_or_else(|| {
             init::repo(
                 directory,
-                &mut OutputChannel::new_without_pager_non_json(args.format.unwrap()),
+                &mut OutputChannel::new_without_pager_non_json(args.format),
                 false,
             )
             .and_then(|()| LegacyProject::find_by_worktree_dir(directory))

--- a/crates/but/src/rub/squash.rs
+++ b/crates/but/src/rub/squash.rs
@@ -1,18 +1,16 @@
-use std::io::Write;
-
+use super::undo::stack_id_by_commit_id;
+use crate::utils::OutputChannel;
 use but_oxidize::ObjectIdExt;
 use colored::Colorize;
 use gitbutler_command_context::CommandContext;
 use gix::ObjectId;
 
-use super::undo::stack_id_by_commit_id;
-
 pub(crate) fn commits(
     ctx: &mut CommandContext,
     source: &ObjectId,
     destination: &ObjectId,
+    out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let mut stdout = std::io::stdout();
     let source_stack = stack_id_by_commit_id(ctx, source)?;
     let destination_stack = stack_id_by_commit_id(ctx, destination)?;
     if source_stack != destination_stack {
@@ -25,12 +23,13 @@ pub(crate) fn commits(
         vec![source.to_git2()],
         destination.to_git2(),
     )?;
-    writeln!(
-        stdout,
-        "Squashed {} → {}",
-        source.to_string()[..7].blue(),
-        destination.to_string()[..7].blue()
-    )
-    .ok();
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "Squashed {} → {}",
+            source.to_string()[..7].blue(),
+            destination.to_string()[..7].blue()
+        )?
+    }
     Ok(())
 }

--- a/crates/but/src/rub/undo.rs
+++ b/crates/but/src/rub/undo.rs
@@ -1,15 +1,19 @@
-use std::io::Write;
-
+use crate::utils::OutputChannel;
 use but_core::ref_metadata::StackId;
 use but_oxidize::ObjectIdExt;
 use colored::Colorize;
 use gitbutler_command_context::CommandContext;
 use gix::ObjectId;
 
-pub(crate) fn commit(ctx: &mut CommandContext, oid: &ObjectId) -> anyhow::Result<()> {
-    let mut stdout = std::io::stdout();
+pub(crate) fn commit(
+    ctx: &mut CommandContext,
+    oid: &ObjectId,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     gitbutler_branch_actions::undo_commit(ctx, stack_id_by_commit_id(ctx, oid)?, oid.to_git2())?;
-    writeln!(stdout, "Uncommitted {}", oid.to_string()[..7].blue()).ok();
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Uncommitted {}", oid.to_string()[..7].blue())?;
+    }
     Ok(())
 }
 

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -4,9 +4,10 @@ use colored::Colorize;
 use std::io::Write;
 
 /// How we should format anything written to [`std::io::stdout()`].
-#[derive(Debug, Copy, Clone, clap::ValueEnum)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum, Default)]
 pub enum OutputFormat {
     /// The output to write is supposed to be for human consumption, and can be more verbose.
+    #[default]
     Human,
     /// The output should be suitable for shells, and assigning the major result to variables so that it can be re-used
     /// in subsequent CLI invocations.

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -13,10 +13,12 @@ pub enum OutputFormat {
     Shell,
     /// Output detailed information as JSON for tool consumption.
     Json,
+    /// Do not output anything, like redirecting to `/dev/null`.
+    None,
 }
 
 /// A utility `std::io::Write` implementation that can always be used to generate output for humans or for scripts.
-pub struct Output {
+pub struct OutputChannel {
     /// How to print the output, one should match on it. Match on this if you prefer this style.
     format: OutputFormat,
     /// The actual writer.
@@ -27,7 +29,7 @@ pub struct Output {
 }
 
 /// Conversions
-impl Output {
+impl OutputChannel {
     /// Provide a write implementation for humans, if the format setting permits.
     pub fn for_human(&mut self) -> Option<&mut (dyn std::fmt::Write + 'static)> {
         matches!(self.format, OutputFormat::Human).then(|| self as &mut dyn std::fmt::Write)
@@ -43,7 +45,7 @@ impl Output {
 }
 
 /// JSON utilities
-impl Output {
+impl OutputChannel {
     /// Write `value` as pretty JSON to the output.
     ///
     /// Note that it's owned to avoid double-printing with [ResultJsonExt::output_json]
@@ -63,38 +65,36 @@ fn json_pretty_to_stdout(value: &impl serde::Serialize) -> std::io::Result<()> {
     Ok(())
 }
 
-/// We allow writing directly, knowing that JSON output will be a blackhole anyway.
-/// TODO: remove this once `std::fmt::Write` is in use everywhere.
-impl Write for Output {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        match self.format {
-            OutputFormat::Human | OutputFormat::Shell => self.inner.write(buf),
-            OutputFormat::Json => Ok(buf.len()),
-        }
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        match self.format {
-            OutputFormat::Human | OutputFormat::Shell => self.inner.flush(),
-            OutputFormat::Json => Ok(()),
-        }
-    }
-}
-
-impl std::fmt::Write for Output {
+impl std::fmt::Write for OutputChannel {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        if let Some(out) = self.pager.as_mut() {
-            out.write_str(s)
-        } else {
-            self.inner
-                .write_all(s.as_bytes())
-                .map_err(|_| std::fmt::Error)
+        match self.format {
+            OutputFormat::Human | OutputFormat::Shell => {
+                if let Some(out) = self.pager.as_mut() {
+                    out.write_str(s)
+                } else {
+                    self.inner.write_all(s.as_bytes()).or_else(|err| {
+                        if err.kind() == std::io::ErrorKind::BrokenPipe {
+                            // Ignore broken pipes and keep writing.
+                            // This allows the caller to use `?` without having to think
+                            // about ignoring errors selectively.
+                            Ok(())
+                        } else {
+                            Err(std::fmt::Error)
+                        }
+                    })
+                }
+            }
+            OutputFormat::Json | OutputFormat::None => {
+                // It's not an error to try to write in JSON mode, it's a feature.
+                // However, the only way to write JSON is to use [Self::write_value()].
+                Ok(())
+            }
         }
     }
 }
 
 /// Lifecycle
-impl Output {
+impl OutputChannel {
     /// Create a new instance to output with `format` (advisory), which affects where it prints to.
     ///
     /// It's configured to print to stdout unless [`OutputFormat::Json`] is used, then it prints everything
@@ -103,20 +103,35 @@ impl Output {
     /// WARNING: the current implementation is static and would cache everything in memory.
     ///          Use `dynamic_output` (cargo feature + see https://docs.rs/minus/5.6.1/minus/#threads) otherwise.
     ///          It also needs to avoid
-    pub fn new(format: OutputFormat) -> Self {
-        Output {
+    pub fn new_with_pager(format: OutputFormat) -> Self {
+        OutputChannel {
             format,
             inner: std::io::stdout(),
-            pager: if std::env::var_os("NOPAGER").is_some() {
+            pager: if !matches!(format, OutputFormat::Human)
+                || std::env::var_os("NOPAGER").is_some()
+            {
                 None
             } else {
                 Some(minus::Pager::new())
             },
         }
     }
+
+    /// Like [`Self::new_with_pager`], but will never create a pager or write JSON.
+    /// Use this if a second instance of a channel is needed, and the first one could have a pager.
+    pub fn new_without_pager_non_json(format: OutputFormat) -> Self {
+        OutputChannel {
+            format: match format {
+                OutputFormat::Human | OutputFormat::Shell | OutputFormat::None => format,
+                OutputFormat::Json => OutputFormat::None,
+            },
+            inner: std::io::stdout(),
+            pager: None,
+        }
+    }
 }
 
-impl Drop for Output {
+impl Drop for OutputChannel {
     fn drop(&mut self) {
         if let Some(pager) = self.pager.take() {
             minus::page_all(pager).ok();
@@ -178,13 +193,11 @@ pub fn into_json_value(value: impl serde::Serialize) -> serde_json::Value {
         .expect("BUG: Failed to serialize JSON value, we should know that at compile time")
 }
 
-pub fn print_grouped_help() -> std::io::Result<()> {
+pub fn print_grouped_help(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     use std::collections::HashSet;
 
     use clap::CommandFactory;
     use terminal_size::{Width, terminal_size};
-
-    let mut stdout = std::io::stdout();
 
     // Get terminal width, default to 80 if detection fails
     let terminal_width = if let Some((Width(w), _)) = terminal_size() {
@@ -229,33 +242,29 @@ pub fn print_grouped_help() -> std::io::Result<()> {
         ),
     ];
 
+    writeln!(out, "{}", "The GitButler CLI change control system".red())?;
+    writeln!(out)?;
+    writeln!(out, "Usage: but [OPTIONS] <COMMAND>")?;
+    writeln!(out, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
+    writeln!(out)?;
     writeln!(
-        stdout,
-        "{}",
-        "The GitButler CLI change control system".red()
-    )?;
-    writeln!(stdout)?;
-    writeln!(stdout, "Usage: but [OPTIONS] <COMMAND>")?;
-    writeln!(stdout, "       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]")?;
-    writeln!(stdout)?;
-    writeln!(
-        stdout,
+        out,
         "The GitButler CLI can be used to do nearly anything the desktop client can do (and more)."
     )?;
     writeln!(
-        stdout,
+        out,
         "It is a drop in replacement for most of the Git commands you would normally use, but Git"
     )?;
     writeln!(
-        stdout,
+        out,
         "commands (blame, log, etc) can also be used, as GitButler is fully Git compatible."
     )?;
-    writeln!(stdout)?;
+    writeln!(out)?;
     writeln!(
-        stdout,
+        out,
         "Checkout the full docs here: https://docs.gitbutler.com/cli-overview"
     )?;
-    writeln!(stdout)?;
+    writeln!(out)?;
 
     // Keep track of which commands we've already printed
     let mut printed_commands = HashSet::new();
@@ -264,7 +273,7 @@ pub fn print_grouped_help() -> std::io::Result<()> {
 
     // Print grouped commands
     for (group_name, command_names) in &groups {
-        writeln!(stdout, "{group_name}:")?;
+        writeln!(out, "{group_name}:")?;
         for cmd_name in command_names {
             if let Some(subcmd) = subcommands.iter().find(|c| c.get_name() == *cmd_name) {
                 let about = subcmd.get_about().unwrap_or_default().to_string();
@@ -273,7 +282,7 @@ pub fn print_grouped_help() -> std::io::Result<()> {
                     terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
                 let truncated_about = truncate_text(&about, available_width);
                 writeln!(
-                    stdout,
+                    out,
                     "  {:<LONGEST_COMMAND_LEN$}{}",
                     cmd_name.green(),
                     truncated_about,
@@ -281,7 +290,7 @@ pub fn print_grouped_help() -> std::io::Result<()> {
                 printed_commands.insert(cmd_name.to_string());
             }
         }
-        writeln!(stdout)?;
+        writeln!(out)?;
     }
 
     // Collect any remaining commands not in the explicit groups
@@ -292,41 +301,41 @@ pub fn print_grouped_help() -> std::io::Result<()> {
 
     // Print MISC section if there are any ungrouped commands
     if !misc_commands.is_empty() {
-        writeln!(stdout, "{}:", "Other Commands".yellow())?;
+        writeln!(out, "{}:", "Other Commands".yellow())?;
         for subcmd in misc_commands {
             let about = subcmd.get_about().unwrap_or_default().to_string();
             // Calculate available width: terminal_width - indent (2) - command column (10) - buffer (1)
             let available_width = terminal_width.saturating_sub(LONGEST_COMMAND_LEN_AND_ELLIPSIS);
             let truncated_about = truncate_text(&about, available_width);
             writeln!(
-                stdout,
+                out,
                 "  {:<LONGEST_COMMAND_LEN$}{}",
                 subcmd.get_name().green(),
                 truncated_about
             )?;
         }
-        writeln!(stdout)?;
+        writeln!(out)?;
     }
 
     // Add command completion instructions
     writeln!(
-        stdout,
+        out,
         "To add command completion, add this to your shell rc: (for example ~/.zshrc)"
     )?;
-    writeln!(stdout, "  eval \"$(but completions zsh)\"")?;
-    writeln!(stdout)?;
+    writeln!(out, "  eval \"$(but completions zsh)\"")?;
+    writeln!(out)?;
 
     writeln!(
-        stdout,
+        out,
         "To use the GitButler CLI with coding agents (Claude Code hooks, Cursor hooks, MCP), see:"
     )?;
     writeln!(
-        stdout,
+        out,
         "  https://docs.gitbutler.com/features/ai-integration/ai-overview"
     )?;
-    writeln!(stdout)?;
+    writeln!(out)?;
 
-    writeln!(stdout, "{}:", "Options".yellow())?;
+    writeln!(out, "{}:", "Options".yellow())?;
     // Truncate long option descriptions if needed
     let option_descriptions = [
         (
@@ -340,7 +349,7 @@ pub fn print_grouped_help() -> std::io::Result<()> {
     for (flag, desc) in option_descriptions {
         let available_width = terminal_width.saturating_sub(flag.len() + 2);
         let truncated_desc = truncate_text(desc, available_width);
-        writeln!(stdout, "{}  {}", flag, truncated_desc)?;
+        writeln!(out, "{}  {}", flag, truncated_desc)?;
     }
 
     Ok(())


### PR DESCRIPTION
That way, it will automatically support paging, just like with Git, but sans the customizability as the pager is built-in.

Tangent to #11236

### Tasks

* [x] port everything
* [x] ~~Use proxy-types in `for_X` results so users can only use it correctly. Remove `Write` impl on `Output` as well.~~ - this would make the usage unergonomic.
* [x] replace `.ok()` with `?` after validating that the ` | head -5` example works without it, or ignore errors in the write impl.
