### PR TITLE
Frontend for new commit insert blank

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -95,6 +95,7 @@ export function createMockUpstreamCommit(
 
 export const MOCK_BRANCH_DETAILS: Workspace.BranchDetails = {
 	name: 'branch-a',
+	reference: 'refs/heads/branch-a',
 	linkedWorktreeId: null,
 	remoteTrackingBranch: null,
 	description: null,
@@ -113,6 +114,7 @@ export const MOCK_BRANCH_DETAILS: Workspace.BranchDetails = {
 
 export const MOCK_BRANCH_DETAILS_BRAND_NEW: Workspace.BranchDetails = {
 	name: MOCK_BRAND_NEW_BRANCH_NAME,
+	reference: `refs/heads/${MOCK_BRAND_NEW_BRANCH_NAME}`,
 	remoteTrackingBranch: null,
 	linkedWorktreeId: null,
 	description: null,

--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -217,7 +217,8 @@
 								projectId,
 								stackId,
 								commitId: undefined,
-								offset: -1
+								offset: 1,
+								reference: contextData.branch.reference
 							});
 							close();
 						}}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -29,7 +29,7 @@ import {
 	type ThunkDispatch,
 	type UnknownAction
 } from '@reduxjs/toolkit';
-import { get } from 'svelte/store';
+import { fromStore, get } from 'svelte/store';
 import type { StackOrder } from '$lib/branches/branch';
 import type { Commit, CommitDetails, UpstreamCommit } from '$lib/branches/v3';
 import type { MoveCommitIllegalAction } from '$lib/commits/commit';
@@ -150,6 +150,16 @@ export type CreateCommitOutcome = {
 	newCommit: string | null;
 	pathsToRejectedChanges: [RejectionReason, string][];
 };
+
+export type RelativeTo =
+	| {
+			type: 'commit';
+			subject: string;
+	  }
+	| {
+			type: 'reference';
+			subject: string;
+	  };
 
 export const STACK_SERVICE = new InjectionToken<StackService>('StackService');
 
@@ -655,7 +665,50 @@ export class StackService {
 	}
 
 	get insertBlankCommit() {
-		return this.api.endpoints.insertBlankCommit.useMutation();
+		const [legacyMutate, legacyStatus] = this.api.endpoints.legacyInsertBlankCommit.useMutation();
+		const [newMutate, newStatus] = this.api.endpoints.insertBlankCommit.useMutation();
+
+		async function mutate(args: {
+			projectId: string;
+			stackId: string;
+			commitId: string | undefined;
+			offset: number;
+			reference?: string;
+		}) {
+			if (get(useNewRebaseEngine)) {
+				const side = args.offset < 0 ? 'above' : 'below';
+				if (args.commitId !== undefined) {
+					// Insert relative to a commit
+					return newMutate({
+						projectId: args.projectId,
+						relativeTo: { type: 'commit', subject: args.commitId },
+						side
+					});
+				} else if (args.reference !== undefined) {
+					// Insert relative to a branch reference
+					return newMutate({
+						projectId: args.projectId,
+						relativeTo: { type: 'reference', subject: args.reference },
+						side
+					});
+				}
+			}
+			// Fall back to legacy API
+			return legacyMutate(args);
+		}
+
+		const newRebaseEngine = fromStore(useNewRebaseEngine);
+
+		const status = $derived.by(() => {
+			if (newRebaseEngine.current) {
+				return newStatus.current;
+			} else {
+				return legacyStatus.current;
+			}
+		});
+
+		// Return a tuple matching the useMutation pattern
+		return [mutate, reactive(() => status)] as const;
 	}
 
 	get unapply() {
@@ -1252,12 +1305,27 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 					invalidatesList(ReduxTag.HeadSha)
 				]
 			}),
-			insertBlankCommit: build.mutation<
+			legacyInsertBlankCommit: build.mutation<
 				void,
 				{ projectId: string; stackId: string; commitId: string | undefined; offset: number }
 			>({
 				extraOptions: {
 					command: 'insert_blank_commit',
+					actionName: 'Insert Blank Commit'
+				},
+				query: (args) => args,
+				invalidatesTags: () => [invalidatesList(ReduxTag.HeadSha)]
+			}),
+			insertBlankCommit: build.mutation<
+				string,
+				{
+					projectId: string;
+					relativeTo: RelativeTo;
+					side: 'above' | 'below';
+				}
+			>({
+				extraOptions: {
+					command: 'commit_insert_blank',
 					actionName: 'Insert Blank Commit'
 				},
 				query: (args) => args,

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -30,6 +30,7 @@ const MOCK_UPSTREAM_COMMIT_A: UpstreamCommit = {
 
 const BRANCH_DETAILS_A: BranchDetails = {
 	name: 'branch-a',
+	reference: 'refs/heads/branch-a',
 	pushStatus: 'nothingToPush',
 	lastUpdatedAt: BigInt(1672531200000), // Example timestamp
 	authors: [MOCK_AUTHOR_A],

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -233,6 +233,11 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         // Original function stays
         #input_fn
 
+        const _: () = {
+            #[allow(dead_code)]
+            pub fn keep_json(_json: #json_ty) {}
+        };
+
         /// Cmd function - this is legacy just while most of its functionality depend on `LegacyProjectId`.
         /// parameter struct input via json value, json output.
         #[cfg(feature = "legacy")]

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -2,11 +2,13 @@
 
 use anyhow::{Result, anyhow};
 use petgraph::{Direction, visit::EdgeRef};
+use serde::{Deserialize, Serialize};
 
 use crate::graph_rebase::{Edge, Editor, Selector, Step};
 
 /// Describes where relative to the selector a step should be inserted
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum InsertSide {
     /// When inserting above, any nodes that point to the selector will now
     /// point to the inserted node instead.

--- a/crates/but-serde/src/lib.rs
+++ b/crates/but-serde/src/lib.rs
@@ -15,6 +15,27 @@ pub mod bstring_lossy {
     }
 }
 
+pub mod fullname_lossy {
+    use bstr::ByteSlice;
+    use serde::{Deserialize, Deserializer, Serialize};
+
+    pub fn serialize<S>(v: &gix::refs::FullName, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        v.as_bstr().to_str_lossy().serialize(s)
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<gix::refs::FullName, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let string = <String as Deserialize>::deserialize(d)?;
+        gix::refs::FullName::try_from(string)
+            .map_err(|err| serde::de::Error::custom(err.to_string()))
+    }
+}
+
 pub mod bstring_vec_lossy {
     use bstr::{BString, ByteSlice};
     use serde::Serialize;

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -130,7 +130,8 @@ pub fn branch_details(
     };
 
     Ok(ui::BranchDetails {
-        name: name.as_bstr().into(),
+        name: name.shorten().into(),
+        reference: name.into(),
         linked_worktree_id: None, /* probably not needed here */
         remote_tracking_branch: remote_tracking_branch.map(|b| b.name().as_bstr().to_owned()),
         description: meta.description.clone(),

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -403,6 +403,7 @@ impl ui::BranchDetails {
                 .category()
                 .is_some_and(|c| matches!(c, gix::refs::Category::RemoteBranch)),
             name: ref_info.ref_name.shorten().into(),
+            reference: ref_info.ref_name,
             linked_worktree_id: ref_info.worktree.and_then(|ws| match ws {
                 but_graph::Worktree::Main => None,
                 but_graph::Worktree::LinkedId(id) => Some(id),

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -198,10 +198,14 @@ pub enum PushStatus {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct BranchDetails {
-    /// The name of the branch.
+    /// The name of the branch. This is the "given name" IE, just `foo` out of `refs/heads/foo`
     #[serde(with = "but_serde::bstring_lossy")]
     #[ts(type = "string")]
     pub name: BString,
+    #[serde(with = "but_serde::fullname_lossy")]
+    #[ts(type = "string")]
+    /// The full reference of the branch
+    pub reference: gix::refs::FullName,
     /// The id of the linked worktree that has the reference of `name` checked out.
     /// Note that we don't list the main worktree here.
     #[serde(with = "but_serde::bstring_opt_lossy")]

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -40,7 +40,10 @@ mod with_workspace {
             but_workspace::branch_details(&repo, refname("A").as_ref(), &store).unwrap(),
             @r#"
         BranchDetails {
-            name: "refs/heads/A",
+            name: "A",
+            reference: FullName(
+                "refs/heads/A",
+            ),
             linked_worktree_id: None,
             remote_tracking_branch: None,
             description: Some(
@@ -89,7 +92,10 @@ mod with_workspace {
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
-            name: "refs/heads/A",
+            name: "A",
+            reference: FullName(
+                "refs/heads/A",
+            ),
             linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",
@@ -142,7 +148,10 @@ mod with_workspace {
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
-            name: "refs/heads/A",
+            name: "A",
+            reference: FullName(
+                "refs/heads/A",
+            ),
             linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",
@@ -180,7 +189,10 @@ mod with_workspace {
         // Remote tracking branches are OK to use as well.
         insta::assert_debug_snapshot!(but_workspace::branch_details(&repo, refname("origin/A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
-            name: "refs/remotes/origin/A",
+            name: "origin/A",
+            reference: FullName(
+                "refs/remotes/origin/A",
+            ),
             linked_worktree_id: None,
             remote_tracking_branch: None,
             description: None,
@@ -223,7 +235,10 @@ mod with_workspace {
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
         BranchDetails {
-            name: "refs/heads/A",
+            name: "A",
+            reference: FullName(
+                "refs/heads/A",
+            ),
             linked_worktree_id: None,
             remote_tracking_branch: Some(
                 "refs/remotes/origin/A",

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -86,6 +86,9 @@ fn unborn_untracked() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                reference: FullName(
+                    "refs/heads/main",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -239,6 +242,9 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                reference: FullName(
+                    "refs/heads/main",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -357,6 +363,9 @@ fn single_branch() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                reference: FullName(
+                    "refs/heads/main",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -548,6 +557,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         branch_details: [
             BranchDetails {
                 name: "main",
+                reference: FullName(
+                    "refs/heads/main",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -569,6 +581,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "nine",
+                reference: FullName(
+                    "refs/heads/nine",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -592,6 +607,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "six",
+                reference: FullName(
+                    "refs/heads/six",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -615,6 +633,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "three",
+                reference: FullName(
+                    "refs/heads/three",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,
@@ -637,6 +658,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
             },
             BranchDetails {
                 name: "one",
+                reference: FullName(
+                    "refs/heads/one",
+                ),
                 linked_worktree_id: None,
                 remote_tracking_branch: None,
                 description: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
@@ -14,7 +14,10 @@ fn disjoint() -> anyhow::Result<()> {
     let actual = branch_details(&repo, "refs/heads/disjoint".try_into()?, &*meta)?;
     insta::assert_debug_snapshot!(actual, @r#"
     BranchDetails {
-        name: "refs/heads/disjoint",
+        name: "disjoint",
+        reference: FullName(
+            "refs/heads/disjoint",
+        ),
         linked_worktree_id: None,
         remote_tracking_branch: None,
         description: None,
@@ -40,7 +43,10 @@ fn disjoint() -> anyhow::Result<()> {
     let actual = branch_details(&repo, "refs/heads/main".try_into()?, &*meta)?;
     insta::assert_debug_snapshot!(actual, @r#"
     BranchDetails {
-        name: "refs/heads/main",
+        name: "main",
+        reference: FullName(
+            "refs/heads/main",
+        ),
         linked_worktree_id: None,
         remote_tracking_branch: None,
         description: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -169,6 +169,9 @@ mod stacks {
             branch_details: [
                 BranchDetails {
                     name: "C-on-A",
+                    reference: FullName(
+                        "refs/heads/C-on-A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
@@ -192,6 +195,9 @@ mod stacks {
                 },
                 BranchDetails {
                     name: "A",
+                    reference: FullName(
+                        "refs/heads/A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",
@@ -286,6 +292,9 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "dependent",
+                    reference: FullName(
+                        "refs/heads/dependent",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
@@ -305,6 +314,9 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "advanced-lane",
+                    reference: FullName(
+                        "refs/heads/advanced-lane",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/advanced-lane",
@@ -361,6 +373,9 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "B-on-A",
+                    reference: FullName(
+                        "refs/heads/B-on-A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
@@ -384,6 +399,9 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "A",
+                    reference: FullName(
+                        "refs/heads/A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",
@@ -420,6 +438,9 @@ mod stack_details {
             branch_details: [
                 BranchDetails {
                     name: "C-on-A",
+                    reference: FullName(
+                        "refs/heads/C-on-A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: None,
                     description: None,
@@ -443,6 +464,9 @@ mod stack_details {
                 },
                 BranchDetails {
                     name: "A",
+                    reference: FullName(
+                        "refs/heads/A",
+                    ),
                     linked_worktree_id: None,
                     remote_tracking_branch: Some(
                         "refs/remotes/origin/A",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -396,7 +396,8 @@ fn main() -> anyhow::Result<()> {
                 claude::claude_cancel_session,
                 claude::claude_is_stack_active,
                 claude::claude_compact_history,
-                commit::tauri_commit_reword::commit_reword
+                commit::tauri_commit_reword::commit_reword,
+                commit::tauri_commit_insert_blank::commit_insert_blank
             ])
             .menu(move |handle| menu::build(handle, &app_settings_for_menu))
             .on_window_event(|window, event| match event {

--- a/packages/core/src/generated/workspace/index.ts
+++ b/packages/core/src/generated/workspace/index.ts
@@ -23,9 +23,13 @@ export type Author = {
  */
 export type BranchDetails = {
 	/**
-	 * The name of the branch.
+	 * The name of the branch. This is the "given name" IE, just `foo` out of `refs/heads/foo`
 	 */
 	name: string;
+	/**
+	 * The full reference of the branch
+	 */
+	reference: string;
 	/**
 	 * The id of the linked worktree that has the reference of `name` checked out.
 	 * Note that we don't list the main worktree here.


### PR DESCRIPTION
Adds the frontend portion for using the new graph editor based insert blank commit functionality.

The goal of this change was to get both running in parallel. Given the divergent interfaces, I've had to adapt between the two on the frontend which is a little bit cumbersome, but mostly limited in scope to the stackService.

The new implementation implemented a hidden bug when inserting a commit beneath a branch header. For some reason the "offset" was set to `-1` instead of `1`, indicating that the commit should be inserted _above_ the reference, not _below_ like we would expect.

The new implementation has no restrictions to say it _shouldn't_ get inserted there because it is technically _not wrong_.