### PR TITLE
Unambiguous committed files CLI IDs

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -12,7 +12,11 @@ use but_hunk_dependency::ui::HunkDependencies;
 use colored::Colorize;
 use gitbutler_project::Project;
 
-use crate::{command::legacy::rub::parse_sources, legacy::id::CliId, utils::OutputChannel};
+use crate::{
+    command::legacy::rub::parse_sources,
+    legacy::id::{CliId, IdDb},
+    utils::OutputChannel,
+};
 
 /// Amends changes into the appropriate commits where they belong.
 ///
@@ -33,8 +37,9 @@ pub(crate) fn handle(
     source: Option<&str>,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
+    let id_db = IdDb::new(ctx)?;
     let source: Option<CliId> = source
-        .and_then(|s| parse_sources(ctx, s).ok())
+        .and_then(|s| parse_sources(ctx, &id_db, s).ok())
         .and_then(|s| {
             s.into_iter().find(|s| {
                 matches!(s, CliId::UncommittedFile { .. }) || matches!(s, CliId::Branch { .. })

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -5,7 +5,7 @@ use but_ctx::{Context, LegacyProject};
 use but_settings::AppSettings;
 use but_workspace::legacy::ui::StackEntry;
 
-use crate::{args::branch, utils::OutputChannel};
+use crate::{args::branch, legacy::id::IdDb, utils::OutputChannel};
 
 mod apply;
 mod json;
@@ -77,6 +77,7 @@ pub async fn handle(
                 legacy_project,
                 AppSettings::load_from_default_path_creating()?,
             );
+            let id_db = IdDb::new(&ctx)?;
             // Get branch name or use canned name
             let branch_name = branch_name.map(Ok).unwrap_or_else(|| {
                 but_api::legacy::workspace::canned_branch_name(legacy_project.id)
@@ -90,7 +91,7 @@ pub async fn handle(
                 let mut ctx = ctx; // Make mutable for CliId resolution
 
                 // Resolve the anchor string to a CliId
-                let anchor_ids = crate::legacy::id::CliId::from_str(&mut ctx, &anchor_str)?;
+                let anchor_ids = id_db.parse_str(&mut ctx, &anchor_str)?;
                 if anchor_ids.is_empty() {
                     return Err(anyhow::anyhow!("Could not find anchor: {}", anchor_str));
                 }

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -1,10 +1,15 @@
-use crate::{legacy::id::CliId, tui, utils::OutputChannel};
 use anyhow::{Result, bail};
 use but_api::diff::ComputeLineStats;
 use but_ctx::Context;
 use but_oxidize::{ObjectIdExt as _, OidExt};
 use gitbutler_project::Project;
 use gix::prelude::ObjectIdExt;
+
+use crate::{
+    legacy::id::{CliId, IdDb},
+    tui,
+    utils::OutputChannel,
+};
 
 pub(crate) fn describe_target(
     project: &Project,
@@ -13,9 +18,10 @@ pub(crate) fn describe_target(
     message: Option<&str>,
 ) -> Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
+    let id_db = IdDb::new(&ctx)?;
 
     // Resolve the commit ID
-    let cli_ids = CliId::from_str(&mut ctx, target)?;
+    let cli_ids = id_db.parse_str(&mut ctx, target)?;
 
     if cli_ids.is_empty() {
         bail!("ID '{}' not found", target);

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -13,7 +13,11 @@ use gitbutler_project::{Project, ProjectId};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::{legacy::id::CliId, tui, utils::OutputChannel};
+use crate::{
+    legacy::id::{CliId, IdDb},
+    tui,
+    utils::OutputChannel,
+};
 
 /// Set the review template for the given project.
 pub fn set_review_template(
@@ -94,7 +98,9 @@ pub async fn publish_reviews(
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let branch_ids = CliId::from_str(&mut ctx, branch_id)?
+    let id_db = IdDb::new(&ctx)?;
+    let branch_ids = id_db
+        .parse_str(&mut ctx, branch_id)?
         .iter()
         .filter_map(|clid| match clid {
             CliId::Branch { name, .. } => Some(name.clone()),

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -7,7 +7,9 @@ use but_rules::Operation;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_project::Project;
 
-use crate::{command::legacy::rub::branch_name_to_stack_id, utils::OutputChannel};
+use crate::{
+    command::legacy::rub::branch_name_to_stack_id, legacy::id::IdDb, utils::OutputChannel,
+};
 
 pub(crate) fn handle(
     project: &Project,
@@ -16,7 +18,8 @@ pub(crate) fn handle(
     delete: bool,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let target_result = crate::legacy::id::CliId::from_str(ctx, target_str)?;
+    let id_db = IdDb::new(ctx)?;
+    let target_result = id_db.parse_str(ctx, target_str)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(
             "Target {} is ambiguous: {:?}",

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -4,6 +4,7 @@ use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_project::Project;
 
 use crate::args::push::Command;
+use crate::legacy::id::IdDb;
 use crate::{args::push, utils::OutputChannel};
 
 pub fn handle(
@@ -12,6 +13,7 @@ pub fn handle(
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
+    let id_db = IdDb::new(&ctx)?;
 
     // Check gerrit mode early
     let gerrit_mode = {
@@ -20,7 +22,7 @@ pub fn handle(
     };
 
     // Resolve branch_id to actual branch name
-    let branch_name = resolve_branch_name(&mut ctx, &args.branch_id)?;
+    let branch_name = resolve_branch_name(&mut ctx, &id_db, &args.branch_id)?;
 
     // Find stack_id from branch name
     let stack_id = find_stack_id_by_branch_name(project, &branch_name)?;
@@ -110,9 +112,9 @@ pub fn get_gerrit_flags(
     Ok(flags)
 }
 
-fn resolve_branch_name(ctx: &mut Context, branch_id: &str) -> anyhow::Result<String> {
+fn resolve_branch_name(ctx: &mut Context, id_db: &IdDb, branch_id: &str) -> anyhow::Result<String> {
     // Try to resolve as CliId first
-    let cli_ids = crate::legacy::id::CliId::from_str(ctx, branch_id)?;
+    let cli_ids = id_db.parse_str(ctx, branch_id)?;
 
     if cli_ids.is_empty() {
         // If no CliId matches, treat as literal branch name but validate it exists

--- a/crates/but/src/command/legacy/rub/commits.rs
+++ b/crates/but/src/command/legacy/rub/commits.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Context as _, Result};
-use bstr::ByteSlice;
+use bstr::BStr;
 use but_core::{DiffSpec, diff::tree_changes};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignmentRequest;
@@ -15,7 +15,7 @@ use crate::{
 
 pub fn commited_file_to_another_commit(
     ctx: &mut Context,
-    path: &str,
+    path: &BStr,
     source_id: gix::ObjectId,
     target_id: gix::ObjectId,
     out: &mut OutputChannel,
@@ -30,7 +30,7 @@ pub fn commited_file_to_another_commit(
     let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
     let relevant_changes = tree_changes
         .into_iter()
-        .filter(|tc| tc.path.to_str_lossy() == path)
+        .filter(|tc| tc.path == path)
         .map(Into::into)
         .collect::<Vec<DiffSpec>>();
 
@@ -56,7 +56,7 @@ pub fn commited_file_to_another_commit(
 
 pub fn uncommit_file(
     ctx: &mut Context,
-    path: &str,
+    path: &BStr,
     source_id: gix::ObjectId,
     target_branch: Option<&str>,
     out: &mut OutputChannel,
@@ -72,7 +72,7 @@ pub fn uncommit_file(
         let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
         tree_changes
             .into_iter()
-            .filter(|tc| tc.path.to_str_lossy() == path)
+            .filter(|tc| tc.path == path)
             .map(Into::into)
             .collect::<Vec<DiffSpec>>()
     };

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -14,7 +14,10 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::{legacy::id::CliId, utils::OutputChannel};
+use crate::{
+    legacy::id::{CliId, IdDb},
+    utils::OutputChannel,
+};
 
 pub(crate) fn handle(
     project: &Project,
@@ -23,7 +26,8 @@ pub(crate) fn handle(
     target_str: &str,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let (sources, target) = ids(ctx, source_str, target_str)?;
+    let id_db = IdDb::new(ctx)?;
+    let (sources, target) = ids(ctx, &id_db, source_str, target_str)?;
 
     for source in sources {
         match (&source, &target) {
@@ -152,9 +156,14 @@ fn makes_no_sense_error(source: &CliId, target: &CliId) -> String {
     )
 }
 
-fn ids(ctx: &mut Context, source: &str, target: &str) -> anyhow::Result<(Vec<CliId>, CliId)> {
-    let sources = parse_sources(ctx, source)?;
-    let target_result = crate::legacy::id::CliId::from_str(ctx, target)?;
+fn ids(
+    ctx: &mut Context,
+    id_db: &IdDb,
+    source: &str,
+    target: &str,
+) -> anyhow::Result<(Vec<CliId>, CliId)> {
+    let sources = parse_sources(ctx, id_db, source)?;
+    let target_result = id_db.parse_str(ctx, target)?;
     if target_result.len() != 1 {
         if target_result.is_empty() {
             return Err(anyhow::anyhow!(
@@ -182,18 +191,22 @@ fn ids(ctx: &mut Context, source: &str, target: &str) -> anyhow::Result<(Vec<Cli
     Ok((sources, target_result[0].clone()))
 }
 
-pub(crate) fn parse_sources(ctx: &mut Context, source: &str) -> anyhow::Result<Vec<CliId>> {
+pub(crate) fn parse_sources(
+    ctx: &mut Context,
+    id_db: &IdDb,
+    source: &str,
+) -> anyhow::Result<Vec<CliId>> {
     // Check if it's a range (contains '-')
     if source.contains('-') {
-        parse_range(ctx, source)
+        parse_range(ctx, id_db, source)
     }
     // Check if it's a list (contains ',')
     else if source.contains(',') {
-        parse_list(ctx, source)
+        parse_list(ctx, id_db, source)
     }
     // Single source
     else {
-        let source_result = crate::legacy::id::CliId::from_str(ctx, source)?;
+        let source_result = id_db.parse_str(ctx, source)?;
         if source_result.len() != 1 {
             if source_result.is_empty() {
                 return Err(anyhow::anyhow!(
@@ -222,7 +235,7 @@ pub(crate) fn parse_sources(ctx: &mut Context, source: &str) -> anyhow::Result<V
     }
 }
 
-fn parse_range(ctx: &mut Context, source: &str) -> anyhow::Result<Vec<CliId>> {
+fn parse_range(ctx: &mut Context, id_db: &IdDb, source: &str) -> anyhow::Result<Vec<CliId>> {
     let parts: Vec<&str> = source.split('-').collect();
     if parts.len() != 2 {
         return Err(anyhow::anyhow!(
@@ -235,8 +248,8 @@ fn parse_range(ctx: &mut Context, source: &str) -> anyhow::Result<Vec<CliId>> {
     let end_str = parts[1];
 
     // Get the start and end IDs
-    let start_matches = crate::legacy::id::CliId::from_str(ctx, start_str)?;
-    let end_matches = crate::legacy::id::CliId::from_str(ctx, end_str)?;
+    let start_matches = id_db.parse_str(ctx, start_str)?;
+    let end_matches = id_db.parse_str(ctx, end_str)?;
 
     if start_matches.len() != 1 {
         return Err(anyhow::anyhow!(
@@ -339,13 +352,13 @@ fn get_all_files_in_display_order(ctx: &mut Context) -> anyhow::Result<Vec<CliId
     Ok(all_files)
 }
 
-fn parse_list(ctx: &mut Context, source: &str) -> anyhow::Result<Vec<CliId>> {
+fn parse_list(ctx: &mut Context, id_db: &IdDb, source: &str) -> anyhow::Result<Vec<CliId>> {
     let parts: Vec<&str> = source.split(',').collect();
     let mut result = Vec::new();
 
     for part in parts {
         let part = part.trim();
-        let matches = crate::legacy::id::CliId::from_str(ctx, part)?;
+        let matches = id_db.parse_str(ctx, part)?;
         if matches.len() != 1 {
             if matches.is_empty() {
                 return Err(anyhow::anyhow!(

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -95,17 +95,38 @@ pub(crate) fn handle(
             (CliId::CommittedFile { .. }, CliId::CommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))
             }
-            (CliId::CommittedFile { path, commit_oid }, CliId::Branch { name, .. }) => {
+            (
+                CliId::CommittedFile {
+                    path, commit_oid, ..
+                },
+                CliId::Branch { name, .. },
+            ) => {
                 create_snapshot(ctx, OperationKind::FileChanges);
-                commits::uncommit_file(ctx, path, *commit_oid, Some(name), out)?;
+                commits::uncommit_file(ctx, path.as_ref(), *commit_oid, Some(name), out)?;
             }
-            (CliId::CommittedFile { path, commit_oid }, CliId::Commit { oid }) => {
+            (
+                CliId::CommittedFile {
+                    path, commit_oid, ..
+                },
+                CliId::Commit { oid },
+            ) => {
                 create_snapshot(ctx, OperationKind::FileChanges);
-                commits::commited_file_to_another_commit(ctx, path, *commit_oid, *oid, out)?;
+                commits::commited_file_to_another_commit(
+                    ctx,
+                    path.as_ref(),
+                    *commit_oid,
+                    *oid,
+                    out,
+                )?;
             }
-            (CliId::CommittedFile { path, commit_oid }, CliId::Unassigned { .. }) => {
+            (
+                CliId::CommittedFile {
+                    path, commit_oid, ..
+                },
+                CliId::Unassigned { .. },
+            ) => {
                 create_snapshot(ctx, OperationKind::FileChanges);
-                commits::uncommit_file(ctx, path, *commit_oid, None, out)?;
+                commits::uncommit_file(ctx, path.as_ref(), *commit_oid, None, out)?;
             }
             (CliId::Branch { .. }, CliId::CommittedFile { .. }) => {
                 bail!(makes_no_sense_error(&source, &target))

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -453,6 +453,7 @@ pub fn print_group(
                     false,
                     show_url,
                     None,
+                    id_db,
                     out,
                 )?;
             }
@@ -485,6 +486,7 @@ pub fn print_group(
                     commit.has_conflicts,
                     show_url,
                     commit.gerrit_review_url.clone(),
+                    id_db,
                     out,
                 )?;
             }
@@ -596,25 +598,6 @@ fn status_from_changes(changes: &[ui::TreeChange], path: BString) -> Option<ui::
     })
 }
 
-pub(crate) fn all_committed_files(ctx: &mut Context) -> anyhow::Result<Vec<CliId>> {
-    let mut committed_files = Vec::new();
-    let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
-    for stack in stacks {
-        let details = but_api::legacy::workspace::stack_details(ctx.legacy_project.id, stack.id)?;
-        for branch in details.branch_details {
-            for commit in branch.commits {
-                let commit_details =
-                    but_api::diff::commit_details(ctx, commit.id, ComputeLineStats::No)?;
-                for change in &commit_details.diff_with_first_parent {
-                    let cid = CliId::committed_file(&change.path.to_string(), commit.id);
-                    committed_files.push(cid);
-                }
-            }
-        }
-    }
-    Ok(committed_files)
-}
-
 #[expect(clippy::too_many_arguments)]
 fn print_commit(
     ctx: &Context,
@@ -629,6 +612,7 @@ fn print_commit(
     has_conflicts: bool,
     show_url: bool,
     review_url: Option<String>,
+    id_db: &mut IdDb,
     out: &mut dyn std::fmt::Write,
 ) -> anyhow::Result<()> {
     let mark = if marked {
@@ -709,8 +693,9 @@ fn print_commit(
         )?;
     }
     if show_files {
-        for change in &commit_details.diff_with_first_parent {
-            let cid = CliId::committed_file(&change.path.to_string(), commit_id)
+        for change in &commit_details.changes.changes {
+            let cid = id_db
+                .committed_file(commit_id, change.path.as_ref())
                 .to_string()
                 .blue()
                 .underline();

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -693,7 +693,7 @@ fn print_commit(
         )?;
     }
     if show_files {
-        for change in &commit_details.changes.changes {
+        for change in &commit_details.diff_with_first_parent {
             let cid = id_db
                 .committed_file(commit_id, change.path.as_ref())
                 .to_string()

--- a/crates/but/src/legacy/id.rs
+++ b/crates/but/src/legacy/id.rs
@@ -79,14 +79,13 @@ impl IdDb {
         })
     }
 
-    fn find_branches_by_name(&mut self, ctx: &Context, name: &BStr) -> anyhow::Result<Vec<CliId>> {
-        let branch_names = branch_names(ctx)?;
+    fn find_branches_by_name(&self, name: &BStr) -> anyhow::Result<Vec<CliId>> {
         let mut matches = Vec::new();
 
-        for branch_name in branch_names {
+        for (branch_name, cli_id) in self.branch_name_to_cli_id.iter() {
             // Partial match is fine
             if branch_name.contains_str(name) {
-                matches.push(self.branch(branch_name.as_ref()).clone())
+                matches.push(cli_id.clone());
             }
         }
 
@@ -208,12 +207,12 @@ impl CliId {
         }
 
         // TODO: make callers of this function pass IdDb instead
-        let mut id_db = IdDb::new(ctx)?;
+        let id_db = IdDb::new(ctx)?;
 
         let mut matches = Vec::new();
 
         // First, try exact branch name match
-        if let Ok(branch_matches) = id_db.find_branches_by_name(ctx, s.into()) {
+        if let Ok(branch_matches) = id_db.find_branches_by_name(s.into()) {
             matches.extend(branch_matches);
         }
 


### PR DESCRIPTION
Sample output (copied from a commit message):
```
╭┄000 [Unassigned Changes]
┊
┊╭┄ux [b00] (no commits)
├╯
┊
┊╭┄wo [work]
┊●   89f03ba test commit
┊│     g0 A a
┊│     h0 A b
┊│     j0 A c
├╯
┊
┊╭┄i0 [i0] (no commits)
├╯
┊
┴ dba337d (common base) [origin/main] 2025-11-11 Merge pull request #2254 from ralphmodales/credent
```

Helps one of several issues in #11437

If any Rust expert out there can think of how to improve my code, feel free to leave suggestions. I struggled particularly with how the Vec binary search returns indexes instead of references to the found element (necessitating an unchecked `v[index]` when `index` is known to be safe because it was returned by binary search) and how I cannot declare a Vec to only contain one specific variant of an enum.