### PR TITLE
rules-followup-updates

### DIFF
--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -28,7 +28,8 @@
 		Icon,
 		Badge,
 		Spacer,
-		SkeletonBone
+		SkeletonBone,
+		Link
 	} from '@gitbutler/ui';
 	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { isDefined } from '@gitbutler/ui/utils/typeguards';
@@ -239,7 +240,13 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} bottomBorder={false} persistId={drawerPersistId} maxHeight="60%" defaultCollapsed={true}>
+<Drawer
+	bind:this={drawer}
+	bottomBorder={false}
+	persistId={drawerPersistId}
+	maxHeight="60%"
+	defaultCollapsed={true}
+>
 	{#snippet header()}
 		<h4 class="text-14 text-semibold truncate">Rules</h4>
 		{#if rules.result.isSuccess}
@@ -325,7 +332,16 @@
 			{:else}
 				<div class="rules-placeholder">
 					<p class="text-13 text-body rules-placeholder-text">
-						Set up rules to automatically route changes to the right branch.
+						Let rules automatically sort your changes.
+						<Link
+							href="https://docs.gitbutler.com/features/branch-management/rules"
+							class="underline-dotted clr-text-2"
+						>
+							Read the docs
+						</Link> or set up your
+						<button type="button" class="underline-dotted clr-text-2" onclick={openRuleEditor}>
+							first rule
+						</button> +
 					</p>
 				</div>
 			{/if}

--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -239,7 +239,7 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} bottomBorder={false} persistId={drawerPersistId} maxHeight="60%">
+<Drawer bind:this={drawer} bottomBorder={false} persistId={drawerPersistId} maxHeight="60%" defaultCollapsed={true}>
 	{#snippet header()}
 		<h4 class="text-14 text-semibold truncate">Rules</h4>
 		{#if rules.result.isSuccess}

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -5,7 +5,6 @@
 	import WorktreeChanges from '$components/WorktreeChanges.svelte';
 	import { ActionEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import noChanges from '$lib/assets/illustrations/no-changes.svg?raw';
-	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
 	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createWorktreeSelection } from '$lib/selection/key';
@@ -26,9 +25,7 @@
 	const uiState = inject(UI_STATE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
-	const settingsService = inject(SETTINGS_SERVICE);
 	const posthog = inject(POSTHOG_WRAPPER);
-	const settingsStore = $derived(settingsService.appSettings);
 	const projectState = $derived(uiState.project(projectId));
 	const unassignedSidebarFolded = $derived(uiState.global.unassignedSidebarFolded);
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
@@ -159,9 +156,7 @@
 			{/if}
 		</div>
 
-		{#if $settingsStore?.featureFlags.rules}
-			<RulesList {projectId} />
-		{/if}
+		<RulesList {projectId} />
 	</div>
 {:else}
 	<div

--- a/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/ExperimentalSettings.svelte
@@ -51,23 +51,6 @@
 			/>
 		{/snippet}
 	</CardGroup.Item>
-	<CardGroup.Item labelFor="rules">
-		{#snippet title()}
-			Workspace Rules
-		{/snippet}
-		{#snippet caption()}
-			Allows you to create rules for assigning new changes to a specific branch based on a
-			condition. Still under development - please let us know what you think!
-		{/snippet}
-		{#snippet actions()}
-			<Toggle
-				id="rules"
-				checked={$settingsStore?.featureFlags.rules}
-				onclick={() =>
-					settingsService.updateFeatureFlags({ rules: !$settingsStore?.featureFlags.rules })}
-			/>
-		{/snippet}
-	</CardGroup.Item>
 	<CardGroup.Item labelFor="f-mode">
 		{#snippet title()}
 			F Mode Navigation

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -6,7 +6,6 @@ import type { IBackend } from '$lib/backend';
 export const SETTINGS_SERVICE = new InjectionToken<SettingsService>('SettingsService');
 
 const WS3_AUTO_TOGGLE = 'ws3AutoToggle';
-const RULES_AUTO_TOGGLE = 'rulesAutoToggle';
 
 export class SettingsService {
 	readonly appSettings = writable<AppSettings | undefined>(undefined, () => {
@@ -73,7 +72,6 @@ export class SettingsService {
 
 	private async nudge(): Promise<void> {
 		await this.autoOptInWs3();
-		await this.autoOptInRules();
 	}
 
 	/**
@@ -103,35 +101,6 @@ export class SettingsService {
 			setStorageItem(WS3_AUTO_TOGGLE, true);
 		} catch (error: unknown) {
 			console.error(`Failed to auto-opt-in to WS3: ${error}`);
-		}
-	}
-
-	/**
-	 * Automatically opt-in to rules if it is not already enabled.
-	 *
-	 * This is done only to kickstart the usage of rules, so that users can try it out.
-	 */
-	private async autoOptInRules() {
-		try {
-			const response = await this.backend.invoke<AppSettings>('get_app_settings');
-			const performedAutoToggle = getStorageItem(RULES_AUTO_TOGGLE) ?? false;
-			// If the auto toggle has already been performed, we do not need to do it again.
-			if (performedAutoToggle) return;
-			if (response.featureFlags.rules) {
-				// If the rules feature flag is already enabled, set the flag and do not toggle it again.
-				setStorageItem(RULES_AUTO_TOGGLE, true);
-				return;
-			}
-
-			// If the rules feature flag is not enabled, we automatically enable it for the
-			// first time, so that the user can try it out.
-			await this.updateFeatureFlags({
-				rules: true
-			});
-
-			setStorageItem(RULES_AUTO_TOGGLE, true);
-		} catch (error: unknown) {
-			console.error(`Failed to auto-opt-in to rules: ${error}`);
 		}
 	}
 

--- a/crates/but-api/src/legacy/diff.rs
+++ b/crates/but-api/src/legacy/diff.rs
@@ -101,14 +101,12 @@ pub fn changes_in_worktree(project_id: ProjectId) -> anyhow::Result<WorktreeChan
         )?,
     };
 
-    if ctx.settings().feature_flags.rules {
-        but_rules::handler::process_workspace_rules(
-            ctx,
-            &assignments,
-            &dependencies.as_ref().ok().cloned(),
-        )
-        .ok();
-    }
+    but_rules::handler::process_workspace_rules(
+        ctx,
+        &assignments,
+        &dependencies.as_ref().ok().cloned(),
+    )
+    .ok();
 
     Ok(WorktreeChanges {
         worktree_changes: changes.into(),

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -104,13 +104,11 @@ impl Handler {
                 .err()
                 .map(|err| serde_error::Error::new(&**err)),
         };
-        if ctx.settings().feature_flags.rules
-            && let Ok(update_count) = but_rules::handler::process_workspace_rules(
-                ctx,
-                &assignments,
-                &dependencies.as_ref().ok().cloned(),
-            )
-            && update_count > 0
+        if let Ok(update_count) = but_rules::handler::process_workspace_rules(
+            ctx,
+            &assignments,
+            &dependencies.as_ref().ok().cloned(),
+        ) && update_count > 0
         {
             // Getting these again since they were updated
             let (assignments, assignments_error) =


### PR DESCRIPTION
- Run workspace rules unconditionally on the backend (remove feature-flag check) and simplify handler logic to react only when update_count > 0.
- Remove the rules feature toggle and auto-opt-in logic from the desktop app (always render RulesList in UnassignedView; drop ExperimentalSettings toggle and SettingsService RULES auto-opt-in).
- Default the Rules drawer to collapsed on desktop (defaultCollapsed={true}) to reduce initial visual clutter.
- Add inline documentation Link to the Rules UI and reformat the Drawer; replace verbose empty-state copy with a concise "Read the docs" link and a "first rule" button that opens the rule editor.