### PR TITLE
Add hidden `but fetch` command

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -532,6 +532,11 @@ pub enum Subcommands {
         #[clap(value_enum)]
         shell: Option<clap_complete::Shell>,
     },
+
+    /// Hidden command that redirects to `but pull --check`
+    #[cfg(feature = "legacy")]
+    #[clap(hide = true)]
+    Fetch,
 }
 
 pub mod actions {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -306,6 +306,23 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
+        Subcommands::Fetch => {
+            if out.for_human().is_some() {
+                use std::fmt::Write;
+                let mut progress = out.progress_channel();
+                writeln!(
+                    progress,
+                    "{}",
+                    "Assuming you meant to check for upstream work, running `but pull --check`"
+                        .yellow()
+                )?;
+            }
+            let ctx = init::init_ctx(&args, Fetch::None, out)?;
+            command::legacy::pull::handle(&ctx, out, true)
+                .await
+                .emit_metrics(metrics_ctx)
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Worktree(worktree::Platform { cmd }) => {
             let ctx = init::init_ctx(&args, Fetch::None, out)?;
             command::legacy::worktree::handle(cmd, &ctx, out)

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -68,6 +68,8 @@ impl Subcommands {
             Subcommands::Diff { .. } => Diff,
             #[cfg(feature = "legacy")]
             Subcommands::Pull { .. } => Pull,
+            #[cfg(feature = "legacy")]
+            Subcommands::Fetch => Pull,
             Subcommands::Branch(branch::Platform { cmd }) => match cmd {
                 None => BranchList,
                 #[cfg(feature = "legacy")]


### PR DESCRIPTION
Introduce a hidden legacy command `fetch` that redirects to `but pull --check` and runs the existing  pull handler in check mode.