### PR TITLE
Minor changes on top of single-branch-mode ChangeIDs.

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -411,9 +411,15 @@ impl RefInfo {
 pub type StackId = Id<'S'>;
 
 impl StackId {
-    /// A special fixed ID use to represent the lane of single branch mode.
+    /// A special fixed ID used to represent the lane in single branch mode.
+    ///
+    /// It can be used like an ordinary ID, with the note that the contents of said stack
+    /// can change drastically with each checkout.
+    ///
+    /// Single branch mode happens when no `gitbutler/workspace` reference is checked out,
+    /// or any branch that is between that and the lowest base of the workspace.
     pub fn single_branch_id() -> Self {
-        Self::from(Uuid::from_u128(0))
+        Self::from(Uuid::from_u128(1))
     }
 }
 

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -700,7 +700,7 @@ impl Graph {
         } else {
             let start = ws_tip_segment;
             let has_seen_base = RefCell::new(false);
-            if let Some(stack) = self
+            let maybe_stack = self
                 .collect_stack_segments(
                     start.id,
                     None,
@@ -730,9 +730,14 @@ impl Graph {
                         segments,
                         Some(StackId::single_branch_id()),
                     )
-                })
-            {
+                });
+            if let Some(stack) = maybe_stack {
                 ws.stacks.push(stack);
+            } else {
+                tracing::warn!(
+                    ?ws,
+                    "Didn't get a single stack for AdHoc workspace - this is unexpected"
+                );
             }
         }
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -51,9 +51,9 @@ fn unborn() -> anyhow::Result<()> {
     }
     "#);
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -82,9 +82,9 @@ fn detached() -> anyhow::Result<()> {
             └── ►:1[1]:other
                 └── ·fafd9d0 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         ├── :0:anon:
         │   └── ·541396b ►tags/annotated, ►tags/release/v1, ►main
         └── :1:other
@@ -197,9 +197,9 @@ fn main_advanced_remote_advanced() -> anyhow::Result<()> {
             └── →:2:
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
-    └── ≡:0:main[🌳] <> origin/main →:1:⇡1⇣1 on ce09734 {0}
+    └── ≡:0:main[🌳] <> origin/main →:1:⇡1⇣1 on ce09734 {1}
         └── :0:main[🌳] <> origin/main →:1:⇡1⇣1
             ├── 🟣5d29d62
             └── ·971953d
@@ -235,9 +235,9 @@ fn only_remote_advanced() -> anyhow::Result<()> {
     // TODO: it should detect that `main` has no own commits as it's fully integrated.
     //       This also affects the base which would have to be 085535d, the first commit.
     //       which is strange but maybe can work?
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-    └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {0}
+    └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
         └── :0:main[🌳] <> origin/main →:1:⇣1
             └── 🟣085535d
     ");
@@ -274,9 +274,9 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
     // TODO: We'd actually have to recognise that the `origin/split-segment` branch
     //       isn't related to our stack and count its commits to `origin/main`.
     //       Right now we are missing dd9f8d9.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-    └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {0}
+    └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
         └── :0:main[🌳] <> origin/main →:1:⇣1
             └── 🟣085535d
     ");
@@ -328,9 +328,9 @@ fn multi_root() -> anyhow::Result<()> {
         4,
         "there are 4 orphaned bases"
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·c6c8c05
             ├── ·76fc5c4
@@ -395,9 +395,9 @@ fn four_diamond() -> anyhow::Result<()> {
         "however, we see only a portion of the edges as the tree can only show simple stacks"
     );
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:merged[🌳] <> ✓!
-    └── ≡:0:merged[🌳] {0}
+    └── ≡:0:merged[🌳] {1}
         ├── :0:merged[🌳]
         │   └── ·8a6c109
         ├── :1:A
@@ -440,9 +440,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ");
 
     // 'main' is frozen because it connects to a 'foreign' remote, the commit was pushed.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
-    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1 on fafd9d0 {0}
+    └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1 on fafd9d0 {1}
         ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
         │   ├── 🟣682be32
         │   └── ·312f819
@@ -469,9 +469,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ");
     // As the remotes don't connect, they are entirely unknown.
     // And if it's weird, it's due to the hard limit
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
-    └── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc {0}
+    └── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc {1}
         └── :0:B[🌳] <> origin/B →:1:⇣1
             └── 🟣682be32
     ");
@@ -506,9 +506,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         └── 🟣e29c23d (0x0|10)
             └── →:2: (main)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
-    └── ≡:0:A <> origin/A →:1:⇡1⇣1 on fafd9d0 {0}
+    └── ≡:0:A <> origin/A →:1:⇡1⇣1 on fafd9d0 {1}
         └── :0:A <> origin/A →:1:⇡1⇣1
             ├── 🟣e29c23d
             └── ·e255adc
@@ -568,9 +568,9 @@ fn with_limits() -> anyhow::Result<()> {
                     └── →:4: (main)
     ");
     // No limits list the first parent everywhere.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         ├── :0:C[🌳]
         │   ├── ·2a95729
         │   ├── ·6861158
@@ -594,9 +594,9 @@ fn with_limits() -> anyhow::Result<()> {
         └── ✂·2a95729 (⌂|1)
     ");
     // The cut by limit is also represented here.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
             └── ✂️·2a95729
     ");
@@ -615,9 +615,9 @@ fn with_limits() -> anyhow::Result<()> {
             └── ►:3[1]:B
                 └── ✂·9908c99 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
             ├── ·2a95729
             └── ✂️·6861158
@@ -640,9 +640,9 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·9908c99 (⌂|1)
                 └── ✂·60d9a56 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
@@ -674,9 +674,9 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·9908c99 (⌂|1)
                 └── ✂·60d9a56 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
@@ -713,9 +713,9 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·60d9a56 (⌂|1)
                 └── ✂·9d171ff (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {0}
+    └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
@@ -806,9 +806,9 @@ fn with_limits() -> anyhow::Result<()> {
                     └── →:1: (main)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:C[🌳] <> ✓! on edc4dee
-    └── ≡:0:C[🌳] on edc4dee {0}
+    └── ≡:0:C[🌳] on edc4dee {1}
         └── :0:C[🌳]
             ├── ·2a95729
             ├── ·6861158
@@ -840,9 +840,9 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     ");
 
     // But special handling for workspace views.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·3686017
             ├── ·9725482
@@ -863,9 +863,9 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
         └── ·85efbe4 (⌂|1) ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             └── ·85efbe4 ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
     ");

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -771,9 +771,9 @@ fn minimal_merge_no_refs() -> anyhow::Result<()> {
 
     // This a very untypical setup, but it's not forbidden. Code might want to check
     // if the workspace commit is actually managed before proceeding.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:gitbutler/workspace[🌳] <> ✓!
-    └── ≡:0:gitbutler/workspace[🌳] {0}
+    └── ≡:0:gitbutler/workspace[🌳] {1}
         └── :0:gitbutler/workspace[🌳]
             ├── ·47e1cf1
             ├── ·f40fb16
@@ -821,9 +821,9 @@ fn segment_on_each_incoming_connection() -> anyhow::Result<()> {
                     └── →:3:
     ");
     // This is an unmanaged workspace, even though commits from a workspace flow into it.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:entrypoint <> ✓!
-    └── ≡:0:entrypoint {0}
+    └── ≡:0:entrypoint {1}
         └── :0:entrypoint
             ├── ·98c5aba
             ├── ·807b6ce
@@ -879,9 +879,9 @@ fn minimal_merge() -> anyhow::Result<()> {
     ");
 
     // Without workspace data this becomes a single-branch workspace, with `main` as normal segment.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:gitbutler/workspace[🌳] <> ✓!
-    └── ≡:0:gitbutler/workspace[🌳] {0}
+    └── ≡:0:gitbutler/workspace[🌳] {1}
         ├── :0:gitbutler/workspace[🌳]
         │   └── ·47e1cf1
         ├── :1:merge-2
@@ -1039,9 +1039,9 @@ fn just_init_with_branches() -> anyhow::Result<()> {
 
     // There is no workspace as `main` is the base of the workspace, so it's shown directly,
     // outside the workspace.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] <> origin/main →:2: {0}
+    └── ≡:0:main[🌳] <> origin/main →:2: {1}
         └── :0:main[🌳] <> origin/main →:2:
             └── ❄️fafd9d0 (🏘️|✓) ►A, ►B, ►C, ►D, ►E, ►F
     ");
@@ -1084,9 +1084,9 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     ");
 
     // ~~There is no segmentation outside the workspace.~~ workspace segmentation always happens so the view is consistent.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] <> origin/main →:2: {0}
+    └── ≡:0:main[🌳] <> origin/main →:2: {1}
         └── :0:main[🌳] <> origin/main →:2:
             └── ❄️fafd9d0 (🏘️|✓)
     ");
@@ -1505,9 +1505,9 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
 
     // If it's checked out, we must show it, but it's not part of the workspace.
     // This is special as other segments still are.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main <> origin/main →:2:⇣2 {0}
+    └── ≡:0:main <> origin/main →:2:⇣2 {1}
         └── :0:main <> origin/main →:2:⇣2
             ├── 🟣ca7baa7 (✓)
             ├── 🟣7ea1468 (✓)
@@ -2164,9 +2164,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                     └── →:0: (A)
     ");
     // It looks like some commits are missing, but it's a first-parent traversal.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:A <> ✓!
-    └── ≡:0:A {0}
+    └── ≡:0:A {1}
         ├── :0:A
         │   ├── ·79bbb29 (🏘️|✓)
         │   ├── ·fc98174 (🏘️|✓)
@@ -2215,9 +2215,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                     └── →:0: (A)
     ");
     // Because the branch is integrated, the surrounding workspace isn't shown.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:A <> ✓!
-    └── ≡:0:A {0}
+    └── ≡:0:A {1}
         └── :0:A
             ├── ·79bbb29 (🏘️|✓)
             ├── ·fc98174 (🏘️|✓)
@@ -2272,9 +2272,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                         └── →:6: (A)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:DETACHED <> ✓! on 79bbb29
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         ├── :0:anon:
         │   ├── ·d0df794 (✓)
         │   ├── ·09c6e08 (✓)
@@ -2331,9 +2331,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                         └── →:5: (A)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:DETACHED <> ✓! on 79bbb29
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         ├── :0:anon:
         │   ├── ·d0df794 (✓)
         │   ├── ·09c6e08 (✓)
@@ -2481,9 +2481,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     ");
 
     // The entrypoint isn't contained in the workspace anymore, so it's standalone.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:A <> ✓!
-    └── ≡:0:A {0}
+    └── ≡:0:A {1}
         ├── :0:A
         │   ├── ❄79bbb29 (🏘️|✓)
         │   ├── ❄fc98174 (🏘️|✓)
@@ -2528,9 +2528,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, standard_options())?
         .validated()?;
     // When the branch is below the forkpoint, the workspace also isn't shown anymore.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main <> origin/main →:2:⇣3 {0}
+    └── ≡:0:main <> origin/main →:2:⇣3 {1}
         └── :0:main <> origin/main →:2:⇣3
             ├── 🟣d0df794 (✓)
             ├── 🟣09c6e08 (✓)
@@ -2543,9 +2543,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     let id = id_by_rev(&repo, "main~1");
     let graph = Graph::from_commit_traversal(id, None, &*meta, standard_options())?.validated()?;
     // Detached states are also possible.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         └── :0:anon:
             ├── ·34d0715 (🏘️|✓)
             └── ·eb5f731 (🏘️|✓)
@@ -2980,9 +2980,9 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
                     └── →:3: (workspace)
     ");
     // Entrypoint is outside of workspace.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {0}
+    └── ≡:0:main {1}
         └── :0:main
             ├── ·2438292 (🏘️|✓)
             ├── ·c056b75 (🏘️|✓)
@@ -3047,9 +3047,9 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
                     └── →:3: (workspace)
     ");
     // The limit is visible as well.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {0}
+    └── ≡:0:main {1}
         └── :0:main
             ├── ·2438292 (🏘️|✓)
             ├── ·c056b75 (🏘️|✓)
@@ -3269,9 +3269,9 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
                             └── →:4: (main-to-workspace)
     ");
     // `main` is integrated, but the entrypoint so it's shown.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {0}
+    └── ≡:0:main {1}
         └── :0:main
             ├── ·bce0c5e (🏘️|✓)
             └── ·3183e43 (🏘️|✓) ►A, ►B

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -46,9 +46,9 @@ fn four_commits_with_short_traversal() -> Result<()> {
     let graph = Graph::from_head(&repo, &*meta, options)?.validated()?;
     let workspace = graph.to_workspace()?;
 
-    insta::assert_snapshot!(graph_workspace(&workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&workspace), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·120e3a9
             └── ❌·a96434e

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -136,9 +136,9 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     ));
     let ws = graph.to_workspace()?;
     // note how the remote isn't interesting as we have no target configured, nor an extra target.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 3183e43
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -354,9 +354,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             └── ·e5d0542 ►A, ►B
     ");
@@ -500,9 +500,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             └── ·e5d0542 ►A, ►B
     ");
@@ -583,9 +583,9 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     let graph = but_graph::Graph::from_commit_traversal(b_id, b_ref, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
     // Note how the existing `gitbutler/workspace` disappears, which is expected here.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:1:B <> ✓!
-    └── ≡:1:B {0}
+    └── ≡:1:B {1}
         └── :1:B
             └── ·e5d0542 ►A, ►main
     ");
@@ -636,9 +636,9 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     graph.options.extra_target_commit_id = None;
     let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·b1540e5
             └── ·e31e6ca
@@ -736,9 +736,9 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     ");
 
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 3183e43
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -892,9 +892,9 @@ fn detached_head_journey() -> anyhow::Result<()> {
     * 3183e43 (main) M1
     ");
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓! on 3183e43
-    └── ≡:0:anon: on 3183e43 {0}
+    └── ≡:0:anon: on 3183e43 {1}
         └── :0:anon:
             └── ·aaa195b ►C
     ");
@@ -1027,9 +1027,9 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     ");
 
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 85efbe4
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -1132,9 +1132,9 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     ");
 
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 85efbe4
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -1809,9 +1809,9 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
 
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -1849,9 +1849,9 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     "#);
 
     let ws = out.graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1260,9 +1260,9 @@ fn errors() -> anyhow::Result<()> {
     let (repo, mut meta) = named_read_only_in_memory_scenario("unborn-empty", "")?;
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
@@ -1294,9 +1294,9 @@ fn errors() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             └── ·c166d42
     ");
@@ -1394,9 +1394,9 @@ fn errors() -> anyhow::Result<()> {
 
     let graph = but_graph::Graph::from_commit_traversal(a_id, a_ref, &*meta, Options::limited())?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:A <> ✓!
-    └── ≡:0:A {0}
+    └── ≡:0:A {1}
         ├── :0:A
         │   ├── ·89cc2d3
         │   └── ·d79bba9
@@ -1446,9 +1446,9 @@ fn errors() -> anyhow::Result<()> {
         },
     )?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:A <> ✓! on 89cc2d3
-    └── ≡:0:A {0}
+    └── ≡:0:A {1}
         └── :0:A
     ");
 
@@ -1500,9 +1500,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_head(&repo, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
             ├── ·281da94
             ├── ·12995d7
@@ -1523,9 +1523,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
     .expect("this works as the branch is unique");
 
     // We always add metadata to new branches.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
         │   └── ·281da94
         └── 📙:1:below-main
@@ -1556,9 +1556,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
         None,
     )?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
         │   └── ·281da94
         └── 📙:1:below-main
@@ -1577,9 +1577,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
         None,
     )?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
         │   └── ·281da94
         ├── 📙:1:below-main
@@ -1622,9 +1622,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
         "no data was stored, it wasn't stored before either, for independent branches\
             There should be no benefit doing that."
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡:0:main[🌳] {0}
+    └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
         │   └── ·281da94
         ├── 📙:1:below-main
@@ -1652,9 +1652,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
         "Data is created/updated for dependent branches though,
             which is a way to make segments appear if there were not visible before due to ambiguity."
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
-    └── ≡📙:0:main[🌳] {0}
+    └── ≡📙:0:main[🌳] {1}
         ├── 📙:0:main[🌳]
         │   └── ·281da94
         ├── 📙:1:below-main
@@ -1679,9 +1679,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     let graph = but_graph::Graph::from_commit_traversal(id, None, &meta, Default::default())?;
     let ws = graph.to_workspace()?;
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         └── :0:anon:
             ├── ·12995d7
             └── ·3d57fc1
@@ -1702,9 +1702,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         None,
     )?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon: {0}
+    └── ≡:0:anon: {1}
         ├── :0:anon:
         │   └── ·12995d7
         └── 📙:1:first
@@ -1744,9 +1744,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         None,
     )?;
     let ws = graph.to_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:second <> ✓!
-    └── ≡📙:0:second {0}
+    └── ≡📙:0:second {1}
         ├── 📙:0:second
         │   └── ·12995d7
         └── 📙:1:first
@@ -1783,9 +1783,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     )?;
     let ws = graph.to_workspace()?;
     // And the extra-target serves as base also in single-branch mode.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:second <> ✓! on 3d57fc1
-    └── ≡📙:0:second on 3d57fc1 {0}
+    └── ≡📙:0:second on 3d57fc1 {1}
         └── 📙:0:second
             └── ·12995d7
     ");

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -29,7 +29,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [
@@ -124,7 +124,7 @@ fn detached() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [
@@ -187,7 +187,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [
@@ -302,7 +302,7 @@ fn single_branch() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [
@@ -426,7 +426,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -36,7 +36,7 @@ fn j01_unborn() -> anyhow::Result<()> {
             stacks: [
                 Stack {
                     id: Some(
-                        00000000-0000-0000-0000-000000000000,
+                        00000000-0000-0000-0000-000000000001,
                     ),
                     base: None,
                     segments: [
@@ -91,7 +91,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
             stacks: [
                 Stack {
                     id: Some(
-                        00000000-0000-0000-0000-000000000000,
+                        00000000-0000-0000-0000-000000000001,
                     ),
                     base: None,
                     segments: [
@@ -152,7 +152,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
             stacks: [
                 Stack {
                     id: Some(
-                        00000000-0000-0000-0000-000000000000,
+                        00000000-0000-0000-0000-000000000001,
                     ),
                     base: None,
                     segments: [
@@ -206,7 +206,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
             stacks: [
                 Stack {
                     id: Some(
-                        00000000-0000-0000-0000-000000000000,
+                        00000000-0000-0000-0000-000000000001,
                     ),
                     base: None,
                     segments: [

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -2847,7 +2847,7 @@ fn disjoint() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [
@@ -3584,7 +3584,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: None,
                 segments: [


### PR DESCRIPTION
Make the SBR StackID 1 so we still have 0 to possibly identify 'null' as special case. Null also typically has a special meaning in programming, so let's not confuse anyone. `1` also nicely highlights the 'single' in single-branch-mode.
