### PR TITLE
Eliminate ambiguity in unassigned area ID

### DIFF
--- a/crates/but/src/id.rs
+++ b/crates/but/src/id.rs
@@ -98,7 +98,10 @@ impl CliId {
     }
 
     pub fn matches(&self, s: &str) -> bool {
-        s == self.to_string()
+        match self {
+            CliId::Unassigned => s.find(|c: char| c != '0').is_none(),
+            _ => s == self.to_string(),
+        }
     }
 
     pub fn matches_prefix(&self, s: &str) -> bool {
@@ -107,6 +110,7 @@ impl CliId {
                 let oid_hash = hash(&oid.to_string());
                 oid_hash.starts_with(s)
             }
+            CliId::Unassigned => s.find(|c: char| c != '0').is_none(),
             _ => self.to_string().starts_with(s),
         }
     }

--- a/crates/but/src/rub/mod.rs
+++ b/crates/but/src/rub/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn handle(
             (CliId::UncommittedFile { .. }, CliId::UncommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::UncommittedFile { path, .. }, CliId::Unassigned) => {
+            (CliId::UncommittedFile { path, .. }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::unassign_file(ctx, path, out)?;
             }
@@ -43,24 +43,24 @@ pub(crate) fn handle(
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_file_to_branch(ctx, path, name, out)?;
             }
-            (CliId::Unassigned, CliId::UncommittedFile { .. }) => {
+            (CliId::Unassigned { .. }, CliId::UncommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Unassigned, CliId::Unassigned) => {
+            (CliId::Unassigned { .. }, CliId::Unassigned { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Unassigned, CliId::Commit { oid }) => {
+            (CliId::Unassigned { .. }, CliId::Commit { oid }) => {
                 create_snapshot(ctx, project, OperationKind::AmendCommit);
                 amend::assignments_to_commit(ctx, None, oid, out)?;
             }
-            (CliId::Unassigned, CliId::Branch { name: to }) => {
+            (CliId::Unassigned { .. }, CliId::Branch { name: to }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_all(ctx, None, Some(to), out)?;
             }
             (CliId::Commit { .. }, CliId::UncommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Commit { oid }, CliId::Unassigned) => {
+            (CliId::Commit { oid }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, project, OperationKind::UndoCommit);
                 undo::commit(ctx, oid, out)?;
             }
@@ -75,7 +75,7 @@ pub(crate) fn handle(
             (CliId::Branch { .. }, CliId::UncommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Branch { name: from }, CliId::Unassigned) => {
+            (CliId::Branch { name: from }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_all(ctx, Some(from), None, out)?;
             }
@@ -104,7 +104,7 @@ pub(crate) fn handle(
                 create_snapshot(ctx, project, OperationKind::FileChanges);
                 commits::commited_file_to_another_commit(ctx, path, *commit_oid, *oid, out)?;
             }
-            (CliId::CommittedFile { path, commit_oid }, CliId::Unassigned) => {
+            (CliId::CommittedFile { path, commit_oid }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, project, OperationKind::FileChanges);
                 commits::uncommit_file(ctx, path, *commit_oid, None, out)?;
             }
@@ -114,7 +114,7 @@ pub(crate) fn handle(
             (CliId::Commit { .. }, CliId::CommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Unassigned, CliId::CommittedFile { .. }) => {
+            (CliId::Unassigned { .. }, CliId::CommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
         }

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -18,7 +18,8 @@ const DATE_ONLY: CustomFormat = CustomFormat::new("%Y-%m-%d");
 
 pub(crate) mod assignment;
 
-use crate::{id::CliId, utils::OutputChannel};
+use crate::id::{CliId, IdDb};
+use crate::utils::OutputChannel;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -564,7 +565,8 @@ pub fn print_group(
             }
         }
     } else {
-        let id = CliId::Unassigned.to_string().underline().blue();
+        let id_db = IdDb::new(ctx)?;
+        let id = id_db.unassigned().to_string().underline().blue();
         writeln!(
             out,
             "╭┄{} [{}] {}",

--- a/crates/but/tests/but/id.rs
+++ b/crates/but/tests/but/id.rs
@@ -1,0 +1,19 @@
+use crate::utils::{Sandbox, setup_metadata};
+
+#[test]
+fn multiple_zeroes_as_unassigned_area() -> anyhow::Result<()> {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    setup_metadata(&env, &["A", "B"])?;
+
+    // Check that 000 is interpreted as the unassigned area.
+    env.but("rub 000 000")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![
+            "Rubbed the wrong way. Operation doesn't make sense. \
+Source[..]the unassigned area[..]target[..]the unassigned area[..]"
+        ]);
+    Ok(())
+}

--- a/crates/but/tests/but/id.rs
+++ b/crates/but/tests/but/id.rs
@@ -17,3 +17,22 @@ Source[..]the unassigned area[..]target[..]the unassigned area[..]"
         ]);
     Ok(())
 }
+
+#[test]
+fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    setup_metadata(&env, &["A", "B"])?;
+
+    env.but("branch new branch001").assert().success();
+
+    // Ensure that the ID of the unassigned area has enough 0s to be unambiguous.
+    env.but("status")
+        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str!["[..]000[..]Unassigned Changes[..]\n..."]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/main.rs
+++ b/crates/but/tests/but/main.rs
@@ -1,5 +1,6 @@
 mod branch;
 mod commit;
+mod id;
 mod journey;
 mod rub;
 mod status;


### PR DESCRIPTION
## 🧢 Changes

Allow any number of 0s to refer to the unassigned area, and in `status`, print the minimum number of `0`s needed to disambiguate (for now, just against branch names).

See transcript below (for the `status` part).

```
[jt@archlinux gitoxide]$ but status
Initialized GitButler project from .. The default target is origin/main
╭┄00 [Unassigned Changes]
┊
┴ dba337d (common base) [origin/main] 2025-11-11 Merge pull request #2254 from ralphmodales/credent
[jt@archlinux gitoxide]$ but branch new b00
Created branch b00
[jt@archlinux gitoxide]$ but status
╭┄000 [Unassigned Changes]
┊
┊╭┄ux [b00] (no commits)
├╯
┊
┴ dba337d (common base) [origin/main] 2025-11-11 Merge pull request #2254 from ralphmodales/credent
```

## ☕️ Reasoning

Fixes bug (see Affected issues below) and this is also the start of centralizing CLI ID generation and interpretation, which allows better management of ambiguity (one such example is in this PR).

## 🎫 Affected issues

Fixes: #11219


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
