### PR TITLE
fix ahead-behind computation for target branch in legacy code

### DIFF
--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="308px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -49,9 +49,11 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┴ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -43,9 +43,11 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┴ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="262px">
 </tspan>
   </text>
 


### PR DESCRIPTION
This isn't a problem in the new implementation, so this is merely a quick fix hoping that the code soon won't run anymore.

The problem can be that the `default_target.sha` field is stale or points to the wrong commit, and we should fix that when consolidating.

Fixes #11518.

### Tasks

* [x] initial fix
* [x] why is it not fixed right after opening?

### Demonstration

The fix is implemented such that the stale virtual-branches.toml data is fixed automatically the next time modern code touches workspace metadata.

https://github.com/user-attachments/assets/3d79550f-28cb-4ef8-a299-e2ef7d9d4b04

But the auto-fixing should happen when the project is set active, so have to look into that.
Edit: it didn't write back when it should have. Now that this is fixed, such issues fix themselves.

