### PR TITLE
Refactor graph access

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -13,9 +13,9 @@ pub fn apply_only(
     ctx: &but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, mut meta, graph) =
-        ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let ws = graph.to_workspace()?;
     let out = but_workspace::branch::apply(
         existing_branch,
@@ -65,8 +65,8 @@ pub fn apply(
 #[instrument(err(Debug))]
 pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges> {
     let guard = ctx.shared_worktree_access();
-    let (repo, _meta, graph) =
-        ctx.graph_and_meta_and_repo_from_head(ctx.repo.get()?.clone(), guard.read_permission())?;
+    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let reference = repo.find_reference(&branch)?;
     let ws = graph.to_workspace()?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, reference.name())

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -16,8 +16,9 @@ pub fn commit_reword_only(
     commit_id: gix::ObjectId,
     message: BString,
 ) -> anyhow::Result<gix::ObjectId> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, _, graph) = ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 
     let (outcome, edited_commit_selector) =
@@ -102,8 +103,9 @@ pub fn commit_insert_blank_only(
     relative_to: ui::RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<gix::ObjectId> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, _, graph) = ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 
     let relative_to = (&relative_to).into();
@@ -155,8 +157,9 @@ pub fn commit_move_changes_between_only(
     destination_commit_id: json::HexHash,
     changes: Vec<but_core::DiffSpec>,
 ) -> anyhow::Result<json::UIMoveChangesResult> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, _, graph) = ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 
     let outcome = move_changes_between_commits(

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -74,9 +74,9 @@ pub fn create_reference(
         })
         .transpose()?;
 
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, mut meta, graph) =
-        ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let graph = but_workspace::branch::create_reference(
         new_ref.clone(),
         anchor,
@@ -105,8 +105,8 @@ pub fn create_branch(
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     use but_workspace::branch::create_reference::Position::Above;
     let mut guard = ctx.exclusive_worktree_access();
-    let (repo, mut meta, graph) =
-        ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let ws = graph.to_workspace()?;
     let stack = ws.try_find_stack_by_id(stack_id)?;
     let new_ref = Category::LocalBranch
@@ -160,8 +160,8 @@ pub fn create_branch(
 pub fn remove_branch(project_id: ProjectId, stack_id: StackId, branch_name: String) -> Result<()> {
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let mut guard = ctx.exclusive_worktree_access();
-    let (repo, mut meta, graph) =
-        ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let ws = graph.to_workspace()?;
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name.as_str())

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -38,9 +38,9 @@ pub fn create_virtual_branch(
 ) -> Result<StackEntryNoOpt> {
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let stack_entry = {
-        let mut guard = ctx.exclusive_worktree_access();
-        let (repo, mut meta, graph) =
-            ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+        let guard = ctx.exclusive_worktree_access();
+        let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+        let repo = ctx.repo.get()?;
         let ws = graph.to_workspace()?;
         let new_ref = Category::LocalBranch
             .to_full_name(

--- a/crates/but-ctx/src/legacy.rs
+++ b/crates/but-ctx/src/legacy.rs
@@ -79,8 +79,6 @@ impl Context {
     ///
     /// The write-permission is required to obtain a mutable metadata instance. Note that it must be held
     /// for until the end of the operation for the protection to be effective.
-    ///
-    /// Use [`Self::graph_and_meta_and_repo_from_head()`] if control over the repository configuration is needed.
     pub fn graph_and_legacy_meta_mut_and_repo_from_reference(
         &self,
         ref_name: &gix::refs::FullNameRef,

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -4,10 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
-use but_core::{
-    RepositoryExt,
-    sync::{WorktreeReadPermission, WorktreeWritePermission},
-};
+use but_core::{RepositoryExt, sync::WorktreeReadPermission};
 use but_settings::AppSettings;
 
 /// Legacy types that shouldn't be used.
@@ -229,44 +226,20 @@ impl Context {
 
 /// Trampolines that create new uncached instances of major types.
 impl Context {
-    /// Open the repository with standard options and create a new Graph traversal from the current HEAD,
-    /// along with a new metadata instance, and the graph itself.
+    /// Create a new Graph traversal from the current HEAD.
     ///
-    /// The write-permission is required to obtain a mutable metadata instance. Note that it must be held
-    /// for until the end of the operation for the protection to be effective.
-    ///
-    /// Use [`Self::graph_and_meta_and_repo_from_head()`] if control over the repository configuration is needed.
-    pub fn graph_and_meta_mut_and_repo_from_head(
-        &self,
-        _write: &mut WorktreeWritePermission,
-    ) -> anyhow::Result<(
-        gix::Repository,
-        impl but_core::RefMetadata + 'static,
-        but_graph::Graph,
-    )> {
-        let repo = self.repo.get()?;
-        let meta = self.meta_inner()?;
-        let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
-        Ok((repo.clone(), meta, graph))
-    }
-
-    /// Create a new Graph traversal from the current HEAD, using (and returning) the given `repo` (configured by the caller),
-    /// along with a new metadata instance, and the graph itself.
+    /// Returns a new metadata instance, and the graph itself.
     ///
     /// The read-permission is required to obtain a shared metadata instance. Note that it must be held
     /// for until the end of the operation for the protection to be effective.
-    pub fn graph_and_meta_and_repo_from_head(
+    pub fn graph_and_meta_from_head(
         &self,
-        repo: gix::Repository,
         _read_only: &WorktreeReadPermission,
-    ) -> anyhow::Result<(
-        gix::Repository,
-        impl but_core::RefMetadata + 'static,
-        but_graph::Graph,
-    )> {
+    ) -> anyhow::Result<(impl but_core::RefMetadata + 'static, but_graph::Graph)> {
+        let repo = self.repo.get()?;
         let meta = self.meta_inner()?;
         let graph = but_graph::Graph::from_head(&repo, &meta, but_graph::init::Options::limited())?;
-        Ok((repo, meta, graph))
+        Ok((meta, graph))
     }
 
     fn meta_inner(&self) -> anyhow::Result<but_meta::VirtualBranchesTomlMetadata> {

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -555,9 +555,9 @@ pub fn remove_reference(
 
 pub fn apply(args: &super::Args, short_name: &str, order: Option<usize>) -> anyhow::Result<()> {
     let ctx = but_ctx::Context::discover(&args.current_dir)?;
-    let mut guard = ctx.exclusive_worktree_access();
-    let (repo, mut meta, graph) =
-        ctx.graph_and_meta_mut_and_repo_from_head(guard.write_permission())?;
+    let guard = ctx.exclusive_worktree_access();
+    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let repo = ctx.repo.get()?;
     let branch = repo.find_reference(short_name)?;
     let ws = graph.to_workspace()?;
     let apply_outcome = but_workspace::branch::apply(

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -22,7 +22,7 @@ pub fn worktree_new(
 ) -> Result<NewWorktreeOutcome> {
     let repo = &*ctx.repo.get()?;
 
-    let (repo, _, graph) = ctx.graph_and_meta_and_repo_from_head(repo.clone(), perm)?;
+    let (_, graph) = ctx.graph_and_meta_from_head(perm)?;
     let ws = graph.to_workspace()?;
     if !ws.refname_is_segment(refname) {
         bail!("Branch not found in workspace");
@@ -52,7 +52,7 @@ pub fn worktree_new(
         base: to_checkout.detach(),
     };
 
-    save_worktree_meta(&repo, meta)?;
+    save_worktree_meta(repo, meta)?;
 
     Ok(NewWorktreeOutcome {
         created: Worktree {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -121,7 +121,9 @@ impl BranchManager<'_> {
         // Assume that this is always about 'apply' and hijack the entire method.
         // That way we'd learn what's missing.
         if self.ctx.settings().feature_flags.apply3 {
-            let (repo, mut meta, graph) = self.ctx.graph_and_meta_mut_and_repo_from_head(perm)?;
+            let (mut meta, graph) = self.ctx.graph_and_meta_from_head(perm.read_permission())?;
+            let repo = self.ctx.repo.get()?;
+
             let ws = graph.to_workspace()?;
             let target = target.to_string();
             let branch_to_apply = target.as_str().try_into()?;


### PR DESCRIPTION
This reduces the interface of the graph & metadata access function from the ctx.

The remaining `graph_and_meta_from_head` only reads, so at least to me it seems reasonable that we only need the `read_permission()`.

Managing write permissions should be a responsibility of the metadata strucutre, perhaps having a read-only and writable variant. Whatever path is taken there, it really doesn’t seem sensible to have a writable permission required in one of these graph creation methods.