### PR TITLE
Prevent dropzone-label-icon from animating when hidden

### DIFF
--- a/apps/desktop/src/components/CardOverlay.svelte
+++ b/apps/desktop/src/components/CardOverlay.svelte
@@ -109,6 +109,10 @@
 				transform: translateY(0) scale(1);
 				opacity: 1;
 			}
+
+			.dropzone-label-icon {
+				animation: icon-shifting 1s infinite;
+			}
 		}
 	}
 
@@ -143,7 +147,6 @@
 	.dropzone-label-icon {
 		width: 14px;
 		height: 14px;
-		animation: icon-shifting 1s infinite;
 	}
 
 	@keyframes icon-shifting {


### PR DESCRIPTION
## 🧢 Changes
Only animate the dropzone label icon when it's actually visible. It used to animate constantly.

This is more or less a critical performance fix for Linux, as CPU usage at idle for me currently takes up 50% of a CPU core. It's the same across three machines. [At least one other user](https://discord.com/channels/1060193121130000425/1073202153163857920/1451520570813583390) also reported issues. Discussed at some length [over here](https://discord.com/channels/1060193121130000425/1445541648686780587/1452042681734660341).

## ☕️ Reasoning
This icon was always rendered and animated for any dropzone with a label, and the lanes in the workspace have dropzones with labels. Thus, any non-empty workspace would suffer constant animations.

WebkitGTK (i.e. Linux) has terrible animation performance, but even running in Chrome the CPU usage was noticable for me.

By only animating the icon when it's actually visible, we save a lot of CPU cycles.

The intent of always rendering the label with opacity=0 is pretty clear to me: in-and-out transitions. Getting a nice out-transition when actually removing an element from the DOM is a bit of a pain in the butt. The animation being left in there is however clearly just an oopsie.

This may seem like a "Linux issue" as it was there we found the performance problem, but I think it's a more general one. Animations aren't free, and having idle animations that are hidden is obviously not useful. But having idle animations at all is perhaps something to consider carefully as well.

> **Note:** We could also prevent the label itself from being rendered until `activated` becomes true (which means you're dragging a file), but I don't see that kind of approach (i.e. not rendering unused components) in the code base at large and don't want to introduce a new thing without prior discussion.

## 🎫 Affected issues

Fixes: #11593 
