### PR TITLE
fix(gitlab): ensure gitlab state initializes per-project and cleans up

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -105,6 +105,10 @@
 	$effect.pre(() => {
 		gitLabState.init(projectId, repoInfo);
 		gitLabClient.set(); // Temporary fix, will refactor.
+
+		return () => {
+			gitLabState.cleanup();
+		};
 	});
 
 	// Forge factory configuration


### PR DESCRIPTION
Fixes #10777

https://github.com/user-attachments/assets/106c1587-ebd4-4e2e-96bd-b7c8cf4570e9

The main reason for this issue is that each project's GitLab state subscription was not properly unsubscribed, which caused the current project to use the previous project's token together with the current project's ID when switching projects.

This PR refactors the subscription and cleanup mechanism for GitLab state to ensure that each project's GitLab state is properly maintained.

A bit of an aside:

Fixing bugs for GitButler has become exhausting for me, but since this bug severely disrupts my workflow, I still spent about an hour fixing it.

I like this software, but the error-prone software quality makes me constantly worry about when the workspace will break again. Sometimes, I spend more time dealing with GitButler's own issues than on the things I actually want to use it for.

I sincerely hope that at least the serious bugs that can be reproduced can be addressed proactively. 