### PR TITLE
Use VirtualList for commits and file list

### DIFF
--- a/apps/desktop/src/components/CommitRow.svelte
+++ b/apps/desktop/src/components/CommitRow.svelte
@@ -201,7 +201,8 @@
 		overflow: hidden;
 		outline: none;
 		background-color: var(--clr-bg-1);
-		transition: background-color var(--transition-fast);
+		/* Incompatible with virtual scroll, scroll thumb becomes laggy. */
+		/* transition: background-color var(--transition-fast); */
 
 		&:hover,
 		&.menu-shown {

--- a/apps/desktop/src/components/ConfigurableVirtualList.svelte
+++ b/apps/desktop/src/components/ConfigurableVirtualList.svelte
@@ -1,0 +1,63 @@
+<script lang="ts" module>
+	type T = unknown;
+</script>
+
+<script lang="ts" generics="T">
+	import { SETTINGS } from '$lib/settings/userSettings';
+	import { inject } from '@gitbutler/core/context';
+	import { VirtualList } from '@gitbutler/ui';
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		items: Array<T>;
+		children?: Snippet<[]>;
+		chunkTemplate: Snippet<[T[]]>;
+		batchSize: number;
+		onloadmore?: () => Promise<void>;
+		grow?: boolean;
+		stickToBottom?: boolean;
+		defaultHeight: number;
+		padding?: {
+			left?: number;
+			right?: number;
+			top?: number;
+			bottom?: number;
+		};
+	};
+
+	const {
+		items,
+		children,
+		chunkTemplate,
+		batchSize,
+		onloadmore,
+		grow,
+		padding,
+		defaultHeight,
+		stickToBottom = false
+	}: Props = $props();
+
+	const userSettings = inject(SETTINGS);
+	let virtualList: VirtualList<T>;
+
+	// Export method to scroll to bottom
+	export function scrollToBottom() {
+		if (virtualList?.scrollToBottom) {
+			virtualList.scrollToBottom();
+		}
+	}
+</script>
+
+<VirtualList
+	bind:this={virtualList}
+	{items}
+	{batchSize}
+	{defaultHeight}
+	visibility={$userSettings.scrollbarVisibilityState}
+	{grow}
+	{stickToBottom}
+	{onloadmore}
+	{padding}
+	{chunkTemplate}
+	{children}
+/>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -53,6 +53,7 @@ export { default as TimeAgo } from '$components/TimeAgo.svelte';
 export { default as Timestamp } from '$components/Timestamp.svelte';
 export { default as Toggle } from '$components/Toggle.svelte';
 export { default as Tooltip } from '$components/Tooltip.svelte';
+export { default as VirtualList } from '$components/VirtualList.svelte';
 
 // ChipToast Components
 export { default as ChipToast } from '$components/chipToast/ChipToast.svelte';


### PR DESCRIPTION
Replace manual iteration with VirtualList in BranchCommitList and
FileList to improve performance with large lists. Create
ConfigurableVirtualList wrapper that applies user's scrollbar
visibility preference. Implement tree flattening for virtual scrolling
in tree mode with expand/collapse support.

- Add ConfigurableVirtualList component wrapping VirtualList with user
  settings
- Add flattenTree() to convert tree structure to flat list for virtual
  rendering
- Add max-height constraint to commit list container
- Remove transition from CommitRow to prevent scroll performance issues