### PR TITLE
Hide stack ID and show top branch in commit prompt

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -8,6 +8,7 @@ use but_api::{
 };
 use but_core::{DiffSpec, ui::TreeChange};
 use but_ctx::Context;
+use colored::Colorize;
 use gitbutler_project::Project;
 
 use crate::{
@@ -434,7 +435,12 @@ fn prompt_for_stack_selection(
     writeln!(stdout, "Multiple stacks found. Choose one to commit to:")?;
 
     for (i, (_stack_id, stack_details)) in stacks.iter().enumerate() {
-        writeln!(stdout, "  {}. {}", i + 1, stack_details.derived_name)?;
+        writeln!(
+            stdout,
+            "  {}. {}",
+            i + 1,
+            stack_details.derived_name.green()
+        )?;
     }
 
     write!(stdout, "Enter selection (1-{}): ", stacks.len())?;

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -433,19 +433,8 @@ fn prompt_for_stack_selection(
     let mut stdout = std::io::stdout();
     writeln!(stdout, "Multiple stacks found. Choose one to commit to:")?;
 
-    for (i, (stack_id, stack_details)) in stacks.iter().enumerate() {
-        let branch_names: Vec<String> = stack_details
-            .branch_details
-            .iter()
-            .map(|b| b.name.to_string())
-            .collect();
-        writeln!(
-            stdout,
-            "  {}. {} [{}]",
-            i + 1,
-            stack_id,
-            branch_names.join(", ")
-        )?;
+    for (i, (_stack_id, stack_details)) in stacks.iter().enumerate() {
+        writeln!(stdout, "  {}. {}", i + 1, stack_details.derived_name)?;
     }
 
     write!(stdout, "Enter selection (1-{}): ", stacks.len())?;

--- a/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
@@ -20,9 +20,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green">Applied Branches</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="dimmed">00</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">25y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
+    <tspan x="10px" y="46px"><tspan class="dimmed">00</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="dimmed">01</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">25y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
+    <tspan x="10px" y="64px"><tspan class="dimmed">01</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>


### PR DESCRIPTION
When multiple stacks are found during `but commit`, the prompt previously displayed the stack UUID along with all branch names. 

```
❯ but commit                                                                                  took 45s
Multiple stacks found. Choose one to commit to:
  1. 5c9646c8-898b-4165-9aa9-70c3fa876e8c [refine-commit-prompt-top-branch]
  2. 32d03043-e71c-40be-8b44-213f3bd848f1 [sc-branch-81]
Enter selection (1-2):
```

Now it does this:

<img width="1176" height="282" alt="CleanShot 2025-12-26 at 13 01 08@2x" src="https://github.com/user-attachments/assets/676c1ad1-2288-4df4-804e-4ccff496017f" />

