### PR TITLE
move `snapshot` command under `oplog` family

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -358,7 +358,7 @@ pub enum Subcommands {
         message: Option<String>,
     },
 
-    /// Show operation history.
+    /// Show operation history and manage snapshots.
     ///
     /// Displays a list of past operations performed in the repository,
     /// including their timestamps and descriptions.
@@ -369,11 +369,7 @@ pub enum Subcommands {
     /// You can use `but restore <oplog-sha>` to restore to a specific state.
     ///
     #[cfg(feature = "legacy")]
-    Oplog {
-        /// Start from this oplog SHA instead of the head
-        #[clap(long)]
-        since: Option<String>,
-    },
+    Oplog(oplog::Platform),
 
     /// Restore to a specific oplog snapshot.
     ///
@@ -399,20 +395,6 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     Undo,
-
-    /// Create an on-demand snapshot with optional message.
-    ///
-    /// This allows you to create a named snapshot of the current state, which
-    /// can be helpful to always be able to return to a known good state.
-    ///
-    /// You can provide an optional message to describe the snapshot.
-    ///
-    #[cfg(feature = "legacy")]
-    Snapshot {
-        /// Message to include with the snapshot
-        #[clap(short = 'm', long = "message")]
-        message: Option<String>,
-    },
 
     /// Amends changes into the appropriate commits where they belong.
     ///
@@ -553,6 +535,7 @@ pub mod actions {
 
 pub mod forge;
 pub mod metrics;
+pub mod oplog;
 pub mod push;
 
 pub mod claude {

--- a/crates/but/src/args/oplog.rs
+++ b/crates/but/src/args/oplog.rs
@@ -1,0 +1,49 @@
+#[derive(Debug, clap::Parser)]
+pub struct Platform {
+    /// Show all operations (uses a pager)
+    #[clap(long, short = 'a', global = true)]
+    pub all: bool,
+    /// Only show named snapshots
+    #[clap(long, short = 's', global = true)]
+    pub snapshots: bool,
+    #[clap(subcommand)]
+    pub cmd: Option<Subcommands>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+    /// List operation history.
+    ///
+    /// Displays a list of past operations performed in the repository,
+    /// including their timestamps and descriptions.
+    ///
+    /// This allows you to restore to any previous point in the history of the
+    /// project. All state is preserved in operations, including uncommitted changes.
+    ///
+    /// You can use `but restore <oplog-sha>` to restore to a specific state.
+    ///
+    List {
+        /// Start from this oplog SHA instead of the head
+        #[clap(long)]
+        since: Option<String>,
+        /// Show all operations (uses a pager)
+        #[clap(long, short = 'a')]
+        all: bool,
+        /// Only show named snapshots
+        #[clap(long, short = 's')]
+        snapshots: bool,
+    },
+
+    /// Create an on-demand snapshot with optional message.
+    ///
+    /// This allows you to create a named snapshot of the current state, which
+    /// can be helpful to always be able to return to a known good state.
+    ///
+    /// You can provide an optional message to describe the snapshot.
+    ///
+    Snapshot {
+        /// Message to include with the snapshot
+        #[clap(short = 'm', long = "message")]
+        message: Option<String>,
+    },
+}

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -56,7 +56,7 @@ impl Subcommands {
     fn to_metrics_command(&self) -> CommandName {
         use CommandName::*;
 
-        use crate::args::{base, branch, claude, cursor, forge, worktree};
+        use crate::args::{base, branch, claude, cursor, forge, oplog, worktree};
         match self {
             #[cfg(feature = "legacy")]
             Subcommands::Status { .. } => Status,
@@ -100,13 +100,15 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Describe { .. } => Describe,
             #[cfg(feature = "legacy")]
-            Subcommands::Oplog { .. } => Oplog,
+            Subcommands::Oplog(oplog::Platform { cmd, .. }) => match cmd {
+                Some(oplog::Subcommands::List { .. }) => Oplog,
+                Some(oplog::Subcommands::Snapshot { .. }) => Snapshot,
+                None => Oplog,
+            },
             #[cfg(feature = "legacy")]
             Subcommands::Restore { .. } => Restore,
             #[cfg(feature = "legacy")]
             Subcommands::Undo => Undo,
-            #[cfg(feature = "legacy")]
-            Subcommands::Snapshot { .. } => Snapshot,
             #[cfg(feature = "legacy")]
             Subcommands::Claude(claude::Platform { cmd }) => match cmd {
                 claude::Subcommands::PreTool => ClaudePreTool,


### PR DESCRIPTION
This moves the `but snapshot` command to `but oplog snapshot` and adds a way to filter the oplog list to only snapshots.

It also removes use of the pager from the normal `but oplog` listing so we can actually restore stuff (unless `—all` is supplied).

The `—all` flag is not ideal - it just sends `usize::MAX` to the api. It would probably be better to have something that is listing out the data as it walks the Git parentage in real time, rather than cache all the data and send it as one big result, but we’ll have to push that to a later implementation.