### PR TITLE
Add Ubuntu 22.04 builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,9 +96,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-24.04 # [linux, x64]
+          - platform: ubuntu-22.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-24.04-arm # [linux, ARM64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''
@@ -141,7 +141,7 @@ jobs:
       - name: Rust Cache ${{ matrix.target }}
         uses: Swatinem/rust-cache@v2.8.2
         with:
-          shared-key: app-release-build-${{ github.event.inputs.channel || 'nightly' }}${{ matrix.target }}
+          shared-key: app-release-build-${{ github.event.inputs.channel || 'nightly' }}${{ matrix.target }}${{ matrix.platform }}
       - name: Init Node Environment
         uses: ./.github/actions/init-env-node
 
@@ -183,13 +183,14 @@ jobs:
             librsvg2-dev \
             xdg-utils;
 
+          webkit_version='2.50.*'
           sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
+            libwebkit2gtk-4.1-0="$webkit_version" \
+            libwebkit2gtk-4.1-dev="$webkit_version" \
+            libjavascriptcoregtk-4.1-0="$webkit_version" \
+            libjavascriptcoregtk-4.1-dev="$webkit_version" \
+            gir1.2-javascriptcoregtk-4.1="$webkit_version" \
+            gir1.2-webkit2-4.1="$webkit_version";
 
       - uses: actions/download-artifact@v7
         name: Download SvelteKit build output
@@ -348,9 +349,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-24.04 # [linux, x64]
+          - platform: ubuntu-22.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-24.04-arm # [linux, ARM64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''


### PR DESCRIPTION
## 🧢 Changes
Replaces the default Ubuntu 24.04 build with a Ubuntu 22.04 build.

The Ubuntu 24.04 build is hidden away under a different S3 object key. Depending on how the access control is configured on the S3 bucket, configuration may be needed to access the Ubuntu 24.04 build.

<details>
<summary>The original reasoning of this post (pretty outdated now)</summary>
This PR does two (highly related) things.

1. Adds Ubuntu 22.04 builds for x86_64 and ARM64 (side note: are the Linux ARM64 builds actually used??)
2. ~Upgrades the core Linux dependencies, most notably libwebkit2gtk-4.1~
    - Due to large forward-compatibility issues, we'll take this separately

I've been fiddling around with this in my fork to try stuff out in the actual runners, and produced [the Ubuntu 22.04 and Ubuntu 24.04 builds found here](https://github.com/slarse/gitbutler/actions/runs/19802219644).

> Note: Don't mind the fact that the artifacts are 500 MB each, I was veeery lazy and just added the entire `target/release/bundle` directory as an artifact. In other words, the artifacts contain way more stuff than they need to.

The Ubuntu 24.04 AppImage appears to be working very well on my Arch Linux system under Wayland.

I was hoping the Ubuntu 22.04 AppImage would also work, but I'm having some very strange linking issues with it when running on my Arch machine (see below). So, I do believe we need to build for both older and newer systems, independently.

<details>
<summary>Possible linker error when running Ubuntu 22.04 AppImage on Arch Linux</summary>

I run into this error when trying to work with remotes.

```bash
command: fetch_from_remotes
params: {"projectId":"ff91a7a9-1b3d-4b71-abee-6254bc1b7731","action":"modal"})

backend error: git command exited with non-zero exit code 128: ["fetch", "--quiet", "--prune", "upstream", "+refs/heads/*:refs/remotes/upstream/*"]

STDOUT:


STDERR:
git: /tmp/.mount_GitButGDbenp/usr/lib/libpcre2-8.so.0: no version information available (required by git)
/usr/lib/git-core/git: /tmp/.mount_GitButGDbenp/usr/lib/libpcre2-8.so.0: no version information available (required by /usr/lib/git-core/git)
/usr/lib/git-core/git-remote-https: symbol lookup error: /usr/lib/libcurl.so.4: undefined symbol: nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation
fatal: remote helper 'https' aborted session
```

The strangeness is that `nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation` is absolutely defined in `/usr/lib/libcurl.so.4`, so there has to be some linker issue. This error does not occur when using the Ubuntu 24.04 AppImage.
</details>

## ☕️ Reasoning

[See this comment](https://github.com/gitbutlerapp/gitbutler/issues/7671#issuecomment-3591558807) for a pretty comprehensive justification for the addition of the Ubuntu 22.04 build.

As for the dependency upgrades, they are well overdue. The WebkitGTK build that's currently used is years old and pretty buggy. Upgrading the dependencies fixes the freeze issue described in #9955 on my Arch Linux machine, and probably touches many of the other issues reported on the Linux bundles, the AppImage in particular.

## 🎫 Affected issues

Fixes: #9955 (The dependency upgrades in the Ubuntu 24.04 image seems to eliminate this problem)

Also improves upon #7671 with the Ubuntu 22.04 build, which links to GLIBC 2.35 instead of 2.38 (as is the case in the Ubuntu 24.04 build). This will let the AppImage run on older distros.

Very likely touches upon more of the Linux-specific issues, but I have not had the time to evaluate more of them.

## TODO
On 1/3 systems I've tested on (another Arch Linux+Wayland machine), I'm getting `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting ...`. Which is strange. I want to figure that out before proceeding here.

### Testing matrix (AppImage)

| Machine | AppImage | Status | Workaround |
| ------------- | --------------- | --------- | ------------------ |
| Arch Linux + Wayland (mesa) | Ubuntu 22.04 | :x: EGL_BAD_PARAMETER | https://github.com/gitbutlerapp/gitbutler/issues/5282#issuecomment-3598600651 (poor xwayland performance) |
| Arch Linux + Wayland (mesa) | Ubuntu 24.04 | :x: EGL_BAD_PARAMETER | https://github.com/gitbutlerapp/gitbutler/issues/5282#issuecomment-3598600651 (poor xwayland performance) |
| Arch Linux + Wayland (Nvidia) | Ubuntu 22.04 | :warning: Cannot work with remotes ||
| Arch Linux + Wayland (Nvidia) | Ubuntu 24.04 | :heavy_check_mark: No issues detected| |
| Ubuntu 22.04 + X11 (mesa) | Ubuntu 22.04 | :heavy_check_mark: No issues detected | |
| Ubuntu 22.04 + X11 (mesa) | Ubuntu 24.04 | :x: Cannot launch due to GLIBC mismatch | |

</detalis>

## Important caveat: The Ubuntu 22.04 build may not last
I don't know for how long the Ubuntu 22.04 build will keep on building, as the WebKit project dropped official support for it [on 2025-04-25](https://docs.webkit.org/Ports/WebKitGTK%20and%20WPE%20WebKit/DependenciesPolicy.html). Which is odd as Debian Bookworm (the Ubuntu 22.04 base distro) has support until June 2026. `libwebkit2gtk-4.1` is however [still an officially Ubuntu-maintained package](https://packages.ubuntu.com/jammy/libwebkit2gtk-4.1-dev), and the current upstream version 2.50.1 [was released in October](https://webkitgtk.org/2025/10/10/webkitgtk2.50.1-released.html). I think that's sufficient recent activity to make it worthwhile to start running the build.
