### PR TITLE
More changes to make CLI IDs less ambiguous

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -34,8 +34,8 @@ pub(crate) fn handle(
     out: &mut OutputChannel,
     source: Option<&str>,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
     let source: Option<CliId> = source
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -68,8 +68,8 @@ pub fn handle(
             branch_name,
             anchor,
         }) => {
-            let mut id_map = IdMap::new_from_context(ctx)?;
-            id_map.add_file_info_from_context(ctx, None)?;
+            let mut id_map = IdMap::new_from_context(ctx, None)?;
+            id_map.add_committed_file_info_from_context(ctx)?;
             // Get branch name or use canned name
             let branch_name = branch_name.map(Ok).unwrap_or_else(|| {
                 but_api::legacy::workspace::canned_branch_name(ctx.legacy_project.id)

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -20,8 +20,8 @@ pub(crate) fn insert_blank_commit(
     out: &mut OutputChannel,
     target: &str,
 ) -> Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     // Resolve the target ID
     let cli_ids = id_map.resolve_entity_to_ids(target)?;
@@ -150,8 +150,8 @@ pub(crate) fn commit(
     only: bool,
     create_branch: bool,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     // Get all stacks using but-api
     let project_id = ctx.legacy_project.id;

--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -13,9 +13,9 @@ pub fn handle(
     out: &mut OutputChannel,
     target_str: Option<&str>,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
     let wt_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
-    id_map.add_file_info_from_context(ctx, Some(wt_changes.assignments.clone()))?;
+    let mut id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     if let Some(entity) = target_str {
         let id = id_map

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -153,8 +153,8 @@ fn get_branches_without_prs(
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let mut id_map = IdMap::new_from_context(&ctx)?;
-    id_map.add_file_info_from_context(&mut ctx, None)?;
+    let mut id_map = IdMap::new_from_context(&mut ctx, None)?;
+    id_map.add_committed_file_info_from_context(&mut ctx)?;
     let branch_ids = id_map
         .resolve_entity_to_ids(branch_id)?
         .iter()

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -14,8 +14,8 @@ pub(crate) fn handle(
     target_str: &str,
     delete: bool,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
     let target_result = id_map.resolve_entity_to_ids(target_str)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -27,8 +27,8 @@ pub fn handle(
     ctx: &mut Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     // Check gerrit mode early
     let gerrit_mode = {

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -13,8 +13,8 @@ pub(crate) fn reword_target(
     target: &str,
     message: Option<&str>,
 ) -> Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     // Resolve the commit ID
     let cli_ids = id_map.resolve_entity_to_ids(target)?;

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -23,8 +23,8 @@ pub(crate) fn handle(
     source_str: &str,
     target_str: &str,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx)?;
-    id_map.add_file_info_from_context(ctx, None)?;
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str)?;
 
     for source in sources {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -86,8 +86,8 @@ pub(crate) fn worktree(
     let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
     let worktree_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
 
-    let mut id_map = IdMap::new_for_branches_and_commits(&head_info.stacks)?;
-    id_map.add_file_info_from_context(ctx, Some(worktree_changes.assignments))?;
+    let mut id_map = IdMap::new(&head_info.stacks, worktree_changes.assignments.clone())?;
+    id_map.add_committed_file_info_from_context(ctx)?;
 
     let assignments_by_file: BTreeMap<BString, FileAssignment> =
         FileAssignment::get_assignments_by_file(&id_map);

--- a/crates/but/src/id/file_info.rs
+++ b/crates/but/src/id/file_info.rs
@@ -1,15 +1,7 @@
-use std::collections::BTreeMap;
-
 use bstr::BString;
-use but_core::ref_metadata::StackId;
-use but_hunk_assignment::HunkAssignment;
-use nonempty::NonEmpty;
 
-/// Information about files needed for CLI ID generation.
-/// It's really just a named return value.
+/// Information about committed files needed for CLI ID generation.
 pub(crate) struct FileInfo {
-    /// Uncommitted files partitioned by stack assignment and filename.
-    pub(crate) uncommitted_files: Vec<NonEmpty<HunkAssignment>>,
     /// Committed files paired with their commit IDs, ordered by commit ID then filename.
     pub(crate) committed_files: Vec<(gix::ObjectId, BString)>,
 }
@@ -17,13 +9,10 @@ pub(crate) struct FileInfo {
 impl FileInfo {
     /// Extracts file information from workspace commits and worktree status.
     ///
-    /// This function processes workspace commits to find all changed files in each commit,
-    /// and combines this with hunk assignment information to identify uncommitted (and
-    /// possibly assigned) files in the worktree.
+    /// This function processes workspace commits to find all changed files in each commit.
     pub(crate) fn from_workspace_commits_and_status<F>(
         workspace_commit_and_first_parent_ids: &[(gix::ObjectId, Option<gix::ObjectId>)],
         mut changed_paths_fn: F,
-        hunk_assignments: &[HunkAssignment],
     ) -> anyhow::Result<Self>
     where
         F: FnMut(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<BString>>,
@@ -37,24 +26,6 @@ impl FileInfo {
         }
         committed_files.sort();
 
-        let mut uncommitted_files: BTreeMap<(Option<StackId>, BString), NonEmpty<HunkAssignment>> =
-            BTreeMap::new();
-        for assignment in hunk_assignments {
-            // Rust does not let us borrow a tuple from 2 separate fields, so
-            // we have to clone the parts of the key even though we technically
-            // might not need it.
-            let key = (assignment.stack_id, assignment.path_bytes.clone());
-            uncommitted_files
-                .entry(key)
-                .and_modify(|hunk_assignments| {
-                    hunk_assignments.push(assignment.clone());
-                })
-                .or_insert_with(|| NonEmpty::new(assignment.clone()));
-        }
-
-        Ok(Self {
-            committed_files,
-            uncommitted_files: uncommitted_files.into_values().collect(),
-        })
+        Ok(Self { committed_files })
     }
 }

--- a/crates/but/src/id/id_usage.rs
+++ b/crates/but/src/id/id_usage.rs
@@ -18,6 +18,8 @@ impl UintId {
     const SUBSEQUENT_CHARS: &'static [u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
     /// Must be less than this.
     const LIMIT: u16 = 20 * 36 * 37;
+    /// String representation must be at most this long.
+    pub(crate) const LENGTH_LIMIT: usize = 3;
 
     /// If self cannot be represented in 3 characters, `00` is returned.
     pub(crate) fn to_short_id(self) -> ShortId {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -269,12 +269,6 @@ impl IdMap {
                 UncommittedFile { hunk_assignments },
             );
         }
-        for commit_oid_path in committed_files.into_iter() {
-            self.committed_files.insert(CommittedFile {
-                commit_oid_path,
-                id: self.id_usage.next_available()?.to_short_id(),
-            });
-        }
 
         for uncommitted_file in self.uncommitted_files.values() {
             if !uncommitted_file.hunk_assignments.is_empty() {
@@ -287,6 +281,13 @@ impl IdMap {
                     );
                 }
             }
+        }
+
+        for commit_oid_path in committed_files.into_iter() {
+            self.committed_files.insert(CommittedFile {
+                commit_oid_path,
+                id: self.id_usage.next_available()?.to_short_id(),
+            });
         }
 
         Ok(())

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -321,8 +321,8 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
     uncommitted_files: [ g0, i0 ]
-    committed_files: [ j0, k0 ]
-    uncommitted_hunks: [ l0, m0, n0 ]
+    committed_files: [ m0, n0 ]
+    uncommitted_hunks: [ j0, k0, l0 ]
     ");
     insta::assert_debug_snapshot!(id_map.all_ids(), @r#"
     [
@@ -389,19 +389,9 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                 is_entire_file: true,
             },
         ),
-        CommittedFile {
-            commit_id: Sha1(0202020202020202020202020202020202020202),
-            path: "committed1.txt",
-            id: "j0",
-        },
-        CommittedFile {
-            commit_id: Sha1(0202020202020202020202020202020202020202),
-            path: "committed2.txt",
-            id: "k0",
-        },
         Uncommitted(
             UncommittedCliId {
-                id: "l0",
+                id: "j0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
@@ -423,7 +413,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         ),
         Uncommitted(
             UncommittedCliId {
-                id: "m0",
+                id: "k0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
@@ -445,7 +435,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         ),
         Uncommitted(
             UncommittedCliId {
-                id: "n0",
+                id: "l0",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
@@ -463,6 +453,16 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                 is_entire_file: false,
             },
         ),
+        CommittedFile {
+            commit_id: Sha1(0202020202020202020202020202020202020202),
+            path: "committed1.txt",
+            id: "m0",
+        },
+        CommittedFile {
+            commit_id: Sha1(0202020202020202020202020202020202020202),
+            path: "committed2.txt",
+            id: "n0",
+        },
     ]
     "#);
 
@@ -488,8 +488,8 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
     uncommitted_files: [ g0 ]
-    committed_files: [ i0 ]
-    uncommitted_hunks: [ j0 ]
+    committed_files: [ j0 ]
+    uncommitted_hunks: [ i0 ]
     ");
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("0a")?, @r"
@@ -551,11 +551,26 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(id_map.resolve_entity_to_ids("i0")?, @r#"
     [
-        CommittedFile {
-            commit_id: Sha1(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a),
-            path: "committed.txt",
-            id: "i0",
-        },
+        Uncommitted(
+            UncommittedCliId {
+                id: "i0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
     ]
     "#);
     assert_eq!(

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -183,42 +183,22 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
 }
 
 #[test]
-fn multiple_zeroes_as_unassigned_area() -> anyhow::Result<()> {
-    let id_map = IdMap::new(&[], Vec::new())?;
-    insta::assert_debug_snapshot!(id_map.debug_state(), @"workspace_and_remote_commits_count: 0");
-
-    assert_eq!(
-        id_map.resolve_entity_to_ids("000")?,
-        [CliId::Unassigned { id: "00".into() }],
-        "any number of 0s interpreted as the unassigned area"
-    );
-    Ok(())
-}
-
-#[test]
-fn unassigned_area_id_is_unambiguous() -> anyhow::Result<()> {
-    let stacks = &[stack([segment("branch001", [id(1)], None, [])])];
+fn branches_avoid_unassigned_area_id() -> anyhow::Result<()> {
+    let stacks = &[stack([segment("zza", [id(1)], None, [])])];
     let id_map = IdMap::new(stacks, Vec::new())?;
     insta::assert_debug_snapshot!(id_map.debug_state(), @r"
     workspace_and_remote_commits_count: 1
-    branches: [ br ]
+    branches: [ za ]
     ");
 
+    let expected = [CliId::Branch {
+        name: "zza".into(),
+        id: "za".into(),
+    }];
     assert_eq!(
-        id_map.unassigned().to_short_string(),
-        "000",
-        "the ID of the unassigned area should have enough 0s to be unambiguous"
-    );
-    assert_eq!(
-        id_map.resolve_entity_to_ids("00")?,
-        [
-            CliId::Branch {
-                name: "branch001".into(),
-                id: "br".into()
-            },
-            CliId::Unassigned { id: "000".into() }
-        ],
-        "as 00 is matching the substring of a branch now, but also unassigned"
+        id_map.resolve_entity_to_ids("za")?,
+        expected,
+        "avoids unassigned area ID (zz)"
     );
     Ok(())
 }

--- a/crates/but/src/id/uncommitted_info.rs
+++ b/crates/but/src/id/uncommitted_info.rs
@@ -1,0 +1,40 @@
+use std::collections::{BTreeMap, btree_map::Entry};
+
+use bstr::BString;
+use but_core::ref_metadata::StackId;
+use but_hunk_assignment::HunkAssignment;
+use nonempty::NonEmpty;
+
+/// Information about uncommitted files.
+pub(crate) struct UncommittedInfo {
+    /// Uncommitted hunks partitioned by stack assignment and filename.
+    pub(crate) partitioned_hunks: Vec<NonEmpty<HunkAssignment>>,
+}
+
+impl UncommittedInfo {
+    /// Partitions hunk assignments by stack assignment and filename.
+    pub(crate) fn from_hunk_assignments(
+        hunk_assignments: Vec<HunkAssignment>,
+    ) -> anyhow::Result<Self> {
+        let mut uncommitted_hunks: BTreeMap<(Option<StackId>, BString), NonEmpty<HunkAssignment>> =
+            BTreeMap::new();
+        for assignment in hunk_assignments {
+            // Rust does not let us borrow a tuple from 2 separate fields, so
+            // we have to clone the parts of the key even though we technically
+            // might not need it.
+            let key = (assignment.stack_id, assignment.path_bytes.clone());
+            match uncommitted_hunks.entry(key) {
+                Entry::Vacant(vacant_entry) => {
+                    vacant_entry.insert(NonEmpty::new(assignment));
+                }
+                Entry::Occupied(mut occupied_entry) => {
+                    occupied_entry.get_mut().push(assignment);
+                }
+            };
+        }
+
+        Ok(Self {
+            partitioned_hunks: uncommitted_hunks.into_values().collect(),
+        })
+    }
+}

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -73,7 +73,7 @@ fn uncommitted_hunk() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
-    // Verify that the first hunk is m0, and absorb it.
+    // Verify that the first hunk is j0, and absorb it.
     env.but("diff a.txt")
         .env_remove("CLICOLOR_FORCE")
         .assert()
@@ -81,7 +81,7 @@ fn uncommitted_hunk() -> anyhow::Result<()> {
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ────────╮
-m0 a.txt│
+j0 a.txt│
 ────────╯
    1  │-first
      1│+firsta
@@ -89,7 +89,7 @@ m0 a.txt│
    3 3│ line
    4 4│ line
 ────────╮
-n0 a.txt│
+k0 a.txt│
 ────────╯
     6  6│ line
     7  7│ line
@@ -98,7 +98,7 @@ n0 a.txt│
        9│+lasta
 
 "#]]);
-    env.but("absorb m0")
+    env.but("absorb j0")
         .assert()
         .success()
         .stdout_eq(snapbox::file![

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -73,8 +73,31 @@ fn uncommitted_hunk() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
-    // TODO When we have a way to list the hunks and their respective IDs (e.g.
-    //      via a "diff" or "show" command), assert that m0 is the hunk we want.
+    // Verify that the first hunk is m0, and absorb it.
+    env.but("diff a.txt")
+        .env_remove("CLICOLOR_FORCE")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+m0 a.txt│
+────────╯
+   1  │-first
+     1│+firsta
+   2 2│ line
+   3 3│ line
+   4 4│ line
+────────╮
+n0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-last
+       9│+lasta
+
+"#]]);
     env.but("absorb m0")
         .assert()
         .success()

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -213,7 +213,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "j0",
+                  "cliId": "k0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }
@@ -223,7 +223,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "k0",
+                  "cliId": "l0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 }
@@ -233,7 +233,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "l0",
+                  "cliId": "m0",
                   "filePath": "A",
                   "changeType": "added"
                 }
@@ -251,7 +251,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "m0",
+                  "cliId": "n0",
                   "filePath": "B",
                   "changeType": "added"
                 }
@@ -295,7 +295,7 @@ fn shorthand_uncommitted_hunk_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    // Verify that the first hunk is m0, and move it to unassigned.
+    // Verify that the first hunk is j0, and move it to unassigned.
     env.but("diff i0")
         .env_remove("CLICOLOR_FORCE")
         .assert()
@@ -303,7 +303,7 @@ fn shorthand_uncommitted_hunk_to_unassigned() -> anyhow::Result<()> {
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ────────╮
-m0 a.txt│
+j0 a.txt│
 ────────╯
    1  │-first
      1│+firsta
@@ -311,7 +311,7 @@ m0 a.txt│
    3 3│ line
    4 4│ line
 ────────╮
-n0 a.txt│
+k0 a.txt│
 ────────╯
     6  6│ line
     7  7│ line
@@ -320,7 +320,7 @@ n0 a.txt│
        9│+lasta
 
 "#]]);
-    env.but("m0 00")
+    env.but("j0 00")
         .assert()
         .success()
         .stdout_eq(snapbox::file![
@@ -374,7 +374,7 @@ fn uncommitted_hunk_to_branch() -> anyhow::Result<()> {
 
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
-    // Verify that the first hunk is m0, and move it to unassigned.
+    // Verify that the first hunk is j0, and move it to unassigned.
     env.but("diff a.txt")
         .env_remove("CLICOLOR_FORCE")
         .assert()
@@ -382,7 +382,7 @@ fn uncommitted_hunk_to_branch() -> anyhow::Result<()> {
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ────────╮
-m0 a.txt│
+j0 a.txt│
 ────────╯
    1  │-first
      1│+firsta
@@ -390,7 +390,7 @@ m0 a.txt│
    3 3│ line
    4 4│ line
 ────────╮
-n0 a.txt│
+k0 a.txt│
 ────────╯
     6  6│ line
     7  7│ line
@@ -399,7 +399,7 @@ n0 a.txt│
        9│+lasta
 
 "#]]);
-    env.but("rub m0 A")
+    env.but("rub j0 A")
         .assert()
         .success()
         .stdout_eq(snapbox::file![

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -295,8 +295,31 @@ fn shorthand_uncommitted_hunk_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    // TODO When we have a way to list the hunks and their respective IDs (e.g.
-    //      via a "diff" or "show" command), assert that m0 is the hunk we want.
+    // Verify that the first hunk is m0, and move it to unassigned.
+    env.but("diff i0")
+        .env_remove("CLICOLOR_FORCE")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+m0 a.txt│
+────────╯
+   1  │-first
+     1│+firsta
+   2 2│ line
+   3 3│ line
+   4 4│ line
+────────╮
+n0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-last
+       9│+lasta
+
+"#]]);
     env.but("m0 00")
         .assert()
         .success()
@@ -351,8 +374,31 @@ fn uncommitted_hunk_to_branch() -> anyhow::Result<()> {
 
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
-    // TODO When we have a way to list the hunks and their respective IDs (e.g.
-    //      via a "diff" or "show" command), assert that m0 is the hunk we want.
+    // Verify that the first hunk is m0, and move it to unassigned.
+    env.but("diff a.txt")
+        .env_remove("CLICOLOR_FORCE")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+m0 a.txt│
+────────╯
+   1  │-first
+     1│+firsta
+   2 2│ line
+   3 3│ line
+   4 4│ line
+────────╮
+n0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-last
+       9│+lasta
+
+"#]]);
     env.but("rub m0 A")
         .assert()
         .success()

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -58,7 +58,7 @@ fn uncommitted_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("i0 00")
+    env.but("i0 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::file![
@@ -177,7 +177,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("j0 00")
+    env.but("j0 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::file![
@@ -320,7 +320,7 @@ k0 a.txt│
        9│+lasta
 
 "#]]);
-    env.but("j0 00")
+    env.but("j0 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::file![

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -22,7 +22,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -22,7 +22,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -236,12 +236,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "n0",
+                  "cliId": "q0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "o0",
+                  "cliId": "r0",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -251,12 +251,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "k0",
+                  "cliId": "n0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "l0",
+                  "cliId": "o0",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -20,7 +20,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -20,7 +20,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">00</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊</tspan>
 </tspan>


### PR DESCRIPTION
I'll try something new and will describe here why I didn't automerge this PR.

Why I didn't automerge
- In the first commit ("tests: replace TODOs with hunk ID verification") I decided to include the expected CLI output as an inline string instead of the typical SVG file. I'm bringing this up here because it's not usual practice, although in this case, I think it's warranted because a reader needs to know that a specific string is present (which will be used later in the test). I added `env_remove("CLICOLOR_FORCE")` to remove the color codes to make the CLI output easier to read.
- In the last commit ("id: rename unassigned area to zz") I decided to switch the ID of the unassigned area to "zz" (before this PR, it was "00"). I think this is a good change, but it may affect people's workflows, so I'm bringing this up here.

This PR reduces ID ambiguity by making branch IDs not collide with filenames, and by renaming the unassigned area to not collide with commits that start with "00".