### PR TITLE
intermezzo: use latest version of proc-macro everywhere 

### DIFF
--- a/crates/but/src/branch/apply.rs
+++ b/crates/but/src/branch/apply.rs
@@ -14,7 +14,7 @@ pub fn apply(
     ctx: &but_ctx::Context,
     branch_name: &str,
     out: &mut OutputChannel,
-) -> anyhow::Result<but_api::json::Reference> {
+) -> anyhow::Result<()> {
     let legacy_project = &ctx.legacy_project;
     let ctx = ctx.legacy_ctx()?;
     let repo = ctx.gix_repo()?;
@@ -69,7 +69,10 @@ pub fn apply(
         writeln!(out, "{reference_name}", reference_name = reference.name())?;
     }
 
-    Ok(reference.inner.into())
+    if let Some(out) = out.for_json() {
+        out.write_value(but_api::json::Reference::from(reference.inner))?;
+    }
+    Ok(())
 }
 
 fn find_remote_reference<'repo>(

--- a/crates/but/src/branch/mod.rs
+++ b/crates/but/src/branch/mod.rs
@@ -141,9 +141,6 @@ pub enum Subcommands {
         /// Fetch and display review information
         #[clap(short, long)]
         review: bool,
-        /// Disable pager output
-        #[clap(long)]
-        no_pager: bool,
         /// Show files modified in each commit with line counts
         #[clap(short, long)]
         files: bool,
@@ -173,7 +170,6 @@ pub async fn handle(
     cmd: Option<Subcommands>,
     ctx: &but_ctx::Context,
     out: &mut OutputChannel,
-    json: bool,
 ) -> anyhow::Result<serde_json::Value> {
     let legacy_project = &ctx.legacy_project;
     match cmd {
@@ -192,7 +188,7 @@ pub async fn handle(
                 ahead,
                 review,
                 None,
-                json,
+                out,
                 check,
             )
             .await?;
@@ -217,7 +213,7 @@ pub async fn handle(
                 ahead,
                 review,
                 filter,
-                json,
+                out,
                 check,
             )
             .await?;
@@ -226,22 +222,11 @@ pub async fn handle(
         Some(Subcommands::Show {
             branch_id,
             review,
-            no_pager,
             files,
             ai,
             check,
         }) => {
-            show::show(
-                legacy_project,
-                &branch_id,
-                json,
-                review,
-                !no_pager,
-                files,
-                ai,
-                check,
-            )
-            .await?;
+            show::show(legacy_project, &branch_id, out, review, files, ai, check).await?;
             Ok(we_need_proper_json_output_here())
         }
         Some(Subcommands::New {

--- a/crates/but/src/forge/review.rs
+++ b/crates/but/src/forge/review.rs
@@ -1,5 +1,11 @@
 use std::collections::BTreeMap;
 
+use crate::{
+    editor::get_text_from_editor_no_comments,
+    id::CliId,
+    ui::{SimpleBranch, SimpleStack},
+    utils::OutputChannel,
+};
 use anyhow::Context;
 use bstr::ByteSlice;
 use but_api::legacy::forge::ListReviewsParams;
@@ -12,13 +18,7 @@ use colored::{ColoredString, Colorize};
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::{Project, ProjectId};
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    editor::get_text_from_editor_no_comments,
-    id::CliId,
-    ui::{SimpleBranch, SimpleStack},
-    utils::OutputChannel,
-};
+use tracing::instrument;
 
 #[derive(Debug, clap::Parser)]
 pub struct Platform {
@@ -606,6 +606,7 @@ fn extract_commit_title(commit: Option<&Commit>) -> Option<&str> {
 }
 
 /// Get a mapping from branch names to their associated reviews.
+#[instrument(skip(project))]
 pub async fn get_review_map(
     project: &Project,
 ) -> anyhow::Result<std::collections::HashMap<String, Vec<but_forge::ForgeReview>>> {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -253,7 +253,6 @@ async fn match_subcommand(
             let ctx = get_or_init_context_with_legacy_support(&args)?;
             branch::handle(cmd, &ctx, out)
                 .await
-                .output_json(args.json)
                 .emit_metrics(metrics_ctx)
         }
         Subcommands::Worktree(worktree::Platform { cmd }) => {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -251,7 +251,7 @@ async fn match_subcommand(
         }
         Subcommands::Branch(branch::Platform { cmd }) => {
             let ctx = get_or_init_context_with_legacy_support(&args)?;
-            branch::handle(cmd, &ctx, out, args.json)
+            branch::handle(cmd, &ctx, out)
                 .await
                 .output_json(args.json)
                 .emit_metrics(metrics_ctx)

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -191,18 +191,6 @@ where
     }
 }
 
-/// A placeholder, which should be substituted for the actual return value.
-pub fn we_need_proper_json_output_here() -> serde_json::Value {
-    serde_json::Value::Null
-}
-
-/// Convert anything into a json value, **or panic**.
-/// I think this should never fail at runtime, but I am not sure.
-pub fn into_json_value(value: impl serde::Serialize) -> serde_json::Value {
-    serde_json::to_value(&value)
-        .expect("BUG: Failed to serialize JSON value, we should know that at compile time")
-}
-
 pub fn print_grouped_help(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     use std::collections::HashSet;
 

--- a/crates/but/src/utils/table.rs
+++ b/crates/but/src/utils/table.rs
@@ -1,5 +1,4 @@
 use crate::utils::table::types::Table;
-use std::io::Write;
 use terminal_size::Width;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -57,7 +56,7 @@ impl Table {
         self.rows.push(row);
     }
 
-    pub fn render<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    pub fn render<W: std::fmt::Write + ?Sized>(&self, out: &mut W) -> std::fmt::Result {
         if self.headers.is_empty() {
             return Ok(());
         }
@@ -71,27 +70,27 @@ impl Table {
 
         // Render rows
         for row in &self.rows {
-            self.render_row(writer, row, &column_widths)?;
-            writeln!(writer)?;
+            self.render_row(out, row, &column_widths)?;
+            writeln!(out)?;
         }
 
         Ok(())
     }
 
-    fn render_row<W: Write>(
+    fn render_row<W: std::fmt::Write + ?Sized>(
         &self,
-        writer: &mut W,
+        out: &mut W,
         cells: &[Cell],
         column_widths: &[usize],
-    ) -> std::io::Result<()> {
+    ) -> std::fmt::Result {
         for (i, cell) in cells.iter().enumerate() {
             if i > 0 {
-                write!(writer, " ")?;
+                write!(out, " ")?;
             }
 
             let width = column_widths.get(i).copied().unwrap_or(0);
             let formatted = format_cell(&cell.content, width, cell.align);
-            write!(writer, "{}", formatted)?;
+            write!(out, "{}", formatted)?;
         }
         Ok(())
     }


### PR DESCRIPTION
That way, the `but-api` stays a normal library crate without needs regarding JSON serialisation, and each function is then transformed to what it needs to be for the respective consumers.

### Tasks

* [x] fixup `but branch list|show`
* [ ] leave `json::Error` handling for the macro.
* [ ] make `Schemars` work for `gix::ObjectId` - maybe use `HexHash`?

Related to #11236
Follow-up of #11260


