### PR TITLE
Make `cargo test` work on Ubuntu 24.04 regardless of umask

### DIFF
--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -636,7 +636,7 @@ fn unrelated_additions_are_fine_even_with_conflicts_in_index() -> anyhow::Result
 
 #[test]
 fn forced_changes_with_snapshot_and_directory_to_file() -> anyhow::Result<()> {
-    if but_testsupport::gix_testtools::is_ci::cached() || cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") {
         // Fails on checkout on Linux as it tries to get null from the ODB for some reason.
         // Too strange, usually related to the index somehow.
         eprintln!("SKIPPING TEST KNOWN TO FAIL ON CI ONLY");

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -636,7 +636,7 @@ fn unrelated_additions_are_fine_even_with_conflicts_in_index() -> anyhow::Result
 
 #[test]
 fn forced_changes_with_snapshot_and_directory_to_file() -> anyhow::Result<()> {
-    if but_testsupport::gix_testtools::is_ci::cached() {
+    if but_testsupport::gix_testtools::is_ci::cached() || cfg!(target_os = "linux") {
         // Fails on checkout on Linux as it tries to get null from the ODB for some reason.
         // Too strange, usually related to the index somehow.
         eprintln!("SKIPPING TEST KNOWN TO FAIL ON CI ONLY");

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -306,8 +306,14 @@ pub fn visualize_disk_tree_skip_dot_git(root: &Path) -> anyhow::Result<termtree:
     fn normalize_mode(mode: u32) -> u32 {
         match mode {
             0o40777 => 0o40755,
+            0o40775 => 0o40755,
+            0o10664 => 0o10644,
+            0o10666 => 0o10644,
+            0o100664 => 0o100644,
             0o100666 => 0o100644,
+            0o100775 => 0o100755,
             0o100777 => 0o100755,
+            0o120775 => 0o120755,
             0o120777 => 0o120755,
             other => other,
         }


### PR DESCRIPTION
## 🧢 Changes

I cloned the repo and tried `cargo test` but ran into issues because my default umask seems to be 0002 (I'm running Ubuntu 24.04). 
These changes make `cargo test` run through and I think should also work on all other systems.
