### PR TITLE
The beginning of hunk CLI IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,7 @@ dependencies = [
  "gitbutler-stack",
  "gix",
  "insta",
+ "itertools",
  "minus",
  "posthog-rs",
  "regex",

--- a/crates/but-core/src/diff_types.rs
+++ b/crates/but-core/src/diff_types.rs
@@ -43,7 +43,7 @@ impl From<TreeChange> for DiffSpec {
 }
 
 /// The header of a hunk that represents a change to a file.
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct HunkHeader {
     /// The 1-based line number at which the previous version of the file started.

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -423,19 +423,3 @@ pub struct WorktreeChanges {
     /// The conflicting index entries, along with their relative path `(rela_path, [Entries(base, ours, theirs)])`.
     pub index_conflicts: Vec<(BString, Box<[Option<ConflictIndexEntry>; 3]>)>,
 }
-
-#[cfg(test)]
-pub(crate) mod utils {
-    use crate::HunkHeader;
-
-    pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
-        let ((old_start, old_lines), (new_start, new_lines)) =
-            but_testsupport::hunk_header(old, new);
-        HunkHeader {
-            old_start,
-            old_lines,
-            new_start,
-            new_lines,
-        }
-    }
-}

--- a/crates/but-core/src/tree/tests.rs
+++ b/crates/but-core/src/tree/tests.rs
@@ -1,5 +1,17 @@
 mod to_additive_hunks {
-    use crate::{tree::to_additive_hunks, utils::hunk_header};
+    use crate::tree::to_additive_hunks;
+
+    // This needs a copy here to get the types to match, maybe due to cycle-breaking?
+    fn hunk_header(old: &str, new: &str) -> crate::HunkHeader {
+        let ((old_start, old_lines), (new_start, new_lines)) =
+            but_testsupport::hunk_header_raw(old, new);
+        crate::HunkHeader {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+        }
+    }
 
     #[test]
     fn rejected() {

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -21,7 +21,7 @@ pub use sandbox::Sandbox;
 /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
 /// i.e. `hunk_header("-1,10", "+1,10")`.
 /// Returns `( (old_start, old_lines), (new_start, new_lines) )`.
-pub fn hunk_header(old: &str, new: &str) -> ((u32, u32), (u32, u32)) {
+pub fn hunk_header_raw(old: &str, new: &str) -> ((u32, u32), (u32, u32)) {
     fn parse_header(hunk_info: &str) -> (u32, u32) {
         let hunk_info = hunk_info.trim_start_matches(['-', '+'].as_slice());
         let parts: Vec<_> = hunk_info.split(',').collect();
@@ -34,6 +34,19 @@ pub fn hunk_header(old: &str, new: &str) -> ((u32, u32), (u32, u32)) {
         (start, lines)
     }
     (parse_header(old), parse_header(new))
+}
+
+/// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
+/// i.e. `hunk_header("-1,10", "+1,10")`.
+/// Returns a [but_core::HunkHeader].
+pub fn hunk_header(old: &str, new: &str) -> but_core::HunkHeader {
+    let ((old_start, old_lines), (new_start, new_lines)) = hunk_header_raw(old, new);
+    but_core::HunkHeader {
+        old_start,
+        old_lines,
+        new_start,
+        new_lines,
+    }
 }
 
 /// While `gix` can't (or can't conveniently) do everything, let's make using `git` easier,

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -163,19 +163,9 @@ pub fn flatten_diff_specs(input: Vec<DiffSpec>) -> Vec<DiffSpec> {
 
 #[cfg(test)]
 pub(crate) mod utils {
-    use but_core::{HunkHeader, HunkRange};
+    use but_core::HunkRange;
 
     pub fn range(start: u32, lines: u32) -> HunkRange {
         HunkRange { start, lines }
-    }
-    pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
-        let ((old_start, old_lines), (new_start, new_lines)) =
-            but_testsupport::hunk_header(old, new);
-        HunkHeader {
-            old_start,
-            old_lines,
-            new_start,
-            new_lines,
-        }
     }
 }

--- a/crates/but-workspace/src/tree_manipulation/hunk/tests.rs
+++ b/crates/but-workspace/src/tree_manipulation/hunk/tests.rs
@@ -1,6 +1,7 @@
 mod subtract_hunks {
     use super::super::{HunkSubstraction::*, subtract_hunks};
-    use crate::utils::{hunk_header, range};
+    use crate::utils::range;
+    use but_testsupport::hunk_header;
 
     #[test]
     fn removing_all_in_old_leaves_all_new_multi() {

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -1,11 +1,11 @@
 use but_core::DiffSpec;
-use but_testsupport::assure_stable_env;
+use but_testsupport::{assure_stable_env, hunk_header};
 use but_workspace::{commit_engine, commit_engine::Destination};
 use gix::prelude::ObjectIdExt;
 
 use crate::utils::{
     CONTEXT_LINES, commit_from_outcome, commit_whole_files_and_all_hunks_from_workspace, diff_spec,
-    hunk_header, read_only_in_memory_scenario, to_change_specs_all_hunks_with_context_lines,
+    read_only_in_memory_scenario, to_change_specs_all_hunks_with_context_lines,
     to_change_specs_whole_file, visualize_tree, writable_scenario, writable_scenario_with_ssh_key,
     write_sequence,
 };

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -1,5 +1,5 @@
 use but_core::DiffSpec;
-use but_testsupport::{assure_stable_env, visualize_commit_graph};
+use but_testsupport::{assure_stable_env, hunk_header, visualize_commit_graph};
 use but_workspace::{
     commit_engine::{Destination, StackSegmentId},
     legacy::commit_engine::ReferenceFrame,
@@ -16,7 +16,7 @@ use crate::{
         utils::assure_no_worktree_changes,
     },
     utils::{
-        CONTEXT_LINES, hunk_header, read_only_in_memory_scenario, to_change_specs_all_hunks,
+        CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks,
         to_change_specs_whole_file, visualize_index, visualize_index_with_content, visualize_tree,
         worktree_changes_with_diffs, writable_scenario, writable_scenario_with_ssh_key,
         write_sequence,

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -1,13 +1,13 @@
 use bstr::{BString, ByteSlice};
 use but_core::{DiffSpec, HunkHeader, UnifiedPatch};
-use but_testsupport::{git_status, visualize_disk_tree_skip_dot_git};
+use but_testsupport::{git_status, hunk_header, visualize_disk_tree_skip_dot_git};
 use but_workspace::discard_workspace_changes;
 
 use crate::{
     tree_manipulation::hunk::util::{changed_file_in_worktree_with_hunks, previous_change_text},
     utils::{
-        CONTEXT_LINES, hunk_header, read_only_in_memory_scenario, to_change_specs_all_hunks,
-        visualize_index, writable_scenario,
+        CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks, visualize_index,
+        writable_scenario,
     },
 };
 

--- a/crates/but-workspace/tests/workspace/utils.rs
+++ b/crates/but-workspace/tests/workspace/utils.rs
@@ -212,17 +212,6 @@ pub fn cat_commit(commit: gix::Id<'_>) -> anyhow::Result<String> {
     Ok(commit.object()?.data.as_bstr().to_string())
 }
 
-/// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
-pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
-    let ((old_start, old_lines), (new_start, new_lines)) = but_testsupport::hunk_header(old, new);
-    HunkHeader {
-        old_start,
-        old_lines,
-        new_start,
-        new_lines,
-    }
-}
-
 pub fn r(name: &str) -> &gix::refs::FullNameRef {
     name.try_into().expect("statically known valid ref-name")
 }

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -126,3 +126,4 @@ but-testsupport = { workspace = true, features = ["sandbox-but-api"] }
 snapbox = { workspace = true, features = ["term-svg"] }
 shell-words.workspace = true
 insta.workspace = true
+itertools.workspace = true

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -79,7 +79,7 @@ pub(crate) fn assign_all(
     )?
     .changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes), None)?;
 
     let mut reqs = Vec::new();
     for assignment in assignments {
@@ -155,7 +155,7 @@ fn path_to_assignments<'path>(
     )?
     .changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes), None)?;
     Ok(assignments
         .into_iter()
         .filter(move |assignment| assignment.path_bytes == path)

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -1,5 +1,5 @@
-use bstr::BStr;
-use but_core::ref_metadata::StackId;
+use bstr::{BStr, BString};
+use but_core::{HunkHeader, ref_metadata::StackId};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignmentRequest;
 use colored::Colorize;
@@ -12,7 +12,8 @@ pub(crate) fn assign_file_to_branch(
     branch_name: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let reqs = to_assignment_request(ctx, path, Some(branch_name))?;
+    let assignments = path_to_assignments(ctx, path)?;
+    let reqs = to_assignment_request(ctx, assignments, Some(branch_name))?;
     do_assignments(ctx, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(
@@ -25,12 +26,37 @@ pub(crate) fn assign_file_to_branch(
     Ok(())
 }
 
+pub(crate) fn assign_hunk_to_branch(
+    ctx: &mut Context,
+    hunk_header: Option<HunkHeader>,
+    path_bytes: &BStr,
+    branch_name: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let reqs = to_assignment_request(
+        ctx,
+        Some((hunk_header, path_bytes.to_owned())).into_iter(),
+        Some(branch_name),
+    )?;
+    do_assignments(ctx, reqs, out)?;
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "Assigned a hunk in {} → {}.",
+            path_bytes.to_string().bold(),
+            format!("[{branch_name}]").green()
+        )?;
+    }
+    Ok(())
+}
+
 pub(crate) fn unassign_file(
     ctx: &mut Context,
     path: &BStr,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let reqs = to_assignment_request(ctx, path, None)?;
+    let assignments = path_to_assignments(ctx, path)?;
+    let reqs = to_assignment_request(ctx, assignments, None)?;
     do_assignments(ctx, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Unassigned {}", path.to_string().bold())?;
@@ -120,28 +146,36 @@ pub(crate) fn branch_name_to_stack_id(
     Ok(stack_id)
 }
 
-fn to_assignment_request(
+fn path_to_assignments<'path>(
     ctx: &mut Context,
-    path: &BStr,
-    branch_name: Option<&str>,
-) -> anyhow::Result<Vec<HunkAssignmentRequest>> {
-    let stack_id = branch_name_to_stack_id(ctx, branch_name)?;
-
+    path: &'path BStr,
+) -> anyhow::Result<impl Iterator<Item = (Option<HunkHeader>, BString)> + 'path> {
     let changes = but_core::diff::ui::worktree_changes_by_worktree_dir(
         ctx.legacy_project.worktree_dir()?.into(),
     )?
     .changes;
     let (assignments, _assignments_error) =
         but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
+    Ok(assignments
+        .into_iter()
+        .filter(move |assignment| assignment.path_bytes == path)
+        .map(move |assignment| (assignment.hunk_header, assignment.path_bytes)))
+}
+
+fn to_assignment_request(
+    ctx: &mut Context,
+    assignments: impl Iterator<Item = (Option<HunkHeader>, BString)>,
+    branch_name: Option<&str>,
+) -> anyhow::Result<Vec<HunkAssignmentRequest>> {
+    let stack_id = branch_name_to_stack_id(ctx, branch_name)?;
+
     let mut reqs = Vec::new();
-    for assignment in assignments {
-        if assignment.path_bytes == path {
-            reqs.push(HunkAssignmentRequest {
-                hunk_header: assignment.hunk_header,
-                path_bytes: assignment.path_bytes,
-                stack_id,
-            });
-        }
+    for (hunk_header, path_bytes) in assignments {
+        reqs.push(HunkAssignmentRequest {
+            hunk_header,
+            path_bytes,
+            stack_id,
+        });
     }
     Ok(reqs)
 }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -117,6 +117,17 @@ pub(crate) fn handle(
                 create_snapshot(ctx, OperationKind::FileChanges);
                 commits::uncommit_file(ctx, path.as_ref(), *commit_oid, None, out)?;
             }
+            (
+                CliId::UncommittedHunk {
+                    hunk_header,
+                    path: path_bytes,
+                    ..
+                },
+                CliId::Branch { name, .. },
+            ) => {
+                create_snapshot(ctx, OperationKind::MoveHunk);
+                assign::assign_hunk_to_branch(ctx, *hunk_header, path_bytes.as_ref(), name, out)?;
+            }
             _ => {
                 bail!(makes_no_sense_error(&source, &target))
             }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -29,9 +29,6 @@ pub(crate) fn handle(
 
     for source in sources {
         match (&source, &target) {
-            (CliId::UncommittedFile { .. }, CliId::UncommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
             (CliId::UncommittedFile { path, .. }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::unassign_file(ctx, path.as_ref(), out)?;
@@ -49,12 +46,6 @@ pub(crate) fn handle(
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::assign_file_to_branch(ctx, path.as_ref(), name, out)?;
             }
-            (CliId::Unassigned { .. }, CliId::UncommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
-            (CliId::Unassigned { .. }, CliId::Unassigned { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
             (CliId::Unassigned { .. }, CliId::Commit(oid)) => {
                 create_snapshot(ctx, OperationKind::AmendCommit);
                 amend::assignments_to_commit(ctx, None, oid, out)?;
@@ -62,9 +53,6 @@ pub(crate) fn handle(
             (CliId::Unassigned { .. }, CliId::Branch { name: to, .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::assign_all(ctx, None, Some(to), out)?;
-            }
-            (CliId::Commit { .. }, CliId::UncommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
             }
             (CliId::Commit(oid), CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, OperationKind::UndoCommit);
@@ -78,9 +66,6 @@ pub(crate) fn handle(
                 create_snapshot(ctx, OperationKind::MoveCommit);
                 move_commit::to_branch(ctx, oid, name, out)?;
             }
-            (CliId::Branch { .. }, CliId::UncommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
             (CliId::Branch { name: from, .. }, CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::assign_all(ctx, Some(from), None, out)?;
@@ -92,15 +77,6 @@ pub(crate) fn handle(
             (CliId::Branch { name: from, .. }, CliId::Branch { name: to, .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::assign_all(ctx, Some(from), Some(to), out)?;
-            }
-            (CliId::UncommittedFile { .. }, CliId::CommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
-            (CliId::CommittedFile { .. }, CliId::UncommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
-            (CliId::CommittedFile { .. }, CliId::CommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
             }
             (
                 CliId::CommittedFile {
@@ -141,13 +117,7 @@ pub(crate) fn handle(
                 create_snapshot(ctx, OperationKind::FileChanges);
                 commits::uncommit_file(ctx, path.as_ref(), *commit_oid, None, out)?;
             }
-            (CliId::Branch { .. }, CliId::CommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
-            (CliId::Commit { .. }, CliId::CommittedFile { .. }) => {
-                bail!(makes_no_sense_error(&source, &target))
-            }
-            (CliId::Unassigned { .. }, CliId::CommittedFile { .. }) => {
+            _ => {
                 bail!(makes_no_sense_error(&source, &target))
             }
         }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -314,7 +314,7 @@ impl IdMap {
     fn add_file_info<F>(
         &mut self,
         changed_paths_in_commit_fn: F,
-        mut hunk_assignments: Vec<HunkAssignment>,
+        hunk_assignments: Vec<HunkAssignment>,
     ) -> anyhow::Result<()>
     where
         F: FnMut(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<BString>>,
@@ -341,12 +341,6 @@ impl IdMap {
             });
         }
 
-        hunk_assignments.sort_by(|a, b| {
-            a.stack_id
-                .cmp(&b.stack_id)
-                .then_with(|| a.path_bytes.cmp(&b.path_bytes))
-                .then_with(|| a.hunk_header.cmp(&b.hunk_header))
-        });
         for hunk_assignment in hunk_assignments {
             self.uncommitted_hunks.insert(
                 self.id_usage.next_available()?.to_short_id(),
@@ -601,7 +595,9 @@ pub enum CliId {
         id: ShortId,
     },
     /// A commit in the workspace identified by its SHA.
-    // TODO: Ensure our prefixes are unique within the set of known commits.
+    // TODO: Ensure our prefixes are unique within the set of known commits,
+    //       currently we only take the first two characters which can clash
+    //       without us noticing. See commit_ids_are_currently_ambiguous() test.
     Commit(gix::ObjectId),
     /// The unassigned area, as a designated area that files can be put in.
     Unassigned {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -671,14 +671,14 @@ where
         }
     }
 
-    let mut uncommitted_files: Vec<(Option<StackId>, BString)> = Vec::new();
+    let mut uncommitted_files: BTreeSet<(Option<StackId>, BString)> = BTreeSet::new();
     for assignment in hunk_assignments {
-        uncommitted_files.push((assignment.stack_id, assignment.path_bytes));
+        uncommitted_files.insert((assignment.stack_id, assignment.path_bytes));
     }
 
     Ok(FileInfo {
         committed_files,
-        uncommitted_files,
+        uncommitted_files: uncommitted_files.into_iter().collect(),
     })
 }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -394,29 +394,27 @@ impl IdMap {
         }
 
         // Then try CliId matching
-        if entity.len() == 2 {
-            if let Some(UncommittedFile {
-                assignment_path: (assignment, path),
-                ..
-            }) = self.uncommitted_files.get(entity)
-            {
-                matches.push(CliId::UncommittedFile {
-                    assignment: *assignment,
-                    path: path.to_owned(),
-                    id: entity.to_string(),
-                });
-            }
-            if let Some(CommittedFile {
-                commit_oid_path: (commit_oid, path),
-                ..
-            }) = self.committed_files.get(entity)
-            {
-                matches.push(CliId::CommittedFile {
-                    commit_id: *commit_oid,
-                    path: path.to_owned(),
-                    id: entity.to_string(),
-                });
-            }
+        if let Some(UncommittedFile {
+            assignment_path: (assignment, path),
+            ..
+        }) = self.uncommitted_files.get(entity)
+        {
+            matches.push(CliId::UncommittedFile {
+                assignment: *assignment,
+                path: path.to_owned(),
+                id: entity.to_string(),
+            });
+        }
+        if let Some(CommittedFile {
+            commit_oid_path: (commit_oid, path),
+            ..
+        }) = self.committed_files.get(entity)
+        {
+            matches.push(CliId::CommittedFile {
+                commit_id: *commit_oid,
+                path: path.to_owned(),
+                id: entity.to_string(),
+            });
         }
         if entity.find(|c: char| c != '0').is_none() {
             matches.push(self.unassigned().clone());

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -44,10 +44,14 @@ fn uint_id_to_short_id() -> anyhow::Result<()> {
 }
 
 #[test]
-fn commit_id_works_with_two_characters() -> anyhow::Result<()> {
+fn commit_id_works_with_two_or_more_characters() -> anyhow::Result<()> {
     let id1 = id(1);
-    let stacks = &[stack([segment("foo", [id1], None, [])])];
+    let stacks = &[stack([segment("not-important", [id1], None, [])])];
     let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 1
+    branches: [ no ]
+    ");
 
     let expected = [CliId::Commit(id1)];
     assert_eq!(
@@ -60,13 +64,82 @@ fn commit_id_works_with_two_characters() -> anyhow::Result<()> {
         expected,
         "three characters work too"
     );
+    assert_eq!(
+        id_map.resolve_entity_to_ids("1").unwrap_err().to_string(),
+        "Id needs to be at least 2 characters long: '1'",
+        "one character isn't enough"
+    );
+    Ok(())
+}
+
+#[test]
+fn branches_work_with_single_character() -> anyhow::Result<()> {
+    let stacks = &[stack([segment("f", [id(1)], None, [])])];
+    let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 1
+    branches: [ g0 ]
+    ");
+
+    let expected = [CliId::Branch {
+        name: "f".into(),
+        id: "g0".into(),
+    }];
+    assert_eq!(
+        id_map.resolve_entity_to_ids("f")?,
+        expected,
+        "it's OK to have a CliID that is longer, but it would be up to the UI to not show them"
+    );
+    Ok(())
+}
+
+#[test]
+fn branches_match_by_substring() -> anyhow::Result<()> {
+    let stacks = &[stack([
+        segment("foo-bar", [id(1)], None, []),
+        segment("bar", [id(2)], None, []),
+        segment("foo", [id(3)], None, []),
+        segment("baz", [id(4)], None, []),
+    ])];
+
+    let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 4
+    branches: [ az, g0, h0, i0 ]
+    ");
+
+    let expected = [
+        CliId::Branch {
+            name: "foo".into(),
+            id: "i0".into(),
+        },
+        CliId::Branch {
+            name: "foo-bar".into(),
+            id: "g0".into(),
+        },
+    ];
+    assert_eq!(
+        id_map.resolve_entity_to_ids("fo")?,
+        expected,
+        "substring searches can yield multiple items"
+    );
+
+    let expected = [CliId::Branch {
+        name: "baz".into(),
+        id: "az".into(),
+    }];
+    assert_eq!(
+        id_map.resolve_entity_to_ids("az")?,
+        expected,
+        "We see the ID was generated from a substring directly"
+    );
     Ok(())
 }
 
 #[test]
 fn multiple_zeroes_as_unassigned_area() -> anyhow::Result<()> {
-    let stacks = &[stack([segment("foo", [id(1)], None, [])])];
-    let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    let id_map = IdMap::new_for_branches_and_commits(&[])?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @"workspace_and_remote_commits_count: 0");
 
     assert_eq!(
         id_map.resolve_entity_to_ids("000")?,
@@ -80,22 +153,44 @@ fn multiple_zeroes_as_unassigned_area() -> anyhow::Result<()> {
 fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
     let stacks = &[stack([segment("branch001", [id(1)], None, [])])];
     let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 1
+    branches: [ br ]
+    ");
 
     assert_eq!(
         id_map.unassigned().to_short_string(),
         "000",
         "the ID of the unassigned area should have enough 0s to be unambiguous"
     );
+    assert_eq!(
+        id_map.resolve_entity_to_ids("00")?,
+        [
+            CliId::Branch {
+                name: "branch001".into(),
+                id: "br".into()
+            },
+            CliId::Unassigned { id: "000".into() }
+        ],
+        "as 00 is matching the substring of a branch now, but also unassigned"
+    );
     Ok(())
 }
 
 #[test]
-fn branch_avoid_nonalphanumeric() -> anyhow::Result<()> {
-    let stacks = &[stack([segment("x-yz", [id(1)], None, [])])];
+fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
+    let stacks = &[stack([
+        segment("x-yz_/hi", [id(1)], None, []),
+        segment("0ax", [id(1)], None, []),
+    ])];
     let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 2
+    branches: [ ax, yz ]
+    ");
 
     let expected = [CliId::Branch {
-        name: "x-yz".into(),
+        name: "x-yz_/hi".into(),
         id: "yz".into(),
     }];
     assert_eq!(
@@ -103,14 +198,6 @@ fn branch_avoid_nonalphanumeric() -> anyhow::Result<()> {
         expected,
         "avoids non-alphanumeric, taking first alphanumeric pair"
     );
-    Ok(())
-}
-
-#[test]
-fn branch_avoid_hexdigit() -> anyhow::Result<()> {
-    let stacks = &[stack([segment("0ax", [id(1)], None, [])])];
-    let id_map = IdMap::new_for_branches_and_commits(stacks)?;
-
     let expected = [CliId::Branch {
         name: "0ax".into(),
         id: "ax".into(),
@@ -130,6 +217,10 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
         stack([segment("supersubstring", [id(2)], None, [])]),
     ];
     let id_map = IdMap::new_for_branches_and_commits(stacks)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 2
+    branches: [ g0, up ]
+    ");
 
     let expected = [CliId::Branch {
         name: "substring".into(),
@@ -138,7 +229,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
     assert_eq!(
         id_map.resolve_entity_to_ids("substring")?,
         expected,
-        "no unique ID, so take from pool of IDs",
+        "no unique ID, so take from pool of IDs (this one matched precisely)",
     );
     let expected = [CliId::Branch {
         name: "supersubstring".into(),
@@ -147,7 +238,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
     assert_eq!(
         id_map.resolve_entity_to_ids("supersubstring")?,
         expected,
-        "'su' would collide with substring, so 'up' is chosen"
+        "'su' would collide with substring, so 'up' is chosen (this one matched precisely)"
     );
     Ok(())
 }
@@ -190,64 +281,40 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         hunk_assignment("uncommitted2.txt", None),
     ];
     id_map.add_file_info(changed_paths_fn, hunk_assignments)?;
-
-    // Uncommitted files come first
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("g0")?, @r#"
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 1
+    branches: [ h0 ]
+    uncommitted_files: [ g0, i0 ]
+    committed_files: [ j0, k0 ]
+    uncommitted_hunks: [ l0, m0, n0 ]
+    ");
+    insta::assert_debug_snapshot!(id_map.all_ids(), @r#"
     [
         UncommittedFile {
             assignment: None,
             path: "uncommitted1.txt",
             id: "g0",
         },
-    ]
-    "#);
-
-    // uncommitted files do not collide with branches
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("h0")?, @r#"
-    [
-        Branch {
-            name: "h0",
-            id: "h0",
-        },
-    ]
-    "#);
-
-    // uncommitted files also don't collide with themselves
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("i0")?, @r#"
-    [
         UncommittedFile {
             assignment: None,
             path: "uncommitted2.txt",
             id: "i0",
         },
-    ]
-    "#);
-
-    // then come committed files, as per incremented prefix
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("j0")?, @r#"
-    [
         CommittedFile {
             commit_id: Sha1(0202020202020202020202020202020202020202),
             path: "committed1.txt",
             id: "j0",
         },
-    ]
-    "#);
-
-    // committed files also don't collide with themselves
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("k0")?, @r#"
-    [
         CommittedFile {
             commit_id: Sha1(0202020202020202020202020202020202020202),
             path: "committed2.txt",
             id: "k0",
         },
-    ]
-    "#);
-
-    // uncommitted hunks do not collide with anything else
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("l0")?, @r#"
-    [
+        UncommittedHunk {
+            hunk_header: None,
+            path: "uncommitted2.txt",
+            id: "n0",
+        },
         UncommittedHunk {
             hunk_header: Some(
                 HunkHeader("-1,2", "+1,2"),
@@ -255,10 +322,6 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
             path: "uncommitted1.txt",
             id: "l0",
         },
-    ]
-    "#);
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("m0")?, @r#"
-    [
         UncommittedHunk {
             hunk_header: Some(
                 HunkHeader("-3,2", "+3,2"),
@@ -266,14 +329,9 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
             path: "uncommitted1.txt",
             id: "m0",
         },
-    ]
-    "#);
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("n0")?, @r#"
-    [
-        UncommittedHunk {
-            hunk_header: None,
-            path: "uncommitted2.txt",
-            id: "n0",
+        Branch {
+            name: "h0",
+            id: "h0",
         },
     ]
     "#);
@@ -296,8 +354,14 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     };
     let hunk_assignments = vec![hunk_assignment("uncommitted.txt", None)];
     id_map.add_file_info(changed_paths_fn, hunk_assignments)?;
+    insta::assert_debug_snapshot!(id_map.debug_state(), @r"
+    workspace_and_remote_commits_count: 1
+    branches: [ h0 ]
+    uncommitted_files: [ g0 ]
+    committed_files: [ i0 ]
+    uncommitted_hunks: [ j0 ]
+    ");
 
-    // Commits
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("0a")?, @r"
     [
         Commit(
@@ -305,9 +369,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         ),
     ]
     ");
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("0A")?, @"[]");
+    assert_eq!(
+        id_map.resolve_entity_to_ids("0A")?,
+        [],
+        "the case matters for commits"
+    );
 
-    // Branches
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("h0")?, @r#"
     [
         Branch {
@@ -316,9 +383,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         },
     ]
     "#);
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("H0")?, @"[]");
+    assert_eq!(
+        id_map.resolve_entity_to_ids("H0")?,
+        [],
+        "the case matters for branches"
+    );
 
-    // Uncommitted files
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("g0")?, @r#"
     [
         UncommittedFile {
@@ -328,9 +398,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         },
     ]
     "#);
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("G0")?, @"[]");
+    assert_eq!(
+        id_map.resolve_entity_to_ids("G0")?,
+        [],
+        "the case matters for uncommitted files"
+    );
 
-    // Committed files
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("i0")?, @r#"
     [
         CommittedFile {
@@ -340,12 +413,17 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         },
     ]
     "#);
-    insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("I0")?, @"[]");
+    assert_eq!(
+        id_map.resolve_entity_to_ids("I0")?,
+        [],
+        "the case matters for committed files"
+    );
 
     Ok(())
 }
 
 mod util {
+    use crate::{CliId, IdMap};
     use bstr::BString;
     use but_core::ref_metadata::StackId;
     use but_hunk_assignment::HunkAssignment;
@@ -353,6 +431,8 @@ mod util {
         branch::Stack,
         ref_info::{Commit, LocalCommit, Segment},
     };
+    use itertools::Itertools;
+    use std::fmt::Formatter;
 
     pub fn id(byte: u8) -> gix::ObjectId {
         gix::ObjectId::try_from([byte].repeat(20).as_slice()).expect("could not generate ID")
@@ -431,6 +511,99 @@ mod util {
             line_nums_added: None,
             line_nums_removed: None,
             diff: None,
+        }
+    }
+
+    impl IdMap {
+        /// Display internal information to aid understanding and debugging
+        pub fn debug_state(&self) -> DebugState<'_> {
+            DebugState { inner: self }
+        }
+
+        /// Return a sorted list of all CliIds we can provide, excluding unassigned.
+        pub fn all_ids(&self) -> Vec<CliId> {
+            let IdMap {
+                branch_name_to_cli_id,
+                id_usage: _,
+                workspace_commit_and_first_parent_ids: _,
+                remote_commit_ids: _,
+                unassigned: _,
+                uncommitted_files,
+                uncommitted_hunks,
+                committed_files,
+            } = self;
+
+            branch_name_to_cli_id
+                .values()
+                .map(|id| id.to_short_string())
+                .chain(uncommitted_files.iter().map(|f| f.id.clone()))
+                .chain(committed_files.iter().map(|f| f.id.clone()))
+                .chain(uncommitted_hunks.keys().cloned())
+                .flat_map(|id| {
+                    self.resolve_entity_to_ids(&id)
+                        .expect("BUG: valid ID means no error")
+                })
+                .sorted()
+                .collect()
+        }
+    }
+
+    pub struct DebugState<'a> {
+        inner: &'a IdMap,
+    }
+
+    impl std::fmt::Debug for DebugState<'_> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            use itertools::Itertools;
+            let IdMap {
+                branch_name_to_cli_id,
+                id_usage: _,
+                workspace_commit_and_first_parent_ids: _,
+                remote_commit_ids: _,
+                unassigned: _,
+                uncommitted_files,
+                uncommitted_hunks,
+                committed_files,
+            } = self.inner;
+            let commits_count = self.inner.workspace_and_remote_commit_ids().count();
+            writeln!(f, "workspace_and_remote_commits_count: {}", &commits_count)?;
+            id_list_if_not_empty(
+                f,
+                "branches",
+                branch_name_to_cli_id
+                    .values()
+                    .map(|id| id.to_short_string())
+                    .sorted(),
+            )?;
+            id_list_if_not_empty(
+                f,
+                "uncommitted_files",
+                uncommitted_files.iter().sorted().map(|id| id.id.clone()),
+            )?;
+            id_list_if_not_empty(
+                f,
+                "committed_files",
+                committed_files.iter().sorted().map(|id| id.id.clone()),
+            )?;
+            id_list_if_not_empty(
+                f,
+                "uncommitted_hunks",
+                uncommitted_hunks.keys().sorted().cloned(),
+            )?;
+            Ok(())
+        }
+    }
+
+    fn id_list_if_not_empty(
+        f: &mut Formatter<'_>,
+        field: &str,
+        ids: impl Iterator<Item = String>,
+    ) -> std::fmt::Result {
+        let ids: Vec<_> = ids.collect();
+        if !ids.is_empty() {
+            writeln!(f, "{field}: [ {} ]", ids.join(", "))
+        } else {
+            Ok(())
         }
     }
 }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -21,3 +21,62 @@ Rubbed the wrong way. Source 'nonexistent1' not found. If you just performed a G
 
     Ok(())
 }
+
+#[test]
+fn uncommitted_hunk_to_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    env.setup_metadata(&["A", "B"])?;
+
+    env.file("a.txt", format!("first\n{}last\n", "line\n".repeat(100)));
+    env.but("commit A -m create-a").assert().success();
+    env.file("a.txt", format!("firsta\n{}lasta\n", "line\n".repeat(100)));
+
+    // TODO When we have a way to list the hunks and their respective IDs (e.g.
+    // via a "diff" or "show" command), assert that m0 is the hunk we want.
+    env.but("m0 A")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::file![
+            "snapshots/rub/uncommitted-hunk-to-branch.stdout.term.svg"
+        ])
+        .stderr_eq(str![""]);
+
+    // Verify that only one hunk was assigned ("a.txt" appears both in the
+    // unassigned area and in a stack).
+    env.but("--json status -f")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .with_assert(env.assert_with_uuid_and_timestamp_redactions())
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "unassignedChanges": [
+    {
+      "cliId": "i0",
+      "filePath": "a.txt",
+      "changeType": "modified"
+    }
+  ],
+  "stacks": [
+    {
+      "cliId": "g0",
+      "assignedChanges": [
+        {
+          "cliId": "j0",
+          "filePath": "a.txt",
+          "changeType": "modified"
+        }
+      ],
+      "branches": [
+        {
+          "cliId": "g0",
+          "name": "A",
+...
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/snapshots/rub/uncommitted-hunk-to-branch.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/rub/uncommitted-hunk-to-branch.stdout.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Assigned a hunk in </tspan><tspan class="bold">a.txt</tspan><tspan> → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
Right now you can use them in `rub` to assign uncommitted hunks, but that's it. No other operations, no displaying, and so on - those are left for future work. But sending this PR to make sure I'm on the right track.