### PR TITLE
improve-commits-reordering

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -221,7 +221,7 @@
 		{@const hasRemoteCommits = upstreamOnlyCommits.length > 0}
 		{@const hasCommits = localAndRemoteCommits.length > 0}
 
-		{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
+		<!-- {@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))} -->
 
 		{#if hasCommits || hasRemoteCommits}
 			<div
@@ -263,6 +263,8 @@
 						{/snippet}
 					</UpstreamCommitsAction>
 				{/if}
+
+				{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
 
 				{#each localAndRemoteCommits as commit, i (commit.id)}
 					{@const first = i === 0}

--- a/apps/desktop/src/components/CommitLineOverlay.svelte
+++ b/apps/desktop/src/components/CommitLineOverlay.svelte
@@ -14,13 +14,24 @@
 	let containerElement = $state<HTMLDivElement>();
 	let indicatorElement = $state<HTMLDivElement>();
 	let indicatorRect = $state<{ top: number; left: number; width: number; height: number }>();
+	let stackViewElement = $state<Element | null>(null);
 
 	function updatePosition() {
 		if (!indicatorElement) return;
+
 		const rect = indicatorElement.getBoundingClientRect();
+		const stackView = indicatorElement.closest('.stack-view');
+		if (!stackView) return;
+
+		stackViewElement = stackView;
+
+		const stackRect = stackView.getBoundingClientRect();
+		const scrollTop = stackView.scrollTop || 0;
+
+		// Calculate position relative to .stack-view container including scroll offset
 		indicatorRect = {
-			top: rect.top,
-			left: rect.left,
+			top: rect.top - stackRect.top + scrollTop,
+			left: rect.left - stackRect.left,
 			width: rect.width,
 			height: rect.height
 		};
@@ -44,12 +55,12 @@
 	<div bind:this={indicatorElement} class="indicator-placeholder"></div>
 </div>
 
-{#if activated && indicatorRect}
+{#if activated && indicatorRect && stackViewElement}
 	<div
 		class="indicator-portal"
 		class:hovered
 		class:advertize
-		use:portal={'body'}
+		use:portal={stackViewElement}
 		style:top="{indicatorRect.top}px"
 		style:left="{indicatorRect.left}px"
 		style:width="{indicatorRect.width}px"
@@ -73,7 +84,7 @@
 		height: var(--dropzone-height);
 		margin-top: var(--dropzone-overlap);
 		/* For debugging  */
-		background-color: rgba(238, 130, 238, 0.319);
+		/* background-color: rgba(238, 130, 238, 0.319); */
 
 		&:not(.activated) {
 			display: none;
@@ -94,7 +105,7 @@
 	.indicator-portal {
 		display: flex;
 		z-index: var(--z-blocker);
-		position: fixed;
+		position: absolute;
 		align-items: center;
 		pointer-events: none;
 

--- a/apps/desktop/src/components/CommitTitle.svelte
+++ b/apps/desktop/src/components/CommitTitle.svelte
@@ -21,7 +21,7 @@
 	}
 </script>
 
-<Tooltip text={getTitle()}>
+<Tooltip text={getTitle()} delay={1200}>
 	<h3
 		data-testid={TestId.CommitDrawerTitle}
 		class="{className} commit-title"

--- a/packages/ui/src/lib/utils/portal.ts
+++ b/packages/ui/src/lib/utils/portal.ts
@@ -1,5 +1,5 @@
-export function portal(node: HTMLElement, to: string) {
-	const target = document.querySelector(to);
+export function portal(node: HTMLElement, to: string | Element) {
+	const target = typeof to === 'string' ? document.querySelector(to) : to;
 	if (target) {
 		target.appendChild(node);
 	}


### PR DESCRIPTION
Discord report - https://discord.com/channels/1060193121130000425/1443734092330827796/1443741759250108552

---

Before:

https://github.com/user-attachments/assets/d58ae192-7eda-4502-8cbe-9c4f8abea0e4

After:


https://github.com/user-attachments/assets/181a5cf4-f639-483f-bab9-1ae9390f2a51

Here’s a debugging capture:

https://github.com/user-attachments/assets/845c0598-341a-4421-9ef0-14b5e1a7412e


---

## Summary
- Improve commit reordering experience by fixing UI glitches and reducing tooltip flicker.

## Changes
- Add 1200ms delay to commit title tooltip to reduce flicker.
- Fix clipping of dropzones and cropped drop lines.
- Prevent overlay lines from overflowing the stack-view container.
