### PR TITLE
feat(gitlab): support rebase / squash merge method for MR

### DIFF
--- a/apps/desktop/src/components/MergeButton.svelte
+++ b/apps/desktop/src/components/MergeButton.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { MergeMethod } from '$lib/forge/interface/types';
+	import { inject } from '@gitbutler/core/context';
 	import { persisted, type Persisted } from '@gitbutler/shared/persisted';
 
 	import { ContextMenuItem, ContextMenuSection, DropdownButton } from '@gitbutler/ui';
@@ -25,6 +27,9 @@
 		kind = 'outline'
 	}: Props = $props();
 
+	const forge = inject(DEFAULT_FORGE_FACTORY);
+	const isGitLab = $derived(forge.current.name === 'gitlab');
+
 	function persistedAction(projectId: string): Persisted<MergeMethod> {
 		const key = 'projectMergeMethod';
 		return persisted<MergeMethod>(MergeMethod.Merge, key + projectId);
@@ -32,14 +37,28 @@
 
 	const action = persistedAction(projectId);
 
+	// If GitLab and action is rebase, reset to merge
+	$effect(() => {
+		if (isGitLab && $action === MergeMethod.Rebase) {
+			$action = MergeMethod.Merge;
+		}
+	});
+
 	let dropDown: ReturnType<typeof DropdownButton> | undefined;
 	let loading = $state(false);
 
-	const labels = {
-		[MergeMethod.Merge]: 'Merge pull request',
+	// Available merge methods based on forge type
+	const availableMethods = $derived(
+		isGitLab
+			? [MergeMethod.Merge, MergeMethod.Squash]
+			: [MergeMethod.Merge, MergeMethod.Rebase, MergeMethod.Squash]
+	);
+
+	const labels = $derived({
+		[MergeMethod.Merge]: isGitLab ? 'Merge merge request' : 'Merge pull request',
 		[MergeMethod.Rebase]: 'Rebase and merge',
 		[MergeMethod.Squash]: 'Squash and merge'
-	};
+	});
 </script>
 
 <DropdownButton
@@ -62,7 +81,7 @@
 	{labels[$action]}
 	{#snippet contextMenuSlot()}
 		<ContextMenuSection>
-			{#each Object.values(MergeMethod) as method}
+			{#each availableMethods as method}
 				<ContextMenuItem
 					label={labels[method]}
 					onclick={() => {


### PR DESCRIPTION
Hi! While using the GitLab integration, I noticed that the rebase and squash merge methods don't work.
After checking the relevant code, I found that GitButler only implements logic for direct merges and does not handle other merge methods.

I briefly reviewed the GitLab API documentation, then with the help of Claude Sonnet 4.5, I implemented support for rebase and squash when merging MRs.

All the code has gone through my own review and testing, and both the rebase and squash methods work correctly on the official GitLab instance.

Here are a few differences compared to GitHub that are worth noting:

1. Depending on the project configuration, GitLab always creates a merge commit for all merge methods, whereas a rebase merge on GitHub does not.
2. GitLab's rebase merge process consists of two asynchronous steps: first rebasing the MR branch, then performing the merge. In between, the API needs to be polled to check whether the rebase has completed.

For more details, please refer to the code comments I added.

And in advance, Merry Christmas🎄! This isn't an urgent request — feel free to leave this PR until after the holidays.

(Sorry for the delayed reply on Discord — the past two weeks have been unusually busy for me. I'll get back to it soon.)
