### PR TITLE
feature: Allow commit title change on click

### DIFF
--- a/apps/desktop/src/components/CommitTitle.svelte
+++ b/apps/desktop/src/components/CommitTitle.svelte
@@ -7,9 +7,10 @@
 		commitMessage: string;
 		className?: string;
 		editable?: boolean;
+		onclick?: () => void;
 	};
 
-	const { commitMessage, truncate, className, editable }: Props = $props();
+	const { commitMessage, truncate, className, editable, onclick }: Props = $props();
 
 	const title = $derived(splitMessage(commitMessage).title);
 
@@ -27,7 +28,29 @@
 		class="{className} commit-title"
 		class:truncate
 		class:clr-text-3={!title}
+		class:clickable={editable && onclick}
+		onclick={editable && onclick ? onclick : undefined}
+		role={editable && onclick ? 'button' : undefined}
+		tabindex={editable && onclick ? 0 : undefined}
+		onkeydown={editable && onclick
+			? (e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						onclick();
+					}
+				}
+			: undefined}
 	>
 		{getTitle()}
 	</h3>
 </Tooltip>
+
+<style>
+	.commit-title.clickable {
+		cursor: text;
+	}
+
+	.commit-title.clickable:hover {
+		opacity: 0.8;
+	}
+</style>

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -167,6 +167,7 @@
 					commitMessage={commit.message}
 					className="text-14 text-semibold text-body"
 					editable={!isReadOnly}
+					onclick={canEdit() ? () => setMode('edit') : undefined}
 				/>
 			{/snippet}
 


### PR DESCRIPTION
## 🧢 Changes

Clicking the commit details title opens the edit dialog.

## ☕️ Reasoning

Currently, branch names can be inline-edited, but commit details not.
The UX is still a bit different as the implementing svelte classes are totally different (the branch name is rendered as an edit box, but for the commit details we have to pop up the little edit pane).

I chose to make the cursor a caret/text-pointer on hover to mimic the same look as with the branch editing, but I think `cursor: pointer` would also be good as it is not inline editing after all.

See video for before and after:

https://github.com/user-attachments/assets/000cfe79-b91b-42d7-bce2-96038fb590fb
