### PR TITLE
First fixes for reactivity of branch status

### DIFF
--- a/apps/desktop/src/components/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/BranchesViewStack.svelte
@@ -8,10 +8,12 @@
 	type Props = {
 		projectId: string;
 		stackId: string;
+		inWorkspace: boolean;
+		hasLocal: boolean;
 		onerror: (err: unknown) => void;
 	};
 
-	const { projectId, stackId, onerror }: Props = $props();
+	const { projectId, stackId, inWorkspace, hasLocal, onerror }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
 
@@ -24,7 +26,15 @@
 			<p>Stack not found.</p>
 		{:else}
 			{#each getStackBranchNames(stack) as branchName, idx}
-				<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} {onerror} />
+				<BranchesViewBranch
+					{projectId}
+					{stackId}
+					{branchName}
+					isTopBranch={idx === 0}
+					{inWorkspace}
+					{hasLocal}
+					{onerror}
+				/>
 			{/each}
 		{/if}
 	{/snippet}

--- a/apps/desktop/src/components/TargetCommitList.svelte
+++ b/apps/desktop/src/components/TargetCommitList.svelte
@@ -3,6 +3,7 @@
 	import CommitRow from '$components/CommitRow.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
+	import { BranchesSelectionActions } from '$lib/branches/branchesSelection';
 	import { commitCreatedAt, type Commit } from '$lib/branches/v3';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -115,7 +116,7 @@
 						createdAt={commitCreatedAt(commit)}
 						author={commit.author}
 						onclick={() => {
-							branchesState.set({
+							BranchesSelectionActions.selectTargetCommit(branchesState, {
 								commitId: commit.id,
 								branchName: baseBranch.shortName,
 								remote: baseBranch.remoteName

--- a/apps/desktop/src/lib/branches/branchesSelection.ts
+++ b/apps/desktop/src/lib/branches/branchesSelection.ts
@@ -1,0 +1,96 @@
+import type { GlobalProperty } from '$lib/state/uiState.svelte';
+import type { BranchesSelection } from '$lib/state/uiState.svelte';
+
+/**
+ * Centralized functions for managing branches selection state.
+ *
+ * Direct calls to set() in the uiState for branchesSelection should be avoided because
+ * in the past this led to dropping of important state, e.g. dropping the "inWorkspace" field
+ * when selecting a commit in a branch.
+ */
+export const BranchesSelectionActions = {
+	selectStack(
+		state: GlobalProperty<BranchesSelection>,
+		params: {
+			stackId: string;
+			branchName: string;
+			inWorkspace: boolean;
+			hasLocal: boolean;
+			prNumber?: number;
+		}
+	): void {
+		state.set({
+			stackId: params.stackId,
+			branchName: params.branchName,
+			inWorkspace: params.inWorkspace,
+			hasLocal: params.hasLocal,
+			prNumber: params.prNumber
+		});
+	},
+
+	selectBranch(
+		state: GlobalProperty<BranchesSelection>,
+		params: {
+			branchName: string;
+			hasLocal: boolean;
+			remote?: string;
+			prNumber?: number;
+		}
+	): void {
+		state.set({
+			branchName: params.branchName,
+			hasLocal: params.hasLocal,
+			remote: params.remote,
+			prNumber: params.prNumber
+		});
+	},
+
+	/**
+	 * Preserves existing context (stackId, branchName, inWorkspace, etc.) and only updates commitId.
+	 */
+	selectCommit(
+		state: GlobalProperty<BranchesSelection>,
+		params: {
+			commitId: string;
+			remote?: string;
+		}
+	): void {
+		state.update({
+			commitId: params.commitId,
+			...(params.remote !== undefined ? { remote: params.remote } : {})
+		});
+	},
+
+	selectTarget(state: GlobalProperty<BranchesSelection>, branchName: string): void {
+		state.set({
+			branchName,
+			isTarget: true
+		});
+	},
+
+	/**
+	 * Selects a PR by number only (no associated branch).
+	 */
+	selectPr(state: GlobalProperty<BranchesSelection>, prNumber: number): void {
+		state.set({ prNumber });
+	},
+
+	selectTargetCommit(
+		state: GlobalProperty<BranchesSelection>,
+		params: {
+			commitId: string;
+			branchName: string;
+			remote?: string;
+		}
+	): void {
+		state.set({
+			commitId: params.commitId,
+			branchName: params.branchName,
+			remote: params.remote
+		});
+	},
+
+	clear(state: GlobalProperty<BranchesSelection>): void {
+		state.set({});
+	}
+};

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -1,3 +1,4 @@
+import { BranchesSelectionActions } from '$lib/branches/branchesSelection';
 import { type SnapPositionName } from '$lib/floating/types';
 import { InjectionToken } from '@gitbutler/core/context';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
@@ -41,10 +42,15 @@ export type StackState = {
 	addedDirs: string[];
 };
 
-type BranchesSelection = {
+// See lib/branches/branchesSelection.ts for actions to mutate this state
+export type BranchesSelection = {
 	branchName?: string;
 	commitId?: string;
 	stackId?: string;
+	// TODO(mathijs): Remove branch "properties" from this object and make the relevant components
+	// look them up reactively, because currently there are still bugs where you e.g. unapply a
+	// branch and the UI will keep showing the branch as applied because there hasn't been a
+	// selection event.
 	remote?: string;
 	hasLocal?: boolean;
 	isTarget?: boolean;
@@ -543,7 +549,7 @@ export function updateStalePrSelection(uiState: UiState, projectId: string, prs:
 
 	const prNumber = projectState.branchesSelection.current.prNumber;
 	if (!prs.some((pr) => pr.number === prNumber)) {
-		projectState.branchesSelection.set({});
+		BranchesSelectionActions.clear(projectState.branchesSelection);
 	}
 }
 
@@ -555,7 +561,7 @@ export function updateStaleBranchSelectionInBranchesView(
 	const projectState = uiState.project(projectId);
 	const selection = projectState.branchesSelection.current;
 	if (selection.branchName && deletedBranches.includes(selection.branchName)) {
-		projectState.branchesSelection.set({});
+		BranchesSelectionActions.clear(projectState.branchesSelection);
 	}
 }
 
@@ -567,6 +573,6 @@ export function retainBranchSelectionInBranchesView(
 	const projectState = uiState.project(projectId);
 	const selection = projectState.branchesSelection.current;
 	if (selection.branchName && !branches.includes(selection.branchName)) {
-		projectState.branchesSelection.set({});
+		BranchesSelectionActions.clear(projectState.branchesSelection);
 	}
 }


### PR DESCRIPTION
## 🧢 Changes

In various places, fields like `inWorkspace` got dropped because of full object overwrites on branchesSelection. You then see places in the UI where there's a button to apply an already-applied stack or unapply is missing where you would expect it and when clicking around it would suddenly pop up again.
This change improves things by doing updates on the object when possible, but not all weirdness is solved yet. When actually mutating a branch state (e.g. unapply), it may still show up in parts of the UI wrong (until you actually click & select the branch again). To fix this a bigger change is needed, where the inWorkspace state becomes properly derived and is no longer part of the selection object, I added a TODO for that.

I think this may also require a bit of a discussion about the architecture of the frontend code. It is currently very heavy on prop drilling by passing not only the selected branch but also things like isLocal and inWorkspace along through many components. I think a change where components just get the branch ID and then can look up the necessary details themselves would simplify things significantly (and make creating these weird reactivity bugs harder).
