### PR TITLE
fix: ensure first changed file is correctly selected for preview when switching between commits

### DIFF
--- a/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
@@ -46,6 +46,10 @@ export class FileSelectionManager {
 		}
 	>;
 
+	// Track visited selections and first file paths across component instances
+	private visitedSelections = $state<Set<string>>(new Set());
+	private firstPathBySelection = $state<Map<string, string>>(new Map());
+
 	constructor(
 		private stackService: StackService,
 		private uncommittedService: UncommittedService,
@@ -277,5 +281,21 @@ export class FileSelectionManager {
 					path: selectedFile.path
 				});
 		}
+	}
+
+	isFirstVisit(key: string): boolean {
+		return !this.visitedSelections.has(key);
+	}
+
+	markAsVisited(key: string): void {
+		this.visitedSelections.add(key);
+	}
+
+	getFirstPathForSelection(key: string): string | undefined {
+		return this.firstPathBySelection.get(key);
+	}
+
+	setFirstPathForSelection(key: string, path: string): void {
+		this.firstPathBySelection.set(key, path);
 	}
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/effcb600-ce3e-46b9-8ada-37678110c351

This PR fixes an issue in the commit history preview within the branch view, where switching between different commits did not correctly update the preview to the first changed file of the currently selected commit.

The root cause is likely a race condition between multiple Svelte effects in the codebase. The issue is reliably reproducible, but the resulting state can appear somewhat random.

Since race conditions caused by effects execution order in Svelte are complex to reason about, the approach taken here is to add additional logic to ensure that a fresh selection state is always used whenever the context changes, which guarantees correct behavior.