### PR TITLE
Experiment: act as if remote tracking refs are a target in single-branch mode

### DIFF
--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -96,8 +96,9 @@ impl Graph {
 
         let mut candidate = None;
         self.visit_all_segments_including_start_until(a, Direction::Outgoing, |s| {
+            let prune = true;
             if candidate.is_some() {
-                return true;
+                return prune;
             }
             let prune = segments_reachable_by_b.contains(&s.id);
             if prune {

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -785,7 +785,7 @@ impl Graph {
                     None
                 }
                 ComputeBaseTip::SingleBranch(_) => {
-                    // In single-branch mode, and if the checkout out branch is directly reachable from the target
+                    // In single-branch mode, and if the checkout branch is directly reachable from the target
                     // which typically is its remote, it should just be empty. Allow this for now, and see what happens.
                     self.first_commit_or_find_along_first_parent(base)
                         .map(|(c, sidx)| (c.id, sidx))
@@ -1209,7 +1209,7 @@ impl Workspace<'_> {
             .zip(self.lower_bound_segment_id)
             .is_some_and(|(segment, base)|
                 // We can go by branch ID as this also means the first commit is the one that is the base.
-                // This should be fine these kinds of stacks/segments should have at least one commit.
+                // This should be fine, as these kinds of stacks/segments should have at least one commit.
                 // There is no hard guarantee though, so let's see.
                 segment.id == base);
         if !stack_is_base {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -108,6 +108,38 @@ git init detached
   git checkout -f "$(git rev-parse HEAD)"
 )
 
+git init main-advanced-remote-advanced-two-shared
+(cd main-advanced-remote-advanced-two-shared
+  commit init
+  commit M1
+  git checkout -b soon-origin-main
+    commit RM1
+  git checkout main
+    setup_remote_tracking soon-origin-main main "move"
+    commit M2
+  add_main_remote_setup
+)
+
+git init only-remote-advanced
+(cd only-remote-advanced
+  commit init
+  commit M1
+  commit M2
+  git checkout -b soon-origin-main
+    commit RM1
+    git branch soon-other-remote
+      setup_remote_tracking soon-other-remote split-segment "move"
+    commit RM2
+  git checkout main
+    setup_remote_tracking soon-origin-main main "move"
+  add_main_remote_setup
+)
+
+cp -R only-remote-advanced only-remote-advanced-with-special-branch-name
+(cd only-remote-advanced-with-special-branch-name
+  git branch gitbutler/target :/^M1
+)
+
 # A top-down split that is highly unusual, but good to assure we can handle it.
 git init multi-root
 (cd multi-root
@@ -215,6 +247,38 @@ git init special-branches
 
 mkdir ws
 (cd ws
+  git init local-contained-and-target-ahead
+  (cd local-contained-and-target-ahead
+    commit init
+    commit M2
+    commit M3
+    create_workspace_commit_once main
+
+    git checkout -b soon-origin-main main
+      commit RM1
+    git checkout gitbutler/workspace
+    add_main_remote_setup
+    setup_remote_tracking soon-origin-main main "move"
+  )
+
+  git init local-target-and-stack
+  (cd local-target-and-stack
+      commit init
+      git checkout -b A
+        commit A1
+        commit A2
+      git checkout main
+        commit M2
+        commit M3
+    create_workspace_commit_once main A
+
+    git checkout -b soon-origin-main main~1
+      commit RM1
+    git checkout gitbutler/workspace
+    add_main_remote_setup
+    setup_remote_tracking soon-origin-main main "move"
+  )
+
   git init reproduce-11483
   (cd reproduce-11483
       commit M1

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -257,8 +257,9 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
                                 └── ·fafd9d0 (⌂|11)
     ");
 
-    // TODO: The base computation shouldn't be tricked here, and should be updated to the actual segment
-    //       which would have to be… the stack itself. We simply can't have a matching segment here
+    // TODO: We'd actually have to recognise that the `origin/split-segment` branch
+    //       isn't related to our stack and count its commits to `origin/main`.
+    //       Right now we are missing dd9f8d9.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
     └── ≡:0:main[🌳] <> origin/main →:1:⇣1

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -160,6 +160,116 @@ fn detached() -> anyhow::Result<()> {
 }
 
 #[test]
+fn main_advanced_remote_advanced() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("main-advanced-remote-advanced-two-shared")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 971953d (HEAD -> main) M2
+    | * 5d29d62 (origin/main) RM1
+    |/  
+    * ce09734 M1
+    * fafd9d0 init
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    ├── 👉►:0[0]:main[🌳] <> origin/main →:1:
+    │   └── ·971953d (⌂|1)
+    │       └── ►:2[1]:anon:
+    │           ├── ·ce09734 (⌂|11)
+    │           └── ·fafd9d0 (⌂|11)
+    └── ►:1[0]:origin/main →:0:
+        └── 🟣5d29d62 (0x0|10)
+            └── →:2:
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
+    └── ≡:0:main[🌳] <> origin/main →:1:⇡1⇣1 on ce09734
+        └── :0:main[🌳] <> origin/main →:1:⇡1⇣1
+            ├── 🟣5d29d62
+            └── ·971953d
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn only_remote_advanced() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("only-remote-advanced")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 085535d (origin/main) RM2
+    * dd9f8d9 (origin/split-segment) RM1
+    * 971953d (HEAD -> main) M2
+    * ce09734 M1
+    * fafd9d0 init
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    └── ►:1[0]:origin/main →:0:
+        └── 🟣085535d (0x0|10)
+            └── ►:2[1]:origin/split-segment
+                └── 🟣dd9f8d9 (0x0|10)
+                    └── 👉►:0[2]:main[🌳] <> origin/main →:1:
+                        ├── ·971953d (⌂|11)
+                        ├── ·ce09734 (⌂|11)
+                        └── ·fafd9d0 (⌂|11)
+    ");
+
+    // TODO: it should detect that `main` has no own commits as it's fully integrated.
+    //       This also affects the base which would have to be 085535d, the first commit.
+    //       which is strange but maybe can work?
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
+    └── ≡:0:main[🌳] <> origin/main →:1:⇣1
+        └── :0:main[🌳] <> origin/main →:1:⇣1
+            └── 🟣085535d
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
+    let (repo, meta) =
+        read_only_in_memory_scenario("only-remote-advanced-with-special-branch-name")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 085535d (origin/main) RM2
+    * dd9f8d9 (origin/split-segment) RM1
+    * 971953d (HEAD -> main) M2
+    * ce09734 (gitbutler/target) M1
+    * fafd9d0 init
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    └── ►:1[0]:origin/main →:0:
+        └── 🟣085535d (0x0|10)
+            └── ►:3[1]:origin/split-segment
+                └── 🟣dd9f8d9 (0x0|10)
+                    └── 👉►:0[2]:main[🌳] <> origin/main →:1:
+                        └── ·971953d (⌂|11)
+                            └── ►:2[3]:gitbutler/target
+                                ├── ·ce09734 (⌂|11)
+                                └── ·fafd9d0 (⌂|11)
+    ");
+
+    // TODO: The base computation shouldn't be tricked here, and should be updated to the actual segment
+    //       which would have to be… the stack itself. We simply can't have a matching segment here
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
+    └── ≡:0:main[🌳] <> origin/main →:1:⇣1
+        └── :0:main[🌳] <> origin/main →:1:⇣1
+            └── 🟣085535d
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn multi_root() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("multi-root")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -316,19 +426,18 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
 
     // 'main' is frozen because it connects to a 'foreign' remote, the commit was pushed.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:B[🌳] <> ✓!
-    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1
+    ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
+    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1 on fafd9d0
         ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
         │   ├── 🟣682be32
         │   └── ·312f819
-        ├── :2:A <> origin/A →:3:⇡1⇣1
-        │   ├── 🟣e29c23d
-        │   └── ·e255adc
-        └── :4:main
-            └── ❄fafd9d0
+        └── :2:A <> origin/A →:3:⇡1⇣1
+            ├── 🟣e29c23d
+            └── ·e255adc
     ");
 
-    // The hard limit is always respected though.
+    // The hard limit is always respected though, despite yielding an incorrect result overall.
+    // That's why it's the *hard* limit.
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(7))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
@@ -344,16 +453,12 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     └── ►:3[0]:origin/A →:2:
     ");
     // As the remotes don't connect, they are entirely unknown.
+    // And if it's weird, it's due to the hard limit
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:B[🌳] <> ✓!
-    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1
-        ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
-        │   ├── 🟣682be32
-        │   └── ·312f819
-        ├── :2:A <> origin/A →:3:⇡1
-        │   └── ·e255adc
-        └── :4:main
-            └── ·fafd9d0
+    ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
+    └── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc
+        └── :0:B[🌳] <> origin/B →:1:⇣1
+            └── 🟣682be32
     ");
 
     // Everything we encounter is checked for remotes (no limit)
@@ -387,13 +492,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
             └── →:2: (main)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:A <> ✓!
-    └── ≡:0:A <> origin/A →:1:⇡1⇣1
-        ├── :0:A <> origin/A →:1:⇡1⇣1
-        │   ├── 🟣e29c23d
-        │   └── ·e255adc
-        └── :2:main
-            └── ❄fafd9d0
+    ⌂:0:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
+    └── ≡:0:A <> origin/A →:1:⇡1⇣1 on fafd9d0
+        └── :0:A <> origin/A →:1:⇡1⇣1
+            ├── 🟣e29c23d
+            └── ·e255adc
     ");
     Ok(())
 }
@@ -687,23 +790,15 @@ fn with_limits() -> anyhow::Result<()> {
                 └── ·9d171ff (⌂|1)
                     └── →:1: (main)
     ");
-    // TODO(extra-target): we'd have to detect single-branch mode and differentiate between
-    //       integrated-by-workspace and the extra target to be able to decide that
-    //       integrated portions (see below) shouldn't be shown.
+
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳]
-        ├── :0:C[🌳]
-        │   ├── ·2a95729
-        │   ├── ·6861158
-        │   ├── ·4f1f248
-        │   └── ·487ffce
-        └── :1:main
-            ├── ·edc4dee (✓)
-            ├── ·01d0e1e (✓)
-            ├── ·4b3e5a8 (✓)
-            ├── ·34d0715 (✓)
-            └── ·eb5f731 (✓)
+    ⌂:0:C[🌳] <> ✓! on edc4dee
+    └── ≡:0:C[🌳] on edc4dee
+        └── :0:C[🌳]
+            ├── ·2a95729
+            ├── ·6861158
+            ├── ·4f1f248
+            └── ·487ffce
     ");
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -137,10 +137,9 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     let ws = graph.to_workspace()?;
     // note how the remote isn't interesting as we have no target configured, nor an extra target.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main[🌳] <> ✓!
+    ⌂:0:main[🌳] <> ✓! on 3183e43
     └── ≡:0:main[🌳]
         └── :0:main[🌳]
-            └── ·3183e43
     ");
 
     // We cannot apply remote tracking branches directly, but it resolves automatically to local tracking branches.
@@ -738,10 +737,9 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main[🌳] <> ✓!
+    ⌂:0:main[🌳] <> ✓! on 3183e43
     └── ≡:0:main[🌳]
         └── :0:main[🌳]
-            └── ·3183e43
     ");
 
     assert_eq!(
@@ -895,12 +893,10 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon:
-        ├── :0:anon:
-        │   └── ·aaa195b ►C
-        └── :1:main
-            └── ·3183e43 (✓)
+    ⌂:0:DETACHED <> ✓! on 3183e43
+    └── ≡:0:anon: on 3183e43
+        └── :0:anon:
+            └── ·aaa195b ►C
     ");
 
     let out =
@@ -1032,10 +1028,9 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main[🌳] <> ✓!
+    ⌂:0:main[🌳] <> ✓! on 85efbe4
     └── ≡:0:main[🌳]
         └── :0:main[🌳]
-            └── ·85efbe4
     ");
 
     // Apply the dependent branch, to bring in only the dependent branch
@@ -1138,10 +1133,9 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
     let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
-    ⌂:0:main[🌳] <> ✓!
+    ⌂:0:main[🌳] <> ✓! on 85efbe4
     └── ≡:0:main[🌳]
         └── :0:main[🌳]
-            └── ·85efbe4
     ");
 
     // Apply `A` first.

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -183,11 +183,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
         &*meta,
         standard_options_with_extra_target(&repo, "origin/main"),
     );
-    // With an extra target, even in this situation we have a notion of upstream commits.
-    // Thus, it's possible to compute the integration status.
-    // TODO: note that `push_status` now matches the local commit, but it's strange
-    //       that the addition of `lower_bound` removes the integration check. Probably an issue
-    //       that they are on the same segment.
+    // As we see this as base, there is no upstream commits to consider, nor is there local commits.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -184,7 +184,10 @@ fn j03_main_pushed() -> anyhow::Result<()> {
         standard_options_with_extra_target(&repo, "origin/main"),
     );
     // With an extra target, even in this situation we have a notion of upstream commits.
-    // Thus it's possible to compute the integration status.
+    // Thus, it's possible to compute the integration status.
+    // TODO: note that `push_status` now matches the local commit, but it's strange
+    //       that the addition of `lower_bound` removes the integration check. Probably an issue
+    //       that they are on the same segment.
     insta::assert_debug_snapshot!(info, @r#"
     Ok(
         RefInfo {
@@ -207,9 +210,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                             id: NodeIndex(0),
                             ref_name: "►main[🌳]",
                             remote_tracking_ref_name: "None",
-                            commits: [
-                                LocalCommit(fafd9d0, "init\n", integrated(fafd9d0)),
-                            ],
+                            commits: [],
                             commits_on_remote: [],
                             commits_outside: None,
                             metadata: "None",
@@ -224,7 +225,9 @@ fn j03_main_pushed() -> anyhow::Result<()> {
             extra_target: Some(
                 NodeIndex(0),
             ),
-            lower_bound: None,
+            lower_bound: Some(
+                NodeIndex(0),
+            ),
             is_managed_ref: false,
             is_managed_commit: false,
             ancestor_workspace_commit: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -2853,9 +2853,7 @@ fn disjoint() -> anyhow::Result<()> {
                         id: NodeIndex(0),
                         ref_name: "►disjoint[🌳]",
                         remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(32791d2, "disjoint init\n", local),
-                        ],
+                        commits: [],
                         commits_on_remote: [],
                         commits_outside: None,
                         metadata: Branch,
@@ -2870,7 +2868,9 @@ fn disjoint() -> anyhow::Result<()> {
         extra_target: Some(
             NodeIndex(1),
         ),
-        lower_bound: None,
+        lower_bound: Some(
+            NodeIndex(0),
+        ),
         is_managed_ref: false,
         is_managed_commit: false,
         ancestor_workspace_commit: None,


### PR DESCRIPTION
That way, we would automatically get a truncation of the history to display and deal with
in many cases. For example, checkout out `main` won't have to show all commits anymore, but only shows
commits that are not available on the remote, as identified by its remote tracking branch.

Inspired by a comment on Discord that of course I now can't find anymore.

### Tasks

* [x] experiment with implementation so that not everything breaks
* [x] test issues around long uninterrupted segments and the base computation being only on segment granularity
     - segment granularity is enough for workspaces that have two or more stacks, but they aren't enough for single-branch workspaces which can go on, and own the base commit, leading to incorrect 'base' computation.
     - Actually, this really needs a special case for stacks that are 'inline' of the target branch, both for single and multi-stack scenarios.
* [x] show it it works in real-world example, before + after

The single-branch workspace on `main` now sees its remote tracking branch, that it can fast-forward to, as target with which it has a base. We can now truncate such segments, which otherwise would show all commits that aren't naturally interrupted.

```
Workspace(⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2029 on 5088b25) {
    id: 0,
    kind: AdHoc,
    stacks: [
        Stack(≡:0:main[🌳] <> origin/main →:1:⇣1201) {
            segments: [
                StackSegment(:0:main[🌳] <> origin/main →:1:⇣1201) {
                    commits: [],
                    commits_on_remote: [
                        "·11e9e07",
                     ...
```

### Potential follow-ups

* In absence of a remote tracking branch, we could find the remote tracking branch of what `refs/remotes/<default-remote>/HEAD` points to.
  This would seem natural as well, but might be harder to implement as we'd have to make the traversal aware of this so it can follow
  the (then) target branch.
* In utter absence of any target, i.e. because there is no remote, be sure we limit all traversals automatically.
