### PR TITLE
Make renaming a branch to its current name a NOOP

### DIFF
--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -569,7 +569,9 @@ impl Stack {
         let mut updated_heads = self.heads.clone();
 
         // Handle name updates
-        if let Some(name) = update.name.clone() {
+        if let Some(name) = update.name.clone()
+            && name != branch_name
+        {
             let head = updated_heads
                 .iter_mut()
                 .find(|h: &&mut StackBranch| *h.name() == branch_name);

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -379,6 +379,26 @@ fn update_branch_name_fails_validation() -> Result<()> {
 }
 
 #[test]
+fn update_branch_name_to_same_name_is_noop() -> Result<()> {
+    let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
+    let mut test_ctx = test_ctx(&ctx)?;
+    let branch_name = String::from("virtual");
+
+    let update = PatchReferenceUpdate {
+        name: Some(branch_name.clone()),
+        description: None,
+    };
+    let result = test_ctx
+        .stack
+        .update_branch(&ctx, branch_name.clone(), &update);
+
+    assert!(result.is_ok());
+    assert_eq!(test_ctx.stack.heads[0].name(), &branch_name);
+
+    Ok(())
+}
+
+#[test]
 fn update_branch_name_success() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;


### PR DESCRIPTION
## 🧢 Changes
Makes renaming a branch to its current name a NOOP.

## ☕️ Reasoning
This seems like the simplest solution to the issue, and has no particular downsides. It also makes branch renaming idempotent, which at least in web dev is usually rather desirable (unless the NOOP is itself indicative of an error, but I don't think it is in this case).

I fixed this at the lowest level possible.

Renaming a real reference is actually already a NOOP https://github.com/gitbutlerapp/gitbutler/blob/8fee6821a243ba63b8a6f51f15dc666c65c5215c/crates/gitbutler-stack/src/stack_branch.rs#L245-L248

But before we get there, we validate the name in `update_branch` by https://github.com/gitbutlerapp/gitbutler/blob/8fee6821a243ba63b8a6f51f15dc666c65c5215c/crates/gitbutler-stack/src/stack.rs#L571-L581

That validation, among other things, checks that the name doesn't already exist. Which of course it does in this scenario. I think that's a good check to have and don't want to complicate `validate_name()`, so this seems like a decent solution.

## 🎫 Affected issues

Fixes: #11741

## Test output before patch

I like to test that my test actually does something, here's the test output from before applying the production code patch.

```bash
$ cargo test -p gitbutler-stack
<snip>

failures:

---- update_branch_name_to_same_name_is_noop stdout ----

thread 'update_branch_name_to_same_name_is_noop' (138422) panicked at crates/gitbutler-stack/tests/mod.rs:395:5:
assertion failed: result.is_ok()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    update_branch_name_to_same_name_is_noop

test result: FAILED. 49 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 30.77s
```