### PR TITLE
Get the editor from git through `git var`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "shell-words",
  "snapbox",
  "strum",
+ "tempfile",
  "terminal_size",
  "tokio",
  "tracing",

--- a/crates/but-rebase/src/lib.rs
+++ b/crates/but-rebase/src/lib.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context as _, Ok, Result, anyhow, bail};
 use bstr::BString;
-use gix::{objs::Exists, prelude::ObjectIdExt};
+use gix::prelude::ObjectIdExt;
 use tracing::instrument;
 
 use crate::commit::DateMode;
@@ -91,8 +91,10 @@ impl<'repo> Rebase<'repo> {
         base_substitute: Option<gix::ObjectId>,
     ) -> Result<Self> {
         let base = base.into();
-        if base.is_some() && base.filter(|base| repo.exists(base)).is_none() {
-            bail!("Base commit must exist if provided: {}", base.unwrap());
+        if let Some(base) = base
+            && !repo.has_object(base)
+        {
+            bail!("Base commit must exist if provided: {}", base);
         }
         Ok(Self {
             repo,

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -116,6 +116,7 @@ minus = { version = "5.6.1", default-features = false, features = [
 ] }
 unicode-width = "0.2"
 cfg-if = "1.0.4"
+tempfile.workspace = true
 
 [dev-dependencies]
 but-core = { workspace = true, features = ["testing"] }

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -497,8 +497,9 @@ fn get_commit_message_from_editor(
     template.push_str("#\n");
 
     // Read the result from the editor and strip comments
-    let message = tui::get_text::from_editor_no_comments("commit_msg", &template)?;
-    Ok(message)
+    let lossy_message =
+        tui::get_text::from_editor_no_comments("commit_msg", &template)?.to_string();
+    Ok(lossy_message)
 }
 
 fn get_status_char(path: &BString, changes: &[TreeChange]) -> &'static str {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -497,7 +497,7 @@ fn get_commit_message_from_editor(
     template.push_str("#\n");
 
     // Read the result from the editor and strip comments
-    let message = tui::get_text::from_editor_no_comments("but_commit_msg", &template)?;
+    let message = tui::get_text::from_editor_no_comments("commit_msg", &template)?;
     Ok(message)
 }
 

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -236,7 +236,7 @@ fn get_commit_message_from_editor(
     template.push_str("#\n");
 
     // Read the result and strip comments
-    let message = tui::get_text::from_editor_no_comments("but_commit_msg", &template)?;
+    let message = tui::get_text::from_editor_no_comments("commit_msg", &template)?;
 
     if message.is_empty() {
         bail!("Aborting due to empty commit message");
@@ -255,7 +255,7 @@ fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
     template.push_str("# with '#' will be ignored, and an empty name aborts the operation.\n");
     template.push_str("#\n");
 
-    let branch_name = tui::get_text::from_editor_no_comments("but_branch_name", &template)?;
+    let branch_name = tui::get_text::from_editor_no_comments("branch_name", &template)?;
 
     if branch_name.is_empty() {
         bail!("Aborting due to empty branch name");

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -236,13 +236,14 @@ fn get_commit_message_from_editor(
     template.push_str("#\n");
 
     // Read the result and strip comments
-    let message = tui::get_text::from_editor_no_comments("commit_msg", &template)?;
+    let lossy_message =
+        tui::get_text::from_editor_no_comments("commit_msg", &template)?.to_string();
 
-    if message.is_empty() {
+    if lossy_message.is_empty() {
         bail!("Aborting due to empty commit message");
     }
 
-    Ok(message)
+    Ok(lossy_message)
 }
 
 fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
@@ -255,13 +256,14 @@ fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
     template.push_str("# with '#' will be ignored, and an empty name aborts the operation.\n");
     template.push_str("#\n");
 
-    let branch_name = tui::get_text::from_editor_no_comments("branch_name", &template)?;
+    let branch_name_lossy =
+        tui::get_text::from_editor_no_comments("branch_name", &template)?.to_string();
 
-    if branch_name.is_empty() {
+    if branch_name_lossy.is_empty() {
         bail!("Aborting due to empty branch name");
     }
 
-    Ok(branch_name)
+    Ok(branch_name_lossy)
 }
 
 #[cfg(test)]

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -564,7 +564,7 @@ fn get_review_body_from_editor(
     template.push_str("# with '#' will be ignored, and an empty body is allowed.\n");
     template.push_str("#\n");
 
-    let body = get_text::from_editor_no_comments("but_review_body", &template)?;
+    let body = get_text::from_editor_no_comments("review_body", &template)?;
     Ok(body)
 }
 
@@ -606,7 +606,7 @@ fn get_review_title_from_editor(
     template.push_str("# with '#' will be ignored, and an empty title aborts the operation.\n");
     template.push_str("#\n");
 
-    let title = get_text::from_editor_no_comments("but_review_title", &template)?;
+    let title = get_text::from_editor_no_comments("review_title", &template)?;
 
     if title.is_empty() {
         anyhow::bail!("Aborting due to empty review title");

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -564,8 +564,8 @@ fn get_review_body_from_editor(
     template.push_str("# with '#' will be ignored, and an empty body is allowed.\n");
     template.push_str("#\n");
 
-    let body = get_text::from_editor_no_comments("review_body", &template)?;
-    Ok(body)
+    let lossy_body = get_text::from_editor_no_comments("review_body", &template)?.to_string();
+    Ok(lossy_body)
 }
 
 /// Extract the commit description (body) from the commit message, skipping the first line (title).
@@ -606,13 +606,13 @@ fn get_review_title_from_editor(
     template.push_str("# with '#' will be ignored, and an empty title aborts the operation.\n");
     template.push_str("#\n");
 
-    let title = get_text::from_editor_no_comments("review_title", &template)?;
+    let lossy_title = get_text::from_editor_no_comments("review_title", &template)?.to_string();
 
-    if title.is_empty() {
+    if lossy_title.is_empty() {
         anyhow::bail!("Aborting due to empty review title");
     }
 
-    Ok(title)
+    Ok(lossy_title)
 }
 
 /// Extract the commit title from the commit message (first line).

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -26,12 +26,12 @@ pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str) -
 /// Note that this string must be valid in filenames.
 ///
 /// Returns the edited text (*without known encoding*) verbatim.
-pub fn from_editor(identifier: &str, initial_text: &str) -> Result<BString> {
+pub fn from_editor(filename_safe_intent: &str, initial_text: &str) -> Result<BString> {
     let editor_cmd = get_editor_command()?;
 
     // Create a temporary file with the initial text
     let tempfile = tempfile::Builder::new()
-        .prefix(&format!("but_{identifier}_"))
+        .prefix(&format!("but_{filename_safe_intent}_"))
         .suffix(".txt")
         .tempfile()?;
     std::fs::write(&tempfile, initial_text)?;

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -1,5 +1,6 @@
 //! Various functions that involve launching the editor.
 use anyhow::Result;
+use std::collections::HashMap;
 
 /// Launches the user's preferred text editor to edit some initial text,
 /// identified by a unique identifier (to avoid temp file collisions).
@@ -43,41 +44,24 @@ pub fn from_editor(identifier: &str, initial_text: &str) -> Result<String> {
     Ok(edited_text)
 }
 
-/// Checks if the terminal is dumb (TERM environment variable is "dumb")
-fn is_terminal_dumb() -> bool {
-    std::env::var("TERM")
-        .map(|term| term == "dumb")
-        .unwrap_or(false)
-}
-
-/// Implement get_editor_command to match Git's C implementation of `git_editor`.
+/// Get the user's preferred editor command.
+/// Runs `git var GIT_EDITOR`, which lets git do its resolution of the editor command.
+/// This typically uses the git config value for `core.editor`, and env vars like `GIT_EDITOR` or `EDITOR`.
+/// We fallback to notepad (Windows) or vi otherwise just in case we don't get something usable from `git var`.
 ///
-/// - Check GIT_EDITOR environment variable first
-/// - Check git config `core.editor` (editor_program)
-/// - Check VISUAL if terminal is not dumb
-/// - Check EDITOR
-/// - Return error if terminal is dumb and no editor found
-/// - Fall back to platform defaults (vi on Unix, notepad on Windows)
-/// - Add comprehensive unit tests for all scenarios
+/// Note: Because git config parsing is used, the current directory matters for potential local git config overrides.
 fn get_editor_command() -> Result<String> {
-    get_editor_command_impl(&|key| std::env::var(key), is_terminal_dumb())
+    let env: HashMap<String, String> = std::env::vars().collect();
+    get_editor_command_impl(&env)
 }
 
-/// Internal get_editor_command_implementation that can be tested without modifying environment
-fn get_editor_command_impl<F>(env_var: &F, terminal_is_dumb: bool) -> Result<String>
-where
-    F: Fn(&str) -> Result<String, std::env::VarError>,
-{
-    // Try $GIT_EDITOR first
-    if let Ok(editor) = env_var("GIT_EDITOR")
-        && !editor.is_empty()
-    {
-        return Ok(editor);
-    }
-
-    // Try git config `core.editor` (editor_program)
+/// Internal implementation that can be tested with controlled environment
+fn get_editor_command_impl(env: &HashMap<String, String>) -> Result<String> {
+    // Run git var with the controlled environment
     if let Ok(output) = std::process::Command::new(gix::path::env::exe_invocation())
-        .args(["config", "--get", "core.editor"])
+        .args(["var", "GIT_EDITOR"])
+        .env_clear()
+        .envs(env)
         .output()
         && output.status.success()
     {
@@ -87,139 +71,35 @@ where
         }
     }
 
-    // Try $VISUAL if terminal is not dumb
-    if !terminal_is_dumb
-        && let Ok(editor) = env_var("VISUAL")
-        && !editor.is_empty()
-    {
-        return Ok(editor);
-    }
-
-    if let Ok(editor) = env_var("EDITOR")
-        && !editor.is_empty()
-    {
-        return Ok(editor);
-    }
-
-    // If terminal is dumb and no editor was found, return an error
-    if terminal_is_dumb {
-        return Err(anyhow::anyhow!(
-            "Terminal is dumb, but no editor specified in GIT_EDITOR, core.editor, or EDITOR"
-        ));
-    }
-
-    // Fallback to platform defaults (DEFAULT_EDITOR)
-    let default_editor = if cfg!(windows) { "notepad" } else { "vi" };
-    Ok(default_editor.to_string())
+    // Simple fallback to platform defaults
+    Ok(if cfg!(windows) { "notepad" } else { "vi" }.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
-    // Helper to create a mock environment function from a hashmap
-    fn mock_env(vars: HashMap<&str, &str>) -> impl Fn(&str) -> Result<String, std::env::VarError> {
-        move |key: &str| {
-            vars.get(key)
-                .map(|v| v.to_string())
-                .ok_or(std::env::VarError::NotPresent)
-        }
-    }
+    const OUR_PLATFORM_DEFAULT: &str = if cfg!(windows) { "notepad" } else { "vi" };
 
     #[test]
     fn git_editor_takes_precedence() {
-        let env = mock_env(HashMap::from([
-            ("GIT_EDITOR", "git-editor"),
-            ("VISUAL", "visual-editor"),
-            ("EDITOR", "editor"),
-        ]));
-        let actual = get_editor_command_impl(&env, false).unwrap();
-        assert_eq!(actual, "git-editor");
-    }
-
-    #[test]
-    fn visual_when_terminal_not_dumb() {
-        let env = mock_env(visual_and_editor());
-        let actual = get_editor_command_impl(&env, false).unwrap();
-        assert_eq!(actual, "visual-editor");
-    }
-
-    #[test]
-    fn skips_visual_when_terminal_dumb() {
-        let env = mock_env(visual_and_editor());
-        let actual = get_editor_command_impl(&env, true).unwrap();
-        assert_eq!(actual, "editor", "Should skip VISUAL and use EDITOR");
-    }
-
-    #[test]
-    fn uses_editor() {
-        let env = mock_env(HashMap::from([("EDITOR", "editor")]));
-        let actual = get_editor_command_impl(&env, false).unwrap();
-        assert_eq!(actual, "editor");
-    }
-
-    #[test]
-    fn fails_when_terminal_dumb_and_no_editor() {
-        let env = mock_env(HashMap::new());
-        let actual = get_editor_command_impl(&env, true);
-        assert!(actual.unwrap_err().to_string().contains("Terminal is dumb"));
-    }
-
-    #[test]
-    fn fails_when_terminal_dumb_with_only_visual() {
-        let env = mock_env(HashMap::from([("VISUAL", "visual-editor")]));
-        let actual = get_editor_command_impl(&env, true);
-        assert!(
-            actual.unwrap_err().to_string().contains("Terminal is dumb"),
-            "VISUAL isn't used in dumb terminals"
-        );
-    }
-
-    #[test]
-    fn ignores_empty_git_editor() {
-        let env = mock_env(HashMap::from([
-            ("GIT_EDITOR", ""),
-            ("VISUAL", "visual-editor"),
-            ("EDITOR", "editor"),
-        ]));
-        let actual = get_editor_command_impl(&env, false).unwrap();
+        let env = HashMap::from([("GIT_EDITOR".to_string(), "from-GIT_EDITOR".to_string())]);
+        let actual = get_editor_command_impl(&env).unwrap();
         assert_eq!(
-            actual, "visual-editor",
-            "Empty GIT_EDITOR should be ignored, fall through to VISUAL"
+            actual, "from-GIT_EDITOR",
+            "GIT_EDITOR should take precedence if git is executed correctly"
         );
     }
 
     #[test]
-    fn ignores_empty_visual() {
-        let env = mock_env(HashMap::from([("VISUAL", ""), ("EDITOR", "editor")]));
-        let actual = get_editor_command_impl(&env, false).unwrap();
+    fn falls_back_when_nothing_set() {
+        // Empty environment, git considers this "dumb terminal" and `git var` will return empty string
+        // so our own fallback will be used
+        let env = HashMap::new();
+        let actual = get_editor_command_impl(&env).unwrap();
         assert_eq!(
-            actual, "editor",
-            "Empty VISUAL should be ignored, fall through to EDITOR"
+            actual, OUR_PLATFORM_DEFAULT,
+            "Should fall back to vi/notepad when nothing is set"
         );
-    }
-
-    #[test]
-    fn ignores_empty_editor() {
-        let env = mock_env(HashMap::from([("EDITOR", "")]));
-        let actual = get_editor_command_impl(&env, false).unwrap();
-        assert_eq!(
-            actual, PLATFORM_DEFAULT,
-            "Empty EDITOR should be ignored, fall back to default"
-        );
-    }
-
-    #[test]
-    fn falls_back_to_default_when_no_vars_set() {
-        let env = mock_env(HashMap::new());
-        let actual = get_editor_command_impl(&env, false).unwrap();
-        assert_eq!(actual, PLATFORM_DEFAULT);
-    }
-
-    const PLATFORM_DEFAULT: &str = if cfg!(windows) { "notepad" } else { "vi" };
-
-    fn visual_and_editor() -> HashMap<&'static str, &'static str> {
-        HashMap::from([("VISUAL", "visual-editor"), ("EDITOR", "editor")])
     }
 }

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -747,15 +747,15 @@ fn write_conflicts_tree(repo: &git2::Repository) -> Result<git2::Oid> {
         None
     };
     let mut tree_builder = repo.treebuilder(None)?;
-    if merge_parent_blob.is_some() {
+    if let Some(merge_parent_blob) = merge_parent_blob {
         tree_builder.insert(
             "base_merge_parent",
-            merge_parent_blob.unwrap(),
+            merge_parent_blob,
             FileMode::Blob.into(),
         )?;
     }
-    if conflicts_blob.is_some() {
-        tree_builder.insert("conflicts", conflicts_blob.unwrap(), FileMode::Blob.into())?;
+    if let Some(conflicts_blob) = conflicts_blob {
+        tree_builder.insert("conflicts", conflicts_blob, FileMode::Blob.into())?;
     }
     let conflicts_tree = tree_builder.write()?;
     Ok(conflicts_tree)

--- a/crates/gitbutler-url/src/parse.rs
+++ b/crates/gitbutler-url/src/parse.rs
@@ -87,8 +87,7 @@ pub fn parse(input: &BStr) -> Result<Url, Error> {
     if path_without_file_protocol.is_some()
         || (has_no_explicit_protocol(input) && guessed_protocol == "file")
     {
-        let path =
-            path_without_file_protocol.map_or_else(|| input.into(), |stripped_path| stripped_path);
+        let path = path_without_file_protocol.unwrap_or_else(|| input.into());
         if path.is_empty() {
             return Err(Error::MissingRepositoryPath);
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # IMPORTANT: This should match CI so it won't download the toolchain all the time.
-channel = "1.91"
+channel = "1.92"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
We were invoking git anyway for the git config value of core.editor so we can just as well let git return the result of its full logic instead and simplify our code. This also handles the case where e.g. debian/ubuntu have compiled git with a different fallback than the "vi" default.
I kept the GIT_EDITOR check to be able to skip the git invocation if that's handy, and have the extremely simple vi/notepad fallback at the end still just in case something goes wrong with git.