### PR TITLE
Unify uncommitted file and hunk CLI IDs

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -12,7 +12,10 @@ use but_hunk_dependency::ui::HunkDependencies;
 use colored::Colorize;
 use gitbutler_project::Project;
 
-use crate::{CliId, IdMap, command::legacy::rub::parse_sources, utils::OutputChannel};
+use crate::{
+    CliId, IdMap, command::legacy::rub::parse_sources, id::UncommittedFileCliId,
+    utils::OutputChannel,
+};
 
 /// Amends changes into the appropriate commits where they belong.
 ///
@@ -50,9 +53,9 @@ pub(crate) fn handle(
 
     if let Some(source) = source {
         match source {
-            CliId::UncommittedFile {
+            CliId::UncommittedFile(UncommittedFileCliId {
                 hunk_assignments, ..
-            } => {
+            }) => {
                 // Absorb this particular file
                 absorb_assignments(
                     project,

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -13,8 +13,7 @@ use colored::Colorize;
 use gitbutler_project::Project;
 
 use crate::{
-    CliId, IdMap, command::legacy::rub::parse_sources, id::UncommittedFileCliId,
-    utils::OutputChannel,
+    CliId, IdMap, command::legacy::rub::parse_sources, id::UncommittedCliId, utils::OutputChannel,
 };
 
 /// Amends changes into the appropriate commits where they belong.
@@ -42,7 +41,7 @@ pub(crate) fn handle(
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {
             s.into_iter().find(|s| {
-                matches!(s, CliId::UncommittedFile { .. }) || matches!(s, CliId::Branch { .. })
+                matches!(s, CliId::Uncommitted { .. }) || matches!(s, CliId::Branch { .. })
             })
         });
 
@@ -53,7 +52,7 @@ pub(crate) fn handle(
 
     if let Some(source) = source {
         match source {
-            CliId::UncommittedFile(UncommittedFileCliId {
+            CliId::Uncommitted(UncommittedCliId {
                 hunk_assignments, ..
             }) => {
                 // Absorb this particular file

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -4,22 +4,23 @@ use but_hunk_assignment::HunkAssignment;
 use but_workspace::commit_engine::{self, CreateCommitOutcome};
 use colored::Colorize;
 use gix::ObjectId;
-use nonempty::NonEmpty;
 
 use super::assign::branch_name_to_stack_id;
-use crate::utils::OutputChannel;
+use crate::{id::UncommittedCliId, utils::OutputChannel};
 
-pub(crate) fn file_to_commit(
+pub(crate) fn uncommitted_to_commit(
     ctx: &mut Context,
-    hunk_assignments: NonEmpty<HunkAssignment>,
+    uncommitted_cli_id: UncommittedCliId,
     oid: &ObjectId,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let first_hunk_assignment = hunk_assignments.first();
-    let path = first_hunk_assignment.path_bytes.clone();
+    let description = uncommitted_cli_id.describe();
+
+    let first_hunk_assignment = uncommitted_cli_id.hunk_assignments.first();
     let stack_id = first_hunk_assignment.stack_id;
 
-    let diff_specs: Vec<DiffSpec> = hunk_assignments
+    let diff_specs: Vec<DiffSpec> = uncommitted_cli_id
+        .hunk_assignments
         .into_iter()
         .map(|assignment: HunkAssignment| assignment.into())
         .collect();
@@ -33,7 +34,7 @@ pub(crate) fn file_to_commit(
         })
         .unwrap_or_default();
     if let Some(out) = out.for_human() {
-        writeln!(out, "Amended {} → {}", path.to_string().bold(), new_commit)?;
+        writeln!(out, "Amended {} → {}", description, new_commit)?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -16,7 +16,7 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::{CliId, IdMap, id::UncommittedFileCliId, utils::OutputChannel};
+use crate::{CliId, IdMap, utils::OutputChannel};
 
 pub(crate) fn handle(
     project: &Project,
@@ -31,32 +31,17 @@ pub(crate) fn handle(
 
     for source in sources {
         match (source, &target) {
-            (
-                CliId::UncommittedFile(UncommittedFileCliId {
-                    hunk_assignments, ..
-                }),
-                CliId::Unassigned { .. },
-            ) => {
+            (CliId::Uncommitted(uncommitted_cli_id), CliId::Unassigned { .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
-                assign::unassign_file(ctx, hunk_assignments, out)?;
+                assign::unassign_uncommitted(ctx, uncommitted_cli_id, out)?;
             }
-            (
-                CliId::UncommittedFile(UncommittedFileCliId {
-                    hunk_assignments, ..
-                }),
-                CliId::Commit(oid),
-            ) => {
+            (CliId::Uncommitted(uncommitted_cli_id), CliId::Commit(oid)) => {
                 create_snapshot(ctx, OperationKind::AmendCommit);
-                amend::file_to_commit(ctx, hunk_assignments, oid, out)?;
+                amend::uncommitted_to_commit(ctx, uncommitted_cli_id, oid, out)?;
             }
-            (
-                CliId::UncommittedFile(UncommittedFileCliId {
-                    hunk_assignments, ..
-                }),
-                CliId::Branch { name, .. },
-            ) => {
+            (CliId::Uncommitted(uncommitted_cli_id), CliId::Branch { name, .. }) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
-                assign::assign_file_to_branch(ctx, hunk_assignments, name, out)?;
+                assign::assign_uncommitted_to_branch(ctx, uncommitted_cli_id, name, out)?;
             }
             (CliId::Unassigned { .. }, CliId::Commit(oid)) => {
                 create_snapshot(ctx, OperationKind::AmendCommit);
@@ -128,24 +113,6 @@ pub(crate) fn handle(
             ) => {
                 create_snapshot(ctx, OperationKind::FileChanges);
                 commits::uncommit_file(ctx, path.as_ref(), commit_oid, None, out)?;
-            }
-            (
-                CliId::UncommittedHunk {
-                    hunk_header, path, ..
-                },
-                CliId::Unassigned { .. },
-            ) => {
-                create_snapshot(ctx, OperationKind::MoveHunk);
-                assign::unassign_hunk(ctx, hunk_header, path.as_ref(), out)?;
-            }
-            (
-                CliId::UncommittedHunk {
-                    hunk_header, path, ..
-                },
-                CliId::Branch { name, .. },
-            ) => {
-                create_snapshot(ctx, OperationKind::MoveHunk);
-                assign::assign_hunk_to_branch(ctx, hunk_header, path.as_ref(), name, out)?;
             }
             (source, target) => {
                 bail!(makes_no_sense_error(&source, target))

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -16,7 +16,7 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 
-use crate::{CliId, IdMap, utils::OutputChannel};
+use crate::{CliId, IdMap, id::UncommittedFileCliId, utils::OutputChannel};
 
 pub(crate) fn handle(
     project: &Project,
@@ -32,27 +32,27 @@ pub(crate) fn handle(
     for source in sources {
         match (source, &target) {
             (
-                CliId::UncommittedFile {
+                CliId::UncommittedFile(UncommittedFileCliId {
                     hunk_assignments, ..
-                },
+                }),
                 CliId::Unassigned { .. },
             ) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);
                 assign::unassign_file(ctx, hunk_assignments, out)?;
             }
             (
-                CliId::UncommittedFile {
+                CliId::UncommittedFile(UncommittedFileCliId {
                     hunk_assignments, ..
-                },
+                }),
                 CliId::Commit(oid),
             ) => {
                 create_snapshot(ctx, OperationKind::AmendCommit);
                 amend::file_to_commit(ctx, hunk_assignments, oid, out)?;
             }
             (
-                CliId::UncommittedFile {
+                CliId::UncommittedFile(UncommittedFileCliId {
                     hunk_assignments, ..
-                },
+                }),
                 CliId::Branch { name, .. },
             ) => {
                 create_snapshot(ctx, OperationKind::MoveHunk);

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -17,7 +17,7 @@ use crate::id::{
     stacks_info::StacksInfo,
 };
 use bstr::{BStr, BString, ByteSlice};
-use but_core::{HunkHeader, ref_metadata::StackId};
+use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
 use but_workspace::branch::Stack;
@@ -263,14 +263,17 @@ impl IdMap {
             });
         }
 
-        for hunk_assignment in hunk_assignments {
-            self.uncommitted_hunks.insert(
-                self.id_usage.next_available()?.to_short_id(),
-                UncommittedHunk {
-                    hunk_header: hunk_assignment.hunk_header,
-                    path: hunk_assignment.path_bytes,
-                },
-            );
+        for uncommitted_file in self.uncommitted_files.values() {
+            if uncommitted_file.hunk_assignments.len() > 1 {
+                for hunk_assignment in uncommitted_file.hunk_assignments.iter() {
+                    self.uncommitted_hunks.insert(
+                        self.id_usage.next_available()?.to_short_id(),
+                        UncommittedHunk {
+                            hunk_assignment: hunk_assignment.clone(),
+                        },
+                    );
+                }
+            }
         }
 
         Ok(())
@@ -338,11 +341,11 @@ impl IdMap {
             });
         }
         if let Some(uncommitted_hunk) = self.uncommitted_hunks.get(entity) {
-            matches.push(CliId::UncommittedHunk {
-                hunk_header: uncommitted_hunk.hunk_header,
-                path: uncommitted_hunk.path.clone(),
+            matches.push(CliId::Uncommitted(UncommittedCliId {
                 id: entity.to_string(),
-            });
+                hunk_assignments: NonEmpty::new(uncommitted_hunk.hunk_assignment.clone()),
+                is_entire_file: false,
+            }));
         }
         if entity.bytes().all(|c| c == b'0') {
             matches.push(self.unassigned.clone());
@@ -427,13 +430,41 @@ impl IdMap {
     }
 }
 
-/// An uncommitted file in the worktree.
+/// An uncommitted file or hunk in the worktree.
 #[derive(Debug, Clone)]
-pub struct UncommittedFileCliId {
+pub struct UncommittedCliId {
     /// The short CLI ID for this file (typically 2 characters)
     pub id: ShortId,
     /// The hunk assignments
     pub hunk_assignments: NonEmpty<HunkAssignment>,
+    /// True iff self represents all hunks in a (stack assignment, file) pair.
+    /// Note that this file may have hunks with other stack assignments.
+    pub is_entire_file: bool,
+}
+impl UncommittedCliId {
+    /// Describes self.
+    pub fn describe(&self) -> String {
+        let hunk_cardinality = if self.is_entire_file {
+            if self.hunk_assignments.len() == 1 {
+                "the only hunk"
+            } else {
+                "all hunks"
+            }
+        } else {
+            "a hunk"
+        };
+        let assignment = if self.hunk_assignments.first().stack_id.is_some() {
+            "a stack"
+        } else {
+            "the unassigned area"
+        };
+        format!(
+            "{} in {} in {}",
+            hunk_cardinality,
+            self.hunk_assignments.first().path_bytes,
+            assignment
+        )
+    }
 }
 
 /// A user-friendly CLI ID that identifies a GitButler entity,
@@ -445,8 +476,8 @@ pub struct UncommittedFileCliId {
 /// to find it.
 #[derive(Debug, Clone)]
 pub enum CliId {
-    /// An uncommitted file in the worktree.
-    UncommittedFile(UncommittedFileCliId),
+    /// An uncommitted file or hunk in the worktree.
+    Uncommitted(UncommittedCliId),
     /// A file that exists in a commit.
     CommittedFile {
         /// The object ID of the commit containing the change to the file
@@ -454,15 +485,6 @@ pub enum CliId {
         /// The file path relative to the repository root
         path: BString,
         /// The short CLI ID for this file (typically 2 characters)
-        id: ShortId,
-    },
-    /// An uncommitted hunk.
-    UncommittedHunk {
-        /// Same as [HunkAssignment::hunk_header].
-        hunk_header: Option<HunkHeader>,
-        /// Same as [HunkAssignment::path_bytes].
-        path: BString,
-        /// The short CLI ID for this hunk (typically 2 characters)
         id: ShortId,
     },
     /// A branch.
@@ -487,13 +509,10 @@ impl PartialEq for CliId {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (
-                Self::UncommittedFile(UncommittedFileCliId { id: l_id, .. }),
-                Self::UncommittedFile(UncommittedFileCliId { id: r_id, .. }),
+                Self::Uncommitted(UncommittedCliId { id: l_id, .. }),
+                Self::Uncommitted(UncommittedCliId { id: r_id, .. }),
             ) => l_id == r_id,
             (Self::CommittedFile { id: l_id, .. }, Self::CommittedFile { id: r_id, .. }) => {
-                l_id == r_id
-            }
-            (Self::UncommittedHunk { id: l_id, .. }, Self::UncommittedHunk { id: r_id, .. }) => {
                 l_id == r_id
             }
             (Self::Branch { id: l_id, .. }, Self::Branch { id: r_id, .. }) => l_id == r_id,
@@ -510,9 +529,8 @@ impl CliId {
     /// Returns a human-readable description of the entity type.
     pub fn kind_for_humans(&self) -> &'static str {
         match self {
-            CliId::UncommittedFile { .. } => "an uncommitted file",
+            CliId::Uncommitted { .. } => "an uncommitted file or hunk",
             CliId::CommittedFile { .. } => "a committed file",
-            CliId::UncommittedHunk { .. } => "an uncommitted hunk",
             CliId::Branch { .. } => "a branch",
             CliId::Commit { .. } => "a commit",
             CliId::Unassigned { .. } => "the unassigned area",
@@ -522,9 +540,8 @@ impl CliId {
     /// Returns the short ID string for display to users.
     pub fn to_short_string(&self) -> ShortId {
         match self {
-            CliId::UncommittedFile(UncommittedFileCliId { id, .. })
+            CliId::Uncommitted(UncommittedCliId { id, .. })
             | CliId::CommittedFile { id, .. }
-            | CliId::UncommittedHunk { id, .. }
             | CliId::Branch { id, .. }
             | CliId::Unassigned { id, .. } => id.clone(),
             // TODO: make this so we can't display prefixes that are ambiguous.
@@ -552,9 +569,10 @@ impl UncommittedFile {
     }
     /// Turn this instance into a [CliId], using `id` for identification.
     pub fn to_cli_id(&self, id: ShortId) -> CliId {
-        CliId::UncommittedFile(UncommittedFileCliId {
+        CliId::Uncommitted(UncommittedCliId {
             hunk_assignments: self.hunk_assignments.clone(),
             id,
+            is_entire_file: true,
         })
     }
 }
@@ -589,6 +607,5 @@ impl Borrow<str> for CommittedFile {
 
 #[derive(Debug)]
 struct UncommittedHunk {
-    hunk_header: Option<HunkHeader>,
-    path: BString,
+    hunk_assignment: HunkAssignment,
 }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -321,15 +321,15 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
     branches: [ h0 ]
     uncommitted_files: [ g0, i0 ]
     committed_files: [ j0, k0 ]
-    uncommitted_hunks: [ l0, m0, n0 ]
+    uncommitted_hunks: [ l0, m0 ]
     ");
     insta::assert_debug_snapshot!(id_map.all_ids(), @r#"
     [
         Commit(
             Sha1(0202020202020202020202020202020202020202),
         ),
-        UncommittedFile(
-            UncommittedFileCliId {
+        Uncommitted(
+            UncommittedCliId {
                 id: "g0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
@@ -361,14 +361,15 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                         },
                     ],
                 },
+                is_entire_file: true,
             },
         ),
         Branch {
             name: "h0",
             id: "h0",
         },
-        UncommittedFile(
-            UncommittedFileCliId {
+        Uncommitted(
+            UncommittedCliId {
                 id: "i0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
@@ -384,6 +385,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                     },
                     tail: [],
                 },
+                is_entire_file: true,
             },
         ),
         CommittedFile {
@@ -396,25 +398,50 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
             path: "committed2.txt",
             id: "k0",
         },
-        UncommittedHunk {
-            hunk_header: Some(
-                HunkHeader("-1,2", "+1,2"),
-            ),
-            path: "uncommitted1.txt",
-            id: "l0",
-        },
-        UncommittedHunk {
-            hunk_header: Some(
-                HunkHeader("-3,2", "+3,2"),
-            ),
-            path: "uncommitted1.txt",
-            id: "m0",
-        },
-        UncommittedHunk {
-            hunk_header: None,
-            path: "uncommitted2.txt",
-            id: "n0",
-        },
+        Uncommitted(
+            UncommittedCliId {
+                id: "l0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        Uncommitted(
+            UncommittedCliId {
+                id: "m0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-3,2", "+3,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
     ]
     "#);
 
@@ -441,7 +468,6 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     branches: [ h0 ]
     uncommitted_files: [ g0 ]
     committed_files: [ i0 ]
-    uncommitted_hunks: [ j0 ]
     ");
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("0a")?, @r"
@@ -473,8 +499,8 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("g0")?, @r#"
     [
-        UncommittedFile(
-            UncommittedFileCliId {
+        Uncommitted(
+            UncommittedCliId {
                 id: "g0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
@@ -490,6 +516,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
                     },
                     tail: [],
                 },
+                is_entire_file: true,
             },
         ),
     ]

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -328,26 +328,14 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         Commit(
             Sha1(0202020202020202020202020202020202020202),
         ),
-        UncommittedFile {
-            hunk_assignments: NonEmpty {
-                head: HunkAssignment {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    stack_id: None,
-                    hunk_locks: None,
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
-                },
-                tail: [
-                    HunkAssignment {
+        UncommittedFile(
+            UncommittedFileCliId {
+                id: "g0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
                         id: None,
                         hunk_header: Some(
-                            HunkHeader("-3,2", "+3,2"),
+                            HunkHeader("-1,2", "+1,2"),
                         ),
                         path: "",
                         path_bytes: "uncommitted1.txt",
@@ -357,31 +345,47 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                         line_nums_removed: None,
                         diff: None,
                     },
-                ],
+                    tail: [
+                        HunkAssignment {
+                            id: None,
+                            hunk_header: Some(
+                                HunkHeader("-3,2", "+3,2"),
+                            ),
+                            path: "",
+                            path_bytes: "uncommitted1.txt",
+                            stack_id: None,
+                            hunk_locks: None,
+                            line_nums_added: None,
+                            line_nums_removed: None,
+                            diff: None,
+                        },
+                    ],
+                },
             },
-            id: "g0",
-        },
+        ),
         Branch {
             name: "h0",
             id: "h0",
         },
-        UncommittedFile {
-            hunk_assignments: NonEmpty {
-                head: HunkAssignment {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted2.txt",
-                    stack_id: None,
-                    hunk_locks: None,
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+        UncommittedFile(
+            UncommittedFileCliId {
+                id: "i0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
                 },
-                tail: [],
             },
-            id: "i0",
-        },
+        ),
         CommittedFile {
             commit_id: Sha1(0202020202020202020202020202020202020202),
             path: "committed1.txt",
@@ -469,23 +473,25 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("g0")?, @r#"
     [
-        UncommittedFile {
-            hunk_assignments: NonEmpty {
-                head: HunkAssignment {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted.txt",
-                    stack_id: None,
-                    hunk_locks: None,
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+        UncommittedFile(
+            UncommittedFileCliId {
+                id: "g0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
                 },
-                tail: [],
             },
-            id: "g0",
-        },
+        ),
     ]
     "#);
     assert_eq!(

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -1,0 +1,131 @@
+use crate::utils::Sandbox;
+use snapbox::str;
+
+#[test]
+fn uncommitted_file() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    env.setup_metadata(&["A", "B"])?;
+
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    env.but("absorb i0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::file![
+            "snapshots/absorb/uncommitted-file.stdout.term.svg"
+        ])
+        .stderr_eq(str![""]);
+
+    // Change was absorbed
+    let repo = env.open_repo()?;
+    let mut blob = repo.find_blob(repo.rev_parse_single(b"A:a.txt")?)?;
+    insta::assert_snapshot!(String::from_utf8(blob.take_data())?, @r"
+    firsta
+    line
+    line
+    line
+    line
+    line
+    line
+    line
+    lasta
+    ");
+
+    // Status is clean
+    env.but("--json status -f")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "unassignedChanges": [],
+...
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn uncommitted_hunk() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    // Must set metadata to match the scenario
+    env.setup_metadata(&["A", "B"])?;
+
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    // TODO When we have a way to list the hunks and their respective IDs (e.g.
+    //      via a "diff" or "show" command), assert that m0 is the hunk we want.
+    env.but("absorb m0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::file![
+            "snapshots/absorb/uncommitted-hunk.stdout.term.svg"
+        ])
+        .stderr_eq(str![""]);
+
+    // Change was partially absorbed
+    let repo = env.open_repo()?;
+    let mut blob = repo.find_blob(repo.rev_parse_single(b"A:a.txt")?)?;
+    insta::assert_snapshot!(String::from_utf8(blob.take_data())?, @r"
+    firsta
+    line
+    line
+    line
+    line
+    line
+    line
+    line
+    last
+    ");
+
+    // Status is not clean
+    env.but("--json status -f")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "unassignedChanges": [
+    {
+      "cliId": "i0",
+      "filePath": "a.txt",
+      "changeType": "modified"
+    }
+  ],
+...
+
+"#]]);
+
+    Ok(())
+}
+
+mod util {
+    use crate::utils::Sandbox;
+
+    /// Create a file with `filename`, commit it to `branch`, then edit it once more to have two uncommitted hunks.
+    pub fn commit_file_with_worktree_changes_as_two_hunks(
+        env: &Sandbox,
+        branch: &str,
+        filename: &str,
+    ) {
+        let context_distance = (env.app_settings().context_lines * 2 + 1) as usize;
+        env.file(
+            filename,
+            format!("first\n{}last\n", "line\n".repeat(context_distance)),
+        );
+        env.but(format!("commit {branch} -m {filename}"))
+            .assert()
+            .success();
+        env.file(
+            filename,
+            format!("firsta\n{}lasta\n", "line\n".repeat(context_distance)),
+        );
+    }
+}
+use crate::command::absorb::util::commit_file_with_worktree_changes_as_two_hunks;

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -1,6 +1,8 @@
 //! Put command-specific tests here. They should be focused on what's important for each command.
 //! Ideally they *show* the initial state, and the *post* state, to validate the commands actually do what they claim.
 //! **Only** test the *happy path* of a typical user journey, while keeping details in unit tests with private module access.
+#[cfg(feature = "legacy")]
+mod absorb;
 mod branch;
 #[cfg(feature = "legacy")]
 mod commit;

--- a/crates/but/tests/but/command/snapshots/absorb/uncommitted-file.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/absorb/uncommitted-file.stdout.term.svg
@@ -2,7 +2,6 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -17,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Assigned a hunk in a.txt in the unassigned area → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
+    <tspan x="10px" y="28px"><tspan>Absorbed changes into commit 4fa8217</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/absorb/uncommitted-hunk.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/absorb/uncommitted-hunk.stdout.term.svg
@@ -2,7 +2,6 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -17,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Assigned a hunk in a.txt in the unassigned area → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
+    <tspan x="10px" y="28px"><tspan>Absorbed changes into commit 4fa8217</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/rub/uncommitted-file-to-branch.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/rub/uncommitted-file-to-branch.stdout.term.svg
@@ -17,7 +17,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Assigned a hunk in a.txt in the unassigned area → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
+    <tspan x="10px" y="28px"><tspan>Assigned all hunks in a.txt in the unassigned area → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/rub/uncommitted-file-to-unassigned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/rub/uncommitted-file-to-unassigned.stdout.term.svg
@@ -2,7 +2,6 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -17,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Assigned a hunk in a.txt in the unassigned area → </tspan><tspan class="fg-green">[A]</tspan><tspan>.</tspan>
+    <tspan x="10px" y="28px"><tspan>Unassigned all hunks in a.txt in a stack</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/rub/uncommitted-hunk-to-unassigned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/rub/uncommitted-hunk-to-unassigned.stdout.term.svg
@@ -6,7 +6,6 @@
       padding: 0 10px;
       line-height: 18px;
     }
-    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -17,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Unassigned a hunk in </tspan><tspan class="bold">a.txt</tspan>
+    <tspan x="10px" y="28px"><tspan>Unassigned a hunk in a.txt in a stack</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
Copy and paste from commit message:

Teach `IdMap` to return the same data type regardless of whether the
given CLI ID represents a file or a hunk. (Internally, `IdMap` still
recognizes the difference.) This simplifies the `rub` code, which no
longer needs to handle both cases.

I made the design decision to generate uncommitted hunk IDs only if the
(stack assignment, path) pair has more than one hunk. This is because
operating on the lone hunk of a (stack assignment, path) pair is the
same as operating on the pair itself, so it would seem strange to me
as a user if I had 2 separate IDs for that concept. I've included a
describing mechanism to make it clear to the user that we are operating
on hunks, and when a hunk is the lone hunk of the (stack assignment,
path) pair.

The only other command that accepts CLI IDs as input (`absorb`) gains
the ability to operate on hunks "for free".