### PR TITLE
UI fixes. Missing styles for the "System" message type. Textarea overflow

### DIFF
--- a/apps/desktop/src/components/DialogBubble.svelte
+++ b/apps/desktop/src/components/DialogBubble.svelte
@@ -93,7 +93,6 @@
 	.bubble {
 		width: 100%;
 		max-width: 90%;
-		/* overflow: hidden; */
 	}
 
 	.bubble-wrap_user {
@@ -119,8 +118,6 @@
 		align-items: center;
 		padding: 12px;
 		gap: 8px;
-		/* border: 1px solid var(--clr-border-2); */
-
 		border-bottom: none;
 		border-radius: var(--radius-l) var(--radius-l) 0 0;
 	}
@@ -129,8 +126,6 @@
 		padding: 12px;
 		overflow-x: auto;
 		border-top: 1px solid var(--clr-border-2);
-		/* border: 1px solid var(--clr-border-2); */
-
 		border-radius: 0 0 var(--radius-l) var(--radius-l);
 		color: var(--clr-text-1);
 	}
@@ -145,6 +140,7 @@
 
 	.textarea {
 		width: 100%;
+		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
 		border-radius: 0 0 var(--radius-l) var(--radius-l);
 		background-color: var(--clr-bg-1);

--- a/apps/desktop/src/components/DialogBubble.svelte
+++ b/apps/desktop/src/components/DialogBubble.svelte
@@ -31,13 +31,16 @@
 	class="bubble-wrap"
 	class:editing
 	class:bubble-wrap_user={role === MessageRole.User}
-	class:bubble-wrap_assistant={role === MessageRole.Assistant}
+	class:bubble-wrap_assistant={role === MessageRole.Assistant || role === MessageRole.System}
 >
 	<div class="bubble">
 		<div class="bubble__header text-13 text-bold">
 			{#if role === MessageRole.User}
 				<Icon name="profile" />
 				<span>User</span>
+			{:else if role === MessageRole.System}
+				<Icon name="robot" />
+				<span>System</span>
 			{:else}
 				<Icon name="robot" />
 				<span>Assistant</span>


### PR DESCRIPTION
This addresses https://github.com/gitbutlerapp/gitbutler/pull/11370#event-21198538473

---

This pull request updates the `DialogBubble.svelte` component to better support and visually distinguish system messages, while also making minor style cleanups.

**Support for system messages:**
* The `bubble-wrap_assistant` class is now applied to both assistant and system messages, ensuring consistent styling for these roles.
* The header now displays a robot icon and "System" label for system messages, making them visually distinct from user and assistant messages.

**Style and code cleanups:**
* Removed commented-out CSS related to borders and overflow for a cleaner codebase. [[1]](diffhunk://#diff-be1d2cdb640fa0562f0490de0aabc3827313ced27005c39303d6992be7cd2c91L96) [[2]](diffhunk://#diff-be1d2cdb640fa0562f0490de0aabc3827313ced27005c39303d6992be7cd2c91L122-L123) [[3]](diffhunk://#diff-be1d2cdb640fa0562f0490de0aabc3827313ced27005c39303d6992be7cd2c91L132-L133)
* Added `overflow: hidden` to the `.textarea` class to prevent `textarea` borders from spilling out.