### PR TITLE
`but` defaults to `but status`, with a hint

### DIFF
--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -23,6 +23,13 @@ use std::ffi::OsString;
 
 use anyhow::Result;
 
+/// Default aliases that ship with `but` and can be overridden by git config.
+const DEFAULT_ALIASES: &[(&str, &str)] = &[
+    ("default", "status --hint"),
+    ("st", "status"),
+    ("stf", "status --files"),
+];
+
 /// Expands command aliases before argument parsing.
 ///
 /// If the first argument after "but" is an alias defined in git config
@@ -97,11 +104,10 @@ pub fn is_known_subcommand(cmd: &str) -> bool {
 /// These are convenience aliases that ship with `but` but can be overridden
 /// by setting them in git config.
 pub fn get_all_default_aliases() -> Vec<(String, String)> {
-    vec![
-        ("default".to_string(), "status --hint".to_string()),
-        ("st".to_string(), "status".to_string()),
-        ("stf".to_string(), "status --files".to_string()),
-    ]
+    DEFAULT_ALIASES
+        .iter()
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect()
 }
 
 /// Gets a default alias value for built-in aliases that can be overridden.
@@ -117,10 +123,10 @@ pub fn get_all_default_aliases() -> Vec<(String, String)> {
 ///
 /// The default alias value if one exists, or `None`
 pub fn get_default_alias(alias_name: &str) -> Option<String> {
-    get_all_default_aliases()
-        .into_iter()
-        .find(|(name, _)| name == alias_name)
-        .map(|(_, value)| value)
+    DEFAULT_ALIASES
+        .iter()
+        .find(|(name, _)| *name == alias_name)
+        .map(|(_, value)| value.to_string())
 }
 
 /// Reads a git config alias value using gix.

--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -82,47 +82,26 @@ pub fn expand_aliases(args: Vec<OsString>) -> Result<Vec<OsString>> {
 /// Checks if a command is a known subcommand (not an alias).
 ///
 /// This prevents known commands from being treated as aliases.
-fn is_known_subcommand(cmd: &str) -> bool {
-    matches!(
-        cmd,
-        "status"
-            | "st"
-            | "rub"
-            | "diff"
-            | "init"
-            | "pull"
-            | "branch"
-            | "worktree"
-            | "mark"
-            | "unmark"
-            | "gui"
-            | "."
-            | "commit"
-            | "push"
-            | "new"
-            | "reword"
-            | "oplog"
-            | "restore"
-            | "undo"
-            | "absorb"
-            | "discard"
-            | "forge"
-            | "pr"
-            | "review"
-            | "mcp"
-            | "claude"
-            | "cursor"
-            | "actions"
-            | "metrics"
-            | "completions"
-            | "resolve"
-            | "fetch"
-            | "alias"
-            | "uncommit"
-            | "amend"
-            | "stage"
-            | "unstage"
-    )
+/// Extracts subcommand names directly from clap's Command structure.
+pub fn is_known_subcommand(cmd: &str) -> bool {
+    use clap::CommandFactory;
+
+    let command = crate::args::Args::command();
+    command.get_subcommands().any(|subcmd| {
+        subcmd.get_name() == cmd || subcmd.get_all_aliases().any(|alias| alias == cmd)
+    })
+}
+
+/// Gets all default aliases as a vector of (name, value) tuples.
+///
+/// These are convenience aliases that ship with `but` but can be overridden
+/// by setting them in git config.
+pub fn get_all_default_aliases() -> Vec<(String, String)> {
+    vec![
+        ("default".to_string(), "status --hint".to_string()),
+        ("st".to_string(), "status".to_string()),
+        ("stf".to_string(), "status --files".to_string()),
+    ]
 }
 
 /// Gets a default alias value for built-in aliases that can be overridden.
@@ -137,11 +116,11 @@ fn is_known_subcommand(cmd: &str) -> bool {
 /// # Returns
 ///
 /// The default alias value if one exists, or `None`
-fn get_default_alias(alias_name: &str) -> Option<String> {
-    match alias_name {
-        "stf" => Some("status --files".to_string()),
-        _ => None,
-    }
+pub fn get_default_alias(alias_name: &str) -> Option<String> {
+    get_all_default_aliases()
+        .into_iter()
+        .find(|(name, _)| name == alias_name)
+        .map(|(_, value)| value)
 }
 
 /// Reads a git config alias value using gix.
@@ -174,12 +153,12 @@ mod tests {
     #[test]
     fn test_is_known_subcommand() {
         assert!(is_known_subcommand("status"));
-        assert!(is_known_subcommand("st"));
         assert!(is_known_subcommand("commit"));
         assert!(is_known_subcommand("push"));
         assert!(is_known_subcommand("gui"));
         assert!(!is_known_subcommand("unknown"));
         assert!(!is_known_subcommand("co"));
+        assert!(!is_known_subcommand("st"));
     }
 
     #[test]

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -9,7 +9,12 @@
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
-#[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("VERSION").unwrap_or("dev"))]
+#[clap(
+    name = "but",
+    about = "A GitButler CLI tool",
+    version = option_env!("VERSION").unwrap_or("dev"),
+    disable_help_subcommand = true
+)]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
     #[clap(short = 't', long, action = clap::ArgAction::Count, hide = true, env = "BUT_TRACE")]
@@ -653,6 +658,14 @@ pub enum Subcommands {
         #[clap(required = false)]
         branch: Option<String>,
     },
+
+    /// Show help information grouped by category.
+    ///
+    /// Displays all available commands organized into functional categories
+    /// such as Inspection, Branching and Committing, Server Interactions, etc.
+    ///
+    /// This is equivalent to running `but -h` to see the command overview.
+    Help,
 }
 
 pub mod alias;

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -82,7 +82,6 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[clap(alias = "st")]
     Status {
         /// Determines whether the committed files should be shown as well.
         #[clap(short = 'f', alias = "files", default_value_t = false)]
@@ -96,6 +95,9 @@ pub enum Subcommands {
         /// Show detailed list of upstream commits that haven't been integrated yet.
         #[clap(short = 'u', long = "upstream", default_value_t = false)]
         upstream: bool,
+        /// Show a hint about available commands at the end of output.
+        #[clap(long = "hint", default_value_t = false)]
+        hint: bool,
     },
 
     /// Combines two entities together to perform an operation like amend, squash, stage, or move.

--- a/crates/but/src/command/alias.rs
+++ b/crates/but/src/command/alias.rs
@@ -2,53 +2,46 @@
 //!
 //! Provides subcommands to list, add, and remove aliases stored in git config.
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use bstr::ByteSlice;
 use but_ctx::Context;
 use colored::Colorize;
+use serde::Serialize;
 
 use crate::utils::OutputChannel;
 
-/// List all configured `but` aliases
-pub fn list(out: &mut OutputChannel) -> Result<()> {
-    // Use gix to read aliases from git config
-    let mut user_aliases: Vec<(String, String)> = Vec::new();
+/// Represents where an alias is configured
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AliasScope {
+    Local,
+    Global,
+    Both,
+}
 
-    if let Ok(repo) = gix::discover(".") {
-        let cfg = repo.config_snapshot(); // resolved view of config stack  [oai_citation:4‡Docs.rs](https://docs.rs/gix/latest/gix/struct.Repository.html)
-
-        for section in cfg.sections() {
-            let header = section.header();
-            let section_name = header.name().to_str_lossy();
-            if section_name != "but" {
-                continue;
-            }
-
-            let subsection = header.subsection_name().map(|s| s.to_str_lossy()); //  [oai_citation:7‡Docs.rs](https://docs.rs/gix/latest/gix/config/parse/section/struct.Header.html)
-
-            for value_name in section.value_names() {
-                let vn = value_name.as_ref();
-
-                // Normalize to a dotted key we can prefix-test: "but.alias.<rest>"
-                let dotted = match &subsection {
-                    // [but "alias"] foo = bar  => but.alias.foo
-                    Some(sub) => format!("{}.{}.{}", section_name, sub, vn),
-                    // [but] alias.foo = bar    => but.alias.foo
-                    None => format!("{}.{}", section_name, vn),
-                };
-
-                if !dotted.starts_with("but.alias.") {
-                    continue;
-                }
-
-                if let Some(val) = section.value(vn) {
-                    // Extract the alias name from "but.alias.<name>"
-                    let alias_name = dotted.strip_prefix("but.alias.").unwrap();
-                    user_aliases.push((alias_name.to_string(), val.to_str_lossy().into_owned()));
-                }
-            }
+impl std::fmt::Display for AliasScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AliasScope::Local => write!(f, "local"),
+            AliasScope::Global => write!(f, "global"),
+            AliasScope::Both => write!(f, "both"),
         }
     }
+}
+
+/// An alias entry with its name, value, and scope
+#[derive(Debug, Clone, Serialize)]
+pub struct AliasEntry {
+    pub name: String,
+    pub value: String,
+    pub scope: AliasScope,
+}
+
+/// List all configured `but` aliases
+pub fn list(out: &mut OutputChannel) -> Result<()> {
+    let user_aliases = get_all_aliases()?;
 
     // Get default aliases
     let default_aliases = get_default_aliases();
@@ -59,7 +52,7 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
             writeln!(out, "No aliases configured.")?;
             writeln!(out)?;
             writeln!(out, "Create an alias with:")?;
-            writeln!(out, "  but alias add st status")?;
+            writeln!(out, "  but alias add stup 'status --upstream'")?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
                 "user": {},
@@ -69,15 +62,12 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
         return Ok(());
     }
 
-    // Sort aliases by name
-    user_aliases.sort_by(|a, b| a.0.cmp(&b.0));
-
     if let Some(out) = out.for_human() {
         // Calculate max name length for alignment
         let max_name_len = user_aliases
             .iter()
-            .chain(default_aliases.iter())
-            .map(|(name, _)| name.len())
+            .map(|a| a.name.len())
+            .chain(default_aliases.iter().map(|(name, _)| name.len()))
             .max()
             .unwrap_or(0);
 
@@ -86,13 +76,19 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
             writeln!(out, "{}:", "User aliases".bold())?;
             writeln!(out)?;
 
-            for (name, value) in &user_aliases {
+            for alias in &user_aliases {
+                let scope_indicator = match alias.scope {
+                    AliasScope::Local => "(local)".dimmed(),
+                    AliasScope::Global => "(global)".dimmed(),
+                    AliasScope::Both => "(local+global)".dimmed(),
+                };
                 writeln!(
                     out,
-                    "  {:<width$}  {}  {}",
-                    name.green(),
+                    "  {:<width$}  {}  {} {}",
+                    alias.name.green(),
                     "→".dimmed(),
-                    value.cyan(),
+                    alias.value.cyan(),
+                    scope_indicator,
                     width = max_name_len
                 )?;
             }
@@ -111,7 +107,7 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
 
             for (name, value) in &default_aliases {
                 // Check if this default is overridden
-                let is_overridden = user_aliases.iter().any(|(n, _)| n == name);
+                let is_overridden = user_aliases.iter().any(|a| &a.name == name);
 
                 if is_overridden {
                     writeln!(
@@ -136,9 +132,15 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
             }
         }
     } else if let Some(out) = out.for_json() {
-        let user_json: serde_json::Map<String, serde_json::Value> = user_aliases
-            .into_iter()
-            .map(|(k, v)| (k, serde_json::Value::String(v)))
+        let user_json: Vec<serde_json::Value> = user_aliases
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "name": a.name,
+                    "value": a.value,
+                    "scope": a.scope
+                })
+            })
             .collect();
 
         let default_json: serde_json::Map<String, serde_json::Value> = default_aliases
@@ -153,6 +155,84 @@ pub fn list(out: &mut OutputChannel) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Get all user-configured aliases from local and global git config and defaults
+fn get_all_aliases() -> Result<Vec<AliasEntry>> {
+    // Track aliases by name with their scopes
+    let mut alias_map: HashMap<String, (String, bool, bool)> = HashMap::new(); // name -> (value, is_local, is_global)
+
+    if let Ok(repo) = gix::discover(".") {
+        let cfg = repo.config_snapshot();
+
+        for section in cfg.sections() {
+            let header = section.header();
+            let section_name = header.name().to_str_lossy();
+            if section_name != "but" {
+                continue;
+            }
+
+            // Determine if this section is from local or global config
+            let source = section.meta().source;
+            let is_local = matches!(
+                source,
+                gix::config::Source::Local | gix::config::Source::Worktree
+            );
+            let is_global = matches!(source, gix::config::Source::User | gix::config::Source::Git);
+
+            let subsection = header.subsection_name().map(|s| s.to_str_lossy());
+
+            for value_name in section.value_names() {
+                let vn = value_name.as_ref();
+
+                // Normalize to a dotted key we can prefix-test: "but.alias.<rest>"
+                let dotted = match &subsection {
+                    // [but "alias"] foo = bar  => but.alias.foo
+                    Some(sub) => format!("{}.{}.{}", section_name, sub, vn),
+                    // [but] alias.foo = bar    => but.alias.foo
+                    None => format!("{}.{}", section_name, vn),
+                };
+
+                if !dotted.starts_with("but.alias.") {
+                    continue;
+                }
+
+                if let Some(val) = section.value(vn) {
+                    let alias_name = dotted.strip_prefix("but.alias.").unwrap().to_string();
+                    let value = val.to_str_lossy().into_owned();
+
+                    alias_map
+                        .entry(alias_name)
+                        .and_modify(|(v, local, global)| {
+                            *v = value.clone(); // Last value wins
+                            if is_local {
+                                *local = true;
+                            }
+                            if is_global {
+                                *global = true;
+                            }
+                        })
+                        .or_insert((value, is_local, is_global));
+                }
+            }
+        }
+    }
+
+    let mut user_aliases: Vec<AliasEntry> = alias_map
+        .into_iter()
+        .map(|(name, (value, is_local, is_global))| {
+            let scope = match (is_local, is_global) {
+                (true, true) => AliasScope::Both,
+                (true, false) => AliasScope::Local,
+                (false, true) => AliasScope::Global,
+                (false, false) => AliasScope::Local, // Shouldn't happen, but default to local
+            };
+            AliasEntry { name, value, scope }
+        })
+        .collect();
+
+    user_aliases.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(user_aliases)
 }
 
 /// Get all default aliases
@@ -176,21 +256,15 @@ pub fn add(
         );
     }
 
-    // Use git config command to set the alias
-    // This is more reliable and simpler than using gix's config mutation APIs
-    let config_key = format!("but.alias.{}", name);
-
-    dbg!("setting alias", &config_key, value, global);
-
+    // ok, let's set the value in git config (using git2)
+    let key = format!("but.alias.{}", name);
     let repo = &*ctx.git2_repo.get()?;
     if global {
         let all = git2::Config::open_default()?;
         let mut global = all.open_level(git2::ConfigLevel::Global)?;
-        let key = format!("but.alias.{}", name);
         global.set_str(&key, value)?;
     } else {
         let mut cfg = repo.config()?; // repo (local) config
-        let key = format!("but.alias.{}", name);
         cfg.set_str(&key, value)?;
     }
 
@@ -218,6 +292,43 @@ pub fn add(
 }
 
 /// Remove an alias
-pub fn remove(_out: &mut OutputChannel, _name: &str, _global: bool) -> Result<()> {
+pub fn remove(ctx: &mut Context, out: &mut OutputChannel, name: &str, global: bool) -> Result<()> {
+    // ok, let's try to remove the value in git config (using git2)
+    let mut success = false;
+    let key = format!("but.alias.{}", name);
+    let repo = &*ctx.git2_repo.get()?;
+    if global {
+        let all = git2::Config::open_default()?;
+        let mut global = all.open_level(git2::ConfigLevel::Global)?;
+        if global.get_entry(&key).is_ok() {
+            global.remove(&key)?;
+            success = true;
+        }
+    } else {
+        let mut cfg = repo.config()?; // repo (local) config
+        if cfg.get_entry(&key).is_ok() {
+            cfg.remove(&key)?;
+            success = true;
+        }
+    }
+
+    if let Some(out) = out.for_human() {
+        if !success {
+            writeln!(out, "{} Alias '{}' not found", "✗".red(), name.green())?;
+            return Ok(());
+        } else {
+            writeln!(out, "Alias '{}' removed", name.green())?;
+            if global {
+                writeln!(out, "  (globally)")?;
+            }
+        }
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "name": name,
+            "scope": if global { "global" } else { "local" },
+            "removed": success
+        }))?;
+    }
+
     Ok(())
 }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -73,6 +73,7 @@ pub(crate) async fn worktree(
     verbose: bool,
     refresh_prs: bool,
     show_upstream: bool,
+    hint: bool,
 ) -> anyhow::Result<()> {
     // Check if we're in edit mode first, before doing any expensive operations
     let mode = gitbutler_operating_modes::operating_mode(ctx);
@@ -417,6 +418,12 @@ pub(crate) async fn worktree(
             String::new()
         }
     )?;
+
+    if hint {
+        writeln!(out)?;
+        writeln!(out, "{}", "Hint: run but help for all commands".dimmed())?;
+    }
+
     Ok(())
 }
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -89,6 +89,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let use_pager = match args.cmd {
         #[cfg(feature = "legacy")]
         Some(Subcommands::Status { .. }) | Some(Subcommands::Oplog(..)) => false,
+        Some(Subcommands::Help) => false,
         _ => true,
     };
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
@@ -215,7 +216,8 @@ async fn match_subcommand(
                 command::alias::add(&mut ctx, out, &name, &value, global).emit_metrics(metrics_ctx)
             }
             Some(alias_args::Subcommands::Remove { name, global }) => {
-                command::alias::remove(out, &name, global).emit_metrics(metrics_ctx)
+                let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
+                command::alias::remove(&mut ctx, out, &name, global).emit_metrics(metrics_ctx)
             }
         },
         Subcommands::Branch(branch::Platform { cmd }) => {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -197,6 +197,11 @@ async fn match_subcommand(
         Subcommands::Completions { shell } => {
             command::completions::generate_completions(shell).emit_metrics(metrics_ctx)
         }
+        Subcommands::Help => {
+            command::help::print_grouped(out)?;
+            Ok(())
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
             Some(alias_args::Subcommands::List) | None => {
                 command::alias::list(out).emit_metrics(metrics_ctx)
@@ -205,7 +210,10 @@ async fn match_subcommand(
                 name,
                 value,
                 global,
-            }) => command::alias::add(out, &name, &value, global).emit_metrics(metrics_ctx),
+            }) => {
+                let mut ctx = init::init_ctx(&args, Fetch::Auto, out)?;
+                command::alias::add(&mut ctx, out, &name, &value, global).emit_metrics(metrics_ctx)
+            }
             Some(alias_args::Subcommands::Remove { name, global }) => {
                 command::alias::remove(out, &name, global).emit_metrics(metrics_ctx)
             }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -137,6 +137,7 @@ impl Subcommands {
                 forge::integration::Subcommands::ListUsers => ForgeListUsers,
             },
             Subcommands::Completions { .. } => Completions,
+            Subcommands::Help => Unknown,
             Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
                 None | Some(alias_args::Subcommands::List) => AliasCheck,
                 Some(alias_args::Subcommands::Add { .. }) => AliasAdd,


### PR DESCRIPTION
Instead of `but` by default showing `but help` output, run `but status` by default. This adds a `but default` alias that is overridable, in case a user wants something different to be the default. It also by default runs status with a `—hint` flag that looks at the state of the repository and suggests next commands you might want to run.