### PR TITLE
tests: extension trait to add color for SVG

### DIFF
--- a/crates/but/tests/but/command/help.rs
+++ b/crates/but/tests/but/command/help.rs
@@ -1,6 +1,6 @@
 use snapbox::str;
 
-use crate::utils::Sandbox;
+use crate::utils::{CommandExt as _, Sandbox};
 
 #[cfg(feature = "legacy")]
 #[test]
@@ -9,14 +9,14 @@ fn rub_looks_good() -> anyhow::Result<()> {
 
     // The help should be nice, as it's a complex command.
     env.but("rub --help")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(snapbox::file![
             "snapshots/help/rub-long-help.stdout.term.svg"
         ]);
     env.but("rub -h")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(snapbox::file![

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1,4 +1,4 @@
-use crate::utils::Sandbox;
+use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
 fn worktrees() -> anyhow::Result<()> {
@@ -21,7 +21,7 @@ fn worktrees() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
 
     env.but("status")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -30,7 +30,7 @@ fn worktrees() -> anyhow::Result<()> {
         ]);
 
     env.but("status --verbose")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -273,7 +273,7 @@ fn long_cli_ids() -> anyhow::Result<()> {
 
     // For "add A13" and "add A3", the IDs have 3 characters. The others have 2.
     env.but("status")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stderr_eq(snapbox::str![])

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -1,7 +1,7 @@
 //! Tests for various nice user-journeys, from different starting points, performing multiple common steps in sequence.
 use snapbox::str;
 
-use crate::utils::Sandbox;
+use crate::utils::{CommandExt as _, Sandbox};
 
 #[cfg(not(feature = "legacy"))]
 #[test]
@@ -140,13 +140,13 @@ fn from_workspace() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
 
     env.but("status")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(file!["snapshots/from-workspace/status01.stdout.term.svg"]);
 
     env.but("status -v")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(file![
@@ -155,14 +155,14 @@ fn from_workspace() -> anyhow::Result<()> {
 
     // List is the default
     env.but("branch")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(file!["snapshots/from-workspace/branch01.stdout.term.svg"]);
 
     // But list is also explicit.
     env.but("branch list")
-        .env("CLICOLOR_FORCE", "1")
+        .with_color_for_svg()
         .assert()
         .success()
         .stdout_eq(file!["snapshots/from-workspace/branch01.stdout.term.svg"]);

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -118,3 +118,16 @@ impl Sandbox {
             .current_dir(self.projects_root())
     }
 }
+
+pub trait CommandExt {
+    fn with_color_for_svg(self) -> Self;
+}
+
+impl CommandExt for snapbox::cmd::Command {
+    /// Force terminal color codes to be emitted. This should be used when
+    /// asserting with [snapbox::cmd::OutputAssert::stdout_eq] against an SVG
+    /// file.
+    fn with_color_for_svg(self) -> snapbox::cmd::Command {
+        self.env("CLICOLOR_FORCE", "1")
+    }
+}


### PR DESCRIPTION
This makes it clearer at the call site that callers want color for SVG output.

