### PR TITLE
ui-branch-rendering-and-fixes

### DIFF
--- a/apps/desktop/src/components/BranchBadge.svelte
+++ b/apps/desktop/src/components/BranchBadge.svelte
@@ -22,7 +22,7 @@
 	{label}
 </span>
 
-<style class="postcss">
+<style lang="postcss">
 	.branch-badge {
 		display: flex;
 		align-items: center;

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -60,6 +60,7 @@
 		pushStatus: PushStatus;
 		lastUpdatedAt?: number;
 		isConflicted: boolean;
+		applied?: boolean;
 		contextMenu?: typeof BranchHeaderContextMenu;
 		dropzones: DropzoneHandler[];
 		numberOfCommits: number;
@@ -206,7 +207,7 @@
 				conflicts={args.isConflicted}
 				{showPrCreation}
 				dragArgs={{
-					disabled: args.isConflicted,
+					disabled: args.isConflicted || (args.type === 'stack-branch' && args.applied === false),
 					label: branchName,
 					pushStatus: args.pushStatus,
 					data:

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -130,7 +130,8 @@
 		// For stack branches not committing, check if actions are visible and structural conditions
 		if (args.type === 'stack-branch' && !args.isCommitting) {
 			const hasActions = args.buttons !== undefined || args.menu !== undefined;
-			const structurallyRounded = args.hasCodegenRow || args.numberOfCommits === 0;
+			const structurallyRounded =
+				args.hasCodegenRow || (args.numberOfCommits === 0 && args.numberOfUpstreamCommits === 0);
 			return hasActions && structurallyRounded;
 		}
 

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -41,6 +41,7 @@
 		lastUpdatedAt?: number;
 		isTopBranch?: boolean;
 		isNewBranch?: boolean;
+		roundedBottom?: boolean;
 		onclick: () => void;
 		branchContent: Snippet;
 		codegenRow?: Snippet;
@@ -296,6 +297,7 @@
 			readonly
 			{isPushed}
 			onclick={args.onclick}
+			roundedBottom={args.roundedBottom}
 		>
 			{#snippet emptyState()}
 				<span class="branch-header__empty-state-span">There are no commits yet on this branch.</span

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -142,7 +142,7 @@
 			></div>
 		{/if}
 
-		{#if !conflicts}
+		{#if dragArgs && !dragArgs.disabled && !conflicts}
 			<div class="branch-header__drag-handle" data-no-drag>
 				<Icon name="draggable-narrow" />
 			</div>

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -142,6 +142,12 @@
 			></div>
 		{/if}
 
+		{#if !conflicts}
+			<div class="branch-header__drag-handle" data-no-drag>
+				<Icon name="draggable-narrow" />
+			</div>
+		{/if}
+
 		<div class="branch-header__content">
 			<div class="branch-header__title text-14 text-bold">
 				<div class="branch-header__title-content">
@@ -161,10 +167,6 @@
 						<Badge style="danger">Conflicts</Badge>
 					</div>
 				{/if}
-
-				<div class="branch-header__drag-handle" data-no-drag>
-					<Icon name="draggable-narrow" />
-				</div>
 			</div>
 
 			{#if isEmpty}
@@ -234,6 +236,7 @@
 		flex-direction: column;
 		align-items: center;
 		justify-content: flex-start;
+		padding-right: var(--branch-side-padding);
 		padding-left: var(--branch-side-padding);
 		overflow: hidden;
 		border-bottom: none;
@@ -294,8 +297,6 @@
 		align-items: center;
 		justify-content: space-between;
 		min-width: 0;
-		/* margin-right: 12px; */
-		/* gap: 4px; */
 	}
 
 	.branch-header__title-content {
@@ -303,13 +304,13 @@
 		flex-grow: 1;
 		align-items: center;
 		min-width: 0;
+		padding-right: 8px;
 		gap: 6px;
 	}
 
 	.branch-header__top-badges {
 		display: flex;
 		align-items: center;
-		margin-left: 6px;
 		gap: 4px;
 		transform: translateY(-2px);
 	}
@@ -327,12 +328,12 @@
 
 	.branch-header__drag-handle {
 		display: flex;
-		position: relative;
+		position: absolute;
+		top: 6px;
+		right: 4px;
 		align-items: center;
 		justify-content: flex-end;
 		width: 10px;
-		margin-top: -20px;
-		margin-right: 3px;
 		color: var(--clr-text-1);
 		opacity: 0;
 		transition:

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -79,7 +79,7 @@
 	{@const commitType: 'Remote' | 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = isUpstream ? 'Remote' : ((branchFirstCommitType as 'LocalOnly' | 'LocalAndRemote' | 'Integrated') ?? 'LocalOnly')}
 	{@const isDiverged = localCommit
 		? localCommit.state.type === 'LocalAndRemote' &&
-			commit.id !== (localCommit.state as any).subject
+			commit.id !== localCommit.state.subject
 		: false}
 	{@const shouldShowMenu = !(
 		branchesSelection.current.inWorkspace || branchesSelection.current.isTarget

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -129,7 +129,7 @@
 						menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
 							? undefined
 							: menu}
-					></CommitRow>
+					/>
 				{/each}
 				{#each branch.commits || [] as commit, idx}
 					{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
@@ -157,7 +157,7 @@
 						menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
 							? undefined
 							: menu}
-					></CommitRow>
+					/>
 				{/each}
 			</div>
 		{/snippet}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -5,7 +5,7 @@
 	import CommitRow from '$components/CommitRow.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { BranchesSelectionActions } from '$lib/branches/branchesSelection';
-	import { commitCreatedAt } from '$lib/branches/v3';
+	import { commitCreatedAt, type Commit, type UpstreamCommit } from '$lib/branches/v3';
 	import { getColorFromPushStatus, pushStatusToIcon, type BranchDetails } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -50,11 +50,7 @@
 
 <ReduxResult result={branchQuery.result} {projectId} {stackId} {onerror}>
 	{#snippet children(branch, env)}
-		{#if stackId}
-			{@render branchCard(branch, env)}
-		{:else}
-			{@render branchCard(branch, env)}
-		{/if}
+		{@render branchCard(branch, env)}
 	{/snippet}
 </ReduxResult>
 
@@ -68,10 +64,60 @@
 	/>
 {/snippet}
 
+{#snippet renderCommitRow(
+	commit: Commit | UpstreamCommit,
+	idx: number,
+	isUpstream: boolean,
+	totalUpstream: number,
+	totalLocal: number,
+	branchFirstCommitType: string | undefined
+)}
+	{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
+		{@render commitMenu(rightClickTrigger, commit.id)}
+	{/snippet}
+	{@const localCommit = isUpstream ? undefined : (commit as Commit)}
+	{@const commitType: 'Remote' | 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = isUpstream ? 'Remote' : ((branchFirstCommitType as 'LocalOnly' | 'LocalAndRemote' | 'Integrated') ?? 'LocalOnly')}
+	{@const isDiverged = localCommit
+		? localCommit.state.type === 'LocalAndRemote' &&
+			commit.id !== (localCommit.state as any).subject
+		: false}
+	{@const shouldShowMenu = !(
+		branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
+	)}
+	<CommitRow
+		disableCommitActions={false}
+		{stackId}
+		type={commitType}
+		diverged={isDiverged}
+		commitMessage={commit.message}
+		gerritReviewUrl={localCommit?.gerritReviewUrl ?? undefined}
+		createdAt={commitCreatedAt(commit)}
+		commitId={commit.id}
+		{branchName}
+		selected={commit.id === branchesSelection?.current.commitId}
+		onclick={() => {
+			BranchesSelectionActions.selectCommit(branchesSelection, {
+				commitId: commit.id,
+				remote
+			});
+		}}
+		lastCommit={isUpstream ? idx === totalUpstream - 1 && totalLocal === 0 : idx === totalLocal - 1}
+		active={!isUpstream}
+		{...shouldShowMenu && { menu }}
+	/>
+{/snippet}
+
 {#snippet branchCard(branch: BranchDetails, env: { projectId: string; stackId?: string })}
 	{@const commitColor = getColorFromPushStatus(branch.pushStatus)}
-	{@const hasCommits =
-		(branch.upstreamCommits?.length ?? 0) > 0 || (branch.commits?.length ?? 0) > 0}
+	{@const upstreamCount = branch.upstreamCommits?.length ?? 0}
+	{@const localCount = branch.commits?.length ?? 0}
+	{@const hasCommits = upstreamCount > 0 || localCount > 0}
+	{@const isBranchSelected =
+		branchesSelection.current.branchName === branch.name &&
+		branchesSelection.current.stackId === env.stackId &&
+		!branchesSelection.current.commitId}
+	{@const branchFirstCommitType = branch.commits?.at(0)?.state.type}
+
 	<BranchCard
 		type="normal-branch"
 		first={isTopBranch}
@@ -79,14 +125,12 @@
 		projectId={env.projectId}
 		branchName={branch.name}
 		{isTopBranch}
-		isNewBranch={branch.commits?.length === 0}
+		isNewBranch={localCount === 0}
 		iconName={pushStatusToIcon(branch.pushStatus)}
 		trackingBranch={branch.remoteTrackingBranch || undefined}
 		readonly
 		roundedBottom={!hasCommits}
-		selected={branchesSelection.current.branchName === branch.name &&
-			branchesSelection.current.stackId === env.stackId &&
-			!branchesSelection.current.commitId}
+		selected={isBranchSelected}
 		onclick={() => {
 			if (env.stackId) {
 				BranchesSelectionActions.selectStack(branchesSelection, {
@@ -109,60 +153,25 @@
 		{#snippet branchContent()}
 			{#if hasCommits}
 				<div class="branch-commits">
-					{#each branch.upstreamCommits || [] as commit, idx}
-						{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
-							{@render commitMenu(rightClickTrigger, commit.id)}
-						{/snippet}
-						<CommitRow
-							disableCommitActions={false}
-							stackId={env.stackId}
-							type="Remote"
-							active
-							commitMessage={commit.message}
-							createdAt={commitCreatedAt(commit)}
-							commitId={commit.id}
-							branchName={branch.name}
-							selected={commit.id === branchesSelection?.current.commitId}
-							onclick={() => {
-								BranchesSelectionActions.selectCommit(branchesSelection, {
-									commitId: commit.id,
-									remote
-								});
-							}}
-							lastCommit={idx === branch.upstreamCommits.length - 1 && branch.commits.length === 0}
-							menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
-								? undefined
-								: menu}
-						/>
+					{#each branch.upstreamCommits ?? [] as commit, idx}
+						{@render renderCommitRow(
+							commit,
+							idx,
+							true,
+							upstreamCount,
+							localCount,
+							branchFirstCommitType
+						)}
 					{/each}
-					{#each branch.commits || [] as commit, idx}
-						{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
-							{@render commitMenu(rightClickTrigger, commit.id)}
-						{/snippet}
-						<CommitRow
-							disableCommitActions={false}
-							stackId={env.stackId}
-							type={branch.commits.at(0)?.state.type || 'LocalOnly'}
-							diverged={commit.state.type === 'LocalAndRemote' &&
-								commit.id !== commit.state.subject}
-							commitMessage={commit.message}
-							gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
-							createdAt={commitCreatedAt(commit)}
-							commitId={commit.id}
-							branchName={branch.name}
-							selected={commit.id === branchesSelection?.current.commitId}
-							onclick={() => {
-								BranchesSelectionActions.selectCommit(branchesSelection, {
-									commitId: commit.id,
-									remote
-								});
-							}}
-							lastCommit={idx === branch.commits.length - 1}
-							active
-							menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
-								? undefined
-								: menu}
-						/>
+					{#each branch.commits ?? [] as commit, idx}
+						{@render renderCommitRow(
+							commit,
+							idx,
+							false,
+							upstreamCount,
+							localCount,
+							branchFirstCommitType
+						)}
 					{/each}
 				</div>
 			{/if}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -75,7 +75,8 @@
 	{/snippet}
 	{@const localCommit = commit as Commit}
 	{@const commitType: 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = (branchFirstCommitType as 'LocalOnly' | 'LocalAndRemote' | 'Integrated') ?? 'LocalOnly'}
-	{@const isDiverged = localCommit.state.type === 'LocalAndRemote' && commit.id !== localCommit.state.subject}
+	{@const isDiverged =
+		localCommit.state.type === 'LocalAndRemote' && commit.id !== localCommit.state.subject}
 	{@const shouldShowMenu = !(
 		branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
 	)}
@@ -148,12 +149,7 @@
 			{#if hasCommits}
 				<div class="branch-commits">
 					{#each branch.commits ?? [] as commit, idx}
-						{@render renderCommitRow(
-							commit,
-							idx,
-							localCount,
-							branchFirstCommitType
-						)}
+						{@render renderCommitRow(commit, idx, localCount, branchFirstCommitType)}
 					{/each}
 				</div>
 			{/if}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -70,6 +70,8 @@
 
 {#snippet branchCard(branch: BranchDetails, env: { projectId: string; stackId?: string })}
 	{@const commitColor = getColorFromPushStatus(branch.pushStatus)}
+	{@const hasCommits =
+		(branch.upstreamCommits?.length ?? 0) > 0 || (branch.commits?.length ?? 0) > 0}
 	<BranchCard
 		type="normal-branch"
 		first={isTopBranch}
@@ -81,6 +83,7 @@
 		iconName={pushStatusToIcon(branch.pushStatus)}
 		trackingBranch={branch.remoteTrackingBranch || undefined}
 		readonly
+		roundedBottom={!hasCommits}
 		selected={branchesSelection.current.branchName === branch.name &&
 			branchesSelection.current.stackId === env.stackId &&
 			!branchesSelection.current.commitId}
@@ -104,62 +107,65 @@
 		}}
 	>
 		{#snippet branchContent()}
-			<div class="branch-commits hide-when-empty">
-				{#each branch.upstreamCommits || [] as commit, idx}
-					{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
-						{@render commitMenu(rightClickTrigger, commit.id)}
-					{/snippet}
-					<CommitRow
-						disableCommitActions={false}
-						stackId={env.stackId}
-						type="Remote"
-						active
-						commitMessage={commit.message}
-						createdAt={commitCreatedAt(commit)}
-						commitId={commit.id}
-						branchName={branch.name}
-						selected={commit.id === branchesSelection?.current.commitId}
-						onclick={() => {
-							BranchesSelectionActions.selectCommit(branchesSelection, {
-								commitId: commit.id,
-								remote
-							});
-						}}
-						lastCommit={idx === branch.upstreamCommits.length - 1 && branch.commits.length === 0}
-						menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
-							? undefined
-							: menu}
-					/>
-				{/each}
-				{#each branch.commits || [] as commit, idx}
-					{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
-						{@render commitMenu(rightClickTrigger, commit.id)}
-					{/snippet}
-					<CommitRow
-						disableCommitActions={false}
-						stackId={env.stackId}
-						type={branch.commits.at(0)?.state.type || 'LocalOnly'}
-						diverged={commit.state.type === 'LocalAndRemote' && commit.id !== commit.state.subject}
-						commitMessage={commit.message}
-						gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
-						createdAt={commitCreatedAt(commit)}
-						commitId={commit.id}
-						branchName={branch.name}
-						selected={commit.id === branchesSelection?.current.commitId}
-						onclick={() => {
-							BranchesSelectionActions.selectCommit(branchesSelection, {
-								commitId: commit.id,
-								remote
-							});
-						}}
-						lastCommit={idx === branch.commits.length - 1}
-						active
-						menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
-							? undefined
-							: menu}
-					/>
-				{/each}
-			</div>
+			{#if hasCommits}
+				<div class="branch-commits">
+					{#each branch.upstreamCommits || [] as commit, idx}
+						{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
+							{@render commitMenu(rightClickTrigger, commit.id)}
+						{/snippet}
+						<CommitRow
+							disableCommitActions={false}
+							stackId={env.stackId}
+							type="Remote"
+							active
+							commitMessage={commit.message}
+							createdAt={commitCreatedAt(commit)}
+							commitId={commit.id}
+							branchName={branch.name}
+							selected={commit.id === branchesSelection?.current.commitId}
+							onclick={() => {
+								BranchesSelectionActions.selectCommit(branchesSelection, {
+									commitId: commit.id,
+									remote
+								});
+							}}
+							lastCommit={idx === branch.upstreamCommits.length - 1 && branch.commits.length === 0}
+							menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
+								? undefined
+								: menu}
+						/>
+					{/each}
+					{#each branch.commits || [] as commit, idx}
+						{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
+							{@render commitMenu(rightClickTrigger, commit.id)}
+						{/snippet}
+						<CommitRow
+							disableCommitActions={false}
+							stackId={env.stackId}
+							type={branch.commits.at(0)?.state.type || 'LocalOnly'}
+							diverged={commit.state.type === 'LocalAndRemote' &&
+								commit.id !== commit.state.subject}
+							commitMessage={commit.message}
+							gerritReviewUrl={commit.gerritReviewUrl ?? undefined}
+							createdAt={commitCreatedAt(commit)}
+							commitId={commit.id}
+							branchName={branch.name}
+							selected={commit.id === branchesSelection?.current.commitId}
+							onclick={() => {
+								BranchesSelectionActions.selectCommit(branchesSelection, {
+									commitId: commit.id,
+									remote
+								});
+							}}
+							lastCommit={idx === branch.commits.length - 1}
+							active
+							menu={branchesSelection.current.inWorkspace || branchesSelection.current.isTarget
+								? undefined
+								: menu}
+						/>
+					{/each}
+				</div>
+			{/if}
 		{/snippet}
 	</BranchCard>
 {/snippet}

--- a/apps/desktop/src/components/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/BranchesViewStack.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+	import BranchDividerLine from '$components/BranchDividerLine.svelte';
 	import BranchesViewBranch from '$components/BranchesViewBranch.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { getStackBranchNames } from '$lib/stacks/stack';
+	import { getColorFromPushStatus, getStackBranchNames } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { inject } from '@gitbutler/core/context';
 
@@ -26,6 +27,16 @@
 			<p>Stack not found.</p>
 		{:else}
 			{#each getStackBranchNames(stack) as branchName, idx}
+				{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
+				{@const branchDetails = branchDetailsQuery.response}
+				{@const lineColor = branchDetails
+					? getColorFromPushStatus(branchDetails.pushStatus)
+					: 'var(--clr-commit-local)'}
+
+				{#if idx > 0}
+					<BranchDividerLine {lineColor} />
+				{/if}
+
 				<BranchesViewBranch
 					{projectId}
 					{stackId}

--- a/apps/desktop/src/components/WelcomeSigninAction.svelte
+++ b/apps/desktop/src/components/WelcomeSigninAction.svelte
@@ -90,7 +90,7 @@
 	</CardGroup>
 {/if}
 
-<style class="postcss">
+<style lang="postcss">
 	.welcome-signin-action {
 		display: flex;
 		flex-direction: row;

--- a/apps/desktop/src/components/branchesPage/BranchesCardTemplate.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesCardTemplate.svelte
@@ -33,7 +33,7 @@
 	</div>
 </div>
 
-<style class="postcss">
+<style lang="postcss">
 	/* TARGET CARD */
 	.branches-list-card {
 		display: flex;

--- a/apps/desktop/src/components/branchesPage/BranchesListGroup.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchesListGroup.svelte
@@ -16,7 +16,7 @@
 	</div>
 </div>
 
-<style class="postcss">
+<style lang="postcss">
 	.branches-list-wrap {
 		display: flex;
 		flex-direction: column;

--- a/packages/ui/src/lib/components/Badge.svelte
+++ b/packages/ui/src/lib/components/Badge.svelte
@@ -93,7 +93,7 @@
 			color: var(--clr-theme-warn-on-element);
 		}
 
-		&.error.solid {
+		&.danger.solid {
 			background-color: var(--clr-theme-danger-element);
 			color: var(--clr-theme-danger-on-element);
 		}
@@ -124,7 +124,7 @@
 			color: var(--clr-theme-warn-on-soft);
 		}
 
-		&.error.soft {
+		&.danger.soft {
 			background-color: var(--clr-theme-danger-soft);
 			color: var(--clr-theme-danger-on-soft);
 		}

--- a/packages/ui/src/stories/components/Badge.stories.svelte
+++ b/packages/ui/src/stories/components/Badge.stories.svelte
@@ -18,7 +18,7 @@
 				control: { type: 'text' }
 			},
 			style: {
-				options: ['gray', 'pop', 'safe', 'warning', 'error', 'purple'],
+				options: ['gray', 'pop', 'safe', 'warning', 'danger', 'purple'],
 				control: { type: 'select' }
 			},
 			kind: {


### PR DESCRIPTION
Show commit line dividers between branches for unapplied stacks.

Before:
<img width="398" height="388" alt="image" src="https://github.com/user-attachments/assets/35d1b228-4de0-488b-90fd-22d35201c352" />

After:
<img width="410" height="391" alt="image" src="https://github.com/user-attachments/assets/48336c69-dc65-48ae-bb1c-07135be4d71d" />

---

Round branch corners and don't render commit list if it's empty for unapplied branches.

Before:
<img width="369" height="132" alt="image" src="https://github.com/user-attachments/assets/f4be068b-0298-44fa-a2b2-09649def1edc" />

After:
<img width="417" height="159" alt="image" src="https://github.com/user-attachments/assets/e126ee61-7a33-4248-9786-e1ff9e2b55d1" />

---

Fix rounded borders for the case where there are upstream commits but no local commits

Before:
<img width="467" height="285" alt="image" src="https://github.com/user-attachments/assets/e39eb97f-c1b2-4034-bb37-e562d0b3f5a7" />

After:
<img width="451" height="247" alt="image" src="https://github.com/user-attachments/assets/8e1a9a79-492e-4d05-9eda-688556f88acc" />

---

Also:

- Fix the `Bandge` component styles
- Fix elements positioning in the `BranchHeader` component
- FIx style tags `lang` attribute
- `BranchesViewBranch` refactor