### PR TITLE
Add `but resolve` edit-mode workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,8 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-branch-actions",
  "gitbutler-commit",
+ "gitbutler-edit-mode",
+ "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-project",
  "gitbutler-reference",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "but-meta",
  "but-oxidize",
  "but-path",
+ "but-rebase",
  "but-rules",
  "but-secret",
  "but-serde",

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -76,6 +76,7 @@ pub fn abort_edit_and_return_to_workspace(project_id: ProjectId) -> Result<()> {
     Ok(())
 }
 
+// GUI-facing API that returns () for serialization compatibility
 #[but_api]
 #[instrument(err(Debug))]
 pub fn save_edit_and_return_to_workspace(project_id: ProjectId) -> Result<()> {
@@ -83,6 +84,14 @@ pub fn save_edit_and_return_to_workspace(project_id: ProjectId) -> Result<()> {
 
     gitbutler_edit_mode::commands::save_and_return_to_workspace(&ctx)?;
 
+    Ok(())
+}
+
+#[but_api]
+#[instrument(err(Debug))]
+pub fn save_edit_and_return_to_workspace_with_output(project_id: ProjectId) -> Result<()> {
+    let ctx = Context::new_from_legacy_project_id(project_id)?;
+    gitbutler_edit_mode::commands::save_and_return_to_workspace(&ctx)?;
     Ok(())
 }
 

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -49,6 +49,7 @@ but-secret.workspace = true
 but-oxidize.workspace = true
 but-path.workspace = true
 but-ctx.workspace = true
+but-rebase.workspace = true
 # NOTE: "legacy" is needed as long as virtual-branches.toml is around.
 but-meta = { workspace = true, features = ["legacy"] }
 # NOTE: close to mostly 'proper', but depends on `gitbutler-user`

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -37,6 +37,8 @@ legacy = [
     "dep:gitbutler-branch",
     "dep:gitbutler-reference",
     "dep:gitbutler-oplog",
+    "dep:gitbutler-edit-mode",
+    "dep:gitbutler-operating-modes",
 ]
 
 [dependencies]
@@ -76,6 +78,8 @@ gitbutler-branch-actions = { workspace = true, optional = true }
 gitbutler-branch = { workspace = true, optional = true }
 gitbutler-reference = { workspace = true, optional = true }
 gitbutler-oplog = { workspace = true, optional = true }
+gitbutler-edit-mode = { workspace = true, optional = true }
+gitbutler-operating-modes = { workspace = true, optional = true }
 
 git2.workspace = true
 async-openai.workspace = true

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -42,6 +42,7 @@ pub enum CommandName {
     PrTemplate,
     Completions,
     RefreshRemoteData,
+    Resolve,
     #[default]
     Unknown,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -545,6 +545,30 @@ pub enum Subcommands {
         shell: Option<clap_complete::Shell>,
     },
 
+    /// Resolve conflicts in a commit.
+    ///
+    /// When a commit is in a conflicted state (marked with conflicts during rebase),
+    /// use this command to enter resolution mode, resolve the conflicts, and finalize.
+    ///
+    /// ## Workflow
+    ///
+    /// 1. Enter resolution mode: `but resolve <commit-id>`
+    /// 2. Resolve conflicts in your editor (remove conflict markers)
+    /// 3. Check remaining conflicts: `but resolve status`
+    /// 4. Finalize resolution: `but resolve finish`
+    ///    Or cancel: `but resolve cancel`
+    ///
+    /// When in resolution mode, `but status` will also show that you're resolving conflicts.
+    ///
+    #[cfg(feature = "legacy")]
+    Resolve {
+        /// Subcommand to run (defaults to entering resolution mode)
+        #[clap(subcommand)]
+        cmd: Option<resolve::Subcommands>,
+        /// Commit ID to enter resolution mode for (when no subcommand is provided)
+        commit: Option<String>,
+    },
+
     /// Hidden command that redirects to `but pull --check`
     #[cfg(feature = "legacy")]
     #[clap(hide = true)]
@@ -582,6 +606,8 @@ pub mod metrics;
 #[cfg(feature = "legacy")]
 pub mod oplog;
 pub mod push;
+#[cfg(feature = "legacy")]
+pub mod resolve;
 
 pub mod claude {
     #[derive(Debug, clap::Parser)]

--- a/crates/but/src/args/resolve.rs
+++ b/crates/but/src/args/resolve.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+    /// Show the status of conflict resolution, listing remaining conflicted files.
+    Status,
+
+    /// Finalize conflict resolution and return to workspace mode.
+    ///
+    /// This commits the resolved changes, clears the conflict markers,
+    /// and returns to the normal workspace.
+    Finish,
+
+    /// Cancel conflict resolution and return to workspace mode.
+    ///
+    /// This discards all changes made during resolution and restores
+    /// the workspace to its pre-resolution state.
+    Cancel,
+}

--- a/crates/but/src/args/resolve.rs
+++ b/crates/but/src/args/resolve.rs
@@ -5,8 +5,8 @@ pub enum Subcommands {
 
     /// Finalize conflict resolution and return to workspace mode.
     ///
-    /// This commits the resolved changes, clears the conflict markers,
-    /// and returns to the normal workspace.
+    /// This commits the resolved changes, rebases any commits on top of the
+    /// resolved commit, and returns to the normal workspace.
     Finish,
 
     /// Cancel conflict resolution and return to workspace mode.

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -15,6 +15,7 @@ pub mod oplog;
 pub mod pull;
 pub mod push;
 pub mod refresh;
+pub mod resolve;
 pub mod reword;
 pub mod rub;
 pub mod status;

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -520,7 +520,22 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                                     false
                                 };
 
-                                if still_conflicted {
+                                // Also check if any commits in the branch have conflicts
+                                let has_conflicted_commits =
+                                    but_api::legacy::workspace::stack_details(
+                                        ctx.legacy_project.id,
+                                        Some(*stack_id),
+                                    )
+                                    .ok()
+                                    .map(|details| {
+                                        details
+                                            .branch_details
+                                            .iter()
+                                            .any(|bd| bd.commits.iter().any(|c| c.has_conflicts))
+                                    })
+                                    .unwrap_or(false);
+
+                                if still_conflicted || has_conflicted_commits {
                                     conflicted_rebases.push(branch_name.to_string());
                                 } else {
                                     successful_rebases.push(branch_name.to_string());
@@ -643,14 +658,19 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(out, "{}", "To resolve conflicts:".bold())?;
                         writeln!(
                             out,
-                            "  1. Run {} to see conflicted files",
+                            "  1. Run {} to see conflicted commits",
                             "`but status`".bright_cyan()
                         )?;
-                        writeln!(out, "  2. Edit the files to resolve conflicts")?;
                         writeln!(
                             out,
-                            "  3. Run {} to commit the resolution",
-                            "`but commit`".bright_cyan()
+                            "  2. Run {} to enter resolution mode on any conflicted commit",
+                            "`but resolve <commit>`".bright_cyan()
+                        )?;
+                        writeln!(out, "  3. Edit files to resolve the conflicts")?;
+                        writeln!(
+                            out,
+                            "  4. Run {} to finalize the resolution",
+                            "`but resolve finish`".bright_cyan()
                         )?;
                     }
 

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -122,7 +122,7 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     drop(commit);
     drop(git2_repo);
 
-    // Show user-friendly output
+    // Show checkout message
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -130,23 +130,10 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
             "Checking out conflicted commit".bold(),
             commit_oid.to_string()[..7].cyan()
         )?;
-        writeln!(
-            out,
-            "You are now in edit mode - resolve all conflicts and finalize with {} or cancel with {}",
-            "but resolve finish".green().bold(),
-            "but resolve cancel".red().bold()
-        )?;
-        writeln!(
-            out,
-            "  view remaining issues with {}",
-            "but resolve status".yellow().bold()
-        )?;
     }
 
-    // Show initial conflicted files (ignore the return value here)
-    let _all_resolved = show_conflicted_files(ctx, out)?;
-
-    Ok(())
+    // Now show the same status as `but resolve status` would show
+    show_status(ctx, out)
 }
 
 fn show_status(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -1,0 +1,432 @@
+use anyhow::{Context as _, Result, bail};
+use bstr::ByteSlice;
+use but_api::legacy::modes::{
+    abort_edit_and_return_to_workspace, edit_initial_index_state, enter_edit_mode,
+    save_edit_and_return_to_workspace,
+};
+use but_ctx::Context;
+use colored::Colorize;
+use gitbutler_commit::commit_ext::CommitExt;
+use gitbutler_operating_modes::OperatingMode;
+
+use crate::{IdMap, args::resolve::Subcommands, id::CliId, utils::OutputChannel};
+
+pub(crate) fn handle(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    cmd: Option<Subcommands>,
+    commit_id: Option<String>,
+) -> Result<()> {
+    match cmd {
+        Some(Subcommands::Status) => show_status(ctx, out),
+        Some(Subcommands::Finish) => finish_resolution(ctx, out),
+        Some(Subcommands::Cancel) => cancel_resolution(ctx, out),
+        None => {
+            // Default action: enter resolution mode for the specified commit
+            if let Some(commit_id_str) = commit_id {
+                enter_resolution(ctx, out, &commit_id_str)
+            } else {
+                // Check if we're already in edit mode
+                let mode = gitbutler_operating_modes::operating_mode(ctx);
+                if matches!(mode, OperatingMode::Edit(_)) {
+                    // If in edit mode, show status instead of help
+                    show_status(ctx, out)
+                } else {
+                    // Otherwise, show helpful workflow guide
+                    show_workflow_help(out)
+                }
+            }
+        }
+    }
+}
+
+fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &str) -> Result<()> {
+    // Create an IdMap to resolve commit IDs (supports both CLI IDs and partial SHAs)
+    let id_map = IdMap::new_from_context(ctx)?;
+
+    // Resolve the commit ID using the IdMap
+    let matches = id_map.resolve_entity_to_ids(commit_id_str)?;
+
+    if matches.is_empty() {
+        bail!(
+            "Commit '{}' not found. Try running 'but status' to see available commits.",
+            commit_id_str
+        );
+    }
+
+    if matches.len() > 1 {
+        bail!(
+            "Commit ID '{}' is ambiguous. Please provide more characters to uniquely identify the commit.",
+            commit_id_str
+        );
+    }
+
+    // Extract the commit OID from the matched CliId
+    let commit_oid = match &matches[0] {
+        CliId::Commit(oid) => git2::Oid::from_bytes(oid.as_slice())?,
+        _ => bail!("'{}' does not refer to a commit", commit_id_str),
+    };
+
+    // Get the commit and check if it's conflicted
+    let git2_repo = ctx.git2_repo.get()?;
+    let commit = git2_repo
+        .find_commit(commit_oid)
+        .context("Failed to find commit")?;
+
+    if !commit.is_conflicted() {
+        bail!(
+            "Commit {} is not in a conflicted state. Only conflicted commits can be resolved.",
+            &commit_oid.to_string()[..7]
+        );
+    }
+
+    // Find which stack this commit belongs to
+    let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
+    let mut found_stack_id = None;
+    for stack in &stacks {
+        // Check if this commit is in any of the stack's heads
+        for head in &stack.heads {
+            let head_oid = git2::Oid::from_bytes(head.tip.as_slice())?;
+            // Walk the commit history to see if our commit is in this stack
+            let mut revwalk = git2_repo.revwalk()?;
+            revwalk.push(head_oid)?;
+            revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+
+            for oid in revwalk {
+                if oid? == commit_oid {
+                    found_stack_id = stack.id;
+                    break;
+                }
+            }
+            if found_stack_id.is_some() {
+                break;
+            }
+        }
+        if found_stack_id.is_some() {
+            break;
+        }
+    }
+
+    let stack_id = found_stack_id.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not find stack containing commit {}",
+            &commit_oid.to_string()[..7]
+        )
+    })?;
+
+    // Enter edit mode
+    enter_edit_mode(ctx.legacy_project.id, commit_oid.to_string(), stack_id)
+        .context("Failed to enter edit mode")?;
+
+    // Drop the git2 objects to release the borrow
+    drop(commit);
+    drop(git2_repo);
+
+    // Show user-friendly output
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{} {}",
+            "Checking out conflicted commit".bold(),
+            commit_oid.to_string()[..7].cyan()
+        )?;
+        writeln!(
+            out,
+            "You are now in edit mode - resolve all conflicts and finalize with {} or cancel with {}",
+            "but resolve finish".green().bold(),
+            "but resolve cancel".red().bold()
+        )?;
+        writeln!(
+            out,
+            "  view remaining issues with {}",
+            "but resolve status".yellow().bold()
+        )?;
+    }
+
+    // Show initial conflicted files
+    show_conflicted_files(ctx, out)?;
+
+    Ok(())
+}
+
+fn show_status(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    // Check if we're in edit mode
+    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        // Not in edit mode, show the workflow help instead
+        return show_workflow_help(out);
+    }
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{}\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
+            "You are currently in conflict resolution mode.".bold(),
+            "but resolve finish".green().bold(),
+            "but resolve cancel".red().bold()
+        )?;
+    }
+
+    show_conflicted_files(ctx, out)?;
+
+    Ok(())
+}
+
+fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let conflicted_files = edit_initial_index_state(ctx.legacy_project.id)
+        .context("Failed to get conflicted files")?;
+
+    let initially_conflicted: Vec<_> = conflicted_files
+        .iter()
+        .filter(|(_, conflict)| conflict.is_some())
+        .collect();
+
+    // Check which files still have conflict markers
+    let git2_repo = ctx.git2_repo.get()?;
+    let repo_path = git2_repo.workdir().context("No workdir")?;
+    let mut still_conflicted = Vec::new();
+    let mut resolved = Vec::new();
+
+    for (change, _) in &initially_conflicted {
+        let file_path = repo_path.join(change.path.to_str_lossy().as_ref());
+        if file_path.exists() {
+            match std::fs::read_to_string(&file_path) {
+                Ok(content) => {
+                    if has_conflict_markers(&content) {
+                        still_conflicted.push(change);
+                    } else {
+                        resolved.push(change);
+                    }
+                }
+                Err(_) => {
+                    // If we can't read the file, consider it still conflicted
+                    still_conflicted.push(change);
+                }
+            }
+        } else {
+            // If file doesn't exist, it was deleted - consider it resolved
+            resolved.push(change);
+        }
+    }
+
+    if still_conflicted.is_empty() {
+        if let Some(out) = out.for_human() {
+            writeln!(out, "{}", "No conflicted files remaining!".green())?;
+            if !resolved.is_empty() {
+                writeln!(out, "{} resolved:", "Files".green())?;
+                for change in &resolved {
+                    writeln!(
+                        out,
+                        "  {} {}",
+                        "✓".green(),
+                        change.path.to_str_lossy().green()
+                    )?;
+                }
+            }
+            writeln!(
+                out,
+                "Run {} to finalize the resolution.",
+                "but resolve finish".green().bold()
+            )?;
+        }
+    } else {
+        if let Some(out) = out.for_human() {
+            writeln!(out, "{}:", "Conflicted files remaining".yellow().bold())?;
+            for change in &still_conflicted {
+                writeln!(
+                    out,
+                    "  {} {}",
+                    "✗".red(),
+                    change.path.to_str_lossy().yellow()
+                )?;
+            }
+            if !resolved.is_empty() {
+                writeln!(out, "\n{} resolved:", "Files".green())?;
+                for change in &resolved {
+                    writeln!(
+                        out,
+                        "  {} {}",
+                        "✓".green(),
+                        change.path.to_str_lossy().green()
+                    )?;
+                }
+            }
+        } else if let Some(out) = out.for_json() {
+            let conflicted_list: Vec<String> = still_conflicted
+                .iter()
+                .map(|change| change.path.to_str_lossy().to_string())
+                .collect();
+            let resolved_list: Vec<String> = resolved
+                .iter()
+                .map(|change| change.path.to_str_lossy().to_string())
+                .collect();
+            out.write_value(&serde_json::json!({
+                "conflicted_files": conflicted_list,
+                "resolved_files": resolved_list,
+                "conflicted_count": conflicted_list.len(),
+                "resolved_count": resolved_list.len()
+            }))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if a file contains git conflict markers
+/// Matches the logic from the GUI's looksConflicted() function
+fn has_conflict_markers(content: &str) -> bool {
+    content.lines().any(|line| line.starts_with("<<<<<<<"))
+}
+
+fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    // Check if we're in edit mode
+    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        // Not in edit mode, show the workflow help instead
+        return show_workflow_help(out);
+    }
+
+    // Note: We don't check if conflicts are actually resolved because:
+    // 1. The backend API doesn't validate this - it just commits the working directory
+    // 2. There's no reliable way to detect if conflict markers were resolved
+    // 3. The GUI trusts the user to resolve conflicts before clicking "Save"
+    // The user can run `but resolve status` to see which files were originally conflicted
+
+    // Save and return to workspace
+    save_edit_and_return_to_workspace(ctx.legacy_project.id)
+        .context("Failed to save resolution and return to workspace")?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{}",
+            "✓ Conflict resolution finalized successfully!"
+                .green()
+                .bold()
+        )?;
+        writeln!(
+            out,
+            "The commit has been updated with your resolved changes."
+        )?;
+    }
+
+    Ok(())
+}
+
+fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    // Check if we're in edit mode
+    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        // Not in edit mode, show the workflow help instead
+        return show_workflow_help(out);
+    }
+
+    // Abort and return to workspace
+    abort_edit_and_return_to_workspace(ctx.legacy_project.id)
+        .context("Failed to cancel resolution and return to workspace")?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "{}", "Conflict resolution cancelled.".yellow())?;
+        writeln!(
+            out,
+            "All changes made during resolution have been discarded."
+        )?;
+    }
+
+    Ok(())
+}
+
+fn show_workflow_help(out: &mut OutputChannel) -> Result<()> {
+    if let Some(out) = out.for_human() {
+        writeln!(out, "{}", "Conflict Resolution Workflow".bold().underline())?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "This command is used when you have a commit in a conflicted state"
+        )?;
+        writeln!(out)?;
+        writeln!(out, "{}", "To resolve conflicts in a commit:".bold())?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "  {} Enter resolution mode for a conflicted commit:",
+            "1.".bold()
+        )?;
+        writeln!(out, "     {}", "but resolve <commit>".green())?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "  {} Resolve conflicts in the conflicted files",
+            "2.".bold()
+        )?;
+        writeln!(
+            out,
+            "     Edit the files to remove conflict markers ({}, {}, {})",
+            "<<<<<<<".red(),
+            "=======".yellow(),
+            ">>>>>>>".red()
+        )?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "  {} Check which files are still conflicted:",
+            "3.".bold()
+        )?;
+        writeln!(out, "     {}", "but resolve status".green())?;
+        writeln!(out)?;
+        writeln!(out, "  {} Finalize or cancel the resolution:", "4.".bold())?;
+        writeln!(out, "     {}", "but resolve finish".green())?;
+        writeln!(out, "     {}", "OR".dimmed())?;
+        writeln!(out, "     {}", "but resolve cancel".green())?;
+        writeln!(out)?;
+        writeln!(out, "{}", "Example:".bold())?;
+        writeln!(out, "  {} (find conflicted commits)", "but status".green())?;
+        writeln!(
+            out,
+            "  {} (enter resolution mode)",
+            "but resolve 55".green()
+        )?;
+        writeln!(
+            out,
+            "  {} (edit files to resolve conflicts)",
+            "vim src/file.rs".dimmed()
+        )?;
+        writeln!(
+            out,
+            "  {} (check remaining conflicts)",
+            "but resolve status".green()
+        )?;
+        writeln!(out, "  {} (finalize)", "but resolve finish".green())?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(&serde_json::json!({
+            "workflow": [
+                {
+                    "step": 1,
+                    "description": "Enter resolution mode for a conflicted commit",
+                    "command": "but resolve <commit>"
+                },
+                {
+                    "step": 2,
+                    "description": "Resolve conflicts in the conflicted files",
+                    "details": "Edit the files to remove conflict markers (<<<<<<<, =======, >>>>>>>)"
+                },
+                {
+                    "step": 3,
+                    "description": "Check which files are still conflicted",
+                    "command": "but resolve status"
+                },
+                {
+                    "step": 4,
+                    "description": "Finalize the resolution",
+                    "command": "but resolve finish"
+                }
+            ],
+            "other_commands": {
+                "cancel": "but resolve cancel",
+                "view_status": "but status"
+            }
+        }))?;
+    }
+
+    Ok(())
+}

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -51,40 +51,9 @@ struct UpstreamState {
     author_email: String,
 }
 
-fn show_edit_mode_status(out: &mut OutputChannel) -> anyhow::Result<()> {
-    let Some(out) = out.for_human() else {
-        // TODO: support JSON output for edit mode status
-        return Ok(());
-    };
-
-    writeln!(
-        out,
-        "{}",
-        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            .yellow()
-    )?;
-    writeln!(
-        out,
-        "{} {} \n\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
-        "⚠".yellow().bold(),
-        "You are currently in conflict resolution mode.".bold(),
-        "but resolve finish".green().bold(),
-        "but resolve cancel".red().bold()
-    )?;
-    writeln!(
-        out,
-        "  view remaining issues with {}",
-        "but resolve status".yellow().bold()
-    )?;
-    writeln!(
-        out,
-        "{}",
-        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            .yellow()
-    )?;
-    writeln!(out)?; // Empty line after the notice
-
-    Ok(())
+fn show_edit_mode_status(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    // Delegate to the resolve status logic to show actual conflict details
+    crate::command::legacy::resolve::show_resolve_status(ctx, out)
 }
 
 pub(crate) fn worktree(
@@ -98,8 +67,8 @@ pub(crate) fn worktree(
     // Check if we're in edit mode first, before doing any expensive operations
     let mode = gitbutler_operating_modes::operating_mode(ctx);
     if let gitbutler_operating_modes::OperatingMode::Edit(_metadata) = mode {
-        // In edit mode, show a simplified status with just the conflicted files
-        return show_edit_mode_status(out);
+        // In edit mode, show the conflict resolution status
+        return show_edit_mode_status(ctx, out);
     }
 
     but_rules::process_rules(ctx).ok(); // TODO: this is doing double work (hunk-dependencies can be reused)

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -531,6 +531,14 @@ async fn match_subcommand(
             command::legacy::refresh::handle(&mut ctx, out, fetch, prs, ci)
                 .emit_metrics(metrics_ctx)
         }
+        #[cfg(feature = "legacy")]
+        Subcommands::Resolve { cmd, commit } => {
+            let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
+            command::legacy::resolve::handle(&mut ctx, out, cmd, commit)
+                .context("Failed to handle conflict resolution.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
     }
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -138,7 +138,10 @@ impl Subcommands {
             },
             Subcommands::Completions { .. } => Completions,
             Subcommands::Metrics { .. } => Unknown,
+            #[cfg(feature = "legacy")]
             Subcommands::RefreshRemoteData { .. } => RefreshRemoteData,
+            #[cfg(feature = "legacy")]
+            Subcommands::Resolve { .. } => Resolve,
         }
     }
 }


### PR DESCRIPTION
Introduce a new `but resolve <commit>` command and accompanying subcommands (status, finish, cancel) to enter an edit-mode resolution flow for conflicted commits. 

Status warns you of edit state:

<img width="1654" height="458" alt="CleanShot 2026-01-07 at 11 37 39@2x" src="https://github.com/user-attachments/assets/314833d5-e3d1-4a0c-9c36-92b6f539b4f7" />

`but resolve status` tells you which files are still outstanding:

<img width="1146" height="406" alt="CleanShot 2026-01-07 at 11 40 11@2x" src="https://github.com/user-attachments/assets/86a1c5b3-52a4-4849-9eec-901ef81cebce" />

Finishing a resolution:

<img width="1208" height="664" alt="CleanShot 2026-01-07 at 11 40 48@2x" src="https://github.com/user-attachments/assets/3553ff13-b937-488a-b077-0b6ca04b7813" />

Help output:

<img width="1622" height="1182" alt="CleanShot 2026-01-07 at 11 41 10@2x" src="https://github.com/user-attachments/assets/c853fd1a-623c-4279-b392-3869f01f1d91" />

