### PR TITLE
feat(settings): add img-src extra hosts and propagate to CSP

### DIFF
--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -34,7 +34,9 @@
 	// Allows for additional "connect-src" hosts to be included. Requires app restart.
 	"extraCsp": {
 		// Additional hosts that the application can connect to.
-		"hosts": []
+		"hosts": [],
+		// Additional hosts for img-src that the application can load images from.
+		"imgSrc": []
 	},
 	// Settings related to fetching.
 	"fetch": {

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -53,6 +53,8 @@ pub struct FeatureFlags {
 pub struct ExtraCsp {
     /// Additional hosts that the application can connect to.
     pub hosts: Vec<String>,
+    /// Additional hosts for img-src that the application can load images from.
+    pub img_src: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -414,7 +414,10 @@ impl Sandbox {
                 rules: true,
                 single_branch: true,
             },
-            extra_csp: ExtraCsp { hosts: vec![] },
+            extra_csp: ExtraCsp {
+                hosts: vec![],
+                img_src: vec![],
+            },
             fetch: Fetch {
                 auto_fetch_interval_minutes: 0,
             },

--- a/crates/gitbutler-tauri/src/csp.rs
+++ b/crates/gitbutler-tauri/src/csp.rs
@@ -2,28 +2,41 @@ use anyhow::Result;
 use but_settings::AppSettingsWithDiskSync;
 use tauri::utils::config::{Csp, CspDirectiveSources};
 
-/// Constructs a new CSP object with additional `connect-src` hosts as provided by the AppSettings.
+/// Constructs a new CSP object with additional `connect-src` and `img-src` hosts as provided by the AppSettings.
 pub fn csp_with_extras(
     csp: Option<Csp>,
     settings: &AppSettingsWithDiskSync,
 ) -> Result<Option<Csp>> {
-    let hosts = settings
-        .get()?
-        .clone()
-        .extra_csp
+    let extra_csp = settings.get()?.clone().extra_csp;
+
+    let hosts = extra_csp
         .hosts
         .iter()
         .filter_map(|host| url::Url::parse(host).ok())
         .map(|h| h.to_string())
         .collect::<Vec<_>>();
 
-    if hosts.is_empty() {
+    let img_src = extra_csp
+        .img_src
+        .iter()
+        .filter_map(|host| url::Url::parse(host).ok())
+        .map(|h| h.to_string())
+        .collect::<Vec<_>>();
+
+    if hosts.is_empty() && img_src.is_empty() {
         return Ok(csp); // noop
     }
 
     let new_csp = if let Some(Csp::DirectiveMap(mut map)) = csp {
-        if let Some(CspDirectiveSources::Inline(sources)) = map.get_mut("connect-src") {
+        if !hosts.is_empty()
+            && let Some(CspDirectiveSources::Inline(sources)) = map.get_mut("connect-src")
+        {
             sources.push_str(&format!(" {}", hosts.join(" ")));
+        }
+        if !img_src.is_empty()
+            && let Some(CspDirectiveSources::Inline(sources)) = map.get_mut("img-src")
+        {
+            sources.push_str(&format!(" {}", img_src.join(" ")));
         }
         Some(Csp::DirectiveMap(map))
     } else {


### PR DESCRIPTION
Before:
<img width="1281" height="894" src="https://github.com/user-attachments/assets/6e9ee21c-f1b8-4e7a-8bde-66b137cf9dce" />

After:
<img width="1370" height="849" src="https://github.com/user-attachments/assets/abe820aa-f3bb-4438-91db-d6b25cae82ca" />

<img width="1150" height="376" src="https://github.com/user-attachments/assets/5e3cdb95-c8fe-4c12-9a70-940674ee67c9" />

This PR adds an internal setting to the application that allows users to manually add CSP exception rules for `img-src`.

The image resources shown in the PR description are very likely hosted at non-whitelisted addresses, and I think it's a reasonable requirement to let users configure these manually.

As for images in GitHub PRs, they currently redirect to S3 URLs, but I'm not sure whether GitHub uses a single bucket (most likely not). Adding exceptions for those domains one by one would be impractical, and I don't think we should add a domain exception for them.

By the way, wildcard configurations such as `https://github-production-user-asset-*.s3.amazonaws.com` did not work in my testing.

We probably need a better way to handle CSP rules in general. They introduce a lot of unexpected resource blocking issues that only show up in production builds, making them hard to notice during development.

That said, I don't really have a better solution either. Handing over control of some non-sensitive CSP settings to users seems like a reasonable compromise.