### PR TITLE
refactor(branch): remove unused upstream_head field from stack types

### DIFF
--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -44,9 +44,6 @@ mod stack {
         /// Upstream tracking branch reference, added when creating a stack from a branch.
         /// Used e.g. when listing commits from a fork.
         pub upstream: Option<RemoteRefname>,
-        // upstream_head is the last commit on we've pushed to the upstream branch
-        #[serde(with = "but_serde::object_id_opt", default)]
-        pub upstream_head: Option<gix::ObjectId>,
         // order is the number by which UI should sort branches
         pub order: usize,
         /// This is the new metric for determining whether the branch is in the workspace, which means it's applied
@@ -152,7 +149,6 @@ mod stack {
                 // Don't keep redundant information
                 source_refname: None,
                 upstream: None,
-                upstream_head: None,
 
                 // For serialization backwards compatibility
                 #[allow(deprecated)]

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -85,7 +85,7 @@ impl BranchManager<'_> {
             }
         }
 
-        let branch = Stack::create(self.ctx, name.clone(), None, None, None, None, order, false)?;
+        let branch = Stack::create(self.ctx, name.clone(), None, None, None, order, false)?;
 
         vb_state.set_stack(branch.clone())?;
         self.ctx.add_branch_reference(&branch)?;
@@ -214,7 +214,6 @@ impl BranchManager<'_> {
             .find_by_top_reference_name_where_not_in_workspace(&target.to_string())?
             .or(vb_state.find_by_source_refname_where_not_in_workspace(target)?)
         {
-            branch.upstream_head = upstream_branch.is_some().then_some(head_commit.id());
             branch.upstream = upstream_branch; // Used as remote when listing commits.
             branch.order = order;
             branch.in_workspace = true;
@@ -224,13 +223,11 @@ impl BranchManager<'_> {
             vb_state.set_stack(branch.clone())?;
             branch
         } else {
-            let upstream_head = upstream_branch.is_some().then_some(head_commit.id());
             Stack::create(
                 self.ctx,
                 branch_name.clone(),
                 Some(target.clone()),
                 upstream_branch,
-                upstream_head,
                 None,
                 order,
                 true, // allow duplicate branch name if created from an existing branch


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11831 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #11830 
<!-- GitButler Footer Boundary Bottom -->

