### PR TITLE
fix(ui): show parsed error message in credential checks

### DIFF
--- a/apps/desktop/src/components/CredentialCheck.svelte
+++ b/apps/desktop/src/components/CredentialCheck.svelte
@@ -3,6 +3,7 @@
 	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
 	import { inject } from '@gitbutler/core/context';
+	import { parseError } from '$lib/error/parser';
 	import { Button, Icon, InfoMessage, Link } from '@gitbutler/ui';
 	import { slide } from 'svelte/transition';
 
@@ -86,7 +87,7 @@
 									</i>{check.name}
 
 									{#await check.promise catch err}
-										- {err}
+										- {parseError(err).message}
 									{/await}
 								</div>
 							{/each}

--- a/apps/desktop/src/components/CredentialCheck.svelte
+++ b/apps/desktop/src/components/CredentialCheck.svelte
@@ -2,8 +2,8 @@
 	import SectionCardDisclaimer from '$components/SectionCardDisclaimer.svelte';
 	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
-	import { inject } from '@gitbutler/core/context';
 	import { parseError } from '$lib/error/parser';
+	import { inject } from '@gitbutler/core/context';
 	import { Button, Icon, InfoMessage, Link } from '@gitbutler/ui';
 	import { slide } from 'svelte/transition';
 


### PR DESCRIPTION
## 🧢 Changes

Import parseError and use it to display a user-friendly error message when awaiting credential check promises. 
This change ensures clearer, consistent error text in the UI.

## ☕️ Reasoning

Currently, the git credential check error is showing as `[object Object]`. This resolves that. 

