### PR TITLE
refactor(segment-control): unify API and Item subcomponent

### DIFF
--- a/apps/desktop/src/components/BranchExplorer.svelte
+++ b/apps/desktop/src/components/BranchExplorer.svelte
@@ -4,7 +4,6 @@
 	import BranchesListGroup from '$components/branchesPage/BranchesListGroup.svelte';
 	import noBranchesSvg from '$lib/assets/empty-state/no-branches.svg?raw';
 	import {
-		BRANCH_FILTER_OPTIONS,
 		combineBranchesAndPrs,
 		groupBranches,
 		isBranchFilterOption,
@@ -19,7 +18,6 @@
 	import { inject } from '@gitbutler/core/context';
 	import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 	import { Badge, Button, EmptyStatePlaceholder, SegmentControl } from '@gitbutler/ui';
-
 	import Fuse from 'fuse.js';
 	import type { ForgeUser } from '$lib/forge/interface/types';
 	import type { Snippet } from 'svelte';

--- a/apps/desktop/src/components/BranchExplorer.svelte
+++ b/apps/desktop/src/components/BranchExplorer.svelte
@@ -18,7 +18,7 @@
 	import { debounce } from '$lib/utils/debounce';
 	import { inject } from '@gitbutler/core/context';
 	import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
-	import { Badge, Button, EmptyStatePlaceholder, Segment, SegmentControl } from '@gitbutler/ui';
+	import { Badge, Button, EmptyStatePlaceholder, SegmentControl } from '@gitbutler/ui';
 
 	import Fuse from 'fuse.js';
 	import type { ForgeUser } from '$lib/forge/interface/types';
@@ -128,12 +128,6 @@
 		}
 	});
 
-	const selectedFilterIndex = $derived.by(() => {
-		const index = BRANCH_FILTER_OPTIONS.findIndex((item) => selectedOption === item);
-		if (index === -1) return 0;
-		return index;
-	});
-
 	function setFilter(id: string) {
 		if (isBranchFilterOption(id)) {
 			selectedOption = id;
@@ -183,9 +177,9 @@
 			</div>
 		</div>
 
-		<SegmentControl fullWidth defaultIndex={selectedFilterIndex} onselect={setFilter}>
+		<SegmentControl fullWidth selected={selectedOption} onselect={setFilter}>
 			{#each Object.entries(filterOptions) as [segmentId, segmentCopy]}
-				<Segment id={segmentId}>{segmentCopy}</Segment>
+				<SegmentControl.Item id={segmentId}>{segmentCopy}</SegmentControl.Item>
 			{/each}
 		</SegmentControl>
 	</div>

--- a/apps/desktop/src/components/FileListMode.svelte
+++ b/apps/desktop/src/components/FileListMode.svelte
@@ -2,7 +2,7 @@
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { inject } from '@gitbutler/core/context';
 	import { persisted } from '@gitbutler/shared/persisted';
-	import { Segment, SegmentControl, TestId } from '@gitbutler/ui';
+	import { SegmentControl, TestId } from '@gitbutler/ui';
 
 	type Mode = 'tree' | 'list';
 	type Props = {
@@ -22,13 +22,13 @@
 </script>
 
 <SegmentControl
-	defaultIndex={mode === 'list' ? 0 : 1}
+	selected={mode}
 	onselect={(id) => {
 		// Update saved preference; the effect will sync mode
 		$saved = id as Mode;
 	}}
 	size="small"
 >
-	<Segment id="list" testId={TestId.FileListModeOption} icon="list-view" />
-	<Segment id="tree" testId={TestId.FileListModeOption} icon="tree-view" />
+	<SegmentControl.Item id="list" testId={TestId.FileListModeOption} icon="list-view" />
+	<SegmentControl.Item id="tree" testId={TestId.FileListModeOption} icon="tree-view" />
 </SegmentControl>

--- a/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
@@ -31,10 +31,9 @@
 			in <code class="code-string">.local.md</code> override regular project prompts.
 		</p>
 
-		<SegmentControl selected={selectedSegment}>
+		<SegmentControl selected={selectedSegment} onselect={(id) => (selectedSegment = id)}>
 			{#each promptDirs as dir}
 				<SegmentControl.Item
-					onselect={() => (selectedSegment = dir.label)}
 					id={dir.label}
 					icon={dir.label === 'Global' ? 'global-small' : 'folder'}
 				>
@@ -42,7 +41,6 @@
 				</SegmentControl.Item>
 			{/each}
 		</SegmentControl>
-
 		{#if selectedSegment === 'Global'}
 			{@render pathContent({
 				path: promptDirs.find((d) => d.label === 'Global')?.path || '',

--- a/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Codeblock } from '@gitbutler/ui';
-	import { Modal, Segment, SegmentControl, Button } from '@gitbutler/ui';
+	import { Modal, SegmentControl, Button } from '@gitbutler/ui';
 	import type { PromptDir } from '$lib/codegen/types';
 
 	type Props = {
@@ -31,15 +31,15 @@
 			in <code class="code-string">.local.md</code> override regular project prompts.
 		</p>
 
-		<SegmentControl defaultIndex={0}>
+		<SegmentControl selected={selectedSegment}>
 			{#each promptDirs as dir}
-				<Segment
+				<SegmentControl.Item
 					onselect={() => (selectedSegment = dir.label)}
 					id={dir.label}
 					icon={dir.label === 'Global' ? 'global-small' : 'folder'}
 				>
 					{dir.label}
-				</Segment>
+				</SegmentControl.Item>
 			{/each}
 		</SegmentControl>
 

--- a/packages/ui/src/lib/components/ImageDiff.svelte
+++ b/packages/ui/src/lib/components/ImageDiff.svelte
@@ -2,8 +2,7 @@
 	import Badge from '$components/Badge.svelte';
 	import RangeInput from '$components/RangeInput.svelte';
 	import SkeletonBone from '$components/SkeletonBone.svelte';
-	import Segment from '$components/segmentControl/Segment.svelte';
-	import SegmentControl from '$components/segmentControl/SegmentControl.svelte';
+	import { SegmentControl } from '$components/segmentControl';
 
 	type Props = {
 		beforeImageUrl?: string | null;
@@ -283,10 +282,14 @@
 <div class="imagediff-container">
 	{#if beforeImageUrl && afterImageUrl && !isLoading}
 		<div class="view-mode-controls">
-			<SegmentControl size="small" defaultIndex={0} onselect={(id) => (viewMode = id as ViewMode)}>
-				<Segment id="2-up">2-up</Segment>
-				<Segment id="swipe">Swipe</Segment>
-				<Segment id="onion-skin">Onion Skin</Segment>
+			<SegmentControl
+				size="small"
+				selected={viewMode}
+				onselect={(id) => (viewMode = id as ViewMode)}
+			>
+				<SegmentControl.Item id="2-up">2-up</SegmentControl.Item>
+				<SegmentControl.Item id="swipe">Swipe</SegmentControl.Item>
+				<SegmentControl.Item id="onion-skin">Onion Skin</SegmentControl.Item>
 			</SegmentControl>
 		</div>
 	{/if}

--- a/packages/ui/src/lib/components/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/components/segmentControl/Segment.svelte
@@ -9,7 +9,6 @@
 	interface SegmentProps {
 		testId?: string;
 		id: string;
-		onselect?: (id: string) => void;
 		disabled?: boolean;
 		children?: Snippet;
 		tooltip?: string;
@@ -17,8 +16,7 @@
 		icon?: keyof typeof iconsJson;
 	}
 
-	const { id, onselect, children, disabled, icon, tooltip, tooltipPosition, testId }: SegmentProps =
-		$props();
+	const { id, children, disabled, icon, tooltip, tooltipPosition, testId }: SegmentProps = $props();
 
 	const context = getContext<SegmentContext>('SegmentControl');
 	const selectedSegmentId = context.selectedSegmentId;
@@ -52,14 +50,12 @@
 		onclick={() => {
 			if (!isSelected) {
 				context.selectSegment(id);
-				onselect?.(id);
 			}
 		}}
 		onkeydown={({ key }) => {
 			if (key === 'Enter' || key === ' ') {
 				if (!isSelected) {
 					context.selectSegment(id);
-					onselect?.(id);
 				}
 			}
 		}}

--- a/packages/ui/src/lib/components/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/components/segmentControl/Segment.svelte
@@ -21,12 +21,11 @@
 		$props();
 
 	const context = getContext<SegmentContext>('SegmentControl');
-	const index = context.setIndex();
-	const selectedSegmentIndex = context.selectedSegmentIndex;
+	const selectedSegmentId = context.selectedSegmentId;
 
 	let elRef = $state<HTMLButtonElement>();
 	let isFocused = $state(false);
-	const isSelected = $derived(index === $selectedSegmentIndex);
+	const isSelected = $derived($selectedSegmentId === id);
 
 	$effect(() => {
 		if (elRef && isFocused) {
@@ -35,7 +34,7 @@
 	});
 
 	onMount(() => {
-		context.addSegment({ index });
+		context.registerSegment(id);
 	});
 </script>
 
@@ -51,26 +50,16 @@
 		tabindex={isSelected || disabled ? -1 : 0}
 		aria-selected={isSelected}
 		onclick={() => {
-			if (index !== $selectedSegmentIndex) {
-				context.setSelected({
-					index,
-					id
-				});
-				if (onselect) {
-					onselect(id);
-				}
+			if (!isSelected) {
+				context.selectSegment(id);
+				onselect?.(id);
 			}
 		}}
 		onkeydown={({ key }) => {
 			if (key === 'Enter' || key === ' ') {
-				if (index !== $selectedSegmentIndex) {
-					context.setSelected({
-						index,
-						id
-					});
-					if (onselect) {
-						onselect(id);
-					}
+				if (!isSelected) {
+					context.selectSegment(id);
+					onselect?.(id);
 				}
 			}
 		}}

--- a/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
+++ b/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
@@ -37,9 +37,10 @@
 		registerSegment: (id: string) => {
 			if (!registeredSegments.includes(id)) {
 				registeredSegments.push(id);
-				// If no segment is selected, select the first one
+				// If no segment is selected, select the first one (silent initialization, do not call onselect)
 				if ($selectedSegmentId === undefined) {
 					selectedSegmentId.set(id);
+					// Do not call onselect here to avoid side effects before user interaction
 				}
 			}
 		},

--- a/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
+++ b/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import type { SegmentContext, SegmentItem } from '$components/segmentControl/segmentTypes';
+	import type { SegmentContext } from '$components/segmentControl/segmentTypes';
 	import type { Snippet } from 'svelte';
 
 	interface SegmentProps {
-		defaultIndex: number;
+		selected?: string;
 		fullWidth?: boolean;
 		shrinkable?: boolean;
 		size?: 'default' | 'small';
@@ -14,39 +14,38 @@
 	}
 
 	const {
-		defaultIndex,
-		fullWidth,
+		selected,
+		fullWidth = false,
 		shrinkable = false,
-		size,
+		size = 'default',
 		onselect,
 		children
 	}: SegmentProps = $props();
 
-	let indexesIterator = -1;
-	let segments: SegmentItem[] = [];
+	const registeredSegments: string[] = [];
+	const selectedSegmentId = writable<string | undefined>(selected);
 
-	let selectedSegmentIndex = writable(defaultIndex);
-
+	// Sync external selected prop to internal store
 	$effect(() => {
-		$selectedSegmentIndex = defaultIndex;
+		if (selected !== undefined) {
+			selectedSegmentId.set(selected);
+		}
 	});
 
 	const context: SegmentContext = {
-		selectedSegmentIndex,
-		setIndex: () => {
-			indexesIterator += 1;
-			return indexesIterator;
-		},
-		addSegment: ({ index }) => {
-			segments = [...segments, { index }];
-		},
-		setSelected: ({ index: segmentIndex, id }) => {
-			if (segmentIndex >= 0 && segmentIndex < segments.length) {
-				$selectedSegmentIndex = segmentIndex;
-				if (onselect) {
-					onselect(id);
+		selectedSegmentId,
+		registerSegment: (id: string) => {
+			if (!registeredSegments.includes(id)) {
+				registeredSegments.push(id);
+				// If no segment is selected, select the first one
+				if ($selectedSegmentId === undefined) {
+					selectedSegmentId.set(id);
 				}
 			}
+		},
+		selectSegment: (id: string) => {
+			selectedSegmentId.set(id);
+			onselect?.(id);
 		}
 	};
 

--- a/packages/ui/src/lib/components/segmentControl/index.ts
+++ b/packages/ui/src/lib/components/segmentControl/index.ts
@@ -1,0 +1,13 @@
+import SegmentItem from '$components/segmentControl/Segment.svelte';
+import SegmentControlRoot from '$components/segmentControl/SegmentControl.svelte';
+
+type SegmentControlType = typeof SegmentControlRoot & {
+	Item: typeof SegmentItem;
+};
+
+const SegmentControl = Object.assign(SegmentControlRoot, {
+	Item: SegmentItem
+}) as SegmentControlType;
+
+export { SegmentControl };
+export { SegmentItem };

--- a/packages/ui/src/lib/components/segmentControl/segmentTypes.ts
+++ b/packages/ui/src/lib/components/segmentControl/segmentTypes.ts
@@ -1,11 +1,7 @@
 import type { Writable } from 'svelte/store';
 
-export interface SegmentItem {
-	index: number;
-}
 export interface SegmentContext {
-	selectedSegmentIndex: Writable<number>;
-	setIndex(): number;
-	addSegment(segment: SegmentItem): void;
-	setSelected({ index, id }: { index: number; id: string }): void;
+	selectedSegmentId: Writable<string | undefined>;
+	registerSegment(id: string): void;
+	selectSegment(id: string): void;
 }

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -109,8 +109,7 @@ export {
 } from '$components/scroll/Scrollbar.svelte';
 
 // Segment Control Components
-export { default as Segment } from '$components/segmentControl/Segment.svelte';
-export { default as SegmentControl } from '$components/segmentControl/SegmentControl.svelte';
+export { SegmentControl, SegmentItem } from '$components/segmentControl';
 
 // Commit Lines Components
 export { default as Cell } from '$components/commitLines/Cell.svelte';

--- a/packages/ui/src/stories/components/SegmentControl.stories.svelte
+++ b/packages/ui/src/stories/components/SegmentControl.stories.svelte
@@ -1,12 +1,11 @@
 <script module lang="ts">
-	import Segment from '$components/segmentControl/Segment.svelte';
-	import SegmentControl from '$components/segmentControl/SegmentControl.svelte';
+	import { SegmentControl } from '$components/segmentControl';
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
 	const { Story } = defineMeta({
 		title: 'Inputs / Segment Control',
 		args: {
-			defaultIndex: 0,
+			selected: '1',
 			fullWidth: false,
 			size: 'default',
 			segments: [
@@ -16,9 +15,9 @@
 			]
 		},
 		argTypes: {
-			defaultIndex: {
+			selected: {
 				control: {
-					type: 'number'
+					type: 'text'
 				}
 			},
 			fullWidth: {
@@ -42,16 +41,18 @@
 <Story name="default">
 	{#snippet template(args)}
 		<SegmentControl
-			defaultIndex={args.defaultIndex}
+			selected={args.selected}
 			fullWidth={args.fullWidth}
 			onselect={(id) => {
 				// eslint-disable-next-line no-console
-				console.log('Selected index:', id);
+				console.log('Selected ID:', id);
 			}}
 			size={args.size}
 		>
 			{#each args.segments as segment}
-				<Segment id={segment.id} icon={segment.icon}>{segment.label}</Segment>
+				<SegmentControl.Item id={segment.id} icon={segment.icon}
+					>{segment.label}</SegmentControl.Item
+				>
 			{/each}
 		</SegmentControl>
 	{/snippet}


### PR DESCRIPTION
- Replace separate Segment and SegmentControl with a single
  SegmentControl that exposes Item as a namespaced subcomponent.
  This simplifies imports and usage across the codebase.
- Update SegmentControl API from index-based props to ID-based props:
  defaultIndex -> selected (string), segment registration and selection
  via IDs. Adjusted context types accordingly (selectedSegmentId,
  registerSegment, selectSegment).
- Replace inline Segment usage with SegmentControl.Item in multiple
  components and stories (ImageDiff, SegmentControl stories, FileListMode)
  and update prop names (defaultIndex -> selected) and event logging.
- Add segmentControl index barrel to re-export SegmentControl and
  SegmentItem and update library exports to use the new entrypoint.
- Minor cleanup: adapt tests and attributes to new prop names and
  update console log message text.

This refactor standardizes the segment control API, improves ergonomics
for consumers, and prepares the component for ID-based selection and
composability.