### PR TITLE
feat(ui): add dotted background to stack draft

### DIFF
--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -108,7 +108,7 @@
 </script>
 
 {#if visible}
-	<div data-testid={TestId.StackDraft} class="draft-stack">
+	<div data-testid={TestId.StackDraft} class="draft-stack dotted-pattern">
 		<ConfigurableScrollableContainer childrenWrapHeight="100%">
 			<div
 				class="draft-stack__scroll-wrap"


### PR DESCRIPTION
Add a dotted-pattern CSS class to the StackDraft component wrapper to ensure consistency with other lanes.

---

Before:

https://github.com/user-attachments/assets/97e284ff-5f7c-4d0a-a168-805e7a0a8f46

After:

https://github.com/user-attachments/assets/e100917a-e590-4b90-b73e-1d5fe8b02e10

