### PR TITLE
diff: get id-assignment pairs from `IdMap`

### DIFF
--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -25,22 +25,18 @@ pub fn handle(
             .ok_or_else(|| anyhow::anyhow!("No ID found for entity"))?;
 
         match id {
-            CliId::Uncommitted(id) => {
-                show::worktree(wt_changes, id_map, out, Some(Filter::Uncommitted(id)))
-            }
-            CliId::Unassigned { .. } => {
-                show::worktree(wt_changes, id_map, out, Some(Filter::Unassigned))
-            }
+            CliId::Uncommitted(id) => show::worktree(id_map, out, Some(Filter::Uncommitted(id))),
+            CliId::Unassigned { .. } => show::worktree(id_map, out, Some(Filter::Unassigned)),
             CliId::CommittedFile {
                 commit_id, path, ..
             } => show::commit(ctx, out, commit_id, Some(path)),
             CliId::Branch { name, .. } => show::branch(ctx, out, name),
             CliId::Commit { commit_id: id, .. } => show::commit(ctx, out, id, None),
             CliId::Stack { id: _, stack_id } => {
-                show::worktree(wt_changes, id_map, out, Some(Filter::Stack(stack_id)))
+                show::worktree(id_map, out, Some(Filter::Stack(stack_id)))
             }
         }
     } else {
-        show::worktree(wt_changes, id_map, out, None)
+        show::worktree(id_map, out, None)
     }
 }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -161,7 +161,7 @@ pub struct IdMap {
     /// It's public for convenience in `but rub` currently.
     pub uncommitted_files: BTreeMap<ShortId, UncommittedFile>,
     /// Uncommitted hunks.
-    uncommitted_hunks: HashMap<ShortId, UncommittedHunk>,
+    pub uncommitted_hunks: HashMap<ShortId, UncommittedHunk>,
     /// Committed files with their assigned IDs
     committed_files: BTreeSet<CommittedFile>,
 }
@@ -480,22 +480,6 @@ impl IdMap {
         self.stack_ids.get(&stack_id)
     }
 
-    /// Returns the [`CliId::Uncommitted`] for a given hunk assignment, if it exists.
-    ///
-    /// Searches for a matching hunk assignment in the uncommitted hunks map and returns
-    /// its corresponding CLI ID if found.
-    pub fn resolve_uncommitted_hunk(&self, hunk: &HunkAssignment) -> Option<CliId> {
-        self.uncommitted_hunks.iter().find_map(|(id, uh)| {
-            (uh.hunk_assignment == *hunk).then(|| {
-                CliId::Uncommitted(UncommittedCliId {
-                    id: id.clone(),
-                    hunk_assignments: NonEmpty::new(hunk.clone()),
-                    is_entire_file: false, // TODO: figure out if we can know this here
-                })
-            })
-        })
-    }
-
     /// Returns the [`CliId::Unassigned`] for the unassigned area, which is useful as an
     /// ID for a destination of operations.
     ///
@@ -742,7 +726,9 @@ impl Borrow<str> for CommittedFile {
     }
 }
 
+/// An uncommitted hunk.
 #[derive(Debug)]
-struct UncommittedHunk {
-    hunk_assignment: HunkAssignment,
+pub struct UncommittedHunk {
+    /// The hunk assignment.
+    pub hunk_assignment: HunkAssignment,
 }


### PR DESCRIPTION
Currently, `diff` obtains worktree changes, passes them to `IdMap`, and then iterates through the worktree changes itself to find relevant hunks to present to the user while consulting `IdMap` about their CLI IDs. Each hunk definitely has a CLI ID (because the worktree changes as seen by `IdMap` and by `diff` are the same), but this is not known to the type checker, so `IdMap` has to defensively include a fallback.

Teach `diff` to use `IdMap`'s map of IDs to hunks directly so that the type checker knows that each hunk has an ID and we do not need to defensively include a fallback.

Note that we need to sort the hunks before displaying them to the user. We cannot use a `BTreeMap` or similar because `ShortId`s are not sortable by generation order (e.g. `zy` is generated before `g00`, but will not sort that way). Perhaps in the future, if we have a map that maintains insertion order, we could use that.
