### PR TITLE
feat: tweak draft panel width default to 22

### DIFF
--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -143,7 +143,7 @@
 					persistId="resizer-darft-panel"
 					viewport={draftPanelEl}
 					direction="right"
-					defaultValue={20}
+					defaultValue={22}
 					minWidth={16}
 					maxWidth={64}
 				/>


### PR DESCRIPTION
Shift default width rightward
for draft resizer to match new UX
more room, preserves limits