### PR TITLE
`gitbutler-command-ctx` to `but-ctx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,11 +1026,9 @@ name = "but-feedback"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-ctx",
  "but-graph",
- "but-settings",
  "chrono",
- "gitbutler-command-context",
- "gitbutler-project",
  "tempfile",
  "walkdir",
  "zip",

--- a/crates/but-ctx/src/legacy/mod.rs
+++ b/crates/but-ctx/src/legacy/mod.rs
@@ -1,0 +1,52 @@
+use crate::{Context, LegacyProjectId};
+use but_settings::AppSettings;
+use gitbutler_command_context::CommandContext;
+
+pub(crate) mod types {
+    /// A UUID based project ID which is associated with metadata via `<app-dir>/projects.json`
+    ///
+    /// The goal is to bring this metadata into `<project-data-dir>/`, and use `ProjectHandle` in future
+    /// which is self-describing and able to point to a path on disk while being URL safe.
+    pub type LegacyProjectId = gitbutler_project::ProjectId;
+
+    /// Project metadata and utilities to access it. Superseded by [`Context`].
+    pub type LegacyProject = gitbutler_project::Project;
+}
+
+/// Legacy Lifecycle
+impl Context {
+    /// Create a context from a legacy `project_id`,
+    /// which requires reading `projects.json` to map it to metadata.
+    pub fn new_from_legacy_project_id(project_id: LegacyProjectId) -> anyhow::Result<Self> {
+        let legacy_project = gitbutler_project::get(project_id)?;
+        let repo = gix::open(legacy_project.git_dir())?;
+        Ok(Context {
+            settings: AppSettings::load_from_default_path_creating()?,
+            legacy_project,
+            repo,
+        })
+    }
+}
+
+/// Legacy - none of this should be kept.
+impl Context {
+    /// Return a context for calling into `gitbutler-` functions.
+    pub fn legacy_ctx(&self) -> anyhow::Result<CommandContext> {
+        CommandContext::open(&self.legacy_project, self.settings.clone())
+    }
+
+    /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
+    /// to read data.
+    /// This is helping to prevent races with mutable instances.
+    // TODO: remove _read_only as we don't need it anymore with a DB based implementation as long as the instances
+    //       starts a transaction to isolate reads.
+    //       For a correct implementation, this would also have to hold on to `_read_only`.
+    pub fn legacy_meta(
+        &self,
+        _read_only: &but_core::sync::WorktreeReadPermission,
+    ) -> anyhow::Result<but_meta::VirtualBranchesTomlMetadata> {
+        but_meta::VirtualBranchesTomlMetadata::from_path(
+            self.project_data_dir().join("virtual_branches.toml"),
+        )
+    }
+}

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -1,11 +1,28 @@
 //! A crate to host a `Context` type, suitable to provide the context *applications* need to operate on a Git repository.
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
-use std::path::{Path, PathBuf};
 
 use but_settings::AppSettings;
 #[cfg(feature = "legacy")]
 use gitbutler_command_context::CommandContext;
+use std::path::{Path, PathBuf};
+
+/// A UUID based project ID which is associated with metadata via `<app-dir>/projects.json`
+///
+/// The goal is to bring this metadata into `<project-data-dir>/`, and use `ProjectHandle` in future
+/// which is self-describing and able to point to a path on disk while being URL safe.
+#[cfg(feature = "legacy")]
+pub type LegacyProjectId = gitbutler_project::ProjectId;
+
+/// Project metadata and utilities to access it. Superseded by [`Context`].
+#[cfg(feature = "legacy")]
+pub type LegacyProject = gitbutler_project::Project;
+
+/// A self-describing handle to the path of the project on disk, typically the `.git` directory of a Git repository.
+///
+/// With it, all project data and metadata can be accessed.
+/// Further, this ID is URL-safe, but it is *not* for human consumption.
+pub type ProjectHandle = String;
 
 /// A context specific to a repository, along with commonly used information to make higher-level functions
 /// more convenient to implement.
@@ -17,9 +34,52 @@ pub struct Context {
     pub settings: AppSettings,
     /// The legacy implementation, for all the old code.
     #[cfg(feature = "legacy")]
-    pub legacy_project: gitbutler_project::Project,
+    pub legacy_project: LegacyProject,
     /// The repository of the project, which also provides access to the `git_dir`.
     pub repo: gix::Repository,
+}
+
+/// Legacy Lifecycle
+#[cfg(feature = "legacy")]
+impl Context {
+    /// Create a context from a legacy `project_id`,
+    /// which requires reading `projects.json` to map it to metadata.
+    pub fn new_from_legacy_project_id(project_id: LegacyProjectId) -> anyhow::Result<Self> {
+        let legacy_project = gitbutler_project::get(project_id)?;
+        let repo = gix::open(legacy_project.git_dir())?;
+        Ok(Context {
+            settings: AppSettings::load_from_default_path_creating()?,
+            legacy_project,
+            repo,
+        })
+    }
+
+    /// Discover the Git repository in `directory` and return it as context.
+    pub fn discover(directory: impl AsRef<Path>) -> anyhow::Result<Context> {
+        let directory = directory.as_ref();
+        let repo = gix::discover(directory)?;
+        #[cfg(feature = "legacy")]
+        {
+            use anyhow::Context;
+            let worktree_dir = repo
+                .workdir()
+                .context("Bare repositories aren't yet supported.")?;
+            let project = LegacyProject::find_by_worktree_dir(worktree_dir)?;
+            Ok(crate::Context {
+                settings: AppSettings::load_from_default_path_creating()?,
+                legacy_project: project,
+                repo,
+            })
+        }
+
+        #[cfg(not(feature = "legacy"))]
+        {
+            Ok(crate::Context {
+                settings: AppSettings::load_from_default_path_creating()?,
+                repo,
+            })
+        }
+    }
 }
 
 /// Legacy - none of this should be kept.
@@ -41,7 +101,7 @@ impl Context {
         _read_only: &but_core::sync::WorktreeReadPermission,
     ) -> anyhow::Result<but_meta::VirtualBranchesTomlMetadata> {
         but_meta::VirtualBranchesTomlMetadata::from_path(
-            self.legacy_project.gb_dir().join("virtual_branches.toml"),
+            self.project_data_dir().join("virtual_branches.toml"),
         )
     }
 }
@@ -55,14 +115,14 @@ impl Context {
     /// Note that this in-process locking works only under the assumption that no two instances of
     /// GitButler are able to read or write the same repository.
     pub fn exclusive_worktree_access(&self) -> but_core::sync::WorkspaceWriteGuard {
-        but_core::sync::exclusive_worktree_access(self.git_dir())
+        but_core::sync::exclusive_worktree_access(self.gitdir())
     }
 
     /// Return a guard for shared (read) worktree access, and block while waiting for writers to disappear.
     /// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
     /// thus block readers to prevent writer starvation.
     pub fn shared_worktree_access(&self) -> but_core::sync::WorkspaceReadGuard {
-        but_core::sync::shared_worktree_access(self.git_dir())
+        but_core::sync::shared_worktree_access(self.gitdir())
     }
 }
 
@@ -79,12 +139,25 @@ impl Context {
         _read_only: &but_core::sync::WorktreeReadPermission,
     ) -> anyhow::Result<impl but_core::RefMetadata> {
         but_meta::VirtualBranchesTomlMetadata::from_path(
-            self.data_dir().join("virtual_branches.toml"),
+            self.project_data_dir().join("virtual_branches.toml"),
         )
     }
 }
 
-/// Repository helpers.
+/// Paths and locations.
+impl Context {
+    /// The location where project-specific data can be stored that is owned by the application.
+    pub fn project_data_dir(&self) -> PathBuf {
+        self.gitdir().join("gitbutler")
+    }
+
+    /// The path to the worktree directory or the `.git` directory if there is no worktree directory.
+    pub fn workdir_or_gitdir(&self) -> &Path {
+        self.repo.workdir().unwrap_or(self.repo.git_dir())
+    }
+}
+
+/// Repository helpers, for when you need something more specific than [Self::repo].
 impl Context {
     /// Open an isolated repository, one that didn't read options beyond `.git/config` and
     /// knows no environment variables.
@@ -92,7 +165,7 @@ impl Context {
     /// Use it for fastest-possible access, when incomplete configuration is acceptable.
     pub fn open_isolated_repo(&self) -> anyhow::Result<gix::Repository> {
         Ok(gix::open_opts(
-            self.git_dir(),
+            self.gitdir(),
             gix::open::Options::isolated(),
         )?)
     }
@@ -104,19 +177,17 @@ impl Context {
     ///
     /// Diffing and merging is better done with [`Self::open_repo_for_merging()`].
     pub fn open_repo(&self) -> anyhow::Result<gix::Repository> {
-        Ok(gix::open(self.git_dir())?)
+        Ok(gix::open(self.gitdir())?)
     }
 
     /// Calls [`but_core::open_repo_for_merging()`]
     pub fn open_repo_for_merging(&self) -> anyhow::Result<gix::Repository> {
-        but_core::open_repo_for_merging(self.git_dir())
+        but_core::open_repo_for_merging(self.gitdir())
     }
 
-    fn git_dir(&self) -> &Path {
+    /// The repository `.git` directory, and always the best paths to identify an actual repository
+    /// (or repository associated with a submodule or worktree).
+    fn gitdir(&self) -> &Path {
         self.repo.git_dir()
-    }
-
-    fn data_dir(&self) -> PathBuf {
-        self.git_dir().join("gitbutler")
     }
 }

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -3,20 +3,12 @@
 #![forbid(unsafe_code)]
 
 use but_settings::AppSettings;
-#[cfg(feature = "legacy")]
-use gitbutler_command_context::CommandContext;
 use std::path::{Path, PathBuf};
 
-/// A UUID based project ID which is associated with metadata via `<app-dir>/projects.json`
-///
-/// The goal is to bring this metadata into `<project-data-dir>/`, and use `ProjectHandle` in future
-/// which is self-describing and able to point to a path on disk while being URL safe.
 #[cfg(feature = "legacy")]
-pub type LegacyProjectId = gitbutler_project::ProjectId;
-
-/// Project metadata and utilities to access it. Superseded by [`Context`].
+mod legacy;
 #[cfg(feature = "legacy")]
-pub type LegacyProject = gitbutler_project::Project;
+pub use legacy::types::{LegacyProject, LegacyProjectId};
 
 /// A self-describing handle to the path of the project on disk, typically the `.git` directory of a Git repository.
 ///
@@ -39,21 +31,8 @@ pub struct Context {
     pub repo: gix::Repository,
 }
 
-/// Legacy Lifecycle
-#[cfg(feature = "legacy")]
+/// Lifecycle
 impl Context {
-    /// Create a context from a legacy `project_id`,
-    /// which requires reading `projects.json` to map it to metadata.
-    pub fn new_from_legacy_project_id(project_id: LegacyProjectId) -> anyhow::Result<Self> {
-        let legacy_project = gitbutler_project::get(project_id)?;
-        let repo = gix::open(legacy_project.git_dir())?;
-        Ok(Context {
-            settings: AppSettings::load_from_default_path_creating()?,
-            legacy_project,
-            repo,
-        })
-    }
-
     /// Discover the Git repository in `directory` and return it as context.
     pub fn discover(directory: impl AsRef<Path>) -> anyhow::Result<Context> {
         let directory = directory.as_ref();
@@ -79,30 +58,6 @@ impl Context {
                 repo,
             })
         }
-    }
-}
-
-/// Legacy - none of this should be kept.
-#[cfg(feature = "legacy")]
-impl Context {
-    /// Return a context for calling into `gitbutler-` functions.
-    pub fn legacy_ctx(&self) -> anyhow::Result<CommandContext> {
-        CommandContext::open(&self.legacy_project, self.settings.clone())
-    }
-
-    /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
-    /// to read data.
-    /// This is helping to prevent races with mutable instances.
-    // TODO: remove _read_only as we don't need it anymore with a DB based implementation as long as the instances
-    //       starts a transaction to isolate reads.
-    //       For a correct implementation, this would also have to hold on to `_read_only`.
-    pub fn legacy_meta(
-        &self,
-        _read_only: &but_core::sync::WorktreeReadPermission,
-    ) -> anyhow::Result<but_meta::VirtualBranchesTomlMetadata> {
-        but_meta::VirtualBranchesTomlMetadata::from_path(
-            self.project_data_dir().join("virtual_branches.toml"),
-        )
     }
 }
 

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -12,10 +12,7 @@ doctest = false
 
 [dependencies]
 but-graph.workspace = true
-but-settings.workspace = true
-
-gitbutler-command-context.workspace = true
-gitbutler-project.workspace = true
+but-ctx = { workspace = true, features = ["legacy"] }
 
 anyhow.workspace = true
 # Version must match the one in `tauri plugin updater` to avoid duplication.

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -3,8 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use but_settings::AppSettings;
-use gitbutler_project::ProjectId;
+use but_ctx::LegacyProjectId;
 
 /// A utility to keep important paths to make archival/zip-file creation easier later.
 pub struct Archival {
@@ -21,32 +20,25 @@ fn filesafe_date_time() -> String {
 
 impl Archival {
     /// Create an archive of the entire repository behind `project_id`.
-    pub fn zip_entire_repository(&self, project_id: ProjectId) -> Result<PathBuf> {
-        let project = gitbutler_project::get(project_id)?;
+    pub fn zip_entire_repository(&self, project_id: LegacyProjectId) -> Result<PathBuf> {
+        let ctx = but_ctx::Context::new_from_legacy_project_id(project_id)?;
         let output_file = self
             .cache_dir
             .join(format!("project-{date}.zip", date = filesafe_date_time()));
-        create_zip_file_from_dir(
-            project.worktree_dir().unwrap_or(project.git_dir()),
-            output_file,
-        )
+        create_zip_file_from_dir(ctx.workdir_or_gitdir(), output_file)
     }
 
     /// Create an archive commit graph behind `project_id` such that it doesn't reveal PII.
-    pub fn zip_anonymous_graph(&self, project_id: ProjectId) -> Result<PathBuf> {
-        let project = gitbutler_project::get(project_id)?;
-        let ctx = gitbutler_command_context::CommandContext::open(
-            &project,
-            AppSettings::load_from_default_path_creating()?,
-        )?;
-        let guard = project.shared_worktree_access();
-        let repo = ctx.gix_repo()?;
-        let meta = ctx.meta(guard.read_permission())?;
-        let mut graph = but_graph::Graph::from_head(&repo, &*meta, meta.to_graph_options())
-            .or_else(|_| {
+    pub fn zip_anonymous_graph(&self, project_id: LegacyProjectId) -> Result<PathBuf> {
+        let ctx = but_ctx::Context::new_from_legacy_project_id(project_id)?;
+        let guard = ctx.shared_worktree_access();
+        let repo = &ctx.repo;
+        let meta = ctx.legacy_meta(guard.read_permission())?;
+        let mut graph =
+            but_graph::Graph::from_head(repo, &meta, meta.to_graph_options()).or_else(|_| {
                 but_graph::Graph::from_head(
-                    &repo,
-                    &*meta,
+                    repo,
+                    &meta,
                     but_graph::init::Options {
                         // Assume it fails because of post-processing, try again without.
                         dangerously_skip_postprocessing_for_debugging: true,

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -35,14 +35,14 @@ impl Archival {
         let repo = &ctx.repo;
         let meta = ctx.legacy_meta(guard.read_permission())?;
         let mut graph =
-            but_graph::Graph::from_head(repo, &meta, meta.to_graph_options()).or_else(|_| {
+            but_graph::Graph::from_head(repo, &meta, Default::default()).or_else(|_| {
                 but_graph::Graph::from_head(
                     repo,
                     &meta,
                     but_graph::init::Options {
                         // Assume it fails because of post-processing, try again without.
                         dangerously_skip_postprocessing_for_debugging: true,
-                        ..meta.to_graph_options()
+                        ..Default::default()
                     },
                 )
             })?;

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -15,10 +15,12 @@ function setup_remote_tracking() {
   local mode=${3:-"cp"}
   mkdir -p .git/refs/remotes/origin
 
+  local dst=".git/refs/remotes/origin/$remote_branch_name";
+  mkdir -p "${dst%/*}"
   if [[ "$mode" == "cp" ]]; then
-    cp ".git/refs/heads/$branch_name" ".git/refs/remotes/origin/$remote_branch_name"
+    cp ".git/refs/heads/$branch_name" $dst
   else
-    mv ".git/refs/heads/$branch_name" ".git/refs/remotes/origin/$remote_branch_name"
+    mv ".git/refs/heads/$branch_name" $dst
   fi
 }
 
@@ -1019,6 +1021,7 @@ EOF
     commit init
     commit M1
     git branch gitbutler/target
+    setup_remote_tracking "gitbutler/target"
     commit M2
     setup_target_to_match_main
     git checkout -b A

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -4369,44 +4369,51 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
     * c59457b (A) top
     * e146f13 (gitbutler/edit) middle
     * 971953d (origin/main, main) M2
-    * ce09734 (gitbutler/target) M1
+    * ce09734 (origin/gitbutler/target, gitbutler/target) M1
     * fafd9d0 init
     ");
 
     add_workspace(&mut meta);
+    let mut md = meta.workspace("refs/heads/gitbutler/workspace".try_into()?)?;
+    md.target_ref = Some("refs/remotes/origin/gitbutler/target".try_into()?);
+    meta.set_workspace(&md)?;
+
     let graph = Graph::from_head(
         &repo,
         &*meta,
-        standard_options_with_extra_target(&repo, "gitbutler/target"),
+        // standard_options_with_extra_target(&repo, "gitbutler/target"),
+        standard_options(),
     )?
     .validated()?;
     // Standard handling after traversal and post-processing.
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·270738b (⌂|🏘|1)
-    │       └── ►:4[1]:A
+    │       └── ►:3[1]:A
     │           └── ·c59457b (⌂|🏘|1)
-    │               └── ►:5[2]:gitbutler/edit
+    │               └── ►:4[2]:gitbutler/edit
     │                   └── ·e146f13 (⌂|🏘|1)
-    │                       └── ►:2[3]:main <> origin/main →:1:
-    │                           └── ·971953d (⌂|🏘|✓|11)
-    │                               └── ►:3[4]:gitbutler/target
-    │                                   ├── ·ce09734 (⌂|🏘|✓|11)
-    │                                   └── ·fafd9d0 (⌂|🏘|✓|11)
-    └── ►:1[0]:origin/main →:2:
-        └── →:2: (main →:1:)
+    │                       └── ►:5[3]:main <> origin/main →:6:
+    │                           └── ·971953d (⌂|🏘|101)
+    │                               └── ►:2[4]:gitbutler/target <> origin/gitbutler/target →:1:
+    │                                   ├── ·ce09734 (⌂|🏘|✓|111)
+    │                                   └── ·fafd9d0 (⌂|🏘|✓|111)
+    ├── ►:1[0]:origin/gitbutler/target →:2:
+    │   └── →:2: (gitbutler/target →:1:)
+    └── ►:6[0]:origin/main →:5:
+        └── →:5: (main →:6:)
     ");
 
     // But special handling for workspace views. Note how we don't overshoot
     // and stop exactly where we have to, magically even.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
-    └── ≡:4:A on ce09734
-        ├── :4:A
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/gitbutler/target on ce09734
+    └── ≡:3:A on ce09734
+        ├── :3:A
         │   ├── ·c59457b (🏘️)
         │   └── ·e146f13 (🏘️)
-        └── :2:main <> origin/main →:1:
-            └── ❄️971953d (🏘️|✓)
+        └── :5:main <> origin/main →:6:
+            └── ❄️971953d (🏘️)
     ");
     Ok(())
 }

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -164,19 +164,6 @@ impl VirtualBranchesTomlMetadata {
     }
 }
 
-/// Utilities
-impl VirtualBranchesTomlMetadata {
-    /// Return default options that limit single-branch commits to a sane amount (instead of traversing the whole graph),
-    /// and configure other values that require our meta-data to guide the traversal.
-    #[cfg(feature = "legacy")]
-    pub fn to_graph_options(&self) -> but_graph::init::Options {
-        but_graph::init::Options {
-            extra_target_commit_id: self.data().default_target.as_ref().map(|t| t.sha),
-            ..but_graph::init::Options::limited()
-        }
-    }
-}
-
 // Emergency-behaviour in case the application winds down, we don't want data-loss (at least a chance).
 impl Drop for VirtualBranchesTomlMetadata {
     fn drop(&mut self) {
@@ -551,7 +538,7 @@ fn branch_from_ref_name(ref_name: &FullNameRef) -> anyhow::Result<RemoteRefname>
     }
 
     // TODO: remove this as we don't handle symbolic names with slashes correctly.
-    // At least try to not always set this value, but this test is also ambiguous.
+    //       At least try to not always set this value, but this test is also ambiguous.
     let slash_pos = short_name
         .find_byte(b'/')
         .context("remote branch didn't have '/' in the name, but should be 'origin/foo'")?;

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -90,7 +90,7 @@ fn handle_amend(
     )?;
     let ref_info_options = but_workspace::ref_info::Options {
         expensive_commit_info: true,
-        traversal: meta.to_graph_options(),
+        traversal: but_graph::init::Options::limited(),
     };
     let info = but_workspace::head_info(&repo, &meta, ref_info_options)?;
     let mut commit_id: Option<gix::ObjectId> = None;

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -86,7 +86,7 @@ pub fn repo_and_maybe_project_and_graph(
 )> {
     let (repo, project) = repo_and_maybe_project(args, mode)?;
     let meta = meta_from_maybe_project(project.as_ref())?;
-    let graph = but_graph::Graph::from_head(&repo, &*meta, meta.to_graph_options())?;
+    let graph = but_graph::Graph::from_head(&repo, &*meta, Default::default())?;
     Ok((repo, project, graph, meta))
 }
 

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -225,7 +225,7 @@ pub fn stacks_v3(
 
     let options = ref_info::Options {
         expensive_commit_info: false,
-        traversal: meta.to_graph_options(),
+        traversal: but_graph::init::Options::limited(),
     };
     let info = match ref_name_override {
         None => head_info(repo, meta, options),
@@ -461,7 +461,7 @@ pub fn stack_details_v3(
     let mut ref_info_options = ref_info::Options {
         // TODO(perf): make this so it can be enabled for a specific stack-id.
         expensive_commit_info: true,
-        traversal: meta.to_graph_options(),
+        traversal: but_graph::init::Options::limited(),
     };
     let mut stack = match stack_id {
         None => {

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1488,7 +1488,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
         * 3d57fc1 1
         ");
 
-    let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -1667,16 +1667,16 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         ");
 
     let id = id_by_rev(&repo, "@~1");
-    let graph = but_graph::Graph::from_commit_traversal(id, None, &meta, meta.to_graph_options())?;
+    let graph = but_graph::Graph::from_commit_traversal(id, None, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:DETACHED <> ✓!
-        └── ≡:0:anon:
-            └── :0:anon:
-                ├── ·12995d7 (✓)
-                └── ·3d57fc1 (✓)
-        ");
+    ⌂:0:DETACHED <> ✓!
+    └── ≡:0:anon:
+        └── :0:anon:
+            ├── ·12995d7
+            └── ·3d57fc1
+    ");
 
     let first_ref = rc("refs/heads/first");
     let first_id = id_by_rev(&repo, "@~2");
@@ -1694,13 +1694,13 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:DETACHED <> ✓!
-        └── ≡:0:anon:
-            ├── :0:anon:
-            │   └── ·12995d7 (✓)
-            └── 📙:2:first
-                └── ·3d57fc1 (✓)
-        ");
+    ⌂:0:DETACHED <> ✓!
+    └── ≡:0:anon:
+        ├── :0:anon:
+        │   └── ·12995d7
+        └── 📙:1:first
+            └── ·3d57fc1
+    ");
 
     let new = r("refs/heads/new-independent");
     let err = but_workspace::branch::create_reference(
@@ -1736,13 +1736,13 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-        ⌂:0:second <> ✓!
-        └── ≡📙:0:second
-            ├── 📙:0:second
-            │   └── ·12995d7 (✓)
-            └── 📙:2:first
-                └── ·3d57fc1 (✓)
-        ");
+    ⌂:0:second <> ✓!
+    └── ≡📙:0:second
+        ├── 📙:0:second
+        │   └── ·12995d7
+        └── 📙:1:first
+            └── ·3d57fc1
+    ");
 
     let err = but_workspace::branch::create_reference(
         new,
@@ -1769,7 +1769,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         &meta,
         Options {
             extra_target_commit_id: Some(first_id.detach()),
-            ..meta.to_graph_options()
+            ..Default::default()
         },
     )?;
     let ws = graph.to_workspace()?;

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -190,7 +190,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
             &*meta,
             Options {
                 expensive_commit_info: true,
-                traversal: meta.to_graph_options(),
+                traversal: but_graph::init::Options::limited(),
             },
         )?;
 

--- a/crates/gitbutler-command-context/Cargo.toml
+++ b/crates/gitbutler-command-context/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 but-db.workspace = true
 but-settings.workspace = true
-but-meta.workspace = true
+but-meta = { workspace = true, features = ["legacy"] }
 but-graph.workspace = true
 
 gitbutler-project.workspace = true

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -124,7 +124,7 @@ impl CommandContext {
         but_graph::Graph,
     )> {
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
         Ok((repo, VirtualBranchesTomlMetadata(meta), graph))
     }
 
@@ -153,7 +153,7 @@ impl CommandContext {
     )> {
         let repo = self.gix_repo()?;
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
         Ok((repo, VirtualBranchesTomlMetadataMut(meta), graph))
     }
 
@@ -181,7 +181,7 @@ impl CommandContext {
             commit_id,
             reference.name().to_owned(),
             &meta,
-            meta.to_graph_options(),
+            but_graph::init::Options::limited(),
         )?;
         Ok((repo, VirtualBranchesTomlMetadataMut(meta), graph))
     }


### PR DESCRIPTION
These two structures are basically the same, and porting the legacy one to `but-*` with feature-toggled legacy portions will allow all old code to use the new thing,
probably without any adjustments initially.

### Tasks

* [x] lay out path for `ProjectId`
    - [x] how to get a graph from just metadata without legacy support?
* [ ] fold `gitbutler-command-context`

Related to #11236
