### PR TITLE
fix-message-border-max-height

### DIFF
--- a/apps/desktop/src/components/ToastController.svelte
+++ b/apps/desktop/src/components/ToastController.svelte
@@ -40,7 +40,6 @@
 		z-index: var(--z-blocker);
 		position: absolute;
 		right: 0;
-
 		bottom: 0;
 		flex-direction: column;
 		max-width: 480px;

--- a/packages/ui/src/lib/components/InfoMessage.svelte
+++ b/packages/ui/src/lib/components/InfoMessage.svelte
@@ -206,7 +206,7 @@
 	.info {
 		border: 0 solid var(--clr-border-2);
 	}
-	.error {
+	.danger {
 		border: 0 solid var(--clr-theme-danger-element);
 	}
 	.warning {

--- a/packages/ui/src/lib/components/InfoMessage.svelte
+++ b/packages/ui/src/lib/components/InfoMessage.svelte
@@ -241,8 +241,9 @@
 
 	/* ERROR BLOCK */
 	.info-message__error-block {
+		max-height: 350px;
 		padding: 10px 10px 0;
-		overflow-x: scroll;
+		overflow: auto;
 		border-radius: var(--radius-s);
 		background-color: var(--clr-theme-danger-bg);
 		color: var(--clr-theme-danger-text);

--- a/packages/ui/src/stories/components/InfoMessage.stories.svelte
+++ b/packages/ui/src/stories/components/InfoMessage.stories.svelte
@@ -283,7 +283,64 @@
 				style="danger"
 				error="Error: Failed to connect to server at https://api.example.com
 Status: 500 Internal Server Error
-Details: Connection timeout after 30 seconds"
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com Error: Failed to connect to server at https://api.example.comError: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+
+Error: Failed to connect to server at https://api.example.com
+Status: 500 Internal Server Error
+Details: Connection timeout after 30 seconds
+"
 			>
 				{#snippet title()}
 					Connection Error

--- a/packages/ui/src/stories/components/InfoMessage.stories.svelte
+++ b/packages/ui/src/stories/components/InfoMessage.stories.svelte
@@ -278,6 +278,8 @@
 	{#snippet template()}
 		<div style="padding: 20px; background: var(--clr-bg-1);">
 			<InfoMessage
+				primaryLabel="Retry"
+				primaryAction={() => alert('Retry clicked!')}
 				style="danger"
 				error="Error: Failed to connect to server at https://api.example.com
 Status: 500 Internal Server Error


### PR DESCRIPTION
Fixes:
- The error message now has a maximum height. The issue: https://discord.com/channels/1060193121130000425/1206670506271707156/1450623888466903040
- The error border style was broken.

Fixed:
<img width="649" height="542" alt="image" src="https://github.com/user-attachments/assets/bef92339-d8c3-494e-96e9-ddd49d63c2a2" />
