### PR TITLE
fix(ui): default skeleton opacity and reduce animation peak

### DIFF
--- a/packages/ui/src/lib/components/SkeletonBone.svelte
+++ b/packages/ui/src/lib/components/SkeletonBone.svelte
@@ -12,7 +12,7 @@
 		height = '1rem',
 		radius = 'var(--radius-ml)',
 		color = 'var(--clr-scale-ntrl-70)',
-		opacity = 0.2
+		opacity = 0.35
 	}: Props = $props();
 </script>
 
@@ -35,7 +35,7 @@
 			opacity: var(--opacity-value);
 		}
 		100% {
-			opacity: calc(var(--opacity-value) + var(--opacity-value) * 0.7);
+			opacity: calc(var(--opacity-value) + var(--opacity-value) * 0.5);
 		}
 	}
 </style>


### PR DESCRIPTION
This pull request makes minor adjustments to the appearance of the `SkeletonBone` component, specifically tuning its opacity levels for a more balanced visual effect.

- Visual adjustments to opacity:
  * Increased the base opacity of the skeleton bone from 0.2 to 0.35 for improved visibility.
  * Reduced the maximum opacity in the animation from a 70% increase to a 50% increase, resulting in a subtler shimmer effect.