### PR TITLE
id: ensure committed file info is sorted

### DIFF
--- a/crates/but/src/id/file_info.rs
+++ b/crates/but/src/id/file_info.rs
@@ -35,6 +35,7 @@ impl FileInfo {
                 committed_files.push((*commit_id, changed_path));
             }
         }
+        committed_files.sort();
 
         let mut uncommitted_files: BTreeMap<(Option<StackId>, BString), NonEmpty<HunkAssignment>> =
             BTreeMap::new();

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -16,7 +16,7 @@ fn looks_good_and_can_be_invoked_in_various_ways_non_legacy() -> anyhow::Result<
 #[test]
 fn looks_good_and_can_be_invoked_in_various_ways() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
-    env.but(None)
+    env.but("")
         .assert()
         .success()
         .stdout_eq(snapbox::file!["snapshots/help/no-arg.stdout.term.svg"]);

--- a/crates/but/tests/but/command/snapshots/rub/committed-file-to-unassigned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/rub/committed-file-to-unassigned.stdout.term.svg
@@ -1,0 +1,25 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Uncommitted changes</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -234,12 +234,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "k0",
+                  "cliId": "n0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "l0",
+                  "cliId": "o0",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -249,12 +249,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "m0",
+                  "cliId": "k0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "n0",
+                  "cliId": "l0",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -96,12 +96,13 @@ impl Sandbox {
 
 /// Invocations
 impl Sandbox {
-    /// Create a command suitable for testing the output of the invocation with `args`.
-    /// Note that more args can be added later as well, whie `None` is a valid argument as well.
-    pub fn but<'a>(&self, args: impl Into<Option<&'a str>>) -> snapbox::cmd::Command {
-        let args = args.into();
+    /// Create a command suitable for testing the output of the invocation with `args`. If `args` is empty,
+    /// no arguments are provided.
+    /// Note that more arguments can be added to the returned [snapbox::cmd::Command] later as well.
+    pub fn but(&self, args: impl AsRef<str>) -> snapbox::cmd::Command {
+        let args = args.as_ref();
         let mut cmd = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("but"));
-        if let Some(args) = args {
+        if !args.is_empty() {
             cmd = cmd
                 .args(shell_words::split(args).expect("statically known args must split correctly"))
         }


### PR DESCRIPTION
I put this on #11588 because it depends on `id: split into modules`. (If that PR is rejected for whatever reason, I can make the same change in the old location of the code.)

---


Info about committed files will later go into a `BTreeSet` with specific ordering requirements; the caller in `mod.rs` assumes the invariants documented in `FileInfo`. In `from_workspace_commits_and_status`, sort the info so that we maintain those invariants.
