### PR TITLE
intermezzo: use latest version of proc-macro everywhere 

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -114,13 +114,13 @@ jobs:
       - run: cargo check --workspace --all-targets
       - run: |
           # should work without the "legacy" feature
-          cargo check -p but-ctx
-          cargo check -p but-serde
-          cargo check -p but-meta
-          cargo check -p but-graph
-          cargo check -p but-workspace
-          cargo check -p but-github
-          cargo check -p but-api
+          cargo check -p but-ctx --all-targets
+          cargo check -p but-serde --all-targets
+          cargo check -p but-meta --all-targets
+          cargo check -p but-graph --all-targets
+          cargo check -p but-workspace --all-targets
+          cargo check -p but-github --all-targets
+          cargo check -p but-api --all-targets
         name: Special `cargo check` runs
         env:
           RUSTFLAGS: '--deny warnings'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "axum",
  "but-api",
  "but-broadcaster",
+ "but-claude",
  "but-db",
  "but-feedback",
  "but-path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "but-core",
+ "but-graph",
  "but-meta",
  "but-serde",
  "but-testsupport",

--- a/crates/but-api/src/legacy/zip.rs
+++ b/crates/but-api/src/legacy/zip.rs
@@ -1,62 +1,24 @@
 use std::path::PathBuf;
 
-use anyhow::Context;
-use but_error::Code;
-use serde::Deserialize;
-
-use crate::{App, json::Error};
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetProjectArchivePathParams {
-    pub project_id: String,
-}
+use crate::json::Error;
+use gitbutler_project::ProjectId;
 
 pub fn get_project_archive_path(
-    app: &App,
-    params: GetProjectArchivePathParams,
+    archival: &but_feedback::Archival,
+    project_id: ProjectId,
 ) -> Result<PathBuf, Error> {
-    let project_id = params
-        .project_id
-        .parse()
-        .context(but_error::Context::new_static(
-            Code::Validation,
-            "Malformed project id",
-        ))?;
-    app.archival
+    archival
         .zip_entire_repository(project_id)
         .map_err(Into::into)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetAnonymousGraphPathParams {
-    pub project_id: String,
-}
-
 pub fn get_anonymous_graph_path(
-    app: &App,
-    params: GetAnonymousGraphPathParams,
+    archival: &but_feedback::Archival,
+    project_id: ProjectId,
 ) -> Result<PathBuf, Error> {
-    let project_id = params
-        .project_id
-        .parse()
-        .context(but_error::Context::new_static(
-            Code::Validation,
-            "Malformed project id",
-        ))?;
-    app.archival
-        .zip_anonymous_graph(project_id)
-        .map_err(Into::into)
+    archival.zip_anonymous_graph(project_id).map_err(Into::into)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetLogsArchivePathParams {}
-
-pub fn get_logs_archive_path(
-    app: &App,
-    _params: GetLogsArchivePathParams,
-) -> Result<PathBuf, Error> {
-    app.archival.zip_logs().map_err(Into::into)
+pub fn get_logs_archive_path(archival: &but_feedback::Archival) -> Result<PathBuf, Error> {
+    archival.zip_logs().map_err(Into::into)
 }

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -7,23 +7,10 @@
 //! Lower-level crates like `but-workspace` won't use filesystem-based locking beyond what Git offers natively.
 #![forbid(unsafe_code)]
 
-use std::sync::Arc;
-
-use but_broadcaster::Broadcaster;
-use but_claude::bridge::Claudes;
-use tokio::sync::Mutex;
-
 #[cfg(feature = "legacy")]
 pub mod legacy;
 
 pub mod github;
-
-#[derive(Clone)]
-pub struct App {
-    pub broadcaster: Arc<Mutex<Broadcaster>>,
-    pub archival: Arc<but_feedback::Archival>,
-    pub claudes: Arc<Claudes>,
-}
 
 /// Types meant to be serialised to JSON, without degenerating information despite the need to be UTF-8 encodable.
 /// EXPERIMENTAL

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -28,7 +28,16 @@ pub mod permissions;
 pub mod prompt_templates;
 mod rules;
 
+use crate::bridge::Claudes;
 pub use permissions::Permission;
+
+/// Various in-memory state that is required for calling most claude functions.
+// TODO: There are UI concepts like broadcasting tied into this type.
+#[derive(Clone)]
+pub struct Claude {
+    pub broadcaster: Arc<Mutex<Broadcaster>>,
+    pub instance_by_stack: Arc<Claudes>,
+}
 
 /// Represents a Claude Code session that GitButler is tracking.
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 doctest = false
 
 [dependencies]
-but-graph = { workspace = true, features = ["legacy"] }
+but-graph.workspace = true
 but-settings.workspace = true
 
 gitbutler-command-context.workspace = true

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -42,22 +42,18 @@ impl Archival {
         let guard = project.shared_worktree_access();
         let repo = ctx.gix_repo()?;
         let meta = ctx.meta(guard.read_permission())?;
-        let mut graph = but_graph::Graph::from_head(
-            &repo,
-            &*meta,
-            but_graph::init::Options::from_legacy_meta(&meta),
-        )
-        .or_else(|_| {
-            but_graph::Graph::from_head(
-                &repo,
-                &*meta,
-                but_graph::init::Options {
-                    // Assume it fails because of post-processing, try again without.
-                    dangerously_skip_postprocessing_for_debugging: true,
-                    ..but_graph::init::Options::from_legacy_meta(&meta)
-                },
-            )
-        })?;
+        let mut graph = but_graph::Graph::from_head(&repo, &*meta, meta.to_graph_options())
+            .or_else(|_| {
+                but_graph::Graph::from_head(
+                    &repo,
+                    &*meta,
+                    but_graph::init::Options {
+                        // Assume it fails because of post-processing, try again without.
+                        dangerously_skip_postprocessing_for_debugging: true,
+                        ..meta.to_graph_options()
+                    },
+                )
+            })?;
         let dot_file_contents = graph.anonymize(&repo.remote_names())?.dot_graph();
         let output_file = self.cache_dir.join(format!(
             "commit-graph-anon-{date}.zip",

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-but-meta.workspace = true
+but-meta = { workspace = true, features = ["legacy"]}
 but-testsupport.workspace = true
 
 gitbutler-reference.workspace = true

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -11,12 +11,8 @@ rust-version = "1.89"
 doctest = false
 test = false
 
-[features]
-legacy = ["dep:but-meta"]
-
 [dependencies]
 but-core.workspace = true
-but-meta = { workspace = true, optional = true, features = ["legacy"] }
 
 gix = { workspace = true, features = ["revision"] }
 bstr.workspace = true

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -99,16 +99,6 @@ impl Options {
             ..Default::default()
         }
     }
-
-    /// Return default options that limit single-branch commits to a sane amount (instead of traversing the whole graph),
-    /// and configure other values that require our meta-data to guide the traversal.
-    #[cfg(feature = "legacy")]
-    pub fn from_legacy_meta(meta: &but_meta::VirtualBranchesTomlMetadata) -> Self {
-        Options {
-            extra_target_commit_id: meta.data().default_target.as_ref().map(|t| t.sha),
-            ..Self::limited()
-        }
-    }
 }
 
 /// Builder

--- a/crates/but-meta/Cargo.toml
+++ b/crates/but-meta/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 [features]
 legacy = [
     "dep:but-serde",
+    "dep:but-graph",
     "dep:gitbutler-reference",
     "dep:tracing",
     "dep:itertools",
@@ -26,11 +27,12 @@ legacy = [
 
 [dependencies]
 but-core.workspace = true
+but-serde = { workspace = true, optional = true }
+but-graph = { workspace = true, optional = true }
 
 bstr.workspace = true
 anyhow.workspace = true
 
-but-serde = { workspace = true, optional = true }
 gitbutler-reference = {workspace = true, optional = true}
 gix = { workspace = true, features = ["revision"], optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -124,6 +124,7 @@ pub struct VirtualBranchesTomlMetadata {
     snapshot: Snapshot,
 }
 
+/// Lifecycle
 impl VirtualBranchesTomlMetadata {
     /// Initialize a store backed by a file on disk.
     ///
@@ -160,6 +161,19 @@ impl VirtualBranchesTomlMetadata {
     /// Return a snapshot of the underlying data. Useful for working around (intended) limitations of the RefMetadata trait.
     pub fn data(&self) -> &VirtualBranches {
         &self.snapshot.content
+    }
+}
+
+/// Utilities
+impl VirtualBranchesTomlMetadata {
+    /// Return default options that limit single-branch commits to a sane amount (instead of traversing the whole graph),
+    /// and configure other values that require our meta-data to guide the traversal.
+    #[cfg(feature = "legacy")]
+    pub fn to_graph_options(&self) -> but_graph::init::Options {
+        but_graph::init::Options {
+            extra_target_commit_id: self.data().default_target.as_ref().map(|t| t.sha),
+            ..but_graph::init::Options::limited()
+        }
     }
 }
 

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 but-db.workspace = true
 but-core.workspace = true
 but-hunk-assignment.workspace = true
-but-graph = { workspace = true, features = ["legacy"] }
+but-graph.workspace = true
 but-meta = { workspace = true, features = ["legacy"] }
 but-workspace = { workspace = true, features = ["legacy"] }
 but-hunk-dependency.workspace = true

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -90,7 +90,7 @@ fn handle_amend(
     )?;
     let ref_info_options = but_workspace::ref_info::Options {
         expensive_commit_info: true,
-        traversal: but_graph::init::Options::from_legacy_meta(&meta),
+        traversal: meta.to_graph_options(),
     };
     let info = but_workspace::head_info(&repo, &meta, ref_info_options)?;
     let mut commit_id: Option<gix::ObjectId> = None;

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 
 [dependencies]
 but-api = { workspace = true, features = ["path-bytes", "legacy"] }
+but-claude.workspace = true
 but-broadcaster.workspace = true
 but-db.workspace = true
 but-path.workspace = true

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
+use crate::Extra;
 use anyhow::{Context as _, Result};
-use but_api::{App, json::ToError};
+use but_api::json::ToError;
 use but_broadcaster::FrontendEvent;
+use but_claude::Claude;
 use but_db::poll::DBWatcherHandle;
 use but_settings::AppSettingsWithDiskSync;
 use gitbutler_command_context::CommandContext;
@@ -10,8 +12,6 @@ use gitbutler_project::{Project, ProjectId};
 use gitbutler_watcher::{Change, WatcherHandle};
 use serde::Deserialize;
 use serde_json::json;
-
-use crate::Extra;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -40,7 +40,7 @@ impl ActiveProjects {
     pub fn set_active(
         &mut self,
         project: &Project,
-        ctx: &App,
+        ctx: &Claude,
         app_settings_sync: AppSettingsWithDiskSync,
     ) -> Result<()> {
         if self.projects.contains_key(&project.id) {
@@ -139,7 +139,7 @@ pub async fn list_projects(extra: &Extra) -> Result<serde_json::Value, but_api::
 }
 
 pub async fn set_project_active(
-    ctx: &App,
+    ctx: &Claude,
     extra: &Extra,
     app_settings_sync: AppSettingsWithDiskSync,
     params: serde_json::Value,

--- a/crates/but-testing/Cargo.toml
+++ b/crates/but-testing/Cargo.toml
@@ -20,7 +20,7 @@ but-settings.workspace = true
 but-core.workspace = true
 but-db.workspace = true
 but-workspace = {workspace = true, features = ["legacy"]}
-but-graph = {workspace = true, features = ["legacy"]}
+but-graph.workspace = true
 but-hunk-dependency.workspace = true
 but-hunk-assignment.workspace = true
 but-meta = { workspace = true, features = ["legacy"] }

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -86,11 +86,7 @@ pub fn repo_and_maybe_project_and_graph(
 )> {
     let (repo, project) = repo_and_maybe_project(args, mode)?;
     let meta = meta_from_maybe_project(project.as_ref())?;
-    let graph = but_graph::Graph::from_head(
-        &repo,
-        &*meta,
-        but_graph::init::Options::from_legacy_meta(&meta),
-    )?;
+    let graph = but_graph::Graph::from_head(&repo, &*meta, meta.to_graph_options())?;
     Ok((repo, project, graph, meta))
 }
 

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -18,7 +18,6 @@ legacy = [
     "dep:gitbutler-project",
     "dep:gitbutler-commit",
     "dep:gitbutler-repo",
-    "but-graph/legacy"
 ]
 
 [dependencies]

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -225,7 +225,7 @@ pub fn stacks_v3(
 
     let options = ref_info::Options {
         expensive_commit_info: false,
-        traversal: but_graph::init::Options::from_legacy_meta(meta),
+        traversal: meta.to_graph_options(),
     };
     let info = match ref_name_override {
         None => head_info(repo, meta, options),
@@ -461,7 +461,7 @@ pub fn stack_details_v3(
     let mut ref_info_options = ref_info::Options {
         // TODO(perf): make this so it can be enabled for a specific stack-id.
         expensive_commit_info: true,
-        traversal: but_graph::init::Options::from_legacy_meta(meta),
+        traversal: meta.to_graph_options(),
     };
     let mut stack = match stack_id {
         None => {

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1488,11 +1488,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
         * 3d57fc1 1
         ");
 
-    let graph = but_graph::Graph::from_head(
-        &repo,
-        &meta,
-        but_graph::init::Options::from_legacy_meta(&meta),
-    )?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -1671,12 +1667,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         ");
 
     let id = id_by_rev(&repo, "@~1");
-    let graph = but_graph::Graph::from_commit_traversal(
-        id,
-        None,
-        &meta,
-        but_graph::init::Options::from_legacy_meta(&meta),
-    )?;
+    let graph = but_graph::Graph::from_commit_traversal(id, None, &meta, meta.to_graph_options())?;
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -1778,7 +1769,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         &meta,
         Options {
             extra_target_commit_id: Some(first_id.detach()),
-            ..but_graph::init::Options::from_legacy_meta(&meta)
+            ..meta.to_graph_options()
         },
     )?;
     let ws = graph.to_workspace()?;

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -18,7 +18,7 @@ but-gerrit.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-rebase.workspace = true
 but-core.workspace = true
-but-graph = { workspace = true, features = ["legacy"] }
+but-graph.workspace = true
 but-oxidize.workspace = true
 but-forge.workspace = true
 

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -190,7 +190,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
             &*meta,
             Options {
                 expensive_commit_info: true,
-                traversal: but_graph::init::Options::from_legacy_meta(&meta),
+                traversal: meta.to_graph_options(),
             },
         )?;
 

--- a/crates/gitbutler-command-context/Cargo.toml
+++ b/crates/gitbutler-command-context/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 but-db.workspace = true
 but-settings.workspace = true
 but-meta.workspace = true
-but-graph = { workspace = true, features = ["legacy"] }
+but-graph.workspace = true
 
 gitbutler-project.workspace = true
 

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -124,11 +124,7 @@ impl CommandContext {
         but_graph::Graph,
     )> {
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(
-            &repo,
-            &meta,
-            but_graph::init::Options::from_legacy_meta(&meta),
-        )?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
         Ok((repo, VirtualBranchesTomlMetadata(meta), graph))
     }
 
@@ -157,11 +153,7 @@ impl CommandContext {
     )> {
         let repo = self.gix_repo()?;
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(
-            &repo,
-            &meta,
-            but_graph::init::Options::from_legacy_meta(&meta),
-        )?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
         Ok((repo, VirtualBranchesTomlMetadataMut(meta), graph))
     }
 
@@ -189,7 +181,7 @@ impl CommandContext {
             commit_id,
             reference.name().to_owned(),
             &meta,
-            but_graph::init::Options::from_legacy_meta(&meta),
+            meta.to_graph_options(),
         )?;
         Ok((repo, VirtualBranchesTomlMetadataMut(meta), graph))
     }

--- a/crates/gitbutler-tauri/src/claude.rs
+++ b/crates/gitbutler-tauri/src/claude.rs
@@ -1,5 +1,4 @@
 use but_api::{
-    App,
     json::Error,
     legacy::claude::{
         self, CancelSessionParams, CompactHistoryParams, GetMessagesParams, IsStackActiveParams,
@@ -7,7 +6,8 @@ use but_api::{
     },
 };
 use but_claude::{
-    ClaudeMessage, ClaudeUserParams, ModelType, PermissionMode, PromptAttachment, ThinkingLevel,
+    Claude, ClaudeMessage, ClaudeUserParams, ModelType, PermissionMode, PromptAttachment,
+    ThinkingLevel,
 };
 use but_core::ref_metadata::StackId;
 use gitbutler_project::ProjectId;
@@ -16,9 +16,9 @@ use tracing::instrument;
 
 #[allow(clippy::too_many_arguments)]
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(claude), err(Debug))]
 pub async fn claude_send_message(
-    app: State<'_, App>,
+    claude: State<'_, Claude>,
     project_id: ProjectId,
     stack_id: StackId,
     message: String,
@@ -30,7 +30,7 @@ pub async fn claude_send_message(
     attachments: Option<Vec<PromptAttachment>>,
 ) -> Result<(), Error> {
     claude::claude_send_message(
-        &app,
+        &claude,
         SendMessageParams {
             project_id,
             stack_id,
@@ -49,14 +49,14 @@ pub async fn claude_send_message(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(claude), err(Debug))]
 pub fn claude_get_messages(
-    app: State<'_, App>,
+    claude: State<'_, Claude>,
     project_id: ProjectId,
     stack_id: StackId,
 ) -> Result<Vec<ClaudeMessage>, Error> {
     claude::claude_get_messages(
-        &app,
+        &claude,
         GetMessagesParams {
             project_id,
             stack_id,
@@ -65,14 +65,14 @@ pub fn claude_get_messages(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(claude), err(Debug))]
 pub async fn claude_cancel_session(
-    app: State<'_, App>,
+    claude: State<'_, Claude>,
     project_id: ProjectId,
     stack_id: StackId,
 ) -> Result<bool, Error> {
     claude::claude_cancel_session(
-        &app,
+        &claude,
         CancelSessionParams {
             project_id,
             stack_id,
@@ -82,14 +82,14 @@ pub async fn claude_cancel_session(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(claude), err(Debug))]
 pub async fn claude_is_stack_active(
-    app: State<'_, App>,
+    claude: State<'_, Claude>,
     project_id: ProjectId,
     stack_id: StackId,
 ) -> Result<bool, Error> {
     claude::claude_is_stack_active(
-        &app,
+        &claude,
         IsStackActiveParams {
             project_id,
             stack_id,
@@ -99,14 +99,14 @@ pub async fn claude_is_stack_active(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(claude), err(Debug))]
 pub async fn claude_compact_history(
-    app: State<'_, App>,
+    claude: State<'_, Claude>,
     project_id: ProjectId,
     stack_id: StackId,
 ) -> Result<(), Error> {
     claude::claude_compact_history(
-        &app,
+        &claude,
         CompactHistoryParams {
             project_id,
             stack_id,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,8 +14,9 @@
 use std::sync::Arc;
 
 use anyhow::bail;
-use but_api::{App, github, legacy};
+use but_api::{github, legacy};
 use but_broadcaster::Broadcaster;
+use but_claude::Claude;
 use but_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::{
     WindowState, action, askpass, bot, claude, csp::csp_with_extras, env, logs, menu, projects,
@@ -166,18 +167,17 @@ fn main() -> anyhow::Result<()> {
                     }
                 });
 
+                let claude = Claude {
+                    broadcaster: broadcaster.clone(),
+                    instance_by_stack: Default::default(),
+                };
                 let archival = Arc::new(but_feedback::Archival {
                     cache_dir: app_cache_dir.clone(),
                     logs_dir: app_log_dir.clone(),
                 });
-                let app = App {
-                    broadcaster: broadcaster.clone(),
-                    archival: archival.clone(),
-                    claudes: Default::default(),
-                };
-
+                app_handle.manage(archival);
                 app_handle.manage(app_settings);
-                app_handle.manage(app);
+                app_handle.manage(claude);
 
                 tauri_app.on_menu_event(move |handle, event| {
                     menu::handle_event(handle, &window.clone(), &event)

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -1,45 +1,33 @@
 #![allow(clippy::used_underscore_binding)]
 use std::path::PathBuf;
 
-use but_api::{
-    json::Error,
-    legacy::zip::{
-        self, GetAnonymousGraphPathParams, GetLogsArchivePathParams, GetProjectArchivePathParams,
-    },
-};
+use but_api::{json::Error, legacy::zip};
+use gitbutler_project::ProjectId;
 use tauri::State;
 use tracing::instrument;
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(archival), err(Debug))]
 pub fn get_project_archive_path(
-    app: State<'_, but_api::App>,
-    project_id: &str,
+    archival: State<'_, but_feedback::Archival>,
+    project_id: ProjectId,
 ) -> Result<PathBuf, Error> {
-    zip::get_project_archive_path(
-        &app,
-        GetProjectArchivePathParams {
-            project_id: project_id.to_string(),
-        },
-    )
+    zip::get_project_archive_path(&archival, project_id)
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
+#[instrument(skip(archival), err(Debug))]
 pub fn get_anonymous_graph_path(
-    app: State<'_, but_api::App>,
-    project_id: &str,
+    archival: State<'_, but_feedback::Archival>,
+    project_id: ProjectId,
 ) -> Result<PathBuf, Error> {
-    zip::get_anonymous_graph_path(
-        &app,
-        GetAnonymousGraphPathParams {
-            project_id: project_id.to_string(),
-        },
-    )
+    zip::get_anonymous_graph_path(&archival, project_id)
 }
 
 #[tauri::command(async)]
-#[instrument(skip(app), err(Debug))]
-pub fn get_logs_archive_path(app: State<'_, but_api::App>) -> Result<PathBuf, Error> {
-    zip::get_logs_archive_path(&app, GetLogsArchivePathParams {})
+#[instrument(skip(archival), err(Debug))]
+pub fn get_logs_archive_path(
+    archival: State<'_, but_feedback::Archival>,
+) -> Result<PathBuf, Error> {
+    zip::get_logs_archive_path(&archival)
 }


### PR DESCRIPTION
That way, the `but-api` stays a normal library crate without needs regarding JSON serialisation, and each function is then transformed to what it needs to be for the respective consumers.

### Tasks

* [x] make `Schemars` work for `gix::ObjectId` - maybe use `HexHash`?
* [x] cleanup claude part 1
* [ ] fold `but-broadcaster`
* [ ] leave `json::Error` handling for the macro.

Related to #11236
Follow-up of #11275


