### PR TITLE
Remove extra 'hi' in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,3 @@ at the [DEVELOPMENT.md](DEVELOPMENT.md) file.
 <a href="https://github.com/gitbutlerapp/gitbutler/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=gitbutlerapp/gitbutler" />
 </a>
-hi


### PR DESCRIPTION
Clearly I didn't mean to leave it there and had I used Copilot review,
I am sure it would have been caught.
