### PR TITLE
id: canonical IDs for most branch names

### DIFF
--- a/crates/but/src/absorb.rs
+++ b/crates/but/src/absorb.rs
@@ -53,7 +53,7 @@ pub(crate) fn handle(
                 // Absorb this particular file
                 absorb_file(project, &path, assignment, &assignments, &dependencies, out)?;
             }
-            CliId::Branch { name } => {
+            CliId::Branch { name, .. } => {
                 // Absorb everything that is assigned to this lane
                 absorb_branch(project, &name, &assignments, &dependencies, out)?;
             }

--- a/crates/but/src/branch/mod.rs
+++ b/crates/but/src/branch/mod.rs
@@ -189,7 +189,7 @@ pub async fn handle(
                             position: but_workspace::branch::create_reference::Position::Above,
                         })
                     }
-                    crate::id::CliId::Branch { name } => Some(
+                    crate::id::CliId::Branch { name, .. } => Some(
                         but_api::legacy::stack::create_reference::Anchor::AtReference {
                             short_name: name.clone(),
                             position: but_workspace::branch::create_reference::Position::Above,

--- a/crates/but/src/commit.rs
+++ b/crates/but/src/commit.rs
@@ -54,7 +54,7 @@ pub(crate) fn insert_blank_commit(
                 ),
             )
         }
-        CliId::Branch { name } => {
+        CliId::Branch { name, .. } => {
             // For branches, we need to find the branch and get its head commit
             let head_commit_id = find_branch_head_commit(project.id, name)?;
             (
@@ -238,7 +238,7 @@ pub(crate) fn commit(
                 // If no exact match, try to parse as CLI ID and match
                 if let Ok(cli_ids) = crate::id::CliId::from_str(&mut ctx, hint) {
                     for cli_id in cli_ids {
-                        if let crate::id::CliId::Branch { name } = cli_id
+                        if let crate::id::CliId::Branch { name, .. } = cli_id
                             && let Some(branch) =
                                 target_stack.branch_details.iter().find(|b| b.name == name)
                         {
@@ -416,7 +416,7 @@ fn find_stack_by_hint(
     // Try CLI ID parsing
     let cli_ids = CliId::from_str(ctx, hint).ok()?;
     for cli_id in cli_ids {
-        if let CliId::Branch { name } = cli_id {
+        if let CliId::Branch { name, .. } = cli_id {
             for (stack_id, stack_details) in stacks {
                 if stack_details.branch_details.iter().any(|b| b.name == name) {
                     return Some((*stack_id, stack_details.clone()));

--- a/crates/but/src/describe.rs
+++ b/crates/but/src/describe.rs
@@ -31,7 +31,7 @@ pub(crate) fn describe_target(
     let cli_id = &cli_ids[0];
 
     match cli_id {
-        CliId::Branch { name } => {
+        CliId::Branch { name, .. } => {
             edit_branch_name(&ctx, project, name, out)?;
         }
         CliId::Commit { oid } => {

--- a/crates/but/src/forge/review.rs
+++ b/crates/but/src/forge/review.rs
@@ -137,7 +137,7 @@ fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<St
     let branch_ids = CliId::from_str(&mut ctx, branch_id)?
         .iter()
         .filter_map(|clid| match clid {
-            CliId::Branch { name } => Some(name.clone()),
+            CliId::Branch { name, .. } => Some(name.clone()),
             _ => None,
         })
         .collect::<Vec<_>>();

--- a/crates/but/src/id.rs
+++ b/crates/but/src/id.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 use bstr::ByteSlice;
 use but_core::ref_metadata::StackId;
@@ -6,6 +6,7 @@ use but_hunk_assignment::HunkAssignment;
 use gitbutler_command_context::CommandContext;
 
 pub struct IdDb {
+    branch_name_to_cli_id: HashMap<String, CliId>,
     unassigned: CliId,
 }
 
@@ -13,18 +14,82 @@ impl IdDb {
     pub fn new(ctx: &CommandContext) -> anyhow::Result<Self> {
         let mut max_zero_count = 1; // Ensure at least two "0" in ID.
         let stacks = crate::utils::commits::stacks(ctx)?;
-        for stack in stacks {
+        let mut pairs_to_count: HashMap<u16, u8> = HashMap::new();
+        for stack in &stacks {
             for head in &stack.heads {
+                for pair in head.name.windows(2) {
+                    if !pair[0].is_ascii_alphanumeric() || !pair[1].is_ascii_alphanumeric() {
+                        continue;
+                    }
+                    if pair[0].is_ascii_hexdigit() && pair[1].is_ascii_hexdigit() {
+                        // Avoid confusion with commits
+                        continue;
+                    }
+                    let u16pair = pair[0] as u16 * 256 + pair[1] as u16;
+                    pairs_to_count
+                        .entry(u16pair)
+                        .and_modify(|count| *count = count.saturating_add(1))
+                        .or_insert(1);
+                }
                 for field in head.name.fields_with(|c| c != '0') {
                     max_zero_count = std::cmp::max(field.len(), max_zero_count);
                 }
             }
         }
+
+        let mut branch_name_to_cli_id: HashMap<String, CliId> = HashMap::new();
+        for stack in stacks {
+            'head: for head in &stack.heads {
+                // Find first non-conflicting pair and use it as CliId.
+                for pair in head.name.windows(2) {
+                    let u16pair = pair[0] as u16 * 256 + pair[1] as u16;
+                    if let Some(1) = pairs_to_count.get(&u16pair) {
+                        let name = head.name.to_string();
+                        let id = str::from_utf8(pair).unwrap().to_owned();
+                        branch_name_to_cli_id.insert(name.clone(), CliId::Branch { name, id });
+                        continue 'head;
+                    }
+                }
+            }
+        }
         Ok(Self {
+            branch_name_to_cli_id,
             unassigned: CliId::Unassigned {
                 id: str::repeat("0", max_zero_count + 1),
             },
         })
+    }
+
+    fn find_branches_by_name(
+        &mut self,
+        ctx: &CommandContext,
+        name: &str,
+    ) -> anyhow::Result<Vec<CliId>> {
+        let stacks = crate::utils::commits::stacks(ctx)?;
+        let mut matches = Vec::new();
+
+        for stack in stacks {
+            for head in &stack.heads {
+                let branch_name = head.name.to_string();
+                // Exact match or partial match
+                if branch_name == name || branch_name.contains(name) {
+                    matches.push(self.branch(&branch_name).clone())
+                }
+            }
+        }
+
+        Ok(matches)
+    }
+
+    /// Returns the ID for a branch of the given name. If no such ID exists,
+    /// generate one.
+    pub fn branch(&mut self, name: &str) -> &CliId {
+        self.branch_name_to_cli_id
+            .entry(name.to_owned())
+            .or_insert_with(|| CliId::Branch {
+                name: name.to_owned(),
+                id: hash(name),
+            })
     }
 
     /// Represents the unassigned area. Its ID is a repeated string of '0', long
@@ -46,6 +111,7 @@ pub enum CliId {
     },
     Branch {
         name: String,
+        id: String,
     },
     Commit {
         oid: gix::ObjectId,
@@ -69,12 +135,6 @@ impl CliId {
         CliId::Commit { oid }
     }
 
-    pub fn branch(name: &str) -> Self {
-        CliId::Branch {
-            name: name.to_owned(),
-        }
-    }
-
     pub fn file_from_assignment(assignment: &HunkAssignment) -> Self {
         CliId::UncommittedFile {
             path: assignment.path.clone(),
@@ -87,23 +147,6 @@ impl CliId {
             path: path.to_string(),
             commit_oid,
         }
-    }
-
-    fn find_branches_by_name(ctx: &CommandContext, name: &str) -> anyhow::Result<Vec<Self>> {
-        let stacks = crate::utils::commits::stacks(ctx)?;
-        let mut matches = Vec::new();
-
-        for stack in stacks {
-            for head in &stack.heads {
-                let branch_name = head.name.to_string();
-                // Exact match or partial match
-                if branch_name == name || branch_name.contains(name) {
-                    matches.push(CliId::branch(&branch_name));
-                }
-            }
-        }
-
-        Ok(matches)
     }
 
     fn find_commits_by_sha(ctx: &CommandContext, sha_prefix: &str) -> anyhow::Result<Vec<Self>> {
@@ -152,12 +195,12 @@ impl CliId {
         }
 
         // TODO: make callers of this function pass IdDb instead
-        let id_db = IdDb::new(ctx)?;
+        let mut id_db = IdDb::new(ctx)?;
 
         let mut matches = Vec::new();
 
         // First, try exact branch name match
-        if let Ok(branch_matches) = Self::find_branches_by_name(ctx, s) {
+        if let Ok(branch_matches) = id_db.find_branches_by_name(ctx, s) {
             matches.extend(branch_matches);
         }
 
@@ -242,8 +285,8 @@ impl Display for CliId {
                 let value = hash(&format!("{commit_oid}{path}"));
                 write!(f, "{value}")
             }
-            CliId::Branch { name } => {
-                write!(f, "{}", hash(name))
+            CliId::Branch { id, .. } => {
+                write!(f, "{}", id)
             }
             CliId::Unassigned { id } => {
                 write!(f, "{}", id)
@@ -263,7 +306,6 @@ pub(crate) fn hash(input: &str) -> String {
     for byte in input.bytes() {
         hash = hash.wrapping_mul(31).wrapping_add(byte as u64);
     }
-
     // First character: g-z (20 options)
     let first_chars = "ghijklmnopqrstuvwxyz";
     let first_char = first_chars.chars().nth((hash % 20) as usize).unwrap();

--- a/crates/but/src/mark.rs
+++ b/crates/but/src/mark.rs
@@ -30,7 +30,7 @@ pub(crate) fn handle(
         but_rules::delete_rule(ctx, &rule.id())?;
     }
     match target_result[0].clone() {
-        crate::id::CliId::Branch { name } => mark_branch(ctx, name, delete, out),
+        crate::id::CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out),
         crate::id::CliId::Commit { oid } => mark_commit(ctx, oid, delete, out),
         _ => bail!("Nope"),
     }

--- a/crates/but/src/push/mod.rs
+++ b/crates/but/src/push/mod.rs
@@ -270,7 +270,7 @@ fn resolve_branch_name(ctx: &mut CommandContext, branch_id: &str) -> anyhow::Res
         let branch_names: Vec<String> = cli_ids
             .iter()
             .filter_map(|id| match id {
-                crate::id::CliId::Branch { name } => Some(name.clone()),
+                crate::id::CliId::Branch { name, .. } => Some(name.clone()),
                 _ => None,
             })
             .collect();
@@ -290,7 +290,7 @@ fn resolve_branch_name(ctx: &mut CommandContext, branch_id: &str) -> anyhow::Res
     }
 
     match &cli_ids[0] {
-        crate::id::CliId::Branch { name } => Ok(name.clone()),
+        crate::id::CliId::Branch { name, .. } => Ok(name.clone()),
         _ => Err(anyhow::anyhow!(
             "Expected branch identifier, got {}. Please use a branch name or branch CLI ID.",
             cli_ids[0].kind()

--- a/crates/but/src/rub/mod.rs
+++ b/crates/but/src/rub/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn handle(
                 create_snapshot(ctx, project, OperationKind::AmendCommit);
                 amend::file_to_commit(ctx, path, *assignment, oid, out)?;
             }
-            (CliId::UncommittedFile { path, .. }, CliId::Branch { name }) => {
+            (CliId::UncommittedFile { path, .. }, CliId::Branch { name, .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_file_to_branch(ctx, path, name, out)?;
             }
@@ -53,7 +53,7 @@ pub(crate) fn handle(
                 create_snapshot(ctx, project, OperationKind::AmendCommit);
                 amend::assignments_to_commit(ctx, None, oid, out)?;
             }
-            (CliId::Unassigned { .. }, CliId::Branch { name: to }) => {
+            (CliId::Unassigned { .. }, CliId::Branch { name: to, .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_all(ctx, None, Some(to), out)?;
             }
@@ -68,22 +68,22 @@ pub(crate) fn handle(
                 create_snapshot(ctx, project, OperationKind::SquashCommit);
                 squash::commits(ctx, source, destination, out)?;
             }
-            (CliId::Commit { oid }, CliId::Branch { name }) => {
+            (CliId::Commit { oid }, CliId::Branch { name, .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveCommit);
                 move_commit::to_branch(ctx, oid, name, out)?;
             }
             (CliId::Branch { .. }, CliId::UncommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::Branch { name: from }, CliId::Unassigned { .. }) => {
+            (CliId::Branch { name: from, .. }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_all(ctx, Some(from), None, out)?;
             }
-            (CliId::Branch { name }, CliId::Commit { oid }) => {
+            (CliId::Branch { name, .. }, CliId::Commit { oid }) => {
                 create_snapshot(ctx, project, OperationKind::AmendCommit);
                 amend::assignments_to_commit(ctx, Some(name), oid, out)?;
             }
-            (CliId::Branch { name: from }, CliId::Branch { name: to }) => {
+            (CliId::Branch { name: from, .. }, CliId::Branch { name: to, .. }) => {
                 create_snapshot(ctx, project, OperationKind::MoveHunk);
                 assign::assign_all(ctx, Some(from), Some(to), out)?;
             }
@@ -96,7 +96,7 @@ pub(crate) fn handle(
             (CliId::CommittedFile { .. }, CliId::CommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::CommittedFile { path, commit_oid }, CliId::Branch { name }) => {
+            (CliId::CommittedFile { path, commit_oid }, CliId::Branch { name, .. }) => {
                 create_snapshot(ctx, project, OperationKind::FileChanges);
                 commits::uncommit_file(ctx, path, *commit_oid, Some(name), out)?;
             }
@@ -152,7 +152,7 @@ fn ids(
                     CliId::Commit { oid } => {
                         format!("{} (commit {})", id, &oid.to_string()[..7])
                     }
-                    CliId::Branch { name } => format!("{id} (branch '{name}')"),
+                    CliId::Branch { name, .. } => format!("{id} (branch '{name}')"),
                     _ => format!("{} ({})", id, id.kind()),
                 })
                 .collect();
@@ -191,7 +191,7 @@ pub(crate) fn parse_sources(ctx: &mut CommandContext, source: &str) -> anyhow::R
                         CliId::Commit { oid } => {
                             format!("{} (commit {})", id, &oid.to_string()[..7])
                         }
-                        CliId::Branch { name } => format!("{id} (branch '{name}')"),
+                        CliId::Branch { name, .. } => format!("{id} (branch '{name}')"),
                         _ => format!("{} ({})", id, id.kind()),
                     })
                     .collect();

--- a/crates/but/tests/but/id.rs
+++ b/crates/but/tests/but/id.rs
@@ -36,3 +36,75 @@ fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn branch_avoid_nonalphanumeric() -> anyhow::Result<()> {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    setup_metadata(&env, &["A", "B"])?;
+
+    env.but("branch new x-yz").assert().success();
+
+    env.but("status")
+        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![
+            "...
+[..]yz[..]x-yz[..]
+..."
+        ]);
+
+    Ok(())
+}
+
+#[test]
+fn branch_avoid_hexdigit() -> anyhow::Result<()> {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    setup_metadata(&env, &["A", "B"])?;
+
+    env.but("branch new 0ax").assert().success();
+
+    env.but("status")
+        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![
+            "...
+[..]ax[..]0ax[..]
+..."
+        ]);
+
+    Ok(())
+}
+
+#[test]
+fn branch_cannot_generate_id() -> anyhow::Result<()> {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    setup_metadata(&env, &["A", "B"])?;
+
+    // Exercise the case where we cannot generate an ID for a branch (any ID we
+    // generate would also match supersubstring).
+    env.but("branch new substring").assert().success();
+    env.but("branch new supersubstring").assert().success();
+
+    // The ID of the substring is a hash and cannot be asserted, so only
+    // assert the supersubstring. It is "up" because "su" would conflict with
+    // "substring".
+    env.but("status")
+        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![
+            "...
+[..]up[..]supersubstring[..]
+..."
+        ]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/id.rs
+++ b/crates/but/tests/but/id.rs
@@ -68,6 +68,7 @@ fn branch_avoid_hexdigit() -> anyhow::Result<()> {
 
     env.but("branch new 0ax").assert().success();
 
+    // TODO: put special handling of branch CliId naming rules into more unit-level tests of `IdDb` directly.
     env.but("status")
         .with_assert(env.assert_with_uuid_and_timestamp_redactions())
         .assert()
@@ -102,6 +103,8 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
         .success()
         .stdout_eq(snapbox::str![
             "...
+[..]tp[..]substring[..]
+...
 [..]up[..]supersubstring[..]
 ..."
         ]);


### PR DESCRIPTION
## 🧢 Changes

(copied from commit message)

Currently, all CLI IDs of branches are hashes (deterministically pseudorandom). Generating them based on the branch names would result in a more comfortable user experience, but this was not possible without the risk of collisions, since each branch ID was computed independently of every other branch (e.g. taking the first 2 characters as ID would cause "aaa" and "aab" to collide). However, an ID database was introduced recently, which makes it possible to compute branch IDs in view of all branch names.

Therefore, teach it to supply branch names.

The ID of each branch is the first pair of characters in the branch name that are alphanumeric and cannot be confused with another branch name or an OID. If no such ID is possible, fall back to the existing way of computing the ID (i.e. hashing). Ideally, we would check this ID for collisions against all other IDs and alter it slightly if there is a collision, but this cannot be done until we ensure that all CLI commands interpret and/or generate IDs in exactly one place, and does not add/rename/remove any branches within that place. This is left for future work.

(end copy)

Related to #11263

From a code health perspective, this also enables future changes (e.g. when generating file `CliId`s, we can ensure that those don't conflict with any branch `CliId`s).