### PR TITLE
fix-some-dark-colors

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "1.6.0",
+		"@gitbutler/design-core": "1.6.1",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/desktop/src/components/CommitRow.svelte
+++ b/apps/desktop/src/components/CommitRow.svelte
@@ -238,7 +238,7 @@
 			}
 
 			.commit-name {
-				color: var(--clr-theme-danger-element);
+				color: var(--clr-theme-danger-on-soft);
 			}
 		}
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@gitbutler/design-core": "1.6.0",
+		"@gitbutler/design-core": "1.6.1",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/web/src/routes/color-generator/utils/colorScale.ts
+++ b/apps/web/src/routes/color-generator/utils/colorScale.ts
@@ -41,8 +41,8 @@ const LIGHTNESS_RANGES = {
 	soft: { min: 0.4, max: 0.9, exponent: 0.9 },
 	solid: { min: 0.22, max: 0.48 },
 	text: {
-		gray: { min: 0.08, max: 0.22, exponent: 1 },
-		colored: { min: 0.11, max: 0.26, exponent: 0.85 }
+		gray: { min: 0.06, max: 0.22, exponent: 1 },
+		colored: { min: 0.08, max: 0.26, exponent: 0.85 }
 	}
 } as const;
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.11.2",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "1.6.0",
+		"@gitbutler/design-core": "1.6.1",
 		"@lezer/common": "^1.2.3",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: 1.6.1
+        version: 1.6.1
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -383,8 +383,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: 1.6.1
+        version: 1.6.1
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -450,7 +450,7 @@ importers:
         version: 5.38.0
       svelte-check:
         specifier: catalog:svelte
-        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.2)
+        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 6.3.5(@types/node@22.19.3)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -619,7 +619,7 @@ importers:
         version: 2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: catalog:svelte
-        version: 2.4.0(svelte@5.38.0)(typescript@5.9.2)
+        version: 2.4.0(svelte@5.38.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
         version: 6.1.0(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -658,7 +658,7 @@ importers:
         version: 6.1.2
       svelte-check:
         specifier: catalog:svelte
-        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.2)
+        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -780,8 +780,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: 1.6.1
+        version: 1.6.1
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.4.0
@@ -817,7 +817,7 @@ importers:
         version: 3.0.8(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/package':
         specifier: catalog:svelte
-        version: 2.4.0(svelte@5.38.0)(typescript@5.9.2)
+        version: 2.4.0(svelte@5.38.0)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
         version: 6.1.0(svelte@5.38.0)(vite@6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -880,7 +880,7 @@ importers:
         version: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       svelte-check:
         specifier: catalog:svelte
-        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.2)
+        version: 4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1793,8 +1793,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.6.0':
-    resolution: {integrity: sha512-KEuK1q3C7xCR8yG9m7On1vmcxay20rpihc6K3r8bTJ5bozCyF14Nf1HJR1hW3RpP2jv9GviYZW0DIFgXpv234A==}
+  '@gitbutler/design-core@1.6.1':
+    resolution: {integrity: sha512-0HebqKKRv9f4/GBQHIJLKOuufzDOLEmOTPjjroT4R8kNZUtAkGmmLCQ1GP+ctenNo1PLXIQdfq7FqLGHlKanxg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -8587,7 +8587,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.6.0': {}
+  '@gitbutler/design-core@1.6.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -9994,14 +9994,14 @@ snapshots:
       svelte: 5.38.0
       vite: 6.3.5(@types/node@24.10.4)(sass-embedded@1.96.0)(sass@1.96.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@sveltejs/package@2.4.0(svelte@5.38.0)(typescript@5.9.2)':
+  '@sveltejs/package@2.4.0(svelte@5.38.0)(typescript@5.9.3)':
     dependencies:
       chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.3
       svelte: 5.38.0
-      svelte2tsx: 0.7.45(svelte@5.38.0)(typescript@5.9.2)
+      svelte2tsx: 0.7.45(svelte@5.38.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -14422,6 +14422,18 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
+  svelte-check@4.3.1(picomatch@4.0.3)(svelte@5.38.0)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.38.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
+
   svelte-eslint-parser@1.4.1(svelte@5.38.0):
     dependencies:
       eslint-scope: 8.4.0
@@ -14462,13 +14474,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  svelte2tsx@0.7.45(svelte@5.38.0)(typescript@5.9.2):
-    dependencies:
-      dedent-js: 1.0.1
-      scule: 1.3.0
-      svelte: 5.38.0
-      typescript: 5.9.2
 
   svelte2tsx@0.7.45(svelte@5.38.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Fix previous color adjustments. Dark colors 10 and 5 were too bright. Also updated the "danger" design token.

Before:

<img width="444" height="398" alt="image" src="https://github.com/user-attachments/assets/1790ef69-2276-4bea-8d10-44a65f267e23" />


After:

<img width="436" height="395" alt="image" src="https://github.com/user-attachments/assets/91719080-ff5e-4bcb-a47a-38f15f4c3ad1" />
