### PR TITLE
refactor(branch-actions): Remove redundant tree parameter from stack methods

### DIFF
--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -60,9 +60,6 @@ mod stack {
             deserialize_with = "deserialize_u128"
         )]
         pub updated_timestamp_ms: u128,
-        /// tree is the last git tree written to a session, or merge base tree if this is new. use this for delta calculation from the session data
-        #[serde(with = "but_serde::object_id")]
-        pub tree: gix::ObjectId,
         /// head is id of the last "virtual" commit in this branch
         #[serde(with = "but_serde::object_id")]
         pub head: gix::ObjectId,
@@ -91,6 +88,10 @@ mod stack {
         #[deprecated(note = "Legacy field, do not use. Kept for backwards compatibility.")]
         #[serde(default = "default_false")]
         pub post_commits: bool,
+        #[deprecated(note = "Legacy field, do not use. Kept for backwards compatibility.")]
+        #[serde(with = "but_serde::object_id")]
+        #[serde(default = "default_null_object_id")]
+        pub tree: gix::ObjectId,
     }
 
     impl Stack {
@@ -102,6 +103,10 @@ mod stack {
                 .map(|head| head.name.clone())
                 .ok_or_else(|| anyhow!("but_meta::Stack::derived_name: Stack is uninitialized"))
         }
+    }
+
+    fn default_null_object_id() -> gix::ObjectId {
+        gix::hash::Kind::Sha1.null()
     }
 
     fn default_true() -> bool {
@@ -143,7 +148,6 @@ mod stack {
                 heads,
 
                 // Don't keep redundant information
-                tree: gix::hash::Kind::Sha1.null(),
                 head: gix::hash::Kind::Sha1.null(),
                 source_refname: None,
                 upstream: None,
@@ -162,6 +166,8 @@ mod stack {
                 allow_rebasing: true,
                 #[allow(deprecated)]
                 post_commits: false,
+                #[allow(deprecated)]
+                tree: gix::hash::Kind::Sha1.null(),
             }
         }
     }

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -681,7 +681,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
     name = "feat-on-top"
     created_timestamp_ms = 12345
     updated_timestamp_ms = 12345
-    tree = "0000000000000000000000000000000000000000"
     head = "0000000000000000000000000000000000000000"
     order = 0
     in_workspace = true
@@ -689,6 +688,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
     ownership = ""
     allow_rebasing = true
     post_commits = false
+    tree = "0000000000000000000000000000000000000000"
 
     [[branches.1.heads]]
     name = "feat"

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
@@ -3,7 +3,6 @@ use but_core::Reference;
 use but_ctx::Context;
 use but_oxidize::{ObjectIdExt, OidExt};
 use but_rebase::{Rebase, RebaseStep, ReferenceSpec};
-use gitbutler_cherry_pick::GixRepositoryExt;
 use gitbutler_repo::logging::{LogUntil, RepositoryExt as _};
 use gitbutler_stack::{CommitOrChangeId, StackBranch, StackId, VirtualBranchesHandle};
 
@@ -229,16 +228,7 @@ pub fn split_into_dependent_branch(
         Some(source_branch_name),
     )?;
 
-    source_stack.set_stack_head(
-        &vb_state,
-        &repository,
-        new_head.id().to_git2(),
-        Some(
-            repository
-                .find_real_tree(&new_head.id(), Default::default())?
-                .to_git2(),
-        ),
-    )?;
+    source_stack.set_stack_head(&vb_state, &repository, new_head.id().to_git2())?;
     source_stack.set_heads_from_rebase_output(ctx, source_result.clone().references)?;
 
     let move_changes_result = MoveChangesResult {

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -220,7 +220,6 @@ pub(crate) fn set_base_branch(
                 Some(head_name),
                 upstream,
                 upstream_head,
-                current_head_commit.tree_id(),
                 current_head_commit.id(),
                 0,
                 !branch_matches_target, // allow duplicate name since here we are creating a lane from an existing branch

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -170,7 +170,7 @@ pub fn integrate_branch_with_steps(
     let result = rebase.rebase()?;
     let head = result.top_commit.to_git2();
 
-    source_stack.set_stack_head(&vb_state, &repository, head, None)?;
+    source_stack.set_stack_head(&vb_state, &repository, head)?;
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
     source_stack.set_heads_from_rebase_output(ctx, result.references)?;

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -309,12 +309,7 @@ fn verify_head_is_clean(ctx: &Context, perm: &mut WorktreeWritePermission) -> Re
             "failed to find rebased commit {rebased_commit_oid}"
         ))?;
 
-        new_branch.set_stack_head(
-            &vb_handle,
-            &gix_repo,
-            rebased_commit.id(),
-            Some(rebased_commit.tree_id()),
-        )?;
+        new_branch.set_stack_head(&vb_handle, &gix_repo, rebased_commit.id())?;
 
         head = rebased_commit.id();
     }

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -5,7 +5,6 @@ use but_meta::virtual_branches_legacy_types::CommitOrChangeId;
 use but_oxidize::ObjectIdExt;
 use but_rebase::{Rebase, RebaseStep};
 use but_workspace::legacy::stack_ext::StackExt;
-use gitbutler_cherry_pick::GixRepositoryExt;
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_stack::{StackBranch, VirtualBranchesHandle};
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes};
@@ -194,15 +193,7 @@ fn inject_branch_steps_into_destination(
 
     destination_stack.add_series(ctx, new_head, Some(target_branch_name.to_string()))?;
 
-    destination_stack.set_stack_head(
-        vb_state,
-        repo,
-        new_destination_head.id().to_git2(),
-        Some(
-            repo.find_real_tree(&new_destination_head.id(), Default::default())?
-                .to_git2(),
-        ),
-    )?;
+    destination_stack.set_stack_head(vb_state, repo, new_destination_head.id().to_git2())?;
 
     destination_stack
         .set_heads_from_rebase_output(ctx, destination_rebase_result.clone().references)?;
@@ -238,16 +229,7 @@ fn extract_and_rebase_source_branch(
 
         source_stack.remove_branch(ctx, subject_branch_name)?;
 
-        source_stack.set_stack_head(
-            vb_state,
-            repository,
-            new_source_head.id().to_git2(),
-            Some(
-                repository
-                    .find_real_tree(&new_source_head.id(), Default::default())?
-                    .to_git2(),
-            ),
-        )?;
+        source_stack.set_stack_head(vb_state, repository, new_source_head.id().to_git2())?;
 
         source_stack.set_heads_from_rebase_output(ctx, source_rebase_result.clone().references)?;
     }

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -174,7 +174,7 @@ fn take_commit_from_source_stack(
 
     source_stack.set_heads_from_rebase_output(ctx, output.references)?;
     let vb_state = ctx.legacy_project.virtual_branches();
-    source_stack.set_stack_head(&vb_state, &gix_repo, new_source_head, None)?;
+    source_stack.set_stack_head(&vb_state, &gix_repo, new_source_head)?;
     Ok(None)
 }
 
@@ -203,6 +203,6 @@ fn move_commit_to_destination_stack(
     let new_destination_head_oid = output.top_commit.to_git2();
 
     destination_stack.set_heads_from_rebase_output(ctx, output.references)?;
-    destination_stack.set_stack_head(vb_state, &gix_repo, new_destination_head_oid, None)?;
+    destination_stack.set_stack_head(vb_state, &gix_repo, new_destination_head_oid)?;
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -64,7 +64,7 @@ pub fn reorder_stack(
     let new_head = output.top_commit.to_git2();
 
     // Ensure the stack head is set to the new oid after rebasing
-    stack.set_stack_head(&state, &gix_repo, new_head, None)?;
+    stack.set_stack_head(&state, &gix_repo, new_head)?;
 
     stack.set_heads_from_rebase_output(ctx, output.references.clone())?;
 

--- a/crates/gitbutler-branch-actions/src/squash.rs
+++ b/crates/gitbutler-branch-actions/src/squash.rs
@@ -254,7 +254,7 @@ fn do_squash_commits(
 
     let new_stack_head = output.top_commit.to_git2();
 
-    stack.set_stack_head(&vb_state, &gix_repo, new_stack_head, None)?;
+    stack.set_stack_head(&vb_state, &gix_repo, new_stack_head)?;
 
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, path::PathBuf, vec};
 
 use anyhow::{Context as _, Result, bail};
 use but_ctx::{Context, access::WorktreeWritePermission};
-use but_oxidize::ObjectIdExt;
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_diff::{Hunk, diff_files_into_hunks};
 use gitbutler_hunk_dependency::locks::HunkDependencyResult;
@@ -137,13 +136,7 @@ pub fn get_applied_status_cached(
         .collect::<Vec<_>>();
 
     // write updated state if not resolving
-    let repo = ctx.repo.get()?;
-    for (vbranch, files) in &mut hunks_by_branch {
-        vbranch.set_tree(gitbutler_diff::write::hunks_onto_oid(
-            ctx,
-            vbranch.head_oid(&repo)?.to_git2(),
-            files,
-        )?);
+    for (vbranch, _) in &mut hunks_by_branch {
         vb_state
             .set_stack(vbranch.clone())
             .context(format!("failed to write virtual branch {}", vbranch.name))?;

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -50,7 +50,7 @@ pub(crate) fn undo_commit(
     let output = rebase.rebase()?;
 
     let new_head = output.top_commit.to_git2();
-    stack.set_stack_head(&vb_state, &repo, new_head, None)?;
+    stack.set_stack_head(&vb_state, &repo, new_head)?;
 
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -155,7 +155,6 @@ pub struct Resolution {
 enum IntegrationResult {
     UpdatedObjects {
         head: git2::Oid,
-        tree: Option<git2::Oid>,
         rebase_output: Option<RebaseOutput>,
         for_archival: Vec<Reference>,
     },
@@ -591,7 +590,6 @@ pub(crate) fn integrate_upstream(
         for (maybe_stack_id, integration_result) in &integration_results {
             let IntegrationResult::UpdatedObjects {
                 head,
-                tree,
                 rebase_output,
                 for_archival,
             } = integration_result
@@ -623,7 +621,7 @@ pub(crate) fn integrate_upstream(
                 }
             }
 
-            stack.set_stack_head(&virtual_branches_state, &gix_repo, *head, *tree)?;
+            stack.set_stack_head(&virtual_branches_state, &gix_repo, *head)?;
 
             let delete_local_refs = resolutions
                 .iter()
@@ -749,7 +747,6 @@ fn compute_resolutions(
                         stack.id,
                         IntegrationResult::UpdatedObjects {
                             head: new_head.id(),
-                            tree: None,
                             rebase_output: None,
                             for_archival: vec![],
                         },
@@ -824,7 +821,6 @@ fn compute_resolutions(
                         stack.id,
                         IntegrationResult::UpdatedObjects {
                             head: new_head,
-                            tree: None,
                             rebase_output: Some(output),
                             for_archival,
                         },

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -186,7 +186,7 @@ pub fn commit(
     let commit_oid = ctx.commit(message, &tree, &[&parent_commit], None)?;
 
     let vb_state = ctx.legacy_project.virtual_branches();
-    branch.set_stack_head(&vb_state, &gix_repo, commit_oid, Some(tree_oid))?;
+    branch.set_stack_head(&vb_state, &gix_repo, commit_oid)?;
 
     crate::integration::update_workspace_commit(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
@@ -416,7 +416,7 @@ pub(crate) fn insert_blank_commit(
         .collect::<Vec<_>>();
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 
-    stack.set_stack_head(&vb_state, &repo, output.top_commit.to_git2(), None)?;
+    stack.set_stack_head(&vb_state, &repo, output.top_commit.to_git2())?;
 
     crate::integration::update_workspace_commit(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
@@ -479,7 +479,7 @@ pub(crate) fn update_commit_message(
     let output = rebase.rebase()?;
 
     let new_head = output.top_commit.to_git2();
-    stack.set_stack_head(&vb_state, &gix_repo, new_head, None)?;
+    stack.set_stack_head(&vb_state, &gix_repo, new_head)?;
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 
     crate::integration::update_workspace_commit(&vb_state, ctx, false)

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -576,7 +576,7 @@ fn set_stack_head_commit_invalid() -> Result<()> {
     let gix_repo = ctx.repo.get()?;
     let result = test_ctx
         .stack
-        .set_stack_head(&vb_state, &gix_repo, git2::Oid::zero(), None);
+        .set_stack_head(&vb_state, &gix_repo, git2::Oid::zero());
     assert!(result.is_err());
     Ok(())
 }
@@ -590,7 +590,7 @@ fn set_stack_head() -> Result<()> {
     let gix_repo = ctx.repo.get()?;
     let result = test_ctx
         .stack
-        .set_stack_head(&vb_state, &gix_repo, commit.id(), None);
+        .set_stack_head(&vb_state, &gix_repo, commit.id());
     assert!(result.is_ok());
     let branches = test_ctx.stack.branches();
     assert_eq!(


### PR DESCRIPTION
the tree is set, but never actually read (there is the `tree` method which doesnt use the field)