### PR TITLE
Use `OutputChannel::prepare_for_terminal_input()` to set an example for acquiring input.

### DIFF
--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    io::{self, Read},
-    path::Path,
-    str::FromStr,
-};
+use std::{collections::HashMap, path::Path, str::FromStr};
 
 use anyhow::{Context as _, Result, anyhow};
 use but_action::{
@@ -20,8 +15,6 @@ use gitbutler_branch::BranchCreateRequest;
 use gitbutler_project::Project;
 use gitbutler_stack::VirtualBranchesHandle;
 use serde::{Deserialize, Serialize};
-
-// use crate::command::file_lock;
 
 mod file_lock;
 use but_core::{HunkHeader, ref_metadata::StackId};
@@ -91,8 +84,8 @@ pub struct ClaudeStopInput {
     pub stop_hook_active: Option<bool>,
 }
 
-pub async fn handle_stop() -> anyhow::Result<ClaudeHookOutput> {
-    let input: ClaudeStopInput = serde_json::from_str(&stdin()?)
+pub async fn handle_stop(read: impl std::io::Read) -> anyhow::Result<ClaudeHookOutput> {
+    let input: ClaudeStopInput = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {}", e))?;
 
     let transcript = Transcript::from_file(Path::new(&input.transcript_path))?;
@@ -347,8 +340,8 @@ pub struct ClaudePreToolUseInput {
     pub tool_input: ToolInput,
 }
 
-pub fn handle_pre_tool_call() -> anyhow::Result<ClaudeHookOutput> {
-    let mut input: ClaudePreToolUseInput = serde_json::from_str(&stdin()?)
+pub fn handle_pre_tool_call(read: impl std::io::Read) -> anyhow::Result<ClaudeHookOutput> {
+    let mut input: ClaudePreToolUseInput = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {}", e))?;
 
     let dir = std::path::Path::new(&input.tool_input.file_path)
@@ -385,8 +378,8 @@ pub fn handle_pre_tool_call() -> anyhow::Result<ClaudeHookOutput> {
     })
 }
 
-pub fn handle_post_tool_call() -> anyhow::Result<ClaudeHookOutput> {
-    let mut input: ClaudePostToolUseInput = serde_json::from_str(&stdin()?)
+pub fn handle_post_tool_call(read: impl std::io::Read) -> anyhow::Result<ClaudeHookOutput> {
+    let mut input: ClaudePostToolUseInput = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {}", e))?;
 
     let hook_headers = input
@@ -525,12 +518,6 @@ pub fn get_or_create_session(
         stack_id
     };
     Ok(stack_id)
-}
-
-fn stdin() -> anyhow::Result<String> {
-    let mut buffer = String::new();
-    io::stdin().read_to_string(&mut buffer)?;
-    Ok(buffer.trim().to_string())
 }
 
 fn create_stack(

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    io::{self, Read},
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use but_action::{ActionHandler, OpenAiProvider, Source, reword::CommitEvent};
 use but_ctx::Context;
@@ -124,8 +119,8 @@ fn cursor_path_to_pathbuf(input: &str) -> PathBuf {
     }
 }
 
-pub async fn handle_after_edit() -> anyhow::Result<CursorHookOutput> {
-    let mut input: FileEditEvent = serde_json::from_str(&stdin()?)
+pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<CursorHookOutput> {
+    let mut input: FileEditEvent = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {}", e))?;
     let hook_headers = input
         .edits
@@ -199,8 +194,11 @@ pub async fn handle_after_edit() -> anyhow::Result<CursorHookOutput> {
     Ok(CursorHookOutput::default())
 }
 
-pub async fn handle_stop(nightly: bool) -> anyhow::Result<CursorHookOutput> {
-    let input: StopEvent = serde_json::from_str(&stdin()?)
+pub async fn handle_stop(
+    nightly: bool,
+    read: impl std::io::Read,
+) -> anyhow::Result<CursorHookOutput> {
+    let input: StopEvent = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {}", e))?;
     let dir = input
         .workspace_roots
@@ -312,12 +310,6 @@ pub async fn handle_stop(nightly: bool) -> anyhow::Result<CursorHookOutput> {
     }
 
     Ok(CursorHookOutput::default())
-}
-
-fn stdin() -> anyhow::Result<String> {
-    let mut buffer = String::new();
-    io::stdin().read_to_string(&mut buffer)?;
-    Ok(buffer.trim().to_string())
 }
 
 #[cfg(test)]

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -97,23 +97,17 @@ pub async fn create_pr(
             let mut inout = out.prepare_for_terminal_input().context(
                 "Terminal input not available. Please specify a branch using command line arguments.",
             )?;
-            let response = inout.prompt(&format!(
-                "Do you want to open a new PR on branch '{}'? [y/n]",
-                branch_name
-            ))?;
-            match response {
-                Some(r)
-                    if r.trim().eq_ignore_ascii_case("y")
-                        || r.trim().eq_ignore_ascii_case("yes") =>
-                {
-                    Some(vec![branch_name.clone()])
-                }
-                _ => {
-                    if let Some(out) = out.for_human() {
-                        writeln!(out, "Aborted.")?;
-                    }
-                    return Ok(());
-                }
+            let response = inout
+                .prompt(format!(
+                    "Do you want to open a new PR on branch '{}'? [y/n]",
+                    branch_name
+                ))?
+                .context("Aborted.")?
+                .to_lowercase();
+            if response == "y" || response == "yes" {
+                Some(vec![branch_name.clone()])
+            } else {
+                return Ok(());
             }
         } else {
             // Multiple branches without PRs - let the prompt handle it

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -255,15 +255,11 @@ fn handle_no_branch_specified(
 
     // Check if we're in an interactive terminal
     let is_interactive = std::io::stdin().is_terminal() && out.for_human().is_some();
-
     if !is_interactive {
+        tracing::info!(
+            "Non-interactive mode detected. Pushing all branches with unpushed commits..."
+        );
         // Non-interactive mode: push all branches with unpushed commits
-        if let Some(out) = out.for_human() {
-            writeln!(
-                out,
-                "Non-interactive mode detected. Pushing all branches with unpushed commits..."
-            )?;
-        }
         return Ok(BranchSelection::All);
     }
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -227,16 +227,22 @@ async fn match_subcommand(
         Subcommands::Claude(claude::Platform { cmd }) => {
             use but_claude::hooks::OutputClaudeJson;
             match cmd {
-                claude::Subcommands::PreTool => but_claude::hooks::handle_pre_tool_call()
-                    .output_claude_json()
-                    .emit_metrics(metrics_ctx),
-                claude::Subcommands::PostTool => but_claude::hooks::handle_post_tool_call()
-                    .output_claude_json()
-                    .emit_metrics(metrics_ctx),
-                claude::Subcommands::Stop => but_claude::hooks::handle_stop()
-                    .await
-                    .output_claude_json()
-                    .emit_metrics(metrics_ctx),
+                claude::Subcommands::PreTool => {
+                    but_claude::hooks::handle_pre_tool_call(std::io::stdin().lock())
+                        .output_claude_json()
+                        .emit_metrics(metrics_ctx)
+                }
+                claude::Subcommands::PostTool => {
+                    but_claude::hooks::handle_post_tool_call(std::io::stdin().lock())
+                        .output_claude_json()
+                        .emit_metrics(metrics_ctx)
+                }
+                claude::Subcommands::Stop => {
+                    but_claude::hooks::handle_stop(std::io::stdin().lock())
+                        .await
+                        .output_claude_json()
+                        .emit_metrics(metrics_ctx)
+                }
                 claude::Subcommands::PermissionPromptMcp { session_id } => {
                     but_claude::mcp::start(&args.current_dir, &session_id).await
                 }
@@ -289,14 +295,18 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Cursor(cursor::Platform { cmd }) => match cmd {
-            cursor::Subcommands::AfterEdit => but_cursor::handle_after_edit()
-                .await
-                .output_json(true)
-                .emit_metrics(metrics_ctx),
-            cursor::Subcommands::Stop { nightly } => but_cursor::handle_stop(nightly)
-                .await
-                .output_json(true)
-                .emit_metrics(metrics_ctx),
+            cursor::Subcommands::AfterEdit => {
+                but_cursor::handle_after_edit(std::io::stdin().lock())
+                    .await
+                    .output_json(true)
+                    .emit_metrics(metrics_ctx)
+            }
+            cursor::Subcommands::Stop { nightly } => {
+                but_cursor::handle_stop(nightly, std::io::stdin().lock())
+                    .await
+                    .output_json(true)
+                    .emit_metrics(metrics_ctx)
+            }
         },
         #[cfg(feature = "legacy")]
         Subcommands::Pull { check } => {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 mod output_channel;
-pub use output_channel::OutputChannel;
+pub use output_channel::{InputOutputChannel, OutputChannel};
 
 pub mod metrics;
 #[cfg(feature = "legacy")]


### PR DESCRIPTION
The generalised input facilities help to unify user prompting, and generally make the code doing it much less error prone.