### PR TITLE
rename `but review` to `but pr`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "posthog-rs",
  "regex",
  "rmcp",
+ "schemars 1.1.0",
  "serde",
  "serde_json",
  "shell-words",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -79,6 +79,7 @@ gitbutler-oplog = { workspace = true, optional = true }
 
 git2.workspace = true
 async-openai.workspace = true
+schemars.workspace = true
 posthog-rs = { version = "0.3.7" }
 serde.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }

--- a/crates/but/src/args/forge.rs
+++ b/crates/but/src/args/forge.rs
@@ -1,16 +1,17 @@
-pub mod review {
+pub mod pr {
     #[derive(Debug, clap::Parser)]
     pub struct Platform {
         #[clap(subcommand)]
-        pub cmd: Subcommands,
+        pub cmd: Option<Subcommands>,
     }
     #[derive(Debug, clap::Subcommand)]
     pub enum Subcommands {
-        /// Publish review requests for active branches in your workspace.
-        /// By default, publishes reviews for all active branches.
-        Publish {
-            /// Publish reviews only for the specified branch.
-            #[clap(long, short = 'b')]
+        /// Create a new pull request for a branch.
+        /// If no branch is specified, you will be prompted to select one.
+        /// If there is only one branch without a PR, you will be asked to confirm.
+        New {
+            /// The branch to create a PR for.
+            #[clap(value_name = "BRANCH")]
             branch: Option<String>,
             /// Force push even if it's not fast-forward (defaults to true).
             #[clap(long, short = 'f', default_value_t = true)]
@@ -21,15 +22,15 @@ pub mod review {
             /// Run pre-push hooks (defaults to true).
             #[clap(long, short = 'r', default_value_t = true)]
             run_hooks: bool,
-            /// Use the default content for the review title and description, skipping any prompts.
-            /// If the review contains only a single commit, the commit message will be used for the review title and description.
+            /// Use the default content for the PR title and description, skipping any prompts.
+            /// If the branch contains only a single commit, the commit message will be used.
             #[clap(long, short = 't', default_value_t = false)]
             default: bool,
         },
-        /// Configure the template to use for review descriptions.
+        /// Configure the template to use for PR descriptions.
         /// This will list all available templates found in the repository and allow you to select one.
         Template {
-            /// Path to the review template file within the repository.
+            /// Path to the PR template file within the repository.
             template_path: Option<String>,
         },
     }

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -38,8 +38,8 @@ pub enum CommandName {
     ForgeAuth,
     ForgeListUsers,
     ForgeForget,
-    PublishReview,
-    ReviewTemplate,
+    PrNew,
+    PrTemplate,
     Completions,
     #[default]
     Unknown,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -439,7 +439,7 @@ pub enum Subcommands {
     /// Commands for interacting with forges like GitHub, GitLab (coming soon), etc.
     ///
     /// The `but forge` tools allow you to authenticate with a forge from the CLI,
-    /// which then enables features like creating pull requests with the `but review`
+    /// which then enables features like creating pull requests with the `but pr`
     /// commands.
     ///
     /// Start by running `but forge auth` to authenticate with your forge.
@@ -452,14 +452,18 @@ pub enum Subcommands {
     ///
     Forge(forge::integration::Platform),
 
-    /// Commands for creating and publishing code reviews to a forge.
+    /// Commands for creating and managing pull requests on a forge.
     ///
     /// If you are authenticated with a forge using `but forge auth`, you can use
-    /// the `but review` commands to create pull requests (or merge requests) on
+    /// the `but pr` commands to create pull requests (or merge requests) on
     /// the remote repository for your branches.
     ///
+    /// Running `but pr` without a subcommand defaults to `but pr new`, which
+    /// will prompt you to select a branch to create a PR for.
+    ///
     #[cfg(feature = "legacy")]
-    Review(forge::review::Platform),
+    #[clap(visible_alias = "review")]
+    Pr(forge::pr::Platform),
 
     /// AI: Starts up the MCP server.
     ///

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -37,10 +37,7 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
             "Branching and Committing".yellow(),
             vec!["commit", "new", "branch", "base", "mark", "unmark"],
         ),
-        (
-            "Server Interactions".yellow(),
-            vec!["push", "review", "forge"],
-        ),
+        ("Server Interactions".yellow(), vec!["push", "pr", "forge"]),
         (
             "Editing Commits".yellow(),
             vec!["rub", "describe", "absorb"],

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -127,9 +127,9 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Absorb { .. } => Absorb,
             #[cfg(feature = "legacy")]
-            Subcommands::Review(forge::review::Platform { cmd }) => match cmd {
-                forge::review::Subcommands::Publish { .. } => PublishReview,
-                forge::review::Subcommands::Template { .. } => ReviewTemplate,
+            Subcommands::Pr(forge::pr::Platform { cmd }) => match cmd {
+                None | Some(forge::pr::Subcommands::New { .. }) => PrNew,
+                Some(forge::pr::Subcommands::Template { .. }) => PrTemplate,
             },
             #[cfg(feature = "legacy")]
             Subcommands::Actions(_) | Subcommands::Mcp { .. } | Subcommands::Init { .. } => Unknown,

--- a/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
@@ -67,7 +67,7 @@
 </tspan>
     <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-green">push         </tspan><tspan>Push changes in a branch to remote</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-green">review       </tspan><tspan>Commands for creating and publishing code reviews to a forge</tspan>
+    <tspan x="10px" y="460px"><tspan>  </tspan><tspan class="fg-green">pr           </tspan><tspan>Commands for creating and managing pull requests on a forge</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-green">forge        </tspan><tspan>Commands for interacting with forges like GitHub, GitLab (comin…</tspan>
 </tspan>


### PR DESCRIPTION
there should be `but pr new (<branch-id>)` to open a new PR. just `but pr` should default to `but pr new` and prompt for which branch to open a pr on. if there is only one branch without a pr, it should prompt "do you want to open a new PR on branch [name]?".

currently it opens two tempfiles - one for the title and one for the description. reduce this to a single tempfile call and extract the first line as the title and the rest as the description. add comments into the tempfile to explain this

also made the output nicer:

<img width="1418" height="532" alt="CleanShot 2025-12-28 at 09 43 04@2x" src="https://github.com/user-attachments/assets/3ea9b4e9-892d-483e-890f-5b8f2e73b24c" />
