### PR TITLE
but: use file locks to prevent multiple background refreshes

### DIFF
--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -6,5 +6,6 @@ mod json_samples;
 mod ref_metadata;
 mod settings;
 mod snapshot;
+mod sync;
 mod unified_diff;
 mod worktree;

--- a/crates/but-core/tests/core/sync.rs
+++ b/crates/but-core/tests/core/sync.rs
@@ -1,0 +1,107 @@
+use but_core::sync::{LockScope, try_exclusive_inter_process_access};
+use but_testsupport::gix_testtools;
+
+#[test]
+fn exclusive_lock_prevents_second_acquisition() -> anyhow::Result<()> {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+
+    // First process acquires the lock
+    let _lock1 = try_exclusive_inter_process_access(tmp.path(), LockScope::AllOperations)?;
+
+    // Second process should fail to acquire the same lock
+    let result = try_exclusive_inter_process_access(tmp.path(), LockScope::AllOperations);
+    assert!(
+        result.is_err(),
+        "Second lock acquisition should fail when first lock is held"
+    );
+    let err_msg = result.err().unwrap().to_string();
+    assert!(
+        err_msg.contains("already opened for writing by another GitButler instance"),
+        "Error message should indicate lock is already held by another instance, got: {}",
+        err_msg
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lock_released_on_drop() -> anyhow::Result<()> {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+
+    // Acquire and immediately drop the lock
+    {
+        let _lock = try_exclusive_inter_process_access(tmp.path(), LockScope::AllOperations)?;
+    } // lock dropped here
+
+    // Should be able to acquire the lock again
+    let _lock2 = try_exclusive_inter_process_access(tmp.path(), LockScope::AllOperations)?;
+
+    Ok(())
+}
+
+#[test]
+fn different_lock_scopes_use_different_lock_files() -> anyhow::Result<()> {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+
+    // Acquire lock for all operations
+    let _lock_all = try_exclusive_inter_process_access(tmp.path(), LockScope::AllOperations)?;
+
+    // Should be able to acquire lock for background refresh operations (different lock file)
+    let _lock_bg =
+        try_exclusive_inter_process_access(tmp.path(), LockScope::BackgroundRefreshOperations)?;
+
+    // Both locks should coexist
+    assert!(
+        tmp.path().join("project.lock").exists(),
+        "AllOperations lock file should exist"
+    );
+    assert!(
+        tmp.path().join("background-refresh.lock").exists(),
+        "BackgroundRefreshOperations lock file should exist"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn background_refresh_lock_prevents_second_background_refresh() -> anyhow::Result<()> {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+
+    // First process acquires background refresh lock
+    let _lock1 =
+        try_exclusive_inter_process_access(tmp.path(), LockScope::BackgroundRefreshOperations)?;
+
+    // Second process should fail to acquire the same background refresh lock
+    let result =
+        try_exclusive_inter_process_access(tmp.path(), LockScope::BackgroundRefreshOperations);
+    assert!(
+        result.is_err(),
+        "Second background refresh lock should fail when first is held"
+    );
+    let err_msg = result.err().unwrap().to_string();
+    assert!(
+        err_msg.contains("already being refreshed in the background by another GitButler instance"),
+        "Error message should indicate background refresh is already in progress, got: {}",
+        err_msg
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lock_scope_converts_to_correct_path() {
+    let all_ops_path: std::path::PathBuf = LockScope::AllOperations.into();
+    assert_eq!(all_ops_path, std::path::PathBuf::from("project.lock"));
+
+    let bg_refresh_path: std::path::PathBuf = LockScope::BackgroundRefreshOperations.into();
+    assert_eq!(
+        bg_refresh_path,
+        std::path::PathBuf::from("background-refresh.lock")
+    );
+}
+
+#[test]
+fn default_lock_scope_is_all_operations() {
+    let default_scope = LockScope::default();
+    assert!(matches!(default_scope, LockScope::AllOperations));
+}

--- a/crates/but-ctx/src/access.rs
+++ b/crates/but-ctx/src/access.rs
@@ -1,4 +1,9 @@
 use crate::Context;
+use but_core::sync::LockScope::AllOperations;
+pub use but_core::sync::{
+    LockFile, WorkspaceReadGuard, WorkspaceWriteGuard, WorktreeReadPermission,
+    WorktreeWritePermission,
+};
 
 /// Locking utilities to protect against concurrency on the same repo.
 impl Context {
@@ -9,7 +14,7 @@ impl Context {
     /// Note that the lock is automatically released on `Drop`, or when the process quits for any reason,
     /// so it can't go stale.
     pub fn try_exclusive_access(&self) -> anyhow::Result<but_core::sync::LockFile> {
-        but_core::sync::try_exclusive_inter_process_access(&self.gitdir)
+        but_core::sync::try_exclusive_inter_process_access(&self.gitdir, AllOperations)
     }
     /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for someone else,
     /// in the same process only, to release it, or for all readers to disappear.
@@ -28,8 +33,3 @@ impl Context {
         but_core::sync::shared_worktree_access(&self.gitdir)
     }
 }
-
-pub use but_core::sync::{
-    LockFile, WorkspaceReadGuard, WorkspaceWriteGuard, WorktreeReadPermission,
-    WorktreeWritePermission,
-};

--- a/crates/but/src/command/legacy/refresh.rs
+++ b/crates/but/src/command/legacy/refresh.rs
@@ -1,3 +1,4 @@
+use but_core::sync::LockScope;
 use std::fmt::Write;
 
 pub fn handle(
@@ -7,6 +8,12 @@ pub fn handle(
     prs: bool,
     ci: bool,
 ) -> anyhow::Result<()> {
+    // Obtain a lock to prevent concurrent background refreshes
+    let _exclusive_access = but_core::sync::try_exclusive_inter_process_access(
+        &ctx.gitdir,
+        LockScope::BackgroundRefreshOperations,
+    )?;
+
     if fetch {
         out.write_str("\nFetching from remotes...")?;
         let fetch_result = but_api::legacy::virtual_branches::fetch_from_remotes(

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -24,7 +24,6 @@ Error: The reference 'main' did not exist
 // TODO: maybe this should be a non-legacy journey only as we start out without workspace?
 #[cfg(feature = "legacy")]
 #[test]
-#[ignore = "While it's flaky because of spawning background processes running migrations at the same time"]
 fn from_empty() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 


### PR DESCRIPTION
• Added configurable lock scope for inter-process access
• Implemented inter-process locking for background refresh operations

Also re-enables the but journey test. This PR, together with https://github.com/gitbutlerapp/gitbutler/pull/11719 should eliminate flakiness 