### PR TITLE
Compatibility Linux: Add support for older Linux Distros

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,9 +96,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-20.04 # [linux, x64]
+          - platform: ubuntu-22.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-20.04-arm # [linux, ARM64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''
@@ -348,9 +348,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-20.04 # [linux, x64]
+          - platform: ubuntu-22.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-20.04-arm # [linux, ARM64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,9 +96,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-24.04 # [linux, x64]
+          - platform: ubuntu-20.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-24.04-arm # [linux, ARM64]
+          - platform: ubuntu-20.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''
@@ -348,9 +348,9 @@ jobs:
             target: ''
           - platform: macos-15 # [macOs, x64] - cross-compile
             target: x86_64-apple-darwin
-          - platform: ubuntu-24.04 # [linux, x64]
+          - platform: ubuntu-20.04 # [linux, x64]
             target: ''
-          - platform: ubuntu-24.04-arm # [linux, ARM64]
+          - platform: ubuntu-20.04-arm # [linux, ARM64]
             target: ''
           - platform: windows-latest # [windows, x64]
             target: ''


### PR DESCRIPTION
## 🧢 Changes
made changes to the build workflow to build on ubuntu-22.04 instead of latest ubuntu-24

## ☕️ Reasoning
this change will lower the glic requirements and will allow it run on older linux distros

## 🎫 Affected issues

Fixes: #11484 

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
