### PR TITLE
Refactor but: pass around context instead of legacy project

### DIFF
--- a/crates/but/src/command/legacy/actions.rs
+++ b/crates/but/src/command/legacy/actions.rs
@@ -1,17 +1,15 @@
 use but_action::Source;
 use but_ctx::Context;
-use gitbutler_project::Project;
 use serde::Serialize;
 
 use crate::utils::OutputChannel;
 
 pub(crate) fn handle_changes(
-    project: &Project,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     handler: impl Into<but_action::ActionHandler>,
     change_description: &str,
 ) -> anyhow::Result<()> {
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
     let response = but_action::handle_changes(
         ctx,
         change_description,
@@ -32,13 +30,11 @@ impl From<crate::args::actions::Handler> for but_action::ActionHandler {
 }
 
 pub(crate) fn list_actions(
-    project: &Project,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     offset: i64,
     limit: i64,
 ) -> anyhow::Result<()> {
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-
     let response = but_action::list_actions(ctx, offset, limit)?;
     print_json_or_human(&response, out)
 }

--- a/crates/but/src/command/legacy/describe.rs
+++ b/crates/but/src/command/legacy/describe.rs
@@ -8,14 +8,13 @@ use gix::prelude::ObjectIdExt;
 use crate::{CliId, IdMap, tui, utils::OutputChannel};
 
 pub(crate) fn describe_target(
-    project: &Project,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     target: &str,
     message: Option<&str>,
 ) -> Result<()> {
-    let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let mut id_map = IdMap::new_from_context(&ctx)?;
-    id_map.add_file_info_from_context(&mut ctx)?;
+    let mut id_map = IdMap::new_from_context(ctx)?;
+    id_map.add_file_info_from_context(ctx)?;
 
     // Resolve the commit ID
     let cli_ids = id_map.resolve_entity_to_ids(target)?;
@@ -36,10 +35,10 @@ pub(crate) fn describe_target(
 
     match cli_id {
         CliId::Branch { name, .. } => {
-            edit_branch_name(&ctx, project, name, out, message)?;
+            edit_branch_name(ctx, &ctx.legacy_project, name, out, message)?;
         }
         CliId::Commit(oid) => {
-            edit_commit_message_by_id(&ctx, project, *oid, out, message)?;
+            edit_commit_message_by_id(ctx, &ctx.legacy_project, *oid, out, message)?;
         }
         _ => {
             bail!(

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -5,17 +5,15 @@ use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_rules::Operation;
 use gitbutler_commit::commit_ext::CommitExt;
-use gitbutler_project::Project;
 
 use crate::{CliId, IdMap, command::legacy::rub::branch_name_to_stack_id, utils::OutputChannel};
 
 pub(crate) fn handle(
-    project: &Project,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     target_str: &str,
     delete: bool,
 ) -> anyhow::Result<()> {
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
     let mut id_map = IdMap::new_from_context(ctx)?;
     id_map.add_file_info_from_context(ctx)?;
     let target_result = id_map.resolve_entity_to_ids(target_str)?;
@@ -143,9 +141,7 @@ pub(crate) fn commit_marked(ctx: &mut Context, commit_id: String) -> anyhow::Res
     Ok(rules)
 }
 
-pub(crate) fn unmark(project: &Project, out: &mut OutputChannel) -> anyhow::Result<()> {
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-
+pub(crate) fn unmark(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
     let rules = but_rules::list_rules(ctx)?;
     let rule_count = rules.len();
 

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -3,7 +3,6 @@ use bstr::BStr;
 use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use colored::Colorize;
-use gitbutler_project::Project;
 mod amend;
 mod assign;
 mod commits;
@@ -19,12 +18,11 @@ use gitbutler_oplog::{
 use crate::{CliId, IdMap, utils::OutputChannel};
 
 pub(crate) fn handle(
-    project: &Project,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     source_str: &str,
     target_str: &str,
 ) -> anyhow::Result<()> {
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
     let mut id_map = IdMap::new_from_context(ctx)?;
     id_map.add_file_info_from_context(ctx)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str)?;

--- a/crates/but/src/legacy/mod.rs
+++ b/crates/but/src/legacy/mod.rs
@@ -1,10 +1,10 @@
-use but_ctx::LegacyProject;
+use but_ctx::{Context, LegacyProject};
 
 use crate::{args::Args, command, utils::OutputChannel};
 
 pub mod commits;
 
-pub fn get_or_init_non_bare_project(args: &Args) -> anyhow::Result<LegacyProject> {
+pub fn get_or_init_non_bare_ctx(args: &Args) -> anyhow::Result<Context> {
     let repo = gix::discover(&args.current_dir)?;
     if let Some(path) = repo.workdir() {
         let project = match LegacyProject::find_by_worktree_dir(path) {
@@ -18,7 +18,7 @@ pub fn get_or_init_non_bare_project(args: &Args) -> anyhow::Result<LegacyProject
                 LegacyProject::find_by_worktree_dir(path)
             }
         }?;
-        Ok(project)
+        Context::new_from_legacy_project(project)
     } else {
         anyhow::bail!("Bare repositories are not supported.");
     }


### PR DESCRIPTION
The aim here is to minimise the use of LegacyProject