### PR TITLE
Auto-focus codegen input

### DIFF
--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -340,6 +340,7 @@
 					monospaceFont={$userSettings.diffFont}
 					tabSize={$userSettings.tabSize}
 					enableLigatures={$userSettings.diffLigatures}
+					autoFocus={false}
 				>
 					{#snippet plugins()}
 						<Formatter bind:this={formatter} />

--- a/packages/ui/src/lib/richText/RichTextEditor.svelte
+++ b/packages/ui/src/lib/richText/RichTextEditor.svelte
@@ -64,6 +64,7 @@
 		monospaceFont?: string;
 		tabSize?: number;
 		enableLigatures?: boolean;
+		autoFocus?: boolean;
 	}
 
 	let {
@@ -87,7 +88,8 @@
 		useMonospaceFont,
 		monospaceFont,
 		tabSize,
-		enableLigatures
+		enableLigatures,
+		autoFocus = true
 	}: Props = $props();
 
 	/** Standard configuration for our commit message editor. */
@@ -321,7 +323,6 @@
 			<CodeBlockTypeAhead />
 			<MarkdownShortcutPlugin transformers={[INLINE_CODE_TRANSFORMER, PARAGRAPH_TRANSFORMER]} />
 		{:else}
-			<AutoFocusPlugin />
 			<AutoLinkPlugin />
 			<CheckListPlugin />
 			<CodeActionMenuPlugin anchorElem={editorDiv} />
@@ -332,6 +333,9 @@
 			<LinkPlugin />
 			<MarkdownShortcutPlugin transformers={ALL_TRANSFORMERS} />
 			<RichTextPlugin />
+		{/if}
+		{#if autoFocus}
+			<AutoFocusPlugin />
 		{/if}
 		<HistoryPlugin />
 


### PR DESCRIPTION
This adds a new optional “autofocus” paramater which is enabled by 
default.
Previously, the AutoFocus plugin was tied to whether it was rich or not 
which doesn’t really make sense