### PR TITLE
ui-branch-creation

### DIFF
--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -133,6 +133,7 @@
 	autocorrect="off"
 	spellcheck="false"
 	data-remove-from-panning
+	data-no-drag
 	use:clickOutside={{
 		handler: () => inputEl?.blur()
 	}}

--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -133,7 +133,6 @@
 	autocorrect="off"
 	spellcheck="false"
 	data-remove-from-panning
-	data-no-drag
 	use:clickOutside={{
 		handler: () => inputEl?.blur()
 	}}

--- a/apps/desktop/src/components/MainViewport.svelte
+++ b/apps/desktop/src/components/MainViewport.svelte
@@ -188,7 +188,7 @@ the window, then enlarge it and retain the original widths of the layout.
 	{/if}
 
 	<div
-		class="main-section view-wrapper dotted-pattern"
+		class="main-section"
 		style:min-width={middleMinWidth + 'rem'}
 		style:margin-right={right ? '0' : ''}
 	>
@@ -292,10 +292,10 @@ the window, then enlarge it and retain the original widths of the layout.
 	}
 
 	.main-section {
+		display: flex;
 		position: relative;
 		flex-grow: 1;
 		flex-shrink: 1;
-		flex-direction: column;
 		height: 100%;
 		margin-left: 8px;
 		overflow-x: hidden;

--- a/apps/desktop/src/components/MultiStackOfflaneDropzone.svelte
+++ b/apps/desktop/src/components/MultiStackOfflaneDropzone.svelte
@@ -46,7 +46,7 @@
 </script>
 
 <div
-	class="hidden-dropzone"
+	class="hidden-dropzone dotted-pattern"
 	data-testid={TestId.StackOfflaneDropzone}
 	use:focusable
 	use:intersectionObserver={{
@@ -144,12 +144,17 @@
 <style lang="postcss">
 	.hidden-dropzone {
 		display: flex;
+		z-index: var(--z-ground);
 		position: relative;
+		width: 100%;
 		min-width: 400px;
 		max-width: 400px;
 		height: 100%;
+		margin-left: -1px;
 		overflow: hidden;
 		border-right: 1px solid var(--clr-border-2);
+		border-left: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-2);
 	}
 
 	.hidden-dropzone__lane {

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -190,7 +190,7 @@
 		{#each mutableStacks as stack, i (stack.id)}
 			<div
 				bind:this={stackElements[stack.id || 'branchless']}
-				class="reorderable-stack"
+				class="reorderable-stack dotted-pattern"
 				role="presentation"
 				animate:flip={{ duration: 150 }}
 				onmousedown={onReorderMouseDown}
@@ -270,6 +270,8 @@
 				{/if}
 			{/snippet}
 		</MultiStackOfflaneDropzone>
+
+		<div class="dotted-pattern"></div>
 	</div>
 
 	{#if lanesScrollableEl}
@@ -282,7 +284,7 @@
 		display: flex;
 		flex: 1;
 		height: 100%;
-		margin: 0 -1px;
+		margin-right: -1px; /* to hide vertical lane border gap */
 		overflow-x: auto;
 		overflow-y: hidden;
 	}
@@ -290,6 +292,12 @@
 	.lanes-scrollable {
 		display: flex;
 		position: relative;
+		min-width: fill-available;
+		height: 100%;
+	}
+
+	.dotted-pattern {
+		width: fill-available;
 		height: 100%;
 	}
 
@@ -303,13 +311,13 @@
 
 	.reorderable-stack {
 		display: flex;
+		z-index: var(--z-ground);
 		flex-shrink: 0;
 		flex-direction: column;
 		width: fit-content;
 		height: 100%;
-
-		&:first-child {
-			border-left: 1px solid var(--clr-border-2);
-		}
+		margin-left: -1px;
+		border-left: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-2);
 	}
 </style>

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -192,7 +192,7 @@
 				bind:this={stackElements[stack.id || 'branchless']}
 				class="reorderable-stack dotted-pattern"
 				role="presentation"
-				animate:flip={{ duration: 150 }}
+				animate:flip={{ duration: draggingStack ? 200 : 0 }}
 				onmousedown={onReorderMouseDown}
 				ondragstart={(e) => {
 					if (!stack.id) return;

--- a/apps/desktop/src/components/StackDragHandle.svelte
+++ b/apps/desktop/src/components/StackDragHandle.svelte
@@ -145,8 +145,8 @@
 		justify-content: center;
 		width: 18px;
 		height: 10px;
-		padding: 2px;
-		border-radius: 3px;
+		padding: 3px;
+		border-radius: var(--radius-s);
 		background-color: var(--clr-bg-2);
 		color: var(--clr-text-3);
 		pointer-events: none;

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -537,7 +537,7 @@
 		>
 			<ReduxResult projectId={stableProjectId} result={branchesQuery.result}>
 				{#snippet children(branches)}
-					<div class="stack-v">
+					<div class="stack-v" data-fade-on-reorder>
 						<!-- If we are currently committing, we should keep this open so users can actually stop committing again :wink: -->
 						<StackDragHandle stackId={stableStackId} {projectId} disabled={isCommitting} />
 
@@ -773,7 +773,6 @@
 		flex-shrink: 0;
 		height: 100%;
 		overflow: hidden;
-		/* border-right: 1px solid var(--clr-border-2); */
 		transition: opacity 0.15s;
 
 		&.dimmed {

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -85,10 +85,29 @@
 	// If the user is making a commit to a different lane we dim this one.
 	const dimmed = $derived(action?.type === 'commit' && action?.stackId !== stableStackId);
 
-	// Get the default width from global state, but don't make it reactive during initialization
-	const defaultStackWidth = uiState.global.stackWidth.current;
+	// Resizer configuration for stack panels and details view
+	const RESIZER_CONFIG: {
+		panel1: { minWidth: number; maxWidth: number; defaultValue: number };
+		panel2: { minWidth: number; maxWidth: number; defaultValue: number };
+	} = {
+		panel1: {
+			minWidth: 20,
+			maxWidth: 64,
+			defaultValue: 23
+		},
+		panel2: {
+			minWidth: 20,
+			maxWidth: 64,
+			defaultValue: 32
+		}
+	};
+
 	const persistedStackWidth = $derived(
-		persistWithExpiration(defaultStackWidth, `ui-stack-width-${stableStackId}`, 1440)
+		persistWithExpiration(
+			RESIZER_CONFIG.panel1.defaultValue,
+			`ui-stack-width-${stableStackId}`,
+			1440
+		)
 	);
 
 	const branchesQuery = $derived(stackService.branches(stableProjectId, stableStackId));
@@ -143,20 +162,6 @@
 
 	const defaultBranchQuery = $derived(stackService.defaultBranch(stableProjectId, stableStackId));
 	const defaultBranch = $derived(defaultBranchQuery?.response);
-
-	// Resizer configuration for stack panels and details view
-	const RESIZER_CONFIG = {
-		panel1: {
-			minWidth: 20,
-			maxWidth: 64,
-			defaultValue: 23
-		},
-		panel2: {
-			minWidth: 20,
-			maxWidth: 64,
-			defaultValue: 32
-		}
-	} as const;
 
 	function checkSelectedFilesForCommit() {
 		const stackAssignments = stableStackId
@@ -619,14 +624,14 @@
 					<!-- RESIZE PANEL 1 -->
 					{#if stackViewEl}
 						<Resizer
-							persistId="resizer-panel1-${stableStackId}"
+							persistId="ui-stack-width-${stableStackId}"
 							viewport={stackViewEl}
 							zIndex="var(--z-lifted)"
 							direction="right"
 							showBorder={!isDetailsViewOpen}
 							minWidth={RESIZER_CONFIG.panel1.minWidth}
 							maxWidth={RESIZER_CONFIG.panel1.maxWidth}
-							defaultValue={RESIZER_CONFIG.panel1.defaultValue}
+							defaultValue={$persistedStackWidth ?? RESIZER_CONFIG.panel1.defaultValue}
 							syncName="panel1"
 							onWidth={(newWidth) => {
 								// Update the persisted stack width when panel1 resizer changes

--- a/apps/desktop/src/lib/dragging/ReorderClone.svelte
+++ b/apps/desktop/src/lib/dragging/ReorderClone.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	type Props = {
+		element: HTMLElement;
+		preserveOriginalSize?: boolean;
+		originalHeight?: number;
+		originalWidth?: number;
+	};
+
+	let { element, preserveOriginalSize = false, originalHeight, originalWidth }: Props = $props();
+
+	function appendElement(node: HTMLDivElement) {
+		// Append the cloned DOM element to preserve computed styles and state
+		node.appendChild(element);
+	}
+</script>
+
+<div
+	use:appendElement
+	class="reorder-clone"
+	class:preserve-size={preserveOriginalSize}
+	style:height={preserveOriginalSize && originalHeight ? `${originalHeight}px` : 'auto'}
+	style:width={preserveOriginalSize && originalWidth ? `${originalWidth}px` : undefined}
+	style:max-height={`${window.innerHeight - 100}px`}
+></div>
+
+<style>
+	.reorder-clone {
+		z-index: -1;
+		position: absolute;
+		top: -10000px;
+		left: -10000px;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-2);
+		pointer-events: none;
+	}
+
+	.reorder-clone.preserve-size {
+		/* Preserve original dimensions (e.g., for collapsed lanes) */
+		flex-shrink: 0;
+	}
+</style>

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -308,7 +308,7 @@ export function cloneElement(node: HTMLElement) {
 	const cloneEl = node.cloneNode(true) as HTMLElement;
 
 	// exclude all ignored elements from the clone
-	const ignoredElements = Array.from(cloneEl.querySelectorAll('[data-no-drag]'));
+	const ignoredElements = Array.from(cloneEl.querySelectorAll('[data-drag-clone-ignore]'));
 	ignoredElements.forEach((el) => el.remove());
 
 	return cloneEl;

--- a/packages/ui/src/lib/components/scroll/Scrollbar.svelte
+++ b/packages/ui/src/lib/components/scroll/Scrollbar.svelte
@@ -300,6 +300,7 @@
 	bind:this={track}
 	data-remove-from-panning
 	data-no-drag
+	data-drag-clone-ignore
 	class="scrollbar-track"
 	class:horz
 	class:vert


### PR DESCRIPTION
I updated styles for the lanes in order to avoid overlapping and expose overlaying elements:

Before (in slowmo):


https://github.com/user-attachments/assets/9983f978-dd36-4f25-af0a-05b3fb852be1


After (in slowmo):

https://github.com/user-attachments/assets/84be4131-9e3d-4348-9122-5cc21af386ac

After (normal speed):

https://github.com/user-attachments/assets/6dbdd575-a710-476d-bf84-23660d484c88


---

This pull request refactors and improves the drag-and-drop reordering experience in the stack view, enhances visual consistency with dotted patterns, and streamlines resizer configuration and persistence. The most significant changes include introducing a dedicated `ReorderClone` Svelte component for drag clones, refining how elements are faded during reorder, updating visual styles, and improving resizer persistence logic.

**Drag-and-drop reordering improvements:**

* Introduced a new `ReorderClone.svelte` component to encapsulate the drag clone's rendering and styling, preserving original element size and appearance during reordering. The drag clone now uses a Svelte mount for better style encapsulation and state management. [[1]](diffhunk://#diff-03297318cd97c6c1e64a15840a89d081ba8e5eecc173d8950686a25550ca395bR1-R43) [[2]](diffhunk://#diff-938a84062dd5ce50a2dc0317e8d9e33a090c4848b98ad00e84b0baac9413e63bL52-R97)
* Updated the reordering logic to fade only the inner stack element (`data-fade-on-reorder`) during drag, instead of the entire stack, for a smoother visual effect. The fade is reset when the drag ends. [[1]](diffhunk://#diff-938a84062dd5ce50a2dc0317e8d9e33a090c4848b98ad00e84b0baac9413e63bL52-R97) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L540-R545)
* Changed the selector for ignored elements in drag clones from `[data-no-drag]` to `[data-drag-clone-ignore]`, and updated relevant components to use this new attribute. [[1]](diffhunk://#diff-5e11dd7c375087e7cb6466abef240f680d3fa651761ca01b5bd529b2fc310001L311-R311) [[2]](diffhunk://#diff-5638bb87309b3003e7ace2a032686822716209d2a14ac093649e589486ee2da3R303)

**Visual and layout enhancements:**

* Added and standardized the use of the `dotted-pattern` class across stack containers, dropzones, and reorderable elements for consistent visual separation. Improved background colors, borders, and z-index stacking for stack and dropzone elements. [[1]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864L193-R195) [[2]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864R314-R321) [[3]](diffhunk://#diff-56f48b3ef764a5326f7a86649002e8a11b3dfb75badf8f3f7824639dd07f74adL49-R49) [[4]](diffhunk://#diff-56f48b3ef764a5326f7a86649002e8a11b3dfb75badf8f3f7824639dd07f74adR147-R157) [[5]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864R273-R274) [[6]](diffhunk://#diff-5ef7502284ff42d5351a9c8ae1370123c325091933168807d2859ad6e26afa80L191-R191) [[7]](diffhunk://#diff-5ef7502284ff42d5351a9c8ae1370123c325091933168807d2859ad6e26afa80R295-L298)
* Adjusted the drag handle padding and border radius to use theme variables for better alignment with the overall UI.

**Resizer configuration and persistence:**

* Refactored stack panel resizer configuration to use a centralized `RESIZER_CONFIG` object and updated the logic to persist stack widths using a consistent key (`ui-stack-width-${stableStackId}`), improving reliability and clarity. [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L88-R110) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L622-R634) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L147-L160)
* Ensured the resizer uses the persisted width value if available, falling back to the default when necessary.

**Miscellaneous style adjustments:**

* Improved flexbox layout and sizing for stack containers and dropzones, fixed border gaps, and ensured minimum widths for better usability. [[1]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864L285-R300) [[2]](diffhunk://#diff-56f48b3ef764a5326f7a86649002e8a11b3dfb75badf8f3f7824639dd07f74adR147-R157) [[3]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864R314-R321) [[4]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864R273-R274) [[5]](diffhunk://#diff-5ef7502284ff42d5351a9c8ae1370123c325091933168807d2859ad6e26afa80R295-L298)
* Removed commented-out border styles and cleaned up unused code for clarity.

These changes collectively make the stack reordering experience smoother, visually clearer, and more maintainable.