### PR TITLE
fix: ctrl + a to select files on windows

### DIFF
--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -225,6 +225,7 @@
 
 		return updateSelection({
 			allowMultiple: true,
+			ctrlKey: e.ctrlKey,
 			metaKey: e.metaKey,
 			shiftKey: e.shiftKey,
 			key: e.key,

--- a/apps/desktop/src/lib/selection/fileSelectionUtils.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionUtils.ts
@@ -54,6 +54,7 @@ function getBottomFile(
 
 interface UpdateSelectionParams {
 	allowMultiple: boolean;
+	ctrlKey: boolean;
 	metaKey: boolean;
 	shiftKey: boolean;
 	key: string;
@@ -67,6 +68,7 @@ interface UpdateSelectionParams {
 
 export function updateSelection({
 	allowMultiple,
+	ctrlKey,
 	metaKey,
 	shiftKey,
 	key,
@@ -115,10 +117,10 @@ export function updateSelection({
 	}
 
 	switch (key) {
-		// To support either Cmd+a or Cmd+shift+a?
+		// Cmd+A on Mac, Ctrl+A on Windows/Linux
 		case 'a':
 		case 'A':
-			if (allowMultiple && metaKey) {
+			if (allowMultiple && (metaKey || ctrlKey)) {
 				preventDefault();
 
 				for (let i = 0; i < files.length; i++) {


### PR DESCRIPTION
When selecting all files with the keybind it only checked `metaKey`, so on Windows only `ctrl + win + a` worked.

This change makes `ctrl + a` work too.