### PR TITLE
Sort out a fix for #11483 

### DIFF
--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -215,6 +215,18 @@ git init special-branches
 
 mkdir ws
 (cd ws
+  git init reproduce-11483
+  (cd reproduce-11483
+      commit M1
+      git branch below
+      setup_target_to_match_main
+      git checkout -b A
+        commit A
+      git checkout -b B main
+        commit B
+    create_workspace_commit_once B A
+  )
+
   git init reproduce-11459
   (cd reproduce-11459
     commit M1

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -163,14 +163,14 @@ impl Snapshot {
                 .collect();
 
             for (segment, segment_name) in segments_to_add {
+                let first_commit_or_null = segment
+                    .commits
+                    .first()
+                    .map_or(gix::hash::Kind::Sha1.null(), |c| c.id)
+                    .to_string();
+                tracing::warn!(segment_name=%segment_name.shorten(), %first_commit_or_null, stack_id=?vb_stack.id, "Adding head to stack");
                 vb_stack.heads.push(StackBranch {
-                    head: CommitOrChangeId::CommitId(
-                        segment
-                            .commits
-                            .first()
-                            .map_or(gix::hash::Kind::Sha1.null(), |c| c.id)
-                            .to_string(),
-                    ),
+                    head: CommitOrChangeId::CommitId(first_commit_or_null),
                     name: segment_name.shorten().to_string(),
                     description: None,
                     pr_number: None,


### PR DESCRIPTION
Intermediate shows that the reconciliation once again is involved in making something worse, as it happily breaks invariants in the workspace data.

But I don't yet have to complete picture on what happens to the data after inserting a new branch to the workspace.

### Tasks

* [x] understand how the data ends up so botched in reconciliation - it does its job, but it starts out wrong already
    - [x] but-graph test it - *seems to be a problem with the workspace generation as the branch ends up in the wrong spot*
    - [x] fix it
* [x] fix or postpone to #11546 - **postpone** - we can see what we should do in these cases - ideally branches match and we just need tests for additions and deletions then.

Fixes #11483.

### Research

Inserting `st-branch-3` to `some-other-branch` yields the following reconciliation data, which is opposite compared to what it
should be, i.e. vb-toml is what it should be, but our workspace is the opposite.

And after reconciliation, they are just as botched as both are made equal to each other, duplicating the `st-branch-3` name.

```
[crates/but-meta/src/legacy.rs:274:13] &ws_stack = Stack(≡📙:4:some-branch on 4dc5571 {878676cac7c14149955c7682ab9959b}) {
    segments: [
        StackSegment(📙:4:some-branch) {
            commits: [
                "·99cc8ae (🏘\u{fe0f})",
            ],
            commits_on_remote: [],
            commits_outside: None,
        },
        StackSegment(📙:5:st-branch-3) {
            commits: [],
            commits_on_remote: [],
            commits_outside: None,
        },
    ],
    id: 878676ca-c7c1-4149-955c-7682ab90959b,
}
[crates/but-meta/src/legacy.rs:274:13] &vb_stack = Stack {
    id: 878676ca-c7c1-4149-955c-7682ab90959b,
    name: "some-branch",
    notes: "",
    source_refname: None,
    upstream: None,
    upstream_head: None,
    created_timestamp_ms: 1765198231000,
    updated_timestamp_ms: 1765198231000,
    tree: Sha1(0000000000000000000000000000000000000000),
    head: Sha1(0000000000000000000000000000000000000000),
    ownership: BranchOwnershipClaims {
        claims: [],
    },
    order: 3,
    selected_for_changes: None,
    allow_rebasing: true,
    in_workspace: true,
    not_in_workspace_wip_change_id: None,
    heads: [
        StackBranch {
            head: CommitId(
                "99cc8ae0622999b6ed97310e34887e7ef587096e",
            ),
            name: "some-branch",
            description: None,
            pr_number: None,
            archived: false,
            review_id: None,
        },
    ],
    post_commits: false,
}
[crates/but-meta/src/legacy.rs:274:13] &ws_stack = Stack(≡📙:3:some-other-branch on 4dc5571 {beaa5ff2adb41dabc95acd6aa9dbb5}) {
    segments: [
        StackSegment(📙:3:some-other-branch) {
            commits: [
                "·fce4ba5 (🏘\u{fe0f})",
            ],
            commits_on_remote: [],
            commits_outside: None,
        },
    ],
    id: bea0a5ff-2adb-41da-bc95-a0cd6aa9dbb5,
}
[crates/but-meta/src/legacy.rs:274:13] &vb_stack = Stack {
    id: bea0a5ff-2adb-41da-bc95-a0cd6aa9dbb5,
    name: "some-other-branch",
    notes: "",
    source_refname: None,
    upstream: None,
    upstream_head: None,
    created_timestamp_ms: 1765198228000,
    updated_timestamp_ms: 1765198228000,
    tree: Sha1(0000000000000000000000000000000000000000),
    head: Sha1(0000000000000000000000000000000000000000),
    ownership: BranchOwnershipClaims {
        claims: [],
    },
    order: 0,
    selected_for_changes: None,
    allow_rebasing: true,
    in_workspace: true,
    not_in_workspace_wip_change_id: None,
    heads: [
        StackBranch {
            head: CommitId(
                "0000000000000000000000000000000000000000",
            ),
            name: "st-branch-3",
            description: None,
            pr_number: None,
            archived: false,
            review_id: None,
        },
        StackBranch {
            head: CommitId(
                "fce4ba54362de5535ddf3f1e7e9b9930e882c70c",
            ),
            name: "some-other-branch",
            description: None,
            pr_number: None,
            archived: false,
            review_id: None,
        },
    ],
    post_commits: false,
}
```
