### PR TITLE
vb.toml auto-fix improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "itertools",
  "md5",
  "serde",
+ "snapbox",
  "toml 0.9.10+spec-1.1.0",
  "tracing",
 ]

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -522,13 +522,22 @@ impl Graph {
             )?;
             graph.extra_target = Some(sidx);
         }
-        for target_commit in additional_target_commits {
+        for target_commit_id in additional_target_commits {
+            // These are possibly from metadata, and thus might not exist (anymore). Ignore if that's the case.
+            if let Err(err) = repo.find_commit(target_commit_id) {
+                tracing::warn!(
+                    ?target_commit_id,
+                    ?err,
+                    "Ignoring stale target commit id as it didn't exist"
+                );
+                continue;
+            }
             // We don't really have a place to store the segment index of the segment owning the target commit
             // so we will re-acquire it later when building the workspace projection.
             let _sidx_to_be_reobtained_later = add_extra_target(
                 &mut graph,
                 &mut next,
-                target_commit,
+                target_commit_id,
                 meta,
                 &ctx,
                 target_limit,

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1210,7 +1210,7 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
 
     let heads = &mut meta.data_mut().branches.get_mut(&stack_id).unwrap().heads;
     heads[0].archived = true;
-    heads[2].archived = true;
+    heads[1].archived = true;
     heads[2].archived = true;
 
     // Archiving everything removes the stack entirely.

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1207,6 +1207,15 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
         ├── 📙:3:C
         └── 📙:4:B
     ");
+
+    let heads = &mut meta.data_mut().branches.get_mut(&stack_id).unwrap().heads;
+    heads[0].archived = true;
+    heads[2].archived = true;
+    heads[2].archived = true;
+
+    // Archiving everything removes the stack entirely.
+    let graph = graph.redo_traversal_with_overlay(&repo, &*meta, Default::default())?;
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
     Ok(())
 }
 

--- a/crates/but-meta/Cargo.toml
+++ b/crates/but-meta/Cargo.toml
@@ -47,5 +47,6 @@ hex = { version = "0.4.3", optional = true }
 but-meta = {workspace = true, features = ["legacy"] }
 but-testsupport.workspace = true
 
-insta = "1.45.1"
+insta.workspace = true
+snapbox.workspace = true
 

--- a/crates/but-meta/tests/fixtures/legacy/non-unique-branches.toml
+++ b/crates/but-meta/tests/fixtures/legacy/non-unique-branches.toml
@@ -1,0 +1,70 @@
+# 'confidence' is a segment in 'real-embed', but it's also a separate 'stack'.
+# Prefer it as stack then.
+[default_target]
+branchName = "main"
+remoteName = "origin"
+remoteUrl = "https://github.com/A2va/dlib-rs"
+sha = "39b41821d90a6445815f32777ec5dbebb716897f"
+pushRemoteName = "origin"
+
+[branch_targets]
+
+[branches.1819a203-26ef-477c-ac56-2d07a034ddb8]
+id = "1819a203-26ef-477c-ac56-2d07a034ddb8"
+name = "real-embed"
+notes = ""
+source_refname = "refs/heads/real-embed"
+upstream = "refs/remotes/origin/real-embed"
+upstream_head = "121e048bd5d483f8c6c4f14a13c76cf006672dfd"
+created_timestamp_ms = "1764514312033"
+updated_timestamp_ms = "1765788590699"
+tree = "086076eb7dc19973afeef1ee031aa279ec8700e7"
+head = "50c1d2e8298877802fcbcda10af7df748ae90611"
+ownership = ""
+order = 0
+selected_for_changes = 1764514312027
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.1819a203-26ef-477c-ac56-2d07a034ddb8.heads]]
+name = "confidence"
+archived = false
+
+[branches.1819a203-26ef-477c-ac56-2d07a034ddb8.heads.head]
+CommitId = "50c1d2e8298877802fcbcda10af7df748ae90611"
+
+[[branches.1819a203-26ef-477c-ac56-2d07a034ddb8.heads]]
+name = "main"
+archived = true
+
+[branches.1819a203-26ef-477c-ac56-2d07a034ddb8.heads.head]
+CommitId = "50c1d2e8298877802fcbcda10af7df748ae90611"
+
+[branches.a3102d3c-4c62-4a8a-955c-421f72d4df74]
+id = "a3102d3c-4c62-4a8a-955c-421f72d4df74"
+name = "confidence"
+notes = ""
+created_timestamp_ms = "1764610180000"
+updated_timestamp_ms = "1764792789760"
+tree = "0000000000000000000000000000000000000000"
+head = "33ce4486eea72dd513505f857e54e235cb2d2616"
+ownership = ""
+order = 0
+allow_rebasing = true
+in_workspace = false
+post_commits = false
+
+[[branches.a3102d3c-4c62-4a8a-955c-421f72d4df74.heads]]
+name = "confidence"
+archived = false
+
+[branches.a3102d3c-4c62-4a8a-955c-421f72d4df74.heads.head]
+CommitId = "50c1d2e8298877802fcbcda10af7df748ae90611"
+
+[[branches.a3102d3c-4c62-4a8a-955c-421f72d4df74.heads]]
+name = "main"
+archived = false
+
+[branches.a3102d3c-4c62-4a8a-955c-421f72d4df74.heads.head]
+CommitId = "7214ef6e0d06cc632f057defed086d43809f8548"

--- a/crates/but-meta/tests/fixtures/scenario/dlib-standin.sh
+++ b/crates/but-meta/tests/fixtures/scenario/dlib-standin.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Emulate a two-segment stack with names suitable for the respective vb.toml file.
+set -eu -o pipefail
+
+git init
+commit M1
+git branch confidence
+commit M2
+
+setup_target_to_match_main
+create_workspace_commit_once main
+
+# Switch back to main to simulate single-branch mode
+git checkout main

--- a/crates/but-meta/tests/fixtures/scenario/shared.sh
+++ b/crates/but-meta/tests/fixtures/scenario/shared.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function commit() {
   local message=${1:?first argument is the commit message}
   git commit -am "$message" --allow-empty

--- a/crates/but-meta/tests/fixtures/scenario/shared.sh
+++ b/crates/but-meta/tests/fixtures/scenario/shared.sh
@@ -1,0 +1,49 @@
+function commit() {
+  local message=${1:?first argument is the commit message}
+  git commit -am "$message" --allow-empty
+}
+
+function setup_remote_tracking() {
+  local branch_name="${1:?}"
+  local remote_branch_name=${2:-"$branch_name"}
+  local mode=${3:-"cp"}
+  mkdir -p .git/refs/remotes/origin
+
+  if [[ "$mode" == "cp" ]]; then
+    cp ".git/refs/heads/$branch_name" ".git/refs/remotes/origin/$remote_branch_name"
+  else
+    mv ".git/refs/heads/$branch_name" ".git/refs/remotes/origin/$remote_branch_name"
+  fi
+}
+
+function setup_target_to_match_main() {
+  setup_remote_tracking main
+  # This is for `but` which needs it right now to set a target.
+  echo "ref: refs/remotes/origin/main" >.git/refs/remotes/origin/HEAD
+
+  cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+EOF
+}
+
+# can only be called once per test setup
+function create_workspace_commit_once() {
+  local workspace_commit_subject="GitButler Workspace Commit"
+
+  if [ $# == 1 ]; then
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$current_branch" != "$1" ]]; then
+      echo "BUG: Must assure the current branch is the branch passed as argument: $current_branch != $1"
+      return 42
+    fi
+  fi
+
+  git checkout -b gitbutler/workspace
+  if [ $# == 1 ] || [ $# == 0 ]; then
+    git commit --allow-empty -m "$workspace_commit_subject"
+  else
+    git merge --no-ff -m "$workspace_commit_subject" "${@}"
+  fi
+}

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -276,13 +276,21 @@ pub fn stack_details_v3(
             // another way that still allows to extend the range via gas-stations. Maybe one day we won't need this.
             ref_info_options.traversal.hard_limit = Some(500);
             let mut info = head_info(repo, meta, ref_info_options)?;
-            if info.stacks.len() != 1 {
-                bail!(
-                    "BUG(opt-stack-id): should have gotten exactly one stack, got {}",
-                    info.stacks.len()
-                );
+            if info.is_entrypoint {
+                if info.stacks.len() != 1 {
+                    bail!(
+                        "BUG(opt-stack-id): should have gotten exactly one stack, got {}",
+                        info.stacks.len()
+                    );
+                }
+                info.stacks.pop().unwrap()
+            } else {
+                info.stacks
+                    .iter()
+                    .find(|stack| stack.segments.iter().any(|segment| segment.is_entrypoint))
+                    .cloned()
+                    .context("BUG: expected to find one segment with entrypoint")?
             }
-            info.stacks.pop().unwrap()
         }
         Some(stack_id) => {
             // Even though it shouldn't be the case, the ids can totally go out of sync. Use both to play it safer.


### PR DESCRIPTION
Related to #11546. This PR tries to first isolate problems in vb.toml in real-world failures
and fix them, along with a test for the auto-fix/reconciliation.

Ideally, this already helps to climb out of the correctness hole this impl seems to be in, so more steps aren't necessary.

### Tasks

* [x] fix `dlib-rs` "really couldn't find stack": [dlib-rs.zip](https://github.com/user-attachments/files/24204308/dlib-rs.zip)
* [x] now vb.toml data that needs fixing beyond reconcilation will be written, too. 
* [x] stack-id reconciliation  test
* [x] ensure `small` is working on `master`: [small.zip](https://github.com/user-attachments/files/24204362/small.zip)
* [x] ensure `deno` is working - actually it is working, it's just the assignments which now have issues with missing stack ids

Maybe fixed due to ordering improvements: https://github.com/gitbutlerapp/gitbutler/issues/10983 
