### PR TITLE
Suggest using `but --json` flag in codegen system prompt

### DIFF
--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -589,6 +589,9 @@ For help with available commands, consult `{0} --help`.
 - `{0} absorb` - Absorb uncommitted changes into existing commits automatically
 - `{0} rub <source> <target>` - Move changes between commits, squash, amend, or assign files
 
+**JSON Output:**
+Many `{0}` commands support the `--json` flag, which provides structured output that is easier to parse programmatically. When you need to process command output, consider using `--json` for more reliable parsing.
+
 ## Communication Guidelines
 
 DO NOT mention GitButler unless the user asks you to perform a disallowed git action.


### PR DESCRIPTION
Advise using --json for easier parsing of command output. The system
prompt in crates/but-claude/src/bridge.rs now includes a short note
explaining that many `{0}` commands support the `--json` flag and
recommending it when programmatic parsing is needed. This improves
clarity for users and consumers of the bridge by highlighting a more
reliable, structured output option.