### PR TITLE
update help command groupings

### DIFF
--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -32,16 +32,16 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
 
     // Define command groupings and their order (excluding MISC)
     let groups = [
-        ("Inspection".yellow(), vec!["status"]),
+        ("Inspection".yellow(), vec!["status", "diff"]),
         (
             "Branching and Committing".yellow(),
-            vec!["commit", "new", "branch", "base", "mark", "unmark"],
+            vec!["commit", "new", "branch", "mark", "unmark"],
         ),
-        ("Server Interactions".yellow(), vec!["push", "pr", "forge"]),
         (
-            "Editing Commits".yellow(),
-            vec!["rub", "describe", "absorb"],
+            "Server Interactions".yellow(),
+            vec!["push", "pull", "base", "pr", "forge"],
         ),
+        ("Editing Commits".yellow(), vec!["rub", "absorb", "reword"]),
         (
             "Operation History".yellow(),
             vec!["oplog", "undo", "restore"],

--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -2,38 +2,6 @@ use snapbox::str;
 
 use crate::utils::Sandbox;
 
-#[cfg(not(feature = "legacy"))]
-#[test]
-fn looks_good_and_can_be_invoked_in_various_ways_non_legacy() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
-    env.but("").assert().success().stdout_eq(snapbox::file![
-        "snapshots/help/no-arg-no-legacy.stdout.term.svg"
-    ]);
-    Ok(())
-}
-
-#[cfg(feature = "legacy")]
-#[test]
-fn looks_good_and_can_be_invoked_in_various_ways() -> anyhow::Result<()> {
-    let env = Sandbox::empty()?;
-    env.but("")
-        .assert()
-        .success()
-        .stdout_eq(snapbox::file!["snapshots/help/no-arg.stdout.term.svg"]);
-
-    env.but("-h")
-        .assert()
-        .success()
-        .stdout_eq(snapbox::file!["snapshots/help/no-arg.stdout.term.svg"]);
-
-    env.but("--help")
-        .assert()
-        .success()
-        .stdout_eq(snapbox::file!["snapshots/help/no-arg.stdout.term.svg"]);
-
-    Ok(())
-}
-
 #[cfg(feature = "legacy")]
 #[test]
 fn rub_looks_good() -> anyhow::Result<()> {


### PR DESCRIPTION
We have some stuff like `pull` and `diff` in "Other Commands", so taking a second to regroup commands into the proper groups.

<img width="1556" height="1168" alt="CleanShot 2026-01-02 at 11 05 36@2x" src="https://github.com/user-attachments/assets/503da7d0-2d79-4fd0-aef1-3a0c62b1e122" />
