### PR TITLE
refactor(stack): remove deprecated `head` field and related methods

### DIFF
--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -47,9 +47,6 @@ mod stack {
         // upstream_head is the last commit on we've pushed to the upstream branch
         #[serde(with = "but_serde::object_id_opt", default)]
         pub upstream_head: Option<gix::ObjectId>,
-        /// head is id of the last "virtual" commit in this branch
-        #[serde(with = "but_serde::object_id")]
-        pub head: gix::ObjectId,
         // order is the number by which UI should sort branches
         pub order: usize,
         /// This is the new metric for determining whether the branch is in the workspace, which means it's applied
@@ -96,6 +93,10 @@ mod stack {
         #[deprecated(note = "Legacy field, do not use. Kept for backwards compatibility.")]
         #[serde(default)]
         pub name: String,
+        #[deprecated(note = "Legacy field, do not use. Kept for backwards compatibility.")]
+        #[serde(with = "but_serde::object_id")]
+        #[serde(default = "default_null_object_id")]
+        pub head: gix::ObjectId,
     }
 
     impl Stack {
@@ -149,7 +150,6 @@ mod stack {
                 heads,
 
                 // Don't keep redundant information
-                head: gix::hash::Kind::Sha1.null(),
                 source_refname: None,
                 upstream: None,
                 upstream_head: None,
@@ -171,6 +171,8 @@ mod stack {
                 updated_timestamp_ms: 0,
                 #[allow(deprecated)]
                 name: String::default(),
+                #[allow(deprecated)]
+                head: gix::hash::Kind::Sha1.null(),
             }
         }
     }

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -639,7 +639,6 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
 
     [branches.1]
     id = "1"
-    head = "0000000000000000000000000000000000000000"
     order = 0
     in_workspace = true
     notes = ""
@@ -650,6 +649,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
     created_timestamp_ms = "0"
     updated_timestamp_ms = "0"
     name = ""
+    head = "0000000000000000000000000000000000000000"
 
     [[branches.1.heads]]
     name = "feat"

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -220,7 +220,7 @@ pub(crate) fn set_base_branch(
                 Some(head_name),
                 upstream,
                 upstream_head,
-                current_head_commit.id(),
+                Some(current_head_commit.id()),
                 0,
                 !branch_matches_target, // allow duplicate name since here we are creating a lane from an existing branch
             )?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -57,7 +57,6 @@ impl BranchManager<'_> {
         perm: &mut WorktreeWritePermission,
     ) -> Result<Stack> {
         let vb_state = self.ctx.legacy_project.virtual_branches();
-        let default_target = vb_state.get_default_target()?;
 
         let mut all_stacks = vb_state
             .list_stacks_in_workspace()
@@ -86,16 +85,7 @@ impl BranchManager<'_> {
             }
         }
 
-        let branch = Stack::create(
-            self.ctx,
-            name.clone(),
-            None,
-            None,
-            None,
-            default_target.sha,
-            order,
-            false,
-        )?;
+        let branch = Stack::create(self.ctx, name.clone(), None, None, None, None, order, false)?;
 
         vb_state.set_stack(branch.clone())?;
         self.ctx.add_branch_reference(&branch)?;
@@ -230,7 +220,7 @@ impl BranchManager<'_> {
             branch.in_workspace = true;
 
             // This seems to ensure that there is at least one head.
-            branch.initialize(self.ctx, true, branch_name.clone())?;
+            branch.initialize(self.ctx, true, branch_name.clone(), None)?;
             vb_state.set_stack(branch.clone())?;
             branch
         } else {
@@ -241,7 +231,7 @@ impl BranchManager<'_> {
                 Some(target.clone()),
                 upstream_branch,
                 upstream_head,
-                head_commit.id(),
+                None,
                 order,
                 true, // allow duplicate branch name if created from an existing branch
             )?


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11831 
- <kbd>&nbsp;1&nbsp;</kbd> #11830 👈 
<!-- GitButler Footer Boundary Bottom -->

