### PR TITLE
Fix codegen template starting with [object promise]

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -218,8 +218,8 @@
 		return short ? thinkingLevel.shortLabel : thinkingLevel.label;
 	}
 
-	function insertTemplate(templateContent: string) {
-		const currentPrompt = inputRef?.getText();
+	async function insertTemplate(templateContent: string) {
+		const currentPrompt = await inputRef?.getText();
 		const newPrompt = currentPrompt + (currentPrompt ? '\n\n' : '') + templateContent;
 		onChange?.(newPrompt);
 		inputRef?.setText(newPrompt);


### PR DESCRIPTION
The code’s intention is to keep any existing text at the start of the message box, and append the template, but it ignored the fact that to get the text it needed to be awaited.

- Fixes https://github.com/gitbutlerapp/gitbutler/issues/11448#issuecomment-3611213509