### PR TITLE
Fix default editor on debian-derived distros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber",
  "unicode-width",
+ "which",
 ]
 
 [[package]]
@@ -2759,6 +2760,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -11515,6 +11522,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.2",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12113,6 +12131,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -116,6 +116,7 @@ minus = { version = "5.6.1", default-features = false, features = [
 ] }
 unicode-width = "0.2"
 cfg-if = "1.0.4"
+which = "8.0.0"
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
The current change still didn't do the right thing for me. I finally figured out how it works: debian-based distros use a symlink "editor" to point to the user's preferred editor and they compile git with the default fallback value replaced by that:
https://sources.debian.org/src/git/1%3A2.51.0-1/debian/rules#L17

This change detects that we're on a distro that has an "editor" binary/symlink and uses that if possible.

@Byron will you take a look?