### PR TITLE
Make it clear when the graph traversal is stopped early due to hard limit

### DIFF
--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -363,6 +363,11 @@ pub(crate) mod function {
         opts: super::Options,
     ) -> anyhow::Result<RefInfo> {
         let graph = Graph::from_head(repo, meta, opts.traversal.clone())?;
+        if graph.hard_limit_hit() {
+            tracing::warn!(hard_limit=?opts.traversal.hard_limit,
+                "Commit-graph traversal might be incorrect as it was stopped too early due to hard limit",
+            );
+        }
         graph_to_ref_info(graph, repo, opts)
     }
 


### PR DESCRIPTION
Or else it's very confusing if the UI doesn't show what it should and various debugging tools show things correctly.
