### PR TITLE
Fix local relative upstream path

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -222,7 +222,13 @@ where
     );
 
     let cwd = match harness_env {
-        HarnessEnv::Repo(p) | HarnessEnv::Global(p) => p,
+        HarnessEnv::Repo(p) =>
+        // repo_path is the .git/ dir in the repository.
+        // Take the parent dir, so that e.g. an origin that's a relative path works.
+        {
+            p.as_ref().parent().unwrap_or(p.as_ref()).to_path_buf()
+        }
+        HarnessEnv::Global(p) => p.as_ref().to_path_buf()
     };
     let mut child_process = core::pin::pin! {
         async {


### PR DESCRIPTION
## 🧢 Changes

Fix the active directory to be the repo root instead of `.git`

## ☕️ Reasoning

I used the following script to set up a quick test repo + local remote
```
#!/bin/bash
mkdir remote
cd remote
git init --bare
cd ..
mkdir local
cd local
git init
touch first_file.txt
git add first_file.txt
git commit -m "first commit"
git remote add origin ../remote
git push origin master

echo "local repo + local remote set up"
```

When loading `local` into GitButler there are errors that remote isn't a git repo because it's running git from within the `.git` dir and then the relative `../remote` doesn't exist.

I don't know if it's possible to use this setup script as the start of an integration test? If you think that's a good idea then I'd love a small pointer of where to add that.