### PR TITLE
Revert "Add custom PR message prompt support for concistency" - didn't work properly

### DIFF
--- a/apps/desktop/src/components/AIPromptEdit.svelte
+++ b/apps/desktop/src/components/AIPromptEdit.svelte
@@ -7,7 +7,7 @@
 	import type { Prompts, UserPrompt } from '$lib/ai/types';
 
 	interface Props {
-		promptUse: 'commits' | 'branches' | 'pullRequests';
+		promptUse: 'commits' | 'branches';
 	}
 
 	const { promptUse }: Props = $props();
@@ -18,10 +18,8 @@
 
 	if (promptUse === 'commits') {
 		prompts = promptService.commitPrompts;
-	} else if (promptUse === 'branches') {
-		prompts = promptService.branchPrompts;
 	} else {
-		prompts = promptService.prPrompts;
+		prompts = promptService.branchPrompts;
 	}
 
 	const userPrompts = $derived(prompts.userPrompts);
@@ -44,11 +42,7 @@
 {#if prompts && $userPrompts}
 	<div class="prompt-item__title">
 		<h3 class="text-15 text-bold">
-			{promptUse === 'commits'
-				? 'Commit message'
-				: promptUse === 'branches'
-					? 'Branch name'
-					: 'PR message'}
+			{promptUse === 'commits' ? 'Commit message' : 'Branch name'}
 		</h3>
 		<Button kind="outline" icon="plus-small" onclick={createNewPrompt}>New prompt</Button>
 	</div>

--- a/apps/desktop/src/components/AIPromptSelect.svelte
+++ b/apps/desktop/src/components/AIPromptSelect.svelte
@@ -8,7 +8,7 @@
 
 	type Props = {
 		projectId: string;
-		promptUse: 'commits' | 'branches' | 'pullRequests';
+		promptUse: 'commits' | 'branches';
 	};
 
 	const { projectId, promptUse }: Props = $props();
@@ -21,12 +21,9 @@
 	if (promptUse === 'commits') {
 		prompts = promptService.commitPrompts;
 		selectedPromptId = promptService.selectedCommitPromptId(projectId);
-	} else if (promptUse === 'branches') {
+	} else {
 		prompts = promptService.branchPrompts;
 		selectedPromptId = promptService.selectedBranchPromptId(projectId);
-	} else {
-		prompts = promptService.prPrompts;
-		selectedPromptId = promptService.selectedPrPromptId(projectId);
 	}
 
 	let userPrompts = prompts.userPrompts;
@@ -55,11 +52,7 @@
 <Select
 	value={$selectedPromptId}
 	options={allPrompts.map((p) => ({ label: p.name, value: p.id }))}
-	label={promptUse === 'commits'
-		? 'Commit message'
-		: promptUse === 'branches'
-			? 'Branch name'
-			: 'PR message'}
+	label={promptUse === 'commits' ? 'Commit message' : 'Branch name'}
 	wide={true}
 	searchable
 	disabled={allPrompts.length === 1}

--- a/apps/desktop/src/components/CloudForm.svelte
+++ b/apps/desktop/src/components/CloudForm.svelte
@@ -81,7 +81,6 @@
 
 		<AiPromptSelect {projectId} promptUse="commits" />
 		<AiPromptSelect {projectId} promptUse="branches" />
-		<AiPromptSelect {projectId} promptUse="pullRequests" />
 
 		<Spacer margin={8} />
 

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -13,7 +13,6 @@
 	import PrTemplateSection from '$components/PrTemplateSection.svelte';
 	import MessageEditor from '$components/editor/MessageEditor.svelte';
 	import MessageEditorInput from '$components/editor/MessageEditorInput.svelte';
-	import { PROMPT_SERVICE } from '$lib/ai/promptService';
 	import { AI_SERVICE } from '$lib/ai/service';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { type Commit } from '$lib/branches/v3';
@@ -60,7 +59,6 @@
 	const prService = $derived(forge.current.prService);
 	const stackService = inject(STACK_SERVICE);
 	const aiService = inject(AI_SERVICE);
-	const promptService = inject(PROMPT_SERVICE);
 	const remotesService = inject(REMOTES_SERVICE);
 	const uiState = inject(UI_STATE);
 	const settingsService = inject(SETTINGS_SERVICE);
@@ -354,13 +352,11 @@
 		let firstToken = true;
 
 		try {
-			const prTemplate = promptService.selectedPrPrompt(projectId);
 			const description = await aiService?.describePR({
 				title: $prTitle,
 				body: $prBody,
 				commitMessages: commits.map((c) => c.message),
 				prBodyTemplate: prBody.default,
-				prTemplate,
 				onToken: (token) => {
 					if (firstToken) {
 						prBody.reset();

--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -463,16 +463,14 @@
 		Custom AI prompts
 	{/snippet}
 	{#snippet description()}
-		GitButler's AI assistant generates commit messages, branch names, and PR messages. Use default
-		prompts or create your own. Assign prompts in the project settings.
+		GitButler's AI assistant generates commit messages and branch names. Use default prompts or
+		create your own. Assign prompts in the project settings.
 	{/snippet}
 
 	<div class="prompt-groups">
 		<AIPromptEdit promptUse="commits" />
 		<Spacer margin={12} />
 		<AIPromptEdit promptUse="branches" />
-		<Spacer margin={12} />
-		<AIPromptEdit promptUse="pullRequests" />
 	</div>
 </Section>
 

--- a/apps/desktop/src/lib/ai/promptService.ts
+++ b/apps/desktop/src/lib/ai/promptService.ts
@@ -2,8 +2,7 @@ import {
 	LONG_DEFAULT_BRANCH_TEMPLATE,
 	SHORT_DEFAULT_BRANCH_TEMPLATE,
 	LONG_DEFAULT_COMMIT_TEMPLATE,
-	SHORT_DEFAULT_COMMIT_TEMPLATE,
-	SHORT_DEFAULT_PR_TEMPLATE
+	SHORT_DEFAULT_COMMIT_TEMPLATE
 } from '$lib/ai/prompts';
 import { InjectionToken } from '@gitbutler/core/context';
 import { persisted, type Persisted } from '@gitbutler/shared/persisted';
@@ -12,8 +11,7 @@ import type { Prompt, Prompts, UserPrompt } from '$lib/ai/types';
 
 enum PromptPersistedKey {
 	Branch = 'aiBranchPrompts',
-	Commit = 'aiCommitPrompts',
-	PullRequest = 'aiPullRequestPrompts'
+	Commit = 'aiCommitPrompts'
 }
 
 export const PROMPT_SERVICE = new InjectionToken<PromptService>('PromptService');
@@ -30,13 +28,6 @@ export class PromptService {
 		return {
 			defaultPrompt: LONG_DEFAULT_COMMIT_TEMPLATE,
 			userPrompts: persisted<UserPrompt[]>([], PromptPersistedKey.Commit)
-		};
-	}
-
-	get prPrompts(): Prompts {
-		return {
-			defaultPrompt: SHORT_DEFAULT_PR_TEMPLATE,
-			userPrompts: persisted<UserPrompt[]>([], PromptPersistedKey.PullRequest)
 		};
 	}
 
@@ -62,21 +53,6 @@ export class PromptService {
 		if (!id) return;
 
 		return this.findPrompt(get(this.commitPrompts.userPrompts), id);
-	}
-
-	selectedPrPromptId(projectId: string): Persisted<string | undefined> {
-		return persisted<string | undefined>(
-			undefined,
-			`${PromptPersistedKey.PullRequest}-${projectId}`
-		);
-	}
-
-	selectedPrPrompt(projectId: string): Prompt | undefined {
-		const id = get(this.selectedPrPromptId(projectId));
-
-		if (!id) return;
-
-		return this.findPrompt(get(this.prPrompts.userPrompts), id);
 	}
 
 	findPrompt(prompts: UserPrompt[], promptId: string) {
@@ -113,16 +89,11 @@ export class PromptService {
 		return false;
 	}
 
-	createDefaultUserPrompt(type: 'commits' | 'branches' | 'pullRequests'): UserPrompt {
+	createDefaultUserPrompt(type: 'commits' | 'branches'): UserPrompt {
 		return {
 			id: crypto.randomUUID(),
 			name: 'My prompt',
-			prompt:
-				type === 'branches'
-					? SHORT_DEFAULT_BRANCH_TEMPLATE
-					: type === 'commits'
-						? SHORT_DEFAULT_COMMIT_TEMPLATE
-						: SHORT_DEFAULT_PR_TEMPLATE
+			prompt: type === 'branches' ? SHORT_DEFAULT_BRANCH_TEMPLATE : SHORT_DEFAULT_COMMIT_TEMPLATE
 		};
 	}
 }


### PR DESCRIPTION
This reverts commit 52c34ac86347f8fda613b7db4a76aa58662bd5eb.

See https://github.com/gitbutlerapp/gitbutler/pull/11370#issuecomment-3583299801 for more information.

Also when testing it in the nightly, it didn't do anything anymore. Very strange.

It's also notable how I made assumptions about: "I can edit the first bubble, and it picks up, so it works",
even though the second bubble can't be edited.
Also, now it doesn't seem to pickup anymore.
