### PR TITLE
Fix creating dependent branch not reflecting in ui

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1201,8 +1201,9 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 					actionName: 'Create Branch'
 				},
 				query: (args) => args,
-				invalidatesTags: (_result, _error, _args) => [
+				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.HeadSha),
+					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
 				]
 			}),


### PR DESCRIPTION
The issue seems to be stemming from this PR 
https://github.com/gitbutlerapp/gitbutler/pull/11159 which tries to move
invalidation from purely the JS side, to basing it on when certain 
references change.
I think the idea behind the change was to try and respond better when 
the CLI or even `git` itself performs an action. This approach might 
however need a bit more finessing.
The issue we are seeing here is that adding a new references doesn't 
change any existing references, which means we then don't reflect the 
change in the frontend.
It seems like there are still some "old" style invalidations in the 
frontend, so for now I'm going to add back in the particular 
invalidation that is now missing & causing the problem.