### PR TITLE
feat(ui): add scrollToTop and auto-scroll on tab change in settings modal

### DIFF
--- a/apps/desktop/src/components/ConfigurableScrollableContainer.svelte
+++ b/apps/desktop/src/components/ConfigurableScrollableContainer.svelte
@@ -18,6 +18,13 @@
 			scrollableContainer.scrollToBottom();
 		}
 	}
+
+	// Export method to scroll to top
+	export function scrollToTop() {
+		if (scrollableContainer?.scrollToTop) {
+			scrollableContainer.scrollToTop();
+		}
+	}
 </script>
 
 <ScrollableContainer

--- a/apps/desktop/src/components/SettingsModalLayout.svelte
+++ b/apps/desktop/src/components/SettingsModalLayout.svelte
@@ -27,11 +27,18 @@
 
 	let currentSelectedId = $state(selectedId || pages[0]?.id || '');
 	const currentPage = $derived(pages.find((p) => p.id === currentSelectedId));
+	let scrollableContainer: ConfigurableScrollableContainer;
 
 	function selectPage(pageId: string) {
 		currentSelectedId = pageId;
 		onSelectPage(pageId);
 	}
+
+	$effect(() => {
+		if (currentSelectedId) {
+			scrollableContainer?.scrollToTop();
+		}
+	});
 </script>
 
 <div class="modal-settings-wrapper">
@@ -64,7 +71,7 @@
 	</div>
 
 	<section class="page-view" use:focusable={{ vertical: true }}>
-		<ConfigurableScrollableContainer>
+		<ConfigurableScrollableContainer bind:this={scrollableContainer}>
 			<div class="page-view__content">
 				{@render content({ currentPage })}
 			</div>


### PR DESCRIPTION
## 🧢 Changes

The Global settings and Project settings windows in GitButler don't reset the scroll position when switching tabs, which causes each newly switched tab to start in the middle.

This PR automatically resets the scroll position when switching tabs, for a better user experience.

Before and after comparisons:

https://github.com/user-attachments/assets/057ef2c6-9ee9-443c-8ef6-8aebba6c401f
