### PR TITLE
Return friendly error when GUI path missing

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -121,6 +121,15 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
                 .as_ref()
                 .expect("path is checked to be Some in match guard");
             let path = std::path::Path::new(args.current_dir.as_path()).join(maybe_path);
+
+            // Check if the path exists before trying to open the GUI
+            if !path.exists() {
+                anyhow::bail!(
+                    "\"but {}\" is not a command. Type \"but --help\" to see all available commands.",
+                    maybe_path
+                );
+            }
+
             command::gui::open(&path)?;
             Ok(())
         }


### PR DESCRIPTION
When a user runs a command like `but log` and the corresponding directory does not exist, the code attempted to canonicalize the path and produced a low-level filesystem error. Instead, detect the missing path early and return a clear, user-facing message telling the user that "but <cmd>" is not a command and to run "but --help" to see available commands.

This adds a path.exists() check before opening the GUI and bails with an explanatory error to improve UX and avoid confusing OS errors.

Before:

```
❯ but test
Error: Failed to canonicalize path: ./test

Caused by:
    No such file or directory (os error 2)
```

After:
```
❯ ./target/debug/but test                                                                                           
Error: "but test" is not a command. Type "but --help" to see all available commands.
```