### PR TITLE
implement `but status --upstream` to see upstream commits

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -93,6 +93,9 @@ pub enum Subcommands {
         /// Forces a sync of pull requests from the forge before showing status.
         #[clap(short = 'r', long = "refresh-prs", default_value_t = false)]
         refresh_prs: bool,
+        /// Show detailed list of upstream commits that haven't been integrated yet.
+        #[clap(short = 'u', long = "upstream", default_value_t = false)]
+        upstream: bool,
     },
 
     /// Overview of the uncommitted changes in the repository with files shown.

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -158,7 +158,7 @@ pub(crate) fn worktree(
                                 .to_string()
                                 .replace('\n', " ")
                                 .chars()
-                                .take(50)
+                                .take(30)
                                 .collect::<String>();
 
                             let formatted_date = commit
@@ -282,43 +282,55 @@ pub(crate) fn worktree(
     if let Some(upstream) = &upstream_state {
         let dot = "●".yellow();
 
-        writeln!(
-            out,
-            "┊{dot} {} (upstream) ⏫ {} new commits {} {}{}",
-            upstream.latest_commit.dimmed(),
-            upstream.behind_count,
-            upstream.commit_date.dimmed(),
-            upstream.message,
-            last_checked_text.dimmed()
-        )?;
-
-        // Display detailed list of upstream commits if --upstream flag is set
         if show_upstream {
-            if let Some(ref base_branch) = base_branch {
-                if !base_branch.upstream_commits.is_empty() {
-                    writeln!(out)?;
-                    let commits = base_branch.upstream_commits.iter().take(3);
-                    for commit in commits {
-                        writeln!(
-                            out,
-                            "┊  {} {}",
-                            commit.id[..7].yellow(),
-                            commit
-                                .description
-                                .to_string()
-                                .replace('\n', " ")
-                                .chars()
-                                .take(72)
-                                .collect::<String>()
-                                .dimmed()
-                        )?;
-                    }
-                    let hidden_commits = base_branch.behind.saturating_sub(3);
-                    if hidden_commits > 0 {
-                        writeln!(out, "┊  {}", format!("... ({hidden_commits} more)").dimmed())?;
-                    }
+            // When showing detailed commits, only show count in summary
+            writeln!(
+                out,
+                "┊╭┄(upstream) ⏫ {} new commits{}",
+                upstream.behind_count,
+                last_checked_text.dimmed()
+            )?;
+
+            // Display detailed list of upstream commits
+            if let Some(ref base_branch) = base_branch
+                && !base_branch.upstream_commits.is_empty()
+            {
+                let commits = base_branch.upstream_commits.iter().take(8);
+                for commit in commits {
+                    writeln!(
+                        out,
+                        "┊{dot} {} {}",
+                        commit.id[..7].yellow(),
+                        commit
+                            .description
+                            .to_string()
+                            .replace('\n', " ")
+                            .chars()
+                            .take(72)
+                            .collect::<String>()
+                            .dimmed()
+                    )?;
+                }
+                let hidden_commits = base_branch.behind.saturating_sub(8);
+                if hidden_commits > 0 {
+                    writeln!(
+                        out,
+                        "┊    {}",
+                        format!("and {hidden_commits} more…").dimmed()
+                    )?;
                 }
             }
+            writeln!(out, "┊┊")?;
+        } else {
+            // Without --upstream, show the summary with latest commit info
+            writeln!(
+                out,
+                "┊{dot} {} (upstream) ⏫ {} new commits {} {}",
+                upstream.latest_commit.dimmed(),
+                upstream.behind_count,
+                upstream.commit_date.dimmed(),
+                last_checked_text.dimmed()
+            )?;
         }
     }
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -344,9 +344,10 @@ async fn match_subcommand(
             show_files,
             verbose,
             refresh_prs: sync_prs,
+            upstream,
         } => {
             let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
-            command::legacy::status::worktree(&mut ctx, out, show_files, verbose, sync_prs)
+            command::legacy::status::worktree(&mut ctx, out, show_files, verbose, sync_prs, upstream)
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
@@ -355,7 +356,7 @@ async fn match_subcommand(
             refresh_prs,
         } => {
             let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
-            command::legacy::status::worktree(&mut ctx, out, true, verbose, refresh_prs)
+            command::legacy::status::worktree(&mut ctx, out, true, verbose, refresh_prs, false)
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -347,8 +347,10 @@ async fn match_subcommand(
             upstream,
         } => {
             let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
-            command::legacy::status::worktree(&mut ctx, out, show_files, verbose, sync_prs, upstream)
-                .emit_metrics(metrics_ctx)
+            command::legacy::status::worktree(
+                &mut ctx, out, show_files, verbose, sync_prs, upstream,
+            )
+            .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Stf {

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -50,7 +50,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -44,7 +44,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced </tspan>
+    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
 </tspan>


### PR DESCRIPTION
<img width="1972" height="1072" alt="CleanShot 2026-01-06 at 17 04 20@2x" src="https://github.com/user-attachments/assets/0bb23f7f-16e4-4310-a624-98493754e947" />
