### PR TITLE
fix(desktop): remove redundant type assertion in branch component

### DIFF
--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -73,7 +73,7 @@
 	{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
 		{@render commitMenu(rightClickTrigger, commit.id)}
 	{/snippet}
-	{@const localCommit = commit as Commit}
+	{@const localCommit = commit}
 	{@const commitType: 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = (branchFirstCommitType as 'LocalOnly' | 'LocalAndRemote' | 'Integrated') ?? 'LocalOnly'}
 	{@const isDiverged =
 		localCommit.state.type === 'LocalAndRemote' && commit.id !== localCommit.state.subject}


### PR DESCRIPTION
Simplify BranchesViewBranch.svelte by removing an unnecessary
TypeScript-style assertion on the commit variable:
- Change "const localCommit = commit as Commit" to "const localCommit = commit".

This removes redundant casting that is not needed in the Svelte template,
reducing noise and avoiding potential confusion about type assumptions. The
behavior remains unchanged.