### PR TITLE
Do not invoke pager for `but status` output

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -85,8 +85,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     } else {
         args.format
     };
-    // Set it so code past this point can assume it's set.;
-    let mut out = OutputChannel::new_with_pager(output_format);
+    // Determine if pager should be used based on the command
+    let use_pager = !matches!(
+        args.cmd,
+        Some(Subcommands::Status { .. }) | Some(Subcommands::Stf { .. })
+    );
+    // Set it so code past this point can assume it's set.
+    let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
 
     if args.trace > 0 {
         trace::init(args.trace)?;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -86,11 +86,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         args.format
     };
     // Determine if pager should be used based on the command
-    let use_pager = !matches!(
-        args.cmd,
-        Some(Subcommands::Status { .. }) | Some(Subcommands::Stf { .. })
-    );
-    // Set it so code past this point can assume it's set.
+    let use_pager = match args.cmd {
+        #[cfg(feature = "legacy")]
+        Some(Subcommands::Status { .. }) | Some(Subcommands::Stf { .. }) => false,
+        _ => true,
+    };
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
 
     if args.trace > 0 {

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -71,19 +71,17 @@ impl std::fmt::Write for OutputChannel {
 /// Lifecycle
 impl OutputChannel {
     /// Create a new instance to output with `format` (advisory), which affects where it prints to.
+    /// The `use_pager` parameter controls whether a pager should be created.
     ///
     /// It's configured to print to stdout unless [`OutputFormat::Json`] is used, then it prints everything
     /// to a `/dev/null` equivalent, so callers never have to worry if they interleave JSON with other output.
-    ///
-    /// WARNING: the current implementation is static and would cache everything in memory.
-    ///          Use `dynamic_output` (cargo feature + see https://docs.rs/minus/5.6.1/minus/#threads) otherwise.
-    ///          It also needs to avoid
-    pub fn new_with_pager(format: OutputFormat) -> Self {
+    pub fn new_with_optional_pager(format: OutputFormat, use_pager: bool) -> Self {
         OutputChannel {
             format,
             inner: std::io::stdout(),
             pager: if !matches!(format, OutputFormat::Human)
                 || std::env::var_os("NOPAGER").is_some()
+                || !use_pager
             {
                 None
             } else {


### PR DESCRIPTION
Avoid starting the pager for the output of the `but status` (and `stf`) command by passing an explicit flag when constructing the OutputChannel. Previously the code always created a pager-capable OutputChannel; now we determine if the pager should be used based on the invoked subcommand and call new_with_optional_pager accordingly.

This change adds a new constructor new_with_optional_pager(format, use_pager). The pager logic now also respects the use_pager flag so JSON/Non-human output or NOPAGER still disable paging, and callers can opt out for commands (like status) that should never invoke a pager.