### PR TITLE
Reimplement insert blank commit

### DIFF
--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -1,6 +1,7 @@
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_rebase::graph_rebase::{GraphExt, LookupStep as _};
 use tracing::instrument;
 
 /// Rewords a commit
@@ -15,8 +16,15 @@ pub fn commit_reword_only(
 ) -> anyhow::Result<gix::ObjectId> {
     let mut guard = ctx.exclusive_worktree_access();
     let (repo, _, graph) = ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let editor = graph.to_editor(&repo)?;
 
-    but_workspace::commit::reword(&graph, &repo, commit_id, message.as_bstr())
+    let (outcome, edited_commit_selector) =
+        but_workspace::commit::reword(editor, commit_id, message.as_bstr())?;
+
+    let outcome = outcome.materialize()?;
+    let id = outcome.lookup_pick(edited_commit_selector)?;
+
+    Ok(id)
 }
 
 /// Rewords a commit, but without updating the oplog.

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -3,7 +3,7 @@ use but_api_macros::but_api;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use tracing::instrument;
 
-/// Rewords a commit, but without updating the oplog.
+/// Rewords a commit
 ///
 /// Returns the ID of the newly renamed commit
 #[but_api]

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -15,7 +15,7 @@ impl Editor {
     }
 
     /// Writes a commit with correct signing to the in memory repository.
-    pub fn write_commit(
+    pub fn new_commit(
         &self,
         commit: but_core::Commit<'_>,
         date_mode: DateMode,

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -1,7 +1,8 @@
 //! Functions for materializing a rebase
-use std::collections::HashMap;
-
-use anyhow::Result;
+use crate::graph_rebase::{
+    Checkout, MaterializeOutcome, Step, SuccessfulRebase, util::collect_ordered_parents,
+};
+use anyhow::{Context, Result, bail};
 use but_core::{
     ObjectStorageExt as _,
     worktree::{
@@ -9,15 +10,6 @@ use but_core::{
         safe_checkout_from_head,
     },
 };
-
-use crate::graph_rebase::{Checkouts, rebase::SuccessfulRebase};
-
-/// The outcome of a materialize
-#[derive(Debug, Clone)]
-pub struct MaterializeOutcome {
-    /// A mapping of any commits that were rewritten as part of the rebase
-    pub commit_mapping: HashMap<gix::ObjectId, gix::ObjectId>,
-}
 
 impl SuccessfulRebase {
     /// Materializes a history rewrite
@@ -29,21 +21,34 @@ impl SuccessfulRebase {
 
         for checkout in self.checkouts {
             match checkout {
-                Checkouts::Head => {
-                    let head_oid = repo.head_commit()?.id;
-                    if let Some(new_head) = self.commit_mapping.get(&head_oid) {
-                        // If the head has changed (which means it's in the
-                        // commit mapping), perform a safe checkout.
-                        safe_checkout_from_head(
-                            *new_head,
-                            &repo,
-                            Options {
-                                uncommitted_changes:
-                                    UncommitedWorktreeChanges::KeepAndAbortOnConflict,
-                                skip_head_update: true,
-                            },
-                        )?;
-                    }
+                Checkout::Head(selector) => {
+                    let selector = self.history.normalize_selector(selector)?;
+                    let step = self.graph[selector.id].clone();
+
+                    let new_head = match step {
+                        Step::None => bail!("Checkout selector is pointing to none"),
+                        Step::Pick { id, .. } => id,
+                        Step::Reference { .. } => {
+                            let parents = collect_ordered_parents(&self.graph, selector.id);
+                            let parent_step_id =
+                                parents.first().context("No first parent to reference")?;
+                            let Step::Pick { id, .. } = self.graph[*parent_step_id] else {
+                                bail!("collect_ordered_parents should always return a commit pick");
+                            };
+                            id
+                        }
+                    };
+
+                    // If the head has changed (which means it's in the
+                    // commit mapping), perform a safe checkout.
+                    safe_checkout_from_head(
+                        new_head,
+                        &repo,
+                        Options {
+                            uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
+                            skip_head_update: true,
+                        },
+                    )?;
                 }
             }
         }
@@ -51,7 +56,8 @@ impl SuccessfulRebase {
         repo.edit_references(self.ref_edits.clone())?;
 
         Ok(MaterializeOutcome {
-            commit_mapping: self.commit_mapping,
+            graph: self.graph,
+            history: self.history,
         })
     }
 }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -6,11 +6,17 @@
 
 mod creation;
 pub mod rebase;
+use anyhow::{Result, bail};
+use gix::refs::transaction::RefEdit;
+use std::collections::HashMap;
+
+use anyhow::Context;
 pub use creation::GraphExt;
 pub mod cherry_pick;
 pub mod commit;
 pub mod materialize;
 pub mod mutate;
+pub(crate) mod util;
 
 /// Utilities for testing
 pub mod testing;
@@ -65,16 +71,17 @@ type StepGraphIndex = petgraph::stable_graph::NodeIndex;
 type StepGraph = petgraph::stable_graph::StableDiGraph<Step, Edge>;
 
 /// Points to a step in the rebase editor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Selector {
     id: StepGraphIndex,
+    revision: usize,
 }
 
 /// Represents places where `safe_checkout` should be called from
 #[derive(Debug, Clone)]
-pub(crate) enum Checkouts {
+pub(crate) enum Checkout {
     /// The HEAD of the `repo` the editor was created for.
-    Head,
+    Head(Selector),
 }
 
 /// Used to manipulate a set of picks.
@@ -86,7 +93,103 @@ pub struct Editor {
     /// deleted.
     initial_references: Vec<gix::refs::FullName>,
     /// Worktrees that we might need to perform `safe_checkout` on.
-    checkouts: Vec<Checkouts>,
+    checkouts: Vec<Checkout>,
     /// The in-memory repository that the rebase engine works with.
     repo: gix::Repository,
+    history: RevisionHistory,
+}
+
+/// Represents a successful rebase, and any valid, but potentially conflicting scenarios it had.
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct SuccessfulRebase {
+    pub(crate) repo: gix::Repository,
+    /// Any reference edits that need to be committed as a result of the history
+    /// rewrite
+    pub(crate) ref_edits: Vec<RefEdit>,
+    /// The new step graph
+    pub(crate) graph: StepGraph,
+    pub(crate) checkouts: Vec<Checkout>,
+    pub(crate) history: RevisionHistory,
+}
+
+/// The outcome of a materialize
+#[derive(Debug, Clone)]
+pub struct MaterializeOutcome {
+    pub(crate) graph: StepGraph,
+    pub(crate) history: RevisionHistory,
+}
+
+/// Provides lookup for different steps that a selector might point to.
+pub trait LookupStep {
+    /// Look up the step that a given selector corresponds to.
+    fn lookup_step(&self, selector: Selector) -> Result<Step>;
+
+    /// Look up the step a given selector and assert it's a pick.
+    fn lookup_pick(&self, selector: Selector) -> Result<gix::ObjectId> {
+        match self.lookup_step(selector)? {
+            Step::Pick { id, .. } => Ok(id),
+            _ => bail!("Expected selector to point to a pick"),
+        }
+    }
+
+    /// Look up the step a given selector and assert it's a pick.
+    fn lookup_reference(&self, selector: Selector) -> Result<gix::refs::FullName> {
+        match self.lookup_step(selector)? {
+            Step::Reference { refname } => Ok(refname),
+            _ => bail!("Expected selector to point to a reference"),
+        }
+    }
+}
+
+impl LookupStep for Editor {
+    fn lookup_step(&self, selector: Selector) -> Result<Step> {
+        lookup_step(&self.graph, &self.history, selector)
+    }
+}
+
+impl LookupStep for SuccessfulRebase {
+    fn lookup_step(&self, selector: Selector) -> Result<Step> {
+        lookup_step(&self.graph, &self.history, selector)
+    }
+}
+
+impl LookupStep for MaterializeOutcome {
+    fn lookup_step(&self, selector: Selector) -> Result<Step> {
+        lookup_step(&self.graph, &self.history, selector)
+    }
+}
+
+fn lookup_step(graph: &StepGraph, history: &RevisionHistory, selector: Selector) -> Result<Step> {
+    let normalized = history.normalize_selector(selector)?;
+    Ok(graph[normalized.id].clone())
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RevisionHistory {
+    mappings: Vec<HashMap<StepGraphIndex, StepGraphIndex>>,
+}
+
+impl RevisionHistory {
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    pub(crate) fn current_revision(&self) -> usize {
+        self.mappings.len()
+    }
+
+    pub(crate) fn normalize_selector(&self, mut selector: Selector) -> Result<Selector> {
+        while selector.revision < self.current_revision() {
+            selector.id = *self.mappings[selector.revision]
+                .get(&selector.id)
+                .context("Failed to normalize selector, selector was missing from the mapping")?;
+            selector.revision += 1;
+        }
+        Ok(selector)
+    }
+
+    pub(crate) fn add_revision(&mut self, mapping: HashMap<StepGraphIndex, StepGraphIndex>) {
+        self.mappings.push(mapping);
+    }
 }

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -2,35 +2,17 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use crate::graph_rebase::{
+    Editor, Step, StepGraph, StepGraphIndex, SuccessfulRebase,
+    cherry_pick::{CherryPickOutcome, cherry_pick},
+    util::collect_ordered_parents,
+};
 use anyhow::{Context, Result, bail};
 use gix::refs::{
     Target,
     transaction::{Change, LogChange, PreviousValue, RefEdit},
 };
 use petgraph::{Direction, visit::EdgeRef};
-
-use crate::graph_rebase::{
-    Checkouts, Editor, Step, StepGraph, StepGraphIndex,
-    cherry_pick::{CherryPickOutcome, cherry_pick},
-};
-
-/// Represents a successful rebase, and any valid, but potentially conflicting scenarios it had.
-#[allow(unused)]
-#[derive(Debug, Clone)]
-pub struct SuccessfulRebase {
-    pub(crate) repo: gix::Repository,
-    /// A mapping of any commits that were rewritten as part of the rebase
-    pub(crate) commit_mapping: HashMap<gix::ObjectId, gix::ObjectId>,
-    /// A mapping between the original step graph and the new one
-    pub(crate) graph_mapping: HashMap<StepGraphIndex, StepGraphIndex>,
-    /// Any reference edits that need to be committed as a result of the history
-    /// rewrite
-    pub(crate) ref_edits: Vec<RefEdit>,
-    /// The new step graph
-    pub(crate) graph: StepGraph,
-    /// To checkout
-    pub(crate) checkouts: Vec<Checkouts>,
-}
 
 impl Editor {
     /// Perform the rebase
@@ -202,56 +184,17 @@ impl Editor {
             }
         }
 
+        let mut history = self.history;
+        history.add_revision(graph_mapping);
+
         Ok(SuccessfulRebase {
             repo: self.repo,
             ref_edits,
-            commit_mapping,
-            graph_mapping,
             graph: output_graph,
             checkouts: self.checkouts.to_owned(),
+            history,
         })
     }
-}
-
-/// Find the parents of a given node that are commit - in correct parent
-/// ordering.
-///
-/// We do this via a pruned depth first search.
-fn collect_ordered_parents(graph: &StepGraph, target: StepGraphIndex) -> Vec<StepGraphIndex> {
-    let mut potential_parent_edges = graph
-        .edges_directed(target, petgraph::Direction::Outgoing)
-        .collect::<Vec<_>>();
-    potential_parent_edges.sort_by_key(|e| e.weight().order);
-    potential_parent_edges.reverse();
-
-    let mut seen = potential_parent_edges
-        .iter()
-        .map(|e| e.target())
-        .collect::<HashSet<_>>();
-
-    let mut parents = vec![];
-
-    while let Some(candidate) = potential_parent_edges.pop() {
-        if let Step::Pick { .. } = graph[candidate.target()] {
-            parents.push(candidate.target());
-            // Don't pursue the children
-            continue;
-        };
-
-        let mut outgoings = graph
-            .edges_directed(candidate.target(), petgraph::Direction::Outgoing)
-            .collect::<Vec<_>>();
-        outgoings.sort_by_key(|e| e.weight().order);
-        outgoings.reverse();
-
-        for edge in outgoings {
-            if seen.insert(edge.target()) {
-                potential_parent_edges.push(edge);
-            }
-        }
-    }
-
-    parents
 }
 
 /// Creates a list of step indicies ordered in the dependency order.
@@ -311,118 +254,6 @@ fn order_steps_picking(graph: &StepGraph, heads: &[StepGraphIndex]) -> VecDeque<
 
 #[cfg(test)]
 mod test {
-    mod collect_ordered_parents {
-        use std::str::FromStr as _;
-
-        use anyhow::Result;
-
-        use crate::graph_rebase::{Edge, Step, StepGraph, rebase::collect_ordered_parents};
-
-        #[test]
-        fn basic_scenario() -> Result<()> {
-            let mut graph = StepGraph::new();
-            let a_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
-            let a = graph.add_node(Step::Pick {
-                id: a_id,
-                preserved_parents: None,
-            });
-            // First parent
-            let b_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
-            let b = graph.add_node(Step::Pick {
-                id: b_id,
-                preserved_parents: None,
-            });
-            // Second parent - is a reference
-            let c = graph.add_node(Step::Reference {
-                refname: "refs/heads/foobar".try_into()?,
-            });
-            // Second parent's first child
-            let d_id = gix::ObjectId::from_str("3000000000000000000000000000000000000000")?;
-            let d = graph.add_node(Step::Pick {
-                id: d_id,
-                preserved_parents: None,
-            });
-            // Second parent's second child
-            let e_id = gix::ObjectId::from_str("4000000000000000000000000000000000000000")?;
-            let e = graph.add_node(Step::Pick {
-                id: e_id,
-                preserved_parents: None,
-            });
-            // Third parent
-            let f_id = gix::ObjectId::from_str("5000000000000000000000000000000000000000")?;
-            let f = graph.add_node(Step::Pick {
-                id: f_id,
-                preserved_parents: None,
-            });
-
-            // A's parents
-            graph.add_edge(a, b, Edge { order: 0 });
-            graph.add_edge(a, c, Edge { order: 1 });
-            graph.add_edge(a, f, Edge { order: 2 });
-
-            // C's parents
-            graph.add_edge(c, d, Edge { order: 0 });
-            graph.add_edge(c, e, Edge { order: 1 });
-
-            let parents = collect_ordered_parents(&graph, a);
-            assert_eq!(&parents, &[b, d, e, f]);
-
-            Ok(())
-        }
-
-        #[test]
-        fn insertion_order_is_irrelevant() -> Result<()> {
-            let mut graph = StepGraph::new();
-            let a_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
-            let a = graph.add_node(Step::Pick {
-                id: a_id,
-                preserved_parents: None,
-            });
-            // First parent
-            let b_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
-            let b = graph.add_node(Step::Pick {
-                id: b_id,
-                preserved_parents: None,
-            });
-            // Second parent - is a reference
-            let c = graph.add_node(Step::Reference {
-                refname: "refs/heads/foobar".try_into()?,
-            });
-            // Second parent's second child
-            let d_id = gix::ObjectId::from_str("3000000000000000000000000000000000000000")?;
-            let d = graph.add_node(Step::Pick {
-                id: d_id,
-                preserved_parents: None,
-            });
-            // Second parent's first child
-            let e_id = gix::ObjectId::from_str("4000000000000000000000000000000000000000")?;
-            let e = graph.add_node(Step::Pick {
-                id: e_id,
-                preserved_parents: None,
-            });
-            // Third parent
-            let f_id = gix::ObjectId::from_str("5000000000000000000000000000000000000000")?;
-            let f = graph.add_node(Step::Pick {
-                id: f_id,
-                preserved_parents: None,
-            });
-
-            // A's parents
-            graph.add_edge(a, f, Edge { order: 2 });
-            graph.add_edge(a, c, Edge { order: 1 });
-            graph.add_edge(a, b, Edge { order: 0 });
-
-            // C's parents
-            graph.add_edge(c, d, Edge { order: 1 });
-            graph.add_edge(c, e, Edge { order: 0 });
-
-            let parents = collect_ordered_parents(&graph, a);
-            assert_eq!(&parents, &[b, e, d, f]);
-
-            Ok(())
-        }
-    }
-
     mod order_steps_picking {
         use std::str::FromStr;
 

--- a/crates/but-rebase/src/graph_rebase/testing.rs
+++ b/crates/but-rebase/src/graph_rebase/testing.rs
@@ -3,7 +3,7 @@
 
 use petgraph::dot::{Config, Dot};
 
-use crate::graph_rebase::{Editor, Step, StepGraph, rebase::SuccessfulRebase};
+use crate::graph_rebase::{Editor, Step, StepGraph, SuccessfulRebase};
 
 /// An extension trait that adds debugging output for graphs
 pub trait TestingDot {

--- a/crates/but-rebase/src/graph_rebase/util.rs
+++ b/crates/but-rebase/src/graph_rebase/util.rs
@@ -1,0 +1,166 @@
+//! Utilities around the step graph for internal use.
+
+use std::collections::HashSet;
+
+use petgraph::visit::EdgeRef as _;
+
+use crate::graph_rebase::{Step, StepGraph, StepGraphIndex};
+
+/// Find the parents of a given node that are commit - in correct parent
+/// ordering.
+///
+/// We do this via a pruned depth first search.
+pub(crate) fn collect_ordered_parents(
+    graph: &StepGraph,
+    target: StepGraphIndex,
+) -> Vec<StepGraphIndex> {
+    let mut potential_parent_edges = graph
+        .edges_directed(target, petgraph::Direction::Outgoing)
+        .collect::<Vec<_>>();
+    potential_parent_edges.sort_by_key(|e| e.weight().order);
+    potential_parent_edges.reverse();
+
+    let mut seen = potential_parent_edges
+        .iter()
+        .map(|e| e.target())
+        .collect::<HashSet<_>>();
+
+    let mut parents = vec![];
+
+    while let Some(candidate) = potential_parent_edges.pop() {
+        if let Step::Pick { .. } = graph[candidate.target()] {
+            parents.push(candidate.target());
+            // Don't pursue the children
+            continue;
+        };
+
+        let mut outgoings = graph
+            .edges_directed(candidate.target(), petgraph::Direction::Outgoing)
+            .collect::<Vec<_>>();
+        outgoings.sort_by_key(|e| e.weight().order);
+        outgoings.reverse();
+
+        for edge in outgoings {
+            if seen.insert(edge.target()) {
+                potential_parent_edges.push(edge);
+            }
+        }
+    }
+
+    parents
+}
+
+#[cfg(test)]
+mod test {
+    mod collect_ordered_parents {
+        use std::str::FromStr as _;
+
+        use anyhow::Result;
+
+        use crate::graph_rebase::{Edge, Step, StepGraph, util::collect_ordered_parents};
+
+        #[test]
+        fn basic_scenario() -> Result<()> {
+            let mut graph = StepGraph::new();
+            let a_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
+            let a = graph.add_node(Step::Pick {
+                id: a_id,
+                preserved_parents: None,
+            });
+            // First parent
+            let b_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
+            let b = graph.add_node(Step::Pick {
+                id: b_id,
+                preserved_parents: None,
+            });
+            // Second parent - is a reference
+            let c = graph.add_node(Step::Reference {
+                refname: "refs/heads/foobar".try_into()?,
+            });
+            // Second parent's first child
+            let d_id = gix::ObjectId::from_str("3000000000000000000000000000000000000000")?;
+            let d = graph.add_node(Step::Pick {
+                id: d_id,
+                preserved_parents: None,
+            });
+            // Second parent's second child
+            let e_id = gix::ObjectId::from_str("4000000000000000000000000000000000000000")?;
+            let e = graph.add_node(Step::Pick {
+                id: e_id,
+                preserved_parents: None,
+            });
+            // Third parent
+            let f_id = gix::ObjectId::from_str("5000000000000000000000000000000000000000")?;
+            let f = graph.add_node(Step::Pick {
+                id: f_id,
+                preserved_parents: None,
+            });
+
+            // A's parents
+            graph.add_edge(a, b, Edge { order: 0 });
+            graph.add_edge(a, c, Edge { order: 1 });
+            graph.add_edge(a, f, Edge { order: 2 });
+
+            // C's parents
+            graph.add_edge(c, d, Edge { order: 0 });
+            graph.add_edge(c, e, Edge { order: 1 });
+
+            let parents = collect_ordered_parents(&graph, a);
+            assert_eq!(&parents, &[b, d, e, f]);
+
+            Ok(())
+        }
+
+        #[test]
+        fn insertion_order_is_irrelevant() -> Result<()> {
+            let mut graph = StepGraph::new();
+            let a_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
+            let a = graph.add_node(Step::Pick {
+                id: a_id,
+                preserved_parents: None,
+            });
+            // First parent
+            let b_id = gix::ObjectId::from_str("1000000000000000000000000000000000000000")?;
+            let b = graph.add_node(Step::Pick {
+                id: b_id,
+                preserved_parents: None,
+            });
+            // Second parent - is a reference
+            let c = graph.add_node(Step::Reference {
+                refname: "refs/heads/foobar".try_into()?,
+            });
+            // Second parent's second child
+            let d_id = gix::ObjectId::from_str("3000000000000000000000000000000000000000")?;
+            let d = graph.add_node(Step::Pick {
+                id: d_id,
+                preserved_parents: None,
+            });
+            // Second parent's first child
+            let e_id = gix::ObjectId::from_str("4000000000000000000000000000000000000000")?;
+            let e = graph.add_node(Step::Pick {
+                id: e_id,
+                preserved_parents: None,
+            });
+            // Third parent
+            let f_id = gix::ObjectId::from_str("5000000000000000000000000000000000000000")?;
+            let f = graph.add_node(Step::Pick {
+                id: f_id,
+                preserved_parents: None,
+            });
+
+            // A's parents
+            graph.add_edge(a, f, Edge { order: 2 });
+            graph.add_edge(a, c, Edge { order: 1 });
+            graph.add_edge(a, b, Edge { order: 0 });
+
+            // C's parents
+            graph.add_edge(c, d, Edge { order: 1 });
+            graph.add_edge(c, e, Edge { order: 0 });
+
+            let parents = collect_ordered_parents(&graph, a);
+            assert_eq!(&parents, &[b, e, d, f]);
+
+            Ok(())
+        }
+    }
+}

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -45,13 +45,13 @@ fn insert_below_merge_commit() -> Result<()> {
         .context("Failed to find commit a in editor graph")?;
     // replace it with the new one
     editor.insert(
-        &selector,
+        selector,
         Step::Pick {
             id: new_commit,
             preserved_parents: None,
         },
         InsertSide::Below,
-    );
+    )?;
 
     let outcome = editor.rebase()?;
     outcome.materialize()?;
@@ -108,13 +108,13 @@ fn insert_above_commit_with_two_children() -> Result<()> {
         .context("Failed to find commit a in editor graph")?;
     // replace it with the new one
     editor.insert(
-        &selector,
+        selector,
         Step::Pick {
             id: new_commit,
             preserved_parents: None,
         },
         InsertSide::Above,
-    );
+    )?;
 
     let outcome = editor.rebase()?;
     outcome.materialize()?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
@@ -47,12 +47,12 @@ fn reword_a_commit() -> Result<()> {
         .context("Failed to find commit a in editor graph")?;
     // replace it with the new one
     editor.replace(
-        &a_selector,
+        a_selector,
         Step::Pick {
             id: a_new,
             preserved_parents: None,
         },
-    );
+    )?;
 
     let outcome = editor.rebase()?;
     outcome.materialize()?;
@@ -128,12 +128,12 @@ fn amend_a_commit() -> Result<()> {
         .context("Failed to find commit a in editor graph")?;
     // replace it with the new one
     editor.replace(
-        &a_selector,
+        a_selector,
         Step::Pick {
             id: a_new,
             preserved_parents: None,
         },
-    );
+    )?;
 
     let outcome = editor.rebase()?;
     outcome.materialize()?;

--- a/crates/but-workspace/src/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/src/commit/insert_blank_commit.rs
@@ -1,0 +1,41 @@
+//! Insertion of a blank commit
+
+/// Describes where the blank commit should be inserted relative to.
+#[derive(Debug, Clone)]
+pub enum RelativeTo<'a> {
+    /// Relative to a commit
+    Commit(gix::ObjectId),
+    /// Relative to a reference
+    Reference(&'a gix::refs::FullNameRef),
+}
+
+pub(crate) mod function {
+    use anyhow::Result;
+    use but_rebase::{
+        commit::DateMode,
+        graph_rebase::{Editor, Selector, Step, SuccessfulRebase, mutate::InsertSide},
+    };
+
+    use crate::commit::insert_blank_commit::RelativeTo;
+
+    /// Inserts a blank commit relative to either a reference or a commit
+    pub fn insert_blank_commit(
+        mut editor: Editor,
+        side: InsertSide,
+        relative_to: RelativeTo,
+    ) -> Result<(SuccessfulRebase, Selector)> {
+        let target_selector = match relative_to {
+            RelativeTo::Commit(id) => editor.select_commit(id)?,
+            RelativeTo::Reference(r) => editor.select_reference(r)?,
+        };
+
+        let commit = editor.empty_commit()?;
+        let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorUpdate)?;
+
+        let blank_commit_selector = editor.insert(target_selector, Step::new_pick(new_id), side)?;
+
+        let outcome = editor.rebase()?;
+
+        Ok((outcome, blank_commit_selector))
+    }
+}

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -6,6 +6,8 @@ use crate::WorkspaceCommit;
 
 pub mod reword;
 pub use reword::function::reword;
+pub mod insert_blank_commit;
+pub use insert_blank_commit::function::insert_blank_commit;
 
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
 #[derive(Clone)]

--- a/crates/but-workspace/src/commit/reword.rs
+++ b/crates/but-workspace/src/commit/reword.rs
@@ -5,31 +5,28 @@ pub(crate) mod function {
     use bstr::BStr;
     use but_rebase::{
         commit::DateMode,
-        graph_rebase::{GraphExt, Step},
+        graph_rebase::{Editor, Selector, Step, SuccessfulRebase},
     };
 
     /// This action will rewrite a commit and any relevant history so it uses
     /// the new name.
     ///
-    /// Returns the ID of the newly renamed commit
+    /// Returns a selector to the rewritten commit
     pub fn reword(
-        graph: &but_graph::Graph,
-        repo: &gix::Repository,
+        mut editor: Editor,
         commit_id: gix::ObjectId,
         new_message: &BStr,
-    ) -> Result<gix::ObjectId> {
-        let mut editor = graph.to_editor(repo)?;
+    ) -> Result<(SuccessfulRebase, Selector)> {
         let target_selector = editor.select_commit(commit_id)?;
 
         let mut commit = editor.find_commit(commit_id)?;
         commit.message = new_message.to_owned();
-        let new_id = editor.write_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
+        let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
 
-        editor.replace(&target_selector, Step::new_pick(new_id));
+        editor.replace(target_selector, Step::new_pick(new_id))?;
 
         let outcome = editor.rebase()?;
-        outcome.materialize()?;
 
-        Ok(new_id)
+        Ok((outcome, target_selector))
     }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/insert-blank-commit-three-commits copy.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/insert-blank-commit-three-commits copy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "/remote/" > .gitignore
+mkdir remote
+pushd remote
+git init
+popd
+
+git init
+
+git remote add origin ./remote
+
+git checkout -b one
+echo "foo" > one.txt
+git add .
+git commit -m "commit one"
+
+git checkout -b two
+echo "foo" > two.txt
+git add .
+git commit -m "commit two"
+
+git push -u origin two
+
+git checkout -b three
+echo "foo" > three.txt
+git add .
+git commit -m "commit three"

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -1,0 +1,142 @@
+use anyhow::Result;
+use but_rebase::graph_rebase::GraphExt as _;
+use but_rebase::graph_rebase::mutate::InsertSide;
+use but_testsupport::{assure_stable_env, visualize_commit_graph_all};
+use but_workspace::commit::insert_blank_commit;
+use but_workspace::commit::insert_blank_commit::RelativeTo;
+
+use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
+
+#[test]
+fn insert_below_commit() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let id = repo.rev_parse_single("two")?;
+
+    let editor = graph.to_editor(&repo)?;
+    insert_blank_commit(editor, InsertSide::Below, RelativeTo::Commit(id.detach()))?
+        .0
+        .materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 31dbfdc (HEAD -> three) commit three
+    * b65c813 (two) commit two
+    * d2b480d 
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn insert_above_commit() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let id = repo.rev_parse_single("two")?;
+
+    let editor = graph.to_editor(&repo)?;
+    insert_blank_commit(editor, InsertSide::Above, RelativeTo::Commit(id.detach()))?
+        .0
+        .materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 923c9cd (HEAD -> three) commit three
+    * 8bf04f0 (two) 
+    * 16fd221 (origin/two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn insert_below_reference() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let reference = repo.find_reference("two")?;
+
+    let editor = graph.to_editor(&repo)?;
+    insert_blank_commit(
+        editor,
+        InsertSide::Below,
+        RelativeTo::Reference(reference.name()),
+    )?
+    .0
+    .materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 923c9cd (HEAD -> three) commit three
+    * 8bf04f0 (two) 
+    * 16fd221 (origin/two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn insert_above_reference() -> Result<()> {
+    assure_stable_env();
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let head_tree = repo.head_tree_id()?;
+    let reference = repo.find_reference("two")?;
+
+    let editor = graph.to_editor(&repo)?;
+    insert_blank_commit(
+        editor,
+        InsertSide::Above,
+        RelativeTo::Reference(reference.name()),
+    )?
+    .0
+    .materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 923c9cd (HEAD -> three) commit three
+    * 8bf04f0 
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -1,3 +1,4 @@
+mod insert_blank_commit;
 mod reword;
 
 mod from_new_merge_with_metadata {

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use but_rebase::graph_rebase::GraphExt;
 use but_testsupport::{assure_stable_env, visualize_commit_graph_all};
 use but_workspace::commit::reword;
 
@@ -17,7 +18,10 @@ fn reword_head_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("three")?;
-    reword(&graph, &repo, id.detach(), b"New name".into())?;
+    let editor = graph.to_editor(&repo)?;
+    reword(editor, id.detach(), b"New name".into())?
+        .0
+        .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 7580b8e (HEAD -> three) New name
@@ -43,7 +47,10 @@ fn reword_middle_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("two")?;
-    reword(&graph, &repo, id.detach(), b"New name".into())?;
+    let editor = graph.to_editor(&repo)?;
+    reword(editor, id.detach(), b"New name".into())?
+        .0
+        .materialize()?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 086ad49 (HEAD -> three) commit three
@@ -71,7 +78,10 @@ fn reword_base_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("one")?;
-    reword(&graph, &repo, id.detach(), b"New name".into())?;
+    let editor = graph.to_editor(&repo)?;
+    reword(editor, id.detach(), b"New name".into())?
+        .0
+        .materialize()?;
 
     // We end up with two divergent histories here. This is to be expected if we
     // rewrite the very bottom commit in a repository.


### PR DESCRIPTION
Implements insert blank commit & has some refactors to the rebase engine (see commit message).

Insert blank commit hasn't been added to the but-api or hooked into the frontend
<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #11473 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #11452 
- <kbd>&nbsp;1&nbsp;</kbd> #11195 
<!-- GitButler Footer Boundary Bottom -->

