### PR TITLE
Simplify 'check' task in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,9 +22,7 @@
 			"cache": false,
 			"persistent": true
 		},
-		"check": {
-			"dependsOn": ["package"]
-		},
+		"check": {},
 		"playwright:install": {},
 		"test": {
 			"dependsOn": ["package", "playwright:install"]


### PR DESCRIPTION
Remove the unnecessary dependsOn configuration for the "check" task in turbo.json. The task had a dependency on "package" which is not required, so this change cleans up the task definition by making it an empty object, aligning it with other simple tasks and avoiding unintended task ordering or execution.

Your changes are safe for CI - the workflow builds all necessary packages and generates type definitions before running pnpm check , so removing the package dependency from the check task won't break the build.