### PR TITLE
demo of `status` output with local and remote commits

### DIFF
--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -1,0 +1,50 @@
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .italic { font-style: italic; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>┊│     </tspan><tspan class="underline">h0</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">28baf9a</tspan><tspan> (upstream) ⏫ 1 new commits </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>├╯ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="208px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -75,6 +75,25 @@ Error: No push remote set
 }
 
 #[test]
+fn remote_and_local_files() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("remote-local-divergence")?;
+
+    // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
+    env.setup_metadata(&["main"])?;
+
+    env.but("status --files")
+        .with_color_for_svg()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::file![
+            "snapshots/status/remote-and-local-files.stdout.term.svg"
+        ]);
+
+    Ok(())
+}
+
+#[test]
 fn json_shows_paths_as_strings() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 

--- a/crates/but/tests/fixtures/scenario/remote-local-divergence.sh
+++ b/crates/but/tests/fixtures/scenario/remote-local-divergence.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+commit-file M
+commit-file only-on-remote
+setup_target_to_match_main
+git reset --hard @~1
+
+commit-file only-on-local
+create_workspace_commit_once main
+# git log --decorate --oneline --graph gitbutler/workspace refs/remotes/origin/main >/tmp/x
+# * df9a986 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+# * 643ade3 (main) add only-on-local
+# | * 28baf9a (origin/main, origin/HEAD) add only-on-remote
+# |/  
+# * 0dc3733 add M
+


### PR DESCRIPTION
Here's a demo of `but status` output when local and remote commits diverge. The `git status` output in the .sh file is as I expect, but not the `but status` output. In particular, the "[origin/main]" is in the wrong place (it should be on 28baf9a), and looking at the code, I expect "upstream: on" (crates/but/src/command/legacy/status/mod.rs:640) to be printed, but it is not.

DO NOT SUBMIT
