### PR TITLE
Use the workdir as CWD for Git invocations if available. (#11465)

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -63,7 +63,7 @@ pub type Error<E> = RepositoryError<
 >;
 
 enum HarnessEnv<P: AsRef<Path>> {
-    /// The contained P is the repo's path
+    /// The contained P is the repository's worktree directory or its `.git` directory.
     Repo(P),
     /// The contained P is the path that the command should be executed in
     Global(P),

--- a/crates/gitbutler-repo-actions/src/repository.rs
+++ b/crates/gitbutler-repo-actions/src/repository.rs
@@ -198,13 +198,13 @@ impl RepoActionsExt for Context {
         // NOTE(qix-): work around a time-sensitive change that was necessary
         // NOTE(qix-): without having to refactor a large portion of the codebase.
         if use_git_executable {
-            let path = self.gitdir.clone();
+            let repo_path = self.workdir_or_gitdir()?;
             let remote = branch.remote().to_string();
             match std::thread::spawn(move || {
                 tokio::runtime::Runtime::new()
                     .unwrap()
                     .block_on(gitbutler_git::push(
-                        path,
+                        repo_path,
                         gitbutler_git::tokio::TokioExecutor,
                         &remote,
                         gitbutler_git::RefSpec::parse(refspec).unwrap(),
@@ -300,13 +300,13 @@ impl RepoActionsExt for Context {
         // NOTE(qix-): work around a time-sensitive change that was necessary
         // NOTE(qix-): without having to refactor a large portion of the codebase.
         if self.legacy_project.preferred_key == AuthKey::SystemExecutable {
-            let path = self.legacy_project.git_dir().to_owned();
+            let repo_path = self.workdir_or_gitdir()?;
             let remote = remote_name.to_string();
             return std::thread::spawn(move || {
                 tokio::runtime::Runtime::new()
                     .unwrap()
                     .block_on(gitbutler_git::fetch(
-                        path,
+                        repo_path,
                         gitbutler_git::tokio::TokioExecutor,
                         &remote,
                         gitbutler_git::RefSpec::parse(refspec).unwrap(),


### PR DESCRIPTION
That way, relative paths for remotes will work as one would expect. It turns out that Git won't CWD into the workdir if it's started from a `.git` dir.
