### PR TITLE
gerrit: fallback review URL when push has no new changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,11 +1108,13 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-db",
+ "but-testsupport",
  "chrono",
  "gitbutler-commit",
  "gix",
  "serde",
  "sha-1",
+ "tempfile",
  "uuid",
 ]
 

--- a/crates/but-gerrit/Cargo.toml
+++ b/crates/but-gerrit/Cargo.toml
@@ -8,7 +8,6 @@ rust-version.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 but-core.workspace = true
@@ -24,3 +23,11 @@ bstr.workspace = true
 chrono.workspace = true
 serde.workspace = true
 gix = { workspace = true }
+
+[dev-dependencies]
+
+but-testsupport.workspace = true
+
+gix = { workspace = true, features = ["revision"] }
+
+tempfile = "3"

--- a/crates/but-gerrit/src/lib.rs
+++ b/crates/but-gerrit/src/lib.rs
@@ -203,6 +203,7 @@ fn mappings(
     push_output: PushOutput,
 ) -> anyhow::Result<Vec<ChangeIdMapping>> {
     let mut mappings = vec![];
+    let host = gerrit_host(repo);
     for id in candidate_ids {
         let commit = repo.find_commit(id)?;
         let msg = commit.message_bstr().to_string();
@@ -217,20 +218,46 @@ fn mappings(
                     .change_id()
                     .map(|change_id| (change_id, c.url.clone()))
             });
+
         if let Some((change_id, review_url)) = change_id_review_url {
             mappings.push(ChangeIdMapping {
                 commit_id: id,
                 change_id,
                 review_url,
             });
+        } else if let (Some(change_id), Some(host)) = (commit.change_id(), host.as_ref()) {
+            // Fallback: generate review URL if we have a change ID and a host
+            if let Ok(uuid) = uuid::Uuid::parse_str(&change_id) {
+                let gerrit_change_id = GerritChangeId::from(uuid);
+                let review_url = format!("https://{}/q/{}", host, gerrit_change_id);
+                mappings.push(ChangeIdMapping {
+                    commit_id: id,
+                    change_id,
+                    review_url,
+                });
+            }
         }
     }
     Ok(mappings)
 }
 
+fn gerrit_host(repo: &gix::Repository) -> Option<String> {
+    let name = repo.remote_default_name(gix::remote::Direction::Push);
+    let name = name
+        .as_ref()
+        .map(|n| n.as_ref())
+        .unwrap_or(b"origin".as_bstr());
+    let remote = repo.find_remote(name).ok()?;
+    let url = remote
+        .url(gix::remote::Direction::Push)
+        .or_else(|| remote.url(gix::remote::Direction::Fetch))?;
+    url.host().map(|h| format!("{}", h))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn output_is_41_characters_long() {
         let uuid = Uuid::new_v4();

--- a/crates/but-gerrit/src/lib.rs
+++ b/crates/but-gerrit/src/lib.rs
@@ -251,7 +251,7 @@ fn gerrit_host(repo: &gix::Repository) -> Option<String> {
     let url = remote
         .url(gix::remote::Direction::Push)
         .or_else(|| remote.url(gix::remote::Direction::Fetch))?;
-    url.host().map(|h| format!("{}", h))
+    url.host().map(|h| h.to_string())
 }
 
 #[cfg(test)]

--- a/crates/but-gerrit/tests/integration_test.rs
+++ b/crates/but-gerrit/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use but_ctx::Context;
-use but_gerrit::{record_push_metadata, parse::PushOutput, GerritChangeId};
+use but_gerrit::{GerritChangeId, parse::PushOutput, record_push_metadata};
 use but_testsupport::CommandExt;
 
 #[test]
@@ -31,7 +31,10 @@ fn test_record_push_metadata_fallback_url() {
         message: "Test commit".into(),
         extra_headers: vec![
             (b"gitbutler-headers-version".into(), b"2".into()),
-            (b"gitbutler-change-id".into(), change_uuid.to_string().into()),
+            (
+                b"gitbutler-change-id".into(),
+                change_uuid.to_string().into(),
+            ),
         ],
     };
     let commit_id = gix_repo.write_object(&commit_obj).unwrap().detach();

--- a/crates/but-gerrit/tests/integration_test.rs
+++ b/crates/but-gerrit/tests/integration_test.rs
@@ -12,7 +12,7 @@ fn test_record_push_metadata_fallback_url() {
     let change_uuid = uuid::Uuid::new_v4();
 
     let tree_id = gix_repo
-        .write_object(&gix::objs::Tree::empty())
+        .write_object(gix::objs::Tree::empty())
         .unwrap()
         .detach();
     let author = gix::actor::Signature {

--- a/crates/but-gerrit/tests/integration_test.rs
+++ b/crates/but-gerrit/tests/integration_test.rs
@@ -1,0 +1,67 @@
+use but_ctx::Context;
+use but_gerrit::{record_push_metadata, parse::PushOutput, GerritChangeId};
+use but_testsupport::CommandExt;
+
+#[test]
+fn test_record_push_metadata_fallback_url() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let gix_repo = gix::init(temp_dir.path()).unwrap();
+    let mut ctx = Context::from_repo(gix_repo.clone()).unwrap();
+
+    // 1. Create a commit with GitButler headers
+    let change_uuid = uuid::Uuid::new_v4();
+
+    let tree_id = gix_repo
+        .write_object(&gix::objs::Tree::empty())
+        .unwrap()
+        .detach();
+    let author = gix::actor::Signature {
+        name: "Author".into(),
+        email: "author@example.com".into(),
+        time: gix::date::Time::now_local_or_utc(),
+    };
+    let committer = author.clone();
+
+    let commit_obj = gix::objs::Commit {
+        tree: tree_id,
+        parents: Default::default(),
+        author,
+        committer,
+        encoding: None,
+        message: "Test commit".into(),
+        extra_headers: vec![
+            (b"gitbutler-headers-version".into(), b"2".into()),
+            (b"gitbutler-change-id".into(), change_uuid.to_string().into()),
+        ],
+    };
+    let commit_id = gix_repo.write_object(&commit_obj).unwrap().detach();
+
+    // 2. Set up a remote so we can derive the host
+    but_testsupport::git(&gix_repo)
+        .args(["remote", "add", "origin", "https://gerrithost/project"])
+        .run();
+
+    let gix_repo = gix::open(gix_repo.path()).unwrap();
+    let candidate_ids = vec![commit_id];
+    let push_output = PushOutput {
+        success: true,
+        warnings: vec![],
+        changes: vec![], // Empty changes to trigger fallback
+        processing_info: None,
+    };
+
+    record_push_metadata(&mut ctx, &gix_repo, candidate_ids, push_output).unwrap();
+
+    let mut db = ctx.db.get_mut().unwrap();
+    let mut db = db.gerrit_metadata();
+    let meta = db
+        .get(&change_uuid.to_string())
+        .unwrap()
+        .expect("Metadata should be recorded");
+
+    let gerrit_change_id = GerritChangeId::from(change_uuid);
+    assert_eq!(
+        meta.review_url,
+        format!("https://gerrithost/q/{}", gerrit_change_id)
+    );
+}


### PR DESCRIPTION
Fixes #10188

When pushing to Gerrit, if a commit was already pushed outside GitButler, Gerrit may reject with `(no new changes)`. GitButler treats this as success, but the push output contains no change URLs, so no Gerrit metadata was recorded and the UI kept the commit as 'unpushed' / missing the CR link.

This adds a fallback in `but-gerrit` to derive the Gerrit host from the repo push remote and generate a review URL from the commit's GitButler change UUID (the same `I<sha1(uuid)>` `Change-Id` used in trailers), e.g. `https://<gerrit-host>/q/<change-id>`.

**Tests**
- `cargo test -p but-gerrit`