### PR TITLE
Dragndrop UX/UI refactor

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -209,7 +209,7 @@
 					disabled: args.isConflicted,
 					label: branchName,
 					pushStatus: args.pushStatus,
-					viewportId: 'board-viewport',
+
 					data:
 						args.type === 'stack-branch' && args.stackId
 							? new BranchDropData(

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -209,7 +209,6 @@
 					disabled: args.isConflicted,
 					label: branchName,
 					pushStatus: args.pushStatus,
-
 					data:
 						args.type === 'stack-branch' && args.stackId
 							? new BranchDropData(

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -345,7 +345,6 @@
 											branchName
 										)
 									: undefined,
-								viewportId: 'board-viewport',
 								dropzoneRegistry,
 								dragStateService
 							}}

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -3,7 +3,6 @@
 		disabled: boolean;
 		label: string;
 		pushStatus: PushStatus | undefined;
-		viewportId: string;
 		data: BranchDropData | undefined;
 	};
 </script>

--- a/apps/desktop/src/components/BranchLineOverlay.svelte
+++ b/apps/desktop/src/components/BranchLineOverlay.svelte
@@ -60,6 +60,7 @@
 
 		&.dimmed {
 			& .indicator {
+				background-color: var(--clr-text-2);
 				opacity: 0.4;
 			}
 		}
@@ -73,7 +74,6 @@
 		height: 3px;
 		transform: translate(-50%, -50%);
 		border-radius: var(--radius-m);
-		background-color: transparent;
 		background-color: var(--clr-theme-pop-element);
 
 		transition:

--- a/apps/desktop/src/components/CardOverlay.svelte
+++ b/apps/desktop/src/components/CardOverlay.svelte
@@ -25,18 +25,13 @@
 	const extraPaddingBottom = extraPaddings?.bottom ?? 0;
 	const extraPaddingLeft = extraPaddings?.left ?? 0;
 
-	// Track if this specific instance has set the label
-	let hasSetLabel = $state(false);
-
 	$effect(() => {
-		const shouldShow = activated && hovered && label;
-
-		if (shouldShow && !hasSetLabel) {
-			dragStateService?.setDropLabel(label);
-			hasSetLabel = true;
-		} else if (!shouldShow && hasSetLabel) {
-			dragStateService?.clearDropLabel(label);
-			hasSetLabel = false;
+		if (activated && hovered && label && dragStateService) {
+			// Set the label and get a token for cleanup
+			const token = dragStateService.setDropLabel(label);
+			return () => {
+				dragStateService.clearDropLabel(token);
+			};
 		}
 	});
 </script>

--- a/apps/desktop/src/components/CardOverlay.svelte
+++ b/apps/desktop/src/components/CardOverlay.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { injectOptional } from '@gitbutler/core/context';
+	import { DRAG_STATE_SERVICE } from '@gitbutler/ui/drag/dragStateService.svelte';
 	import { pxToRem } from '@gitbutler/ui/utils/pxToRem';
 
 	interface Props {
@@ -16,11 +18,36 @@
 
 	const { visible, hovered, activated, label = 'Drop here', extraPaddings }: Props = $props();
 	let defaultPadding = 4;
+	const dragStateService = injectOptional(DRAG_STATE_SERVICE, undefined);
 
 	const extraPaddingTop = extraPaddings?.top ?? 0;
 	const extraPaddingRight = extraPaddings?.right ?? 0;
 	const extraPaddingBottom = extraPaddings?.bottom ?? 0;
 	const extraPaddingLeft = extraPaddings?.left ?? 0;
+
+	let labelWeSet = $state<string | undefined>(undefined);
+
+	$effect(() => {
+		// If dropzone is not activated, reset our tracking state
+		if (!activated) {
+			labelWeSet = undefined;
+			return;
+		}
+
+		const isActivatedAndHovered = activated && hovered && !!label;
+
+		if (isActivatedAndHovered) {
+			// Set label immediately when hovering an activated dropzone
+			console.log('CardOverlay effect: setting label', label);
+			dragStateService?.setDropLabel(label);
+			labelWeSet = label;
+		} else if (labelWeSet && labelWeSet === label) {
+			// We previously set this exact label, now clear it
+			console.log('CardOverlay effect: clearing label (we set it)', label);
+			dragStateService?.clearDropLabel(label);
+			labelWeSet = undefined;
+		}
+	});
 </script>
 
 <div
@@ -35,26 +62,6 @@
 	)}rem; --padding-left: {pxToRem(defaultPadding + extraPaddingLeft)}rem"
 >
 	<div class="container">
-		{#if label !== ''}
-			<div class="dropzone-label">
-				<svg
-					class="dropzone-label-icon"
-					viewBox="0 0 15 14"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<path
-						d="M12.5303 7.73599L8.23738 3.4431C7.84686 3.05257 7.21369 3.05257 6.82317 3.4431L2.53027 7.73599"
-						stroke="currentColor"
-						stroke-width="1.5"
-					/>
-					<path d="M7.53027 3.73602L7.53027 11.736" stroke="currentColor" stroke-width="1.5" />
-				</svg>
-
-				<span class="text-11 text-bold">{label}</span>
-			</div>
-		{/if}
-
 		<!-- SVG rectangle to simulate a dashed outline with a precise dash offset. -->
 		<svg width="100%" height="100%" class="animated-rectangle">
 			<rect width="100%" height="100%" rx="6" ry="6" vector-effect="non-scaling-stroke" />
@@ -104,15 +111,6 @@
 				stroke: var(--dropzone-stroke-hover);
 				animation: dropzone-dash 4s linear infinite;
 			}
-
-			.dropzone-label {
-				transform: translateY(0) scale(1);
-				opacity: 1;
-			}
-
-			.dropzone-label-icon {
-				animation: icon-shifting 1s infinite;
-			}
 		}
 	}
 
@@ -125,42 +123,6 @@
 		height: 100%;
 		pointer-events: none;
 	}
-
-	.dropzone-label {
-		display: flex;
-		z-index: 1;
-		align-items: center;
-		padding: 4px 8px 4px 6px;
-		gap: 5px;
-		transform: translateY(3px) scale(0.95);
-		border-radius: 100px;
-		background-color: var(--clr-theme-gray-element);
-		color: var(--clr-theme-gray-on-element);
-		opacity: 0;
-
-		transition:
-			opacity 0.1s,
-			transform 0.15s;
-		will-change: transform, opacity;
-	}
-
-	.dropzone-label-icon {
-		width: 14px;
-		height: 14px;
-	}
-
-	@keyframes icon-shifting {
-		0% {
-			transform: translateY(0);
-		}
-		50% {
-			transform: translateY(-2px);
-		}
-		100% {
-			transform: translateY(0);
-		}
-	}
-
 	.animated-rectangle {
 		position: absolute;
 		top: 0;

--- a/apps/desktop/src/components/CardOverlay.svelte
+++ b/apps/desktop/src/components/CardOverlay.svelte
@@ -25,27 +25,18 @@
 	const extraPaddingBottom = extraPaddings?.bottom ?? 0;
 	const extraPaddingLeft = extraPaddings?.left ?? 0;
 
-	let labelWeSet = $state<string | undefined>(undefined);
+	// Track if this specific instance has set the label
+	let hasSetLabel = $state(false);
 
 	$effect(() => {
-		// If dropzone is not activated, reset our tracking state
-		if (!activated) {
-			labelWeSet = undefined;
-			return;
-		}
+		const shouldShow = activated && hovered && label;
 
-		const isActivatedAndHovered = activated && hovered && !!label;
-
-		if (isActivatedAndHovered) {
-			// Set label immediately when hovering an activated dropzone
-			console.log('CardOverlay effect: setting label', label);
+		if (shouldShow && !hasSetLabel) {
 			dragStateService?.setDropLabel(label);
-			labelWeSet = label;
-		} else if (labelWeSet && labelWeSet === label) {
-			// We previously set this exact label, now clear it
-			console.log('CardOverlay effect: clearing label (we set it)', label);
+			hasSetLabel = true;
+		} else if (!shouldShow && hasSetLabel) {
 			dragStateService?.clearDropLabel(label);
-			labelWeSet = undefined;
+			hasSetLabel = false;
 		}
 	});
 </script>

--- a/apps/desktop/src/components/CommitLineOverlay.svelte
+++ b/apps/desktop/src/components/CommitLineOverlay.svelte
@@ -101,7 +101,7 @@
 
 	.indicator-portal {
 		display: flex;
-		z-index: var(--z-blocker);
+		z-index: var(--z-modal);
 		position: absolute;
 		align-items: center;
 		pointer-events: none;

--- a/apps/desktop/src/components/Dropzone.svelte
+++ b/apps/desktop/src/components/Dropzone.svelte
@@ -14,6 +14,7 @@
 		handlers: DropzoneHandler[];
 		hideWhenInactive?: boolean;
 		onActivated?: (activated: boolean) => void;
+		onHovered?: (hovered: boolean) => void;
 		overlay?: Snippet<[{ hovered: boolean; activated: boolean; handler?: DropzoneHandler }]>;
 		children?: Snippet;
 		overflow?: boolean;
@@ -25,6 +26,7 @@
 		maxHeight = false,
 		handlers,
 		onActivated,
+		onHovered,
 		overlay,
 		children,
 		hideWhenInactive,
@@ -38,11 +40,13 @@
 	function onHoverStart(args: HoverArgs) {
 		hovered = true;
 		hoveredHandler = args.handler;
+		onHovered?.(hovered);
 	}
 
 	function onHoverEnd() {
 		hovered = false;
 		hoveredHandler = undefined;
+		onHovered?.(hovered);
 	}
 
 	let activated = $state(false);

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -170,7 +170,6 @@
 		label: getFilename(change.path),
 		filePath: change.path,
 		data: new FileChangeDropData(projectId, change, idSelection, selectionId, stackId || undefined),
-		viewportId: 'board-viewport',
 		disabled: draggableDisabled,
 		chipType: 'file',
 		dropzoneRegistry,

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -80,7 +80,7 @@
 
 	const stableStackId = $derived(stackId);
 	const stableProjectId = $derived(projectId);
-	let lanesSrollableEl = $state<HTMLDivElement>();
+	let lanesScrollableEl = $state<HTMLDivElement>();
 
 	let dropzoneActivated = $state(false);
 	let dropzoneHovered = $state(false);
@@ -541,7 +541,7 @@
 		},
 		options: {
 			threshold: 0.5,
-			root: lanesSrollableEl
+			root: lanesScrollableEl
 		}
 	}}
 	use:focusable={{

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -592,7 +592,6 @@
 									projectId={stableProjectId}
 									stackId={stableStackId}
 									mode="assigned"
-									dropzoneVisible={changes.current.length === 0 && !isCommitting}
 									onDropzoneActivated={(activated) => {
 										dropzoneActivated = activated;
 									}}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -82,6 +82,9 @@
 	const stableProjectId = $derived(projectId);
 	let lanesSrollableEl = $state<HTMLDivElement>();
 
+	let dropzoneActivated = $state(false);
+	let dropzoneHovered = $state(false);
+
 	const stackService = inject(STACK_SERVICE);
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
@@ -128,8 +131,6 @@
 	const branchesQuery = $derived(stackService.branches(stableProjectId, stableStackId));
 
 	let active = $state(false);
-
-	let dropzoneActivated = $state(false);
 
 	const laneState = $derived(uiState.lane(laneId));
 	const selection = $derived(laneState.selection);
@@ -584,6 +585,7 @@
 								class:remove-border-bottom={(isCommitting && changes.current.length === 0) ||
 									!startCommitVisible.current}
 								class:dropzone-activated={dropzoneActivated && changes.current.length === 0}
+								class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
 							>
 								<WorktreeChanges
 									title="Assigned"
@@ -593,6 +595,9 @@
 									dropzoneVisible={changes.current.length === 0 && !isCommitting}
 									onDropzoneActivated={(activated) => {
 										dropzoneActivated = activated;
+									}}
+									onDropzoneHovered={(hovered) => {
+										dropzoneHovered = hovered;
 									}}
 									onselect={() => {
 										// Clear one selection when you modify the other.
@@ -981,6 +986,12 @@
 
 			& .assigned-changes-empty__text {
 				color: var(--clr-theme-pop-on-soft);
+			}
+		}
+
+		&.dropzone-hovered {
+			& .assigned-changes-empty__text {
+				opacity: 1;
 			}
 		}
 	}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -526,6 +526,7 @@
 <div
 	bind:clientWidth
 	bind:clientHeight
+	data-scrollable-for-dragging
 	class="stack-view-wrapper"
 	role="presentation"
 	class:dimmed

--- a/apps/desktop/src/components/TreeListFolder.svelte
+++ b/apps/desktop/src/components/TreeListFolder.svelte
@@ -79,7 +79,6 @@
 		label: node.name,
 		filePath: folderPath,
 		data: new FolderChangeDropData(folderPath, getTreeChanges, selectionId, stackId),
-		viewportId: 'board-viewport',
 		disabled: draggableDisabled,
 		chipType: 'folder',
 		dropzoneRegistry,

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -82,11 +82,11 @@
 
 	function getDropzoneLabel(handler: DropzoneHandler | undefined): string {
 		if (handler instanceof UncommitDzHandler) {
-			return 'Uncommit changes';
+			return 'Uncommit';
 		} else if (mode === 'assigned') {
-			return 'Assign changes';
+			return 'Assign';
 		} else {
-			return 'Unassign changes';
+			return 'Unassign';
 		}
 	}
 </script>

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -116,11 +116,7 @@
 	onHovered={onDropzoneHovered}
 >
 	{#snippet overlay({ hovered, activated, handler })}
-		<CardOverlay
-			{hovered}
-			{activated}
-			label={getDropzoneLabel(handler)}
-		/>
+		<CardOverlay {hovered} {activated} label={getDropzoneLabel(handler)} />
 	{/snippet}
 
 	<div class="uncommitted-changes-wrap">

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -28,6 +28,7 @@
 		mode?: 'unassigned' | 'assigned';
 		dropzoneVisible?: boolean;
 		onDropzoneActivated?: (activated: boolean) => void;
+		onDropzoneHovered?: (hovered: boolean) => void;
 		emptyPlaceholder?: Snippet;
 		foldButton?: Snippet;
 		onselect?: () => void;
@@ -41,6 +42,7 @@
 		mode = 'unassigned',
 		dropzoneVisible,
 		onDropzoneActivated,
+		onDropzoneHovered,
 		emptyPlaceholder,
 		foldButton,
 		onselect,
@@ -111,10 +113,10 @@
 	handlers={[uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
 	maxHeight
 	onActivated={onDropzoneActivated}
+	onHovered={onDropzoneHovered}
 >
 	{#snippet overlay({ hovered, activated, handler })}
 		<CardOverlay
-			visible={dropzoneVisible}
 			{hovered}
 			{activated}
 			label={getDropzoneLabel(handler)}

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -26,7 +26,6 @@
 		stackId?: string;
 		title: string;
 		mode?: 'unassigned' | 'assigned';
-		dropzoneVisible?: boolean;
 		onDropzoneActivated?: (activated: boolean) => void;
 		onDropzoneHovered?: (hovered: boolean) => void;
 		emptyPlaceholder?: Snippet;
@@ -40,7 +39,6 @@
 		stackId,
 		title,
 		mode = 'unassigned',
-		dropzoneVisible,
 		onDropzoneActivated,
 		onDropzoneHovered,
 		emptyPlaceholder,

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -404,6 +404,6 @@
 	/* Dim the original element when it's being dragged */
 	:global(.dragging) {
 		opacity: 0.5;
-		transition: opacity 0.2s ease;
+		pointer-events: none;
 	}
 </style>

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -28,9 +28,8 @@
 		dragStateService
 	}: Props = $props();
 
-	const dropLabel = $derived(
-		dragStateService?.dropLabel ?? readable<string | undefined>(undefined)
-	);
+	const fallbackDropLabelStore = readable<string | undefined>(undefined);
+	const dropLabel = $derived(dragStateService?.dropLabel ?? fallbackDropLabelStore);
 
 	const commitColor = $derived(
 		type === 'commit' && commitType ? getColorFromCommitState(commitType, false) : undefined

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -234,21 +234,6 @@
 		box-shadow: var(--chip-shadow);
 	}
 
-	.dragchip-amount {
-		display: flex;
-		position: absolute;
-		top: -6px;
-		right: -8px;
-		align-items: center;
-		justify-content: center;
-		min-width: 16px;
-		margin-left: 5px;
-		padding: 2px 4px;
-		border-radius: 16px;
-		background-color: var(--clr-theme-gray-element);
-		color: var(--clr-theme-gray-on-element);
-	}
-
 	/* if dragging more then one item */
 	.drag-animation-wrapper.dragchip-two::after,
 	.drag-animation-wrapper.dragchip-multiple::before,

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -42,7 +42,11 @@
 	<div class="drag-action-label-container">
 		{#if opt.label}
 			<div class="text-11 text-bold drag-action-label drag-action-label__action">
-				{opt.label}
+				<span>{opt.label}</span>
+
+				<div class="drag-action-label-icon">
+					<Icon name="arrow-down" size={12} />
+				</div>
 			</div>
 		{/if}
 		{#if opt.amount && opt.amount > 1}
@@ -149,11 +153,11 @@
 		align-items: center;
 
 		&.activated {
-			animation: dropzone-scale 0.2s ease forwards;
+			animation: drogchip-scale 0.2s ease forwards;
 		}
 	}
 
-	@keyframes dropzone-scale {
+	@keyframes drogchip-scale {
 		0% {
 			transform: scale(1);
 		}
@@ -184,7 +188,7 @@
 	}
 
 	.drag-action-label {
-		display: inline-flex;
+		display: flex;
 		z-index: 4;
 		align-items: center;
 		padding: 4px 7px;
@@ -196,13 +200,26 @@
 	}
 
 	.drag-action-label__action {
+		gap: 4px;
 		background-color: var(--clr-theme-pop-element);
 		color: var(--clr-theme-pop-on-element);
 	}
 
 	.drag-action-label-icon {
-		width: 14px;
-		height: 14px;
+		display: flex;
+		animation: icon-shifting 1s ease infinite;
+	}
+
+	@keyframes icon-shifting {
+		0% {
+			transform: translateY(0);
+		}
+		50% {
+			transform: translateY(-2px);
+		}
+		100% {
+			transform: translateY(0);
+		}
 	}
 
 	.dragchip {

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -5,6 +5,8 @@
 	import { type PushStatus } from '$lib/stacks/stack';
 	import { Icon } from '@gitbutler/ui';
 	import { getFileIcon } from '@gitbutler/ui/components/file/getFileIcon';
+	import { type DragStateService } from '@gitbutler/ui/drag/dragStateService.svelte';
+	import { readable } from 'svelte/store';
 
 	type Props = {
 		type: 'branch' | 'commit' | 'file' | 'folder' | 'hunk' | 'ai-session';
@@ -13,100 +15,194 @@
 		commitType?: CommitStatusType;
 		childrenAmount?: number;
 		pushStatus?: PushStatus;
+		dragStateService?: DragStateService;
 	};
 
-	let { type, label, filePath, commitType, childrenAmount = 1, pushStatus }: Props = $props();
+	let {
+		type,
+		label,
+		filePath,
+		commitType,
+		childrenAmount = 1,
+		pushStatus,
+		dragStateService
+	}: Props = $props();
+
+	const dropLabel = $derived(
+		dragStateService?.dropLabel ?? readable<string | undefined>(undefined)
+	);
 
 	const commitColor = $derived(
 		type === 'commit' && commitType ? getColorFromCommitState(commitType, false) : undefined
 	);
 	const fileIcon = $derived(filePath ? getFileIcon(filePath) : undefined);
-	// Debug log
 </script>
+
+{#snippet dropLabelSnippet(opt: { label?: string; amount?: number })}
+	<div class="drag-action-label-container">
+		{#if opt.label}
+			<div class="text-11 text-bold drag-action-label drag-action-label__action">
+				{opt.label}
+			</div>
+		{/if}
+		{#if opt.amount && opt.amount > 1}
+			<div class="text-11 text-bold drag-action-label" class:has-label={opt.label}>
+				{opt.amount}
+			</div>
+		{/if}
+	</div>
+{/snippet}
 
 {#if type === 'branch'}
 	<div class="draggable-branch-card">
-		{#if pushStatus}
-			<BranchHeaderIcon iconName="branch-local" color="var(--clr-commit-local)" small />
-		{/if}
-		<span class="truncate text-15 text-bold">
-			{label}
-		</span>
+		<div class="drag-animation-wrapper" class:activated={$dropLabel !== undefined}>
+			{@render dropLabelSnippet({ label: $dropLabel, amount: childrenAmount })}
+			{#if pushStatus}
+				<BranchHeaderIcon iconName="branch-local" color="var(--clr-commit-local)" small />
+			{/if}
+			<span class="truncate text-15 text-bold">
+				{label}
+			</span>
+		</div>
 	</div>
 {:else if type === 'commit'}
 	<div
-		class="draggable-commit-v3"
-		class:draggable-commit-v3-local={commitType === 'LocalOnly' ||
+		class="draggable-commit"
+		class:draggable-commit-local={commitType === 'LocalOnly' ||
 			commitType === 'Integrated' ||
 			commitType === 'Base'}
-		class:draggable-commit-v3-remote={commitType !== 'LocalOnly' &&
+		class:draggable-commit-remote={commitType !== 'LocalOnly' &&
 			commitType !== 'Integrated' &&
 			commitType !== 'Base'}
 		style:--commit-color={commitColor}
 	>
-		<div class="draggable-commit-v3-indicator"></div>
-		<div class="truncate text-13 text-semibold draggable-commit-v3-label">
-			{label || 'Empty commit'}
+		<div class="drag-animation-wrapper" class:activated={$dropLabel !== undefined}>
+			{@render dropLabelSnippet({ label: $dropLabel, amount: childrenAmount })}
+			<div class="draggable-commit-indicator"></div>
+			<div class="truncate text-13 text-semibold draggable-commit-label">
+				{label || 'Empty commit'}
+			</div>
 		</div>
 	</div>
 {:else if type === 'ai-session'}
 	<div class="dragchip-container">
-		<div class="dragchip-ai-session-container">
-			<Icon name="ai-small" />
-			{#if label}
-				<span class="text-12 text-semibold truncate dragchip-ai-session-label">{label}</span>
-			{/if}
-			<Icon name="draggable" />
+		<div class="drag-animation-wrapper" class:activated={$dropLabel !== undefined}>
+			{@render dropLabelSnippet({ label: $dropLabel, amount: childrenAmount })}
+			<div class="dragchip-ai-session-container">
+				<Icon name="ai-small" />
+				{#if label}
+					<span class="text-12 text-semibold truncate dragchip-ai-session-label">{label}</span>
+				{/if}
+				<Icon name="draggable" />
+			</div>
 		</div>
 	</div>
 {:else}
 	<!-- File, Folder, or Hunk chips -->
-	<div
-		class="dragchip-container"
-		class:dragchip-two={childrenAmount === 2}
-		class:dragchip-multiple={childrenAmount > 2}
-	>
-		<div class="dragchip">
-			{#if type === 'file'}
-				<div class="dragchip-file-container">
-					{#if fileIcon}
-						<img src={fileIcon} alt="" class="dragchip-file-icon" />
-					{/if}
-					<span class="text-12 text-semibold truncate dragchip-file-name">
-						{label || 'Empty file'}
-					</span>
-				</div>
-			{:else if type === 'folder'}
-				<div class="dragchip-file-container">
-					<Icon name="folder" />
-					<span class="text-12 text-semibold truncate dragchip-file-name">
-						{label || 'Empty folder'}
-					</span>
-				</div>
-			{:else if type === 'hunk'}
-				<div class="dragchip-hunk-container">
-					<div class="dragchip-hunk-decorator">〈/〉</div>
-					<span class="dragchip-hunk-label">{label || 'Empty hunk'}</span>
-				</div>
-			{/if}
-
-			{#if childrenAmount > 1}
-				<div class="text-11 text-bold dragchip-amount">{childrenAmount}</div>
-			{/if}
+	<div class="dragchip-container">
+		<div
+			class="drag-animation-wrapper"
+			class:activated={$dropLabel !== undefined}
+			class:dragchip-two={childrenAmount === 2}
+			class:dragchip-multiple={childrenAmount > 2}
+		>
+			{@render dropLabelSnippet({ label: $dropLabel, amount: childrenAmount })}
+			<div class="dragchip">
+				{#if type === 'file'}
+					<div class="dragchip-file-container">
+						{#if fileIcon}
+							<img src={fileIcon} alt="" class="dragchip-file-icon" />
+						{/if}
+						<span class="text-12 text-semibold truncate dragchip-file-name">
+							{label || 'Empty file'}
+						</span>
+					</div>
+				{:else if type === 'folder'}
+					<div class="dragchip-file-container">
+						<Icon name="folder" />
+						<span class="text-12 text-semibold truncate dragchip-file-name">
+							{label || 'Empty folder'}
+						</span>
+					</div>
+				{:else if type === 'hunk'}
+					<div class="dragchip-hunk-container">
+						<div class="dragchip-hunk-decorator">〈/〉</div>
+						<span class="dragchip-hunk-label">{label || 'Empty hunk'}</span>
+					</div>
+				{/if}
+			</div>
 		</div>
 	</div>
 {/if}
 
-<style>
+<style lang="postcss">
 	/* DRAG CHIPS.
 	 * General styles
 	 * Basic container for single and multiple items */
 	.dragchip-container {
 		display: flex;
-		position: absolute;
-		top: -1000px;
-		left: -1000px;
 		pointer-events: none;
+	}
+
+	.drag-animation-wrapper {
+		display: flex;
+		align-items: center;
+
+		&.activated {
+			animation: dropzone-scale 0.2s ease forwards;
+		}
+	}
+
+	@keyframes dropzone-scale {
+		0% {
+			transform: scale(1);
+		}
+		50% {
+			transform: scale(1.05);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+
+	/* root */
+	:global(:root) {
+		--chip-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+	}
+	/* dark mode */
+	:global(:root.dark) {
+		--chip-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+	}
+
+	.drag-action-label-container {
+		display: flex;
+		position: absolute;
+		top: -12px;
+		right: -12px;
+		gap: 2px;
+		pointer-events: none;
+	}
+
+	.drag-action-label {
+		display: inline-flex;
+		z-index: 4;
+		align-items: center;
+		padding: 4px 7px;
+		border-radius: 100px;
+		background-color: var(--clr-theme-gray-element);
+		color: var(--clr-theme-gray-on-element);
+		white-space: nowrap;
+		pointer-events: none;
+	}
+
+	.drag-action-label__action {
+		background-color: var(--clr-theme-pop-element);
+		color: var(--clr-theme-pop-on-element);
+	}
+
+	.drag-action-label-icon {
+		width: 14px;
+		height: 14px;
 	}
 
 	.dragchip {
@@ -118,6 +214,7 @@
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-1);
+		box-shadow: var(--chip-shadow);
 	}
 
 	.dragchip-amount {
@@ -136,19 +233,19 @@
 	}
 
 	/* if dragging more then one item */
-	.dragchip-two:after,
-	.dragchip-multiple:before,
-	.dragchip-multiple:after {
+	.drag-animation-wrapper.dragchip-two::after,
+	.drag-animation-wrapper.dragchip-multiple::before,
+	.drag-animation-wrapper.dragchip-multiple::after {
 		position: absolute;
 		width: 100%;
 		height: 100%;
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-2);
+		background-color: var(--clr-bg-1);
 		content: '';
 	}
 
-	.dragchip-two {
+	.drag-animation-wrapper.dragchip-two {
 		&::after {
 			z-index: 2;
 			top: 6px;
@@ -156,7 +253,7 @@
 		}
 	}
 
-	.dragchip-multiple {
+	.drag-animation-wrapper.dragchip-multiple {
 		&::before {
 			z-index: 2;
 			top: 6px;
@@ -213,6 +310,12 @@
 	}
 
 	/* AI SESSION DRAG */
+	.dragchip-container {
+		& .drag-animation-wrapper:has(.dragchip-ai-session-container) {
+			width: auto;
+		}
+	}
+
 	.dragchip-ai-session-container {
 		display: flex;
 		align-items: center;
@@ -224,54 +327,57 @@
 		background-position: 0% 50%;
 		background-size: 200% 200%;
 		background: var(--codegen-gradient);
+		box-shadow: var(--chip-shadow);
 		color: var(--codegen-color);
 	}
 
 	/* BRANCH DRAG CARD */
-
 	.draggable-branch-card {
-		display: flex;
-		position: absolute;
-		align-items: center;
-		min-width: 50px;
-		max-width: 220px;
-		height: 36px;
-		padding: 0 10px;
-		overflow: hidden;
-		gap: 10px;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-1);
-	}
+		pointer-events: none;
 
-	/* COMMIT DRAG CARD V3 */
-	.draggable-commit-v3 {
-		display: flex;
-		position: absolute;
-		align-items: center;
-		min-width: 50px;
-		max-width: 240px;
-		height: 36px;
-		padding: 0 10px;
-		overflow: hidden;
-		gap: 10px;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-1);
-
-		&::before {
-			z-index: 1;
-			position: absolute;
-			top: 0;
-			left: 14px;
-			width: 2px;
-			height: 100%;
-			background-color: var(--commit-color);
-			content: '';
+		& .drag-animation-wrapper {
+			min-width: 50px;
+			max-width: 220px;
+			height: 36px;
+			padding: 0 10px;
+			gap: 10px;
+			border: 1px solid var(--clr-border-2);
+			border-radius: var(--radius-m);
+			background-color: var(--clr-bg-1);
+			box-shadow: var(--chip-shadow);
 		}
 	}
 
-	.draggable-commit-v3-indicator {
+	/* COMMIT DRAG CARD */
+	.draggable-commit {
+		pointer-events: none;
+
+		& .drag-animation-wrapper {
+			position: relative;
+			min-width: 50px;
+			max-width: 240px;
+			height: 36px;
+			padding: 0 10px;
+			gap: 10px;
+			border: 1px solid var(--clr-border-2);
+			border-radius: var(--radius-m);
+			background-color: var(--clr-bg-1);
+			box-shadow: var(--chip-shadow);
+
+			&::before {
+				z-index: 1;
+				position: absolute;
+				top: 0;
+				left: 14px;
+				width: 2px;
+				height: 100%;
+				background-color: var(--commit-color);
+				content: '';
+			}
+		}
+	}
+
+	.draggable-commit-indicator {
 		z-index: 2;
 		flex-shrink: 0;
 		width: 10px;
@@ -280,27 +386,16 @@
 		background-color: var(--commit-color);
 	}
 
-	.draggable-commit-v3-local {
-		& .draggable-commit-v3-indicator {
+	.draggable-commit-local {
+		& .draggable-commit-indicator {
 			border-radius: 50%;
 		}
 	}
 
-	.draggable-commit-v3-remote {
-		& .draggable-commit-v3-indicator {
+	.draggable-commit-remote {
+		& .draggable-commit-indicator {
 			transform: rotate(45deg) scale(0.9);
 			border-radius: 2px;
-		}
-	}
-
-	@keyframes dropzone-scale {
-		from {
-			transform: scale(0.96);
-			opacity: 0;
-		}
-		to {
-			transform: scale(1);
-			opacity: 1;
 		}
 	}
 

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -153,11 +153,11 @@
 		align-items: center;
 
 		&.activated {
-			animation: drogchip-scale 0.23s ease forwards;
+			animation: dragchip-scale 0.23s ease forwards;
 		}
 	}
 
-	@keyframes drogchip-scale {
+	@keyframes dragchip-scale {
 		0% {
 			transform: scale(1);
 		}

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -153,7 +153,7 @@
 		align-items: center;
 
 		&.activated {
-			animation: drogchip-scale 0.2s ease forwards;
+			animation: drogchip-scale 0.23s ease forwards;
 		}
 	}
 
@@ -162,7 +162,7 @@
 			transform: scale(1);
 		}
 		50% {
-			transform: scale(1.05);
+			transform: scale(1.08);
 		}
 		100% {
 			transform: scale(1);

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -213,15 +213,14 @@ function setupDragHandlers(
 		dragStartPosition = { x: e.clientX, y: e.clientY };
 		currentMousePosition = { x: e.clientX, y: e.clientY };
 
-		// Add listeners for potential drag
-		window.addEventListener('mousemove', handleMouseMoveMaybeStart, { passive: false });
-		window.addEventListener('mouseup', handleMouseUpBeforeDrag, { passive: false });
+		// Add listeners for potential drag - using passive listeners
+		window.addEventListener('mousemove', handleMouseMoveMaybeStart);
+		window.addEventListener('mouseup', handleMouseUpBeforeDrag);
 	}
 
 	function handleMouseMoveMaybeStart(e: MouseEvent) {
 		if (!dragStartPosition || !dragHandle) return;
 
-		e.preventDefault();
 		currentMousePosition = { x: e.clientX, y: e.clientY };
 
 		// Check if moved enough to start drag
@@ -242,6 +241,7 @@ function setupDragHandlers(
 		// User released before moving enough - cancel
 		window.removeEventListener('mousemove', handleMouseMoveMaybeStart);
 		window.removeEventListener('mouseup', handleMouseUpBeforeDrag);
+
 		dragHandle = null;
 		dragStartPosition = null;
 		currentMousePosition = null;
@@ -317,8 +317,8 @@ function setupDragHandlers(
 			document.body.appendChild(clone);
 		}
 
-		// Add drag listeners
-		window.addEventListener('mousemove', handleMouseMove, { passive: false });
+		// Add drag listeners - mousemove is passive, mouseup needs passive:false for preventDefault
+		window.addEventListener('mousemove', handleMouseMove);
 		window.addEventListener('mouseup', handleMouseUp, { passive: false });
 
 		// Start position observer
@@ -328,7 +328,6 @@ function setupDragHandlers(
 	function handleMouseMove(e: MouseEvent) {
 		if (!isDragging) return;
 
-		e.preventDefault();
 		currentMousePosition = { x: e.clientX, y: e.clientY };
 
 		// Update clone position with GPU-accelerated transform
@@ -461,6 +460,7 @@ function setupDragHandlers(
 		if (newOpts.disabled) return;
 		opts = newOpts;
 
+		// Mousedown needs passive:false because we call preventDefault
 		node.addEventListener('mousedown', handleMouseDown, { passive: false });
 	}
 

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -312,7 +312,6 @@ function setupDragHandlers(
 			clone.style.transform = `translate(${e.clientX}px, ${e.clientY}px) translate(-50%, -50%)`;
 			clone.style.pointerEvents = 'none';
 			clone.style.zIndex = 'var(--z-blocker)';
-			clone.style.willChange = 'transform';
 
 			document.body.appendChild(clone);
 		}

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -151,7 +151,7 @@ function setupDragHandlers(
 				// Get chromium to fire dragover & drop events
 				// https://stackoverflow.com/questions/6481094/html5-drag-and-drop-ondragover-not-firing-in-chrome/6483205#6483205
 				e.dataTransfer?.setData('text/html', 'd'); // cannot be empty string
-				e.dataTransfer.effectAllowed = 'uninitialized';
+				e.dataTransfer.effectAllowed = 'move';
 			}
 		}
 	}

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -178,16 +178,6 @@ function setupDragHandlers(
 			clone.style.transform = `translate(${e.clientX}px, ${e.clientY}px) translate(-50%, -50%)`;
 		}
 
-		// Check if cursor is over any dropzone, clear label if not
-		if (opts?.dragStateService && e.clientX !== 0 && e.clientY !== 0) {
-			const elementUnderCursor = document.elementFromPoint(e.clientX, e.clientY);
-			const isOverDropzone = elementUnderCursor?.closest('.dropzone-target') !== null;
-
-			if (!isOverDropzone) {
-				opts.dragStateService.setDropLabel(undefined);
-			}
-		}
-
 		if (!viewport) return;
 
 		const scrollSpeed = (viewport.clientWidth || 500) / 3; // Fine-tune the scroll speed

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -48,7 +48,6 @@ export type DraggableConfig = {
 	readonly authorImgUrl?: string;
 	readonly commitType?: CommitStatusType;
 	readonly data?: DropData;
-	readonly viewportId?: string;
 	readonly chipType?: chipType;
 	readonly dropzoneRegistry: DropzoneRegistry;
 	readonly dragStateService?: DragStateService;
@@ -81,6 +80,7 @@ function setupDragHandlers(
 	let observerAnimationFrame: number | undefined;
 	const scrollIntervals = new Map<HTMLElement, ReturnType<typeof setInterval>>();
 	let currentHoveredDropzone: HTMLElement | null = null;
+	let cachedScrollContainers: HTMLElement[] = [];
 
 	// Auto-scroll detection
 	const SCROLL_EDGE_SIZE = 50;
@@ -119,9 +119,8 @@ function setupDragHandlers(
 	function handleAutoScroll(mouseX: number, mouseY: number) {
 		if (!currentMousePosition) return;
 
-		const scrollContainers = findScrollableContainers(node);
-
-		scrollContainers.forEach((container) => {
+		// Use cached scroll containers (calculated once at drag start)
+		cachedScrollContainers.forEach((container) => {
 			const rect = container.getBoundingClientRect();
 			let scrollX = 0;
 			let scrollY = 0;
@@ -238,6 +237,9 @@ function setupDragHandlers(
 		}
 
 		// Start drag state tracking
+		// Cache scrollable containers once at drag start (not on every mousemove)
+		cachedScrollContainers = findScrollableContainers(node);
+
 		if (opts.dragStateService) {
 			endDragging = opts.dragStateService.startDragging();
 		}
@@ -419,6 +421,7 @@ function setupDragHandlers(
 
 		// Reset state
 		dragHandle = null;
+		cachedScrollContainers = [];
 		dragStartPosition = null;
 		currentMousePosition = null;
 		selectedElements = [];

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -417,8 +417,10 @@ function setupDragHandlers(
 		}
 
 		// Remove listeners
-		window.removeEventListener('mousemove', handleMouseMove);
-		window.removeEventListener('mouseup', handleMouseUp);
+		if (isDragging) {
+			window.removeEventListener('mousemove', handleMouseMove);
+			window.removeEventListener('mouseup', handleMouseUp);
+		}
 		window.removeEventListener('mousemove', handleMouseMoveMaybeStart);
 		window.removeEventListener('mouseup', handleMouseUpBeforeDrag);
 

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -474,7 +474,10 @@ function setupDragHandlers(
 
 	return {
 		update(newOpts: DraggableConfig) {
-			clean();
+			// Don't clean up if a drag is in progress - let it complete first
+			if (!isDragging) {
+				clean();
+			}
 			setup(newOpts);
 		},
 		destroy() {

--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -167,10 +167,10 @@ export class Dropzone {
 		e.preventDefault();
 		if (!this.activated) return;
 
-		// For native drag events, check if we're really leaving (not just entering a child)
+		// For native drag or mouse events, check if we're really leaving (not just entering a child)
 		if ('relatedTarget' in e) {
-			const relatedTarget = (e as DragEvent).relatedTarget as HTMLElement | null;
-			if (relatedTarget && this.target.contains(relatedTarget)) {
+			const relatedTarget = (e as { relatedTarget: EventTarget | null }).relatedTarget;
+			if (relatedTarget instanceof HTMLElement && this.target.contains(relatedTarget)) {
 				return;
 			}
 		}

--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -167,12 +167,10 @@ export class Dropzone {
 		e.preventDefault();
 		if (!this.activated) return;
 
-		// For native drag or mouse events, check if we're really leaving (not just entering a child)
-		if ('relatedTarget' in e) {
-			const relatedTarget = (e as { relatedTarget: EventTarget | null }).relatedTarget;
-			if (relatedTarget instanceof HTMLElement && this.target.contains(relatedTarget)) {
-				return;
-			}
+		// For drag and mouse events, check if we're really leaving (not just entering a child)
+		const relatedTarget = e.relatedTarget as Node | null;
+		if (relatedTarget && this.target.contains(relatedTarget)) {
+			return;
 		}
 
 		this.hovered = false;

--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -23,9 +23,11 @@ export class Dropzone {
 	private target!: HTMLElement;
 	private data?: unknown;
 
-	private boundOnDrop: (e: DragEvent) => void;
-	private boundOnDragEnter: (e: DragEvent) => void;
-	private boundOnDragLeave: (e: DragEvent) => void;
+	private boundOnDrop: (e: DragEvent | MouseEvent) => void;
+	private boundOnDragEnter: (e: DragEvent | MouseEvent) => void;
+	private boundOnDragLeave: (e: DragEvent | MouseEvent) => void;
+	private boundOnMouseUp: (e: MouseEvent) => void;
+	private boundOnDragOver: (e: DragEvent) => void;
 
 	constructor(
 		private configuration: DropzoneConfiguration,
@@ -34,6 +36,8 @@ export class Dropzone {
 		this.boundOnDrop = this.onDrop.bind(this);
 		this.boundOnDragEnter = this.onDragEnter.bind(this);
 		this.boundOnDragLeave = this.onDragLeave.bind(this);
+		this.boundOnMouseUp = this.onMouseUp.bind(this);
+		this.boundOnDragOver = this.onDragOver.bind(this);
 
 		this.setTarget();
 	}
@@ -46,10 +50,9 @@ export class Dropzone {
 		this.registered = true;
 		this.registerListeners();
 
-		setTimeout(() => {
-			this.configuration.onActivationStart();
-			this.activated = true;
-		}, 10);
+		// Activate immediately for pointer-based drags (no need for setTimeout with new system)
+		this.configuration.onActivationStart();
+		this.activated = true;
 	}
 
 	reactivate(newConfig: DropzoneConfiguration) {
@@ -79,17 +82,40 @@ export class Dropzone {
 		this.hovered = false;
 	}
 
+	triggerEnter() {
+		if (!this.activated) return;
+		if (this.hovered) return; // Already hovering
+		this.hovered = true;
+		this.configuration.onHoverStart({ handler: this.acceptedHandler });
+	}
+
+	triggerLeave() {
+		if (!this.activated) return;
+		if (!this.hovered) return; // Not hovering
+		this.hovered = false;
+		this.configuration.onHoverEnd();
+	}
+
+	getTarget() {
+		return this.target;
+	}
+
 	private registerListeners() {
-		this.target.addEventListener('drop', this.boundOnDrop);
-		this.target.addEventListener('dragenter', this.boundOnDragEnter);
-		this.target.addEventListener('dragleave', this.boundOnDragLeave);
+		// Support both native drag events and pointer-based events
+		this.target.addEventListener('drop', this.boundOnDrop as EventListener);
+		this.target.addEventListener('dragenter', this.boundOnDragEnter as EventListener);
+		this.target.addEventListener('dragleave', this.boundOnDragLeave as EventListener);
+		this.target.addEventListener('dragover', this.boundOnDragOver as EventListener);
+		this.target.addEventListener('mouseup', this.boundOnMouseUp as EventListener);
 		this.registered = true;
 	}
 
 	private unregisterListeners() {
-		this.target.removeEventListener('drop', this.boundOnDrop);
-		this.target.removeEventListener('dragenter', this.boundOnDragEnter);
-		this.target.removeEventListener('dragleave', this.boundOnDragLeave);
+		this.target.removeEventListener('drop', this.boundOnDrop as EventListener);
+		this.target.removeEventListener('dragenter', this.boundOnDragEnter as EventListener);
+		this.target.removeEventListener('dragleave', this.boundOnDragLeave as EventListener);
+		this.target.removeEventListener('dragover', this.boundOnDragOver as EventListener);
+		this.target.removeEventListener('mouseup', this.boundOnMouseUp as EventListener);
 		this.registered = false;
 	}
 
@@ -103,23 +129,51 @@ export class Dropzone {
 		}
 	}
 
-	private async onDrop(e: DragEvent) {
+	private async onDrop(e: DragEvent | MouseEvent) {
 		e.preventDefault();
 		e.stopPropagation();
 		if (!this.activated) return;
 		this.acceptedHandler?.ondrop(this.data);
 	}
 
-	private onDragEnter(e: DragEvent) {
+	private onMouseUp(e: MouseEvent) {
+		// Handle drop via pointer events (mouseup)
+		if (!this.activated || !this.hovered) return;
+
+		e.preventDefault();
+		e.stopPropagation();
+
+		this.acceptedHandler?.ondrop(this.data);
+	}
+
+	private onDragOver(e: DragEvent) {
+		// Required for native drag-and-drop to work
+		if (!this.activated) return;
+		e.preventDefault();
+	}
+
+	private onDragEnter(e: DragEvent | MouseEvent) {
 		e.preventDefault();
 		if (!this.activated) return;
+
+		// Prevent duplicate hover state
+		if (this.hovered) return;
+
 		this.hovered = true;
 		this.configuration.onHoverStart({ handler: this.acceptedHandler });
 	}
 
-	private onDragLeave(e: DragEvent) {
+	private onDragLeave(e: DragEvent | MouseEvent) {
 		e.preventDefault();
 		if (!this.activated) return;
+
+		// For native drag events, check if we're really leaving (not just entering a child)
+		if ('relatedTarget' in e) {
+			const relatedTarget = (e as DragEvent).relatedTarget as HTMLElement | null;
+			if (relatedTarget && this.target.contains(relatedTarget)) {
+				return;
+			}
+		}
 
 		this.hovered = false;
 		this.configuration.onHoverEnd();

--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -141,7 +141,8 @@ export class Dropzone {
 		if (!this.activated || !this.hovered) return;
 
 		e.preventDefault();
-		e.stopPropagation();
+		// Don't call stopPropagation() here - the draggable needs the mouseup event
+		// to reach the window listener so it can clean up the drag clone
 
 		this.acceptedHandler?.ondrop(this.data);
 	}

--- a/apps/desktop/src/lib/dragging/registry.ts
+++ b/apps/desktop/src/lib/dragging/registry.ts
@@ -20,4 +20,7 @@ export class DropzoneRegistry {
 	values() {
 		return this.map.values();
 	}
+	entries() {
+		return this.map.entries();
+	}
 }

--- a/apps/desktop/src/lib/dragging/registry.ts
+++ b/apps/desktop/src/lib/dragging/registry.ts
@@ -17,6 +17,9 @@ export class DropzoneRegistry {
 	delete(key: HTMLElement) {
 		this.map.delete(key);
 	}
+	has(key: HTMLElement) {
+		return this.map.has(key);
+	}
 	values() {
 		return this.map.values();
 	}

--- a/apps/desktop/src/styles/styles.css
+++ b/apps/desktop/src/styles/styles.css
@@ -1,9 +1,9 @@
 @import '@gitbutler/ui/main.css';
 
 :root {
-	--dropzone-fill: oklch(from var(--clr-theme-pop-element) l c h / 0.1);
+	--dropzone-fill: oklch(from var(--clr-core-pop-50) l c h / 0.1);
 	--dropzone-stroke: oklch(from var(--clr-theme-pop-element) l c h / 0.8);
-	--dropzone-fill-hover: oklch(from var(--clr-theme-pop-element) l c h / 0.16);
+	--dropzone-fill-hover: oklch(from var(--clr-core-pop-50) l c h / 0.25);
 	--dropzone-stroke-hover: oklch(from var(--clr-theme-pop-element) l c h / 1);
 }
 

--- a/apps/desktop/src/styles/styles.css
+++ b/apps/desktop/src/styles/styles.css
@@ -145,7 +145,7 @@ body {
 }
 
 .dotted-pattern {
-	background-image: radial-gradient(oklch(from var(--clr-text-3) l c h / 0.13) 1px, #ffffff00 1px);
+	background-image: radial-gradient(oklch(from var(--clr-text-3) l c h / 0.18) 1px, #ffffff00 1px);
 	background-size: 5px 5px;
 }
 

--- a/packages/ui/src/lib/components/Tooltip.svelte
+++ b/packages/ui/src/lib/components/Tooltip.svelte
@@ -159,7 +159,7 @@
 	.tooltip-container {
 		display: flex;
 		display: inline-block;
-		z-index: var(--z-blocker);
+		z-index: var(--z-tooltip);
 		position: fixed;
 		flex-direction: column;
 		justify-content: center;

--- a/packages/ui/src/lib/drag/dragStateService.svelte.ts
+++ b/packages/ui/src/lib/drag/dragStateService.svelte.ts
@@ -13,9 +13,15 @@ export const DRAG_STATE_SERVICE: InjectionToken<DragStateService> = new Injectio
 export class DragStateService {
 	private dragCount = 0;
 	private readonly _isDragging = writable(false);
+	private readonly _dropLabel = writable<string | undefined>(undefined);
+	private currentDropLabel: string | undefined = undefined;
 
 	get isDragging(): Readable<boolean> {
 		return this._isDragging;
+	}
+
+	get dropLabel(): Readable<string | undefined> {
+		return this._dropLabel;
 	}
 
 	startDragging(): () => void {
@@ -30,11 +36,31 @@ export class DragStateService {
 		return () => this.endDragging();
 	}
 
+	setDropLabel(label: string | undefined): void {
+		// Cancel any pending clear
+		if (label !== this.currentDropLabel) {
+			console.warn('[DragStateService] setDropLabel called:', label);
+			this.currentDropLabel = label;
+			this._dropLabel.set(label);
+		}
+	}
+
+	clearDropLabel(labelToClear: string): void {
+		// Only clear if this label is currently set
+		if (this.currentDropLabel === labelToClear) {
+			console.warn('[DragStateService] clearDropLabel: clearing label', labelToClear);
+			this.currentDropLabel = undefined;
+			this._dropLabel.set(undefined);
+		}
+	}
+
 	private endDragging(): void {
 		this.dragCount = Math.max(0, this.dragCount - 1);
 
 		if (this.dragCount === 0) {
 			this._isDragging.set(false);
+			this._dropLabel.set(undefined);
+			this.currentDropLabel = undefined;
 		}
 	}
 }

--- a/packages/ui/src/lib/drag/dragStateService.svelte.ts
+++ b/packages/ui/src/lib/drag/dragStateService.svelte.ts
@@ -37,18 +37,13 @@ export class DragStateService {
 	}
 
 	setDropLabel(label: string | undefined): void {
-		// Cancel any pending clear
-		if (label !== this.currentDropLabel) {
-			console.warn('[DragStateService] setDropLabel called:', label);
-			this.currentDropLabel = label;
-			this._dropLabel.set(label);
-		}
+		this.currentDropLabel = label;
+		this._dropLabel.set(label);
 	}
 
 	clearDropLabel(labelToClear: string): void {
 		// Only clear if this label is currently set
 		if (this.currentDropLabel === labelToClear) {
-			console.warn('[DragStateService] clearDropLabel: clearing label', labelToClear);
 			this.currentDropLabel = undefined;
 			this._dropLabel.set(undefined);
 		}

--- a/packages/ui/src/lib/drag/dragStateService.svelte.ts
+++ b/packages/ui/src/lib/drag/dragStateService.svelte.ts
@@ -15,6 +15,7 @@ export class DragStateService {
 	private readonly _isDragging = writable(false);
 	private readonly _dropLabel = writable<string | undefined>(undefined);
 	private currentDropLabel: string | undefined = undefined;
+	private currentLabelToken: symbol | undefined = undefined;
 
 	get isDragging(): Readable<boolean> {
 		return this._isDragging;
@@ -36,15 +37,19 @@ export class DragStateService {
 		return () => this.endDragging();
 	}
 
-	setDropLabel(label: string | undefined): void {
+	setDropLabel(label: string | undefined): symbol {
+		const token = Symbol('dropLabel');
+		this.currentLabelToken = token;
 		this.currentDropLabel = label;
 		this._dropLabel.set(label);
+		return token;
 	}
 
-	clearDropLabel(labelToClear: string): void {
-		// Only clear if this label is currently set
-		if (this.currentDropLabel === labelToClear) {
+	clearDropLabel(token: symbol): void {
+		// Only clear if this token is the current one
+		if (this.currentLabelToken === token) {
 			this.currentDropLabel = undefined;
+			this.currentLabelToken = undefined;
 			this._dropLabel.set(undefined);
 		}
 	}
@@ -56,6 +61,7 @@ export class DragStateService {
 			this._isDragging.set(false);
 			this._dropLabel.set(undefined);
 			this.currentDropLabel = undefined;
+			this.currentLabelToken = undefined;
 		}
 	}
 }

--- a/packages/ui/src/lib/drag/dragStateService.svelte.ts
+++ b/packages/ui/src/lib/drag/dragStateService.svelte.ts
@@ -14,8 +14,7 @@ export class DragStateService {
 	private dragCount = 0;
 	private readonly _isDragging = writable(false);
 	private readonly _dropLabel = writable<string | undefined>(undefined);
-	private currentDropLabel: string | undefined = undefined;
-	private currentLabelToken: symbol | undefined = undefined;
+	private activeLabels = new Map<symbol, string | undefined>();
 
 	get isDragging(): Readable<boolean> {
 		return this._isDragging;
@@ -39,19 +38,24 @@ export class DragStateService {
 
 	setDropLabel(label: string | undefined): symbol {
 		const token = Symbol('dropLabel');
-		this.currentLabelToken = token;
-		this.currentDropLabel = label;
-		this._dropLabel.set(label);
+		this.activeLabels.set(token, label);
+		this.updateDropLabel();
 		return token;
 	}
 
 	clearDropLabel(token: symbol): void {
-		// Only clear if this token is the current one
-		if (this.currentLabelToken === token) {
-			this.currentDropLabel = undefined;
-			this.currentLabelToken = undefined;
-			this._dropLabel.set(undefined);
+		// Remove the token from active labels
+		if (this.activeLabels.delete(token)) {
+			this.updateDropLabel();
 		}
+	}
+
+	private updateDropLabel(): void {
+		// Get the most recently added label (Map maintains insertion order)
+		// Note: If the same token is updated, it won't change position in the Map
+		const labels = Array.from(this.activeLabels.values());
+		const currentLabel = labels.at(-1);
+		this._dropLabel.set(currentLabel);
 	}
 
 	private endDragging(): void {
@@ -60,8 +64,7 @@ export class DragStateService {
 		if (this.dragCount === 0) {
 			this._isDragging.set(false);
 			this._dropLabel.set(undefined);
-			this.currentDropLabel = undefined;
-			this.currentLabelToken = undefined;
+			this.activeLabels.clear();
 		}
 	}
 }

--- a/packages/ui/src/lib/drag/dragStateService.test.ts
+++ b/packages/ui/src/lib/drag/dragStateService.test.ts
@@ -1,0 +1,104 @@
+import { DragStateService } from '$lib/drag/dragStateService.svelte';
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+
+describe('DragStateService', () => {
+	it('should handle rapid label changes without race conditions', () => {
+		const service = new DragStateService();
+
+		// Start dragging
+		service.startDragging();
+
+		// Simulate rapid movement between dropzones
+		const token1 = service.setDropLabel('Zone A');
+		expect(get(service.dropLabel)).toBe('Zone A');
+
+		const token2 = service.setDropLabel('Zone B');
+		expect(get(service.dropLabel)).toBe('Zone B');
+
+		const token3 = service.setDropLabel('Zone C');
+		expect(get(service.dropLabel)).toBe('Zone C');
+
+		// Clear tokens in non-sequential order (simulating race condition)
+		service.clearDropLabel(token1);
+		// Label should still be 'Zone C' because token2 and token3 are still active
+		expect(get(service.dropLabel)).toBe('Zone C');
+
+		service.clearDropLabel(token3);
+		// Label should now be 'Zone B' because it's the last remaining active label
+		expect(get(service.dropLabel)).toBe('Zone B');
+
+		service.clearDropLabel(token2);
+		// Label should be undefined now
+		expect(get(service.dropLabel)).toBeUndefined();
+	});
+
+	it('should track multiple concurrent labels correctly', () => {
+		const service = new DragStateService();
+
+		service.startDragging();
+
+		// Set multiple labels
+		const tokenA = service.setDropLabel('Label A');
+		const tokenB = service.setDropLabel('Label B');
+		const tokenC = service.setDropLabel('Label C');
+
+		// Most recent label should be shown
+		expect(get(service.dropLabel)).toBe('Label C');
+
+		// Clear the most recent one
+		service.clearDropLabel(tokenC);
+		// Should fall back to the previous one
+		expect(get(service.dropLabel)).toBe('Label B');
+
+		// Clear in reverse order
+		service.clearDropLabel(tokenA);
+		// Should still show 'Label B'
+		expect(get(service.dropLabel)).toBe('Label B');
+
+		service.clearDropLabel(tokenB);
+		expect(get(service.dropLabel)).toBeUndefined();
+	});
+
+	it('should clear all labels when dragging ends', () => {
+		const service = new DragStateService();
+
+		const cleanup = service.startDragging();
+
+		const token1 = service.setDropLabel('Label 1');
+		const token2 = service.setDropLabel('Label 2');
+
+		expect(get(service.dropLabel)).toBe('Label 2');
+
+		// End dragging should clear everything
+		cleanup();
+
+		expect(get(service.dropLabel)).toBeUndefined();
+		expect(get(service.isDragging)).toBe(false);
+
+		// Clearing tokens after drag ends should be safe (no-op)
+		service.clearDropLabel(token1);
+		service.clearDropLabel(token2);
+		expect(get(service.dropLabel)).toBeUndefined();
+	});
+
+	it('should handle clearing non-existent tokens gracefully', () => {
+		const service = new DragStateService();
+
+		service.startDragging();
+
+		const token1 = service.setDropLabel('Label 1');
+		const fakeToken = Symbol('fake');
+
+		// Clearing a fake token should not affect the current label
+		service.clearDropLabel(fakeToken);
+		expect(get(service.dropLabel)).toBe('Label 1');
+
+		// Clearing the same token twice should be safe
+		service.clearDropLabel(token1);
+		expect(get(service.dropLabel)).toBeUndefined();
+
+		service.clearDropLabel(token1);
+		expect(get(service.dropLabel)).toBeUndefined();
+	});
+});

--- a/packages/ui/src/styles/core/variables.css
+++ b/packages/ui/src/styles/core/variables.css
@@ -10,7 +10,7 @@
 	--z-floating: 3;
 	--z-modal: 4;
 	--z-tooltip: 5;
-	--z-blocker: calc(infinity);
+	--z-blocker: 9999;
 
 	/* TODO: add focus color */
 	--focus-color: var(--clr-theme-pop-element);

--- a/packages/ui/src/styles/core/variables.css
+++ b/packages/ui/src/styles/core/variables.css
@@ -9,6 +9,7 @@
 	--z-lifted: 2;
 	--z-floating: 3;
 	--z-modal: 4;
+	--z-tooltip: 5;
 	--z-blocker: calc(infinity);
 
 	/* TODO: add focus color */


### PR DESCRIPTION
## Motivation:

- Improved UX for showing DND labels. Now they will always be visible.
- Improved the performance (at least for macOS). Previously, we were using native DND events to handle dragging, which was not ideal.
- Overall improved styles and the UI for DND.

Before:

https://github.com/user-attachments/assets/8aa60c7c-e2d9-44de-aaca-c8e4f945683d

After:

https://github.com/user-attachments/assets/901f3d87-70ed-4f64-84af-d4fae474bf23


---

These changes also fix the cursor flickering on start dragging:

https://github.com/user-attachments/assets/889bacdc-65c8-4fbb-a761-0f38275d9c87

---

## TODOS:

- Address in a separate PR the issue with multiple scroll zones (different lanes) when moving a file/commit
- Update branches reordering too.

---

GENERATED DESCRIPTION:

This pull request introduces improvements to the drag-and-drop user experience and codebase simplification, particularly around drag overlays, dropzone feedback, and drag clone visuals. The most significant changes include removing the unused `viewportId` prop, enhancing visual feedback during drag-and-drop operations, and refactoring how dropzone and drag state are managed and communicated between components.

**Drag-and-drop visual and interaction improvements:**

* The drag clone (`DragClone.svelte`) now displays context-sensitive action labels (such as "Assign", "Unassign", or "Uncommit") during drag-and-drop, based on the current drop target, and animates the chip when a dropzone is active. This uses the new `dragStateService` and a derived store for the drop label. [[1]](diffhunk://#diff-908130d9df4d6fb8ed3291c3371aae055d3195ea1ed04a45baa640be2c83d113R8-R9) [[2]](diffhunk://#diff-908130d9df4d6fb8ed3291c3371aae055d3195ea1ed04a45baa640be2c83d113R18-R93) [[3]](diffhunk://#diff-908130d9df4d6fb8ed3291c3371aae055d3195ea1ed04a45baa640be2c83d113R102-R112) [[4]](diffhunk://#diff-908130d9df4d6fb8ed3291c3371aae055d3195ea1ed04a45baa640be2c83d113L92-R223)
* The `CardOverlay.svelte` component no longer displays a static label; instead, it sets the drop label dynamically via the injected `dragStateService`, ensuring that the drag clone's label reflects the current drop action. [[1]](diffhunk://#diff-191b813613e920f8d0e9aa5d5eb3bc2f54754bf1cb2dc6a9f292d4945d91f280R2-R3) [[2]](diffhunk://#diff-191b813613e920f8d0e9aa5d5eb3bc2f54754bf1cb2dc6a9f292d4945d91f280R21-R36) [[3]](diffhunk://#diff-191b813613e920f8d0e9aa5d5eb3bc2f54754bf1cb2dc6a9f292d4945d91f280L38-L57) [[4]](diffhunk://#diff-191b813613e920f8d0e9aa5d5eb3bc2f54754bf1cb2dc6a9f292d4945d91f280L107-L115) [[5]](diffhunk://#diff-191b813613e920f8d0e9aa5d5eb3bc2f54754bf1cb2dc6a9f292d4945d91f280L128-L163)
* Dropzone activation and hover states are now tracked and communicated using new `onDropzoneHovered` callbacks and state variables, allowing parent components like `StackView.svelte` to respond visually when a dropzone is hovered. [[1]](diffhunk://#diff-75a2b6a34a295314f23324ef9034379f4ccaaefb7a78237bd539eeb3123939b0R17) [[2]](diffhunk://#diff-75a2b6a34a295314f23324ef9034379f4ccaaefb7a78237bd539eeb3123939b0R29) [[3]](diffhunk://#diff-75a2b6a34a295314f23324ef9034379f4ccaaefb7a78237bd539eeb3123939b0R43-R49) [[4]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L83-R86) [[5]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L132-L133) [[6]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R589-R601) [[7]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R991-R996) [[8]](diffhunk://#diff-dd81973390b31c7161fd561f46437ee4bc603510203c6798cdde9bb7653a5cc4L29-R30) [[9]](diffhunk://#diff-dd81973390b31c7161fd561f46437ee4bc603510203c6798cdde9bb7653a5cc4L42-R43) [[10]](diffhunk://#diff-dd81973390b31c7161fd561f46437ee4bc603510203c6798cdde9bb7653a5cc4R114-R117)
* Dropzone labels are now shorter and more action-oriented ("Assign", "Unassign", "Uncommit" instead of "Assign changes", etc.) for improved clarity.

**Codebase simplification and cleanup:**

* The unused `viewportId` prop has been removed from various drag-and-drop related components and their usages, reducing unnecessary props and simplifying component interfaces. [[1]](diffhunk://#diff-4719bea7c284e3942fab655243a6b3e5eb3d6fb01756da229ad02097ab89fe43L212) [[2]](diffhunk://#diff-149974f0265cdf94b6eee58ae93dd3014bed081d9fa151bb16d9db73669ca820L348) [[3]](diffhunk://#diff-0c631c84cf9ddc0a2474da7cb3847df8d4beb39ead3dae14cd9475cd3b2fa495L6) [[4]](diffhunk://#diff-35f3444ca798dbf6fda95481a686008177e18acc03d9fd806a411a8a436ff5d0L173) [[5]](diffhunk://#diff-5b9188fefc73702f5be007f9b33563f9340716a0ee0ed48b1f50a254b3695516L82)
* Minor style and variable naming fixes, including correcting a typo (`lanesSrollableEl` → `lanesScrollableEl`) and updating z-index usage for overlays. [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L542-R544) [[2]](diffhunk://#diff-02ab956bba430a50f252550577754c886891d2ba15d50c7b956aac101fd08b70L104-R104)

**Dropzone and overlay visual tweaks:**

* The `BranchLineOverlay.svelte` indicator now uses a more visible background color when dimmed, improving visual clarity. [[1]](diffhunk://#diff-c40a9f0402c8a30115fbde36d3d90310de1db60a639ae2962ba762d1ab9e6deaR63) [[2]](diffhunk://#diff-c40a9f0402c8a30115fbde36d3d90310de1db60a639ae2962ba762d1ab9e6deaL76)

These changes collectively result in a more responsive and intuitive drag-and-drop experience, cleaner component interfaces, and improved visual feedback during user interactions.