### PR TITLE
some-tabbing-fixes

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "^1.3.2",
+		"@gitbutler/design-core": "1.3.4",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "1.3.4",
+		"@gitbutler/design-core": "1.3.8",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/desktop/src/components/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/CreateBranchModal.svelte
@@ -139,7 +139,7 @@
 			onslugifiedvalue={(value) => (slugifiedRefName = value)}
 		/>
 
-		<div class="options-wrap">
+		<div class="options-wrap" role="radiogroup" aria-label="Branch type selection">
 			<!-- Option 1 -->
 			<label for="new-stack" class="radio-label" class:radio-selected={createRefType === 'stack'}>
 				<div class="radio-btn">

--- a/apps/desktop/src/components/DeleteBranchModal.svelte
+++ b/apps/desktop/src/components/DeleteBranchModal.svelte
@@ -40,7 +40,7 @@
 		Are you sure you want to delete <code class="code-string">{branchName}</code>?
 	</p>
 	{#snippet controls(close)}
-		<Button kind="outline" onclick={close}>Cancel</Button>
+		<Button kind="outline" onclick={close} autofocus>Cancel</Button>
 		<Button
 			testId={TestId.BranchHeaderDeleteModal_ActionButton}
 			style="error"

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -76,7 +76,7 @@
 		{#snippet content()}
 			<button
 				type="button"
-				class="chevron-btn focus-state"
+				class="chevron-btn"
 				class:expanded={!$collapsed}
 				onclick={(e) => {
 					e.stopPropagation();

--- a/apps/desktop/src/components/UnassignedFoldButton.svelte
+++ b/apps/desktop/src/components/UnassignedFoldButton.svelte
@@ -7,7 +7,7 @@
 	const { active, onclick }: Props = $props();
 </script>
 
-<button type="button" class="fold-btn focus-state" class:active {onclick} aria-label="Toggle fold">
+<button type="button" class="fold-btn" class:active {onclick} aria-label="Toggle fold">
 	<div class="fold-icon__frame"></div>
 </button>
 

--- a/apps/desktop/src/components/WorktreeTipsFooter.svelte
+++ b/apps/desktop/src/components/WorktreeTipsFooter.svelte
@@ -26,11 +26,7 @@
 {#snippet GbLink(props: { label: string; href: string; icon: keyof typeof iconsJson })}
 	{@const { label, href, icon } = props}
 	<Tooltip text={label} position="top">
-		<a
-			type="button"
-			{href}
-			target="_blank"
-			class="focus-state text-13 text-semibold text-body tip-footer__link"
+		<a type="button" {href} target="_blank" class="text-13 text-semibold text-body tip-footer__link"
 			><Icon name={icon} />
 		</a>
 	</Tooltip>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@gitbutler/design-core": "^1.3.2",
+		"@gitbutler/design-core": "1.3.4",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@gitbutler/design-core": "1.3.4",
+		"@gitbutler/design-core": "1.3.8",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "1.3.4",
+		"@gitbutler/design-core": "1.3.8",
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.56.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "^1.3.2",
+		"@gitbutler/design-core": "1.3.4",
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.56.1",

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -314,6 +314,8 @@
 			--theme-solid-text: var(--clr-theme-ntrl-on-element);
 			--theme-solid-bg: var(--clr-theme-ntrl-element);
 			--theme-solid-bg-hover: var(--clr-theme-ntrl-element-hover);
+			--theme-focus-color: var(--clr-theme-pop-element);
+			--theme-focus-mix-ratio: 100%;
 		}
 
 		:where(&.pop) {
@@ -323,6 +325,7 @@
 			--theme-solid-text: var(--clr-theme-pop-on-element);
 			--theme-solid-bg: var(--clr-theme-pop-element);
 			--theme-solid-bg-hover: var(--clr-theme-pop-element-hover);
+			--theme-focus-color: var(--clr-theme-pop-element);
 		}
 
 		:where(&.success) {
@@ -332,6 +335,7 @@
 			--theme-solid-text: var(--clr-theme-succ-on-element);
 			--theme-solid-bg: var(--clr-theme-succ-element);
 			--theme-solid-bg-hover: var(--clr-theme-succ-element-hover);
+			--theme-focus-color: var(--clr-theme-succ-element);
 		}
 
 		:where(&.error) {
@@ -341,6 +345,7 @@
 			--theme-solid-text: var(--clr-theme-err-on-element);
 			--theme-solid-bg: var(--clr-theme-err-element);
 			--theme-solid-bg-hover: var(--clr-theme-err-element-hover);
+			--theme-focus-color: var(--clr-theme-err-element);
 		}
 
 		:where(&.warning) {
@@ -350,6 +355,7 @@
 			--theme-solid-text: var(--clr-theme-warn-on-element);
 			--theme-solid-bg: var(--clr-theme-warn-element);
 			--theme-solid-bg-hover: var(--clr-theme-warn-element-hover);
+			--theme-focus-color: var(--clr-theme-warn-element);
 		}
 
 		:where(&.purple) {
@@ -359,6 +365,24 @@
 			--theme-solid-text: var(--clr-theme-purp-on-element);
 			--theme-solid-bg: var(--clr-theme-purp-element);
 			--theme-solid-bg-hover: var(--clr-theme-purp-element-hover);
+			--theme-focus-color: var(--clr-theme-purp-element);
+		}
+
+		/* Focus styles for all themed buttons */
+		:where(&.outline:focus-visible),
+		:where(&.ghost:focus-visible) {
+			outline: 2px solid var(--theme-focus-color);
+			outline-offset: -2px;
+		}
+
+		:where(&.solid:focus-visible) {
+			outline: 2px solid
+				color-mix(
+					in srgb,
+					var(--theme-focus-color) var(--theme-focus-mix-ratio, 60%),
+					var(--clr-text-1)
+				);
+			outline-offset: -2px;
 		}
 
 		/* Apply patterns using consolidated theme variables */

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -8,6 +8,7 @@
 		activated?: boolean;
 		tabindex?: number | undefined;
 		type?: 'submit' | 'reset' | 'button' | undefined;
+		autofocus?: boolean;
 		// Layout props
 		shrinkable?: boolean;
 		reversedDirection?: boolean;
@@ -51,6 +52,7 @@
 	import { focusable } from '$lib/focus/focusable';
 	import { formatHotkeyForPlatform } from '$lib/utils/hotkeySymbols';
 	import { pxToRem } from '$lib/utils/pxToRem';
+	import { onMount, tick } from 'svelte';
 	import type iconsJson from '$lib/data/icons.json';
 	import type { ComponentColorType, ComponentKindType } from '$lib/utils/colorTypes';
 	import type { Snippet } from 'svelte';
@@ -63,6 +65,7 @@
 		activated = false,
 		tabindex,
 		type = 'button',
+		autofocus = false,
 		shrinkable = false,
 		reversedDirection = false,
 		width,
@@ -110,6 +113,14 @@
 		tooltipInstance?.dismiss();
 		onmousedownExternal?.(e);
 	}
+
+	onMount(() => {
+		if (autofocus) {
+			tick().then(() => {
+				el?.focus();
+			});
+		}
+	});
 </script>
 
 <Tooltip

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -131,7 +131,7 @@
 			}
 		}}
 		class={[
-			'btn focus-state',
+			'btn',
 			style,
 			kind,
 			size && `${size}-size`,

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -468,8 +468,4 @@
 			text-overflow: ellipsis;
 		}
 	}
-	/* See `tabbable.ts` for more on this class. */
-	:global(.focus-visible) {
-		outline: 2px solid var(--clr-theme-pop-element-hover);
-	}
 </style>

--- a/packages/ui/src/lib/components/Checkbox.svelte
+++ b/packages/ui/src/lib/components/Checkbox.svelte
@@ -87,7 +87,7 @@
 			}
 		}}
 		type="checkbox"
-		class="focus-state checkbox-input"
+		class="checkbox-input"
 		{value}
 		id={name}
 		{name}

--- a/packages/ui/src/lib/components/Checkbox.svelte
+++ b/packages/ui/src/lib/components/Checkbox.svelte
@@ -128,7 +128,11 @@
 				opacity: 1;
 			}
 		}
-
+		/* NOT CHECKED. FOCUS */
+		&:not(.checked):not(.disabled):has(.checkbox-input:focus-visible) {
+			outline: 2px solid var(--clr-theme-pop-element);
+			outline-offset: -2px;
+		}
 		/* CHECKED */
 		&:not(.disabled).checked {
 			background-color: var(--clr-theme-pop-element);
@@ -146,7 +150,12 @@
 				opacity: 1;
 			}
 		}
-
+		/* CHECKED. FOCUS */
+		&:not(.disabled).checked:has(.checkbox-input:focus-visible) {
+			outline: 2px solid color-mix(in srgb, var(--clr-theme-pop-element) 80%, var(--clr-text-1));
+			outline-offset: -2px;
+			background-color: var(--clr-theme-pop-element);
+		}
 		/* CURSOR */
 		&:not(.disabled) {
 			& .checkbox-input {
@@ -202,5 +211,15 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
+
+		&:not(:disabled):not(:checked):focus-visible {
+			outline: 2px solid var(--clr-theme-pop-element);
+			outline-offset: -2px;
+		}
+
+		&:checked:focus-visible {
+			outline: 2px solid color-mix(in srgb, var(--clr-theme-pop-element) 60%, var(--clr-text-1));
+			outline-offset: -2px;
+		}
 	}
 </style>

--- a/packages/ui/src/lib/components/ContextMenuItem.svelte
+++ b/packages/ui/src/lib/components/ContextMenuItem.svelte
@@ -64,7 +64,7 @@
 	<button
 		data-testid={testId}
 		type="button"
-		class="menu-item focus-state no-select"
+		class="menu-item no-select"
 		style:--item-height={caption ? 'auto' : '1.625rem'}
 		class:disabled
 		{disabled}

--- a/packages/ui/src/lib/components/ProfilePictureUpload.svelte
+++ b/packages/ui/src/lib/components/ProfilePictureUpload.svelte
@@ -60,7 +60,7 @@
 </script>
 
 <label
-	class="profile-pic-wrapper focus-state {className || ''}"
+	class="profile-pic-wrapper {className || ''}"
 	for="profile-picture-upload"
 	style="width: {size}rem; height: {size}rem;"
 >

--- a/packages/ui/src/lib/components/RadioButton.svelte
+++ b/packages/ui/src/lib/components/RadioButton.svelte
@@ -24,7 +24,7 @@
 
 <input
 	type="radio"
-	class="focus-state radio {className}"
+	class="radio {className}"
 	class:small
 	{id}
 	{value}

--- a/packages/ui/src/lib/components/RadioButton.svelte
+++ b/packages/ui/src/lib/components/RadioButton.svelte
@@ -68,6 +68,10 @@
 			}
 		}
 
+		&:not(:disabled):not(:checked):focus-visible {
+			outline: 2px solid var(--clr-theme-pop-element);
+			outline-offset: -2px;
+		}
 		&:disabled {
 			background-color: var(--clr-scale-ntrl-70);
 			cursor: not-allowed;
@@ -86,7 +90,10 @@
 			}
 		}
 
-		/* tick element */
+		&:checked:focus-visible {
+			outline: 2px solid color-mix(in srgb, var(--clr-theme-pop-element) 60%, var(--clr-text-1));
+			outline-offset: -2px;
+		} /* tick element */
 		&::after {
 			position: absolute;
 			top: 4px;

--- a/packages/ui/src/lib/components/RadioButton.svelte
+++ b/packages/ui/src/lib/components/RadioButton.svelte
@@ -31,6 +31,7 @@
 	{name}
 	{disabled}
 	{checked}
+	tabindex={disabled ? -1 : 0}
 	{onchange}
 	onkeydown={(e) => {
 		if (e.key === 'Enter') {

--- a/packages/ui/src/lib/components/TagInput.svelte
+++ b/packages/ui/src/lib/components/TagInput.svelte
@@ -128,7 +128,7 @@
 					{#if !disabled && !readonly}
 						<button
 							type="button"
-							class="tag-remove focus-state"
+							class="tag-remove"
 							onclick={(e) => {
 								e.stopPropagation();
 								removeTag(tag.id);

--- a/packages/ui/src/lib/components/Toggle.svelte
+++ b/packages/ui/src/lib/components/Toggle.svelte
@@ -72,6 +72,11 @@
 			background-color: var(--clr-border-1);
 		}
 
+		&:focus-visible {
+			outline: 2px solid var(--clr-theme-pop-element);
+			outline-offset: -2px;
+		}
+
 		&:disabled {
 			border-color: none;
 			background-color: var(--clr-scale-ntrl-60);
@@ -86,6 +91,11 @@
 
 			&:hover {
 				background-color: var(--clr-theme-pop-element-hover);
+			}
+
+			&:focus-visible {
+				outline: 2px solid color-mix(in srgb, var(--clr-theme-pop-element) 60%, var(--clr-text-1));
+				outline-offset: -2px;
 			}
 
 			&:disabled {

--- a/packages/ui/src/lib/components/Toggle.svelte
+++ b/packages/ui/src/lib/components/Toggle.svelte
@@ -32,6 +32,15 @@
 		onclick?.(e);
 	}}
 	onchange={(e) => onchange?.(e.currentTarget.checked)}
+	onkeydown={(e) => {
+		// Prevent Enter key from submitting forms, but manually toggle the checkbox
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			const target = e.currentTarget;
+			target.checked = !target.checked;
+			onchange?.(target.checked);
+		}
+	}}
 	type="checkbox"
 	class="toggle"
 	class:small

--- a/packages/ui/src/lib/components/file/FolderListItem.svelte
+++ b/packages/ui/src/lib/components/file/FolderListItem.svelte
@@ -76,7 +76,7 @@
 		<button
 			type="button"
 			aria-label="Toggle folder"
-			class="folder-list-item__arrow focus-state"
+			class="folder-list-item__arrow"
 			class:expanded={isFolderExpanded}
 			onclick={(e) => {
 				e.stopPropagation();

--- a/packages/ui/src/lib/components/popoverActions/PopoverActionsItem.svelte
+++ b/packages/ui/src/lib/components/popoverActions/PopoverActionsItem.svelte
@@ -40,7 +40,7 @@
 		type="button"
 		bind:this={el}
 		data-clickable="true"
-		class="overflow-actions-btn focus-state"
+		class="overflow-actions-btn"
 		{disabled}
 		class:thin
 		class:activated

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: 1.3.4
+        version: 1.3.4
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -392,8 +392,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: 1.3.4
+        version: 1.3.4
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -789,8 +789,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: 1.3.4
+        version: 1.3.4
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1664,8 +1664,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.3.2':
-    resolution: {integrity: sha512-8LS6kZP/YHlvoTahS+/hKhfy2wE/CfbooOnGP89BW1Xa8EzlehJVDvb4AT8QYiDaQfqy1TayV7gYKsQ/ZHQj3A==}
+  '@gitbutler/design-core@1.3.4':
+    resolution: {integrity: sha512-KQisD3B+9AKds6NlHxRxBkR1PxmANaalznbRjTEj+x+IaJLqT+hpzEWliiWjdIN6XNMByBNPnp5mZwzHXdpeWA==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8971,7 +8971,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.3.2': {}
+  '@gitbutler/design-core@1.3.4': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.3.4
-        version: 1.3.4
+        specifier: 1.3.8
+        version: 1.3.8
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -392,8 +392,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.3.4
-        version: 1.3.4
+        specifier: 1.3.8
+        version: 1.3.8
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -789,8 +789,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: 1.3.4
-        version: 1.3.4
+        specifier: 1.3.8
+        version: 1.3.8
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1664,8 +1664,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.3.4':
-    resolution: {integrity: sha512-KQisD3B+9AKds6NlHxRxBkR1PxmANaalznbRjTEj+x+IaJLqT+hpzEWliiWjdIN6XNMByBNPnp5mZwzHXdpeWA==}
+  '@gitbutler/design-core@1.3.8':
+    resolution: {integrity: sha512-lL96MqRi3X0XcS8geP6j0yVlzdm/azsMbCPV9tlLKoowlDMA0gxQ40opZCSUYWzMVOtZik+3lT2Uw+eUdyWNlA==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8971,7 +8971,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.3.4': {}
+  '@gitbutler/design-core@1.3.8': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
- Previously, some modals didn’t have a visible focus-outline.
In this PR, I added more focus styles for UI components like buttons, toggles, checkboxes, and radio buttons to ensure that the outline is visible for all color modes and whether they are checked or not, as we used the same color for checked states and the focus outline.
- I removed the `.focus-state` style to use only a single source of outline style for focus states, which is now `.focus-visible`.
- The `.focus-visible` class is now a part of the design-core package.
- I made some fixes for the `tabbable` and `focusManager` components. In some modals, some buttons previously didn’t have a proper focus outline (see the video below).

Here are some buttons without a focus outline and inconsistent focus styles:

https://github.com/user-attachments/assets/ae031154-182b-4ae6-a474-98190f284c7f

After the changes:

https://github.com/user-attachments/assets/d52f493f-e4ee-4e3e-be97-5acd5d5d8a4b

https://github.com/user-attachments/assets/5921d09d-075a-4d17-9198-1bdd7997a9ed

https://github.com/user-attachments/assets/e09a34e0-f752-4b17-b7e1-4d7bb680ad13

—

The previous outline had an outer offset and was cropped.

https://github.com/user-attachments/assets/974f9c37-b602-4e7e-9383-a33f0106c503

The updated version:

https://github.com/user-attachments/assets/9573b82b-7737-43f4-9938-568b98adf366


