### PR TITLE
Make text-conv filter failure non-fatal (#11453)

### DIFF
--- a/crates/but-core/tests/core/unified_diff.rs
+++ b/crates/but-core/tests/core/unified_diff.rs
@@ -27,6 +27,28 @@ fn file_added_in_worktree() -> anyhow::Result<()> {
 }
 
 #[test]
+fn binary_text_failure() -> anyhow::Result<()> {
+    let repo = crate::diff::worktree_changes::repo("diff-binary-to-text-failure")?;
+    let actual = UnifiedPatch::compute(
+        &repo,
+        "file.binary".into(),
+        None,
+        ChangeState {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
+        None,
+        3,
+    )?;
+
+    assert!(
+        actual.is_none(),
+        "any kind of filter failure is ignored for resiliency"
+    );
+    Ok(())
+}
+
+#[test]
 fn binary_text_in_unborn() -> anyhow::Result<()> {
     let repo = crate::diff::worktree_changes::repo("diff-binary-to-text-unborn")?;
     let actual = extract_patch(UnifiedPatch::compute(

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -284,6 +284,17 @@ git init binary-file-unborn
   printf '\0hi\0' >with-null-bytes
 )
 
+git init diff-binary-to-text-failure
+(cd diff-binary-to-text-failure
+  printf '\0hi\0' >file.binary
+  echo "*.binary diff=fail" >.gitattributes
+
+cat <<EOF >>.git/config
+[diff "fail"]
+	textconv = "false"
+EOF
+)
+
 git init diff-binary-to-text-unborn
 (cd diff-binary-to-text-unborn
   printf '\0hi\0' >file.binary


### PR DESCRIPTION
This will lead to empty or partial hunk dependencies, which unfortunately are in the critical path.

Don't fail if a text conversion fails, instead just print a warning so we know this happened
and can more easily change it when needed.

Fixes #11453.
