### PR TITLE
Refactor changes_in_worktree API to take Context

### DIFF
--- a/crates/but-api/src/legacy/diff.rs
+++ b/crates/but-api/src/legacy/diff.rs
@@ -68,9 +68,7 @@ fn changes_in_branch_inner(ctx: Context, branch: Refname) -> anyhow::Result<Tree
 /// All ignored status changes are also provided so they can be displayed separately.
 #[but_api]
 #[instrument(err(Debug))]
-pub fn changes_in_worktree(project_id: ProjectId) -> anyhow::Result<WorktreeChanges> {
-    let project = gitbutler_project::get(project_id)?;
-    let ctx = &mut Context::new_from_legacy_project(project.clone())?;
+pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges> {
     let changes = but_core::diff::worktree_changes(&*ctx.repo.get()?)?;
 
     let dependencies =

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -45,7 +45,7 @@ pub(crate) fn handle(
         });
 
     // Get all worktree changes, assignments, and dependencies
-    let worktree_changes = diff::changes_in_worktree(ctx.legacy_project.id)?;
+    let worktree_changes = diff::changes_in_worktree(ctx)?;
     let assignments = worktree_changes.assignments;
     let dependencies = worktree_changes.dependencies;
 

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -65,16 +65,7 @@ pub async fn handle(
             ai,
             check,
         }) => {
-            show::show(
-                &ctx.legacy_project,
-                &branch_id,
-                out,
-                review,
-                files,
-                ai,
-                check,
-            )
-            .await?;
+            show::show(ctx, &branch_id, out, review, files, ai, check).await?;
             Ok(())
         }
         Some(Subcommands::New {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -180,7 +180,7 @@ pub(crate) fn commit(
     )?;
 
     // Get changes and assignments using but-api
-    let worktree_changes = diff::changes_in_worktree(project_id)?;
+    let worktree_changes = diff::changes_in_worktree(ctx)?;
     let changes = worktree_changes.worktree_changes.changes;
 
     let assignments_by_file: BTreeMap<BString, FileAssignment> =

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -80,7 +80,7 @@ pub(crate) async fn worktree(
     };
 
     let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
-    let worktree_changes = but_api::legacy::diff::changes_in_worktree(ctx.legacy_project.id)?;
+    let worktree_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
 
     let assignments_by_file: BTreeMap<BString, FileAssignment> =
         FileAssignment::get_assignments_by_file(&id_map);


### PR DESCRIPTION
This simplifies cli usage and potentially improves performance (less
calls context creation)