### PR TITLE
API: Ability to switch back to workspace

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -69,13 +69,12 @@
 	const isNotInWorkspace = $derived(
 		currentMode?.type !== 'OpenWorkspace' && currentMode?.type !== 'Edit'
 	);
-	const [setBaseBranchTarget, targetBranchSwitch] = baseBranchService.setTarget;
+	const [switchBackToWorkspace, workspaceSwitch] = baseBranchService.switchBackToWorkspace;
 
 	async function switchToWorkspace() {
 		if (base) {
-			await setBaseBranchTarget({
-				projectId,
-				branch: base.branchName
+			await switchBackToWorkspace({
+				projectId
 			});
 		}
 	}
@@ -244,7 +243,7 @@
 					style="warning"
 					onclick={switchToWorkspace}
 					reversedDirection
-					disabled={targetBranchSwitch.current.isLoading}
+					disabled={workspaceSwitch.current.isLoading}
 				>
 					Back to workspace
 				</Button>

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -125,6 +125,10 @@ export default class BaseBranchService {
 		return this.api.endpoints.setTarget.useMutation();
 	}
 
+	get switchBackToWorkspace() {
+		return this.api.endpoints.switchBackToWorkspace.useMutation();
+	}
+
 	get push() {
 		return this.api.endpoints.push.useMutation();
 	}
@@ -161,6 +165,15 @@ function injectEndpoints(api: BackendApi) {
 				{ projectId: string; branch: string; pushRemote?: string; stashUncommitted?: boolean }
 			>({
 				extraOptions: { command: 'set_base_branch' },
+				query: (args) => args,
+				invalidatesTags: [
+					invalidatesType(ReduxTag.BaseBranchData),
+					invalidatesList(ReduxTag.Stacks), // Probably this is still needed??
+					invalidatesList(ReduxTag.StackDetails) // Probably this is still needed??
+				]
+			}),
+			switchBackToWorkspace: build.mutation<BaseBranch, { projectId: string }>({
+				extraOptions: { command: 'switch_back_to_workspace' },
 				query: (args) => args,
 				invalidatesTags: [
 					invalidatesType(ReduxTag.BaseBranchData),

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -293,6 +293,9 @@ async fn handle_command(
             legacy::virtual_branches::get_base_branch_data_cmd(request.params)
         }
         "set_base_branch" => legacy::virtual_branches::set_base_branch_cmd(request.params),
+        "switch_back_to_workspace" => {
+            legacy::virtual_branches::switch_back_to_workspace_cmd(request.params)
+        }
         "push_base_branch" => legacy::virtual_branches::push_base_branch_cmd(request.params),
         "update_stack_order" => legacy::virtual_branches::update_stack_order_cmd(request.params),
         "unapply_stack" => legacy::virtual_branches::unapply_stack_cmd(request.params),

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -265,6 +265,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_delete_local_branch::delete_local_branch,
                 legacy::virtual_branches::tauri_get_base_branch_data::get_base_branch_data,
                 legacy::virtual_branches::tauri_set_base_branch::set_base_branch,
+                legacy::virtual_branches::tauri_switch_back_to_workspace::switch_back_to_workspace,
                 legacy::virtual_branches::tauri_push_base_branch::push_base_branch,
                 legacy::virtual_branches::tauri_integrate_upstream_commits::integrate_upstream_commits,
                 legacy::virtual_branches::tauri_get_initial_integration_steps_for_branch::get_initial_integration_steps_for_branch,


### PR DESCRIPTION
- Add a dedicated API to switch back to the workspace
- The UI uses that new API

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11818 
- <kbd>&nbsp;1&nbsp;</kbd> #11819 👈 
<!-- GitButler Footer Boundary Bottom -->

