### PR TITLE
follow-up of #11530

### DIFF
--- a/crates/but-action/src/openai.rs
+++ b/crates/but-action/src/openai.rs
@@ -1,15 +1,13 @@
 use std::{collections::HashMap, fmt::Display, ops::Deref, sync::Arc};
 
 use anyhow::{Context as _, Result};
-use async_openai::types::chat::{
-    ChatCompletionMessageToolCalls, ChatCompletionRequestToolMessageContent,
-};
 use async_openai::{
     Client,
     config::OpenAIConfig,
     types::chat::{
-        ChatCompletionRequestAssistantMessageContent, ChatCompletionRequestMessage,
-        ChatCompletionRequestSystemMessage, ChatCompletionRequestUserMessageContent,
+        ChatCompletionMessageToolCalls, ChatCompletionRequestAssistantMessageContent,
+        ChatCompletionRequestMessage, ChatCompletionRequestSystemMessage,
+        ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessageContent,
         CreateChatCompletionRequestArgs, ResponseFormat, ResponseFormatJsonSchema,
     },
 };

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
+
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use std::collections::HashMap;
 use syn::{Expr, FnArg, ItemFn, Pat, parse_macro_input};
 
 /// A macro to help generate wrappers which are used by some clients to support deserialisation of parameters

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1,7 +1,9 @@
 use but_core::worktree::checkout::UncommitedWorktreeChanges;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
-use but_workspace::branch::OnWorkspaceMergeConflict;
-use but_workspace::branch::apply::{WorkspaceMerge, WorkspaceReferenceNaming};
+use but_workspace::branch::{
+    OnWorkspaceMergeConflict,
+    apply::{WorkspaceMerge, WorkspaceReferenceNaming},
+};
 
 /// Apply `existing_branch` to the workspace in the repository that `ctx` refers to, or create the workspace with default name.
 pub fn apply_only(

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use crate::json::HexHash;
 use anyhow::{Context as _, Result};
 use but_api_macros::but_api;
 use but_core::DiffSpec;
@@ -15,6 +14,8 @@ use gitbutler_repo::{
 };
 use gitbutler_repo_actions::askpass;
 use tracing::instrument;
+
+use crate::json::HexHash;
 
 #[but_api]
 #[instrument(err(Debug))]

--- a/crates/but-clap/tests/mdx_generation.rs
+++ b/crates/but-clap/tests/mdx_generation.rs
@@ -317,5 +317,9 @@ fn test_frontmatter_only_first_line() {
     assert!(mdx.contains("description: \"First line of description\""));
 
     // But full description should be in the body
-    assert!(mdx.contains("# First line of description\n\nFirst line of description\nSecond line of description\nThird line"));
+    assert!(
+        mdx.contains(
+            "# First line of description\n\nFirst line of description\nSecond line of description\nThird line"
+        )
+    );
 }

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -153,9 +153,9 @@ impl LockFile {
         self.inner.try_lock().or_else(|err| {
             if err.kind() == std::io::ErrorKind::Unsupported {
                 tracing::warn!(
-                "Filesystem hosting '{}' doesn't support file locking - pretending to own lock to avoid failure",
-                self.path.display()
-            );
+                    "Filesystem hosting '{}' doesn't support file locking - pretending to own lock to avoid failure",
+                    self.path.display()
+                );
                 Ok(true)
             } else {
                 Err(err)

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -2,10 +2,11 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+use std::path::{Path, PathBuf};
+
 use but_core::sync::{WorktreeReadPermission, WorktreeWritePermission};
 use but_settings::AppSettings;
 use gix::Repository;
-use std::path::{Path, PathBuf};
 
 /// Legacy types that shouldn't be used.
 #[cfg(feature = "legacy")]

--- a/crates/but-fs/src/lib.rs
+++ b/crates/but-fs/src/lib.rs
@@ -157,9 +157,11 @@ fn persist_tempfile(
 ) -> std::io::Result<()> {
     match tempfile.persist(to_path) {
         Ok(Some(_opened_file)) => Ok(()),
-        Ok(None) => unreachable!(
-            "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
-        ),
+        Ok(None) => {
+            unreachable!(
+                "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
+            )
+        }
         Err(err) => Err(err.error),
     }
 }

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -1,12 +1,18 @@
-use crate::Worktree;
-use crate::init::walk::WorktreeByBranch;
-use crate::init::{Entrypoint, Overlay, walk::RefsById};
-use anyhow::bail;
-use but_core::{RefMetadata, ref_metadata};
-use gix::{prelude::ReferenceExt, refs::Target};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
+};
+
+use anyhow::bail;
+use but_core::{RefMetadata, ref_metadata};
+use gix::{prelude::ReferenceExt, refs::Target};
+
+use crate::{
+    Worktree,
+    init::{
+        Entrypoint, Overlay,
+        walk::{RefsById, WorktreeByBranch},
+    },
 };
 
 impl Overlay {

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -7,11 +7,13 @@ use but_testsupport::{
     InMemoryRefMetadata, graph_tree, graph_workspace, visualize_commit_graph_all,
 };
 
-use crate::init::utils::{add_stack, add_workspace_with_target};
 use crate::init::{
     StackState, add_stack_with_segments, add_workspace, id_at, id_by_rev,
     read_only_in_memory_scenario, standard_options,
-    utils::{add_workspace_without_target, remove_target, standard_options_with_extra_target},
+    utils::{
+        add_stack, add_workspace_with_target, add_workspace_without_target, remove_target,
+        standard_options_with_extra_target,
+    },
 };
 
 #[test]

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -1,4 +1,12 @@
-use crate::virtual_branches_legacy_types::{CommitOrChangeId, Stack, StackBranch, VirtualBranches};
+use std::{
+    any::Any,
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashSet},
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
 use anyhow::{Context as _, bail};
 use bstr::ByteSlice;
 use but_core::{
@@ -16,16 +24,9 @@ use gix::{
     refs::{FullName, FullNameRef},
 };
 use itertools::Itertools;
-use std::collections::{BTreeMap, BTreeSet};
-use std::{
-    any::Any,
-    cell::RefCell,
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-    path::{Path, PathBuf},
-    time::Instant,
-};
 use tracing::instrument;
+
+use crate::virtual_branches_legacy_types::{CommitOrChangeId, Stack, StackBranch, VirtualBranches};
 
 #[derive(Debug, Clone)]
 struct Snapshot {
@@ -966,9 +967,11 @@ mod fs {
     ) -> std::io::Result<()> {
         match tempfile.persist(to_path) {
             Ok(Some(_opened_file)) => Ok(()),
-            Ok(None) => unreachable!(
-                "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
-            ),
+            Ok(None) => {
+                unreachable!(
+                    "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
+                )
+            }
             Err(err) => Err(err.error),
         }
     }

--- a/crates/but-oplog/src/lib.rs
+++ b/crates/but-oplog/src/lib.rs
@@ -75,9 +75,10 @@ pub mod legacy {
 
 #[cfg(feature = "legacy")]
 mod oplog_snapshot {
-    use crate::UnmaterializedOplogSnapshot;
     use but_oxidize::{ObjectIdExt, OidExt};
     use gitbutler_oplog::OplogExt;
+
+    use crate::UnmaterializedOplogSnapshot;
 
     /// Lifecycle
     impl UnmaterializedOplogSnapshot {

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -2,12 +2,13 @@
 
 use std::path::PathBuf;
 
-use crate::{cherry_pick::function::ConflictEntries, commit::DateMode};
 use anyhow::{Context as _, Result, bail};
 use bstr::BString;
 use but_core::commit::{HEADERS_CONFLICTED_FIELD, HeadersV2, TreeKind};
 use but_oxidize::GixRepositoryExt as _;
 use gix::{objs::tree::EntryKind, prelude::ObjectIdExt as _};
+
+use crate::{cherry_pick::function::ConflictEntries, commit::DateMode};
 
 /// Describes the outcome of cherrypick.
 #[derive(Debug, Clone, Copy)]

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -1,7 +1,6 @@
 //! Functions for materializing a rebase
 use std::collections::HashMap;
 
-use crate::graph_rebase::{Checkouts, rebase::SuccessfulRebase};
 use anyhow::Result;
 use but_core::{
     ObjectStorageExt as _,
@@ -10,6 +9,8 @@ use but_core::{
         safe_checkout_from_head,
     },
 };
+
+use crate::graph_rebase::{Checkouts, rebase::SuccessfulRebase};
 
 /// The outcome of a materialize
 #[derive(Debug, Clone)]

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -2,16 +2,17 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::graph_rebase::{
-    Checkouts, Editor, Step, StepGraph, StepGraphIndex,
-    cherry_pick::{CherryPickOutcome, cherry_pick},
-};
 use anyhow::{Context, Result, bail};
 use gix::refs::{
     Target,
     transaction::{Change, LogChange, PreviousValue, RefEdit},
 };
 use petgraph::{Direction, visit::EdgeRef};
+
+use crate::graph_rebase::{
+    Checkouts, Editor, Step, StepGraph, StepGraphIndex,
+    cherry_pick::{CherryPickOutcome, cherry_pick},
+};
 
 /// Represents a successful rebase, and any valid, but potentially conflicting scenarios it had.
 #[allow(unused)]
@@ -423,8 +424,9 @@ mod test {
     }
 
     mod order_steps_picking {
-        use anyhow::Result;
         use std::str::FromStr;
+
+        use anyhow::Result;
 
         use crate::graph_rebase::{
             Edge, Step, StepGraph, rebase::order_steps_picking, testing::TestingDot as _,

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -700,9 +700,11 @@ fn indices_or_headers_to_hunk_headers(
                 .changes
                 .into_iter()
                 .find(|change| {
-                    change.path == *path
-                        && change.previous_path() == previous_path.as_ref().map(|p| p.as_bstr())
-                }).with_context(|| format!("Couldn't find worktree change for file at '{path}' (previous-path: {previous_path:?}"))?;
+                    change.path == *path && change.previous_path() == previous_path.as_ref().map(|p| p.as_bstr())
+                })
+                .with_context(|| {
+                    format!("Couldn't find worktree change for file at '{path}' (previous-path: {previous_path:?}")
+                })?;
             let Some(UnifiedPatch::Patch { hunks, .. }) =
                 worktree_changes.unified_patch(repo, UI_CONTEXT_LINES)?
             else {

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -1,7 +1,5 @@
-use crate::{
-    git_status, graph_workspace_determinisitcally, invoke_bash_at_dir, isolate_snapbox_cmd,
-    visualize_commit_graph_all_from_dir,
-};
+use std::{io::Write, ops::DerefMut, path::Path};
+
 use but_core::{
     RefMetadata,
     ref_metadata::{StackId, WorkspaceCommitRelation},
@@ -9,7 +7,11 @@ use but_core::{
 use but_meta::VirtualBranchesTomlMetadata;
 use gix_testtools::{Creation, tempfile};
 use snapbox::{Assert, Redactions};
-use std::{io::Write, ops::DerefMut, path::Path};
+
+use crate::{
+    git_status, graph_workspace_determinisitcally, invoke_bash_at_dir, isolate_snapbox_cmd,
+    visualize_commit_graph_all_from_dir,
+};
 
 /// A sandbox for a GitButler application that assumes read-write testing, so all data is editable and is cleaned up afterward.
 pub struct Sandbox {
@@ -179,7 +181,8 @@ impl Sandbox {
         redactions
             .insert(
                 "[UUID]",
-                regex::Regex::new(r#"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"#).unwrap(),
+                regex::Regex::new(r#"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"#)
+                    .unwrap(),
             )
             .unwrap();
         redactions

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -171,7 +171,8 @@ impl Tool for Commit {
             You can specify the commit message, target branch name, and a list of file paths to commit.
             If the branch does not exist, it will be created.
         </important_notes>
-        ".to_string()
+        "
+        .to_string()
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -1072,7 +1073,8 @@ impl Tool for GetBranchChanges {
             Call this tool before splitting a branch.
             Use this to inspect what files have been changed on a branch.
         </important_notes>
-        ".to_string()
+        "
+        .to_string()
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -1494,7 +1496,8 @@ impl Tool for SplitCommit {
             Each shard must have a unique set of files, and all files in the source commit must be assigned to a shard.
             The order of the shards determines the order of the resulting commits.
         </important_notes>
-        ".to_string()
+        "
+        .to_string()
     }
 
     fn parameters(&self) -> serde_json::Value {

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -234,7 +234,8 @@ pub(crate) mod function {
                 .tip_commit()
                 .context("Workspace must point to a commit to check out")?;
             let current_head_commit = workspace
-                .graph.entrypoint_commit()
+                .graph
+                .entrypoint_commit()
                 .context("The entrypoint must have a commit - it's equal to HEAD, and we skipped unborn earlier")?;
             but_core::worktree::safe_checkout(
                 current_head_commit.id,
@@ -336,8 +337,9 @@ pub(crate) mod function {
         {
             None => {
                 // Pretend to create a workspace reference later at the current AdHoc workspace id
-                let tip = workspace.tip_commit().map(|c| c.id)
-                    .context("BUG: how can an empty ad-hoc workspace exist? Should have at least one stack-segment with commit")?;
+                let tip = workspace.tip_commit().map(|c| c.id).context(
+                    "BUG: how can an empty ad-hoc workspace exist? Should have at least one stack-segment with commit",
+                )?;
                 (tip, false)
             }
             Some(mut existing_workspace_reference) => {

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -70,14 +70,11 @@ pub fn branch_details(
         )?;
         // TODO: have a test that shows why this must/should be last. Then maybe make it easy to do
         //       the right thing whenever the mergebase with the integration branch is needed.
-        merge_bases
-            .last()
-            .map(|id| id.detach())
-            .unwrap_or_else(|| {
+        merge_bases.last().map(|id| id.detach()).unwrap_or_else(|| {
             tracing::warn!("No merge-base found between {name} and the integration branch {integration_branch_name}");
-                // default to the tip just like the code previously did, resulting in no information
-                // TODO: we should probably indicate that there is no merge-base instead of just glossing over it.
-                branch_id.detach()
+            // default to the tip just like the code previously did, resulting in no information
+            // TODO: we should probably indicate that there is no merge-base instead of just glossing over it.
+            branch_id.detach()
         })
     };
 

--- a/crates/but-workspace/src/legacy/commit_engine/mod.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/mod.rs
@@ -1,5 +1,7 @@
 //! The machinery used to alter and mutate commits in various ways whilst adjusting descendant commits within a [reference frame](ReferenceFrame).
 
+use std::path::Path;
+
 use anyhow::{Context as _, bail};
 use bstr::BString;
 use but_core::{DiffSpec, ref_metadata::StackId, tree::create_tree::RejectionReason};
@@ -7,7 +9,6 @@ use but_ctx::{Context, access::WorktreeWritePermission};
 use but_rebase::merge::ConflictErrorContext;
 use gitbutler_stack::{VirtualBranchesHandle, VirtualBranchesState};
 use gix::{prelude::ObjectIdExt, refs::transaction::PreviousValue};
-use std::path::Path;
 
 use crate::{
     WorkspaceCommit,

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -477,20 +477,22 @@ pub fn stack_details_v3(
         }
         Some(stack_id) => {
             // Even though it shouldn't be the case, the ids can totally go out of sync. Use both to play it safer.
-            let (vb_stack, alt_stack_id) = meta.data().branches.iter()
-                .find_map(|(k, s)| if s.id == stack_id {
-                    Some((s, Some(*k)))
-                } else if *k == stack_id {
-                    Some((s, Some(s.id)))
-                } else {
-                    None
-                }
-                )
+            let (vb_stack, alt_stack_id) = meta
+                .data()
+                .branches
+                .iter()
+                .find_map(|(k, s)| {
+                    if s.id == stack_id {
+                        Some((s, Some(*k)))
+                    } else if *k == stack_id {
+                        Some((s, Some(s.id)))
+                    } else {
+                        None
+                    }
+                })
                 .with_context(|| {
-                format!(
-                    "Couldn't find {stack_id} even when looking at virtual_branches.toml directly"
-                )
-            })?;
+                    format!("Couldn't find {stack_id} even when looking at virtual_branches.toml directly")
+                })?;
             let full_name = gix::refs::FullName::try_from(format!(
                 "refs/heads/{shortname}",
                 shortname = vb_stack.derived_name()?
@@ -715,7 +717,8 @@ fn upstream_only_commits(
     for commit in branch_commits.upstream_only.iter() {
         let matches_known_commit = local_and_remote.iter().any(|c| {
             // If the id matches verbatim or if there is a known remote_id (in the case of LocalAndRemote) that matches
-            c.id == commit.id().to_gix() || matches!(&c.state, CommitState::LocalAndRemote(remote_id) if remote_id == &commit.id().to_gix())
+            c.id == commit.id().to_gix()
+                || matches!(&c.state, CommitState::LocalAndRemote(remote_id) if remote_id == &commit.id().to_gix())
         });
         // Ignore commits that strictly speaking are remote only, but they match a known local commit (rebase etc)
         if !matches_known_commit {

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
@@ -44,11 +44,7 @@ pub fn split_commit(
     let commit_mapping = result
         .commit_mapping
         .iter()
-        .filter_map(
-            |(_, old, new)| {
-                if old == new { None } else { Some((*old, *new)) }
-            },
-        )
+        .filter_map(|(_, old, new)| if old == new { None } else { Some((*old, *new)) })
         .collect();
 
     let mut source_stack = source_stack;

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -57,8 +57,7 @@ pub use ref_info::function::{head_info, ref_info};
 
 mod branch_details;
 pub use branch_details::{branch_details, local_commits_for_branch};
-use but_graph::SegmentIndex;
-use but_graph::projection::TargetCommit;
+use but_graph::{SegmentIndex, projection::TargetCommit};
 
 /// Information about refs, as seen from within or outsie of a workspace.
 ///

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -11,13 +11,14 @@ pub use ref_info::inner::RefInfo;
 
 /// This code is a fork of [`gitbutler_branch_actions::author`] to avoid depending on the `gitbutler_branch_actions` crate.
 mod author;
+pub use author::Author;
+use but_core::{CommitOwned, commit};
+use ts_rs::TS;
+
 use crate::{
     ref_info::{LocalCommit, LocalCommitRelation},
     ui,
 };
-pub use author::Author;
-use but_core::{CommitOwned, commit};
-use ts_rs::TS;
 
 /// Represents the state a commit could be in.
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1644,10 +1644,10 @@ fn journey_with_commits() -> anyhow::Result<()> {
     )?;
 
     assert!(
-            !meta.branch(main_ref)?.is_default(),
-            "Data is created/updated for dependent branches though,
+        !meta.branch(main_ref)?.is_default(),
+        "Data is created/updated for dependent branches though,
             which is a way to make segments appear if there were not visible before due to ambiguity."
-        );
+    );
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     ⌂:0:main[🌳] <> ✓!
     └── ≡📙:0:main[🌳]

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -847,7 +847,8 @@ fn commit_to_one_below_tip() -> anyhow::Result<()> {
     write_sequence(&repo, "file", [(20, Some(40)), (80, None), (30, Some(50))])?;
     let first_commit = Destination::NewCommit {
         parent_commit_id: Some(repo.rev_parse_single("first-commit")?.into()),
-        message: "we apply a change with line offsets on top of the first commit, so a cherry-pick is necessary.".into(),
+        message: "we apply a change with line offsets on top of the first commit, so a cherry-pick is necessary."
+            .into(),
         stack_segment: None,
     };
 

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -70,11 +70,9 @@ fn non_modifications_trigger_error() -> anyhow::Result<()> {
             CONTEXT_LINES,
         )
         .unwrap_err();
-        assert!(
-            err.to_string().starts_with(
-                "Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead"
-            ),
-        );
+        assert!(err.to_string().starts_with(
+            "Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead"
+        ),);
     }
     Ok(())
 }

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -9,8 +9,7 @@ fn clap() {
 mod push {
     #[cfg(feature = "legacy")]
     mod get_gerrit_flags {
-        use crate::args::push::Command as Args;
-        use crate::command::legacy::push::get_gerrit_flags;
+        use crate::{args::push::Command as Args, command::legacy::push::get_gerrit_flags};
 
         #[test]
         fn non_gerrit_mode() {

--- a/crates/but/src/command/branch/mod.rs
+++ b/crates/but/src/command/branch/mod.rs
@@ -1,8 +1,8 @@
 mod apply;
-use crate::args::branch::Subcommands;
-use crate::utils::OutputChannel;
 pub use apply::apply;
 use but_ctx::Context;
+
+use crate::{args::branch::Subcommands, utils::OutputChannel};
 
 pub fn handle(
     cmd: Option<Subcommands>,

--- a/crates/but/src/command/legacy/base.rs
+++ b/crates/but/src/command/legacy/base.rs
@@ -129,8 +129,9 @@ pub async fn handle(
                 } => {
                     if !worktree_conflicts.is_empty() {
                         if let Some(out) = out.for_human() {
-                            writeln!(out,
-                                     "❗️ There are uncommitted changes in the worktree that may conflict with
+                            writeln!(
+                                out,
+                                "❗️ There are uncommitted changes in the worktree that may conflict with
                             the updates. Please commit or stash them and try again."
                             )?;
                         }
@@ -150,16 +151,14 @@ pub async fn handle(
                                 }
                                 continue;
                             };
-                            let approach = if status
-                                .branch_statuses
-                                .iter()
-                                .all(|s| s.status == Integrated)
-                            && status.tree_status != gitbutler_branch_actions::upstream_integration::TreeStatus::Conflicted
+                            let approach = if status.branch_statuses.iter().all(|s| s.status == Integrated)
+                                && status.tree_status
+                                    != gitbutler_branch_actions::upstream_integration::TreeStatus::Conflicted
                             {
-                                    ResolutionApproach::Delete
-                                } else {
-                                    ResolutionApproach::Rebase
-                                };
+                                ResolutionApproach::Delete
+                            } else {
+                                ResolutionApproach::Rebase
+                            };
                             let resolution = Resolution {
                                 stack_id,
                                 approach,

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -528,10 +528,11 @@ async fn generate_branch_summary(
     use but_action::OpenAiProvider;
 
     // Get OpenAI provider (tries GitButler proxied, own key, then env var)
-    let provider = OpenAiProvider::with(None)
-        .ok_or_else(|| anyhow::anyhow!(
+    let provider = OpenAiProvider::with(None).ok_or_else(|| {
+        anyhow::anyhow!(
             "No AI credentials found. Configure in GitButler settings or set OPENAI_API_KEY environment variable."
-        ))?;
+        )
+    })?;
 
     // Build the prompt with commit information
     let mut prompt = format!(
@@ -553,7 +554,9 @@ async fn generate_branch_summary(
         prompt.push('\n');
     }
 
-    prompt.push_str("\nProvide a brief, professional summary focusing on the overall purpose and impact of these changes.");
+    prompt.push_str(
+        "\nProvide a brief, professional summary focusing on the overall purpose and impact of these changes.",
+    );
     prompt.push_str(
         "\nHere is a good example:\n\nAdd an --ai flag to the branch show command to allow generating an \nAI-powered summary of a branch's commits. This allows the user to see\nat a glance what the branch is about without reading all commit messages.\n");
 

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -3,9 +3,11 @@ use but_ctx::Context;
 use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_project::Project;
 
-use crate::args::push::Command;
-use crate::{CliId, IdMap};
-use crate::{args::push, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    args::{push, push::Command},
+    utils::OutputChannel,
+};
 
 pub fn handle(
     args: push::Command,

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -9,10 +9,11 @@
 //! Non-goals:
 //! - Completeness: The output structures do not include all the data that the internal but-api has.
 
-use crate::CliId;
 use but_api::diff::ComputeLineStats;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+
+use crate::CliId;
 
 /// JSON output for the `but status` command
 /// This represents the status of the GitButler "workspace".

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use crate::CLI_DATE;
 use assignment::FileAssignment;
 use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
@@ -12,6 +11,8 @@ use but_workspace::ui::StackDetails;
 use colored::{ColoredString, Colorize};
 use gix::date::time::CustomFormat;
 use serde::Serialize;
+
+use crate::CLI_DATE;
 
 const DATE_ONLY: CustomFormat = CustomFormat::new("%Y-%m-%d");
 

--- a/crates/but/src/command/push.rs
+++ b/crates/but/src/command/push.rs
@@ -1,6 +1,7 @@
 pub mod help {
-    use crate::utils::OutputChannel;
     use but_core::RepositoryExt;
+
+    use crate::utils::OutputChannel;
 
     fn is_gerrit_enabled() -> bool {
         // Parse the -C flag from command line arguments

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -6,16 +6,17 @@
 
 #![forbid(missing_docs)]
 
+use std::{
+    borrow::Borrow,
+    collections::{BTreeSet, HashMap, HashSet},
+};
+
 use anyhow::bail;
 use bstr::{BStr, BString, ByteSlice};
 use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
 use but_workspace::branch::Stack;
-use std::{
-    borrow::Borrow,
-    collections::{BTreeSet, HashMap, HashSet},
-};
 
 #[cfg(test)]
 mod tests;

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1,6 +1,7 @@
-use crate::{CliId, IdMap, id::UintId};
 use anyhow::bail;
 use bstr::BString;
+
+use crate::{CliId, IdMap, id::UintId};
 
 #[test]
 fn uint_id_from_short_id() -> anyhow::Result<()> {
@@ -295,8 +296,10 @@ mod util {
     use bstr::BString;
     use but_core::ref_metadata::StackId;
     use but_hunk_assignment::HunkAssignment;
-    use but_workspace::branch::Stack;
-    use but_workspace::ref_info::{Commit, LocalCommit, Segment};
+    use but_workspace::{
+        branch::Stack,
+        ref_info::{Commit, LocalCommit, Segment},
+    };
 
     pub fn id(byte: u8) -> gix::ObjectId {
         gix::ObjectId::try_from([byte].repeat(20).as_slice()).expect("could not generate ID")

--- a/crates/but/src/legacy/mod.rs
+++ b/crates/but/src/legacy/mod.rs
@@ -1,7 +1,6 @@
-use crate::args::Args;
-use crate::command;
-use crate::utils::OutputChannel;
 use but_ctx::LegacyProject;
+
+use crate::{args::Args, command, utils::OutputChannel};
 
 pub mod commits;
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -28,13 +28,17 @@ use anyhow::{Context as _, Result};
 use cfg_if::cfg_if;
 
 pub mod args;
-use crate::utils::ResultJsonExt;
-use crate::utils::{OneshotMetricsContext, OutputChannel, ResultErrorExt, ResultMetricsExt};
-use args::{Args, OutputFormat, Subcommands, forge, metrics};
-use args::{actions, base, branch, claude, cursor, worktree};
+use args::{
+    Args, OutputFormat, Subcommands, actions, base, branch, claude, cursor, forge, metrics,
+    worktree,
+};
 use but_settings::AppSettings;
 use colored::Colorize;
 use gix::date::time::CustomFormat;
+
+use crate::utils::{
+    OneshotMetricsContext, OutputChannel, ResultErrorExt, ResultJsonExt, ResultMetricsExt,
+};
 
 mod id;
 pub use id::{CliId, IdMap};

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -1,7 +1,8 @@
 //! Various functions that involve launching the Git editor (i.e. `GIT_EDITOR`).
+use std::ffi::OsStr;
+
 use anyhow::{Result, bail};
 use bstr::{BStr, BString, ByteSlice};
-use std::ffi::OsStr;
 
 /// Launches the user's preferred text editor to edit some `initial_text`,
 /// identified by a `filename_safe_intent` to help the user understand what's wanted of them.

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -1,5 +1,6 @@
-use crate::utils::Sandbox;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[cfg(not(feature = "legacy"))]
 #[test]
@@ -80,8 +81,9 @@ Applied remote branch 'origin/B' to workspace
     Ok(())
 }
 
-use crate::command::branch::apply::utils::create_local_branch_with_commit_with_message;
 use utils::create_local_branch_with_commit;
+
+use crate::command::branch::apply::utils::create_local_branch_with_commit_with_message;
 
 #[test]
 fn local_branch() -> anyhow::Result<()> {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -1,5 +1,6 @@
-use crate::utils::Sandbox;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[test]
 fn outputs_branch_name() -> anyhow::Result<()> {

--- a/crates/but/tests/but/command/describe.rs
+++ b/crates/but/tests/but/command/describe.rs
@@ -1,6 +1,7 @@
-use crate::utils::Sandbox;
 use gitbutler_commit::commit_ext::CommitExt;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[test]
 fn describe_commit_with_message_flag() -> anyhow::Result<()> {

--- a/crates/but/tests/but/command/gui.rs
+++ b/crates/but/tests/but/command/gui.rs
@@ -1,5 +1,6 @@
-use crate::utils::Sandbox;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[test]
 fn good_error_message_for_non_directories() -> anyhow::Result<()> {

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -1,5 +1,6 @@
-use crate::utils::Sandbox;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[cfg(not(feature = "legacy"))]
 #[test]

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -1,6 +1,7 @@
 //! Tests for various nice user-journeys, from different starting points, performing multiple common steps in sequence.
-use crate::utils::Sandbox;
 use snapbox::str;
+
+use crate::utils::Sandbox;
 
 #[cfg(not(feature = "legacy"))]
 #[test]

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -1,6 +1,9 @@
+use std::{
+    env,
+    ops::{Deref, DerefMut},
+};
+
 use but_testsupport::isolate_snapbox_cmd;
-use std::ops::Deref;
-use std::{env, ops::DerefMut};
 
 /// A wrapper around [but_testsupport::Sandbox] to add `but` invocation support, which can only come from the crate that
 /// defines the binary.

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
@@ -100,7 +100,9 @@ mod util {
         Author {
             name: Some("author".into()),
             email: Some("author@example.com".into()),
-            gravatar_url: Some("https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=100&r=g&d=retro".into()),
+            gravatar_url: Some(
+                "https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=100&r=g&d=retro".into(),
+            ),
         }
     }
 

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -4,8 +4,7 @@ use anyhow::{Context as _, Result};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
 use but_serde::BStringForFrontend;
 use git2::DiffHunk;
-use gitbutler_cherry_pick::RepositoryExt;
-use gitbutler_cherry_pick::RepositoryExtLite;
+use gitbutler_cherry_pick::{RepositoryExt, RepositoryExtLite};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -3,8 +3,10 @@ use std::collections::HashMap;
 use anyhow::{Context as _, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_core::{TreeChange, ref_metadata::StackId};
-use but_ctx::Context;
-use but_ctx::access::{WorktreeReadPermission, WorktreeWritePermission};
+use but_ctx::{
+    Context,
+    access::{WorktreeReadPermission, WorktreeWritePermission},
+};
 use but_oxidize::{
     GixRepositoryExt, ObjectIdExt, OidExt, RepoExt, git2_to_gix_object_id, gix_to_git2_index,
 };

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -1,7 +1,8 @@
+use std::{collections::HashMap, path::Path, time::Duration};
+
 use futures::{FutureExt, select};
 use gix::bstr::ByteSlice;
 use rand::Rng;
-use std::{collections::HashMap, path::Path, time::Duration};
 
 use super::executor::{AskpassServer, GitExecutor, Pid, Socket};
 use crate::RefSpec;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -1,3 +1,10 @@
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    fs,
+    path::Path,
+    str::{FromStr, from_utf8},
+};
+
 use anyhow::{Context as _, Result, anyhow, bail};
 use but_core::{TreeChange, diff::tree_changes};
 use but_ctx::{
@@ -14,12 +21,6 @@ use gitbutler_cherry_pick::RepositoryExtLite;
 use gitbutler_repo::{RepositoryExt, SignaturePurpose};
 use gitbutler_stack::{VirtualBranchesHandle, VirtualBranchesState};
 use gix::{ObjectId, bstr::ByteSlice, prelude::ObjectIdExt};
-use std::path::Path;
-use std::{
-    collections::{HashMap, hash_map::Entry},
-    fs,
-    str::{FromStr, from_utf8},
-};
 use tracing::instrument;
 
 use super::{

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -211,7 +211,10 @@ impl Project {
         self.git_dir = repo.git_dir().to_owned();
         // NOTE: we set the worktree so the frontend is happier until this usage can be reviewed,
         // probably for supporting bare repositories.
-        self.worktree_dir = repo.workdir().context("BUG: we currently only support non-bare repos, yet this one didn't have a worktree dir")?.to_owned();
+        self.worktree_dir = repo
+            .workdir()
+            .context("BUG: we currently only support non-bare repos, yet this one didn't have a worktree dir")?
+            .to_owned();
         Ok(true)
     }
 

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -1,6 +1,5 @@
 use std::str;
 
-use crate::{Config, SignaturePurpose};
 use anyhow::{Context as _, Result, anyhow, bail};
 use bstr::BString;
 use but_core::{GitConfigSettings, RepositoryExt as RepositoryExtGix};
@@ -16,6 +15,8 @@ use gitbutler_commit::commit_headers::CommitHeadersV2;
 use gitbutler_reference::{Refname, RemoteRefname};
 use gix::objs::WriteTo;
 use tracing::instrument;
+
+use crate::{Config, SignaturePurpose};
 
 /// Extension trait for `git2::Repository`.
 ///

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -1,3 +1,9 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    str::FromStr,
+};
+
 use anyhow::{Context as _, Result, anyhow, bail};
 use but_core::Reference;
 pub use but_core::ref_metadata::StackId;
@@ -14,11 +20,6 @@ use gitbutler_repo::{
 use gix::{utils::str::decompose, validate::reference::name_partial};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-};
 
 use crate::{
     StackBranch, VirtualBranchesHandle,

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Display, str::FromStr};
 
-use crate::{Stack, VirtualBranchesHandle};
 use anyhow::{Ok, Result};
 use bstr::{BString, ByteSlice};
 use but_ctx::Context;
@@ -15,6 +14,8 @@ use gix::refs::{
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+
+use crate::{Stack, VirtualBranchesHandle};
 
 /// A GitButler-specific reference type that points to a commit or a patch (change).
 /// The principal difference between a `PatchReference` and a regular git reference is that a `PatchReference` can point to a change (patch) that is mutable.


### PR DESCRIPTION
As a side-effect of #11530 and very messy `virtual-branches.toml` data,
there were frequent issues around stack-details not being found.

The problem turned out to be a stack-id mismatch between the ID that a stack is stored
at and the `id` that is stored on the stack itself.

Basically, this PR fixes this issue at least as it occurs in my test-repository data.

<img width="1010" height="270" alt="Screenshot_2025-12-15_at_15 40 46" src="https://github.com/user-attachments/assets/064f1628-2590-4684-bee9-15c396f02c4e" />

### Tasks

* [x] hack original issue out of existence
* [ ] ~~have reconcilation auto-fix this?~~