### PR TITLE
rename "reword_commit" to "commit_reword" & register but-server entry

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1203,7 +1203,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 				{ projectId: string; commitId: string; message: string }
 			>({
 				extraOptions: {
-					command: 'reword_commit',
+					command: 'commit_reword',
 					actionName: 'Update Commit Message'
 				},
 				query: (args) => args,

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 /// Returns the ID of the newly renamed commit
 #[but_api]
 #[instrument(err(Debug))]
-pub fn reword_commit_only(
+pub fn commit_reword_only(
     ctx: &but_ctx::Context,
     commit_id: gix::ObjectId,
     message: BString,
@@ -19,12 +19,12 @@ pub fn reword_commit_only(
     but_workspace::commit::reword(&graph, &repo, commit_id, message.as_bstr())
 }
 
-/// Rewords a commit.
+/// Rewords a commit, but without updating the oplog.
 ///
 /// Returns the ID of the newly renamed commit
 #[but_api]
 #[instrument(err(Debug))]
-pub fn reword_commit(
+pub fn commit_reword(
     ctx: &but_ctx::Context,
     commit_id: gix::ObjectId,
     message: BString,
@@ -36,7 +36,7 @@ pub fn reword_commit(
     )
     .ok();
 
-    let res = reword_commit_only(ctx, commit_id, message);
+    let res = commit_reword_only(ctx, commit_id, message);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
         snapshot.commit(ctx).ok();
     };

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{
     response::IntoResponse,
     routing::{any, get},
 };
-use but_api::{diff, github, json, legacy};
+use but_api::{commit, diff, github, json, legacy};
 use but_claude::{Broadcaster, Claude};
 use but_settings::AppSettingsWithDiskSync;
 use futures_util::{SinkExt, StreamExt as _};
@@ -617,6 +617,9 @@ async fn handle_command(
             let result = legacy::claude::claude_verify_path(params.project_id, params.path).await;
             result.map(|r| json!(r))
         }
+
+        // New graph based rebasing functions
+        "commit_reword" => commit::commit_reword_cmd(request.params),
 
         _ => Err(anyhow::anyhow!("Command {} not found!", command)),
     }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -384,7 +384,7 @@ fn main() -> anyhow::Result<()> {
                 claude::claude_cancel_session,
                 claude::claude_is_stack_active,
                 claude::claude_compact_history,
-                commit::tauri_reword_commit::reword_commit
+                commit::tauri_commit_reword::commit_reword
             ])
             .menu(move |handle| menu::build(handle, &app_settings_for_menu))
             .on_window_event(|window, event| match event {


### PR DESCRIPTION
This came up after having a bit of a conversation around how we should 
name new API commands.
The idea to have a `noun_verb` scheme seemed quite nice since it would 
naturally group commands when sorting them alphabetically.
IE:
- commit_reword
- commit_insert_blank
- pr_list
- pr_create
- claude_send_message
- claude_list_messages