### PR TITLE
Make timeAgo tests locale-independent

### DIFF
--- a/packages/ui/src/lib/utils/timeAgo.test.ts
+++ b/packages/ui/src/lib/utils/timeAgo.test.ts
@@ -79,13 +79,13 @@ describe.concurrent('timeAgo', () => {
 describe.concurrent('getAbsoluteTimestamp', () => {
 	it('should format a date correctly', () => {
 		const date = new Date('2024-01-15T15:45:30.000Z');
-		const result = getAbsoluteTimestamp(date);
+		const result = getAbsoluteTimestamp(date, 'en-US');
 		expect(result).toMatch(/January 15, 2024 at \d{1,2}:\d{2} [AP]M/);
 	});
 
 	it('should format a timestamp correctly', () => {
 		const timestamp = new Date('2024-12-25T09:30:00.000Z').getTime();
-		const result = getAbsoluteTimestamp(timestamp);
+		const result = getAbsoluteTimestamp(timestamp, 'en-US');
 		expect(result).toMatch(/December 25, 2024 at \d{1,2}:\d{2} [AP]M/);
 	});
 
@@ -93,8 +93,8 @@ describe.concurrent('getAbsoluteTimestamp', () => {
 		const morningDate = new Date('2024-03-10T08:15:00.000Z');
 		const eveningDate = new Date('2024-03-10T20:30:00.000Z');
 
-		const morningResult = getAbsoluteTimestamp(morningDate);
-		const eveningResult = getAbsoluteTimestamp(eveningDate);
+		const morningResult = getAbsoluteTimestamp(morningDate, 'en-US');
+		const eveningResult = getAbsoluteTimestamp(eveningDate, 'en-US');
 
 		expect(morningResult).toMatch(/March 10, 2024 at \d{1,2}:\d{2} [AP]M/);
 		expect(eveningResult).toMatch(/March 10, 2024 at \d{1,2}:\d{2} [AP]M/);

--- a/packages/ui/src/lib/utils/timeAgo.ts
+++ b/packages/ui/src/lib/utils/timeAgo.ts
@@ -84,17 +84,17 @@ export function createTimeAgoStore(
  * Formats a date into an absolute timestamp using browser locale
  * Example: "January 15, 2024 at 3:45 PM" (US) or "15 January 2024 at 15:45" (UK)
  */
-export function getAbsoluteTimestamp(input: Date | number | undefined): string {
+export function getAbsoluteTimestamp(input: Date | number | undefined, locale?: string): string {
 	if (!input) return '';
 	const date = typeof input === 'number' ? new Date(input) : input;
 
-	// Format the date and time using browser locale
-	const dateStr = date.toLocaleDateString(undefined, {
+	// Format the date and time using specified locale or browser locale
+	const dateStr = date.toLocaleDateString(locale, {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric'
 	});
-	const timeStr = date.toLocaleTimeString(undefined, {
+	const timeStr = date.toLocaleTimeString(locale, {
 		hour: '2-digit',
 		minute: '2-digit'
 	});


### PR DESCRIPTION
Add an optional locale parameter to getAbsoluteTimestamp and update
tests to pass 'en-US' explicitly.