### PR TITLE
Don't allow combos in lexical fields

### DIFF
--- a/apps/desktop/src/lib/utils/hotkeys.ts
+++ b/apps/desktop/src/lib/utils/hotkeys.ts
@@ -79,7 +79,8 @@ export function createKeybind(keybinds: KeybindDefinitions) {
 			if (
 				event.repeat ||
 				event.target instanceof HTMLInputElement ||
-				event.target instanceof HTMLTextAreaElement
+				event.target instanceof HTMLTextAreaElement ||
+				('_lexicalHandled' in event && event._lexicalHandled)
 			) {
 				return;
 			}


### PR DESCRIPTION
This adds a check for the `_lexicalHandled` property which seems to be 
an indicator as to whether an event was indeed handled by lexical.

* Closes https://github.com/gitbutlerapp/gitbutler/issues/11536#issuecomment-3654489173