### PR TITLE
add `but discard` command

### DIFF
--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum CommandName {
     Init,
     Absorb,
+    Discard,
     Status,
     Stf,
     Rub,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -437,6 +437,27 @@ pub enum Subcommands {
         source: Option<String>,
     },
 
+    /// Discard uncommitted changes from the worktree.
+    ///
+    /// This command permanently discards changes to files, restoring them to their
+    /// state in the HEAD commit. Use this to undo unwanted modifications.
+    ///
+    /// The ID parameter should be a file ID as shown in `but status`. You can
+    /// discard a whole file or specific hunks within a file.
+    ///
+    /// ## Examples
+    ///
+    /// Discard all changes to a file:
+    ///
+    /// ```text
+    /// but discard a1
+    /// ```
+    #[cfg(feature = "legacy")]
+    Discard {
+        /// The ID of the file or hunk to discard (as shown in `but status`)
+        id: String,
+    },
+
     /// Commands for interacting with forges like GitHub, GitLab (coming soon), etc.
     ///
     /// The `but forge` tools allow you to authenticate with a forge from the CLI,

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -35,7 +35,9 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         ("Inspection".yellow(), vec!["status", "diff"]),
         (
             "Branching and Committing".yellow(),
-            vec!["commit", "new", "branch", "mark", "unmark"],
+            vec![
+                "commit", "new", "branch", "discard", "resolve", "mark", "unmark",
+            ],
         ),
         (
             "Server Interactions".yellow(),

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -1,0 +1,115 @@
+//! Implementation of the `but discard` command.
+//!
+//! This module provides functionality to discard uncommitted changes from the worktree.
+
+use anyhow::{Context as _, Result, bail};
+use bstr::ByteSlice;
+use but_core::DiffSpec;
+use but_ctx::Context;
+
+use crate::{CliId, IdMap, command::legacy::rub::parse_sources, utils::OutputChannel};
+
+/// Handle the `but discard <id>` command.
+///
+/// Discards changes to files or hunks identified by the given ID.
+/// The ID should be a file or hunk ID as shown in `but status`.
+pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()> {
+    // Build ID map to resolve the user's ID
+    let mut id_map = IdMap::new_from_context(ctx, None)?;
+    id_map.add_committed_file_info_from_context(ctx)?;
+
+    // Resolve the ID to get file information
+    let resolved_ids = parse_sources(ctx, &id_map, id)
+        .with_context(|| format!("Could not resolve ID '{}'", id))?;
+
+    // We only support discarding uncommitted files or hunks
+    let first_id = resolved_ids
+        .into_iter()
+        .next()
+        .context("No entity found for the given ID")?;
+
+    // Extract DiffSpec from resolved entity
+    let diff_specs: Vec<DiffSpec> = match first_id {
+        CliId::Uncommitted(uncommitted) => {
+            // Convert hunk assignments to DiffSpecs
+            uncommitted
+                .hunk_assignments
+                .into_iter()
+                .map(|assignment| {
+                    DiffSpec {
+                        previous_path: None, // HunkAssignment doesn't track previous path (renames)
+                        path: assignment.path_bytes,
+                        hunk_headers: assignment.hunk_header.into_iter().collect(),
+                    }
+                })
+                .collect()
+        }
+        CliId::Unassigned { .. } => {
+            bail!("Cannot discard the unassigned area. Use a specific file or hunk ID instead.");
+        }
+        CliId::Branch { .. } => {
+            bail!("Cannot discard a branch. Use a file or hunk ID instead.");
+        }
+        CliId::Commit { .. } => {
+            bail!("Cannot discard a commit. Use a file or hunk ID instead.");
+        }
+        CliId::CommittedFile { .. } => {
+            bail!("Cannot discard a committed file. Use an uncommitted file or hunk ID instead.");
+        }
+    };
+
+    if diff_specs.is_empty() {
+        bail!("No changes found for the given ID");
+    }
+
+    // Perform the discard operation
+    let repo = ctx.repo.get()?;
+    let dropped = but_workspace::discard_workspace_changes(
+        &repo,
+        diff_specs.clone(),
+        3, // context_lines - default value used by GUI
+    )?;
+
+    // Report results
+    if !dropped.is_empty()
+        && let Some(out) = out.for_human()
+    {
+        writeln!(
+            out,
+            "Warning: Some changes could not be discarded (possibly already discarded or modified):"
+        )?;
+        for spec in &dropped {
+            writeln!(out, "  {}", spec.path.as_bstr())?;
+        }
+    }
+
+    let discarded_count = diff_specs.len() - dropped.len();
+    if discarded_count > 0 {
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "Successfully discarded changes to {} {}",
+                discarded_count,
+                if discarded_count == 1 { "item" } else { "items" }
+            )?;
+        }
+        if let Some(out) = out.for_json() {
+            out.write_value(serde_json::json!({
+                "discarded": discarded_count,
+                "failed": dropped.len(),
+            }))?;
+        }
+    } else {
+        if let Some(out) = out.for_human() {
+            writeln!(out, "No changes were discarded.")?;
+        }
+        if let Some(out) = out.for_json() {
+            out.write_value(serde_json::json!({
+                "discarded": 0,
+                "failed": dropped.len(),
+            }))?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -6,6 +6,7 @@ pub mod actions;
 pub mod branch;
 pub mod commit;
 pub mod diff;
+pub mod discard;
 pub mod forge;
 pub mod init;
 pub mod mark;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -482,6 +482,11 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
+        Subcommands::Discard { id } => {
+            let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
+            command::legacy::discard::handle(&mut ctx, out, &id).emit_metrics(metrics_ctx)
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Init { repo } => command::legacy::init::repo(&args.current_dir, out, repo)
             .context("Failed to initialize GitButler project.")
             .emit_metrics(metrics_ctx),

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -125,6 +125,8 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Absorb { .. } => Absorb,
             #[cfg(feature = "legacy")]
+            Subcommands::Discard { .. } => Discard,
+            #[cfg(feature = "legacy")]
             Subcommands::Pr(forge::pr::Platform { cmd }) => match cmd {
                 None | Some(forge::pr::Subcommands::New { .. }) => PrNew,
                 Some(forge::pr::Subcommands::Template { .. }) => PrTemplate,

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -139,6 +139,7 @@ pub enum OperationKind {
     DiscardHunk,
     DiscardFile,
     DiscardChanges,
+    Discard,
     AmendCommit,
     Absorb,
     UndoCommit,


### PR DESCRIPTION
This should work on uncommitted files and also `zz`. Creates an oplog entry before discarding so we don’t lose file contents.

<img width="2122" height="2054" alt="CleanShot 2026-01-09 at 14 47 10@2x" src="https://github.com/user-attachments/assets/4540a130-1384-44f0-ad79-d82ec72515d8" />

