### PR TITLE
Fix PLAYWRIGHT_UI env handling for headless mode

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -59,7 +59,7 @@ function projects() {
 		name: 'Chrome',
 		use: {
 			...devices['Desktop Chrome'],
-			headless: !!process.env.PLAYWRIGHT_UI,
+			headless: process.env.PLAYWRIGHT_UI === '1' ? false : true,
 			channel: 'chrome'
 		}
 	});


### PR DESCRIPTION
Change how PLAYWRIGHT_UI environment variable determines headless mode.

Before: headless was set to !!process.env.PLAYWRIGHT_UI which treats any set value (including '0') as true.
After: headless is set to process.env.PLAYWRIGHT_UI === '1' ? false : true so that only '1' disables headless mode (runs headed), and any other value or unset defaults to headless true.

This prevents unexpected headed runs when PLAYWRIGHT_UI is set to '0' or other non-empty values.