### PR TITLE
Manual update should work with auto update disabled

### DIFF
--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -126,6 +126,21 @@ describe('Updater', () => {
 		expect(mock).toHaveBeenCalledOnce();
 	});
 
+	test('should ignore disableAutoChecks setting when manual update', async () => {
+		const mock = vi.spyOn(backend, 'checkUpdate').mockReturnValue(mockUpdate(null));
+		const manualCheck = true;
+
+		updater.disableAutoChecks.set(true);
+
+		await updater.checkForUpdate(manualCheck);
+		expect(mock).toHaveBeenCalledOnce();
+
+		updater.disableAutoChecks.set(false);
+
+		await updater.checkForUpdate(manualCheck);
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+
 	test('should disable updater when updateIntervalMs is 0', async () => {
 		const mock = vi.spyOn(backend, 'checkUpdate').mockReturnValue(mockUpdate(null));
 

--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -94,7 +94,7 @@ export class UpdaterService {
 	}
 
 	async checkForUpdate(manual = false) {
-		if (get(this.disableAutoChecks)) return;
+		if (get(this.disableAutoChecks) && !manual) return;
 
 		if (manual) {
 			this.manualCheck = manual;


### PR DESCRIPTION
We previously would always return early if you disabled auto-updates. This is clearly not desirable.

This change allows users  who don’t want auto updates to still manually check for updates