### PR TITLE
Remove pub from keep json

### DIFF
--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -235,7 +235,7 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         const _: () = {
             #[allow(dead_code)]
-            pub fn keep_json(_json: #json_ty) {}
+            fn keep_json(_json: #json_ty) {}
         };
 
         /// Cmd function - this is legacy just while most of its functionality depend on `LegacyProjectId`.


### PR DESCRIPTION
In this context the `pub` is not required. It’s likely fine either way but removing it is a bit tidier