### PR TITLE
Improve error message for not finding a merge-base when applying a branch.

### DIFF
--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -414,7 +414,7 @@ pub mod merge {
     ) -> anyhow::Result<(gix::ObjectId, SegmentIndex)> {
         let base_sidx = graph.first_merge_base(left, right).with_context(|| {
             format!(
-                "Couldn't find merge-base between segments {l} and {r}",
+                "Couldn't find merge-base between segments {l} and {r} - they are disjoint in the commit-graph",
                 l = left.index(),
                 r = right.index()
             )

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -9,7 +9,7 @@
 //!   - Currently, there is only one workspace per repository, but this is something we intend to change
 //!     in the future to facilitate new use cases.
 //! * **Workspace Ref**
-//!   - The reference that points to the merge-commit which integrates all *workspace* *stacks*.
+//!   - The reference that points to the merge-ommit which integrates all *workspace* *stacks*.
 //! * **Stack**
 //!   - GitButler implements the concept of a branch stack. This is essentially a collection of "heads"
 //!     (pseudo branches) that contain each other.


### PR DESCRIPTION
This is rare, but could also be caused by a bug with the graph traversal.

Accidental left-over from previous PR.