### PR TITLE
Avoid infinite loop by tracking previous head

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -206,9 +206,14 @@
 	const head = $derived(headResponse.response);
 
 	// If the head changes, invalidate stacks and details
+	// We need to track the previous head value to avoid infinite loops
+	let previousHead = $state<string | undefined>(undefined);
 	$effect(() => {
-		if (head) {
-			stackService.invalidateStacksAndDetails();
+		if (head && head !== previousHead) {
+			untrack(() => {
+				previousHead = head;
+				stackService.invalidateStacksAndDetails();
+			});
 		}
 	});
 


### PR DESCRIPTION
Prevent infinite reactivity loops by storing the previous head value and
only invalidating stacks and details when the head actually changes. The
change introduces a previousHead state variable and uses untrack to 
update it and call stackService.invalidateStacksAndDetails() only when 
head differs from previousHead.