### PR TITLE
skip serializableCheck for RTK Query state/cache

### DIFF
--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -182,7 +182,9 @@ function createStore(params: {
 					}
 				},
 				serializableCheck: {
-					ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
+					ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+					// skip the serializable check for rtk-query cache (contains only serializable data)
+					ignoredPaths: ['backend', 'github', 'gitlab'],
 				}
 			}).concat(backendApi.middleware, githubApi.middleware, gitlabApi.middleware);
 		}

--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -184,7 +184,7 @@ function createStore(params: {
 				serializableCheck: {
 					ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
 					// skip the serializable check for rtk-query cache (contains only serializable data)
-					ignoredPaths: ['backend', 'github', 'gitlab'],
+					ignoredPaths: ['backend', 'github', 'gitlab']
 				}
 			}).concat(backendApi.middleware, githubApi.middleware, gitlabApi.middleware);
 		}


### PR DESCRIPTION
This serializableCheck is not needed since this data is loaded via JSON request and therefore always serializable.

This change makes the UI a lot snappier and
removes these  warnings:

`SerializableStateInvariantMiddleware took 1590ms, which is more than the warning threshold of 32ms. `



