### PR TITLE
Make `prettier --check` actually run in CI when applicable

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,6 +20,7 @@ jobs:
       node: ${{ steps.filter.outputs.node }}
       rust: ${{ steps.filter.outputs.rust }}
       ui: ${{ steps.filter.outputs.ui }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,14 +52,14 @@ jobs:
 
   prettier:
     needs: changes
-    if: ${{ needs.changes.outputs.node == 'false' &&  needs.changes.outputs.docs == 'true'}}
+    if: ${{ needs.changes.outputs.node == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/init-env-node
-      - run: pnpm prettier
+      - run: pnpm prettier .
 
   generate-ts-definitions:
     needs: changes


### PR DESCRIPTION
## 🧢 Changes
I stumbled into the [LINUX.md file commit history](https://github.com/gitbutlerapp/gitbutler/commits/master/LINUX.md) and found that both @Byron and @jonathantanmy2 have cleaned up after my sorry butt forgetting to run formatting. I wondered how, as CI didn't fail on either of my PRs.

As it turns out, the `prettier` job _never_ runs, because there is no `docs` output from the `changes` job. So the condition to run `prettier` is trivially false. This then causes CI failure in [generate-ts-definitions](https://github.com/gitbutlerapp/gitbutler/actions/runs/20797364623/job/59734240631), as the script there runs format and then checks the output to detect changes in TS types. But that doesn't run if you only change docs, so doc-only PRs slip through.

This PR adds the missing output and makes `prettier` run if there are docs changes OR node changes (see checks on this PR for evidence that it runs!). Even though `generate-ts-definitions` will catch formatting errors in the case there are "node" changes, I think that's a rather obtuse way of showing it. It's better if it's clearly showcased here.

For reference, here's a failed run on my own fork showing that it actually functions: https://github.com/slarse/gitbutler/actions/runs/21006637327/job/60390596765