### PR TITLE
Finish disabling the auto-updater for Arch Repository packaging

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -34,6 +34,7 @@ export const MOCK_APP_SETTINGS: AppSettings = {
 	},
 	ui: {
 		useNativeTitleBar: false,
-		cliIsManagedByPackageManager: false
+		cliIsManagedByPackageManager: false,
+		checkForUpdatesIntervalInSeconds: 3600
 	}
 };

--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -21,7 +21,7 @@ describe('AppUpdater', () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		updater = new UpdaterService(backend, posthog, shortcuts, settingsService);
+		updater = new UpdaterService(backend, posthog, shortcuts, 3600 * 1000);
 		context = new Map([[UPDATER_SERVICE._key, updater]]);
 		vi.spyOn(backend, 'listen').mockReturnValue(async () => {});
 		vi.mock('$env/dynamic/public', () => {

--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -21,7 +21,7 @@ describe('AppUpdater', () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		updater = new UpdaterService(backend, posthog, shortcuts);
+		updater = new UpdaterService(backend, posthog, shortcuts, settingsService);
 		context = new Map([[UPDATER_SERVICE._key, updater]]);
 		vi.spyOn(backend, 'listen').mockReturnValue(async () => {});
 		vi.mock('$env/dynamic/public', () => {

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -297,7 +297,12 @@ export function initDependencies(args: {
 	const cliManager = new CLIManager(clientState['backendApi']);
 	const dataSharingService = new DataSharingService(clientState['backendApi']);
 	const promptService = new PromptService(backend);
-	const updaterService = new UpdaterService(backend, posthog, shortcutService, get(settingsService)!.ui.checkForUpdatesIntervalInSeconds * 1000);
+	const updaterService = new UpdaterService(
+		backend,
+		posthog,
+		shortcutService,
+		get(settingsService)!.ui.checkForUpdatesIntervalInSeconds * 1000
+	);
 
 	// ============================================================================
 	// UTILITIES

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -296,7 +296,7 @@ export function initDependencies(args: {
 	const cliManager = new CLIManager(clientState['backendApi']);
 	const dataSharingService = new DataSharingService(clientState['backendApi']);
 	const promptService = new PromptService(backend);
-	const updaterService = new UpdaterService(backend, posthog, shortcutService);
+	const updaterService = new UpdaterService(backend, posthog, shortcutService, settingsService);
 
 	// ============================================================================
 	// UTILITIES

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -89,6 +89,7 @@ import {
 	type ExternalLinkService
 } from '@gitbutler/ui/utils/externalLinkService';
 import { IMECompositionHandler, IME_COMPOSITION_HANDLER } from '@gitbutler/ui/utils/imeHandling';
+import { get } from 'svelte/store';
 import { PUBLIC_API_BASE_URL } from '$env/static/public';
 
 export function initDependencies(args: {
@@ -296,7 +297,7 @@ export function initDependencies(args: {
 	const cliManager = new CLIManager(clientState['backendApi']);
 	const dataSharingService = new DataSharingService(clientState['backendApi']);
 	const promptService = new PromptService(backend);
-	const updaterService = new UpdaterService(backend, posthog, shortcutService, settingsService);
+	const updaterService = new UpdaterService(backend, posthog, shortcutService, get(settingsService)!.ui.checkForUpdatesIntervalInSeconds * 1000);
 
 	// ============================================================================
 	// UTILITIES

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -157,4 +157,6 @@ export type UiSettings = {
 	/** Whether the `but` CLI is managed by a package manager.
 	    When true, the UI should show a specific message instead of installation options. */
 	cliIsManagedByPackageManager: boolean;
+	/** The duration between two update checks in seconds. If `0`, no update checks will be performed. */
+	checkForUpdatesIntervalInSeconds: number;
 };

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -4,7 +4,7 @@ import { type Update } from '$lib/backend';
 import { ShortcutService } from '$lib/shortcuts/shortcutService';
 import { mockCreateBackend } from '$lib/testing/mockBackend';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
-import { UPDATE_INTERVAL_MS, UpdaterService } from '$lib/updater/updater';
+import { UpdaterService } from '$lib/updater/updater';
 import { get } from 'svelte/store';
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
 
@@ -23,7 +23,7 @@ describe('Updater', () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		updater = new UpdaterService(backend, posthog, shortcuts);
+		updater = new UpdaterService(backend, posthog, shortcuts, settingsService);
 		vi.spyOn(backend, 'listen').mockReturnValue(async () => {});
 	});
 
@@ -101,7 +101,7 @@ describe('Updater', () => {
 		expect(mock).toHaveBeenCalledOnce();
 
 		for (let i = 2; i < 12; i++) {
-			await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS);
+			await vi.advanceTimersByTimeAsync(3600 * 1000);
 			expect(mock).toHaveBeenCalledTimes(i);
 		}
 		unsubscribe();

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -20,10 +20,11 @@ describe('Updater', () => {
 	const settingsService = new MockSettingsService();
 	const eventContext = new EventContext();
 	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
+	const updateIntervalMs = 3600 * 1000;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		updater = new UpdaterService(backend, posthog, shortcuts, settingsService);
+		updater = new UpdaterService(backend, posthog, shortcuts, updateIntervalMs);
 		vi.spyOn(backend, 'listen').mockReturnValue(async () => {});
 	});
 
@@ -101,7 +102,7 @@ describe('Updater', () => {
 		expect(mock).toHaveBeenCalledOnce();
 
 		for (let i = 2; i < 12; i++) {
-			await vi.advanceTimersByTimeAsync(3600 * 1000);
+			await vi.advanceTimersByTimeAsync(updateIntervalMs);
 			expect(mock).toHaveBeenCalledTimes(i);
 		}
 		unsubscribe();

--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -1,4 +1,3 @@
-import { SettingsService } from '$lib/config/appSettingsV2';
 import { showToast } from '$lib/notifications/toasts';
 import { InjectionToken } from '@gitbutler/core/context';
 import { persisted } from '@gitbutler/shared/persisted';
@@ -68,7 +67,7 @@ export class UpdaterService {
 		private backend: IBackend,
 		private posthog: PostHogWrapper,
 		private shortcuts: ShortcutService,
-		private settingsService: SettingsService
+		private updateIntervalMs: number
 	) {}
 
 	private async start() {
@@ -77,12 +76,10 @@ export class UpdaterService {
 		this.shortcuts.on('update', () => {
 			this.checkForUpdate(true);
 		});
-		const settings = get(this.settingsService.appSettings);
-		const updateIntervalMs = settings!.ui.checkForUpdatesIntervalInSeconds * 1000;
-		if (updateIntervalMs !== 0) {
+		if (this.updateIntervalMs !== 0) {
 			this.checkForUpdateInterval = setInterval(
 				async () => await this.checkForUpdate(),
-				updateIntervalMs
+				this.updateIntervalMs
 			);
 			this.checkForUpdate();
 		}

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -89,14 +89,14 @@ default = ["custom-protocol", "devtools"]
 builtin-but = ["dep:but", "but-action/builtin-but"]
 ## A very specific utility flag to make clear that the 'but' binary is managed by a package manager.
 packaged-but-distribution = []
-## A forwarding to all crates that have windows-specific adjustments for testing on non-Windows.
-windows = []
-## Allow dev-tools to appear to help debugging the frontend.
-devtools = ["tauri/devtools"]
 ## Disable the auto-updater in the frontend.
 ##
 ## Note that it will still be compiled into the backend, so the technical capability of auto-updates remains.
 disable-auto-updates = []
+## A forwarding to all crates that have windows-specific adjustments for testing on non-Windows.
+windows = []
+## Allow dev-tools to appear to help debugging the frontend.
+devtools = ["tauri/devtools"]
 
 #! ## Development
 ## This feature is used for production builds where `devPath` points to the filesystem

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -38,6 +38,7 @@ pub fn build<R: Runtime>(
     handle: &AppHandle<R>,
     #[cfg_attr(target_os = "linux", allow(unused_variables))] settings: &AppSettingsWithDiskSync,
 ) -> tauri::Result<Menu<R>> {
+    #[cfg(not(feature = "disable-auto-updates"))]
     let check_for_updates =
         MenuItemBuilder::with_id("global/update", "Check for updates…").build(handle)?;
 
@@ -54,20 +55,28 @@ pub fn build<R: Runtime>(
         .build(handle)?;
 
     #[cfg(target_os = "macos")]
-    let mac_menu = &SubmenuBuilder::new(handle, app_name)
-        .about(Some(AboutMetadata::default()))
-        .separator()
-        .item(&settings_menu)
-        .item(&check_for_updates)
-        .separator()
-        .services()
-        .separator()
-        .hide()
-        .hide_others()
-        .show_all()
-        .separator()
-        .quit()
-        .build()?;
+    let mac_menu = {
+        #[cfg_attr(feature = "disable-auto-updates", allow(unused_mut))]
+        let mut menu = SubmenuBuilder::new(handle, app_name)
+            .about(Some(AboutMetadata::default()))
+            .separator()
+            .item(&settings_menu);
+
+        #[cfg(not(feature = "disable-auto-updates"))]
+        {
+            menu = menu.item(&check_for_updates)
+        }
+        &menu
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?
+    };
 
     let file_menu = &SubmenuBuilder::new(handle, "File")
         .items(&[
@@ -91,8 +100,11 @@ pub fn build<R: Runtime>(
     #[cfg(target_os = "macos")]
     file_menu.append(&PredefinedMenuItem::close_window(handle, None)?)?;
 
-    #[cfg(not(target_os = "macos"))]
-    file_menu.append_items(&[&PredefinedMenuItem::quit(handle, None)?, &check_for_updates])?;
+    if cfg!(not(target_os = "macos")) {
+        file_menu.append_items(&[&PredefinedMenuItem::quit(handle, None)?])?;
+        #[cfg(not(feature = "disable-auto-updates"))]
+        file_menu.append_items(&[&check_for_updates])?;
+    }
 
     #[cfg(not(target_os = "linux"))]
     let edit_menu = &Submenu::new(handle, "Edit", true)?;

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -64,10 +64,9 @@ pub fn build<R: Runtime>(
 
         #[cfg(not(feature = "disable-auto-updates"))]
         {
-            menu = menu.item(&check_for_updates)
+            menu = menu.item(&check_for_updates);
         }
-        &menu
-            .separator()
+        menu.separator()
             .services()
             .separator()
             .hide()
@@ -235,7 +234,7 @@ pub fn build<R: Runtime>(
         handle,
         &[
             #[cfg(target_os = "macos")]
-            mac_menu,
+            &mac_menu,
             file_menu,
             #[cfg(not(target_os = "linux"))]
             edit_menu,


### PR DESCRIPTION
This allows users to configure the check frequency, as hidden option, while allowing package maintainers to turn the updater off.

Fixes #11558

### Tasks

* [x] updater service respects that application settings for the updater frequency.
* [x] validate there are no auto-updates when `gitbutler-tauri` is compiled with `disable-auto-updates`
* [x] validate there are auto-updates when `gitbutler-tauri` is *not* compiled with `disable-auto-updates`
* [x] There is no way to trigger auto-updates from the menu bar
