### PR TITLE
Add PlainTextPaste plugin and enable via prop

### DIFF
--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -146,6 +146,7 @@ export { default as Formatter } from '$lib/richText/plugins/Formatter.svelte';
 export { default as GhostTextPlugin } from '$lib/richText/plugins/GhostText.svelte';
 export { default as HardWrapPlugin } from '$lib/richText/plugins/HardWrapPlugin.svelte';
 export { default as FilePlugin } from '$lib/richText/plugins/FilePlugin.svelte';
+export { default as PlainTextPastePlugin } from '$lib/richText/plugins/PlainTextPastePlugin.svelte';
 export { default as UpDownPlugin } from '$lib/richText/plugins/UpDownPlugin.svelte';
 export {
 	default as Mention,

--- a/packages/ui/src/lib/richText/RichTextEditor.svelte
+++ b/packages/ui/src/lib/richText/RichTextEditor.svelte
@@ -7,6 +7,7 @@
 	// import CodeBlockTypeAhead from '$lib/richText/plugins/CodeBlockTypeAhead.svelte';
 	import EmojiPlugin from '$lib/richText/plugins/Emoji.svelte';
 	import IndentPlugin from '$lib/richText/plugins/IndentPlugin.svelte';
+	import PlainTextPastePlugin from '$lib/richText/plugins/PlainTextPastePlugin.svelte';
 	import OnChangePlugin, { type OnChangeCallback } from '$lib/richText/plugins/onChange.svelte';
 	import OnInput, { type OnInputCallback } from '$lib/richText/plugins/onInput.svelte';
 	import { insertTextAtCaret, setEditorText } from '$lib/richText/selection';
@@ -292,6 +293,7 @@
 
 		<RichTextPlugin />
 		<IndentPlugin />
+		<PlainTextPastePlugin />
 		<MarkdownShortcutPlugin transformers={[INLINE_CODE_TRANSFORMER]} />
 
 		{#if autoFocus}

--- a/packages/ui/src/lib/richText/plugins/PlainTextPastePlugin.svelte
+++ b/packages/ui/src/lib/richText/plugins/PlainTextPastePlugin.svelte
@@ -1,0 +1,47 @@
+<!--
+@component
+This plugin strips all formatting from pasted content, only allowing plain text to be inserted.
+Use this when you want a simplified rich text mode without formatted paste support.
+-->
+<script lang="ts">
+	import {
+		$getSelection as getSelection,
+		$isRangeSelection as isRangeSelection,
+		COMMAND_PRIORITY_HIGH,
+		PASTE_COMMAND
+	} from 'lexical';
+	import { getEditor } from 'svelte-lexical';
+
+	const editor = getEditor();
+
+	$effect(() => {
+		const unregisterPaste = editor.registerCommand(
+			PASTE_COMMAND,
+			(event: ClipboardEvent) => {
+				// Get plain text from clipboard
+				const text = event?.clipboardData?.getData('text/plain');
+
+				if (text) {
+					event.preventDefault();
+
+					// Insert as plain text only, stripping all formatting
+					editor.update(() => {
+						const selection = getSelection();
+						if (isRangeSelection(selection)) {
+							selection.insertText(text);
+						}
+					});
+
+					return true; // Prevent default paste behavior
+				}
+
+				return false;
+			},
+			COMMAND_PRIORITY_HIGH
+		);
+
+		return () => {
+			unregisterPaste();
+		};
+	});
+</script>


### PR DESCRIPTION
Add a PlainTextPastePlugin that intercepts paste events and inserts only
plain text, stripping formatting. This plugin addresses the need for a
simplified rich-text mode where pasted content should not carry
formatting. The plugin is registered with the editor and unregistered on
cleanup.