### PR TITLE
Fix paragraph transformer regex to prevent accidental matches

### DIFF
--- a/packages/ui/src/lib/richText/customTransforers.ts
+++ b/packages/ui/src/lib/richText/customTransforers.ts
@@ -23,7 +23,7 @@ export const PARAGRAPH_TRANSFORMER: ElementTransformer = {
 		}
 		return null;
 	},
-	regExp: /(?:)/,
+	regExp: /$.^/,
 	replace: () => false,
 	type: 'element'
 };


### PR DESCRIPTION
The paragraph transformer for the rich text editor used a non-capturing 
empty-group regex (/(?:)/) which effectively matched everywhere and 
could cause the transformer to run unexpectedly. Replace it with a 
never-matching regex (/$.^/) so the transformer will not match by 
default and won't capture or process unintended text.