### PR TITLE
Improve commit vis

### DIFF
--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -7,7 +7,7 @@ use but_rebase::{
     commit::DateMode,
     graph_rebase::{GraphExt as _, LookupStep, Step, mutate::InsertSide},
 };
-use but_testsupport::{git_catfile, visualize_commit_graph_all};
+use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
 #[test]
 fn by_default_conflicts_are_allowed() -> Result<()> {
@@ -33,7 +33,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
     outcome.materialize()?;
 
     // We expect to see conflicted headers
-    insta::assert_snapshot!(git_catfile(&repo, "c")?, @r"
+    insta::assert_snapshot!(cat_commit(&repo, "c")?, @r"
     tree 7c4363d235e51107d74c858038cfab0d192db092
     parent 5e0ba4636be91de6216903697b269915d3db6c53
     author author <author@example.com> 946684800 +0000

--- a/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
@@ -4,7 +4,7 @@ use std::fs;
 use anyhow::Result;
 use but_graph::Graph;
 use but_rebase::graph_rebase::{GraphExt, Pick, Step};
-use but_testsupport::{git_catfile, visualize_commit_graph_all};
+use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable_with_signing, standard_options};
 
@@ -105,7 +105,7 @@ fn commits_are_signed_by_default() -> Result<()> {
     * b6e2f57 (base) base
     ");
 
-    insta::assert_snapshot!(git_catfile(&repo, "c")?, @r"
+    insta::assert_snapshot!(cat_commit(&repo, "c")?, @r"
     tree ea0372ea78d32151cb4c2b6a05a084817947c8f3
     parent 3bfeb524461f65f82bf5027fc895fe9fd5f36203
     author author <author@example.com> 946684800 +0000
@@ -169,7 +169,7 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
     * b6e2f57 (base) base
     ");
 
-    insta::assert_snapshot!(git_catfile(&repo, "c")?, @r"
+    insta::assert_snapshot!(cat_commit(&repo, "c")?, @r"
     tree ea0372ea78d32151cb4c2b6a05a084817947c8f3
     parent 3bfeb524461f65f82bf5027fc895fe9fd5f36203
     author author <author@example.com> 946684800 +0000

--- a/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
@@ -4,7 +4,7 @@ use std::fs;
 use anyhow::Result;
 use but_graph::Graph;
 use but_rebase::graph_rebase::{GraphExt, LookupStep, Pick, Step};
-use but_testsupport::{git_catfile, visualize_commit_graph_all};
+use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, fixture_writable_with_signing, standard_options};
 
@@ -127,7 +127,7 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     * 3b506ba (base) base
     ");
 
-    insta::assert_snapshot!(git_catfile(&repo, "gitbutler/workspace")?, @r"
+    insta::assert_snapshot!(cat_commit(&repo, "gitbutler/workspace")?, @r"
     tree ea0372ea78d32151cb4c2b6a05a084817947c8f3
     parent e15040cb8141e591e34472039a6a7f129f0e9003
     author author <author@example.com> 946684800 +0000
@@ -139,7 +139,7 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     ");
 
     // We expect "c" to remain signed
-    insta::assert_snapshot!(git_catfile(&repo, "c")?, @r"
+    insta::assert_snapshot!(cat_commit(&repo, "c")?, @r"
     tree ea0372ea78d32151cb4c2b6a05a084817947c8f3
     parent 5b128a2ec3b714a5f78d9f97ff6f89b416069017
     author author <author@example.com> 946684800 +0000

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -216,17 +216,11 @@ pub fn git_status_at_dir(dir: impl AsRef<Path>) -> std::io::Result<String> {
     Ok(out.stdout.to_str().expect("no illformed UTF-8").to_string())
 }
 
-/// Run cat-file -p on a particular revision in `repo`
-pub fn git_catfile(repo: &gix::Repository, arg: &str) -> std::io::Result<String> {
-    git_catfile_at_dir(repo.workdir().unwrap_or(repo.git_dir()), arg)
-}
-
-/// Run cat-file -p on a particular revision on the worktree or git_dir pointed
-/// to by `dir`
-pub fn git_catfile_at_dir(dir: impl AsRef<Path>, arg: &str) -> std::io::Result<String> {
-    let out = git_at_dir(dir).args(["cat-file", "-p", arg]).output()?;
-    assert!(out.status.success(), "STDERR: {}", out.stderr.as_bstr());
-    Ok(out.stdout.to_str().expect("no illformed UTF-8").to_string())
+/// Gets the content of a commit at a specific revision, similar to
+/// `git cat-file commit <revision>`
+pub fn cat_commit(repo: &gix::Repository, arg: &str) -> anyhow::Result<String> {
+    let commit_id = repo.rev_parse_single(arg)?;
+    Ok(repo.find_commit(commit_id)?.data.to_str_lossy().to_string())
 }
 
 /// Show one index entry per line, without content.


### PR DESCRIPTION
Byron pointed out that we probably don’t want to call out to git if we can avoid it & since we have specific tree visualization functions, we should probably avoid duplicating responsibility.

This changes the function to be  `gix` based, and renames it to a shorter `cat_commit`, since it’s not calling a git command anymore.

Byron and I breifly discussed whether it should be `visualize_` but I think there is apitite for perhaps using shorter names for these testing utilities like `cat_tree` and `cat_commit`.