### PR TITLE
Reduce usage of legacy `CommandContext` in `IdDb`

### DIFF
--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -332,7 +332,7 @@ fn convert_branch_to_json(
     review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
     id_db: &mut crate::legacy::id::IdDb,
 ) -> anyhow::Result<Branch> {
-    let cli_id = id_db.branch(&branch.name.to_string()).to_string();
+    let cli_id = id_db.branch(branch.name.as_ref()).to_string();
 
     let review_id = if review {
         crate::command::legacy::forge::review::get_review_numbers(
@@ -381,7 +381,7 @@ pub(super) fn build_workspace_status_json(
             let stack_cli_id = details
                 .branch_details
                 .first()
-                .map(|b| id_db.branch(&b.name.to_string()).to_string())
+                .map(|b| id_db.branch(b.name.as_ref()).to_string())
                 .unwrap_or_else(|| "unknown".to_string());
 
             let json_assigned_changes = convert_file_assignments(assignments, worktree_changes);

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -386,7 +386,7 @@ pub fn print_group(
         let mut first = true;
         for branch in &group.branch_details {
             let id = id_db
-                .branch(branch.name.to_str()?)
+                .branch(branch.name.as_ref())
                 .to_string()
                 .underline()
                 .blue();
@@ -557,7 +557,7 @@ pub(crate) fn all_branches(ctx: &Context) -> anyhow::Result<Vec<CliId>> {
     let mut branches = Vec::new();
     for stack in stacks {
         for head in stack.heads {
-            branches.push(id_db.branch(&head.name.to_string()).clone());
+            branches.push(id_db.branch(head.name.as_ref()).clone());
         }
     }
     Ok(branches)

--- a/crates/but/src/legacy/id.rs
+++ b/crates/but/src/legacy/id.rs
@@ -1,9 +1,24 @@
 use std::{collections::HashMap, fmt::Display};
 
-use bstr::ByteSlice;
+use bstr::{BString, ByteSlice};
 use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
+
+fn branch_names(ctx: &Context) -> anyhow::Result<Vec<BString>> {
+    let guard = ctx.shared_worktree_access();
+    let meta = ctx.meta(guard.read_permission())?;
+    let head_info = but_workspace::head_info(&*ctx.repo.get()?, &meta, Default::default())?;
+    let mut branch_names: Vec<BString> = Vec::new();
+    for stack in head_info.stacks {
+        for segment in stack.segments {
+            if let Some(ref_info) = segment.ref_info {
+                branch_names.push(ref_info.ref_name.shorten().to_owned());
+            }
+        }
+    }
+    Ok(branch_names)
+}
 
 pub struct IdDb {
     branch_name_to_cli_id: HashMap<String, CliId>,
@@ -13,50 +28,46 @@ pub struct IdDb {
 impl IdDb {
     pub fn new(ctx: &Context) -> anyhow::Result<Self> {
         let mut max_zero_count = 1; // Ensure at least two "0" in ID.
-        let stacks = crate::legacy::commits::stacks(ctx)?;
+        let branch_names = branch_names(ctx)?;
         let mut pairs_to_count: HashMap<u16, u8> = HashMap::new();
         fn u8_pair_to_u16(two: [u8; 2]) -> u16 {
             two[0] as u16 * 256 + two[1] as u16
         }
-        for stack in &stacks {
-            for head in &stack.heads {
-                for pair in head.name.windows(2) {
-                    let pair: [u8; 2] = pair.try_into()?;
-                    if !pair[0].is_ascii_alphanumeric() || !pair[1].is_ascii_alphanumeric() {
-                        continue;
-                    }
-                    let could_collide_with_commits =
-                        pair[0].is_ascii_hexdigit() && pair[1].is_ascii_hexdigit();
-                    if could_collide_with_commits {
-                        continue;
-                    }
-                    let u16pair = u8_pair_to_u16(pair);
-                    pairs_to_count
-                        .entry(u16pair)
-                        .and_modify(|count| *count = count.saturating_add(1))
-                        .or_insert(1);
+        for branch_name in &branch_names {
+            for pair in branch_name.windows(2) {
+                let pair: [u8; 2] = pair.try_into()?;
+                if !pair[0].is_ascii_alphanumeric() || !pair[1].is_ascii_alphanumeric() {
+                    continue;
                 }
-                for field in head.name.fields_with(|c| c != '0') {
-                    max_zero_count = std::cmp::max(field.len(), max_zero_count);
+                let could_collide_with_commits =
+                    pair[0].is_ascii_hexdigit() && pair[1].is_ascii_hexdigit();
+                if could_collide_with_commits {
+                    continue;
                 }
+                let u16pair = u8_pair_to_u16(pair);
+                pairs_to_count
+                    .entry(u16pair)
+                    .and_modify(|count| *count = count.saturating_add(1))
+                    .or_insert(1);
+            }
+            for field in branch_name.fields_with(|c| c != '0') {
+                max_zero_count = std::cmp::max(field.len(), max_zero_count);
             }
         }
 
         let mut branch_name_to_cli_id: HashMap<String, CliId> = HashMap::new();
-        for stack in stacks {
-            'head: for head in &stack.heads {
-                // Find first non-conflicting pair and use it as CliId.
-                for pair in head.name.windows(2) {
-                    let pair: [u8; 2] = pair.try_into()?;
-                    let u16pair = u8_pair_to_u16(pair);
-                    if let Some(1) = pairs_to_count.get(&u16pair) {
-                        let name = head.name.to_string();
-                        let id = str::from_utf8(&pair)
-                            .expect("if we stored it, it's ascii-alphanum")
-                            .to_owned();
-                        branch_name_to_cli_id.insert(name.clone(), CliId::Branch { name, id });
-                        continue 'head;
-                    }
+        'branch_name: for branch_name in &branch_names {
+            // Find first non-conflicting pair and use it as CliId.
+            for pair in branch_name.windows(2) {
+                let pair: [u8; 2] = pair.try_into()?;
+                let u16pair = u8_pair_to_u16(pair);
+                if let Some(1) = pairs_to_count.get(&u16pair) {
+                    let name = branch_name.to_string();
+                    let id = str::from_utf8(&pair)
+                        .expect("if we stored it, it's ascii-alphanum")
+                        .to_owned();
+                    branch_name_to_cli_id.insert(name.clone(), CliId::Branch { name, id });
+                    continue 'branch_name;
                 }
             }
         }
@@ -69,16 +80,14 @@ impl IdDb {
     }
 
     fn find_branches_by_name(&mut self, ctx: &Context, name: &str) -> anyhow::Result<Vec<CliId>> {
-        let stacks = crate::legacy::commits::stacks(ctx)?;
+        let branch_names = branch_names(ctx)?;
         let mut matches = Vec::new();
 
-        for stack in stacks {
-            for head in &stack.heads {
-                let branch_name = head.name.to_string();
-                // Exact match or partial match
-                if branch_name == name || branch_name.contains(name) {
-                    matches.push(self.branch(&branch_name).clone())
-                }
+        for branch_name in branch_names {
+            let branch_name = branch_name.to_string();
+            // Exact match or partial match
+            if branch_name == name || branch_name.contains(name) {
+                matches.push(self.branch(&branch_name).clone())
             }
         }
 


### PR DESCRIPTION
## 🧢 Changes

Code cleanup with no user-visible changes.

## ☕️ Reasoning

When I started writing these commits, I thought that a good end goal would be to have `IdDb` and all its dependencies not use `CommandContext` at all. These commits definitely bring us closer there. However, right now, I'm wondering if the end goal should instead be to refactor "status" code by shifting the bulk of it into somewhere that can be referenced from `Context`, have that code both serve "status" and anything that requires ID interpreting or generating, and ensure that that code does not use `CommandContext`. These commits bring us closer there, but some of the code changed may end up being discarded.

I have been thinking about whether these commits should be merged - if it were up to me, I lean towards merging them, since they provide a better base for everyone to build on. But if code archeology (e.g. bisect, blame) is an important consideration, maybe it's better to wait until we have a better idea of what the end goal should be.

Related to #11263
