### PR TITLE
Use `gix::hash::Prefix` for object-id prefix checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2533,7 +2533,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.75.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-actor 0.36.0",
  "gix-attributes 0.28.1",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-date 0.11.0",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.28.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-glob 0.22.1",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4177,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "itoa",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-attributes 0.28.1",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-discover 0.43.0",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "dunce",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.44.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "faster-hex",
  "gix-features 0.44.1",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-hash 0.20.1",
  "hashbrown 0.16.1",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-glob 0.22.1",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "19.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-tempfile 19.0.1",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-actor 0.36.0",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.30.1",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-actor 0.36.0",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.72.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "arc-swap",
  "gix-date 0.11.0",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.62.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "clru",
  "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.22"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4823,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4854,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-actor 0.36.0",
  "gix-features 0.44.1",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-glob 0.22.1",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4922,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "gix-commitgraph 0.30.1",
  "gix-date 0.11.0",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4960,7 +4960,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-hash 0.20.1",
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "filetime",
@@ -4994,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "19.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "dashmap",
  "gix-fs 0.17.0",
@@ -5065,7 +5065,7 @@ checksum = "1d3f59a8de2934f6391b6b3a1a7654eae18961fcb9f9c843533fed34ad0f3457"
 [[package]]
 name = "gix-trace"
 version = "0.1.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "tracing-core",
 ]
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.30.1",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.33.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-features 0.44.1",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "thiserror 2.0.17",
@@ -5196,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-attributes 0.28.1",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#d2070759212bda8b36f5e0bb4a94a424e94a00f5"
 dependencies = [
  "bstr",
  "gix-features 0.44.1",
@@ -5724,8 +5724,8 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -6103,7 +6103,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6897,7 +6897,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7475,7 +7475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8137,7 +8137,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8174,9 +8174,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8440,7 +8440,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -8728,7 +8728,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9739,18 +9739,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -9758,16 +9747,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10375,7 +10354,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11543,7 +11522,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -420,10 +420,11 @@ impl IdMap {
             .chars()
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
             && entity.len() >= 2
+            && let Ok(prefix) = gix::hash::Prefix::from_hex_nonempty(entity)
         {
             for oid in self
                 .workspace_and_remote_commit_ids()
-                .filter(|oid| oid.to_string().starts_with(entity))
+                .filter(|oid| prefix.cmp_oid(oid).is_eq())
             {
                 matches.push(CliId::Commit(*oid));
             }


### PR DESCRIPTION
This was the last true gripe I had with the implementation, and it was a low-hanging fruit to pick.
Also a little reward to have something that feels a little like a feature among all the bugfixes.

### Tasks

* [x] upgrade `gix` - waits for https://github.com/GitoxideLabs/gitoxide/pull/2297
* [x] impl
