### PR TITLE
Clarifying `assignments_with_fallback`

### DIFF
--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -275,7 +275,7 @@ pub fn assign(
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
         true,
-    )?;
+    );
 
     // Reconcile with the requested changes
     let with_requests = reconcile::assignments(
@@ -284,7 +284,7 @@ pub fn assign(
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
         true,
-    )?;
+    );
 
     // Reconcile with hunk locks
     let lock_assignments = hunk_dependency_assignments(deps)?;
@@ -294,7 +294,7 @@ pub fn assign(
         &applied_stacks,
         MultipleOverlapping::SetNone,
         false,
-    )?;
+    );
 
     state::set_assignments(db, with_locks.clone())?;
 
@@ -410,7 +410,7 @@ fn reconcile_with_worktree_and_locks(
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
         true,
-    )?;
+    );
 
     let lock_assignments = hunk_dependency_assignments(deps)?;
     let with_locks = reconcile::assignments(
@@ -419,7 +419,7 @@ fn reconcile_with_worktree_and_locks(
         &applied_stacks,
         MultipleOverlapping::SetNone,
         set_assignment_from_locks,
-    )?;
+    );
 
     Ok(with_locks)
 }
@@ -718,8 +718,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
         assert_eq(
             result,
             vec![
@@ -740,8 +739,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
         assert_eq(
             result,
             vec![HunkAssignment::new("foo.rs", 10, 5, None, Some(1))],
@@ -759,8 +757,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
         assert_eq(
             result,
             vec![HunkAssignment::new("foo.rs", 12, 7, Some(1), Some(1))],
@@ -781,8 +778,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
         assert_eq(
             result,
             vec![HunkAssignment::new("foo.rs", 5, 18, Some(2), Some(2))],
@@ -803,8 +799,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetNone,
             true,
-        )
-        .unwrap();
+        );
         assert_eq(
             result,
             vec![HunkAssignment::new("foo.rs", 5, 18, None, Some(2))],
@@ -822,8 +817,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             false,
-        )
-        .unwrap();
+        );
         // TODO: This is actually broken
         assert_eq!(
             result,
@@ -987,8 +981,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
 
         // Binary file should maintain its stack assignment
         assert_eq!(
@@ -1032,8 +1025,7 @@ mod tests {
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
             true,
-        )
-        .unwrap();
+        );
 
         assert_eq!(
             result[0].stack_id,

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -287,7 +287,7 @@ pub fn assign(
     );
 
     // Reconcile with hunk locks
-    let lock_assignments = hunk_dependency_assignments(deps)?;
+    let lock_assignments = hunk_dependency_assignments(deps);
     let with_locks = reconcile::assignments(
         &with_requests,
         &lock_assignments,
@@ -412,7 +412,7 @@ fn reconcile_with_worktree_and_locks(
         true,
     );
 
-    let lock_assignments = hunk_dependency_assignments(deps)?;
+    let lock_assignments = hunk_dependency_assignments(deps);
     let with_locks = reconcile::assignments(
         &with_worktree,
         &lock_assignments,
@@ -424,7 +424,7 @@ fn reconcile_with_worktree_and_locks(
     Ok(with_locks)
 }
 
-fn hunk_dependency_assignments(deps: &HunkDependencies) -> Result<Vec<HunkAssignment>> {
+fn hunk_dependency_assignments(deps: &HunkDependencies) -> Vec<HunkAssignment> {
     let mut assignments = vec![];
     for (path, hunk, locks) in &deps.diffs {
         // If there are locks towards more than one stack, this means double locking and the assignment None - the user can resolve this by partial committing.
@@ -451,7 +451,7 @@ fn hunk_dependency_assignments(deps: &HunkDependencies) -> Result<Vec<HunkAssign
         };
         assignments.push(assignment);
     }
-    Ok(assignments)
+    assignments
 }
 
 /// This also generates a UUID for the assignment

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-use anyhow::Result;
 use but_core::ref_metadata::StackId;
 use itertools::Itertools;
 
@@ -57,7 +56,7 @@ pub(crate) fn assignments(
     applied_stack_ids: &[StackId],
     multiple_overlapping_resolution: MultipleOverlapping,
     update_unassigned: bool,
-) -> Result<Vec<HunkAssignment>> {
+) -> Vec<HunkAssignment> {
     let mut reconciled = vec![];
     for new_assignment in new {
         let mut new_assignment = new_assignment.clone();
@@ -93,5 +92,5 @@ pub(crate) fn assignments(
         }
         reconciled.push(new_assignment);
     }
-    Ok(reconciled)
+    reconciled
 }


### PR DESCRIPTION
I was investigating reducing legacy code in "status" and came across `changes_in_worktree`  in `crates/but-api/src/legacy/diff.rs`, which uses this function. There were some error cases that I didn't fully understand, so I made some refactorings that show how my understanding of the situation (and my understanding may be wrong or incomplete).

In particular, I don't think that the fallback in `assignments_with_fallback` is necessary. But if it is necessary, we shouldn't have `anyhow::Error` twice in the return type, but have an enum as the inner type (so, `Result<(Vec<HunkAssignment>, Option<AssignmentError>)>`) so that callers can know exactly the cases in which we fallback (I didn't do that in this PR).

PTAL - the first 2 commits can be merged as-is, but the 3rd commit (but-hunk-assignment: clarify return value of assignments_with_fallback) has an open question.