### PR TITLE
`but absorb` reasoning

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -16,6 +16,44 @@ use crate::{
     CliId, IdMap, command::legacy::rub::parse_sources, id::UncommittedCliId, utils::OutputChannel,
 };
 
+/// Reason why a file is being absorbed to a particular commit
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AbsorptionReason {
+    /// File has hunk range overlap with this commit
+    HunkDependency,
+    /// File is assigned to this stack and this is the topmost commit
+    StackAssignment,
+    /// Default to leftmost stack's topmost commit
+    DefaultStack,
+}
+
+impl AbsorptionReason {
+    fn description(&self) -> &str {
+        match self {
+            AbsorptionReason::HunkDependency => "files locked to commit due to hunk range overlap",
+            AbsorptionReason::StackAssignment => "last commit in the assigned stack",
+            AbsorptionReason::DefaultStack => "last commit in the primary lane",
+        }
+    }
+}
+
+/// Information about a file being absorbed
+#[derive(Debug, Clone)]
+struct FileAbsorption {
+    path: String,
+    assignment: HunkAssignment,
+}
+
+/// Information about absorptions grouped by commit
+#[derive(Debug)]
+struct CommitAbsorption {
+    stack_id: but_core::ref_metadata::StackId,
+    commit_id: gix::ObjectId,
+    commit_summary: String,
+    files: Vec<FileAbsorption>,
+    reason: AbsorptionReason,
+}
+
 /// Amends changes into the appropriate commits where they belong.
 ///
 /// The semantic for finding "the appropriate commit" is as follows
@@ -87,10 +125,22 @@ fn absorb_assignments(
     // Group changes by their target commit
     let changes_by_commit = group_changes_by_target_commit(project.id, assignments, dependencies)?;
 
+    // Prepare commit absorptions for display
+    let commit_absorptions = prepare_commit_absorptions(project, changes_by_commit)?;
+
+    // Display the plan
+    display_absorption_plan(&commit_absorptions, out)?;
+
     // Apply each group to its target commit
-    for ((stack_id, commit_id), file_hunks) in changes_by_commit {
-        let diff_specs = convert_assignments_to_diff_specs(&file_hunks)?;
-        amend_commit(project, stack_id, commit_id, diff_specs, out)?;
+    for absorption in commit_absorptions {
+        let diff_specs = convert_assignments_to_diff_specs(&absorption.files.iter().map(|f| f.assignment.clone()).collect::<Vec<_>>())?;
+        amend_commit_silent(project, absorption.stack_id, absorption.commit_id, diff_specs)?;
+    }
+
+    // Display completion message
+    if let Some(out) = out.for_human() {
+        writeln!(out)?;
+        writeln!(out, "{}: you can run `but undo` to undo these changes", "Hint".cyan())?;
     }
 
     Ok(())
@@ -134,10 +184,22 @@ fn absorb_branch(
     let changes_by_commit =
         group_changes_by_target_commit(project.id, &stack_assignments, dependencies)?;
 
+    // Prepare commit absorptions for display
+    let commit_absorptions = prepare_commit_absorptions(project, changes_by_commit)?;
+
+    // Display the plan
+    display_absorption_plan(&commit_absorptions, out)?;
+
     // Apply each group to its target commit
-    for ((target_stack_id, commit_id), hunks) in changes_by_commit {
-        let diff_specs = convert_assignments_to_diff_specs(&hunks)?;
-        amend_commit(project, target_stack_id, commit_id, diff_specs, out)?;
+    for absorption in commit_absorptions {
+        let diff_specs = convert_assignments_to_diff_specs(&absorption.files.iter().map(|f| f.assignment.clone()).collect::<Vec<_>>())?;
+        amend_commit_silent(project, absorption.stack_id, absorption.commit_id, diff_specs)?;
+    }
+
+    // Display completion message
+    if let Some(out) = out.for_human() {
+        writeln!(out)?;
+        writeln!(out, "{}: you can run `but undo` to undo these changes", "Hint".cyan())?;
     }
 
     Ok(())
@@ -160,10 +222,22 @@ fn absorb_all(
     // Group all changes by their target commit
     let changes_by_commit = group_changes_by_target_commit(project.id, assignments, dependencies)?;
 
+    // Prepare commit absorptions for display
+    let commit_absorptions = prepare_commit_absorptions(project, changes_by_commit)?;
+
+    // Display the plan
+    display_absorption_plan(&commit_absorptions, out)?;
+
     // Apply each group to its target commit
-    for ((stack_id, commit_id), hunks) in changes_by_commit {
-        let diff_specs = convert_assignments_to_diff_specs(&hunks)?;
-        amend_commit(project, stack_id, commit_id, diff_specs, out)?;
+    for absorption in commit_absorptions {
+        let diff_specs = convert_assignments_to_diff_specs(&absorption.files.iter().map(|f| f.assignment.clone()).collect::<Vec<_>>())?;
+        amend_commit_silent(project, absorption.stack_id, absorption.commit_id, diff_specs)?;
+    }
+
+    // Display completion message
+    if let Some(out) = out.for_human() {
+        writeln!(out)?;
+        writeln!(out, "{}: you can run `but undo` to undo these changes", "Hint".cyan())?;
     }
 
     Ok(())
@@ -174,22 +248,27 @@ fn group_changes_by_target_commit(
     project_id: gitbutler_project::ProjectId,
     assignments: &[HunkAssignment],
     dependencies: &Option<HunkDependencies>,
-) -> anyhow::Result<BTreeMap<(but_core::ref_metadata::StackId, gix::ObjectId), Vec<HunkAssignment>>>
+) -> anyhow::Result<BTreeMap<(but_core::ref_metadata::StackId, gix::ObjectId), (Vec<HunkAssignment>, AbsorptionReason)>>
 {
     let mut changes_by_commit: BTreeMap<
         (but_core::ref_metadata::StackId, gix::ObjectId),
-        Vec<HunkAssignment>,
+        (Vec<HunkAssignment>, AbsorptionReason),
     > = BTreeMap::new();
 
     // Process each assignment
     for assignment in assignments {
         // Determine the target commit for this assignment
-        let (stack_id, commit_id) = determine_target_commit(project_id, assignment, dependencies)?;
+        let (stack_id, commit_id, reason) = determine_target_commit(project_id, assignment, dependencies)?;
 
-        changes_by_commit
+        let entry = changes_by_commit
             .entry((stack_id, commit_id))
-            .or_default()
-            .push(assignment.clone());
+            .or_insert_with(|| (Vec::new(), reason.clone()));
+
+        entry.0.push(assignment.clone());
+        // If we have any hunk dependencies, that takes precedence as the reason for this commit group
+        if reason == AbsorptionReason::HunkDependency {
+            entry.1 = reason;
+        }
     }
 
     Ok(changes_by_commit)
@@ -200,7 +279,7 @@ fn determine_target_commit(
     project_id: gitbutler_project::ProjectId,
     assignment: &HunkAssignment,
     dependencies: &Option<HunkDependencies>,
-) -> anyhow::Result<(but_core::ref_metadata::StackId, gix::ObjectId)> {
+) -> anyhow::Result<(but_core::ref_metadata::StackId, gix::ObjectId, AbsorptionReason)> {
     // Priority 1: Check if there's a dependency lock for this hunk
     if let Some(deps) = dependencies
         && let Some(_hunk_id) = assignment.id
@@ -211,7 +290,7 @@ fn determine_target_commit(
             if path == &assignment.path {
                 // If there's a lock (dependency), use the topmost commit
                 if let Some(lock) = locks.first() {
-                    return Ok((lock.stack_id, lock.commit_id));
+                    return Ok((lock.stack_id, lock.commit_id, AbsorptionReason::HunkDependency));
                 }
             }
         }
@@ -226,7 +305,7 @@ fn determine_target_commit(
         if let Some(branch) = stack_details.branch_details.first()
             && let Some(commit) = branch.commits.first()
         {
-            return Ok((stack_id, commit.id));
+            return Ok((stack_id, commit.id, AbsorptionReason::StackAssignment));
         }
 
         // If there are no commits in the stack, create a blank commit first
@@ -237,7 +316,7 @@ fn determine_target_commit(
         if let Some(branch) = stack_details.branch_details.first()
             && let Some(commit) = branch.commits.first()
         {
-            return Ok((stack_id, commit.id));
+            return Ok((stack_id, commit.id, AbsorptionReason::StackAssignment));
         }
 
         anyhow::bail!("Failed to create blank commit in stack: {:?}", stack_id);
@@ -253,7 +332,7 @@ fn determine_target_commit(
         if let Some(branch) = stack_details.branch_details.first()
             && let Some(commit) = branch.commits.first()
         {
-            return Ok((stack_id, commit.id));
+            return Ok((stack_id, commit.id, AbsorptionReason::DefaultStack));
         }
 
         // If the first stack has no commits, create a blank commit first
@@ -264,7 +343,7 @@ fn determine_target_commit(
         if let Some(branch) = stack_details.branch_details.first()
             && let Some(commit) = branch.commits.first()
         {
-            return Ok((stack_id, commit.id));
+            return Ok((stack_id, commit.id, AbsorptionReason::DefaultStack));
         }
 
         anyhow::bail!("Failed to create blank commit in leftmost stack");
@@ -310,37 +389,107 @@ fn convert_assignments_to_diff_specs(
     Ok(diff_specs)
 }
 
-/// Amend a commit with the given changes
-fn amend_commit(
+/// Prepare commit absorptions with commit summaries
+fn prepare_commit_absorptions(
+    project: &Project,
+    changes_by_commit: BTreeMap<(but_core::ref_metadata::StackId, gix::ObjectId), (Vec<HunkAssignment>, AbsorptionReason)>,
+) -> anyhow::Result<Vec<CommitAbsorption>> {
+    let mut commit_absorptions = Vec::new();
+
+    // Open the repository to read commit messages
+    let repo = project.open_repo()?;
+
+    for ((stack_id, commit_id), (assignments, reason)) in changes_by_commit {
+        // Get commit summary from the git commit
+        let commit_summary = get_commit_summary(&repo, commit_id)?;
+
+        let mut files = Vec::new();
+        for assignment in assignments {
+            files.push(FileAbsorption {
+                path: assignment.path.clone(),
+                assignment,
+            });
+        }
+
+        commit_absorptions.push(CommitAbsorption {
+            stack_id,
+            commit_id,
+            commit_summary,
+            files,
+            reason,
+        });
+    }
+
+    Ok(commit_absorptions)
+}
+
+/// Get the commit summary message
+fn get_commit_summary(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+) -> anyhow::Result<String> {
+    let commit = repo.find_commit(commit_id)?;
+    let message = commit.message()?.title.to_string();
+    Ok(message)
+}
+
+/// Display the absorption plan to the user
+fn display_absorption_plan(
+    commit_absorptions: &[CommitAbsorption],
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    if let Some(out) = out.for_human() {
+        // Count total files
+        let total_files: usize = commit_absorptions.iter().map(|c| c.files.len()).sum();
+
+        writeln!(out, "Found {} changed file{} to absorb:", total_files, if total_files == 1 { "" } else { "s" })?;
+        writeln!(out)?;
+
+        for absorption in commit_absorptions {
+            let short_hash = &absorption.commit_id.to_hex().to_string()[..7];
+
+            writeln!(
+                out,
+                "Absorbed to commit: {} {}",
+                short_hash.cyan(),
+                absorption.commit_summary
+            )?;
+            writeln!(out, "  ({})", absorption.reason.description().dimmed())?;
+
+            for file in &absorption.files {
+                let change_type = if file.path.contains("new file") || !std::path::Path::new(&file.path).exists() {
+                    "A"
+                } else {
+                    "M"
+                };
+
+                writeln!(
+                    out,
+                    "    {} {}",
+                    change_type.green(),
+                    file.path
+                )?;
+            }
+            writeln!(out)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Amend a commit with the given changes (silent version without output)
+fn amend_commit_silent(
     project: &Project,
     stack_id: but_core::ref_metadata::StackId,
     commit_id: gix::ObjectId,
     diff_specs: Vec<DiffSpec>,
-    out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     // Convert commit_id to HexHash
     let hex_hash = HexHash::from(commit_id);
 
-    let outcome = but_api::legacy::workspace::amend_commit_from_worktree_changes(
+    let _outcome = but_api::legacy::workspace::amend_commit_from_worktree_changes(
         project.id, stack_id, hex_hash, diff_specs,
     )?;
-
-    if let Some(out) = out.for_human() {
-        if !outcome.paths_to_rejected_changes.is_empty() {
-            writeln!(
-                out,
-                "{warning}: Failed to absorb {} file(s)",
-                outcome.paths_to_rejected_changes.len(),
-                warning = "warning".yellow(),
-            )?;
-        }
-
-        writeln!(
-            out,
-            "Absorbed changes into commit {}",
-            &commit_id.to_hex().to_string()[..7]
-        )?;
-    }
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -81,6 +81,7 @@ pub(crate) fn show_oplog(
                     OperationKind::CreateCommit => "CREATE",
                     OperationKind::CreateBranch => "BRANCH",
                     OperationKind::AmendCommit => "AMEND",
+                    OperationKind::Absorb => "ABSORB",
                     OperationKind::UndoCommit => "UNDO",
                     OperationKind::SquashCommit => "SQUASH",
                     OperationKind::UpdateCommitMessage => "REWORD",

--- a/crates/but/tests/but/command/snapshots/absorb/uncommitted-file.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/absorb/uncommitted-file.stdout.term.svg
@@ -1,11 +1,13 @@
-<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,9 +18,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Absorbed changes into commit 4fa8217</tspan>
+    <tspan x="10px" y="28px"><tspan>Found 2 changed files to absorb:</tspan>
 </tspan>
     <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>Absorbed to commit: </tspan><tspan class="fg-cyan">4fa8217</tspan><tspan> a.txt</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  (</tspan><tspan class="dimmed">files locked to commit due to hunk range overlap</tspan><tspan>)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>    a.txt </tspan><tspan class="dimmed">@1,4 +1,4</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    a.txt </tspan><tspan class="dimmed">@6,4 +6,4</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-cyan">Hint</tspan><tspan>: you can run `but undo` to undo these changes</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/absorb/uncommitted-hunk.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/absorb/uncommitted-hunk.stdout.term.svg
@@ -1,11 +1,13 @@
-<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,9 +18,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>Absorbed changes into commit 4fa8217</tspan>
+    <tspan x="10px" y="28px"><tspan>Found 1 changed file to absorb:</tspan>
 </tspan>
     <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>Absorbed to commit: </tspan><tspan class="fg-cyan">4fa8217</tspan><tspan> a.txt</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>  (</tspan><tspan class="dimmed">files locked to commit due to hunk range overlap</tspan><tspan>)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>    a.txt </tspan><tspan class="dimmed">@1,4 +1,4</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-cyan">Hint</tspan><tspan>: you can run `but undo` to undo these changes</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
 </tspan>
   </text>
 

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -140,6 +140,7 @@ pub enum OperationKind {
     DiscardFile,
     DiscardChanges,
     AmendCommit,
+    Absorb,
     UndoCommit,
     UnapplyBranch,
     CherryPick,


### PR DESCRIPTION
When you run `but absorb`, display the reasoning used and what was actually done. This works with `but absorb -j` too.

Given this pre-state:

<img width="840" height="938" alt="CleanShot 2026-01-08 at 14 41 11@2x" src="https://github.com/user-attachments/assets/68b46434-2f60-493e-a9cd-ff5320686ea1" />

Running `but absorb` will now output this:

<img width="1222" height="1088" alt="CleanShot 2026-01-08 at 14 41 34@2x" src="https://github.com/user-attachments/assets/da4ae4a9-4609-4f4d-b0e6-359b7e631d7c" />

or this:

```
❯ ../gitbutler/target/debug/but absorb -j
{
  "total_files": 4,
  "commits": [
    {
      "commit_id": "2f8c11308f5722068abb45e04236f1d0f0c535a7",
      "commit_summary": "",
      "reason": "default_stack",
      "reason_description": "last commit in the primary lane",
      "files": [
        {
          "path": "new-file.md",
          "change_type": "M"
        }
      ]
    },
    {
      "commit_id": "64fbd6fac46784980f629f78b79c833c7d329310",
      "commit_summary": "yet another readme\n",
      "reason": "hunk_dependency",
      "reason_description": "files locked to commit due to hunk range overlap",
      "files": [
        {
          "path": "README.md",
          "change_type": "M"
        }
      ]
    },
    {
      "commit_id": "b511e30a207003a49d43e3066528e687481ca886",
      "commit_summary": "new test commit\n",
      "reason": "hunk_dependency",
      "reason_description": "files locked to commit due to hunk range overlap",
      "files": [
        {
          "path": "test.md",
          "change_type": "M"
        }
      ]
    },
    {
      "commit_id": "486e132bc1f5590777b1692fead6c6df83315545",
      "commit_summary": "",
      "reason": "stack_assignment",
      "reason_description": "last commit in the assigned stack",
      "files": [
        {
          "path": "new-file2.md",
          "change_type": "M"
        }
      ]
    }
  ]
}
```

