### PR TITLE
feat: add all changed files panel for applied branch view

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -407,6 +407,7 @@
 										laneId="branches-view"
 										branchName={current.branchName}
 										stackId={current.stackId}
+										showChangedFiles
 										active
 										{onerror}
 									/>


### PR DESCRIPTION
<img width="2658" height="1754" src="https://github.com/user-attachments/assets/21c64158-1803-4af9-a117-fcf33a4d10a3" />

This PR adds an all changed files preview to applied branches in the branch tab. Currently, only unapplied branches have a preview of all changed files. I'm not sure what considerations led to this behavioral difference, but in my opinion, keeping the behavior consistent here would provide a better user experience.

By the way, I noticed that the same component is also used in the stacked branch view, so I added a prop to ensure the ChangedFiles component is rendered only in the appropriate places.