### PR TITLE
intermezzo: use latest version of proc-macro everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,6 @@ dependencies = [
  "shell-words",
  "snapbox",
  "strum 0.27.2",
- "term_size",
  "terminal_size",
  "tokio",
  "tracing",
@@ -10536,16 +10535,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -90,7 +90,6 @@ minus = { version = "5.6.1", default-features = false, features = [
     "search",
 ] }
 unicode-width = "0.1"
-term_size = "0.3"
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }

--- a/crates/but/src/branch/list.rs
+++ b/crates/but/src/branch/list.rs
@@ -572,7 +572,7 @@ fn print_applied_branches_table(
     use but_settings::AppSettings;
     use gitbutler_command_context::CommandContext;
 
-    use crate::table::{Cell, Table};
+    use crate::utils::{Table, table::Cell};
 
     if applied_stacks.is_empty() {
         return Ok(());
@@ -696,7 +696,7 @@ fn print_branches_table(
     merge_status_map: Option<&std::collections::HashMap<String, bool>>,
     id_map: &HashMap<String, String>,
 ) -> Result<(), anyhow::Error> {
-    use crate::table::{Cell, Table};
+    use crate::utils::{Table, table::Cell};
 
     if branches.is_empty() {
         return Ok(());

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
                     &app_settings,
                     CommandName::Rub,
                 ))
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(out)
         }
         None if args.source_or_path.is_some() && args.target.is_none() => {
             // If only one argument is provided without a subcommand, check if this is a valid path.
@@ -132,9 +132,9 @@ async fn match_subcommand(
     cmd: Subcommands,
     args: Args,
     app_settings: AppSettings,
-    mut out: OutputChannel,
+    mut output: OutputChannel,
 ) -> Result<()> {
-    let out = &mut out;
+    let out = &mut output;
     let metrics_ctx = cmd.to_metrics_context(&app_settings);
 
     match cmd {
@@ -258,7 +258,7 @@ async fn match_subcommand(
             let project = get_or_init_legacy_non_bare_project(&args)?;
             worktree::handle(cmd, &project, out)
                 .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Log => {
             let project = get_or_init_legacy_non_bare_project(&args)?;
@@ -285,21 +285,21 @@ async fn match_subcommand(
             rub::handle(&project, out, &source, &target)
                 .context("Rubbed the wrong way.")
                 .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Mark { target, delete } => {
             let project = get_or_init_legacy_non_bare_project(&args)?;
             mark::handle(&project, out, &target, delete)
                 .context("Can't mark this. Taaaa-na-na-na. Can't mark this.")
                 .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Unmark => {
             let project = get_or_init_legacy_non_bare_project(&args)?;
             mark::unmark(&project, out)
                 .context("Can't unmark this. Taaaa-na-na-na. Can't unmark this.")
                 .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Gui => gui::open(&args.current_dir).emit_metrics(metrics_ctx),
         Subcommands::Commit {
@@ -358,7 +358,7 @@ async fn match_subcommand(
             forge::integration::handle(cmd, out)
                 .await
                 .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit()
+                .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Review(forge::review::Platform { cmd }) => match cmd {
             forge::review::Subcommands::Publish {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 use std::{ffi::OsString, path::Path};
 
 use anyhow::{Context, Result};
@@ -40,7 +42,6 @@ mod oplog;
 mod push;
 mod rub;
 mod status;
-mod table;
 mod ui;
 mod worktree;
 

--- a/crates/but/src/rub/mod.rs
+++ b/crates/but/src/rub/mod.rs
@@ -24,12 +24,6 @@ pub(crate) fn handle(
     target_str: &str,
 ) -> anyhow::Result<()> {
     let ctx = &mut CommandContext::open(project, AppSettings::load_from_default_path_creating()?)?;
-
-    if let Some(out) = out.for_human() {
-        writeln!(out, "Amended unassigned files {source_str} → {target_str}")?;
-        return Ok(());
-    }
-
     let (sources, target) = ids(ctx, source_str, target_str)?;
 
     for source in sources {

--- a/crates/but/src/rub/mod.rs
+++ b/crates/but/src/rub/mod.rs
@@ -24,6 +24,12 @@ pub(crate) fn handle(
     target_str: &str,
 ) -> anyhow::Result<()> {
     let ctx = &mut CommandContext::open(project, AppSettings::load_from_default_path_creating()?)?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Amended unassigned files {source_str} → {target_str}")?;
+        return Ok(());
+    }
+
     let (sources, target) = ids(ctx, source_str, target_str)?;
 
     for source in sources {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -4,6 +4,9 @@ use crate::{args::Args, metrics::MetricsContext};
 use colored::Colorize;
 use minus::ExitStrategy;
 
+pub mod table;
+pub use table::types::Table;
+
 /// How we should format anything written to [`std::io::stdout()`].
 #[derive(Debug, Copy, Clone, clap::ValueEnum, Default)]
 pub enum OutputFormat {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -26,8 +26,7 @@ pub enum OutputFormat {
 pub struct OutputChannel {
     /// How to print the output, one should match on it. Match on this if you prefer this style.
     format: OutputFormat,
-    /// The actual writer.
-    // TODO: remove once nobody writes to io::out anymore.
+    /// The output to use if there is no pager.
     inner: std::io::Stdout,
     /// Possibly a pager we are using. If `Some`, our `inner` is the pager itself which we interact with from here.
     pager: Option<minus::Pager>,
@@ -158,11 +157,13 @@ pub trait ResultJsonExt {
 }
 
 pub trait ResultErrorExt {
-    fn show_root_cause_error_then_exit(self) -> !;
+    fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> !;
 }
 
 impl ResultErrorExt for anyhow::Result<()> {
-    fn show_root_cause_error_then_exit(self) -> ! {
+    fn show_root_cause_error_then_exit_without_destructors(self, out: OutputChannel) -> ! {
+        // Trigger the pager to be flushed before exiting early, or destructors aren't called.
+        drop(out);
         let code = if let Err(e) = &self {
             writeln!(std::io::stderr(), "{} {}", e, e.root_cause()).ok();
             1

--- a/crates/but/src/utils/table.rs
+++ b/crates/but/src/utils/table.rs
@@ -1,6 +1,19 @@
+use crate::utils::table::types::Table;
 use std::io::Write;
-
+use terminal_size::Width;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Avoid paths like `table::Table` when importing.
+pub(super) mod types {
+    use crate::utils::table::Cell;
+
+    /// A simple table formatter that can render tables with fixed-width columns
+    pub struct Table {
+        pub(super) headers: Vec<Cell>,
+        pub(super) rows: Vec<Vec<Cell>>,
+        pub(super) terminal_width: usize,
+    }
+}
 
 /// Represents a single cell in a table
 #[derive(Debug, Clone)]
@@ -30,16 +43,9 @@ impl Cell {
     }
 }
 
-/// A simple table formatter that can render tables with fixed-width columns
-pub struct Table {
-    headers: Vec<Cell>,
-    rows: Vec<Vec<Cell>>,
-    terminal_width: usize,
-}
-
 impl Table {
     pub fn new(headers: Vec<Cell>) -> Self {
-        let terminal_width = get_terminal_width();
+        let terminal_width = terminal_width();
         Self {
             headers,
             rows: Vec::new(),
@@ -223,10 +229,6 @@ fn strip_ansi_codes(s: &str) -> String {
     result
 }
 
-fn get_terminal_width() -> usize {
-    if let Some((w, _)) = term_size::dimensions() {
-        w
-    } else {
-        80 // default fallback
-    }
+fn terminal_width() -> usize {
+    terminal_size::terminal_size().map_or(80, |(Width(w), _)| w as usize)
 }


### PR DESCRIPTION
That way, the `but-api` stays a normal library crate without needs regarding JSON serialisation, and each function is then transformed to what it needs to be for the respective consumers.

### Tasks

* [x] fixup 
* [ ] leave `json::Error` handling for the macro.
* [ ] make `Schemars` work for `gix::ObjectId` - maybe use `HexHash`?

Related to #11236
Follow-up of #11255


