### PR TITLE
Add tests for single-branch `but branch apply`

### DIFF
--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -262,8 +262,13 @@ impl Graph {
         static SUFFIX: AtomicUsize = AtomicUsize::new(0);
         let suffix = SUFFIX.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let svg_name = format!("debug-graph-{suffix:02}.svg");
+        let svg_path = std::env::var_os("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_default()
+            .join(svg_name);
         let mut dot = std::process::Command::new("dot")
-            .args(["-Tsvg", "-o", &svg_name])
+            .args(["-Tsvg", "-o"])
+            .arg(&svg_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -284,11 +289,12 @@ impl Graph {
 
         assert!(
             std::process::Command::new("open")
-                .arg(&svg_name)
+                .arg(&svg_path)
                 .status()
                 .unwrap()
                 .success(),
-            "Opening of {svg_name} failed"
+            "Opening of {svg_path} failed",
+            svg_path = svg_path.display()
         );
     }
 

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -358,7 +358,8 @@ impl Graph {
         let tip_is_not_workspace_commit = !workspaces
             .iter()
             .any(|(_, wsrn, _)| Some(wsrn) == ref_name.as_ref());
-        let worktree_by_branch = worktree_branches(repo.for_worktree_only())?;
+        let worktree_by_branch =
+            repo.worktree_branches(graph.entrypoint_ref.as_ref().map(|r| r.as_ref()))?;
 
         let mut ctx = post::Context {
             repo,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -854,7 +854,7 @@ impl Graph {
                 .flat_map(|s| s.commits_by_segment.iter().map(|(sidx, _)| *sidx))
         }) {
             // The workspace might be stale by now as we delete empty segments.
-            // Thus be careful, and ignore non-existing ones - after all our workspace
+            // Thus, be careful, and ignore non-existing ones - after all our workspace
             // is temporary, nothing to worry about.
             let Some(s) = self.inner.node_weight(sidx) else {
                 continue;

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -237,7 +237,8 @@ pub struct Graph {
     hard_limit_hit: bool,
     /// The options used to create the graph, which allows it to regenerate itself after something
     /// possibly changed. This can also be used to simulate changes by injecting would-be information.
-    options: init::Options,
+    /// Public to be able to change it before calling [Graph::redo_traversal_with_overlay()].
+    pub options: init::Options,
 }
 
 /// A resolved entry point into the graph for easy access to the segment, commit,

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -95,7 +95,10 @@ impl Stack {
 
 impl Stack {
     /// A one-line string representing the stack itself, without its contents.
-    pub fn debug_string(&self) -> String {
+    ///
+    /// Use `id_override` to have it use this (usually controlled) id instead of what otherwise
+    /// would be a generated one.
+    pub fn debug_string(&self, id_override: Option<StackId>) -> String {
         let mut dbg = self
             .segments
             .first()
@@ -105,7 +108,7 @@ impl Stack {
             dbg.push_str(&base.to_hex_with_len(7).to_string());
         }
         dbg.insert(0, '≡');
-        if let Some(id) = self.id {
+        if let Some(id) = id_override.or(self.id) {
             let id_string = id.to_string().replace("0", "").replace("-", "");
             dbg.push_str(&format!(
                 " {{{}}}",
@@ -122,7 +125,7 @@ impl Stack {
 
 impl std::fmt::Debug for Stack {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut s = f.debug_struct(&format!("Stack({})", self.debug_string()));
+        let mut s = f.debug_struct(&format!("Stack({})", self.debug_string(None)));
         s.field("segments", &self.segments);
         if let Some(stack_id) = self.id {
             s.field("id", &stack_id);

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -263,14 +263,14 @@ impl std::fmt::Debug for Segment {
                 sibling_segment_id,
                 metadata,
             } = self;
-            f.debug_struct("StackSegment")
+            f.debug_struct("Segment")
                 .field("id", id)
                 .field("generation", generation)
                 .field(
-                    "ref_name",
+                    "ref_info",
                     &match ref_info.as_ref() {
                         None => "None".to_string(),
-                        Some(name) => name.debug_string(),
+                        Some(info) => info.debug_string(),
                     },
                 )
                 .field(

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -14,10 +14,10 @@ fn unborn() -> anyhow::Result<()> {
             node_count: 1,
             edge_count: 0,
             node weights: {
-                0: StackSegment {
+                0: Segment {
                     id: NodeIndex(0),
                     generation: 0,
-                    ref_name: "►main[🌳]",
+                    ref_info: "►main[🌳]",
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [],
@@ -89,10 +89,10 @@ fn detached() -> anyhow::Result<()> {
             edge_count: 1,
             edges: (0, 1),
             node weights: {
-                0: StackSegment {
+                0: Segment {
                     id: NodeIndex(0),
                     generation: 0,
-                    ref_name: "None",
+                    ref_info: "None",
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [
@@ -100,10 +100,10 @@ fn detached() -> anyhow::Result<()> {
                     ],
                     metadata: "None",
                 },
-                1: StackSegment {
+                1: Segment {
                     id: NodeIndex(1),
                     generation: 1,
-                    ref_name: "►other",
+                    ref_info: "►other",
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -55,6 +55,9 @@ impl Snapshot {
             if self.content == Default::default() {
                 std::fs::remove_file(&self.path)?;
             } else {
+                if let Some(dir) = self.path.parent() {
+                    std::fs::create_dir_all(dir)?;
+                }
                 fs::write(
                     &self.path,
                     toml::to_string(&self.to_consistent_data(reconcile))?,

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -592,8 +592,7 @@ pub fn debug_str(input: &dyn std::fmt::Debug) -> String {
 }
 
 mod graph;
-
-pub use graph::{graph_tree, graph_workspace};
+pub use graph::{graph_tree, graph_workspace, graph_workspace_determinisitcally};
 
 mod prepare_cmd_env;
 pub use prepare_cmd_env::isolate_env_std_cmd;

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -388,9 +388,11 @@ pub(crate) mod function {
             .redo_traversal_with_overlay(repo, meta, overlay.clone())?;
 
         let workspace = graph.to_workspace()?;
-        let all_applied_branches_are_already_visible = branches_to_apply
-            .iter()
-            .all(|rn| workspace.refname_is_segment(rn));
+        let all_applied_branches_are_already_visible = branches_to_apply.iter().all(|rn| {
+            workspace
+                .find_segment_and_stack_by_refname(rn)
+                .is_some_and(|(_stack, segment)| !segment.is_projected_from_outside(&graph))
+        });
         let needs_ws_ref_creation = !ws_ref_exists;
         let local_tracking_config_and_ref_info = local_tracking_config_and_ref_info.zip(
             commit_to_create_branch_at.map(|commit| (branch, branch_orig, commit.attach(repo))),

--- a/crates/but-workspace/tests/fixtures/scenario/one-fork.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/one-fork.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A pushed main branch with two forked-off feature branches with the same base. One of these branches is a remote tracking branch.
+git init
+commit-file init
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit-file A
+git checkout B
+  commit-file B
+git checkout main
+  commit M
+
+setup_remote_tracking B B "move"
+echo 'ref: refs/remotes/origin/main' > .git/refs/remotes/origin/HEAD

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -1,10 +1,29 @@
 //! Tests for various nice user-journeys, from different starting points, performing multiple common steps in sequence.
-use snapbox::{file, str};
+use crate::utils::Sandbox;
+use snapbox::str;
 
-use crate::utils::{Sandbox, setup_metadata};
-
+#[cfg(not(feature = "legacy"))]
 #[test]
-fn from_scratch_needs_work() -> anyhow::Result<()> {
+fn from_unborn() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("unborn")?;
+    insta::assert_snapshot!(env.git_log()?, @r"");
+
+    env.but("branch apply main")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: The reference 'main' did not exist
+
+"#]]);
+
+    // TODO: we should be able to use the CLI to create a commit
+    Ok(())
+}
+
+// TODO: maybe this should be a non-legacy journey only as we start out without workspace?
+#[cfg(feature = "legacy")]
+#[test]
+fn from_empty() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
     env.but("status").assert().failure().stderr_eq(str![[r#"
@@ -94,8 +113,11 @@ Error: workspace at refs/heads/main is missing a base
     Ok(())
 }
 
+#[cfg(feature = "legacy")]
 #[test]
 fn from_workspace() -> anyhow::Result<()> {
+    use crate::utils::setup_metadata;
+    use snapbox::file;
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     insta::assert_snapshot!(env.git_log()?, @r"
     *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit

--- a/crates/but/tests/but/main.rs
+++ b/crates/but/tests/but/main.rs
@@ -2,6 +2,5 @@ mod command;
 // TODO: Id tests can be on integration level, but shouldn't involve the CLI
 #[cfg(feature = "legacy")]
 mod id;
-#[cfg(feature = "legacy")]
 mod journey;
 pub mod utils;

--- a/crates/but/tests/fixtures/scenario/one-fork.sh
+++ b/crates/but/tests/fixtures/scenario/one-fork.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A pushed main branch with two forked-off feature branches with the same base. One of these branches is a remote tracking branch.
+git init
+commit-file init
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit-file A
+git checkout B
+  commit-file B
+git checkout main
+  commit M
+
+setup_remote_tracking B B "move"


### PR DESCRIPTION
These are the things only modern code can do.

While at it, also see what happens if there is no worktree, i.e. as there is a bare repository.

### Tasks

* [x] add single-branch test
* [x] make it work - needs more tests in the actual implementation
* [x] now find a 'simpler'/less invasive way to make this work - should be possible to detect this case, and not consider such stacks when applying (instead of not seeing them).

### Road to modernization

* https://github.com/gitbutlerapp/gitbutler/pull/11433
    - needs api_cmd improvements to auto-gen the tauri version while allowing a non-UI centric but-API implementation.
    - with this existing but-workspace related commands can be modernised

### To distribute to others
* [ ] do the same for new/delete for good measure.
* [ ] maybe port 'show' as well.
* [ ] enable from-scratch journey in single-branch mode?

Follow-up of #11371

