### PR TITLE
Add --file option to but commit

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -282,8 +282,16 @@ pub enum Subcommands {
     #[cfg(feature = "legacy")]
     Commit {
         /// Commit message
-        #[clap(short = 'm', long = "message")]
+        #[clap(short = 'm', long = "message", conflicts_with = "file")]
         message: Option<String>,
+        /// Read commit message from file
+        #[clap(
+            short = 'f',
+            long = "file",
+            value_name = "FILE",
+            conflicts_with = "message"
+        )]
+        file: Option<std::path::PathBuf>,
         /// Branch CLI ID or name to derive the stack to commit to
         branch: Option<String>,
         /// Whether to create a new branch for this commit.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -358,15 +358,26 @@ async fn match_subcommand(
         #[cfg(feature = "legacy")]
         Subcommands::Commit {
             message,
+            file,
             branch,
             create,
             only,
         } => {
             let project = legacy::get_or_init_non_bare_project(&args)?;
+            // Read message from file if provided, otherwise use message option
+            let commit_message = match file {
+                Some(path) => Some(std::fs::read_to_string(&path).with_context(|| {
+                    format!(
+                        "Failed to read commit message from file: {}",
+                        path.display()
+                    )
+                })?),
+                None => message,
+            };
             command::legacy::commit::commit(
                 &project,
                 out,
-                message.as_deref(),
+                commit_message.as_deref(),
                 branch.as_deref(),
                 only,
                 create,


### PR DESCRIPTION
Allow providing a commit message via a file with -f/--file (similar to -m). This reads the message from the given path and passes it to the legacy commit handler. The option conflicts with -m/--message so only one source is used.