### PR TITLE
Use the latest version of linux dependencies when publishing (#8411)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -184,12 +184,12 @@ jobs:
             xdg-utils;
 
           sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
+            libwebkit2gtk-4.1-0 \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-0 \
+            libjavascriptcoregtk-4.1-dev \
+            gir1.2-javascriptcoregtk-4.1 \
+            gir1.2-webkit2-4.1;
 
       - uses: actions/download-artifact@v6
         name: Download SvelteKit build output


### PR DESCRIPTION
That way, it seems to not freeze anymore.

This is an experiment that needs validation, but if it builds, it's probably good.

### Tasks

* [ ] create new Nightly
* [ ] validate it