### PR TITLE
Make commit CLI IDs longer if ambiguous

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -42,6 +42,7 @@ There are several community-maintained distributions of GitButler. Issues with t
 ## Known issues and workarounds
 
 ### High CPU usage in WebKitGTK thread
+
 If you're exhibiting high CPU usage in a WebKit-related thread, try disabling hardware acceleration for WebKitGTK.
 
 ```bash

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -97,7 +97,7 @@ pub fn handle(
                 // Create the anchor for create_reference
                 // as dependent branch
                 match anchor_id {
-                    CliId::Commit(oid) => {
+                    CliId::Commit { commit_id: oid, .. } => {
                         Some(but_api::legacy::stack::create_reference::Anchor::AtCommit {
                             commit_id: (*oid).into(),
                             position: but_workspace::branch::create_reference::Position::Above,

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -42,7 +42,7 @@ pub(crate) fn insert_blank_commit(
 
     // Determine target commit ID and offset based on CLI ID type
     let (target_commit_id, offset, success_message) = match cli_id {
-        CliId::Commit(oid) => {
+        CliId::Commit { commit_id: oid, .. } => {
             // For commits, insert before (offset 0) and use the commit ID directly
             (
                 *oid,

--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -35,7 +35,7 @@ pub fn handle(
                 commit_id, path, ..
             } => show::commit(ctx, out, commit_id, Some(path)),
             CliId::Branch { name, .. } => show::branch(ctx, out, name),
-            CliId::Commit(id) => show::commit(ctx, out, id, None),
+            CliId::Commit { commit_id: id, .. } => show::commit(ctx, out, id, None),
         }
     } else {
         show::worktree(wt_changes, id_map, out, None)

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -30,7 +30,7 @@ pub(crate) fn handle(
     }
     match target_result[0].clone() {
         CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out),
-        CliId::Commit(oid) => mark_commit(ctx, oid, delete, out),
+        CliId::Commit { commit_id: oid, .. } => mark_commit(ctx, oid, delete, out),
         _ => bail!("Nope"),
     }
 }

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -37,7 +37,7 @@ pub(crate) fn reword_target(
         CliId::Branch { name, .. } => {
             edit_branch_name(ctx, &ctx.legacy_project, name, out, message)?;
         }
-        CliId::Commit(oid) => {
+        CliId::Commit { commit_id: oid, .. } => {
             edit_commit_message_by_id(ctx, &ctx.legacy_project, *oid, out, message)?;
         }
         _ => {

--- a/crates/but/src/id/file_info.rs
+++ b/crates/but/src/id/file_info.rs
@@ -10,8 +10,10 @@ impl FileInfo {
     /// Extracts file information from workspace commits and worktree status.
     ///
     /// This function processes workspace commits to find all changed files in each commit.
-    pub(crate) fn from_workspace_commits_and_status<F>(
-        workspace_commit_and_first_parent_ids: &[(gix::ObjectId, Option<gix::ObjectId>)],
+    pub(crate) fn from_workspace_commits_and_status<'a, F>(
+        workspace_commit_and_first_parent_ids: impl Iterator<
+            Item = (&'a gix::ObjectId, &'a Option<gix::ObjectId>),
+        >,
         mut changed_paths_fn: F,
     ) -> anyhow::Result<Self>
     where

--- a/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
@@ -1,0 +1,65 @@
+<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="underline">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="underline">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="underline">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="underline">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="370px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/fixtures/scenario/commits-with-same-prefix.sh
+++ b/crates/but/tests/fixtures/scenario/commits-with-same-prefix.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# 2 commits start with 5c.
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+
+git checkout -b A
+  commit-file A1
+  commit-file A2
+  commit-file A3
+  commit-file A4
+  commit-file A5
+  commit-file A6
+  commit-file A7
+  commit-file A8
+  commit-file A9
+  commit-file A10
+  commit-file A11
+  commit-file A12
+  commit-file A13
+create_workspace_commit_once A


### PR DESCRIPTION
This changes `IdMap`, and I've also updated `but status` to show the new IDs. There's a performance hit in that we have to check the `IdMap` whenever we print a commit ID (with a linear scan of the commits in the `IdMap`), but at least the result is more correct. Eventually, `but status` should be updated to get its commits from `IdMap` directly instead of doubly calculating the list of commits to be shown - I'll see how feasible this is (if not, I'll see about improving `IdMap`'s performance with respect to commits, since `but status` is a very commonly used command).
