### PR TITLE
some-ui-improvements

### DIFF
--- a/apps/desktop/src/components/BranchView.svelte
+++ b/apps/desktop/src/components/BranchView.svelte
@@ -98,7 +98,6 @@
 			{grow}
 			{onclose}
 			{ontoggle}
-			bottomBorder
 			noshrink
 		>
 			{#snippet header()}

--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -24,7 +24,6 @@
 		draggableFiles?: boolean;
 		grow?: boolean;
 		noshrink?: boolean;
-		bottomBorder?: boolean;
 		resizer?: Partial<ComponentProps<typeof Resizer>>;
 		autoselect?: boolean;
 		ancestorMostConflictedCommitId?: string;
@@ -44,7 +43,6 @@
 		draggableFiles,
 		grow,
 		noshrink,
-		bottomBorder,
 		resizer,
 		autoselect,
 		ancestorMostConflictedCommitId,
@@ -75,7 +73,6 @@
 	{ontoggle}
 	{resizer}
 	{noshrink}
-	bottomBorder={changes.length > 0}
 	persistId={`changed-files-drawer-${projectId}-${stackId || 'default'}`}
 	childrenWrapHeight={changes.length > 0 ? 'auto' : '100%'}
 	childrenWrapDisplay={changes.length > 0 ? 'block' : 'flex'}
@@ -93,7 +90,7 @@
 		<FileListMode bind:mode={listMode} persistId={`changed-files-${persistId}`} />
 	{/snippet}
 
-	<div class="filelist-wrapper" class:bottom-border={bottomBorder}>
+	<div class="filelist-wrapper">
 		{#if changes.length > 0 || Object.entries(conflictEntries?.entries ?? {}).length > 0}
 			<FileList
 				{selectionId}
@@ -129,9 +126,5 @@
 		height: 100%;
 		margin-bottom: 16px;
 		background-color: var(--clr-bg-1);
-
-		&.bottom-border {
-			border-bottom: 1px solid var(--clr-border-2);
-		}
 	}
 </style>

--- a/apps/desktop/src/components/CommitLineOverlay.svelte
+++ b/apps/desktop/src/components/CommitLineOverlay.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import { portal } from '@gitbutler/ui/utils/portal';
-	import { pxToRem } from '@gitbutler/ui/utils/pxToRem';
 
 	interface Props {
 		hovered: boolean;
 		activated: boolean;
 		advertize?: boolean;
-		yOffsetPx?: number;
 	}
 
-	const { hovered, activated, advertize, yOffsetPx = 0 }: Props = $props();
+	const { hovered, activated, advertize }: Props = $props();
 
 	let containerElement = $state<HTMLDivElement>();
 	let indicatorElement = $state<HTMLDivElement>();
@@ -50,7 +48,6 @@
 	class:activated
 	class:advertize
 	class:hovered
-	style:--y-offset="{pxToRem(yOffsetPx)}rem"
 >
 	<div bind:this={indicatorElement} class="indicator-placeholder"></div>
 </div>

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -159,7 +159,6 @@
 				cancelEdit();
 				onclose?.();
 			}}
-			bottomBorder
 			noshrink
 		>
 			{#snippet header()}

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -36,7 +36,7 @@
 		children,
 		testId,
 		persistId,
-		bottomBorder,
+		bottomBorder = true,
 		grow,
 		noshrink,
 		resizer,
@@ -68,7 +68,7 @@
 	bind:this={containerDiv}
 	bind:clientHeight
 	class:collapsed={$collapsed}
-	class:bottom-border={bottomBorder && !resizer}
+	class:bottom-border={bottomBorder && !$collapsed}
 	class:grow
 	class:noshrink
 >
@@ -126,7 +126,6 @@
 			passive={resizer.passive}
 			disabled={$collapsed}
 			direction="down"
-			showBorder
 			{...resizer}
 			{maxHeight}
 		/>
@@ -154,7 +153,6 @@
 		}
 		&.collapsed {
 			max-height: none;
-			margin-bottom: -1px;
 		}
 	}
 

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -275,9 +275,14 @@
 						onclick={() => createBranchModal?.show()}>create a new branch</button
 					> +
 				{:else}
-					Drag changes here to
+					Drop files to start a branch,
 					<br />
-					branch off your changes
+					or
+					<button
+						type="button"
+						class="underline-dotted pointer-events clr-text-2 link-hover-2"
+						onclick={() => createBranchModal?.show()}>create a new branch</button
+					> +
 				{/if}
 			{/snippet}
 		</MultiStackOfflaneDropzone>

--- a/apps/desktop/src/components/PRBranchView.svelte
+++ b/apps/desktop/src/components/PRBranchView.svelte
@@ -21,11 +21,7 @@
 
 <ReduxResult result={prQuery?.result} {projectId} {onerror}>
 	{#snippet children(pr)}
-		<Drawer
-			testId={TestId.PRBranchDrawer}
-			persistId="pr-branch-drawer-{projectId}-{pr.number}"
-			bottomBorder
-		>
+		<Drawer testId={TestId.PRBranchDrawer} persistId="pr-branch-drawer-{projectId}-{pr.number}">
 			{#snippet header()}
 				<h3 class="text-14 text-semibold truncate">
 					<span class="clr-text-2">PR {unitSymbol}{pr.number}:</span>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -717,7 +717,10 @@
 													{@render assignedChangePreview(assignedStackId)}
 												</ConfigurableScrollableContainer>
 											{:else if selectedFile}
-												<Drawer persistId="file-preview-drawer-{stableStackId}">
+												<Drawer
+													persistId="file-preview-drawer-{stableStackId}"
+													bottomBorder={false}
+												>
 													{#snippet header()}
 														<FileViewHeader
 															noPaddings

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -47,6 +47,7 @@
 			testId={TestId.UnappliedBranchDrawer}
 			persistId="unapplied-branch-drawer-{projectId}-{branch.name}"
 			{onclose}
+			noshrink
 		>
 			{#snippet header()}
 				<div class="branch__header">

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -47,7 +47,6 @@
 			testId={TestId.UnappliedBranchDrawer}
 			persistId="unapplied-branch-drawer-{projectId}-{branch.name}"
 			{onclose}
-			bottomBorder
 		>
 			{#snippet header()}
 				<div class="branch__header">

--- a/apps/desktop/src/components/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/UnappliedCommitView.svelte
@@ -24,7 +24,12 @@
 
 <ReduxResult {projectId} result={commitQuery.result}>
 	{#snippet children(commit)}
-		<Drawer {onclose} bottomBorder persistId="unapplied-commit-drawer-{projectId}-{commitId}">
+		<Drawer
+			{onclose}
+			bottomBorder
+			noshrink
+			persistId="unapplied-commit-drawer-{projectId}-{commitId}"
+		>
 			{#snippet header()}
 				<CommitTitle
 					truncate


### PR DESCRIPTION
- Removed unused yOffsetPx prop from UI components
- Updated dropzone copy and added an inline "create branch" button

Before:
<img width="1247" height="810" alt="Screenshot 2025-11-30 at 21 42 41" src="https://github.com/user-attachments/assets/671013e6-e2c9-4476-851e-1c95b6337d9c" />

After:
<img width="1264" height="754" alt="Screenshot 2025-11-30 at 21 43 10" src="https://github.com/user-attachments/assets/15fe5583-e399-493d-8f60-42cac2476cee" />

- Fixed bottom border rendering conditions for drawers

Before:
<img width="549" height="323" alt="Screenshot 2025-11-30 at 22 49 44" src="https://github.com/user-attachments/assets/28d119e6-ff3f-462b-8d17-a8c23dc5d5ff" />

After:
<img width="544" height="293" alt="Screenshot 2025-11-30 at 22 49 52" src="https://github.com/user-attachments/assets/1ab069f7-d210-4a7b-b4c2-d80c589b6e20" />


- Prevented drawers from shrinking so their full headers remain visible

Before:
<img width="704" height="409" alt="Screenshot 2025-11-30 at 23 18 39" src="https://github.com/user-attachments/assets/d49e3900-d9d6-49c1-a8e2-9c39b905af37" />

After:
<img width="687" height="367" alt="Screenshot 2025-11-30 at 23 18 54" src="https://github.com/user-attachments/assets/bb1c4ec9-eac6-43da-a92c-ff67dea380cc" />

