### PR TITLE
Don't run TS checks if rust has changed

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -83,7 +83,7 @@ jobs:
 
   lint-node:
     needs: changes
-    if: ${{ needs.changes.outputs.node == 'true' || needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.node == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -94,7 +94,7 @@ jobs:
 
   check-node:
     needs: changes
-    if: ${{ needs.changes.outputs.node == 'true' || needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.node == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `generate-ts-definitions` action will flag any changes from the rust
side that might effect typescript, and then the TS can be chagned 
locally.