### PR TITLE
Add --version flag support for but CLI

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
-#[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("GIX_VERSION"))]
+#[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("VERSION").unwrap_or("dev"))]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
     #[clap(short = 't', long, action = clap::ArgAction::Count, hide = true, env = "BUT_TRACE")]

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -48,6 +48,13 @@ type LegacyProject = gitbutler_project::Project;
 pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let args: Vec<_> = args.collect();
 
+    // Check if version is requested
+    if args.iter().any(|arg| arg == "--version" || arg == "-V") {
+        let version = option_env!("VERSION").unwrap_or("dev");
+        println!("but {}", version);
+        return Ok(());
+    }
+
     // Check if help is requested with no subcommand
     if args.len() == 1 || args.iter().any(|arg| arg == "--help" || arg == "-h") && args.len() == 2 {
         let mut out = OutputChannel::new_with_pager(OutputFormat::Human);


### PR DESCRIPTION
Support printing the CLI version when invoked with --version or -V. The 
clap derive was updated to pull the version from the VERSION environment
variable (falling back to "dev"), and handle_args now intercepts 
explicit --version/-V invocations to print "but <version>" and exit 
early. This makes the behavior consistent with the existing pattern used
elsewhere for embedding the build-time version.