### PR TITLE
fix: adjust color scale and bump design-core to 1.4.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "1.4.0",
+		"@gitbutler/design-core": "1.4.1",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@gitbutler/design-core": "1.4.0",
+		"@gitbutler/design-core": "1.4.1",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/web/src/routes/color-generator/utils/colorScale.ts
+++ b/apps/web/src/routes/color-generator/utils/colorScale.ts
@@ -35,13 +35,13 @@ const SHADE_THRESHOLDS = {
 
 const LIGHTNESS_RANGES = {
 	background: {
-		neutral: { min: 0.91, max: 1.0, scale: 0.5 },
-		colored: { min: 0.88, max: 0.98, scale: 0.45 }
+		neutral: { min: 0.88, max: 1, scale: 0.5 },
+		colored: { min: 0.89, max: 0.98, scale: 0.5 }
 	},
-	soft: { min: 0.43, max: 0.91, exponent: 0.7 },
+	soft: { min: 0.4, max: 0.9, exponent: 0.9 },
 	solid: { min: 0.22, max: 0.48 },
 	text: {
-		neutral: { min: 0.08, max: 0.22, exponent: 0.85 },
+		neutral: { min: 0.08, max: 0.22, exponent: 1 },
 		colored: { min: 0.11, max: 0.26, exponent: 0.85 }
 	}
 } as const;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "1.4.0",
+		"@gitbutler/design-core": "1.4.1",
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.56.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.4.1
+        version: 1.4.1
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -392,8 +392,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.4.1
+        version: 1.4.1
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -789,8 +789,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.4.1
+        version: 1.4.1
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1664,8 +1664,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.4.0':
-    resolution: {integrity: sha512-3ZsFUdXwy5XbbdLJfYsKLWDb3OWxsKMlqe4QDYPuvkoGxl5oQpkbg0pE49vFf89Xr9YUZQK7102OzWvvmwOonQ==}
+  '@gitbutler/design-core@1.4.1':
+    resolution: {integrity: sha512-j8/OTBHPVKyNkUNHHMPn9iuS1+EuJ9IdrinOcIqRD5gg4115kkDxmFUsVS5eX+k1yECfWZtCNLR5KKIZOdHWTQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8971,7 +8971,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.4.0': {}
+  '@gitbutler/design-core@1.4.1': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
Update LIGHTNESS_RANGES in colorScale.ts to tweak background,
soft, and text lightness values and exponents for more consistent
and slightly darker colored/soft tones:
- background.neutral: min 0.88, max 1, scale 0.5
- background.colored: min 0.89, max 0.98, scale 0.5
- soft: min 0.4, max 0.9, exponent 0.9
- text.neutral: exponent 1 (was 0.85)

These changes improve contrast and visual consistency for generated
color scales, particularly for colored backgrounds and soft shades.

Bump @gitbutler/design-core dependency from 1.4.0 to 1.4.1 across
pnpm-lock.yaml and package.json files (packages/ui, apps/desktop,
apps/web). Update lockfile resolutions/integrity entries to match
the new version.