### PR TITLE
Add Linux compatibility document

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -1,0 +1,35 @@
+# Linux compatibility
+GitButler should run well on most modern Linux distributions, but there are too many software and hardware combinations for the core team to support on its own. As such, the GitButler project maintains official support for a select few Linux distributions, and otherwise relies on community-maintained packages.
+
+This document outlines the current level of commitment toward Linux distributions and packaging formats.
+
+> A more dynamic overview of the current state of Linux compatibility can be found in https://github.com/gitbutlerapp/gitbutler/issues/8411
+
+## Official support
+The officially supported way to install GitButler is with the `deb` package provided on the [downloads page](https://gitbutler.com/downloads). This package is regularly tested to work well with the following distributions.
+
+* Ubuntu 22.04 LTS (jammy)
+* Ubuntu 24.04 LTS (noble)
+
+On these distributions, we aim to provide as good a user experience as on Windows and macOS. Compatibility is routinely verified and compatibility issues are the domain of the core GitButler team. We know that the current user experience does not quite deliver on all fronts, and work on improvements is underway.
+
+This does not mean that the GitButler project is unconcerned with the woes of other Linux distributions. Reports of compatibility issues with _any_ distribution are welcome in the [issue tracker](https://github.com/gitbutlerapp/gitbutler/issues), but with the caveat that such issues are not guaranteed to get prioritized anytime soon. If there is a compatibility trade-off to be made, it will always be made in favor of the officially supported distributions.
+
+## Experimental distribution: `rpm`
+We provide an experimental `rpm` package alongside the `deb` package. It is fundamentally the same thing as the `deb` package and should have the same level of compatibility, but it is not regularly tested on any distribution as part of the development process. We provide it as it is no extra effort to build with the current toolchain, and have no reason to believe it would come with any particular compatibility caveats.
+
+## Experimental distribution: AppImage
+We provide an experimental AppImage that bundles the core dependencies required to run GitButler. The intention is that it should work on most Linux distributions, but experience shows that compatibility is relatively poor.
+
+The AppImage may be removed in the future if compatibility remains poor.
+
+## Community-maintained distributions
+There are several community-maintained distributions of GitButler. Issues with these distributions should typically be brought to the attention of their respective maintainers.
+
+> Know of one we missed? Submit a PR to keep us in the loop!
+
+* Arch Linux User Repository (AUR)
+    - [gitbutler](https://aur.archlinux.org/packages/gitbutler)
+    - [gitbutler-bin](https://aur.archlinux.org/packages/gitbutler-bin)
+* Flatpak
+    - [GitButler](https://flathub.org/en/apps/com.gitbutler.gitbutler)


### PR DESCRIPTION
## 🧢 Changes
This is a draft for the official Linux compatibility policy of the GitButler project.

This has been discussed at some length in [Discord](https://discord.com/channels/1060193121130000425/1445541648686780587) already, and with this I'm trying to cement what we've discussed.

This is a _draft_, both in terms of content and in terms of location. Suggestions for changes in wording are welcome, nay, _expected_! The idea is that this is somehow communicated via the website as well, perhaps just with a link to this policy.

## ☕️ Reasoning
Linux compatibility is shaky, and above all, _unclear_. Linux is not an operating system. Ubuntu 22.04 is, or Fedora 39, or Arch Linux. They're all quite different, and no concerted effort has been made to provide a good experience on any of them.

The [downloads page](https://gitbutler.com/downloads) provides `deb`, `rpm` and `AppImage` packages, which implies support for "something Debian", "something Redhat" and "anything", yet no details are provided. It's all just rather confusing. The AppImage in particular works poorly in many places, and not at all in more.

There is significant risk that this lack of clarity causes people try out GitButler on some Linux distribution of their choice, have a downright crappy experience, and leave with a sour taste in their mouths. Or worse: spread said sour taste to others through word of mouth. Or Reddit.

My proposal is simple: let's narrow down to provide a _great_ experience on a few, mainstream distributions (here, Ubuntu 22.04 and 24.04). We might branch out from there in the future, or we may simply rely on community support for other Linux distros as popularity for GitButler grows.

## 🎫 Affected issues

https://github.com/gitbutlerapp/gitbutler/issues/8411
