### PR TITLE
intermezzo: cleanup json error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "but-workspace",
  "git2",
  "gitbutler-command-context",
+ "gitbutler-repo",
  "gitbutler-stack",
  "gitbutler-testsupport",
  "gix",

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -83,6 +83,7 @@ pub fn api_cmd_tauri(attr: TokenStream, item: TokenStream) -> TokenStream {
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
     let fn_name = &sig.ident;
+    let asyncness = &sig.asyncness;
     let input = &sig.inputs;
     let output = &sig.output;
 
@@ -142,156 +143,17 @@ pub fn api_cmd_tauri(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect();
 
-    // Struct name: <FunctionName>Params (PascalCase)
-    let struct_name = format_ident!("{}Params", fn_name.to_string().to_case(Case::Pascal));
-
-    // Wrapper function name: <function_name>_params
-    let wrapper_name = format_ident!("{}_params", fn_name);
-
-    // Cmd function name: <function_name>_cmd
-    let cmd_name = format_ident!("{}_cmd", fn_name);
-
-    // Cmd function name: <function_name>_json
-    let json_name = format_ident!("{}_json", fn_name);
-
-    // Module name for tauri-renames, to keep the original function names.
-    let tauri_mod_name = format_ident!("tauri_{}", fn_name);
-    let tauri_cmd_name = format_ident!("__cmd__{}", json_name);
-    let tauri_orig_cmd_name = format_ident!("__cmd__{}", fn_name);
-
-    let convert_json = if let Some((path, is_result_opt)) = outputs_result_option {
-        if is_result_opt {
-            quote! {
-                let result: Option<#path> = result.map(Into::into);
-            }
-        } else {
-            quote! {
-                let result: #path = result.into();
-            }
-        }
+    let call_fn = if asyncness.is_some() {
+        quote! { #fn_name(#(params.#param_names),*).await }
     } else {
-        quote! {}
+        quote! { #fn_name(#(params.#param_names),*) }
     };
 
-    let expanded = quote! {
-        // Original function stays
-        #input_fn
-
-        // Generated struct
-        #[derive(::serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct #struct_name {
-            #(#fields,)*
-        }
-
-        // Wrapper function
-        fn #wrapper_name(params: #struct_name) #output {
-            #fn_name(#(params.#param_names),*)
-        }
-
-        // Cmd function
-        #vis fn #cmd_name(
-            params: ::serde_json::Value,
-        ) -> Result<::serde_json::Value, crate::json::Error> {
-            use crate::json::ToError;
-            let params: #struct_name = ::serde_json::from_value(params).to_error()?;
-            let result = #fn_name(#(params.#param_names),*)?;
-            #convert_json
-            ::serde_json::to_value(result).to_error()
-        }
-
-        // tauri function
-        #[cfg_attr(feature = "tauri", tauri::command(async))]
-        #vis fn #json_name(
-            #input
-        ) -> Result<::serde_json::Value, crate::json::Error> {
-            use crate::json::ToError;
-            let result = #fn_name(#(#arg_idents),*)?;
-            #convert_json
-            ::serde_json::to_value(result).to_error()
-        }
-
-        #[cfg(feature = "tauri")]
-        pub mod #tauri_mod_name {
-            pub use super::#json_name as #fn_name;
-            pub use super::#tauri_cmd_name as #tauri_orig_cmd_name;
-        }
-
-    };
-
-    expanded.into()
-}
-
-/// To be used on `async` functions, so a function `func` will be turned into:
-/// * `func` - the original item, unchanged
-/// * `func_params(FuncParams)` taking a struct with all parameters
-/// * `func_cmd` for calls from the frontend, taking `serde_json::Value` and returning `Result<serde_json::Value, Error>`
-/// * `func_tauri` for calls from the tauri, args and returning `Result<serde_json::Value, Error>`, with `tauri` support.
-#[proc_macro_attribute]
-pub fn api_cmd_async_tauri(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let input_fn = parse_macro_input!(item as ItemFn);
-
-    let vis = &input_fn.vis;
-    let sig = &input_fn.sig;
-    let fn_name = &sig.ident;
-    let input = &sig.inputs;
-    let output = &sig.output;
-
-    let path = if attr.is_empty() {
-        None
+    let call_fn_args = if asyncness.is_some() {
+        quote! { #fn_name(#(#arg_idents),*).await }
     } else {
-        Some(parse_macro_input!(attr as Path))
+        quote! { #fn_name(#(#arg_idents),*) }
     };
-
-    /// Detect `Result<Option<` type
-    fn is_result_option(ty: &syn::Type) -> bool {
-        if let syn::Type::Path(tp) = ty
-            && let Some(seg) = tp.path.segments.last()
-            && seg.ident == "Result"
-            && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
-            && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
-            && let syn::Type::Path(tp) = inner
-            && let Some(first) = tp.path.segments.last()
-            && first.ident == "Option"
-        {
-            true
-        } else {
-            false
-        }
-    }
-
-    let outputs_result_option = path.map(|p| {
-        (
-            p,
-            is_result_option(match &sig.output {
-                syn::ReturnType::Type(_, ty) => ty.as_ref(),
-                syn::ReturnType::Default => panic!("function must return a type"),
-            }),
-        )
-    });
-
-    // Collect parameter names and types
-    let mut fields = Vec::new();
-    let mut param_names = Vec::new();
-    for arg in &sig.inputs {
-        if let FnArg::Typed(pat_type) = arg {
-            let ty = &pat_type.ty;
-            let pat = &pat_type.pat;
-            if let Pat::Ident(ident) = &**pat {
-                let name = &ident.ident;
-                fields.push(quote! { pub #name: #ty });
-                param_names.push(name);
-            }
-        }
-    }
-
-    let arg_idents: Vec<_> = input
-        .iter()
-        .filter_map(|arg| match arg {
-            syn::FnArg::Typed(pat_ty) => Some(&pat_ty.pat),
-            syn::FnArg::Receiver(_) => None, // for &self / self
-        })
-        .collect();
 
     // Struct name: <FunctionName>Params (PascalCase)
     let struct_name = format_ident!("{}Params", fn_name.to_string().to_case(Case::Pascal));
@@ -336,28 +198,28 @@ pub fn api_cmd_async_tauri(attr: TokenStream, item: TokenStream) -> TokenStream 
         }
 
         // Wrapper function
-        async fn #wrapper_name(params: #struct_name) #output {
-            #fn_name(#(params.#param_names),*).await
+        #asyncness fn #wrapper_name(params: #struct_name) #output {
+            #call_fn
         }
 
         // Cmd function
-        #vis async fn #cmd_name(
+        #vis #asyncness fn #cmd_name(
             params: ::serde_json::Value,
         ) -> Result<::serde_json::Value, crate::json::Error> {
             use crate::json::ToError;
             let params: #struct_name = ::serde_json::from_value(params).to_error()?;
-            let result = #fn_name(#(params.#param_names),*).await?;
+            let result = #call_fn?;
             #convert_json
             ::serde_json::to_value(result).to_error()
         }
 
         // tauri function
         #[cfg_attr(feature = "tauri", tauri::command(async))]
-        #vis async fn #json_name(
+        #vis #asyncness fn #json_name(
             #input
         ) -> Result<::serde_json::Value, crate::json::Error> {
             use crate::json::ToError;
-            let result = #fn_name(#(#arg_idents),*).await?;
+            let result = #call_fn_args?;
             #convert_json
             ::serde_json::to_value(result).to_error()
         }

--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -1,6 +1,6 @@
 //! In place of commands.rs
 use anyhow::Result;
-use but_api_macros::{api_cmd, api_cmd_async_tauri, api_cmd_tauri};
+use but_api_macros::{api_cmd, api_cmd_tauri};
 use but_github::{AuthStatusResponse, AuthenticatedUser, Verification};
 use but_secret::Sensitive;
 use tracing::instrument;
@@ -73,27 +73,27 @@ pub mod json {
     }
 }
 
-#[api_cmd_async_tauri]
+#[api_cmd_tauri]
 #[instrument(err(Debug))]
 pub async fn init_device_oauth() -> Result<Verification> {
     but_github::init_device_oauth().await
 }
 
-#[api_cmd_async_tauri(json::AuthStatusResponseSensitive)]
+#[api_cmd_tauri(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn check_auth_status(device_code: String) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
     but_github::check_auth_status(device_code, &storage).await
 }
 
-#[api_cmd_async_tauri(json::AuthStatusResponseSensitive)]
+#[api_cmd_tauri(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
     but_github::store_pat(&access_token, &storage).await
 }
 
-#[api_cmd_async_tauri(json::AuthStatusResponseSensitive)]
+#[api_cmd_tauri(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_github_enterprise_pat(
     access_token: Sensitive<String>,
@@ -113,14 +113,13 @@ pub fn forget_github_account(account: but_github::GithubAccountIdentifier) -> Re
 }
 
 #[api_cmd_tauri]
-#[cfg_attr(feature = "tauri", tauri::command(async))]
 #[instrument(err(Debug))]
 pub fn clear_all_github_tokens() -> Result<()> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
     but_github::clear_all_github_tokens(&storage)
 }
 
-#[api_cmd_async_tauri(json::AuthenticatedUserSensitive)]
+#[api_cmd_tauri(json::AuthenticatedUserSensitive)]
 #[instrument(err(Debug))]
 pub async fn get_gh_user(
     account: but_github::GithubAccountIdentifier,
@@ -129,7 +128,7 @@ pub async fn get_gh_user(
     but_github::get_gh_user(&account, &storage).await
 }
 
-#[api_cmd_async_tauri]
+#[api_cmd_tauri]
 #[instrument(err(Debug))]
 pub async fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdentifier>> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);

--- a/crates/but-hunk-dependency/Cargo.toml
+++ b/crates/but-hunk-dependency/Cargo.toml
@@ -16,6 +16,7 @@ but-serde.workspace = true
 but-oxidize.workspace = true
 
 gitbutler-command-context.workspace = true
+gitbutler-repo.workspace = true
 # For `ui` module
 gitbutler-stack.workspace = true
 # TODO: remove once not needed anymore

--- a/crates/but/src/utils.rs
+++ b/crates/but/src/utils.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use colored::Colorize;
-
 use crate::{args::Args, metrics::MetricsContext};
+use colored::Colorize;
+use minus::ExitStrategy;
 
 /// How we should format anything written to [`std::io::stdout()`].
 #[derive(Debug, Copy, Clone, clap::ValueEnum, Default)]
@@ -114,7 +114,11 @@ impl OutputChannel {
             {
                 None
             } else {
-                Some(minus::Pager::new())
+                let pager = minus::Pager::new();
+                let msg = "can talk to newly created pager";
+                pager.set_exit_strategy(ExitStrategy::PagerQuit).expect(msg);
+                pager.set_prompt("GitButler").expect(msg);
+                Some(pager)
             },
         }
     }


### PR DESCRIPTION
That way, the `but-api` stays a normal library crate without needs regarding JSON serialisation, and each function is then transformed to what it needs to be for the respective consumers.

### Tasks

* [x] 'fix' ancestor bug by git2 replacement.
* [x] deduplicate proc-macro: let it handle `async` via snippets.
* [ ] leave `json::Error` handling for the macro.

Related to #11236
Follow-up of #11253 

