### PR TITLE
Prevent re-tagging

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -418,25 +418,8 @@ jobs:
         env:
           TAG_NAME: '${{ needs.build-tauri.outputs.channel }}/${{ needs.publish-tauri.outputs.version }}'
         run: |
-          function tag_exists() {
-            git tag --list | grep -q "^$1$"
-          }
-          function fetch_tag() {
-            git fetch origin "refs/tags/$1:refs/tags/$1"
-          }
-          function delete_tag() {
-            git push --delete origin "$1"
-          }
-          function create_tag() {
-            git tag --force "$1"
-            git push --tags
-          }
-
-          fetch_tag "$TAG_NAME" || true
-          if tag_exists "$TAG_NAME"; then
-            delete_tag "$TAG_NAME"
-          fi
-          create_tag "$TAG_NAME"
+          git tag "$TAG_NAME"
+          git push --tags
       - name: Trigger Sentry Cron - Complete
         if: ${{ github.event_name == 'schedule' }}
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -395,17 +395,6 @@ jobs:
           source_dir: 'release-s3/'
           destination_dir: 'releases/${{ needs.build-tauri.outputs.channel }}/${{ env.version }}-${{ github.run_number }}'
 
-      # tell our server to update with the version number
-      - name: Notify GitButler API of new release
-        shell: bash
-        run: |
-          curl 'https://app.gitbutler.com/api/releases' \
-            --fail \
-            --request POST \
-            --header 'Content-Type: application/json' \
-            --header 'X-Auth-Token: ${{ secrets.BOT_AUTH_TOKEN }}' \
-            --data '{"channel":"${{ needs.build-tauri.outputs.channel }}","version":"${{ env.version }}-${{ github.run_number }}","sha":"${{ github.sha }}"}'
-
   create-git-tag:
     needs: [publish-tauri, build-tauri]
     runs-on: ubuntu-latest
@@ -420,6 +409,18 @@ jobs:
         run: |
           git tag "$TAG_NAME"
           git push --tags
+
+      # tell our server to update with the version number
+      - name: Notify GitButler API of new release
+        shell: bash
+        run: |
+          curl 'https://app.gitbutler.com/api/releases' \
+            --fail \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --header 'X-Auth-Token: ${{ secrets.BOT_AUTH_TOKEN }}' \
+            --data '{"channel":"${{ needs.build-tauri.outputs.channel }}","version":"${{ env.version }}-${{ github.run_number }}","sha":"${{ github.sha }}"}'
+
       - name: Trigger Sentry Cron - Complete
         if: ${{ github.event_name == 'schedule' }}
         shell: bash


### PR DESCRIPTION
## 🧢 Changes
Prevents the publish script from re-tagging.

If there's a desire for even more control over the release build tags, we could skip tagging for release builds. But I personally think that it's better to just let this work as it does and bump the version again if a "bad build" is found.

## ☕️ Reasoning
Re-taging is naughty. For an elaborate explanation of why, see the "On Re-Tagging" section of the git-tag man page.

Or just go here: https://git-scm.com/docs/git-tag#_on_re_tagging

## 🎫 Affected issues

Fixes: #11549
