### PR TITLE
Narrower `IdMap` constructor arguments, and unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "anstyle-lossy",
  "anstyle-parse",
  "html-escape",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -738,7 +738,6 @@ dependencies = [
  "cli-prompts",
  "colored",
  "command-group",
- "crossterm 0.29.0",
  "git2",
  "gitbutler-branch",
  "gitbutler-branch-actions",
@@ -751,20 +750,19 @@ dependencies = [
  "insta",
  "minus",
  "posthog-rs",
- "ratatui",
  "regex",
  "rmcp",
  "serde",
  "serde_json",
  "shell-words",
  "snapbox",
- "strum 0.27.2",
+ "strum",
  "terminal_size",
  "tokio",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -795,14 +793,14 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-stack",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "reqwest 0.12.24",
  "rmcp",
  "schemars 1.1.0",
  "serde",
  "serde-error",
  "serde_json",
- "strum 0.27.2",
+ "strum",
  "tokio",
  "tracing",
  "uuid",
@@ -951,7 +949,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_lenient",
- "strum 0.27.2",
+ "strum",
  "tokio",
  "tracing",
  "url",
@@ -1142,7 +1140,7 @@ dependencies = [
  "gix",
  "gix-testtools",
  "insta",
- "itertools 0.14.0",
+ "itertools",
  "petgraph",
  "tracing",
 ]
@@ -1158,7 +1156,7 @@ dependencies = [
  "but-db",
  "but-hunk-dependency",
  "gitbutler-stack",
- "itertools 0.14.0",
+ "itertools",
  "serde",
  "serde-error",
  "serde_json",
@@ -1183,7 +1181,7 @@ dependencies = [
  "gix",
  "gix-testtools",
  "insta",
- "itertools 0.14.0",
+ "itertools",
  "serde",
  "serde_json",
 ]
@@ -1203,7 +1201,7 @@ dependencies = [
  "gix",
  "hex",
  "insta",
- "itertools 0.14.0",
+ "itertools",
  "md5",
  "serde",
  "toml 0.9.8",
@@ -1276,7 +1274,7 @@ dependencies = [
  "gitbutler-branch-actions",
  "gitbutler-stack",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "regex",
  "serde",
  "serde_json",
@@ -1383,7 +1381,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-stack",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "serde_json",
  "tokio",
  "tracing",
@@ -1463,7 +1461,7 @@ dependencies = [
  "gitbutler-stack",
  "gix",
  "insta",
- "itertools 0.14.0",
+ "itertools",
  "md5",
  "serde",
  "tempfile",
@@ -1634,21 +1632,6 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.8",
-]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -1889,20 +1872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,15 +1957,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -2180,40 +2140,6 @@ dependencies = [
  "libc",
  "mio 0.8.11",
  "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "mio 1.1.0",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "derive_more 2.0.1",
- "document-features",
- "mio 1.1.0",
- "parking_lot",
- "rustix 1.1.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2468,27 +2394,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "convert_case 0.7.1",
- "proc-macro2",
- "quote",
  "syn 2.0.111",
 ]
 
@@ -3527,7 +3432,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-stack",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "lazy_static",
  "serde",
 ]
@@ -3572,7 +3477,7 @@ dependencies = [
  "gitbutler-workspace",
  "gix",
  "glob",
- "itertools 0.14.0",
+ "itertools",
  "md5",
  "pretty_assertions",
  "serde",
@@ -3716,7 +3621,7 @@ dependencies = [
  "git2",
  "gitbutler-diff",
  "gitbutler-stack",
- "itertools 0.14.0",
+ "itertools",
  "serde",
 ]
 
@@ -3775,10 +3680,10 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-stack",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "pretty_assertions",
  "serde",
- "strum 0.27.2",
+ "strum",
  "tempfile",
  "toml 0.9.8",
  "tracing",
@@ -3802,7 +3707,7 @@ dependencies = [
  "resolve-path",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum",
  "tempfile",
  "tracing",
 ]
@@ -3848,7 +3753,7 @@ dependencies = [
  "ignore",
  "infer",
  "insta",
- "itertools 0.14.0",
+ "itertools",
  "resolve-path",
  "scopeguard",
  "serde",
@@ -3905,7 +3810,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-time",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "serde",
  "tempfile",
  "toml 0.9.8",
@@ -3929,7 +3834,7 @@ dependencies = [
  "gitbutler-url",
  "gitbutler-user",
  "gix",
- "itertools 0.14.0",
+ "itertools",
  "rand 0.9.2",
  "tracing",
 ]
@@ -5529,8 +5434,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -6027,15 +5930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6084,19 +5978,6 @@ dependencies = [
  "once_cell",
  "serde",
  "similar",
-]
-
-[[package]]
-name = "instability"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
-dependencies = [
- "darling 0.20.11",
- "indoc",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -6164,15 +6045,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -6595,15 +6467,6 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "serde",
  "value-bag",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -8159,7 +8022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -8438,27 +8301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.10.0",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -9173,7 +9015,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more 0.99.20",
+ "derive_more",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -9544,7 +9386,6 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.1.0",
  "signal-hook",
 ]
 
@@ -9776,33 +9617,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.111",
+ "strum_macros",
 ]
 
 [[package]]
@@ -10594,7 +10413,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -11266,23 +11085,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "but-forge",
  "but-gerrit",
  "but-github",
+ "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
  "but-meta",

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -337,6 +337,11 @@ impl Context {
         project_data_dir(&self.gitdir)
     }
 
+    /// Return the worktree directory associated with the context Git [repository](Self::repo).
+    pub fn workdir(&self) -> anyhow::Result<Option<PathBuf>> {
+        self.repo.get().map(|repo| repo.workdir().map(Into::into))
+    }
+
     /// The path to the worktree directory or the `.git` directory if there is no worktree directory.
     /// Fallible as it may need to open a repository.
     pub fn workdir_or_gitdir(&self) -> anyhow::Result<PathBuf> {

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -109,8 +109,6 @@ tracing-subscriber = { workspace = true, features = [
     "fmt",
 ] }
 tracing-forest.workspace = true
-ratatui = "0.29.0"
-crossterm = "0.29.0"
 cli-prompts = "0.1.0"
 minus = { version = "5.6.1", default-features = false, features = [
     "static_output",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -22,7 +22,6 @@ legacy = [
     "but-api/legacy",
     "but-ctx/legacy",
     "dep:but-action",
-    "dep:but-hunk-assignment",
     "dep:but-hunk-dependency",
     "dep:but-claude",
     "dep:but-cursor",
@@ -60,7 +59,8 @@ but-api = { workspace = true }
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.
 but-action = { workspace = true, optional = true }
-but-hunk-assignment = { workspace = true, optional = true }
+# Still uses `gitbutler-stack`, but otherwise it is non-legacy.
+but-hunk-assignment.workspace = true
 but-hunk-dependency = { workspace = true, optional = true }
 but-claude = { workspace = true, optional = true }
 but-cursor = { workspace = true, optional = true }

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -121,6 +121,7 @@ cfg-if = "1.0.4"
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }
+but-graph.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 but-testsupport = { workspace = true, features = ["sandbox-but-api"] }
 snapbox = { workspace = true, features = ["term-svg"] }

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -37,7 +37,8 @@ pub(crate) fn handle(
     source: Option<&str>,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(ctx)?;
+    let mut id_map = IdMap::new_from_context(ctx)?;
+    id_map.add_file_info_from_context(ctx)?;
     let source: Option<CliId> = source
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -12,11 +12,7 @@ use but_hunk_dependency::ui::HunkDependencies;
 use colored::Colorize;
 use gitbutler_project::Project;
 
-use crate::{
-    command::legacy::rub::parse_sources,
-    legacy::id::{CliId, IdMap},
-    utils::OutputChannel,
-};
+use crate::{CliId, IdMap, command::legacy::rub::parse_sources, utils::OutputChannel};
 
 /// Amends changes into the appropriate commits where they belong.
 ///

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -5,7 +5,7 @@ use but_ctx::{Context, LegacyProject};
 use but_settings::AppSettings;
 use but_workspace::legacy::ui::StackEntry;
 
-use crate::{args::branch, legacy::id::IdMap, utils::OutputChannel};
+use crate::{CliId, IdMap, args::branch, utils::OutputChannel};
 
 mod apply;
 mod json;
@@ -106,13 +106,13 @@ pub async fn handle(
                 // Create the anchor for create_reference
                 // as dependent branch
                 match anchor_id {
-                    crate::legacy::id::CliId::Commit { oid } => {
+                    CliId::Commit { oid } => {
                         Some(but_api::legacy::stack::create_reference::Anchor::AtCommit {
                             commit_id: (*oid).into(),
                             position: but_workspace::branch::create_reference::Position::Above,
                         })
                     }
-                    crate::legacy::id::CliId::Branch { name, .. } => Some(
+                    CliId::Branch { name, .. } => Some(
                         but_api::legacy::stack::create_reference::Anchor::AtReference {
                             short_name: name.clone(),
                             position: but_workspace::branch::create_reference::Position::Above,

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -77,7 +77,8 @@ pub async fn handle(
                 legacy_project,
                 AppSettings::load_from_default_path_creating()?,
             );
-            let id_map = IdMap::new(&mut ctx)?;
+            let mut id_map = IdMap::new_from_context(&ctx)?;
+            id_map.add_file_info_from_context(&mut ctx)?;
             // Get branch name or use canned name
             let branch_name = branch_name.map(Ok).unwrap_or_else(|| {
                 but_api::legacy::workspace::canned_branch_name(legacy_project.id)

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -12,10 +12,7 @@ use but_hunk_assignment::HunkAssignment;
 use gitbutler_project::Project;
 
 use crate::{
-    command::legacy::status::assignment::FileAssignment,
-    legacy::id::{CliId, IdMap},
-    tui,
-    utils::OutputChannel,
+    CliId, IdMap, command::legacy::status::assignment::FileAssignment, tui, utils::OutputChannel,
 };
 
 pub(crate) fn insert_blank_commit(
@@ -245,7 +242,7 @@ pub(crate) fn commit(
                 // If no exact match, try to parse as CLI ID and match
                 if let Ok(cli_ids) = id_map.parse_str(hint) {
                     for cli_id in cli_ids {
-                        if let crate::legacy::id::CliId::Branch { name, .. } = cli_id
+                        if let CliId::Branch { name, .. } = cli_id
                             && let Some(branch) =
                                 target_stack.branch_details.iter().find(|b| b.name == name)
                         {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -24,7 +24,8 @@ pub(crate) fn insert_blank_commit(
     target: &str,
 ) -> Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
 
     // Resolve the target ID
     let cli_ids = id_map.parse_str(target)?;
@@ -154,7 +155,8 @@ pub(crate) fn commit(
     create_branch: bool,
 ) -> anyhow::Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
 
     // Get all stacks using but-api
     let project_id = project.id;

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -18,7 +18,8 @@ pub(crate) fn describe_target(
     message: Option<&str>,
 ) -> Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
 
     // Resolve the commit ID
     let cli_ids = id_map.parse_str(target)?;

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -5,11 +5,7 @@ use but_oxidize::{ObjectIdExt as _, OidExt};
 use gitbutler_project::Project;
 use gix::prelude::ObjectIdExt;
 
-use crate::{
-    legacy::id::{CliId, IdMap},
-    tui,
-    utils::OutputChannel,
-};
+use crate::{CliId, IdMap, tui, utils::OutputChannel};
 
 pub(crate) fn describe_target(
     project: &Project,

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -13,11 +13,7 @@ use gitbutler_project::{Project, ProjectId};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::{
-    legacy::id::{CliId, IdMap},
-    tui::get_text,
-    utils::OutputChannel,
-};
+use crate::{CliId, IdMap, tui::get_text, utils::OutputChannel};
 
 /// Set the review template for the given project.
 pub fn set_review_template(

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -98,7 +98,8 @@ pub async fn publish_reviews(
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
     let branch_ids = id_map
         .parse_str(branch_id)?
         .iter()

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -7,9 +7,7 @@ use but_rules::Operation;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_project::Project;
 
-use crate::{
-    command::legacy::rub::branch_name_to_stack_id, legacy::id::IdMap, utils::OutputChannel,
-};
+use crate::{CliId, IdMap, command::legacy::rub::branch_name_to_stack_id, utils::OutputChannel};
 
 pub(crate) fn handle(
     project: &Project,
@@ -33,8 +31,8 @@ pub(crate) fn handle(
         but_rules::delete_rule(ctx, &rule.id())?;
     }
     match target_result[0].clone() {
-        crate::legacy::id::CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out),
-        crate::legacy::id::CliId::Commit { oid } => mark_commit(ctx, oid, delete, out),
+        CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out),
+        CliId::Commit { oid } => mark_commit(ctx, oid, delete, out),
         _ => bail!("Nope"),
     }
 }

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -18,7 +18,8 @@ pub(crate) fn handle(
     delete: bool,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(ctx)?;
+    let mut id_map = IdMap::new_from_context(ctx)?;
+    id_map.add_file_info_from_context(ctx)?;
     let target_result = id_map.parse_str(target_str)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -13,7 +13,8 @@ pub fn handle(
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
 
     // Check gerrit mode early
     let gerrit_mode = {

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -4,7 +4,7 @@ use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_project::Project;
 
 use crate::args::push::Command;
-use crate::legacy::id::IdMap;
+use crate::{CliId, IdMap};
 use crate::{args::push, utils::OutputChannel};
 
 pub fn handle(
@@ -138,7 +138,7 @@ fn resolve_branch_name(
         let branch_names: Vec<String> = cli_ids
             .iter()
             .filter_map(|id| match id {
-                crate::legacy::id::CliId::Branch { name, .. } => Some(name.clone()),
+                CliId::Branch { name, .. } => Some(name.clone()),
                 _ => None,
             })
             .collect();
@@ -158,7 +158,7 @@ fn resolve_branch_name(
     }
 
     match &cli_ids[0] {
-        crate::legacy::id::CliId::Branch { name, .. } => Ok(name.clone()),
+        CliId::Branch { name, .. } => Ok(name.clone()),
         _ => Err(anyhow::anyhow!(
             "Expected branch identifier, got {}. Please use a branch name or branch CLI ID.",
             cli_ids[0].kind_for_humans()

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -14,10 +14,7 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::{
-    legacy::id::{CliId, IdMap},
-    utils::OutputChannel,
-};
+use crate::{CliId, IdMap, utils::OutputChannel};
 
 pub(crate) fn handle(
     project: &Project,

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -26,7 +26,8 @@ pub(crate) fn handle(
     target_str: &str,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new(ctx)?;
+    let mut id_map = IdMap::new_from_context(ctx)?;
+    id_map.add_file_info_from_context(ctx)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str)?;
 
     for source in sources {

--- a/crates/but/src/command/legacy/status/assignment.rs
+++ b/crates/but/src/command/legacy/status/assignment.rs
@@ -2,7 +2,7 @@ use bstr::BString;
 use but_core::ref_metadata::StackId;
 use but_hunk_assignment::HunkAssignment;
 
-use crate::legacy::id::IdMap;
+use crate::IdMap;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,16 +48,6 @@ impl FileAssignment {
                 .map(|a| CLIHunkAssignment::from_assignment(id_map, a))
                 .collect(),
         }
-    }
-    #[expect(dead_code)]
-    pub fn hash(&self) -> String {
-        let combined_ids: String = self
-            .assignments
-            .iter()
-            .map(|a| a.inner.id.unwrap_or_default().to_string())
-            .collect::<Vec<_>>()
-            .join("-");
-        crate::legacy::id::hash(&format!("{},{}", &self.path.to_string(), &combined_ids))
     }
 }
 

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -18,7 +18,7 @@ const DATE_ONLY: CustomFormat = CustomFormat::new("%Y-%m-%d");
 pub(crate) mod assignment;
 pub(crate) mod json;
 
-use crate::{legacy::id::IdMap, utils::OutputChannel};
+use crate::{IdMap, utils::OutputChannel};
 
 type StackDetail = (Option<StackDetails>, Vec<FileAssignment>);
 type StackEntry = (Option<gitbutler_stack::StackId>, StackDetail);

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -57,14 +57,13 @@ pub(crate) async fn worktree(
     review: bool,
 ) -> anyhow::Result<()> {
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let mut id_map = IdMap::new(ctx)?;
     but_rules::process_rules(ctx).ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
 
     let guard = ctx.shared_worktree_access();
     let meta = ctx.meta(guard.read_permission())?;
 
     // TODO: use this for status information instead.
-    let _head_info = but_workspace::head_info(
+    let head_info = but_workspace::head_info(
         &*ctx.repo.get()?,
         &meta,
         but_workspace::ref_info::Options {
@@ -72,6 +71,8 @@ pub(crate) async fn worktree(
             ..Default::default()
         },
     )?;
+    let mut id_map = IdMap::new(&head_info.stacks)?;
+    id_map.add_file_info_from_context(ctx)?;
 
     let review_map = if review {
         crate::command::legacy::forge::review::get_review_map(project).await?
@@ -489,7 +490,8 @@ pub fn print_group(
             }
         }
     } else {
-        let id_map = IdMap::new(ctx)?;
+        let mut id_map = IdMap::new_from_context(ctx)?;
+        id_map.add_file_info_from_context(ctx)?;
         let id = id_map.unassigned().to_string().underline().blue();
         writeln!(
             out,

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1,4 +1,4 @@
-use crate::legacy::id::{CliId, IdMap};
+use crate::{CliId, IdMap};
 use anyhow::bail;
 use bstr::BString;
 use but_testsupport::Sandbox;

--- a/crates/but/src/legacy/id/mod.rs
+++ b/crates/but/src/legacy/id/mod.rs
@@ -333,7 +333,6 @@ impl IdMap {
 
         // Then try CliId matching
         if s.len() == 2 {
-            // TODO: a test for this special behaviour (if fully removed, nothing breaks)
             if let Some(UncommittedFile {
                 assignment_path: (assignment, path),
                 ..

--- a/crates/but/src/legacy/id/tests.rs
+++ b/crates/but/src/legacy/id/tests.rs
@@ -1,90 +1,7 @@
 use crate::legacy::id::{CliId, IdMap};
 use anyhow::bail;
 use bstr::BString;
-use but_core::ref_metadata::StackId;
-use but_hunk_assignment::HunkAssignment;
 use but_testsupport::Sandbox;
-use but_workspace::{
-    branch::Stack,
-    ref_info::{Commit, LocalCommit, Segment},
-};
-
-fn id(byte: u8) -> gix::ObjectId {
-    gix::ObjectId::try_from([byte].repeat(20).as_slice()).expect("could not generate ID")
-}
-
-fn segment<const N1: usize, const N2: usize>(
-    shortened_branch_name: &str,
-    local_commit_ids: [gix::ObjectId; N1],
-    base: Option<gix::ObjectId>,
-    remote_commit_ids: [gix::ObjectId; N2],
-) -> Segment {
-    fn commit(id: gix::ObjectId, parent_id: Option<gix::ObjectId>) -> Commit {
-        Commit {
-            id,
-            parent_ids: parent_id.into_iter().collect::<Vec<gix::ObjectId>>(),
-            tree_id: gix::index::hash::Kind::Sha1.empty_tree(),
-            message: Default::default(),
-            author: Default::default(),
-            refs: Vec::new(),
-            flags: Default::default(),
-            has_conflicts: false,
-            change_id: None,
-        }
-    }
-
-    let ref_info = Some(but_graph::RefInfo {
-        ref_name: gix::refs::FullName::try_from(format!("refs/heads/{}", shortened_branch_name))
-            .expect("could not generate ref name"),
-        worktree: None,
-    });
-    let mut commits: Vec<LocalCommit> = Vec::new();
-    for (i, id) in local_commit_ids.iter().enumerate() {
-        let parent_id = local_commit_ids.get(i + 1).or(base.as_ref());
-        commits.push(LocalCommit {
-            inner: commit(*id, parent_id.cloned()),
-            relation: Default::default(),
-        });
-    }
-    let mut commits_on_remote: Vec<Commit> = Vec::new();
-    for id in remote_commit_ids {
-        commits_on_remote.push(commit(id, None))
-    }
-    Segment {
-        ref_info,
-        id: Default::default(),
-        remote_tracking_ref_name: None,
-        commits,
-        commits_on_remote,
-        commits_outside: None,
-        metadata: None,
-        is_entrypoint: false,
-        push_status: but_workspace::ui::PushStatus::NothingToPush,
-        base,
-    }
-}
-
-fn stack<const N: usize>(segments: [Segment; N]) -> Stack {
-    Stack {
-        id: None,
-        base: None,
-        segments: segments.into_iter().collect::<Vec<Segment>>(),
-    }
-}
-
-fn hunk_assignment(path: &str, stack_id: Option<StackId>) -> HunkAssignment {
-    HunkAssignment {
-        id: None,
-        hunk_header: None,
-        path: String::new(),
-        path_bytes: BString::from(path),
-        stack_id,
-        hunk_locks: None,
-        line_nums_added: None,
-        line_nums_removed: None,
-        diff: None,
-    }
-}
 
 // TODO: make the IdMap API more testable, and making better tests should naturally lead to a better API.
 //       This is just an example to avoid more integration tests.
@@ -95,8 +12,9 @@ fn commit_ids_never_collide_due_to_hex_alphabet() -> anyhow::Result<()> {
 
     let mut id_map = IdMap::new_from_context(&ctx)?;
     id_map.add_file_info_from_context(&mut ctx)?;
-    assert_eq!(id_map.commit_ids().count(), 2);
-    for commit_id in id_map.commit_ids() {
+    assert_eq!(id_map.workspace_and_remote_commit_ids().count(), 2);
+
+    for commit_id in id_map.workspace_and_remote_commit_ids() {
         // TODO: fix this - should be read-only, but needs a `but-db` refactor to support read-only DB access.
         let actual = id_map.parse_str(&commit_id.to_hex_with_len(2).to_string())?;
         assert_eq!(actual.len(), 1, "The commit can be resolved");
@@ -113,8 +31,11 @@ fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
     let stacks = &[stack([segment("branch001", [id(1)], None, [])])];
     let id_map = IdMap::new(stacks)?;
 
-    // Ensure that the ID of the unassigned area has enough 0s to be unambiguous.
-    assert_eq!(id_map.unassigned().to_string(), "000");
+    assert_eq!(
+        id_map.unassigned().to_string(),
+        "000",
+        "the ID of the unassigned area should have enough 0s to be unambiguous"
+    );
     Ok(())
 }
 
@@ -140,23 +61,124 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
     ];
     id_map.add_file_info(changed_paths_fn, hunk_assignments)?;
 
-    // Uncommitted files come first
-    assert!(matches!(
+    assert!(
+        matches!(
         id_map.parse_str("g0")?.as_slice(),
-        [CliId::UncommittedFile{path,..}] if path == b"uncommitted1.txt"));
-    // But do not collide with branches
-    assert!(matches!(
+        [CliId::UncommittedFile{path,..}] if path == b"uncommitted1.txt"),
+        "Uncommitted files come first"
+    );
+    assert!(
+        matches!(
         id_map.parse_str("h0")?.as_slice(),
-        [CliId::Branch{name,..}] if name == "h0"));
-    assert!(matches!(
+        [CliId::Branch{name,..}] if name == "h0"),
+        "uncommitted files do not collide with branches"
+    );
+    assert!(
+        matches!(
         id_map.parse_str("i0")?.as_slice(),
-        [CliId::UncommittedFile{path,..}] if path == b"uncommitted2.txt"));
-    // Committed files come next
-    assert!(matches!(
+        [CliId::UncommittedFile{path,..}] if path == b"uncommitted2.txt"),
+        "uncommitted files also don't collide with themselves"
+    );
+    assert!(
+        matches!(
         id_map.parse_str("j0")?.as_slice(),
-        [CliId::CommittedFile{commit_oid, path,..}] if *commit_oid == id(2) && path == b"committed1.txt"));
-    assert!(matches!(
+        [CliId::CommittedFile{commit_oid, path,..}] if *commit_oid == id(2) && path == b"committed1.txt"),
+        "then come committed files, as per incremented prefix"
+    );
+    assert!(
+        matches!(
         id_map.parse_str("k0")?.as_slice(),
-        [CliId::CommittedFile{commit_oid, path,..}] if *commit_oid == id(2) && path == b"committed2.txt"));
+        [CliId::CommittedFile{commit_oid, path,..}] if *commit_oid == id(2) && path == b"committed2.txt"),
+        "committed files also don't collide with themselves"
+    );
     Ok(())
 }
+
+mod util {
+    use bstr::BString;
+    use but_core::ref_metadata::StackId;
+    use but_hunk_assignment::HunkAssignment;
+    use but_workspace::branch::Stack;
+    use but_workspace::ref_info::{Commit, LocalCommit, Segment};
+
+    pub fn id(byte: u8) -> gix::ObjectId {
+        gix::ObjectId::try_from([byte].repeat(20).as_slice()).expect("could not generate ID")
+    }
+
+    pub fn segment<const N1: usize, const N2: usize>(
+        shortened_branch_name: &str,
+        local_commit_ids: [gix::ObjectId; N1],
+        base: Option<gix::ObjectId>,
+        remote_commit_ids: [gix::ObjectId; N2],
+    ) -> Segment {
+        fn commit(id: gix::ObjectId, parent_id: Option<gix::ObjectId>) -> Commit {
+            Commit {
+                id,
+                parent_ids: parent_id.into_iter().collect::<Vec<gix::ObjectId>>(),
+                tree_id: gix::index::hash::Kind::Sha1.empty_tree(),
+                message: Default::default(),
+                author: Default::default(),
+                refs: Vec::new(),
+                flags: Default::default(),
+                has_conflicts: false,
+                change_id: None,
+            }
+        }
+
+        let ref_info = Some(but_graph::RefInfo {
+            ref_name: gix::refs::FullName::try_from(format!(
+                "refs/heads/{}",
+                shortened_branch_name
+            ))
+            .expect("could not generate ref name"),
+            worktree: None,
+        });
+        let mut commits: Vec<LocalCommit> = Vec::new();
+        for (i, id) in local_commit_ids.iter().enumerate() {
+            let parent_id = local_commit_ids.get(i + 1).or(base.as_ref());
+            commits.push(LocalCommit {
+                inner: commit(*id, parent_id.cloned()),
+                relation: Default::default(),
+            });
+        }
+        let mut commits_on_remote: Vec<Commit> = Vec::new();
+        for id in remote_commit_ids {
+            commits_on_remote.push(commit(id, None))
+        }
+        Segment {
+            ref_info,
+            id: Default::default(),
+            remote_tracking_ref_name: None,
+            commits,
+            commits_on_remote,
+            commits_outside: None,
+            metadata: None,
+            is_entrypoint: false,
+            push_status: but_workspace::ui::PushStatus::NothingToPush,
+            base,
+        }
+    }
+
+    pub fn stack<const N: usize>(segments: [Segment; N]) -> Stack {
+        Stack {
+            id: None,
+            base: None,
+            segments: segments.into_iter().collect::<Vec<Segment>>(),
+        }
+    }
+
+    pub fn hunk_assignment(path: &str, stack_id: Option<StackId>) -> HunkAssignment {
+        HunkAssignment {
+            id: None,
+            hunk_header: None,
+            path: String::new(),
+            path_bytes: BString::from(path),
+            stack_id,
+            hunk_locks: None,
+            line_nums_added: None,
+            line_nums_removed: None,
+            diff: None,
+        }
+    }
+}
+use util::{hunk_assignment, id, segment, stack};

--- a/crates/but/src/legacy/id/tests.rs
+++ b/crates/but/src/legacy/id/tests.rs
@@ -9,9 +9,10 @@ fn commit_ids_never_collide_due_to_hex_alphabet() -> anyhow::Result<()> {
     let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
     let mut ctx = env.context()?;
 
-    let id_map = IdMap::new(&mut ctx)?;
-    assert_eq!(id_map.commit_ids.len(), 2);
-    for commit_id in &id_map.commit_ids {
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
+    assert_eq!(id_map.commit_ids().count(), 2);
+    for commit_id in id_map.commit_ids() {
         // TODO: fix this - should be read-only, but needs a `but-db` refactor to support read-only DB access.
         let actual = id_map.parse_str(&commit_id.to_hex_with_len(2).to_string())?;
         assert_eq!(actual.len(), 1, "The commit can be resolved");
@@ -54,7 +55,8 @@ fn assignments_work() -> anyhow::Result<()> {
         None,
     )?;
 
-    let id_map = IdMap::new(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(&ctx)?;
+    id_map.add_file_info_from_context(&mut ctx)?;
     assert_eq!(
         id_map
             .uncommitted_file(Some(a_stack_id), a_path.into())

--- a/crates/but/src/legacy/mod.rs
+++ b/crates/but/src/legacy/mod.rs
@@ -4,7 +4,6 @@ use crate::utils::OutputChannel;
 use but_ctx::LegacyProject;
 
 pub mod commits;
-pub mod id;
 
 pub fn get_or_init_non_bare_project(args: &Args) -> anyhow::Result<LegacyProject> {
     let repo = gix::discover(&args.current_dir)?;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -36,6 +36,9 @@ use but_settings::AppSettings;
 use colored::Colorize;
 use gix::date::time::CustomFormat;
 
+mod id;
+pub use id::{CliId, IdMap};
+
 /// A place for all command implementations.
 pub(crate) mod command;
 mod tui;

--- a/crates/but/tests/but/id.rs
+++ b/crates/but/tests/but/id.rs
@@ -20,25 +20,6 @@ Source[..]the unassigned area[..]target[..]the unassigned area[..]"
 }
 
 #[test]
-fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
-    let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
-
-    // Must set metadata to match the scenario
-    env.setup_metadata(&["A", "B"])?;
-
-    env.but("branch new branch001").assert().success();
-
-    // Ensure that the ID of the unassigned area has enough 0s to be unambiguous.
-    env.but("status")
-        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
-        .assert()
-        .success()
-        .stdout_eq(snapbox::str!["[..]000[..]Unassigned Changes[..]\n..."]);
-
-    Ok(())
-}
-
-#[test]
 fn branch_avoid_nonalphanumeric() -> anyhow::Result<()> {
     let env = Sandbox::open_scenario_with_target_and_default_settings("two-stacks")?;
 


### PR DESCRIPTION
I've narrowed the constructor arguments, which made it possible to add unit tests that are even further from integration tests (so, no `Context` in a sandbox), generating input arguments directly.

I'm not sure if this is the direction we want to go in, but I'm leaning towards it. My main concerns are:
* This requires structs to have all public members. I think that having all public members is a good idea anyway (these are app-wide concepts so I prefer the data-oriented programming approach over OOP's encapsulation - if the nature of a `Stack` changes, then all code that uses it needs to be aware of the change anyway, so you might as well remove the unnecessary layer of indirection, but if the specifics of a database changes, then perhaps it can be isolated to its class, so OOP's encapsulation is good there). But if we move towards structs not having all public members, then we will need to undo my PR's approach.
* This requires custom setup code instead of reusing production code (`Context`) to set up the test. I think the custom setup code is not too much, though, when debugging `IdMap`, it's very useful to not have to go through `Context` to see where each piece of data ends up. 

If we continue in this direction, we'll probably need a new `TestDefault` or `DefaultTest` crate/module/something that contains reasonable defaults for all the structs we need.