### PR TITLE
feat-drag-targeted-autoscroll

### DIFF
--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -149,6 +149,7 @@
 <div
 	class="scrollbar-container hide-native-scrollbar"
 	role="presentation"
+	data-scrollable-for-dragging
 	bind:this={lanesScrollableEl}
 	bind:clientWidth={lanesScrollableWidth}
 	bind:clientHeight={lanesScrollableHeight}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -565,7 +565,7 @@
 			</div>
 		{/snippet}
 		{#snippet children([branches, hasRulesToClear])}
-			<ConfigurableScrollableContainer childrenWrapHeight="100%">
+			<ConfigurableScrollableContainer childrenWrapHeight="100%" enableDragScroll>
 				<div
 					class="stack-view"
 					class:details-open={isDetailsViewOpen}
@@ -778,6 +778,7 @@
 														<ConfigurableScrollableContainer
 															zIndex="var(--z-lifted)"
 															bind:viewport={selectionPreviewScrollContainer}
+															enableDragScroll
 														>
 															{@render assignedChangePreview(assignedStackId)}
 														</ConfigurableScrollableContainer>
@@ -838,6 +839,7 @@
 													<ConfigurableScrollableContainer
 														zIndex="var(--z-lifted)"
 														bind:viewport={selectionPreviewScrollContainer}
+														enableDragScroll
 													>
 														{@render assignedChangePreview(assignedStackId)}
 													</ConfigurableScrollableContainer>

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -151,6 +151,7 @@
 				onscrollTop={(visible) => {
 					scrollTopIsVisible = visible;
 				}}
+				enableDragScroll={mode === 'assigned'}
 			>
 				{@render fileList()}
 			</ScrollableContainer>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -25,6 +25,7 @@
 		viewportHeight?: number;
 		childrenWrapHeight?: string;
 		childrenWrapDisplay?: 'block' | 'contents' | 'flex'; // 'contents' is used for virtual lists to avoid unnecessary height calculations
+		enableDragScroll?: boolean; // Enable auto-scroll when dragging elements
 	}
 </script>
 
@@ -52,7 +53,8 @@
 		viewport = $bindable(),
 		viewportHeight = $bindable(),
 		childrenWrapHeight,
-		childrenWrapDisplay = 'block'
+		childrenWrapDisplay = 'block',
+		enableDragScroll = false
 	}: ScrollableProps = $props();
 
 	let scrollTopVisible = $state<boolean>(true);
@@ -145,6 +147,7 @@
 		style:--overflow-x={horz ? 'auto' : 'hidden'}
 		style:--overflow-y={horz ? 'hidden' : 'auto'}
 		style:--flex-direction={horz ? 'row' : 'column'}
+		data-scrollable-for-dragging={enableDragScroll || undefined}
 	>
 		<div
 			style:min-height={childrenWrapHeight}


### PR DESCRIPTION
https://github.com/user-attachments/assets/9b1e8521-7486-48ce-8273-c978bd6c9b52


---

This pull request improves the drag-and-drop experience by making scrolling during drag operations more reliable and configurable. It introduces a new `enableDragScroll` prop to scrollable containers, updates the drag handler logic to better detect and prioritize scrollable containers under the cursor, and applies these enhancements throughout the UI where appropriate.

**Drag-and-drop scrolling improvements:**

* Added an `enableDragScroll` prop to `ScrollableContainer` and `ConfigurableScrollableContainer` components, allowing auto-scroll during dragging to be enabled on a per-instance basis. (`packages/ui/src/lib/components/scroll/ScrollableContainer.svelte` [[1]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cR28) [[2]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cL55-R57) [[3]](diffhunk://#diff-e28711311673448a29abb261ba1f36b7339af55817ec9493b98be1c223b28e7cR150)
* Updated the drag handler logic in `draggable.ts` to:
  * Mark scrollable containers with a `data-scrollable-for-dragging` attribute when `enableDragScroll` is set. (`apps/desktop/src/components/MultiStackView.svelte` [apps/desktop/src/components/MultiStackView.svelteR152](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864R152))
  * Detect all eligible scrollable containers, including those explicitly marked and those in the parent chain, and cache their bounding rectangles for efficient hit-testing. (`apps/desktop/src/lib/dragging/draggable.ts` [apps/desktop/src/lib/dragging/draggable.tsR94-L123](diffhunk://#diff-5e11dd7c375087e7cb6466abef240f680d3fa651761ca01b5bd529b2fc310001R94-L123))
  * Scroll only the innermost scrollable container under the cursor during a drag, preventing multiple nested containers from scrolling simultaneously. (`apps/desktop/src/lib/dragging/draggable.ts` [apps/desktop/src/lib/dragging/draggable.tsL157-L191](diffhunk://#diff-5e11dd7c375087e7cb6466abef240f680d3fa651761ca01b5bd529b2fc310001L157-L191))

**Component updates to enable drag-scrolling:**

* Enabled the new drag-scroll behavior in key UI components by passing `enableDragScroll`:
  * `StackView.svelte` for main and preview containers. (`apps/desktop/src/components/StackView.svelte` [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L568-R568) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R781) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R842)
  * `WorktreeChanges.svelte` when in assigned mode. (`apps/desktop/src/components/WorktreeChanges.svelte` [apps/desktop/src/components/WorktreeChanges.svelteR154](diffhunk://#diff-dd81973390b31c7161fd561f46437ee4bc603510203c6798cdde9bb7653a5cc4R154))