### PR TITLE
fly-by fixes while looking at #11623

### DIFF
--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -37,7 +37,6 @@ pub(crate) fn unassign_uncommitted(
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let description = uncommitted_cli_id.describe();
-
     let assignments = uncommitted_cli_id
         .hunk_assignments
         .into_iter()
@@ -45,7 +44,7 @@ pub(crate) fn unassign_uncommitted(
     let reqs = to_assignment_request(ctx, assignments, None)?;
     do_assignments(ctx, reqs, out)?;
     if let Some(out) = out.for_human() {
-        writeln!(out, "Unassigned {}", description)?;
+        writeln!(out, "Unassigned {description}")?;
     }
     Ok(())
 }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -449,10 +449,11 @@ pub struct UncommittedCliId {
     pub id: ShortId,
     /// The hunk assignments
     pub hunk_assignments: NonEmpty<HunkAssignment>,
-    /// True iff self represents all hunks in a (stack assignment, file) pair.
+    /// `true` if self represents all hunks in a stack-assignment or file pair.
     /// Note that this file may have hunks with other stack assignments.
     pub is_entire_file: bool,
 }
+
 impl UncommittedCliId {
     /// Describes self.
     pub fn describe(&self) -> String {
@@ -471,10 +472,8 @@ impl UncommittedCliId {
             "the unassigned area"
         };
         format!(
-            "{} in {} in {}",
-            hunk_cardinality,
+            "{hunk_cardinality} in {} in {assignment}",
             self.hunk_assignments.first().path_bytes,
-            assignment
         )
     }
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -29,7 +29,7 @@ use cfg_if::cfg_if;
 
 pub mod args;
 use args::{
-    Args, OutputFormat, Subcommands, actions, base, branch, claude, cursor, forge, metrics, oplog,
+    Args, OutputFormat, Subcommands, actions, base, branch, claude, cursor, forge, metrics,
     worktree,
 };
 use but_settings::AppSettings;
@@ -410,10 +410,10 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Oplog(oplog::Platform { cmd }) => {
+        Subcommands::Oplog(args::oplog::Platform { cmd }) => {
             let mut ctx = init::init_ctx(&args, Fetch::None, out)?;
             match cmd {
-                Some(oplog::Subcommands::List { since, snapshot }) => {
+                Some(args::oplog::Subcommands::List { since, snapshot }) => {
                     let filter = if snapshot {
                         Some(command::legacy::oplog::OplogFilter::Snapshot)
                     } else {
@@ -422,7 +422,7 @@ async fn match_subcommand(
                     command::legacy::oplog::show_oplog(&mut ctx, out, since.as_deref(), filter)
                         .emit_metrics(metrics_ctx)
                 }
-                Some(oplog::Subcommands::Snapshot { message }) => {
+                Some(args::oplog::Subcommands::Snapshot { message }) => {
                     command::legacy::oplog::create_snapshot(&mut ctx, out, message.as_deref())
                         .emit_metrics(metrics_ctx)
                 }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -7,7 +7,7 @@ use posthog_rs::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    args::{Subcommands, metrics::CommandName, oplog},
+    args::{Subcommands, metrics::CommandName},
     utils::ResultMetricsExt,
 };
 
@@ -102,10 +102,10 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Describe { .. } => Describe,
             #[cfg(feature = "legacy")]
-            Subcommands::Oplog(oplog::Platform { cmd }) => match cmd {
+            Subcommands::Oplog(crate::args::oplog::Platform { cmd }) => match cmd {
                 None => OplogList,
-                Some(oplog::Subcommands::List { .. }) => OplogList,
-                Some(oplog::Subcommands::Snapshot { .. }) => OplogSnapshot,
+                Some(crate::args::oplog::Subcommands::List { .. }) => OplogList,
+                Some(crate::args::oplog::Subcommands::Snapshot { .. }) => OplogSnapshot,
             },
             #[cfg(feature = "legacy")]
             Subcommands::Restore { .. } => Restore,

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -1,14 +1,31 @@
+use crate::command::util::commit_file_with_worktree_changes_as_two_hunks;
 use crate::utils::Sandbox;
+use bstr::ByteSlice;
 use snapbox::str;
 
 #[test]
 fn uncommitted_file() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
-    // Must set metadata to match the scenario
     env.setup_metadata(&["A", "B"])?;
-
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    env.but("--json status -f")
+        .env_remove("BUT_OUTPUT_FORMAT")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "unassignedChanges": [
+    {
+      "cliId": "i0",
+      "filePath": "a.txt",
+      "changeType": "modified"
+    }
+  ],
+...
+"#]]);
 
     env.but("absorb i0")
         .assert()
@@ -20,8 +37,8 @@ fn uncommitted_file() -> anyhow::Result<()> {
 
     // Change was absorbed
     let repo = env.open_repo()?;
-    let mut blob = repo.find_blob(repo.rev_parse_single(b"A:a.txt")?)?;
-    insta::assert_snapshot!(String::from_utf8(blob.take_data())?, @r"
+    let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
+    insta::assert_snapshot!(blob.data.as_bstr(), @r"
     firsta
     line
     line
@@ -53,9 +70,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
 fn uncommitted_hunk() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
-    // Must set metadata to match the scenario
     env.setup_metadata(&["A", "B"])?;
-
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     // TODO When we have a way to list the hunks and their respective IDs (e.g.
@@ -70,8 +85,8 @@ fn uncommitted_hunk() -> anyhow::Result<()> {
 
     // Change was partially absorbed
     let repo = env.open_repo()?;
-    let mut blob = repo.find_blob(repo.rev_parse_single(b"A:a.txt")?)?;
-    insta::assert_snapshot!(String::from_utf8(blob.take_data())?, @r"
+    let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
+    insta::assert_snapshot!(blob.data.as_bstr(), @r"
     firsta
     line
     line
@@ -104,28 +119,3 @@ fn uncommitted_hunk() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-mod util {
-    use crate::utils::Sandbox;
-
-    /// Create a file with `filename`, commit it to `branch`, then edit it once more to have two uncommitted hunks.
-    pub fn commit_file_with_worktree_changes_as_two_hunks(
-        env: &Sandbox,
-        branch: &str,
-        filename: &str,
-    ) {
-        let context_distance = (env.app_settings().context_lines * 2 + 1) as usize;
-        env.file(
-            filename,
-            format!("first\n{}last\n", "line\n".repeat(context_distance)),
-        );
-        env.but(format!("commit {branch} -m {filename}"))
-            .assert()
-            .success();
-        env.file(
-            filename,
-            format!("firsta\n{}lasta\n", "line\n".repeat(context_distance)),
-        );
-    }
-}
-use crate::command::absorb::util::commit_file_with_worktree_changes_as_two_hunks;

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -15,3 +15,53 @@ mod help;
 mod rub;
 #[cfg(feature = "legacy")]
 mod status;
+
+mod util {
+    use crate::utils::Sandbox;
+
+    /// Create two files `filename1` and `filename2` and commit them to `branch`,
+    /// each having two lines, `first_line`, then filler, and a last line that are far enough apart to
+    /// ensure that they become 2 hunks when changed.
+    pub fn commit_two_files_as_two_hunks_each(
+        env: &Sandbox,
+        branch: &str,
+        filename1: &str,
+        filename2: &str,
+        first_line: &str,
+    ) {
+        let context_distance = (env.app_settings().context_lines * 2 + 1) as usize;
+        env.file(
+            filename1,
+            format!("{first_line}\n{}last\n", "line\n".repeat(context_distance)),
+        );
+        env.file(
+            filename2,
+            format!("{first_line}\n{}last\n", "line\n".repeat(context_distance)),
+        );
+        env.but(format!(
+            "commit {branch} -m 'create {filename1} and {filename2}'"
+        ))
+        .assert()
+        .success();
+    }
+
+    /// Create a file with `filename`, commit it to `branch`, then edit it once more to have two uncommitted hunks.
+    pub fn commit_file_with_worktree_changes_as_two_hunks(
+        env: &Sandbox,
+        branch: &str,
+        filename: &str,
+    ) {
+        let context_distance = (env.app_settings().context_lines * 2 + 1) as usize;
+        env.file(
+            filename,
+            format!("first\n{}last\n", "line\n".repeat(context_distance)),
+        );
+        env.but(format!("commit {branch} -m {filename}"))
+            .assert()
+            .success();
+        env.file(
+            filename,
+            format!("firsta\n{}lasta\n", "line\n".repeat(context_distance)),
+        );
+    }
+}


### PR DESCRIPTION
- unrelated: also make modern build work again. The less it digresses in the 'churn' period the better.
- deduplicate

Related to #11623.
