### PR TITLE
gitbutler-git: remove test-askpass-path workaround, detect tests dynamically

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -312,7 +312,7 @@ If none of these solutions work, please check our [GitHub Issues](https://github
 To build the app in production mode, run:
 
 ```bash
-$ pnpm tauri build --features devtools --config crates/gitbutler-tauri/tauri.conf.nightly.json
+$ pnpm tauri build --features devtools,builtin-but,disable-auto-updates --config crates/gitbutler-tauri/tauri.conf.nightly-local.json
 ```
 
 This will make an asset similar to our nightly build.

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -61,6 +61,4 @@ glob = "0.3.3"
 tempfile.workspace = true
 but-hunk-assignment.workspace = true
 # Needed to make tests work with stable change ids
-gitbutler-git = { workspace = true, features = [
-    "test-askpass-path",
-] }
+gitbutler-git = { workspace = true }

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -23,8 +23,6 @@ test = false
 default = ["serde", "tokio"]
 serde = ["dep:serde"]
 tokio = ["dep:tokio"]
-## a flag that is needed for integration tests that run this code to work.
-test-askpass-path = []
 ## a flag to indicate benchmarks are run
 benches = []
 

--- a/crates/gitbutler-git/src/lib.rs
+++ b/crates/gitbutler-git/src/lib.rs
@@ -8,15 +8,6 @@
 #![allow(async_fn_in_trait)]
 #![allow(unknown_lints)]
 
-#[cfg(all(
-    not(debug_assertions),
-    not(feature = "benches"),
-    feature = "test-askpass-path"
-))]
-compile_error!(
-    "BUG: in production code this flag should not be set, nor do we run test with `cargo test --release`. Benches must use `--features benches`"
-);
-
 mod error;
 /// utilities to execute a command
 pub mod executor;

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -90,14 +90,12 @@ where
     current_exe = current_exe.canonicalize().unwrap_or(current_exe);
 
     // TODO(qix-): Get parent PID of connecting processes to make sure they're us.
-    // let our_pid = std::process::id();
-
     // This is a bit of a hack. Under a test environment, Cargo is running a
     // test runner with a quasi-random suffix. The actual executables live in
     // the parent directory. Thus, we have to do this under test. It's not
     // ideal, but it works for now.
     //
-    // This logic is used in downstream tests like gitbutler-branch-actions.
+    // TODO: remove this special case once `gitbutler-branch-actions` is gone.
     if current_exe.iter().nth_back(1) == Some("deps".as_ref()) {
         current_exe = current_exe.parent().unwrap().to_path_buf();
     }

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -90,26 +90,21 @@ where
     current_exe = current_exe.canonicalize().unwrap_or(current_exe);
 
     // TODO(qix-): Get parent PID of connecting processes to make sure they're us.
-    //let our_pid = std::process::id();
+    // let our_pid = std::process::id();
 
-    // TODO(qix-): This is a bit of a hack. Under a test environment,
-    // TODO(qix-): Cargo is running a test runner with a quasi-random
-    // TODO(qix-): suffix. The actual executables live in the parent directory.
-    // TODO(qix-): Thus, we have to do this under test. It's not ideal, but
-    // TODO(qix-): it works for now.
-    #[cfg(feature = "test-askpass-path")]
-    let current_exe = current_exe.parent().unwrap();
+    // This is a bit of a hack. Under a test environment, Cargo is running a
+    // test runner with a quasi-random suffix. The actual executables live in
+    // the parent directory. Thus, we have to do this under test. It's not
+    // ideal, but it works for now.
+    //
+    // This logic is used in downstream tests like gitbutler-branch-actions.
+    if current_exe.iter().nth_back(1) == Some("deps".as_ref()) {
+        current_exe = current_exe.parent().unwrap().to_path_buf();
+    }
 
-    let askpath_path = current_exe.with_file_name({
-        #[cfg(unix)]
-        {
-            "gitbutler-git-askpass"
-        }
-        #[cfg(windows)]
-        {
-            "gitbutler-git-askpass.exe"
-        }
-    });
+    let askpath_path = current_exe
+        .with_file_name("gitbutler-git-askpass")
+        .with_extension(std::env::consts::EXE_EXTENSION);
 
     #[cfg(unix)]
     let setsid_path = current_exe.with_file_name("gitbutler-git-setsid");

--- a/crates/gitbutler-tauri/tauri.conf.nightly-local.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly-local.json
@@ -1,0 +1,31 @@
+{
+	"productName": "GitButler Nightly",
+	"identifier": "com.gitbutler.app.nightly",
+	"build": {
+		"beforeBuildCommand": "bash ./crates/gitbutler-tauri/tauri-before-build-command.sh nightly"
+	},
+	"bundle": {
+		"active": true,
+		"icon": [
+			"icons/nightly/32x32.png",
+			"icons/nightly/128x128.png",
+			"icons/nightly/128x128@2x.png",
+			"icons/nightly/icon.icns",
+			"icons/nightly/icon.ico"
+		],
+		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass"]
+	},
+	"plugins": {
+		"updater": {
+			"endpoints": [
+				"https://app.gitbutler.com/releases/nightly/{{target}}-{{arch}}/{{current_version}}"
+			],
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDYwNTc2RDhBM0U0MjM4RUIKUldUck9FSStpbTFYWUE5UkJ3eXhuekZOL2V2RnpKaFUxbGJRNzBMVmF5V0gzV1JvN3hRblJMRDIK"
+		},
+		"deep-link": {
+			"desktop": {
+				"schemes": ["but-nightly"]
+			}
+		}
+	}
+}


### PR DESCRIPTION
While still a hack, this allows running tests in release mode which slightly simplifies package-and-test distro workflows. I don't particularly like depending on the magic `"deps"` folder name, but this shouldn't cause any issues with release builds and if anything changes you'll notice while testing :upside_down_face: 

Xref: https://github.com/NixOS/nixpkgs/pull/473706: This should cut down build times significantly as it's no longer required to build both a release and debug version.