### PR TITLE
fix: prevent skipping single hunk assignments in uncommitted files

### DIFF
--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -276,7 +276,7 @@ impl IdMap {
         }
 
         for uncommitted_file in self.uncommitted_files.values() {
-            if uncommitted_file.hunk_assignments.len() > 1 {
+            if !uncommitted_file.hunk_assignments.is_empty() {
                 for hunk_assignment in uncommitted_file.hunk_assignments.iter() {
                     self.uncommitted_hunks.insert(
                         self.id_usage.next_available()?.to_short_id(),

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -321,7 +321,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
     branches: [ h0 ]
     uncommitted_files: [ g0, i0 ]
     committed_files: [ j0, k0 ]
-    uncommitted_hunks: [ l0, m0 ]
+    uncommitted_hunks: [ l0, m0, n0 ]
     ");
     insta::assert_debug_snapshot!(id_map.all_ids(), @r#"
     [
@@ -442,6 +442,26 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                 is_entire_file: false,
             },
         ),
+        Uncommitted(
+            UncommittedCliId {
+                id: "n0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
     ]
     "#);
 
@@ -468,6 +488,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     branches: [ h0 ]
     uncommitted_files: [ g0 ]
     committed_files: [ i0 ]
+    uncommitted_hunks: [ j0 ]
     ");
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("0a")?, @r"


### PR DESCRIPTION
@jonathantanmy2 I am 99% sure this is a bug, so fixing it here. Let me know if i missed something