### PR TITLE
but: Absorb improvements

### DIFF
--- a/crates/but-workspace/src/commit_engine/ui.rs
+++ b/crates/but-workspace/src/commit_engine/ui.rs
@@ -1,11 +1,11 @@
 #![allow(missing_docs)]
 use but_serde::BStringForFrontend;
+use gix::ObjectId;
 use serde::Serialize;
 
 use crate::commit_engine::RejectionReason;
 
 /// The JSON serializable type of [super::CreateCommitOutcome].
-// TODO(ST): this type should contain mappings from old to new commits so that the UI knows what state to update, maybe.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCommitOutcome {
@@ -14,6 +14,8 @@ pub struct CreateCommitOutcome {
     /// The newly created commit, if there was one. It maybe that a couple of paths were rejected, but the commit was created anyway.
     #[serde(with = "but_serde::object_id_opt")]
     pub new_commit: Option<gix::ObjectId>,
+    /// A listing of all commits `(old, new)` with the initial commit hash on the left and the rewritten version of it on the right side of each tuple.
+    pub commit_mapping: Vec<(ObjectId, ObjectId)>,
 }
 
 impl From<super::CreateCommitOutcome> for CreateCommitOutcome {
@@ -23,16 +25,26 @@ impl From<super::CreateCommitOutcome> for CreateCommitOutcome {
             new_commit,
             changed_tree_pre_cherry_pick: _,
             references: _,
-            rebase_output: _,
+            rebase_output,
             index: _,
         }: super::CreateCommitOutcome,
     ) -> Self {
+        let commit_mapping = if let Some(rebase_output) = rebase_output {
+            rebase_output
+                .commit_mapping
+                .iter()
+                .map(|(_, a, b)| (*a, *b))
+                .collect()
+        } else {
+            Vec::new()
+        };
         CreateCommitOutcome {
             paths_to_rejected_changes: rejected_specs
                 .into_iter()
                 .map(|(reason, spec)| (reason, spec.path.into()))
                 .collect(),
             new_commit,
+            commit_mapping,
         }
     }
 }

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -126,6 +126,7 @@ unicode-width = "0.2"
 cfg-if = "1.0.4"
 tempfile.workspace = true
 nonempty.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 but-graph.workspace = true
@@ -134,4 +135,3 @@ but-testsupport = { workspace = true, features = ["sandbox-but-api"] }
 snapbox = { workspace = true, features = ["term-svg"] }
 shell-words.workspace = true
 insta.workspace = true
-itertools.workspace = true

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -158,3 +158,224 @@ Hint: you can run `but undo` to undo these changes
 
     Ok(())
 }
+
+#[test]
+fn committed_hunk() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    // Verify that the first hunk is j0, and commit it.
+    env.but("diff a.txt")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+j0 a.txt│
+────────╯
+   1  │-first
+     1│+firsta
+   2 2│ line
+   3 3│ line
+   4 4│ line
+────────╮
+k0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-last
+       9│+lasta
+
+"#]]);
+
+    env.but("commit A -m 'partial change to a.txt 1'")
+        .assert()
+        .success();
+
+    let context_distance = (env.app_settings().context_lines * 2 + 1) as usize;
+
+    // Change the file at the top & commit
+    env.file(
+        "a.txt",
+        format!("first\n{}lasta\n", "line\n".repeat(context_distance)),
+    );
+
+    // Verify the hunks
+    env.but("diff a.txt")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+j0 a.txt│
+────────╯
+   1  │-firsta
+     1│+first
+   2 2│ line
+   3 3│ line
+   4 4│ line
+
+"#]]);
+
+    env.but("commit A -m 'partial change to a.txt 2'")
+        .assert()
+        .success();
+
+    // Change the file at the bottom & commit
+    env.file(
+        "a.txt",
+        format!("first\n{}last\n", "line\n".repeat(context_distance)),
+    );
+
+    // Verify the hunks
+    env.but("diff a.txt")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+j0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-lasta
+       9│+last
+
+"#]]);
+
+    env.but("commit A -m 'partial change to a.txt 3'")
+        .assert()
+        .success();
+
+    // Change the file at the top & bottom & absorb
+    env.file(
+        "a.txt",
+        format!("first new\n{}last new\n", "line\n".repeat(context_distance)),
+    );
+
+    // Verify the hunks
+    env.but("diff a.txt")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+────────╮
+j0 a.txt│
+────────╯
+   1  │-first
+     1│+first new
+   2 2│ line
+   3 3│ line
+   4 4│ line
+────────╮
+k0 a.txt│
+────────╯
+    6  6│ line
+    7  7│ line
+    8  8│ line
+    9   │-last
+       9│+last new
+
+"#]]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes] 
+┊   i0 M a.txt 🔒 889385c, a7aa4ef, f4ea7f8
+┊
+┊╭┄g0 [A]  
+┊●   a7aa4ef partial change to a.txt 3  
+┊│     q0 M a.txt
+┊●   889385c partial change to a.txt 2  
+┊│     n0 M a.txt
+┊●   8dc39e0 partial change to a.txt 1  
+┊│     o0 M a.txt
+┊●   f4ea7f8 a.txt  
+┊│     s0 A a.txt
+┊●   9477ae7 add A  
+┊│     p0 A A
+├╯
+┊
+┊╭┄h0 [B]  
+┊●   d3e2ba3 add B  
+┊│     r0 A B
+├╯
+┊
+┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 
+
+"#]]);
+
+    env.but("absorb i0")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Found 2 changed files to absorb:
+
+Absorbed to commit: 889385c partial change to a.txt 2
+  (files locked to commit due to hunk range overlap)
+    a.txt @1,4 +1,4
+
+Absorbed to commit: a7aa4ef partial change to a.txt 3
+  (files locked to commit due to hunk range overlap)
+    a.txt @6,4 +6,4
+
+
+Hint: you can run `but undo` to undo these changes
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   4822140 partial change to a.txt 3  
+┊│     l0 M a.txt
+┊●   4593422 partial change to a.txt 2  
+┊│     k0 M a.txt
+┊●   8dc39e0 partial change to a.txt 1  
+┊│     m0 M a.txt
+┊●   f4ea7f8 a.txt  
+┊│     p0 A a.txt
+┊●   9477ae7 add A  
+┊│     n0 A A
+├╯
+┊
+┊╭┄h0 [B]  
+┊●   d3e2ba3 add B  
+┊│     o0 A B
+├╯
+┊
+┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 
+
+"#]]);
+
+    // Change was full absorbed
+    let repo = env.open_repo()?;
+    let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
+    insta::assert_snapshot!(blob.data.as_bstr(), @"
+    first new
+    line
+    line
+    line
+    line
+    line
+    line
+    line
+    last new
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
- Fixed amending individual hunks in a file to different commits
- Add testing for that

### Changes to the algorithm
- **Find the 'top most lock'**: if a given hunk is locked to multiple commits, find the child-most commit
- **Apply the 'bottom most amend'**: given multiple hunks-to-commit amend targets, start by the parent most and work your way up
- **Keep a map of commits to new commits**: After the first amend is made, track the changes to the commit Id, in order to know where to amend a hunk to.