### PR TITLE
workspace fixes

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -39,6 +39,7 @@ pub mod create_reference {
     }
 }
 
+// TODO: make this non-legacy as soon as `project_id` is a `&but-ctx::Context`.
 #[api_cmd_tauri]
 #[instrument(err(Debug))]
 pub fn create_reference(

--- a/crates/but-ctx/src/legacy/mod.rs
+++ b/crates/but-ctx/src/legacy/mod.rs
@@ -93,7 +93,7 @@ impl Context {
             commit_id,
             reference.name().to_owned(),
             &meta,
-            but_graph::init::Options::limited(),
+            meta.to_graph_options(),
         )?;
         Ok((repo.clone(), meta, graph))
     }
@@ -116,7 +116,7 @@ impl Context {
     )> {
         let repo = self.repo.get()?;
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
         Ok((repo.clone(), meta, graph))
     }
 
@@ -136,7 +136,7 @@ impl Context {
         but_graph::Graph,
     )> {
         let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, meta.to_graph_options())?;
         Ok((repo, meta, graph))
     }
 }

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -19,7 +19,9 @@ pub mod access;
 ///
 /// With it, all project data and metadata can be accessed.
 /// Further, this ID is URL-safe, but it is *not* for human consumption.
-pub type ProjectHandle = String;
+// TODO: needs actual implementation to make it usable in the `Context` API.
+//       Needs implementation to turn it into a `PathBuf`, and to create it from a `Path`.
+pub struct ProjectHandle(#[expect(dead_code)] String);
 
 /// A context specific to a repository, along with commonly used information to make higher-level functions
 /// more convenient to implement.

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -603,6 +603,7 @@ impl Graph {
             &ctx.worktree_by_branch,
         )?;
         max_commits_recharge_location.sort();
+        let mut no_duplicate_parents = gix::hashtable::HashSet::default();
         while let Some((id, mut propagated_flags, instruction, mut limit)) = next.pop_front() {
             if max_commits_recharge_location.binary_search(&id).is_ok() {
                 limit.set_but_keep_goal(max_limit);
@@ -706,6 +707,7 @@ impl Graph {
             let propagated_flags = propagated_flags | maybe_make_id_a_goal_so_remote_can_find_local;
             let hard_limit_hit = queue_parents(
                 &mut next,
+                &mut no_duplicate_parents,
                 &info.parent_ids,
                 propagated_flags,
                 segment_idx_for_id,

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -354,9 +354,15 @@ pub fn try_split_non_empty_segment_at_branch<T: RefMetadata>(
 /// Queue the `parent_ids` of the current commit, whose additional information like `current_kind` and `current_index`
 /// are used.
 /// `limit` is used to determine if the tip is NOT supposed to be dropped, with `0` meaning it's depleted.
+/// TODO(1.0): remove `no_duplicate_parents` once no old code is running anymore.
+/// `no_duplicate_parents` is used to avoid 'broken' merge commits that have multiple parents - our own (probably old) code
+/// seems to do that which breaks invariants. Admittedly, this code runs for all merge commits, not just our workspace commits,
+/// but as a matter of fact under many situations we already miss such duplicate connection due to the way the traversal is run,
+/// so this at least makes this apply to the whole graph uniformly.
 #[must_use]
 pub fn queue_parents(
     next: &mut Queue,
+    no_duplicate_parents: &mut gix::hashtable::HashSet,
     parent_ids: &[gix::ObjectId],
     flags: CommitFlags,
     current_sidx: SegmentIndex,
@@ -371,8 +377,12 @@ pub fn queue_parents(
             parent_above: current_sidx,
             at_commit: current_cidx,
         };
+        no_duplicate_parents.clear();
         let limit_per_parent = limit.per_parent(parent_ids.len());
         for pid in parent_ids {
+            if !no_duplicate_parents.insert(*pid) {
+                continue;
+            };
             if next.push_back_exhausted((*pid, flags, instruction, limit_per_parent)) {
                 return true;
             }

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -214,6 +214,35 @@ git init special-branches
 
 mkdir ws
 (cd ws
+  git init duplicate-workspace-connection
+  (cd duplicate-workspace-connection
+    # this repo is for reproducing a real double-connection, which isn't always happening but causes issues downstream.
+    commit init
+    git branch A
+    git branch B
+    setup_target_to_match_main
+    create_workspace_commit_once main
+    commit_with_duplicate_parents=$(git cat-file -p  @ | sed '/parent/ { p; }' | git hash-object -t commit --stdin -w)
+    git update-ref refs/heads/gitbutler/workspace "${commit_with_duplicate_parents}"
+
+    git checkout -b soon-origin-main main
+      commit RM
+    git checkout gitbutler/workspace
+    mv .git/refs/heads/soon-origin-main .git/refs/remotes/origin/main
+  )
+
+  git init duplicate-workspace-connection-no-target
+  (cd duplicate-workspace-connection-no-target
+    # like above, but don't let the target be advanced.
+    commit init
+    git branch A
+    git branch B
+    setup_target_to_match_main
+    create_workspace_commit_once main
+    commit_with_duplicate_parents=$(git cat-file -p  @ | sed '/parent/ { p; }' | git hash-object -t commit --stdin -w)
+    git update-ref refs/heads/gitbutler/workspace "${commit_with_duplicate_parents}"
+  )
+
   git init ambiguous-worktrees
   (cd ambiguous-worktrees
     commit M1

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -164,6 +164,20 @@ impl VirtualBranchesTomlMetadata {
     }
 }
 
+/// Utilities
+// TODO: remove this once `Target` in `but_core::ref_metadata` has a optional field for the head position to use.
+impl VirtualBranchesTomlMetadata {
+    /// Return default options that limit single-branch commits to a sane amount (instead of traversing the whole graph),
+    /// and configure other values that require our meta-data to guide the traversal.
+    #[cfg(feature = "legacy")]
+    pub fn to_graph_options(&self) -> but_graph::init::Options {
+        but_graph::init::Options {
+            extra_target_commit_id: self.data().default_target.as_ref().map(|t| t.sha),
+            ..but_graph::init::Options::limited()
+        }
+    }
+}
+
 // Emergency-behaviour in case the application winds down, we don't want data-loss (at least a chance).
 impl Drop for VirtualBranchesTomlMetadata {
     fn drop(&mut self) {

--- a/crates/but/src/tui/select_branch/mod.rs
+++ b/crates/but/src/tui/select_branch/mod.rs
@@ -27,7 +27,7 @@ pub fn run(stacks: Vec<TuiStack>) -> Result<Vec<String>> {
 #[derive(Debug, Default)]
 pub struct TuiCommit {
     /// The commit title.
-    // TODO: the dead-code here was probbaly meant to be used some day to show commit information, it's just not implemented.
+    // TODO: the dead-code here was probably meant to be used some day to show commit information, it's just not implemented.
     #[expect(dead_code)]
     title: String,
     /// The short SHA of the commit.

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -170,10 +170,10 @@ fn main() -> anyhow::Result<()> {
                     broadcaster: broadcaster.clone(),
                     instance_by_stack: Default::default(),
                 };
-                let archival = Arc::new(but_feedback::Archival {
+                let archival = but_feedback::Archival {
                     cache_dir: app_cache_dir.clone(),
                     logs_dir: app_log_dir.clone(),
-                });
+                };
                 app_handle.manage(archival);
                 app_handle.manage(app_settings);
                 app_handle.manage(claude);


### PR DESCRIPTION
The workspace traversal seems to be broken now that https://github.com/gitbutlerapp/gitbutler/commit/60d2e25949a10078590a67d39dfa290bd473bcff was done,
and it must be fixed ASAP.

### Tasks

* [x] reproduce and fix Pavel's issue   
* [x] have a specific test using the extra target and advanced target branches
* [x] bring back the special extra target setup as quick fix
    - [x] ~~validate it now works~~ it doesn't work, despite the extra target definitely present.
* [x] fix archival and validate it.

### Next PR

* [ ] fix lack of extra-target properly, so it doesn't depend on that.
* [ ] let metadata store the head position to be able to make the base sticky. This way there is backwards compatibility  for the target, as first-class feature.