### PR TITLE
Three-character `CliId`s and some code cleanup

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -158,9 +158,9 @@ pub(crate) fn handle(
 fn makes_no_sense_error(source: &CliId, target: &CliId) -> String {
     format!(
         "Operation doesn't make sense. Source {} is {} and target {} is {}.",
-        source.to_string().blue().underline(),
+        source.to_short_string().blue().underline(),
         source.kind_for_humans().yellow(),
-        target.to_string().blue().underline(),
+        target.to_short_string().blue().underline(),
         target.kind_for_humans().yellow()
     )
 }
@@ -184,10 +184,16 @@ fn ids(
                 .iter()
                 .map(|id| match id {
                     CliId::Commit(oid) => {
-                        format!("{} (commit {})", id, &oid.to_string()[..7])
+                        format!(
+                            "{} (commit {})",
+                            id.to_short_string(),
+                            &oid.to_string()[..7]
+                        )
                     }
-                    CliId::Branch { name, .. } => format!("{id} (branch '{name}')"),
-                    _ => format!("{} ({})", id, id.kind_for_humans()),
+                    CliId::Branch { name, .. } => {
+                        format!("{} (branch '{}')", id.to_short_string(), name)
+                    }
+                    _ => format!("{} ({})", id.to_short_string(), id.kind_for_humans()),
                 })
                 .collect();
             return Err(anyhow::anyhow!(
@@ -227,10 +233,16 @@ pub(crate) fn parse_sources(
                     .iter()
                     .map(|id| match id {
                         CliId::Commit(oid) => {
-                            format!("{} (commit {})", id, &oid.to_string()[..7])
+                            format!(
+                                "{} (commit {})",
+                                id.to_short_string(),
+                                &oid.to_string()[..7]
+                            )
                         }
-                        CliId::Branch { name, .. } => format!("{id} (branch '{name}')"),
-                        _ => format!("{} ({})", id, id.kind_for_humans()),
+                        CliId::Branch { name, .. } => {
+                            format!("{} (branch '{}')", id.to_short_string(), name)
+                        }
+                        _ => format!("{} ({})", id.to_short_string(), id.kind_for_humans()),
                     })
                     .collect();
                 return Err(anyhow::anyhow!(

--- a/crates/but/src/command/legacy/status/assignment.rs
+++ b/crates/but/src/command/legacy/status/assignment.rs
@@ -17,7 +17,7 @@ impl CLIHunkAssignment {
     fn from_assignment(id_map: &IdMap, inner: HunkAssignment) -> Self {
         let cli_id = id_map
             .resolve_uncommitted_file_or_unassigned(inner.stack_id, inner.path_bytes.as_ref())
-            .to_string();
+            .to_short_string();
         Self { inner, cli_id }
     }
 }

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -335,7 +335,7 @@ fn convert_branch_to_json(
     id_map: &mut crate::IdMap,
 ) -> anyhow::Result<Branch> {
     let cli_id = id_map
-        .resolve_branch_or_insert(branch.name.as_ref())
+        .resolve_branch(branch.name.as_ref())
         .to_short_string();
 
     let review_id = if review {
@@ -392,11 +392,7 @@ pub(super) fn build_workspace_status_json(
             let stack_cli_id = details
                 .branch_details
                 .first()
-                .map(|b| {
-                    id_map
-                        .resolve_branch_or_insert(b.name.as_ref())
-                        .to_short_string()
-                })
+                .map(|b| id_map.resolve_branch(b.name.as_ref()).to_short_string())
                 .unwrap_or_else(|| "unknown".to_string());
 
             let json_assigned_changes = convert_file_assignments(assignments, worktree_changes);

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -177,7 +177,7 @@ impl Branch {
             .iter()
             .map(|c| {
                 Commit::from_local_commit(
-                    CliId::Commit(c.id).to_string(),
+                    CliId::Commit(c.id).to_short_string(),
                     c.clone(),
                     show_files,
                     project_id,
@@ -189,7 +189,9 @@ impl Branch {
         let upstream_commits = branch
             .upstream_commits
             .iter()
-            .map(|c| Commit::from_upstream_commit(CliId::Commit(c.id).to_string(), c.clone(), None))
+            .map(|c| {
+                Commit::from_upstream_commit(CliId::Commit(c.id).to_short_string(), c.clone(), None)
+            })
             .collect();
 
         Ok(Branch {
@@ -235,7 +237,7 @@ impl Commit {
                             commit.id,
                             change.path.as_ref(),
                         );
-                        FileChange::from_tree_change(cli_id.to_string(), change)
+                        FileChange::from_tree_change(cli_id.to_short_string(), change)
                     })
                     .collect(),
             )
@@ -334,7 +336,7 @@ fn convert_branch_to_json(
 ) -> anyhow::Result<Branch> {
     let cli_id = id_map
         .resolve_branch_or_insert(branch.name.as_ref())
-        .to_string();
+        .to_short_string();
 
     let review_id = if review {
         crate::command::legacy::forge::review::get_review_numbers(
@@ -350,7 +352,7 @@ fn convert_branch_to_json(
     };
 
     Branch::from_branch_details(
-        cli_id,
+        cli_id.to_string(),
         branch.clone(),
         review_id,
         show_files,
@@ -390,7 +392,11 @@ pub(super) fn build_workspace_status_json(
             let stack_cli_id = details
                 .branch_details
                 .first()
-                .map(|b| id_map.resolve_branch_or_insert(b.name.as_ref()).to_string())
+                .map(|b| {
+                    id_map
+                        .resolve_branch_or_insert(b.name.as_ref())
+                        .to_short_string()
+                })
                 .unwrap_or_else(|| "unknown".to_string());
 
             let json_assigned_changes = convert_file_assignments(assignments, worktree_changes);
@@ -416,7 +422,7 @@ pub(super) fn build_workspace_status_json(
     let base_commit_decoded = base_commit.decode()?;
     let author: but_workspace::ui::Author = base_commit_decoded.author()?.into();
 
-    let cli_id = CliId::Commit(common_merge_base.commit_id).to_string();
+    let cli_id = CliId::Commit(common_merge_base.commit_id).to_short_string();
     let merge_base_commit = Commit::from_upstream_commit(
         cli_id,
         but_workspace::ui::UpstreamCommit {
@@ -434,7 +440,7 @@ pub(super) fn build_workspace_status_json(
         let upstream_commit_decoded = upstream_commit.decode()?;
         let upstream_author: but_workspace::ui::Author = upstream_commit_decoded.author()?.into();
 
-        let cli_id = CliId::Commit(upstream.commit_id).to_string();
+        let cli_id = CliId::Commit(upstream.commit_id).to_short_string();
         let latest_commit = Commit::from_upstream_commit(
             cli_id,
             but_workspace::ui::UpstreamCommit {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -390,7 +390,7 @@ pub fn print_group(
         for branch in &group.branch_details {
             let id = id_map
                 .resolve_branch_or_insert(branch.name.as_ref())
-                .to_string()
+                .to_short_string()
                 .underline()
                 .blue();
             let notch = if first { "╭" } else { "├" };
@@ -491,7 +491,7 @@ pub fn print_group(
         }
     } else {
         id_map.add_file_info_from_context(ctx)?;
-        let id = id_map.unassigned().to_string().underline().blue();
+        let id = id_map.unassigned().to_short_string().underline().blue();
         writeln!(
             out,
             "╭┄{} [{}] {}",
@@ -666,7 +666,7 @@ fn print_commit(
         for change in &commit_details.diff_with_first_parent {
             let cid = id_map
                 .resolve_file_changed_in_commit_or_unassigned(commit_id, change.path.as_ref())
-                .to_string()
+                .to_short_string()
                 .blue()
                 .underline();
             let path = path_with_color(&change.status, change.path.to_string());

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -389,7 +389,7 @@ pub fn print_group(
         let mut first = true;
         for branch in &group.branch_details {
             let id = id_map
-                .resolve_branch_or_insert(branch.name.as_ref())
+                .resolve_branch(branch.name.as_ref())
                 .to_short_string()
                 .underline()
                 .blue();

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -15,11 +15,9 @@ use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
 use but_workspace::branch::Stack;
-use std::borrow::Cow;
 use std::{
     borrow::Borrow,
     collections::{BTreeSet, HashMap, HashSet},
-    fmt::Display,
 };
 
 #[cfg(test)]
@@ -27,7 +25,6 @@ mod tests;
 
 /// A helper to indicate that this is a short-id as a user would see.
 type ShortId = String;
-type ShortIdBorrow = str;
 
 /// A mapping from user-friendly CLI IDs to GitButler entities.
 ///
@@ -488,20 +485,14 @@ impl CliId {
     }
 
     /// Returns the short ID string for display to users.
-    pub fn to_short_str(&self) -> Cow<'_, ShortIdBorrow> {
+    pub fn to_short_string(&self) -> ShortId {
         match self {
             CliId::UncommittedFile { id, .. }
             | CliId::CommittedFile { id, .. }
             | CliId::Branch { id, .. }
-            | CliId::Unassigned { id, .. } => Cow::Borrowed(id),
-            CliId::Commit(oid) => Cow::Owned(oid.to_hex_with_len(2).to_string()),
+            | CliId::Unassigned { id, .. } => id.clone(),
+            CliId::Commit(oid) => oid.to_hex_with_len(2).to_string(),
         }
-    }
-}
-
-impl Display for CliId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_short_str())
     }
 }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -3,10 +3,6 @@
 //! This module provides a system for generating short, human-friendly IDs for various GitButler
 //! entities including branches, commits, and files. These IDs are used in the CLI to make commands
 //! more convenient and readable than using full SHA-1 hashes or long branch names.
-//!
-//! IDs can be mapped back to their entities in a separate step, and are usually used in a second invocation,
-//! which is why they should be as stable as possible even when facing intermediate mutations of the set of
-//! entities used to create them.
 
 #![forbid(missing_docs)]
 
@@ -501,7 +497,8 @@ impl IdMap {
             })
     }
 
-    /// Returns an iterator over all workspace commit IDs known to this ID map.
+    /// Returns an iterator over all commit IDs (workspace and remote) known to
+    /// this ID map.
     fn workspace_and_remote_commit_ids(&self) -> impl Iterator<Item = &gix::ObjectId> {
         self.workspace_commit_and_first_parent_ids
             .iter()
@@ -583,8 +580,9 @@ impl CliId {
 struct StacksInfo {
     /// Shortened branch names in unspecified order.
     branch_names: Vec<BString>,
-    /// Commit IDs of commits reachable from workspace tips paired with their first parent IDs.
-    /// The parent ID is stored to enable computing diffs on demand.
+    /// Commit IDs of commits reachable from workspace tips paired with their
+    /// first parent IDs in unspecified order. The parent ID is stored to enable
+    /// computing diffs upon an invocation of [IdMap::add_file_info].
     workspace_commit_and_first_parent_ids: Vec<(gix::ObjectId, Option<gix::ObjectId>)>,
     /// Commit IDs that are only reachable from remote-tracking branches (not in workspace).
     remote_commit_ids: Vec<gix::ObjectId>,

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -276,7 +276,11 @@ impl IdMap {
         matches.extend(self.find_branches_by_name(entity.into()).map(Clone::clone));
 
         // Only try SHA matching if the input looks like a hex string
-        if entity.chars().all(|c| c.is_ascii_hexdigit()) && entity.len() >= 2 {
+        if entity
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+            && entity.len() >= 2
+        {
             for oid in self
                 .workspace_and_remote_commit_ids()
                 .filter(|oid| oid.to_string().starts_with(entity))

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -260,6 +260,15 @@ impl IdMap {
     /// Multiple IDs may be returned if the entity matches multiple items; they are returned in
     /// priority order as mentioned above.
     pub fn resolve_entity_to_ids(&self, entity: &str) -> anyhow::Result<Vec<CliId>> {
+        // If a branch matches exactly, use only that.
+        if let Some((_, cli_id)) = self
+            .branch_name_to_cli_id
+            .iter()
+            .find(|(branch_name, _)| *branch_name == entity.as_bytes())
+        {
+            return Ok(vec![cli_id.clone()]);
+        }
+
         if entity.len() < 2 {
             return Err(anyhow::anyhow!(
                 "Id needs to be at least 2 characters long: {}",

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -4,29 +4,39 @@ use bstr::BString;
 
 #[test]
 fn uint_id_from_short_id() -> anyhow::Result<()> {
-    assert_eq!(UintId::try_from(b"a".as_slice()), Err(()));
-    assert_eq!(UintId::try_from(b"a0".as_slice()), Err(()));
-    assert_eq!(UintId::try_from(b"--".as_slice()), Err(()));
-    assert_eq!(UintId::try_from(b"g0".as_slice()), Ok(UintId(0)));
-    assert_eq!(UintId::try_from(b"z0".as_slice()), Ok(UintId(19)));
-    assert_eq!(UintId::try_from(b"gz".as_slice()), Ok(UintId(700)));
-    assert_eq!(UintId::try_from(b"zz".as_slice()), Ok(UintId(719)));
-    assert_eq!(UintId::try_from(b"g00".as_slice()), Ok(UintId(720)));
-    assert_eq!(UintId::try_from(b"gz0".as_slice()), Ok(UintId(1420)));
-    assert_eq!(UintId::try_from(b"zzz".as_slice()), Ok(UintId(26639)));
-    assert_eq!(UintId::try_from(b"g000".as_slice()), Err(()));
+    assert_eq!(UintId::from_name(b"a".as_slice()), None);
+    assert_eq!(UintId::from_name(b"a0".as_slice()), None);
+    assert_eq!(UintId::from_name(b"--".as_slice()), None);
+    assert_eq!(UintId::from_name(b"g0".as_slice()), Some(UintId(0)));
+    assert_eq!(UintId::from_name(b"z0".as_slice()), Some(UintId(19)));
+    assert_eq!(UintId::from_name(b"gz".as_slice()), Some(UintId(700)));
+    assert_eq!(UintId::from_name(b"zz".as_slice()), Some(UintId(719)));
+    assert_eq!(UintId::from_name(b"g00".as_slice()), Some(UintId(720)));
+    assert_eq!(UintId::from_name(b"gz0".as_slice()), Some(UintId(1420)));
+    assert_eq!(UintId::from_name(b"zzz".as_slice()), Some(UintId(26639)));
+    assert_eq!(UintId::from_name(b"g000".as_slice()), None);
     Ok(())
 }
 
 #[test]
 fn uint_id_to_short_id() -> anyhow::Result<()> {
-    assert_eq!(UintId(0).get_short_id(), "g0");
-    assert_eq!(UintId(19).get_short_id(), "z0");
-    assert_eq!(UintId(700).get_short_id(), "gz");
-    assert_eq!(UintId(719).get_short_id(), "zz");
-    assert_eq!(UintId(720).get_short_id(), "g00");
-    assert_eq!(UintId(1420).get_short_id(), "gz0");
-    assert_eq!(UintId(26639).get_short_id(), "zzz");
+    assert_eq!(UintId(0).to_short_id(), "g0");
+    assert_eq!(UintId(19).to_short_id(), "z0");
+    assert_eq!(UintId(700).to_short_id(), "gz");
+    assert_eq!(UintId(719).to_short_id(), "zz");
+    assert_eq!(UintId(720).to_short_id(), "g00");
+    assert_eq!(UintId(1420).to_short_id(), "gz0");
+    assert_eq!(UintId(26639).to_short_id(), "zzz");
+    assert_eq!(
+        UintId(26640).to_short_id(),
+        "00",
+        "too big always yields this"
+    );
+    assert_eq!(
+        UintId(26641).to_short_id(),
+        "00",
+        "too big always yields this"
+    );
     Ok(())
 }
 

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -41,7 +41,7 @@ fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
     let id_map = IdMap::new_for_branches_and_commits(stacks)?;
 
     assert_eq!(
-        id_map.unassigned().to_string(),
+        id_map.unassigned().to_short_string(),
         "000",
         "the ID of the unassigned area should have enough 0s to be unambiguous"
     );

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
 </tspan>
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="190px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -25,7 +25,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> A-remote    </tspan>
 </tspan>
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B    </tspan>
 </tspan>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -96,18 +96,18 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "g0",
+      "cliId": "i0",
       "filePath": "test-file.txt",
       "changeType": "added"
     }
   ],
   "stacks": [
     {
-      "cliId": "l3",
+      "cliId": "g0",
       "assignedChanges": [],
       "branches": [
         {
-          "cliId": "l3",
+          "cliId": "g0",
           "name": "A",
           "commits": [
             {
@@ -129,11 +129,11 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
       ]
     },
     {
-      "cliId": "m3",
+      "cliId": "h0",
       "assignedChanges": [],
       "branches": [
         {
-          "cliId": "m3",
+          "cliId": "h0",
           "name": "B",
           "commits": [
             {

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
 </tspan>
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>    </tspan>
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">l3</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A    </tspan>
 </tspan>
@@ -32,7 +32,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="underline">m3</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B    </tspan>
 </tspan>


### PR DESCRIPTION
As @Byron said in https://github.com/gitbutlerapp/gitbutler/pull/11508#issuecomment-3637803767 :

> The biggest thing I thought I found was the functioning of string_hash which is only good for 720 hashes. It's now called from a non-infinite loop, but it might be too limiting in practice as it's hard-coded to 720 iterations, something that seemed safer than a loop.
>
> However, it also shows that we can't scale up these short hashes, even though that might be needed when dealing with bigger workspaces. To my mind, the CLI ID limit can easily be reached when there is a workspace with many commits.
Is this something you can fix algorithmically? Maybe it can even be done efficiently so we don't allocate a new String each time just to throw it away while it's trying to find a match.

This now allows 3-character IDs (I also changed it to no longer be hashes). I've also made it more efficient in that we don't allocate new Strings when testing whether the string is a non-conflicting ID.

~You also mentioned proofreading the documentation - I'll do that later.~ I did this too.