### PR TITLE
better `but push`

### DIFF
--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -80,25 +80,7 @@ fn push_single_branch(
             "✓".green().bold()
         )?;
         writeln!(progress)?;
-        writeln!(
-            progress,
-            "  {} {}",
-            "Remote:".dimmed(),
-            result.remote.bold()
-        )?;
-        if !gerrit_mode && !result.branch_to_remote.is_empty() {
-            for (branch, remote_ref) in &result.branch_to_remote {
-                writeln!(
-                    progress,
-                    "  {} → {}",
-                    branch.cyan(),
-                    remote_ref.to_string().dimmed()
-                )?;
-            }
-        }
-        // Print SHA information
         if !result.branch_sha_updates.is_empty() {
-            writeln!(progress)?;
             for (branch, before_sha, after_sha) in &result.branch_sha_updates {
                 let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                     "(new branch)".to_string()
@@ -106,10 +88,15 @@ fn push_single_branch(
                     before_sha.chars().take(7).collect()
                 };
                 let after_str: String = after_sha.chars().take(7).collect();
+
+                // Construct simple remote ref format: remote/branch
+                let remote_ref = format!("{}/{}", result.remote, branch);
+
                 writeln!(
                     progress,
-                    "  {} {} → {}",
+                    "  {} -> {} ({} -> {})",
                     branch.cyan(),
+                    remote_ref.dimmed(),
                     before_str.dimmed(),
                     after_str.green()
                 )?;
@@ -231,7 +218,7 @@ fn push_all_branches(
             )?;
             writeln!(progress)?;
 
-            // Print SHA information for all pushed branches
+            // Print combined branch, remote, and SHA information for all pushed branches
             for result in &pushed_results {
                 for (branch, before_sha, after_sha) in &result.branch_sha_updates {
                     let before_str = if before_sha == "0000000000000000000000000000000000000000" {
@@ -240,10 +227,15 @@ fn push_all_branches(
                         before_sha.chars().take(7).collect()
                     };
                     let after_str: String = after_sha.chars().take(7).collect();
+
+                    // Construct simple remote ref format: remote/branch
+                    let remote_ref = format!("{}/{}", result.remote, branch);
+
                     writeln!(
                         progress,
-                        "  {} {} → {}",
+                        "  {} -> {} ({} -> {})",
                         branch.cyan(),
+                        remote_ref.dimmed(),
                         before_str.dimmed(),
                         after_str.green()
                     )?;

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -174,6 +174,15 @@ fn push_all_branches(
         .collect();
 
     if branches_to_push.is_empty() {
+        // Output empty result for JSON
+        if let Some(out) = out.for_json() {
+            let batch_result = BatchPushResult {
+                pushed: vec![],
+                failed: vec![],
+            };
+            out.write_value(&batch_result)?;
+        }
+
         if out.for_human().is_some() {
             writeln!(
                 progress,
@@ -291,7 +300,12 @@ fn push_all_branches(
                 }
             )?;
             for failed in &failed_branches {
-                writeln!(progress, "    {} - {}", failed.branch_name.red(), failed.error.dimmed())?;
+                writeln!(
+                    progress,
+                    "    {} - {}",
+                    failed.branch_name.red(),
+                    failed.error.dimmed()
+                )?;
             }
         }
     }

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -33,6 +33,10 @@ pub struct PushResult {
     pub remote: String,
     /// The list of pushed branches and their corresponding remote refnames.
     pub branch_to_remote: Vec<(String, Refname)>,
+    /// The list of branches with their before/after commit SHAs.
+    /// Format: (branch_name, before_sha, after_sha)
+    /// SHAs are stored as hex strings for serialization
+    pub branch_sha_updates: Vec<(String, String, String)>,
 }
 
 fn find_base_tree<'a>(


### PR DESCRIPTION
Updates `but push` to output more through `progress` so we can get real time output, also updates the format so there are not different formats for pushing a single branch vs all branches. Also now shows starting and ending shas.