### PR TITLE
Allow inline message for but describe

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -347,3 +347,4 @@ corepack prepare pnpm@10.17.0 --activate
 8. **Test on target platform** if making platform-specific changes
 9. **Security**: Check dependencies for vulnerabilities before adding them
 10. **Code marked for refactoring**: Be extra careful with crates in the "Code Hitlist" section
+11. **but CLI happy path testing only**: CLI tests are expensive and should be limited to what really matters.

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -345,6 +345,9 @@ pub enum Subcommands {
     Describe {
         /// Commit ID to edit the message for, or branch ID to rename
         target: String,
+        /// The new commit message or branch name. If not provided, opens an editor.
+        #[clap(short = 'm', long = "message")]
+        message: Option<String>,
     },
 
     /// Show operation history.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -364,9 +364,9 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Describe { target } => {
+        Subcommands::Describe { target, message } => {
             let project = legacy::get_or_init_non_bare_project(&args)?;
-            command::legacy::describe::describe_target(&project, out, &target)
+            command::legacy::describe::describe_target(&project, out, &target, message.as_deref())
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/describe.rs
+++ b/crates/but/tests/but/command/describe.rs
@@ -1,0 +1,154 @@
+use snapbox::str;
+
+use crate::utils::{Sandbox, setup_metadata};
+
+#[test]
+fn describe_commit_with_message_flag() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Use describe with -m flag to change commit message (using commit ID)
+    env.but("describe 9477ae7 -m 'Updated commit message'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Updated commit message for [..] (now [..])
+
+"#]]);
+
+    // Verify the commit message was updated
+    let log = env.git_log()?;
+    assert!(log.contains("Updated commit message"));
+    assert!(!log.contains("add A"));
+
+    Ok(())
+}
+
+// Note: Branch rename test is omitted because the test scenario uses single-character
+// branch names ("A") which don't meet the 2-character minimum requirement for CLI IDs.
+// The branch rename functionality with -m flag is tested manually and works correctly.
+
+#[test]
+fn describe_with_empty_message_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Try to describe commit with empty message
+    env.but("describe 9477ae7 -m ''")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Aborting due to empty commit message
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn describe_with_whitespace_only_message_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Try to describe commit with whitespace-only message
+    env.but("describe 9477ae7 -m '   '")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Aborting due to empty commit message
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn describe_commit_with_same_message_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Try to describe with the same message
+    env.but("describe 9477ae7 -m 'add A'")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: No changes to commit message.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn describe_nonexistent_target_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Try to describe a nonexistent target
+    env.but("describe nonexistent -m 'new message'")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: ID 'nonexistent' not found
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn describe_commit_with_multiline_message() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Use describe with multiline message
+    env.but("describe 9477ae7 -m 'First line\n\nSecond paragraph with details'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Updated commit message for [..] (now [..])
+
+"#]]);
+
+    // Verify the commit message was updated with multiline content
+    let log = env.git_log()?;
+    assert!(log.contains("First line"));
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/describe.rs
+++ b/crates/but/tests/but/command/describe.rs
@@ -1,6 +1,6 @@
-use snapbox::str;
-
 use crate::utils::{Sandbox, setup_metadata};
+use gitbutler_commit::commit_ext::CommitExt;
+use snapbox::str;
 
 #[test]
 fn describe_commit_with_message_flag() -> anyhow::Result<()> {
@@ -22,106 +22,11 @@ Updated commit message for [..] (now [..])
 
 "#]]);
 
-    // Verify the commit message was updated
-    let log = env.git_log()?;
-    assert!(log.contains("Updated commit message"));
-    assert!(!log.contains("add A"));
-
-    Ok(())
-}
-
-// Note: Branch rename test is omitted because the test scenario uses single-character
-// branch names ("A") which don't meet the 2-character minimum requirement for CLI IDs.
-// The branch rename functionality with -m flag is tested manually and works correctly.
-
-#[test]
-fn describe_with_empty_message_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    * d84f3c4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 2f7c570 (A) Updated commit message
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
-
-    setup_metadata(&env, &["A"])?;
-
-    // Try to describe commit with empty message
-    env.but("describe 9477ae7 -m ''")
-        .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Error: Aborting due to empty commit message
-
-"#]]);
-
-    Ok(())
-}
-
-#[test]
-fn describe_with_whitespace_only_message_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
-    ");
-
-    setup_metadata(&env, &["A"])?;
-
-    // Try to describe commit with whitespace-only message
-    env.but("describe 9477ae7 -m '   '")
-        .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Error: Aborting due to empty commit message
-
-"#]]);
-
-    Ok(())
-}
-
-#[test]
-fn describe_commit_with_same_message_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
-    ");
-
-    setup_metadata(&env, &["A"])?;
-
-    // Try to describe with the same message
-    env.but("describe 9477ae7 -m 'add A'")
-        .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Error: No changes to commit message.
-
-"#]]);
-
-    Ok(())
-}
-
-#[test]
-fn describe_nonexistent_target_fails() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    insta::assert_snapshot!(env.git_log()?, @r"
-    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 9477ae7 (A) add A
-    * 0dc3733 (origin/main, origin/HEAD, main) add M
-    ");
-
-    setup_metadata(&env, &["A"])?;
-
-    // Try to describe a nonexistent target
-    env.but("describe nonexistent -m 'new message'")
-        .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Error: ID 'nonexistent' not found
-
-"#]]);
 
     Ok(())
 }
@@ -138,7 +43,7 @@ fn describe_commit_with_multiline_message() -> anyhow::Result<()> {
     setup_metadata(&env, &["A"])?;
 
     // Use describe with multiline message
-    env.but("describe 9477ae7 -m 'First line\n\nSecond paragraph with details'")
+    env.but("describe 9477ae7 -m 'First line\n\n\tSecond paragraph with details'")
         .assert()
         .success()
         .stdout_eq(str![[r#"
@@ -147,8 +52,47 @@ Updated commit message for [..] (now [..])
 "#]]);
 
     // Verify the commit message was updated with multiline content
-    let log = env.git_log()?;
-    assert!(log.contains("First line"));
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * f2c2b50 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * cdf2c74 (A) First line
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
+
+    let repo = env.open_repo()?;
+    assert_eq!(
+        repo.rev_parse_single(":/First line")?
+            .object()?
+            .into_commit()
+            .message_bstr(),
+        "First line\n\n\tSecond paragraph with details"
+    );
+
+    Ok(())
+}
+
+// Note: Branch rename test is omitted because the test scenario uses single-character
+// branch names ("A") which don't meet the 2-character minimum requirement for CLI IDs.
+// The branch rename functionality with -m flag is tested manually and works correctly.
+
+#[test]
+fn describe_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    setup_metadata(&env, &["A"])?;
+
+    // Try to describe with the same message
+    env.but("describe 9477ae7 -m 'add A'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+No changes to commit message - nothing to be done
+
+"#]]);
 
     Ok(())
 }

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -1,5 +1,6 @@
 //! Put command-specific tests here. They should be focused on what's important for each command.
 //! Ideally they *show* the initial state, and the *post* state, to validate the commands actually do what they claim.
+//! **Only** test the *happy path* of a typical user journey, while keeping details in unit tests with private module access.
 mod branch;
 #[cfg(feature = "legacy")]
 mod commit;

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -3,6 +3,8 @@
 mod branch;
 #[cfg(feature = "legacy")]
 mod commit;
+#[cfg(feature = "legacy")]
+mod describe;
 mod format;
 mod help;
 #[cfg(feature = "legacy")]


### PR DESCRIPTION
Add an optional -m/--message flag to the describe command so users can
supply a new commit message or branch name on the command line instead
of opening an editor. This change threads the optional message through
the describe handlers and uses it to validate and apply the supplied
value, when absent it falls back to the existing editor-based flow.

Add tests for 'but describe' commit message handling.