### PR TITLE
Fix bugs related to the image diff feature

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -58,8 +58,8 @@
 		"security": {
 			"csp": {
 				"default-src": "'self'",
-				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com https://*.giphy.com/ blob: tauri://localhost",
-				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097",
+				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com https://*.giphy.com/ blob:",
+				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data: blob:",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"
 			}

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
 			"csp": {
 				"default-src": "'self'",
 				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com https://*.giphy.com/ blob:",
-				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data: blob:",
+				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data:",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"
 			}

--- a/packages/ui/src/lib/components/ImageDiff.svelte
+++ b/packages/ui/src/lib/components/ImageDiff.svelte
@@ -175,7 +175,7 @@
 {/snippet}
 
 {#snippet sizeDifference()}
-	{#if beforeImageMetadata?.size && afterImageMetadata?.size}
+	{#if beforeImageUrl && afterImageUrl && beforeImageMetadata?.size && afterImageMetadata?.size}
 		·
 		<span
 			class:positive={afterImageMetadata.size < beforeImageMetadata.size}


### PR DESCRIPTION
This PR fixes several bugs introduced by that feature PR (https://github.com/gitbutlerapp/gitbutler/pull/11456):

1. Added a CSP exception rule to allow loading image size information in the commit preview. This issue only occurred in production builds.
2. Adjusted the frontend logic for reading before / after image files, removing the `commit` source type — only `blob` and `workspace` are needed.
3. Fixed an issue where image size changes were incorrectly shown for added or deleted files. This information should only appear when both the before and after images exist.

For the first two fixes, please refer to [the discussion on Discord](https://discord.com/channels/1060193121130000425/1204524097241878629/1447820731391016960). The third issue is shown in the image below.

<img width="1201" height="640" src="https://github.com/user-attachments/assets/0db1398c-8097-4795-ac71-e971bad6cfc3" />