### PR TITLE
separate and dim upstream-only commits in status

### DIFF
--- a/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
@@ -1,13 +1,15 @@
-<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
@@ -20,45 +22,47 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="underline">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="underline">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="underline">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="underline">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="underline">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="underline">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="underline">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="underline">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>├╯</tspan>
+    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="underline">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊</tspan>
+    <tspan x="10px" y="334px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+    <tspan x="10px" y="352px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -28,33 +28,39 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="82px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊│     A-remote </tspan>
+    <tspan x="10px" y="100px"><tspan>┊╭┄</tspan><tspan class="fg-yellow">[upstream only]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊ </tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊│     A </tspan>
+    <tspan x="10px" y="136px"><tspan>┊ │     </tspan><tspan class="dimmed">A-remote </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>├╯</tspan>
+    <tspan x="10px" y="154px"><tspan>┊╯┄</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊</tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="190px"><tspan>┊│     A </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="208px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊│     B </tspan>
+    <tspan x="10px" y="226px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>├╯</tspan>
+    <tspan x="10px" y="244px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊</tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+    <tspan x="10px" y="280px"><tspan>┊│     B </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+    <tspan x="10px" y="298px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="370px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -22,45 +23,47 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊</tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊╭┄</tspan><tspan class="fg-yellow">[upstream only]</tspan>
+    <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊ </tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊ │     </tspan><tspan class="dimmed">A-remote </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╯┄</tspan>
+    <tspan x="10px" y="154px"><tspan>┊│     </tspan><tspan class="dimmed">A-remote </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊│     A </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>├╯</tspan>
+    <tspan x="10px" y="208px"><tspan>┊│     A </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan>
+    <tspan x="10px" y="226px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="244px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊│     B </tspan>
+    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>├╯</tspan>
+    <tspan x="10px" y="298px"><tspan>┊│     B </tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>┊</tspan>
+    <tspan x="10px" y="316px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+    <tspan x="10px" y="334px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+    <tspan x="10px" y="352px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -28,27 +28,33 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline">19</tspan><tspan class="dimmed">7ddce</tspan><tspan> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="82px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊╭┄</tspan><tspan class="fg-yellow">[upstream only]</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>├╯</tspan>
+    <tspan x="10px" y="118px"><tspan>┊ </tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╯┄</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="172px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>├╯</tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊</tspan>
+    <tspan x="10px" y="208px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+    <tspan x="10px" y="244px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,7 +1,8 @@
-<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
@@ -22,39 +23,41 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊</tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊╭┄</tspan><tspan class="fg-yellow">[upstream only]</tspan>
+    <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊ </tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╯┄</tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>├╯</tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan>
+    <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>├╯</tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊</tspan>
+    <tspan x="10px" y="262px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base </tspan>
+</tspan>
+    <tspan x="10px" y="334px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -1,13 +1,15 @@
-<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
@@ -20,33 +22,35 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊│     add A </tspan>
+    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>├╯</tspan>
+    <tspan x="10px" y="118px"><tspan>┊│     add A </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan>
+    <tspan x="10px" y="136px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊│     add B </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>├╯</tspan>
+    <tspan x="10px" y="208px"><tspan>┊│     add B </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan>
+    <tspan x="10px" y="226px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+    <tspan x="10px" y="244px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="280px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -1,13 +1,15 @@
-<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
@@ -20,29 +22,31 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-green bold">Unassigned Changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>├╯</tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊</tspan>
+    <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>├╯</tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan>
+    <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+    <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="226px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
   </text>
 


### PR DESCRIPTION
In 'but status' the upstream-only commits were marked only by yellow dots which was too subtle. 

This change separates upstream commits from local ones with an extra spacer line and an ASCII fork, adds a yellow "[upstream]" header, and dims the commit message/details for upstream-only entries.

<img width="1496" height="920" alt="CleanShot 2026-01-09 at 13 17 42@2x" src="https://github.com/user-attachments/assets/80e95c15-eb81-4fd7-9741-94e282fc17d6" />

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11755 
- <kbd>&nbsp;1&nbsp;</kbd> #11756 👈 
<!-- GitButler Footer Boundary Bottom -->

