### PR TITLE
fix(ui): update branch text and bold formatting in project setup

### DIFF
--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -192,7 +192,8 @@
 				</svg>
 
 				<h3 class="text-13 text-body text-semibold">
-					GitButler switches your repo to gitbutler/workspace
+					Gitbutler switches your active branch to <span class="text-bold">gitbutler/workspace</span
+					>
 				</h3>
 			</div>
 

--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -192,7 +192,7 @@
 				</svg>
 
 				<h3 class="text-13 text-body text-semibold">
-					Gitbutler switches your active branch to <span class="text-bold">gitbutler/workspace</span
+					GitButler switches your active branch to <span class="text-bold">gitbutler/workspace</span
 					>
 				</h3>
 			</div>


### PR DESCRIPTION
Clarify wording in the ProjectSetupTarget component to state that
Gitbutler switches the active branch to "gitbutler/workspace" instead
of the previous phrasing. Wrap the branch name in a bold span for
emphasis and adjust markup to avoid malformed HTML.

This improves clarity for users and fixes the component's rendered
output.