### PR TITLE
fix: subscribe persisted store to prevent reused instances from sharing state for FileListMode

### DIFF
--- a/apps/desktop/src/components/FileListMode.svelte
+++ b/apps/desktop/src/components/FileListMode.svelte
@@ -13,11 +13,13 @@
 	let { persistId, mode = $bindable() }: Props = $props();
 
 	const userSettings = inject(SETTINGS);
-	let saved = persisted<Mode | undefined>(undefined, `file-list-mode-${persistId}`);
+	const saved = $derived(persisted<Mode | undefined>(undefined, `file-list-mode-${persistId}`));
 
-	// Initialize mode from saved value or default setting (runs once on mount)
+	// Subscribe to the saved store and update mode
 	$effect(() => {
-		mode = $saved ?? $userSettings.defaultFileListMode;
+		return saved.subscribe((value) => {
+			mode = value ?? $userSettings.defaultFileListMode;
+		});
 	});
 </script>
 
@@ -25,7 +27,7 @@
 	selected={mode}
 	onselect={(id) => {
 		// Update saved preference; the effect will sync mode
-		$saved = id as Mode;
+		saved.set(id as Mode);
 	}}
 	size="small"
 >


### PR DESCRIPTION
https://github.com/user-attachments/assets/05f7040f-49a5-4b9d-b49d-d69f58c8d88a

This PR fixes a bug I mentioned in that issue (https://github.com/gitbutlerapp/gitbutler/issues/11746) but didn't explain in detail.

In the branch tab, the persisted list mode state of the changed file preview for the selected branch did not correctly respond to branch switching, causing all branches to share the list mode state of the first selected branch (from the initial component initialization).

This is addressed by subscribing to the persisted store within the FileListMode component, ensuring that each branch maintains its own list mode state without affecting the others.

Although my proposal in that issue was to share state, I also believe that the state sharing fixed by this PR was clearly a bug. In this case, using isolated state aligns with the current expected behavior.