### PR TITLE
Implement reword_commit as an example of rebase engine usage

### DIFF
--- a/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
-	import { ircEnabled, ircServer, fModeEnabled } from '$lib/config/uiFeatureFlags';
+	import {
+		ircEnabled,
+		ircServer,
+		fModeEnabled,
+		useNewRebaseEngine
+	} from '$lib/config/uiFeatureFlags';
 	import { USER } from '$lib/user/user';
 	import { inject } from '@gitbutler/core/context';
 	import { CardGroup, Textbox, Toggle } from '@gitbutler/ui';
@@ -63,6 +68,21 @@
 				id="f-mode"
 				checked={$fModeEnabled}
 				onclick={() => fModeEnabled.set(!$fModeEnabled)}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+	<CardGroup.Item labelFor="new-rebase-engine">
+		{#snippet title()}
+			New rebase engine
+		{/snippet}
+		{#snippet caption()}
+			Use the new graph-based rebase engine for stack operations.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="new-rebase-engine"
+				checked={$useNewRebaseEngine}
+				onclick={() => useNewRebaseEngine.set(!$useNewRebaseEngine)}
 			/>
 		{/snippet}
 	</CardGroup.Item>

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -15,3 +15,4 @@ export type StagingBehavior = 'all' | 'selection' | 'none';
 export const stagingBehaviorFeature = persisted<StagingBehavior>('all', 'feature-staging-behavior');
 export const fModeEnabled = persisted(true, 'f-mode');
 export const newlineOnEnter = persisted(false, 'feature-newline-on-enter');
+export const useNewRebaseEngine = persisted(false, 'feature-use-new-rebase-engine');

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 tauri = ["dep:tauri", "legacy"]
 ## When paths are turned into strings they are lossy. Also provide a `_bytes` variant of such fields with the original value
 ## for lossless use.
-path-bytes = ["dep:bstr"]
+path-bytes = []
 ## Make legacy functionality available.
 legacy = [
     "but-ctx/legacy",
@@ -86,25 +86,27 @@ but-rules = { workspace = true, optional = true }
 but-gerrit = { workspace = true, optional = true }
 but-worktrees = { workspace = true, optional = true }
 
-gitbutler-user = {workspace = true, optional = true}
-gitbutler-project = {workspace = true, optional = true}
-gitbutler-branch = {workspace = true, optional = true}
-gitbutler-branch-actions = {workspace = true, optional = true}
-gitbutler-commit = {workspace = true, optional = true}
-gitbutler-reference = {workspace = true, optional = true}
-gitbutler-stack = {workspace = true, optional = true}
-gitbutler-repo = {workspace = true, optional = true}
-gitbutler-repo-actions = {workspace = true, optional = true}
-gitbutler-edit-mode = {workspace = true, optional = true}
-gitbutler-operating-modes = {workspace = true, optional = true}
-gitbutler-sync = {workspace = true, optional = true}
-gitbutler-oplog = {workspace = true, optional = true}
-gitbutler-git = {workspace = true, optional = true}
+gitbutler-user = { workspace = true, optional = true }
+gitbutler-project = { workspace = true, optional = true }
+gitbutler-branch = { workspace = true, optional = true }
+gitbutler-branch-actions = { workspace = true, optional = true }
+gitbutler-commit = { workspace = true, optional = true }
+gitbutler-reference = { workspace = true, optional = true }
+gitbutler-stack = { workspace = true, optional = true }
+gitbutler-repo = { workspace = true, optional = true }
+gitbutler-repo-actions = { workspace = true, optional = true }
+gitbutler-edit-mode = { workspace = true, optional = true }
+gitbutler-operating-modes = { workspace = true, optional = true }
+gitbutler-sync = { workspace = true, optional = true }
+gitbutler-oplog = { workspace = true, optional = true }
+gitbutler-git = { workspace = true, optional = true }
 
-tauri = { version = "^2.9.3", features = ["unstable"], optional = true } # For the #[tauri::command(async)] macro only
+tauri = { version = "^2.9.3", features = [
+    "unstable",
+], optional = true } # For the #[tauri::command(async)] macro only
 
 boolean-enums = { version = "0.4.1", features = ["serde"] }
-bstr = { workspace = true, optional = true }
+bstr = { workspace = true }
 schemars.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }
@@ -112,7 +114,7 @@ anyhow.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 serde-error = "0.1.3"
-gix = { workspace = true, features = ["worktree-mutation" ] }
+gix = { workspace = true, features = ["worktree-mutation"] }
 git2.workspace = true
 open.workspace = true
 url = { version = "2.5", optional = true }

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -1,0 +1,44 @@
+use bstr::{BString, ByteSlice};
+use but_api_macros::but_api;
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use tracing::instrument;
+
+/// Rewords a commit, but without updating the oplog.
+///
+/// Returns the ID of the newly renamed commit
+#[but_api]
+#[instrument(err(Debug))]
+pub fn reword_commit_only(
+    ctx: &but_ctx::Context,
+    commit_id: gix::ObjectId,
+    message: BString,
+) -> anyhow::Result<gix::ObjectId> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let (repo, _, graph) = ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+
+    but_workspace::commit::reword(&graph, &repo, commit_id, message.as_bstr())
+}
+
+/// Rewords a commit.
+///
+/// Returns the ID of the newly renamed commit
+#[but_api]
+#[instrument(err(Debug))]
+pub fn reword_commit(
+    ctx: &but_ctx::Context,
+    commit_id: gix::ObjectId,
+    message: BString,
+) -> anyhow::Result<gix::ObjectId> {
+    // NOTE: since this is optional by nature, the same would be true if snapshotting/undo would be disabled via `ctx` app settings, for instance.
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+        ctx,
+        SnapshotDetails::new(OperationKind::UpdateCommitMessage),
+    )
+    .ok();
+
+    let res = reword_commit_only(ctx, commit_id, message);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx).ok();
+    };
+    res
+}

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -16,6 +16,9 @@ pub mod github;
 /// Functions that take a branch as input.
 pub mod branch;
 
+/// Functions that operate commits
+pub mod commit;
+
 /// Functions that show what changed in various Git entities, like trees, commits and the worktree.
 pub mod diff;
 

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -1,4 +1,6 @@
 //! Functions for materializing a rebase
+use std::collections::HashMap;
+
 use crate::graph_rebase::{Checkouts, rebase::SuccessfulRebase};
 use anyhow::Result;
 use but_core::{
@@ -9,9 +11,16 @@ use but_core::{
     },
 };
 
+/// The outcome of a materialize
+#[derive(Debug, Clone)]
+pub struct MaterializeOutcome {
+    /// A mapping of any commits that were rewritten as part of the rebase
+    pub commit_mapping: HashMap<gix::ObjectId, gix::ObjectId>,
+}
+
 impl SuccessfulRebase {
     /// Materializes a history rewrite
-    pub fn materialize(mut self) -> Result<()> {
+    pub fn materialize(mut self) -> Result<MaterializeOutcome> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
             memory.persist(self.repo)?;
@@ -40,6 +49,8 @@ impl SuccessfulRebase {
 
         repo.edit_references(self.ref_edits.clone())?;
 
-        Ok(())
+        Ok(MaterializeOutcome {
+            commit_mapping: self.commit_mapping,
+        })
     }
 }

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -4,6 +4,9 @@ use but_core::ref_metadata::MaybeDebug;
 
 use crate::WorkspaceCommit;
 
+pub mod reword;
+pub use reword::function::reword;
+
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
 #[derive(Clone)]
 pub struct Stack {

--- a/crates/but-workspace/src/commit/reword.rs
+++ b/crates/but-workspace/src/commit/reword.rs
@@ -1,0 +1,35 @@
+//! An action to perform a reword of a commit
+
+pub(crate) mod function {
+    use anyhow::Result;
+    use bstr::BStr;
+    use but_rebase::{
+        commit::DateMode,
+        graph_rebase::{GraphExt, Step},
+    };
+
+    /// This action will rewrite a commit and any relevant history so it uses
+    /// the new name.
+    ///
+    /// Returns the ID of the newly renamed commit
+    pub fn reword(
+        graph: &but_graph::Graph,
+        repo: &gix::Repository,
+        commit_id: gix::ObjectId,
+        new_message: &BStr,
+    ) -> Result<gix::ObjectId> {
+        let mut editor = graph.to_editor(repo)?;
+        let target_selector = editor.select_commit(commit_id)?;
+
+        let mut commit = editor.find_commit(commit_id)?;
+        commit.message = new_message.to_owned();
+        let new_id = editor.write_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
+
+        editor.replace(&target_selector, Step::new_pick(new_id));
+
+        let outcome = editor.rebase()?;
+        outcome.materialize()?;
+
+        Ok(new_id)
+    }
+}

--- a/crates/but-workspace/tests/fixtures/scenario/reword-three-commits.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/reword-three-commits.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "/remote/" > .gitignore
+mkdir remote
+pushd remote
+git init
+popd
+
+git init
+
+git remote add origin ./remote
+
+git checkout -b one
+echo "foo" > one.txt
+git add .
+git commit -m "commit one"
+
+git checkout -b two
+echo "foo" > two.txt
+git add .
+git commit -m "commit two"
+
+git push -u origin two
+
+git checkout -b three
+echo "foo" > three.txt
+git add .
+git commit -m "commit three"

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -1,3 +1,5 @@
+mod reword;
+
 mod from_new_merge_with_metadata {
     use bstr::ByteSlice;
     use but_graph::init::{Options, Overlay};

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use but_testsupport::{assure_stable_env, visualize_commit_graph_all};
+use but_workspace::commit::reword;
+
+use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
+
+#[test]
+fn reword_head_commit() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let id = repo.rev_parse_single("three")?;
+    reword(&graph, &repo, id.detach(), b"New name".into())?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 7580b8e (HEAD -> three) New name
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn reword_middle_commit() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let id = repo.rev_parse_single("two")?;
+    reword(&graph, &repo, id.detach(), b"New name".into())?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 086ad49 (HEAD -> three) commit three
+    * d9cea5b (two) New name
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn reword_base_commit() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let id = repo.rev_parse_single("one")?;
+    reword(&graph, &repo, id.detach(), b"New name".into())?;
+
+    // We end up with two divergent histories here. This is to be expected if we
+    // rewrite the very bottom commit in a repository.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 33b56b8 (HEAD -> three) commit three
+    * 2548c60 (two) commit two
+    * b8c5693 (one) New name
+    * 16fd221 (origin/two) commit two
+    * 8b426d0 commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use anyhow::bail;
-use but_api::{diff, github, legacy};
+use but_api::{commit, diff, github, legacy};
 use but_claude::{Broadcaster, Claude};
 use but_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::{
@@ -384,6 +384,7 @@ fn main() -> anyhow::Result<()> {
                 claude::claude_cancel_session,
                 claude::claude_is_stack_active,
                 claude::claude_compact_history,
+                commit::tauri_reword_commit::reword_commit
             ])
             .menu(move |handle| menu::build(handle, &app_settings_for_menu))
             .on_window_event(|window, event| match event {


### PR DESCRIPTION
In this PR I'm exploring what the first rendition of the new rebase engine might be to look like.

I'm doing this by implementing possibly the simplest operation we've got, and then I'll be scaling it up to some more complex operations, testing as I go along.

I want this to be an open RFC. This is a shed to be biked. A water cooler to be over cooled.

## A break down of the `reword` function in `reword.rs`

I'm going to interleave code followed by text to explain what each part is doing. If it doesn't make sense, then we probably need to switch up some portion of the interface. Please share!

```rs
pub fn reword(
    graph: &but_graph::Graph,
    repo: &gix::Repository,
    target: gix::ObjectId,
    new_message: &BStr,
) -> Result<()> {
```
For the signature of this "plumbing" function, it takes just the graph & repo which are the essentials now.

We don't need to take in any references or stack_ids, just getting the `target` commit is enough to identify what we want to change.

```rs
    let mut editor = graph.to_editor(repo)?;
```

I can build the editor from the graph. It takes in a repo which it actually clones and turns into an in-memory repository. For any commits we rewrite in our business logic we want to use this. I've experimented a little bit with adding some functions to make the commit rewrites we want to do a little bit easier & handle things like signing correctly.

```rs
    let target_selector = editor
        .select_commit(target)
        .context("Failed to find target commit in editor")?;
```

This line gets a reference or "selector" to where the target commit sits inside the editors internal graph structure.

Currently for a selector, we can either replace the thing it points to with another "step" kind, or we can insert a new "step" either below or above it.

I'm strongly considering changing `select_xxx` to return a result & then have `try_select_xxx` versions if the caller really wants to have `Option`s

```rs
    let mut commit = editor.find_commit(target)?;
    commit.message = new_message.to_owned();
    let new_id = editor.write_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
```

The three lines here are concerned actually performing the manipulation where we change the commit's message.

In our app there a handful of ways of getting a commit object we can play around with and how to write a commit, with or without signing.

I really want there to be a single common way we do this with the rebase engine, so I added `find_commit` and `write_commit`.

`find_commit` is important to use anyway because if we're looking up a commit, then it should be from inside the editor's in memory repository in case anything relevant has been written there doing a 2 step rebase (example coming soon...). I considered having this take a selector or having this actually return the selector, but it seemed initially like more faff than benefit.

Find commit is returning a `but_core::Commit` which seems like an easy thing to modify, and has some useful methods around our specific headers so it seemed like a good type to be the mutable "thing" we edit.

`write_commit` then takes the commit and writes it into the editor's in-memory repo. It takes a `DateMode` which enables us to describe if and how to update committers and authors. I liked this because it means we don't have do the faff of getting the signature and then creating a timestamp in this function's body.

```rs
    editor.replace(&target_selector, Step::new_pick(new_id));
```

This replace call doesn't perform any rebases itself. You can call `replace` and `insert` and it's just manipulating an in-memory data structure, without any expensive operations.

```rs
    let outcome = editor.rebase()?;
```

`editor.rebase()` is performing the actual rebase - without checking out any of the results. On a success it's giving us this `outcome` object which on it's own is opaque for now. Currently the only thing you can do with it is call `.materialize()` which actually checks out any changes. As use cases come up methods can be added to it which can describe the effects of the rebase. IE: did it cause any commits to become conflicted, ect... . Further, you will be able to create a new editor out of it for 2 step rebases.

On a failure, this is currently returning an `anyhow` error, but I'm strongly considering doing something with `thiserror` so error variants can be more easily matched over with detail.

`.rebase()` should only succeed if it the outcome can be checked out following the users preferences. Rules like disallowing pushed commits to be rebased should result in a failure variant.

```rs
    outcome.materialize()?;

    Ok(())
}
``` 

`.materialize()` actually updates the references, any relevant metadata, and performs a safe checkout for us.

### The function in full:

```rs
pub fn reword(
    graph: &but_graph::Graph,
    repo: &gix::Repository,
    target: gix::ObjectId,
    new_message: &BStr,
) -> Result<()> {
    let mut editor = graph.to_editor(repo)?;
    let target_selector = editor
        .select_commit(target)
        .context("Failed to find target commit in editor")?;

    let mut commit = editor.find_commit(target)?;
    commit.message = new_message.to_owned();
    let new_id = editor.write_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;

    editor.replace(&target_selector, Step::new_pick(new_id));

    let outcome = editor.rebase()?;
    outcome.materialize()?;

    Ok(())
}
```

### The old world version of this implementation.

There are a few cases that currently aren't covered in the rebase engine, but by the time I'm done they should be functionally identical.

```rs
// changes a commit message for commit_oid, rebases everything above it, updates branch head if successful
pub(crate) fn update_commit_message(
    ctx: &Context,
    stack_id: StackId,
    commit_id: git2::Oid,
    message: &str,
) -> Result<git2::Oid> {
    if message.is_empty() {
        bail!("commit message can not be empty");
    }
    let vb_state = ctx.legacy_project.virtual_branches();
    let default_target = vb_state.get_default_target()?;
    let gix_repo = ctx.repo.get()?;

    let mut stack = vb_state.get_stack_in_workspace(stack_id)?;
    let branch_commit_oids = ctx.git2_repo.get()?.l(
        stack.head_oid(&gix_repo)?.to_git2(),
        LogUntil::Commit(default_target.sha),
        false,
    )?;

    if !branch_commit_oids.contains(&commit_id) {
        bail!("commit {commit_id} not in the branch");
    }

    let pushed_commit_oids = stack.upstream_head.map_or_else(
        || Ok(vec![]),
        |upstream_head| {
            ctx.git2_repo
                .get()?
                .l(upstream_head, LogUntil::Commit(default_target.sha), false)
        },
    )?;

    if pushed_commit_oids.contains(&commit_id) && !stack.allow_rebasing {
        // updating the message of a pushed commit will cause a force push that is not allowed
        bail!("force push not allowed");
    }

    let mut steps = stack.as_rebase_steps(ctx, &gix_repo)?;
    // Update the commit message
    for step in steps.iter_mut() {
        if let RebaseStep::Pick {
            commit_id: id,
            new_message,
        } = step
            && *id == commit_id.to_gix()
        {
            *new_message = Some(message.into());
        }
    }
    let merge_base = stack.merge_base(ctx)?;
    let mut rebase = but_rebase::Rebase::new(&gix_repo, Some(merge_base), None)?;
    rebase.rebase_noops(false);
    rebase.steps(steps)?;
    let output = rebase.rebase()?;

    let new_head = output.top_commit.to_git2();
    stack.set_stack_head(&vb_state, &gix_repo, new_head, None)?;
    stack.set_heads_from_rebase_output(ctx, output.references)?;

    crate::integration::update_workspace_commit(&vb_state, ctx, false)
        .context("failed to update gitbutler workspace")?;

    output
        .commit_mapping
        .iter()
        .find_map(|(_base, old, new)| (*old == commit_id.to_gix()).then_some(new.to_git2()))
        .ok_or(anyhow!(
            "Failed to find the updated commit id after rebasing"
        ))
}
```

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #11473 
- <kbd>&nbsp;2&nbsp;</kbd> #11452 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #11195 
<!-- GitButler Footer Boundary Bottom -->

