### PR TITLE
Adjust release to build a separate `but.exe` (#11461)

### DIFF
--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -21,16 +21,20 @@ CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 # BINARIES
 ASKPASS="gitbutler-git-askpass"
 SETSID="gitbutler-git-setsid"
+BUT="but"
 
 
-if [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ]; then
+if [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ]; then
+    log injecting windows gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
+    cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
+    cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
+    if [ -f "$TARGET_ROOT/$BUT.exe" ]; then
+     cp -v "$TARGET_ROOT/$BUT.exe" "$CRATE_ROOT/$BUT-${TRIPLE}.exe"
+    fi
+elif [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/$ASKPASS" "$CRATE_ROOT/$ASKPASS-${TRIPLE}"
     cp -v "$TARGET_ROOT/$SETSID" "$CRATE_ROOT/$SETSID-${TRIPLE}"
-elif [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ]; then
-    log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
-    cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
-    cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
 else
     log gitbutler-git binaries are not built
     exit 1

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -29,7 +29,7 @@ if [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ]; then
     cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
     cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
     if [ -f "$TARGET_ROOT/$BUT.exe" ]; then
-     cp -v "$TARGET_ROOT/$BUT.exe" "$CRATE_ROOT/$BUT-${TRIPLE}.exe"
+      cp -v "$TARGET_ROOT/$BUT.exe" "$CRATE_ROOT/$BUT-${TRIPLE}.exe"
     fi
 elif [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -9,5 +9,11 @@ else
   pnpm build:desktop -- --mode "$fe_mode"
 fi
 
+set -x
 cargo build --release -p gitbutler-git
+if [ "${OS:-}" == "windows" ]; then
+  # WARNING: should only run if the `builtin-but` feature is *not* selected in `release.sh`.
+  #          Right now we just keep these scripts in sync to do the right thing, assuming it won't change.
+  cargo build --release -p but
+fi
 bash ./crates/gitbutler-tauri/inject-git-binaries.sh

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -13,7 +13,7 @@
 			"icons/nightly/icon.icns",
 			"icons/nightly/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass"]
+		"externalBin": ["to be replaced by `release.sh"]
 	},
 	"plugins": {
 		"updater": {

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -13,7 +13,7 @@
 			"icons/nightly/icon.icns",
 			"icons/nightly/icon.ico"
 		],
-		"externalBin": ["to be replaced by `release.sh"]
+		"externalBin": ["to be replaced by 'release.sh'"]
 	},
 	"plugins": {
 		"updater": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -13,7 +13,7 @@
 			"icons/release/icon.icns",
 			"icons/release/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass"]
+		"externalBin": ["to be replaced by `release.sh"]
 	},
 	"plugins": {
 		"updater": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -13,7 +13,7 @@
 			"icons/release/icon.icns",
 			"icons/release/icon.ico"
 		],
-		"externalBin": ["to be replaced by `release.sh"]
+		"externalBin": ["to be replaced by `release.sh`"]
 	},
 	"plugins": {
 		"updater": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -158,7 +158,7 @@ if [ "$DO_SIGN" = "true" ]; then
 		export APPIMAGETOOL_SIGN_PASSPHRASE="$APPIMAGE_KEY_PASSPHRASE"
 	elif [ "$OS" == "windows" ]; then
 		# Nothing to do on windows
-		:
+		export OS
 	else
 		error "signing is not supported on $(uname -s)"
 	fi
@@ -178,17 +178,25 @@ trap 'rm -rf "$TMP_DIR"' exit
 
 CONFIG_PATH=$(readlink -f "$PWD/../crates/gitbutler-tauri/tauri.conf.$CHANNEL.json")
 
-# update the version in the tauri release config
-jq '.version="'"$VERSION"'"' "$CONFIG_PATH" >"$TMP_DIR/tauri.conf.json"
-
 if [ "$OS" = "windows" ]; then
-  # WARNING: when removing `builtin-but` just must ensure that `but` is built
+  # WARNING: `builtin-but` doesn't work on Windows, see https://github.com/gitbutlerapp/gitbutler/issues/11461.
+  #          Should it be re-added, please ensure that `but` is built
   #          as part of the 'beforeBuildCommand' in tauri.conf AND it must be injected
   #          via 'inject-git-binaries.sh'.
-	FEATURES="builtin-but,windows"
+  EXTERNAL_BIN='["gitbutler-git-setsid", "gitbutler-git-askpass", "but"]'
+	FEATURES="windows"
 else
+  EXTERNAL_BIN='["gitbutler-git-setsid", "gitbutler-git-askpass"]'
 	FEATURES="builtin-but"
 fi
+
+# update the version in the tauri release config
+jq  --arg version "$VERSION"\
+    --argjson externalBin "$EXTERNAL_BIN"\
+  '.version = $version | .bundle.externalBin = $externalBin' "$CONFIG_PATH" >"$TMP_DIR/tauri.conf.json"
+
+# Useful for understanding exactly what goes into the tauri build/bundle.
+cat "$TMP_DIR/tauri.conf.json"
 
 # set the VERSION and CHANNEL as an environment variables so that they available in the but CLI
 export VERSION


### PR DESCRIPTION
Follow-up of #11476.
Solve the 'missing ouput on Windows' problem by building a separate `but` executable.


### Tasks
* [x] adjust release build procedure
* [x] verify nightly build on macOS and Windows
* [ ] ~~see if we can ship with a symlink for `but` and adjust the installation instruction accordingly~~ - let's not prolong this. And symlinks aren't easy as tauri does the final copy of the file.

### Related

* [ ] #11477

### Reference

* [This post](https://discord.com/channels/1060193121130000425/1206670506271707156/1447486161932128337) on Discord
> are the plans to make the CLI standalone (my assumption is it isnt now - pls let me know if my understanding is wrong here) basically I'm interested in using gitbutler programmatically
