### PR TITLE
fix: Improve error handling during repository cloning #8293

### DIFF
--- a/apps/desktop/src/components/CloneForm.svelte
+++ b/apps/desktop/src/components/CloneForm.svelte
@@ -170,7 +170,7 @@
 			{#snippet content()}
 				{#if items && items.length > 0}
 					{#each items as item}
-						{@html item.label}
+						<span>{item.label}</span>
 					{/each}
 				{/if}
 			{/snippet}

--- a/apps/desktop/src/components/CloneForm.svelte
+++ b/apps/desktop/src/components/CloneForm.svelte
@@ -3,6 +3,7 @@
 	import SettingsSection from '$components/SettingsSection.svelte';
 	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { BACKEND } from '$lib/backend';
+	import { parseError } from '$lib/error/parser';
 	import { GIT_SERVICE } from '$lib/git/gitService';
 	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
@@ -47,18 +48,11 @@
 	}
 
 	function getErrorMessage(error: unknown): string {
-		if (error instanceof Error) return error.message;
-
-		if (
-			typeof error === 'object' &&
-			error !== null &&
-			'message' in error &&
-			typeof error.message === 'string'
-		) {
-			return error.message;
+		const parsedError = parseError(error);
+		if (parsedError.name && parsedError.name !== parsedError.message) {
+			return `${parsedError.name}: ${parsedError.message}`;
 		}
-
-		return String(error);
+		return parsedError.message;
 	}
 
 	async function cloneRepository() {


### PR DESCRIPTION
## 🧢 Changes

Use shared parseError to normalize error objects before extracting messages for the repository cloning screen. Construct a clearer display string that includes the error name when it differs from the message, falling back to the parsed message
otherwise.

This replaces ad-hoc checks for message properties and ensures consistent, readable error text for clone failures.

## 🎫 Affected issues

Fixes: https://github.com/gitbutlerapp/gitbutler/issues/8293

<img width="679" height="528" alt="image" src="https://github.com/user-attachments/assets/a0677d11-4682-45fb-8146-0f06ed88fe43" />
