### PR TITLE
Use 32 characters in JJ-style change-id header

### DIFF
--- a/crates/but-core/src/change_id.rs
+++ b/crates/but-core/src/change_id.rs
@@ -7,8 +7,10 @@ use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// How long a reverse hex change id should be if stored in actual reverse hex
-/// ASCII characters, ranging from `z` to `k`.
-const CHANGE_ID_REVERSE_HEX_LEN: usize = 40;
+/// ASCII characters, ranging from `z` to `k`. In accordance with the standard
+/// discussed together with the Jujutsu and Gerrit projects, it is 32.
+/// <https://lore.kernel.org/git/CAESOdVAspxUJKGAA58i0tvks4ZOfoGf1Aa5gPr0FXzdcywqUUw@mail.gmail.com>
+const CHANGE_ID_REVERSE_HEX_LEN: usize = 32;
 /// How long a reverse hex change id should be if stored compactly in bytes.
 const CHANGE_ID_REVERSE_BYTE_LEN: usize = CHANGE_ID_REVERSE_HEX_LEN / 2;
 
@@ -25,7 +27,7 @@ impl ChangeId {
         ChangeId(value.to_string().into())
     }
 
-    /// Creates a random length 40 reverse hex ChangeId.
+    /// Creates a random length 32 reverse hex ChangeId.
     pub fn generate() -> Self {
         let mut rng = rand::rng();
         let bytes: [u8; CHANGE_ID_REVERSE_BYTE_LEN] = rng.random();

--- a/crates/but-core/tests/core/change_id.rs
+++ b/crates/but-core/tests/core/change_id.rs
@@ -2,9 +2,9 @@ mod generate {
     use but_core::ChangeId;
 
     #[test]
-    fn returns_a_40_character_random_string() {
+    fn returns_a_32_character_random_string() {
         let a = ChangeId::generate();
-        assert_eq!(a.to_string().len(), 40);
+        assert_eq!(a.to_string().len(), 32);
         let b = ChangeId::generate();
         assert_ne!(a, b, "these are always different");
     }

--- a/crates/but-core/tests/core/commit.rs
+++ b/crates/but-core/tests/core/commit.rs
@@ -49,12 +49,11 @@ mod headers {
 
         #[test]
         fn with_reverse_hex_change_id() {
-            let commit =
-                commit_with_header([("change-id", "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx")]);
+            let commit = commit_with_header([("change-id", "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx")]);
             insta::assert_debug_snapshot!(Headers::try_from_commit(&commit).expect("reverse hex is parsed as well"), @r#"
             Headers {
                 change_id: Some(
-                    "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx",
+                    "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx",
                 ),
                 conflicted: None,
             }
@@ -77,13 +76,13 @@ mod headers {
         #[test]
         fn with_conflict_header_and_reverse_hex_change_id() {
             let commit = commit_with_header([
-                ("change-id", "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx"),
+                ("change-id", "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx"),
                 ("gitbutler-conflicted", "128"),
             ]);
             insta::assert_debug_snapshot!(Headers::try_from_commit(&commit).expect("both fields are parsed"), @r#"
             Headers {
                 change_id: Some(
-                    "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx",
+                    "zxzxzxzxzxzxzxzxzxzxzxzxzxzxzxzx",
                 ),
                 conflicted: Some(
                     128,


### PR DESCRIPTION
Jujutsu uses 32 characters, so it's better if we generate change-ids of the same lenght. This makes it easier for gitbutler and Jujutsu to be compatible.