### PR TITLE
fix: diff scrolling on a commit preview

### DIFF
--- a/apps/desktop/src/components/CloudForm.svelte
+++ b/apps/desktop/src/components/CloudForm.svelte
@@ -97,11 +97,3 @@
 		</CardGroup.Item>
 	</CardGroup>
 </SettingsSection>
-
-<style lang="postcss">
-	.options {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-</style>

--- a/apps/desktop/src/components/Dropzone.svelte
+++ b/apps/desktop/src/components/Dropzone.svelte
@@ -16,7 +16,6 @@
 		onActivated?: (activated: boolean) => void;
 		overlay?: Snippet<[{ hovered: boolean; activated: boolean; handler?: DropzoneHandler }]>;
 		children?: Snippet;
-		overflow?: boolean;
 	}
 
 	const {
@@ -27,8 +26,7 @@
 		onActivated,
 		overlay,
 		children,
-		hideWhenInactive,
-		overflow
+		hideWhenInactive
 	}: Props = $props();
 
 	let hovered = $state(false);
@@ -72,7 +70,6 @@
 	class:fill-height={fillHeight}
 	class:max-height={maxHeight}
 	style:display={hideWhenInactive && !activated ? 'none' : undefined}
-	style:overflow={overflow ? 'hidden' : undefined}
 	class="dropzone-container"
 >
 	{#if overlay}
@@ -101,5 +98,6 @@
 		flex-grow: 1;
 		flex-direction: column;
 		width: 100%;
+		overflow: hidden;
 	}
 </style>

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -116,7 +116,6 @@
 				onscrollexists={(exists: boolean) => {
 					isScrollable = exists;
 				}}
-				overflow
 				mode="unassigned"
 				foldButton={$settingsStore?.featureFlags.rules ? undefined : foldButton}
 			>

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -27,7 +27,6 @@
 		title: string;
 		mode?: 'unassigned' | 'assigned';
 		dropzoneVisible?: boolean;
-		overflow?: boolean;
 		onDropzoneActivated?: (activated: boolean) => void;
 		emptyPlaceholder?: Snippet;
 		foldButton?: Snippet;
@@ -41,7 +40,6 @@
 		title,
 		mode = 'unassigned',
 		dropzoneVisible,
-		overflow,
 		onDropzoneActivated,
 		emptyPlaceholder,
 		foldButton,
@@ -113,7 +111,6 @@
 	handlers={[uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
 	maxHeight
 	onActivated={onDropzoneActivated}
-	{overflow}
 >
 	{#snippet overlay({ hovered, activated, handler })}
 		<CardOverlay


### PR DESCRIPTION
Fix the issue of being unable to scroll on the commit preview. I’ve added `overflow: hidden` and an optional thing (hopefully this won’t break anything).

Before _(I'm trying to scroll there)_:

https://github.com/user-attachments/assets/33beeff7-4bff-47e7-9d3e-23cc6c409d87

---

After:

https://github.com/user-attachments/assets/8552dcb5-fd72-4acf-b03a-c98aec252e9b

