### PR TITLE
fix(ui): replace "success" color token with "safe"

### DIFF
--- a/apps/desktop/src/components/CodegenRow.svelte
+++ b/apps/desktop/src/components/CodegenRow.svelte
@@ -154,7 +154,7 @@
 						<span class="text-12 codegen-row__todos">Todos ({completedCount}/{totalCount})</span>
 
 						{#if completedCount === totalCount}
-							<Icon name="success-outline" color="success" />
+							<Icon name="success-outline" color="safe" />
 						{/if}
 					{/if}
 				</button>

--- a/apps/desktop/src/components/CredentialCheck.svelte
+++ b/apps/desktop/src/components/CredentialCheck.svelte
@@ -80,7 +80,7 @@
 										{#await check.promise}
 											<Icon name="spinner" spinnerRadius={4} />
 										{:then}
-											<Icon name="success-small" color="success" />
+											<Icon name="success-small" color="safe" />
 										{:catch}
 											<Icon name="error-small" color="danger" />
 										{/await}

--- a/apps/desktop/src/components/codegen/ClaudeCheck.svelte
+++ b/apps/desktop/src/components/codegen/ClaudeCheck.svelte
@@ -94,7 +94,7 @@
 				<Icon name="warning" color="warning" />
 				<h4 class="text-16 text-semibold text-body">Claude Code can't be found</h4>
 			{:else}
-				<Icon name="success" color="success" />
+				<Icon name="success" color="safe" />
 				<h4 class="text-16 text-semibold text-body">Claude code is connected</h4>
 			{/if}
 		</div>

--- a/packages/ui/src/lib/components/ModalHeader.svelte
+++ b/packages/ui/src/lib/components/ModalHeader.svelte
@@ -33,7 +33,7 @@
 	{/if}
 
 	{#if type === 'success'}
-		<Icon name="success" color="success" />
+		<Icon name="success" color="safe" />
 	{/if}
 
 	<h2 class="text-14 text-bold">


### PR DESCRIPTION
Update components to use the "safe" color token instead of "success"
for success-related icons. The change affects ModalHeader, CodegenRow,
CredentialCheck, and ClaudeCheck so that success, success-outline, and
success-small icons consistently use the "safe" theme token.

This aligns icon coloring with the current design token naming and fixes
inconsistent color usage across desktop and UI packages.