### PR TITLE
fix: no-relative-imports fails with windows paths

### DIFF
--- a/packages/no-relative-imports/src/noRelativeImportPaths.ts
+++ b/packages/no-relative-imports/src/noRelativeImportPaths.ts
@@ -21,21 +21,21 @@ type TsConfig = {
  * Takes a file or directory path and tries to find the nearest tsconfig.json.
  */
 function findTsConfigDirectory(absolutePath: string): string | undefined {
-	const pathSegments = absolutePath.split('/').slice(1);
+	let current = path.resolve(absolutePath);
 
-	while (pathSegments.length > 0) {
-		const configPath = '/' + path.join(...pathSegments, 'tsconfig.json');
+	while (true) {
+		const configPath = path.join(current, 'tsconfig.json');
 		try {
 			const configStat = statSync(configPath);
-			if (configStat.isFile()) break;
+			if (configStat.isFile()) return current;
 		} catch (_) {
 			/* empty */
 		}
 
-		pathSegments.pop();
+		const parent = path.dirname(current);
+		if (parent === current) return;
+		current = parent;
 	}
-	if (pathSegments.length === 0) return;
-	return '/' + path.join(...pathSegments);
 }
 
 /**

--- a/packages/no-relative-imports/src/paths.ts
+++ b/packages/no-relative-imports/src/paths.ts
@@ -1,6 +1,13 @@
 import path from 'node:path';
 
 /**
+ * Normalize paths across platforms.
+ */
+export function normalize(p: string) {
+	return path.normalize(p).replace(/\\/g, '/');
+}
+
+/**
  * Checks whether a path entry ends in a glob.
  *
  * The wildcard * can be used in any part of the key and values, but this is a
@@ -41,10 +48,11 @@ export class PathEntry {
 		// The target is defined as being relative to the tsconfig's directory.
 		// When it comes to matching, it's easier to work on the absolute
 		// version instead.
-		this.absoluteTarget = path.normalize(path.join(configDirectory, target));
+		this.absoluteTarget = normalize(path.join(configDirectory, target));
 	}
 
 	tryAliasImport(absoluteImportPath: string): string | undefined {
+		const importPath = normalize(absoluteImportPath);
 		if (hasWildcard(this.absoluteTarget)) {
 			// If the target is a glob, we want to see if the import
 			// starts with the target path. If it does, we then want
@@ -52,9 +60,9 @@ export class PathEntry {
 			// and replace it with the key.
 			const deglobbedPath = removeGlob(this.absoluteTarget);
 
-			if (absoluteImportPath.startsWith(deglobbedPath)) {
+			if (importPath.startsWith(deglobbedPath)) {
 				if (hasWildcard(this.key)) {
-					let newPath = absoluteImportPath.replace(deglobbedPath, '');
+					let newPath = importPath.replace(deglobbedPath, '');
 					newPath = removeGlob(this.key) + newPath;
 					return newPath;
 				} else {
@@ -64,7 +72,7 @@ export class PathEntry {
 		} else {
 			// If the target is not a glob, then we can directly
 			// replace the import with the alias.
-			if (absoluteImportPath === this.absoluteTarget) {
+			if (importPath === this.absoluteTarget) {
 				return this.key;
 			}
 		}


### PR DESCRIPTION
I use Windows, and I just cloned the repo, install, ran the test script, and it failed.

So I fixed some hardcoded forward slashes by using node:path.

Now every test passes locally