### PR TITLE
fix-handle-cmd-a-select-branch-name

### DIFF
--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -60,10 +60,13 @@
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter' || e.key === 'Escape') {
+		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
+			e.stopPropagation();
+			inputEl?.select();
+		} else if (e.key === 'Enter' || e.key === 'Escape') {
+			e.stopPropagation();
 			inputEl?.blur();
 		}
-		e.stopPropagation();
 	}
 
 	function handleDoubleClick(e: MouseEvent) {

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -110,6 +110,17 @@
 	$effect(() => {
 		if (measureElHeight < minHeight) measureElHeight = minHeight;
 	});
+
+	function handleKeydown(e: KeyboardEvent & { currentTarget: HTMLTextAreaElement }) {
+		// Handle cmd+a (Mac) or ctrl+a (Windows/Linux) to select all text
+		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
+			e.preventDefault();
+			e.currentTarget.select();
+		}
+
+		// Call the original onkeydown handler if provided
+		onkeydown?.(e);
+	}
 </script>
 
 <div
@@ -164,7 +175,7 @@
 		{oninput}
 		{onchange}
 		{onblur}
-		{onkeydown}
+		onkeydown={handleKeydown}
 		{onfocus}
 		rows={minRows}
 	></textarea>

--- a/packages/ui/src/lib/components/Textbox.svelte
+++ b/packages/ui/src/lib/components/Textbox.svelte
@@ -116,6 +116,17 @@
 			});
 		}
 	});
+
+	function handleKeydown(e: KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement }) {
+		// Handle cmd+a (Mac) or ctrl+a (Windows/Linux) to select all text
+		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
+			e.preventDefault();
+			e.currentTarget.select();
+		}
+
+		// Call the original onkeydown handler if provided
+		onkeydown?.(e);
+	}
 </script>
 
 <div
@@ -193,7 +204,7 @@
 			onchange={(e) => {
 				onchange?.(e.currentTarget.value);
 			}}
-			{onkeydown}
+			onkeydown={handleKeydown}
 		/>
 
 		{#if type === 'number' && showCountActions}


### PR DESCRIPTION
This pull request enhances the user experience for text input components by adding support for the "Select All" keyboard shortcut (Cmd+A on Mac, Ctrl+A on Windows/Linux) in both the `Textbox` and `Textarea` components. Additionally, it updates the `BranchLabel` component to handle this shortcut consistently. The changes ensure that pressing Cmd/Ctrl+A selects all text within the input, and the original `onkeydown` handlers are still called if provided.

**Keyboard shortcut improvements:**

* Added logic to `packages/ui/src/lib/components/Textbox.svelte` and `packages/ui/src/lib/components/Textarea.svelte` so that pressing Cmd/Ctrl+A selects all text in the input or textarea, and calls the original `onkeydown` handler if present. [[1]](diffhunk://#diff-ebb68e1cbc1cb253d5548e94b92bd88878bc60f3b28b861ea658ce5fc0b96f4aR119-R129) [[2]](diffhunk://#diff-52d5616db6c3e774a0ffe418b311f484f3f92c30c5cd74b3191b4e7d28924d65R113-R123)
* Updated the `onkeydown` event bindings in both `Textbox` and `Textarea` components to use the new handler functions. [[1]](diffhunk://#diff-ebb68e1cbc1cb253d5548e94b92bd88878bc60f3b28b861ea658ce5fc0b96f4aL196-R207) [[2]](diffhunk://#diff-52d5616db6c3e774a0ffe418b311f484f3f92c30c5cd74b3191b4e7d28924d65L167-R178)

**Consistency across components:**

* Modified the `apps/desktop/src/components/BranchLabel.svelte` component to handle Cmd/Ctrl+A for selecting all text, and to stop propagation for Enter/Escape as well as the select-all shortcut.