### PR TITLE
Decorate branches with upstream merge status in status output

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -350,6 +350,7 @@ async fn match_subcommand(
             command::legacy::status::worktree(
                 &mut ctx, out, show_files, verbose, sync_prs, upstream,
             )
+            .await
             .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
@@ -359,6 +360,7 @@ async fn match_subcommand(
         } => {
             let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
             command::legacy::status::worktree(&mut ctx, out, true, verbose, refresh_prs, false)
+                .await
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]


### PR DESCRIPTION
When running `but status --upstream` we should indicate for each branch whether it can be cleanly integrated, is already integrated, has conflicts, or is empty.

<img width="1614" height="886" alt="CleanShot 2026-01-08 at 13 43 32@2x" src="https://github.com/user-attachments/assets/af3ad526-31fa-4d31-9200-ebb0b435815b" />

