### PR TITLE
Add `Graph::into_workspace()` to have a fully-owned version.

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -14,9 +14,8 @@ pub fn apply_only(
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
     let guard = ctx.exclusive_worktree_access();
-    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.into_workspace()?;
     let out = but_workspace::branch::apply(
         existing_branch,
         &ws,
@@ -65,9 +64,8 @@ pub fn apply(
 #[instrument(err(Debug))]
 pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges> {
     let guard = ctx.shared_worktree_access();
-    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (_, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let reference = repo.find_reference(&branch)?;
-    let ws = graph.into_workspace()?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, reference.name())
 }

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -16,7 +16,7 @@ pub fn apply_only(
     let guard = ctx.exclusive_worktree_access();
     let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     let out = but_workspace::branch::apply(
         existing_branch,
         &ws,
@@ -68,6 +68,6 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
     let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let reference = repo.find_reference(&branch)?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, reference.name())
 }

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -17,7 +17,7 @@ pub fn commit_reword_only(
     message: BString,
 ) -> anyhow::Result<gix::ObjectId> {
     let guard = ctx.exclusive_worktree_access();
-    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (_, graph) = ctx.graph_and_read_only_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 
@@ -104,7 +104,7 @@ pub fn commit_insert_blank_only(
     side: InsertSide,
 ) -> anyhow::Result<gix::ObjectId> {
     let guard = ctx.exclusive_worktree_access();
-    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (_, graph) = ctx.graph_and_read_only_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 
@@ -158,7 +158,7 @@ pub fn commit_move_changes_between_only(
     changes: Vec<but_core::DiffSpec>,
 ) -> anyhow::Result<json::UIMoveChangesResult> {
     let guard = ctx.exclusive_worktree_access();
-    let (_, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (_, graph) = ctx.graph_and_read_only_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let editor = graph.to_editor(&repo)?;
 

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -77,18 +77,18 @@ pub fn create_reference(
     let guard = ctx.exclusive_worktree_access();
     let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let graph = but_workspace::branch::create_reference(
+    let ws = graph.into_workspace()?;
+    let ws = but_workspace::branch::create_reference(
         new_ref.clone(),
         anchor,
         &repo,
-        &graph.to_workspace()?,
+        &ws,
         &mut meta,
         |_| StackId::generate(),
         None,
     )?;
 
-    let workspace = graph.to_workspace()?;
-    let stack_id = workspace
+    let stack_id = ws
         .find_segment_and_stack_by_refname(new_ref.as_ref())
         .and_then(|(stack, _)| stack.id);
 
@@ -107,7 +107,7 @@ pub fn create_branch(
     let mut guard = ctx.exclusive_worktree_access();
     let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     let stack = ws.try_find_stack_by_id(stack_id)?;
     let new_ref = Category::LocalBranch
         .to_full_name(request.name.as_str())
@@ -135,7 +135,7 @@ pub fn create_branch(
                 )
                 .or_else(|| {
                     Some(but_workspace::branch::create_reference::Anchor::AtCommit {
-                        commit_id: graph.tip_skip_empty(segment.id)?.id,
+                        commit_id: ws.graph.tip_skip_empty(segment.id)?.id,
                         position: Above,
                     })
                 })
@@ -162,7 +162,7 @@ pub fn remove_branch(project_id: ProjectId, stack_id: StackId, branch_name: Stri
     let mut guard = ctx.exclusive_worktree_access();
     let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name.as_str())
         .map_err(anyhow::Error::from)?;

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -75,9 +75,8 @@ pub fn create_reference(
         .transpose()?;
 
     let guard = ctx.exclusive_worktree_access();
-    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.into_workspace()?;
     let ws = but_workspace::branch::create_reference(
         new_ref.clone(),
         anchor,
@@ -105,9 +104,8 @@ pub fn create_branch(
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     use but_workspace::branch::create_reference::Position::Above;
     let mut guard = ctx.exclusive_worktree_access();
-    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.into_workspace()?;
     let stack = ws.try_find_stack_by_id(stack_id)?;
     let new_ref = Category::LocalBranch
         .to_full_name(request.name.as_str())
@@ -160,9 +158,8 @@ pub fn create_branch(
 pub fn remove_branch(project_id: ProjectId, stack_id: StackId, branch_name: String) -> Result<()> {
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let mut guard = ctx.exclusive_worktree_access();
-    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
-    let ws = graph.into_workspace()?;
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name.as_str())
         .map_err(anyhow::Error::from)?;

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -41,7 +41,7 @@ pub fn create_virtual_branch(
         let guard = ctx.exclusive_worktree_access();
         let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
         let repo = ctx.repo.get()?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         let new_ref = Category::LocalBranch
             .to_full_name(
                 branch
@@ -52,7 +52,7 @@ pub fn create_virtual_branch(
             )
             .map_err(anyhow::Error::from)?;
 
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             new_ref.as_ref(),
             None,
             &repo,
@@ -62,7 +62,6 @@ pub fn create_virtual_branch(
             branch.order,
         )?;
 
-        let ws = graph.to_workspace()?;
         let (stack_idx, segment_idx) = ws
             .find_segment_owner_indexes_by_refname(new_ref.as_ref())
             .context("BUG: didn't find a stack that was just created")?;

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -39,9 +39,8 @@ pub fn create_virtual_branch(
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let stack_entry = {
         let guard = ctx.exclusive_worktree_access();
-        let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+        let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
         let repo = ctx.repo.get()?;
-        let ws = graph.into_workspace()?;
         let new_ref = Category::LocalBranch
             .to_full_name(
                 branch

--- a/crates/but-core/src/branch.rs
+++ b/crates/but-core/src/branch.rs
@@ -12,7 +12,8 @@ pub struct SafeDelete {
 /// The outcome of [`SafeDelete::delete_reference()`]
 #[derive(Debug, Clone)]
 pub struct SafeDeleteOutcome<'parent> {
-    /// The paths to the worktrees that have the to-be-deleted reference checked out.
+    /// The paths to the worktrees that have the to-be-deleted reference checked out,
+    /// which is why the reference wasn't actually deleted.
     pub checked_out_in_worktree_dirs: Option<&'parent [PathBuf]>,
 }
 

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -226,13 +226,26 @@ impl Context {
 
 /// Trampolines that create new uncached instances of major types.
 impl Context {
-    /// Create a new Graph traversal from the current HEAD.
+    /// Create a new workspace as seen from the current HEAD and return it,
+    /// along with read-only metadata.
     ///
-    /// Returns a new metadata instance, and the graph itself.
+    /// The read-permission is required to obtain a shared metadata instance.
+    pub fn workspace_and_meta_from_head(
+        &self,
+        _read_only: &WorktreeReadPermission,
+    ) -> anyhow::Result<(
+        impl but_core::RefMetadata + 'static,
+        but_graph::projection::Workspace,
+    )> {
+        let (meta, graph) = self.graph_and_read_only_meta_from_head(_read_only)?;
+        Ok((meta, graph.into_workspace()?))
+    }
+
+    /// Create a new graph as seen from the current HEAD and return it,
+    /// along with read-only metadata.
     ///
-    /// The read-permission is required to obtain a shared metadata instance. Note that it must be held
-    /// for until the end of the operation for the protection to be effective.
-    pub fn graph_and_meta_from_head(
+    /// The read-permission is required to obtain a shared metadata instance.
+    pub fn graph_and_read_only_meta_from_head(
         &self,
         _read_only: &WorktreeReadPermission,
     ) -> anyhow::Result<(impl but_core::RefMetadata + 'static, but_graph::Graph)> {

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -786,14 +786,14 @@ impl Graph {
 
     /// Like [`Self::redo_traversal_with_overlay()`], but replaces this instance, without overlay, and returns
     /// a newly computed workspace for it.
-    pub fn workspace_of_redone_traversal(
-        &mut self,
+    pub fn into_workspace_of_redone_traversal(
+        mut self,
         repo: &gix::Repository,
         meta: &impl RefMetadata,
-    ) -> anyhow::Result<crate::projection::Workspace<'_>> {
+    ) -> anyhow::Result<crate::projection::Workspace> {
         let new = self.redo_traversal_with_overlay(repo, meta, Default::default())?;
-        *self = new;
-        self.to_workspace()
+        self = new;
+        self.into_workspace()
     }
 }
 

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -591,7 +591,7 @@ impl Graph {
             ws_low_bound_in_ws_sidx,
             ws_low_bound,
         )) = self
-            .to_workspace_inner(workspace::Downgrade::Disallow)
+            .to_workspace_state(workspace::Downgrade::Disallow)
             .ok()
             .and_then(|mut ws| {
                 let md = ws.metadata.take();

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -1310,7 +1310,6 @@ impl Workspace {
 
     /// Return the name of the workspace reference by looking our segment up in `graph`.
     /// Note that for managed workspaces, this can be retrieved via [`WorkspaceKind::Managed`].
-    /// Note that it can be expected to be set on any workspace, but the data would allow it to not be set.
     pub fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
         self.graph[self.id].ref_name()
     }

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -1,9 +1,3 @@
-use std::{
-    cell::RefCell,
-    collections::{BTreeSet, VecDeque},
-    fmt::Formatter,
-};
-
 use anyhow::Context as _;
 use bstr::{BStr, ByteSlice};
 use but_core::{
@@ -16,6 +10,11 @@ use but_core::{
 use gix::reference::Category;
 use itertools::Itertools;
 use petgraph::{Direction, prelude::EdgeRef, visit::NodeRef};
+use std::{
+    cell::RefCell,
+    collections::{BTreeSet, VecDeque},
+    fmt::Formatter,
+};
 use tracing::instrument;
 
 use crate::{
@@ -24,11 +23,11 @@ use crate::{
     segment,
 };
 
-/// A workspace is a list of [Stacks](Stack).
+/// A workspace reference is a list of [Stacks](Stack), with a reference to the underlying [`Graph`].
 #[derive(Clone)]
-pub struct Workspace<'graph> {
+pub struct Workspace {
     /// The underlying graph for providing simplified access to data.
-    pub graph: &'graph Graph,
+    pub graph: Graph,
     /// An ID which uniquely identifies the [graph segment](Segment) that represents the tip of the workspace.
     pub id: SegmentIndex,
     /// Specify what kind of workspace this is.
@@ -71,10 +70,53 @@ pub struct Workspace<'graph> {
     pub metadata: Option<ref_metadata::Workspace>,
 }
 
+/// A copy of all workspace state, to pass it around internally.
+pub(crate) struct WorkspaceState {
+    pub id: SegmentIndex,
+    pub kind: WorkspaceKind,
+    pub stacks: Vec<Stack>,
+    pub lower_bound: Option<gix::ObjectId>,
+    pub lower_bound_segment_id: Option<SegmentIndex>,
+    pub target_ref: Option<TargetRef>,
+    pub target_commit: Option<TargetCommit>,
+    pub extra_target: Option<SegmentIndex>,
+    pub metadata: Option<ref_metadata::Workspace>,
+}
+
+impl Workspace {
+    fn from_state(
+        graph: Graph,
+        WorkspaceState {
+            id,
+            kind,
+            stacks,
+            lower_bound,
+            lower_bound_segment_id,
+            target_ref,
+            target_commit,
+            extra_target,
+            metadata,
+        }: WorkspaceState,
+    ) -> Self {
+        Workspace {
+            graph,
+            id,
+            kind,
+            stacks,
+            lower_bound,
+            lower_bound_segment_id,
+            target_ref,
+            target_commit,
+            extra_target,
+            metadata,
+        }
+    }
+}
+
 pub type CommitOwnerIndexes = (usize, usize, CommitIndex);
 
 /// Utilities
-impl Workspace<'_> {
+impl Workspace {
     /// Return `true` if the workspace itself is where `HEAD` is pointing to.
     /// If `false`, one of the stack-segments is checked out instead.
     pub fn is_entrypoint(&self) -> bool {
@@ -167,20 +209,7 @@ impl Workspace<'_> {
         &self,
         ref_name: &gix::refs::FullNameRef,
     ) -> Option<(usize, usize)> {
-        self.stacks
-            .iter()
-            .enumerate()
-            .find_map(|(stack_idx, stack)| {
-                stack
-                    .segments
-                    .iter()
-                    .enumerate()
-                    .find_map(|(seg_idx, seg)| {
-                        seg.ref_name()
-                            .is_some_and(|rn| rn == ref_name)
-                            .then_some((stack_idx, seg_idx))
-                    })
-            })
+        find_segment_owner_indexes_by_refname(&self.stacks, ref_name)
     }
 
     /// Like [`Self::find_segment_owner_indexes_by_refname`], but fails with an error.
@@ -438,12 +467,22 @@ impl Graph {
     /// This affects what we consider to be the part of the workspace.
     /// Typically, that's a previous location of the target segment.
     #[instrument(level = "trace", skip(self), err(Debug))]
-    pub fn to_workspace(&self) -> anyhow::Result<Workspace<'_>> {
-        self.to_workspace_inner(workspace::Downgrade::Allow)
+    pub fn into_workspace(self) -> anyhow::Result<Workspace> {
+        let state = self.to_workspace_state(workspace::Downgrade::Allow)?;
+        Ok(Workspace::from_state(self, state))
     }
 
-    pub(crate) fn to_workspace_inner(&self, downgrade: Downgrade) -> anyhow::Result<Workspace<'_>> {
-        let (kind, metadata, mut ws_tip_segment, entrypoint_sidx, entrypoint_first_commit_flags) = {
+    pub(crate) fn to_workspace_state(
+        &self,
+        downgrade: Downgrade,
+    ) -> anyhow::Result<WorkspaceState> {
+        let (
+            mut kind,
+            mut metadata,
+            mut ws_tip_segment,
+            entrypoint_sidx,
+            entrypoint_first_commit_flags,
+        ) = {
             let ep = self.lookup_entrypoint()?;
             match ep.segment.workspace_metadata() {
                 None => {
@@ -493,29 +532,22 @@ impl Graph {
             }
         };
 
-        let mut ws = Workspace {
-            graph: self,
-            id: ws_tip_segment.id,
-            kind,
-            stacks: vec![],
-            target_ref: metadata.as_ref().and_then(|md| {
-                TargetRef::from_ref_name_without_commits_ahead(md.target_ref.as_ref()?, self)
-            }),
-            target_commit: metadata
-                .as_ref()
-                .and_then(|md| md.target_commit_id)
-                .and_then(|target_commit_id| TargetCommit::from_commit(target_commit_id, self)),
-            extra_target: self.extra_target,
-            metadata,
-            lower_bound_segment_id: None,
-            lower_bound: None,
-        };
+        let mut target_ref = metadata.as_ref().and_then(|md| {
+            TargetRef::from_ref_name_without_commits_ahead(md.target_ref.as_ref()?, self)
+        });
+        let mut target_commit = metadata
+            .as_ref()
+            .and_then(|md| md.target_commit_id)
+            .and_then(|target_commit_id| TargetCommit::from_commit(target_commit_id, self));
+        let extra_target = self.extra_target;
+        let mut id = ws_tip_segment.id;
+        let mut stacks = vec![];
 
-        let ws_lower_bound = if ws.kind.has_managed_ref() {
+        let ws_lower_bound = if kind.has_managed_ref() {
             self.compute_lowest_base(
-                ComputeBaseTip::WorkspaceCommit(ws.id),
-                ws.target_ref.as_ref(),
-                ws.target_commit.as_ref(),
+                ComputeBaseTip::WorkspaceCommit(id),
+                target_ref.as_ref(),
+                target_commit.as_ref(),
                 self.extra_target,
             )
             .or_else(|| {
@@ -536,9 +568,9 @@ impl Graph {
             })
         } else {
             // Auto-set the target by its remote.
-            if ws.target_ref.is_none() {
-                let ws_head_segment = &self[ws.id];
-                ws.target_ref = ws_head_segment
+            if target_ref.is_none() {
+                let ws_head_segment = &self[id];
+                target_ref = ws_head_segment
                     .remote_tracking_ref_name
                     .as_ref()
                     .zip(ws_head_segment.sibling_segment_id)
@@ -548,11 +580,11 @@ impl Graph {
                         commits_ahead: 0,
                     });
             }
-            if ws.target_ref.is_some() || ws.target_commit.is_some() || ws.extra_target.is_some() {
+            if target_ref.is_some() || target_commit.is_some() || extra_target.is_some() {
                 self.compute_lowest_base(
-                    ComputeBaseTip::SingleBranch(ws.id),
-                    ws.target_ref.as_ref(),
-                    ws.target_commit.as_ref(),
+                    ComputeBaseTip::SingleBranch(id),
+                    target_ref.as_ref(),
+                    target_commit.as_ref(),
                     self.extra_target,
                 )
             } else {
@@ -560,7 +592,7 @@ impl Graph {
             }
         };
 
-        (ws.lower_bound, ws.lower_bound_segment_id) = ws_lower_bound
+        let (mut lower_bound, mut lower_bound_segment_id) = ws_lower_bound
             .map(|(a, b)| (Some(a), Some(b)))
             .unwrap_or_default();
 
@@ -581,34 +613,22 @@ impl Graph {
         {
             // We cannot reach the lowest workspace base, by definition reachable through any path downward,
             // so we are outside the workspace limits which is above us. Turn the data back into entrypoint-only.
-            let Workspace {
-                graph: _,
-                id,
-                kind: head,
-                stacks: _,
-                target_ref,
-                target_commit,
-                metadata,
-                extra_target: _,
-                lower_bound,
-                lower_bound_segment_id,
-            } = &mut ws;
-            *id = ep_sidx;
-            *head = WorkspaceKind::AdHoc;
-            *target_ref = None;
-            *target_commit = None;
-            *metadata = None;
+            id = ep_sidx;
+            kind = WorkspaceKind::AdHoc;
+            target_ref = None;
+            target_commit = None;
+            metadata = None;
             ws_tip_segment = &self[ep_sidx];
-            *lower_bound = None;
-            *lower_bound_segment_id = None;
+            lower_bound = None;
+            lower_bound_segment_id = None;
         }
 
-        if ws.kind.has_managed_ref() && self[ws.id].commits.is_empty() {
+        if kind.has_managed_ref() && self[id].commits.is_empty() {
             let ref_info = ws_tip_segment
                 .ref_info
                 .as_ref()
                 .expect("BUG: must be set or we wouldn't be here");
-            ws.kind = WorkspaceKind::ManagedMissingWorkspaceCommit {
+            kind = WorkspaceKind::ManagedMissingWorkspaceCommit {
                 ref_info: ref_info.clone(),
             };
         }
@@ -620,7 +640,7 @@ impl Graph {
 
         let (lowest_base, lowest_base_sidx) =
             ws_lower_bound.map_or((None, None), |(base, sidx)| (Some(base), Some(sidx)));
-        if ws.kind.has_managed_ref() {
+        if kind.has_managed_ref() {
             let mut used_stack_ids = BTreeSet::default();
             for stack_top_sidx in self
                 .inner
@@ -628,7 +648,7 @@ impl Graph {
             {
                 let stack_segment = &self[stack_top_sidx];
                 let has_seen_base = RefCell::new(false);
-                ws.stacks.extend(
+                stacks.extend(
                     self.collect_stack_segments(
                         stack_top_sidx,
                         entrypoint_sidx,
@@ -670,11 +690,11 @@ impl Graph {
                                     .neighbors_directed(s.id, Direction::Incoming)
                                     .all(|n| n.id() != ws_tip_segment.id)
                         },
-                        |s| Some(s.id) == ws.lower_bound_segment_id && s.metadata.is_none(),
+                        |s| Some(s.id) == lower_bound_segment_id && s.metadata.is_none(),
                     )?
                     .and_then(|segments| {
                         let stack_id = find_matching_stack_id(
-                            ws.metadata.as_ref(),
+                            metadata.as_ref(),
                             &segments,
                             &mut used_stack_ids,
                         );
@@ -732,21 +752,32 @@ impl Graph {
                     )
                 });
             if let Some(stack) = maybe_stack {
-                ws.stacks.push(stack);
+                stacks.push(stack);
             } else {
                 tracing::warn!(
-                    ?ws,
                     "Didn't get a single stack for AdHoc workspace - this is unexpected"
                 );
             }
         }
 
-        if let Some(target) = ws.target_ref.as_mut() {
-            target.compute_and_set_commits_ahead(self, ws.lower_bound_segment_id);
+        if let Some(target) = target_ref.as_mut() {
+            target.compute_and_set_commits_ahead(self, lower_bound_segment_id);
         }
 
+        let mut ws = WorkspaceState {
+            id,
+            kind,
+            stacks,
+            lower_bound,
+            lower_bound_segment_id,
+            target_ref,
+            target_commit,
+            extra_target,
+            metadata,
+        };
+
         ws.prune_archived_segments();
-        ws.mark_remote_reachability()?;
+        ws.mark_remote_reachability(self)?;
         ws.truncate_single_stack_to_match_base();
         Ok(ws)
     }
@@ -1075,7 +1106,7 @@ impl Graph {
 }
 
 /// More processing
-impl Workspace<'_> {
+impl WorkspaceState {
     /// Match the archived flag from our workspace metadata by name with actual segments and prune them,
     /// top to bottom, but only if they are empty all the way down for safety.
     /// Doing so naturally shows segments that we have to show, independently of the archived flag.
@@ -1088,7 +1119,9 @@ impl Workspace<'_> {
     ///
     /// Remove the whole stack if everything is archived.
     fn prune_archived_segments(&mut self) {
-        let Some(md) = &self.metadata else { return };
+        let Some(md) = &self.metadata else {
+            return;
+        };
         let archived_stack_branches = md.stacks(Applied).flat_map(|s| {
             s.branches
                 .iter()
@@ -1097,7 +1130,7 @@ impl Workspace<'_> {
         let mut empty_stacks_to_remove = Vec::new();
         for archived_ref_name in archived_stack_branches {
             let Some((stack_idx, segment_idx)) =
-                self.find_segment_owner_indexes_by_refname(archived_ref_name)
+                find_segment_owner_indexes_by_refname(&self.stacks, archived_ref_name)
             else {
                 continue;
             };
@@ -1126,7 +1159,7 @@ impl Workspace<'_> {
 
     /// Trace the remotes of each segments down to their segment or other segments and set the commit flags accordingly
     /// to indicate if a commit in the workspace is reachable, and how.
-    fn mark_remote_reachability(&mut self) -> anyhow::Result<()> {
+    fn mark_remote_reachability(&mut self, graph: &Graph) -> anyhow::Result<()> {
         let remote_refs: Vec<_> = self
             .stacks
             .iter()
@@ -1139,7 +1172,6 @@ impl Workspace<'_> {
                 })
             })
             .collect();
-        let graph = self.graph;
         for (remote_tracking_ref_name, remote_sidx) in remote_refs {
             let mut remote_commits = Vec::new();
             let mut may_take_commits_from_first_remote = graph[remote_sidx].commits.is_empty();
@@ -1251,8 +1283,25 @@ impl Workspace<'_> {
     }
 }
 
+fn find_segment_owner_indexes_by_refname(
+    stacks: &[Stack],
+    ref_name: &gix::refs::FullNameRef,
+) -> Option<(usize, usize)> {
+    stacks.iter().enumerate().find_map(|(stack_idx, stack)| {
+        stack
+            .segments
+            .iter()
+            .enumerate()
+            .find_map(|(seg_idx, seg)| {
+                seg.ref_name()
+                    .is_some_and(|rn| rn == ref_name)
+                    .then_some((stack_idx, seg_idx))
+            })
+    })
+}
+
 /// Query
-impl<'graph> Workspace<'graph> {
+impl Workspace {
     /// Return `true` if the workspace has workspace metadata associated with it.
     /// This is relevant when creating references for example.
     pub fn has_metadata(&self) -> bool {
@@ -1262,12 +1311,12 @@ impl<'graph> Workspace<'graph> {
     /// Return the name of the workspace reference by looking our segment up in `graph`.
     /// Note that for managed workspaces, this can be retrieved via [`WorkspaceKind::Managed`].
     /// Note that it can be expected to be set on any workspace, but the data would allow it to not be set.
-    pub fn ref_name(&self) -> Option<&'graph gix::refs::FullNameRef> {
+    pub fn ref_name(&self) -> Option<&gix::refs::FullNameRef> {
         self.graph[self.id].ref_name()
     }
 
     /// Like [Self::ref_name()], but returns reference and worktree information instead.
-    pub fn ref_info(&self) -> Option<&'graph crate::RefInfo> {
+    pub fn ref_info(&self) -> Option<&crate::RefInfo> {
         self.graph[self.id].ref_info.as_ref()
     }
 
@@ -1279,10 +1328,10 @@ impl<'graph> Workspace<'graph> {
 }
 
 /// Debugging
-impl Workspace<'_> {
+impl Workspace {
     /// Produce a distinct and compressed debug string to show at a glance what the workspace is about.
     pub fn debug_string(&self) -> String {
-        let graph = self.graph;
+        let graph = &self.graph;
         let (name, sign) = match &self.kind {
             WorkspaceKind::Managed { ref_info } => (
                 Graph::ref_debug_string(ref_info.ref_name.as_ref(), ref_info.worktree.as_ref()),
@@ -1328,7 +1377,7 @@ impl Workspace<'_> {
     }
 }
 
-impl std::fmt::Debug for Workspace<'_> {
+impl std::fmt::Debug for Workspace {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(&format!("Workspace({})", self.debug_string()))
             .field("id", &self.id.index())

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -51,16 +51,16 @@ fn unborn() -> anyhow::Result<()> {
     }
     "#);
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    assert!(
+        graph.managed_entrypoint_commit(&repo)?.is_none(),
+        "there is no commit it could return"
+    );
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
     ");
 
-    assert!(
-        graph.managed_entrypoint_commit(&repo)?.is_none(),
-        "there is no commit it could return"
-    );
     Ok(())
 }
 
@@ -81,14 +81,6 @@ fn detached() -> anyhow::Result<()> {
         └── 👉·541396b (⌂|1) ►tags/annotated, ►tags/release/v1, ►main
             └── ►:1[1]:other
                 └── ·fafd9d0 (⌂|1)
-    ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
-    ⌂:0:DETACHED <> ✓!
-    └── ≡:0:anon: {1}
-        ├── :0:anon:
-        │   └── ·541396b ►tags/annotated, ►tags/release/v1, ►main
-        └── :1:other
-            └── ·fafd9d0
     ");
     insta::assert_debug_snapshot!(graph, @r#"
     Graph {
@@ -170,6 +162,15 @@ fn detached() -> anyhow::Result<()> {
         graph.managed_entrypoint_commit(&repo)?.is_none(),
         "but it's not managed"
     );
+
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:0:DETACHED <> ✓!
+    └── ≡:0:anon: {1}
+        ├── :0:anon:
+        │   └── ·541396b ►tags/annotated, ►tags/release/v1, ►main
+        └── :1:other
+            └── ·fafd9d0
+    ");
     Ok(())
 }
 
@@ -197,7 +198,7 @@ fn main_advanced_remote_advanced() -> anyhow::Result<()> {
             └── →:2:
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
     └── ≡:0:main[🌳] <> origin/main →:1:⇡1⇣1 on ce09734 {1}
         └── :0:main[🌳] <> origin/main →:1:⇡1⇣1
@@ -235,7 +236,7 @@ fn only_remote_advanced() -> anyhow::Result<()> {
     // TODO: it should detect that `main` has no own commits as it's fully integrated.
     //       This also affects the base which would have to be 085535d, the first commit.
     //       which is strange but maybe can work?
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
     └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
         └── :0:main[🌳] <> origin/main →:1:⇣1
@@ -274,7 +275,7 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
     // TODO: We'd actually have to recognise that the `origin/split-segment` branch
     //       isn't related to our stack and count its commits to `origin/main`.
     //       Right now we are missing dd9f8d9.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
     └── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
         └── :0:main[🌳] <> origin/main →:1:⇣1
@@ -328,7 +329,7 @@ fn multi_root() -> anyhow::Result<()> {
         4,
         "there are 4 orphaned bases"
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
@@ -395,7 +396,7 @@ fn four_diamond() -> anyhow::Result<()> {
         "however, we see only a portion of the edges as the tree can only show simple stacks"
     );
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:merged[🌳] <> ✓!
     └── ≡:0:merged[🌳] {1}
         ├── :0:merged[🌳]
@@ -440,7 +441,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ");
 
     // 'main' is frozen because it connects to a 'foreign' remote, the commit was pushed.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
     └── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1 on fafd9d0 {1}
         ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
@@ -469,7 +470,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ");
     // As the remotes don't connect, they are entirely unknown.
     // And if it's weird, it's due to the hard limit
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
     └── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc {1}
         └── :0:B[🌳] <> origin/B →:1:⇣1
@@ -506,7 +507,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         └── 🟣e29c23d (0x0|10)
             └── →:2: (main)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
     └── ≡:0:A <> origin/A →:1:⇡1⇣1 on fafd9d0 {1}
         └── :0:A <> origin/A →:1:⇡1⇣1
@@ -568,7 +569,7 @@ fn with_limits() -> anyhow::Result<()> {
                     └── →:4: (main)
     ");
     // No limits list the first parent everywhere.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
     └── ≡:0:C[🌳] {1}
         ├── :0:C[🌳]
@@ -594,7 +595,7 @@ fn with_limits() -> anyhow::Result<()> {
         └── ✂·2a95729 (⌂|1)
     ");
     // The cut by limit is also represented here.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
     └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
@@ -615,7 +616,7 @@ fn with_limits() -> anyhow::Result<()> {
             └── ►:3[1]:B
                 └── ✂·9908c99 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
     └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
@@ -640,7 +641,7 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·9908c99 (⌂|1)
                 └── ✂·60d9a56 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
     └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
@@ -674,7 +675,7 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·9908c99 (⌂|1)
                 └── ✂·60d9a56 (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓!
     └── ≡:0:C[🌳] {1}
         └── :0:C[🌳]
@@ -713,16 +714,6 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·60d9a56 (⌂|1)
                 └── ✂·9d171ff (⌂|1)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
-    ⌂:0:C[🌳] <> ✓!
-    └── ≡:0:C[🌳] {1}
-        └── :0:C[🌳]
-            ├── ·2a95729
-            ├── ·6861158
-            ├── ·4f1f248
-            └── ✂️·487ffce
-    ");
-
     insta::assert_debug_snapshot!(graph.statistics(), @r#"
     Statistics {
         segments: 5,
@@ -771,6 +762,16 @@ fn with_limits() -> anyhow::Result<()> {
     }
     "#);
 
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    ⌂:0:C[🌳] <> ✓!
+    └── ≡:0:C[🌳] {1}
+        └── :0:C[🌳]
+            ├── ·2a95729
+            ├── ·6861158
+            ├── ·4f1f248
+            └── ✂️·487ffce
+    ");
+
     // We can specify any target, despite not having a workspace setup.
     let graph = Graph::from_head(
         &repo,
@@ -806,7 +807,7 @@ fn with_limits() -> anyhow::Result<()> {
                     └── →:1: (main)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:C[🌳] <> ✓! on edc4dee
     └── ≡:0:C[🌳] on edc4dee {1}
         └── :0:C[🌳]
@@ -840,7 +841,7 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     ");
 
     // But special handling for workspace views.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
@@ -863,7 +864,7 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
         └── ·85efbe4 (⌂|1) ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]

--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -264,7 +264,7 @@ impl Snapshot {
             but_graph::init::Options::limited(),
         )?;
 
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         let mut seen = BTreeSet::new();
 
         if let Some((computed_lower_bound, target)) =

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1231,7 +1231,7 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
     // picked up. But… it also listed as stack (which shouldn't happen), which gets it the stack-id association.
     // Finally, we end up with nothing as that one segment is also marked archived, which leads to it being truncated
     // and fully empty stacks are removed. OMG.
-    insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e");
+    insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e");
 
     let path = store.path().to_owned();
     store.write_reconciled(&repo)?;
@@ -1262,7 +1262,7 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
         &store,
         but_graph::init::Options::limited(),
     )?;
-    insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e");
+    insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e");
 
     let (actual, _uuids) = sanitize_uuids_and_timestamps_with_mapping(debug_str(&ws.stacks));
     // Now both stacks are outside workspace, as is indicated by the workspace above.

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -44,9 +44,9 @@ fn four_commits_with_short_traversal() -> Result<()> {
 
     let options = standard_options().with_hard_limit(4);
     let graph = Graph::from_head(&repo, &*meta, options)?.validated()?;
-    let workspace = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
 
-    insta::assert_snapshot!(graph_workspace(&workspace), @"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         └── :0:main[🌳]
@@ -54,7 +54,7 @@ fn four_commits_with_short_traversal() -> Result<()> {
             └── ❌·a96434e
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let editor = ws.graph.to_editor(&repo)?;
     let outcome = editor.rebase()?;
     outcome.materialize()?;
 

--- a/crates/but-testing/src/command/graph.rs
+++ b/crates/but-testing/src/command/graph.rs
@@ -71,36 +71,31 @@ pub fn doit(
         eprintln!("{:#?}", graph.statistics());
     }
 
-    let workspace = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     if no_debug_workspace {
         eprintln!(
             "Workspace with {} stacks and {} segments across all stacks with {} commits total",
-            workspace.stacks.len(),
-            workspace
-                .stacks
-                .iter()
-                .map(|s| s.segments.len())
-                .sum::<usize>(),
-            workspace
-                .stacks
+            ws.stacks.len(),
+            ws.stacks.iter().map(|s| s.segments.len()).sum::<usize>(),
+            ws.stacks
                 .iter()
                 .flat_map(|s| s.segments.iter().map(|s| s.commits.len()))
                 .sum::<usize>(),
         );
     } else {
-        eprintln!("{workspace:#?}");
+        eprintln!("{ws:#?}");
     }
 
     match dot {
         Some(Dot::Print) => {
-            stdout().write_all(graph.dot_graph().as_bytes())?;
+            stdout().write_all(ws.graph.dot_graph().as_bytes())?;
         }
         Some(Dot::OpenAsSVG) => {
             #[cfg(unix)]
-            graph.open_as_svg();
+            ws.graph.open_as_svg();
         }
         Some(Dot::Debug) => {
-            eprintln!("{graph:#?}");
+            eprintln!("{graph:#?}", graph = ws.graph);
         }
         None => {}
     }

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -538,7 +538,7 @@ pub fn remove_reference(
     let deleted = but_workspace::branch::remove_reference(
         ref_name.as_ref(),
         &repo,
-        &graph.to_workspace()?,
+        &graph.into_workspace()?,
         &mut *meta,
         opts,
     )?
@@ -559,7 +559,7 @@ pub fn apply(args: &super::Args, short_name: &str, order: Option<usize>) -> anyh
     let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let branch = repo.find_reference(short_name)?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     let apply_outcome = but_workspace::branch::apply(
         branch.name(),
         &ws,
@@ -604,7 +604,7 @@ pub fn create_reference(
         .transpose()?;
 
     let new_ref = Category::LocalBranch.to_full_name(short_name)?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     _ = but_workspace::branch::create_reference(
         new_ref.as_ref(),
         anchor,

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -556,10 +556,9 @@ pub fn remove_reference(
 pub fn apply(args: &super::Args, short_name: &str, order: Option<usize>) -> anyhow::Result<()> {
     let ctx = but_ctx::Context::discover(&args.current_dir)?;
     let guard = ctx.exclusive_worktree_access();
-    let (mut meta, graph) = ctx.graph_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let branch = repo.find_reference(short_name)?;
-    let ws = graph.into_workspace()?;
     let apply_outcome = but_workspace::branch::apply(
         branch.name(),
         &ws,

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -9,19 +9,19 @@ use termtree::Tree;
 type StringTree = Tree<String>;
 
 /// Visualize `graph` as a tree.
-pub fn graph_workspace(workspace: &but_graph::projection::Workspace<'_>) -> StringTree {
+pub fn graph_workspace(workspace: &but_graph::projection::Workspace) -> StringTree {
     graph_workspace_inner(workspace, None)
 }
 
 /// Visualize `graph` as a tree, and remap random stack ids to something deterministic.
 pub fn graph_workspace_determinisitcally(
-    workspace: &but_graph::projection::Workspace<'_>,
+    workspace: &but_graph::projection::Workspace,
 ) -> StringTree {
     graph_workspace_inner(workspace, Some(Default::default()))
 }
 
 fn graph_workspace_inner(
-    workspace: &but_graph::projection::Workspace<'_>,
+    workspace: &but_graph::projection::Workspace,
     mut stack_id_map: Option<BTreeMap<StackId, StackId>>,
 ) -> StringTree {
     let commit_flags = if workspace.graph.hard_limit_hit() {

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -272,7 +272,7 @@ impl Sandbox {
     /// Return a worktree visualisation, freshly read from [Self::graph_at_head()].
     pub fn workspace_debug_at_head(&self) -> anyhow::Result<String> {
         let (graph, _repo, _meta) = self.graph_at_head()?;
-        Ok(graph_workspace_determinisitcally(&graph.to_workspace()?).to_string())
+        Ok(graph_workspace_determinisitcally(&graph.into_workspace()?).to_string())
     }
 
     /// Open the graph at `HEAD` as SVG for debugging.

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -36,7 +36,7 @@ impl<'a> Outcome<'a> {
     /// Convert this instance into a fully-owned one.
     pub fn into_owned(self) -> Outcome<'static> {
         let Outcome {
-            workspace: graph,
+            workspace,
             applied_branches,
             workspace_ref_created,
             workspace_merge,
@@ -44,7 +44,7 @@ impl<'a> Outcome<'a> {
         } = self;
 
         Outcome {
-            workspace: Cow::Owned(graph.into_owned()),
+            workspace: Cow::Owned(workspace.into_owned()),
             applied_branches,
             workspace_ref_created,
             workspace_merge,

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -194,10 +194,10 @@ pub trait WorkspaceExt {
     fn has_workspace_commit_in_ancestry(&self, repo: &gix::Repository) -> bool;
 }
 
-impl WorkspaceExt for but_graph::projection::Workspace<'_> {
+impl WorkspaceExt for but_graph::projection::Workspace {
     fn has_workspace_commit_in_ancestry(&self, repo: &Repository) -> bool {
         function::find_ancestor_workspace_commit(
-            self.graph,
+            &self.graph,
             repo,
             self.id,
             self.lower_bound_segment_id,
@@ -452,13 +452,13 @@ pub(crate) mod function {
             metadata,
             lower_bound: _,
             lower_bound_segment_id,
-        } = graph.to_workspace()?;
+        } = graph.into_workspace()?;
 
         let (workspace_ref_info, is_managed_commit, ancestor_workspace_commit) = match kind {
             WorkspaceKind::Managed { ref_info } => (Some(ref_info), true, None),
             WorkspaceKind::ManagedMissingWorkspaceCommit { ref_info: ref_name } => {
                 let maybe_ancestor_workspace_commit =
-                    find_ancestor_workspace_commit(graph, repo, id, lower_bound_segment_id);
+                    find_ancestor_workspace_commit(&graph, repo, id, lower_bound_segment_id);
                 (Some(ref_name), false, maybe_ancestor_workspace_commit)
             }
             WorkspaceKind::AdHoc => (graph[id].ref_info.clone(), false, None),
@@ -502,7 +502,7 @@ pub(crate) mod function {
             msg.push_str(&format!("    git reset --soft {ws_commit_id}"));
             bail!("{msg}");
         }
-        info.compute_similarity(graph, repo, opts.expensive_commit_info)?;
+        info.compute_similarity(&graph, repo, opts.expensive_commit_info)?;
         Ok(info)
     }
 

--- a/crates/but-workspace/src/ui/diff.rs
+++ b/crates/but-workspace/src/ui/diff.rs
@@ -6,7 +6,7 @@ use but_core::ui;
 //       that way computations of merge-bases/commits don't have to be aligned.
 pub fn changes_in_branch(
     repo: &gix::Repository,
-    workspace: &but_graph::projection::Workspace<'_>,
+    workspace: &but_graph::projection::Workspace,
     branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<ui::TreeChanges> {
     let commits = if let Some((_, segment)) = workspace.find_segment_and_stack_by_refname(branch) {

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -35,7 +35,7 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
     * 4979833 GitButler Workspace Commit
     * 3183e43 (main, B, A) M1
     ");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡:2:anon: on 3183e43
@@ -77,7 +77,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     // We know a stack, but nothing is actually in the workspace.
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Put "B" into the workspace, even though it's the dependent branch of A.
@@ -90,8 +90,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
         applied_branches: "[refs/heads/B]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:B on e5d0542 {1}
@@ -101,7 +100,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     // Applying A is always a new stack then.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
-    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -134,7 +133,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
         "refs/heads/gitbutler/workspace".try_into()?,
         ref_metadata::Workspace::default(),
     ));
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     // note how the remote isn't interesting as we have no target configured, nor an extra target.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 3183e43
@@ -173,8 +172,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/main, refs/heads/feature]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     // both branches, main and feature, are available in the newly created workspace ref.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
@@ -228,7 +226,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     * 3183e43 (origin/main, main) M1
     ");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:5:outside →:3: on 3183e43 {1}
@@ -255,7 +253,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     }
     "#);
 
-    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:feature on 3183e43 {2ec}
     │   └── 📙:4:feature
@@ -279,7 +277,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
             |_meta| {},
         )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Put "A" into the workspace, yielding a single branch.
@@ -292,8 +290,8 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let graph = out.graph;
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
@@ -312,7 +310,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     "#);
     // Note how it will create a new stack (to keep it simple),
     // in theory we could also add B as dependent branch.
-    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {42}
     │   └── 📙:3:B
@@ -353,7 +351,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     }
     let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -373,8 +371,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     }
     "#);
 
-    let graph = out.graph;
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -403,8 +400,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         applied_branches: "[refs/heads/main, refs/heads/B]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:4:A on e5d0542 {41}
@@ -425,8 +421,10 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     }
     meta.set_workspace(&ws_md)?;
 
-    let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
-    let ws = graph.to_workspace()?;
+    let ws = ws
+        .graph
+        .redo_traversal_with_overlay(&repo, &meta, Overlay::default())?
+        .into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon: {41}
@@ -450,7 +448,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     * e5d0542 (origin/main, main, B, A) A
     ");
 
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:2:A {41}
@@ -476,7 +474,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     * e5d0542 (origin/main, main, B, A) A
     ");
 
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
@@ -499,7 +497,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
 
     let graph = but_graph::Graph::from_head(&repo, &meta, standard_traversal_options())?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> main, origin/main, B, A) A");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -519,8 +517,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     }
     "#);
 
-    let graph = out.graph;
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     └── ≡📙:3:A on e5d0542 {41}
         └── 📙:3:A
@@ -538,8 +536,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
         applied_branches: "[refs/heads/B]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     ├── ≡📙:4:B on e5d0542 {42}
@@ -576,12 +573,12 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
         )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
     // The default workspace, it's empty as target is set to `main`.
-    insta::assert_snapshot!(graph_workspace(&ws_graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws_graph.into_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Pretend "B" is checked out (it's at the right state independently of that)
     let (b_id, b_ref) = id_at(&repo, "B");
     let graph = but_graph::Graph::from_commit_traversal(b_id, b_ref, &meta, Default::default())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     // Note how the existing `gitbutler/workspace` disappears, which is expected here.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:1:B <> ✓!
@@ -601,7 +598,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     }
     "#);
 
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     // This apply brings both branches into the existing workspace, and it's where HEAD points to.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
@@ -635,7 +632,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
 
     graph.options.extra_target_commit_id = None;
     let graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -654,8 +651,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let graph = out.graph.into_owned();
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:2:A on e31e6ca {41}
@@ -692,8 +688,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let graph = out.graph.into_owned();
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:3:B on e31e6ca {42}
@@ -735,7 +730,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     * 3183e43 (HEAD -> main, origin/main) M1
     ");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 3183e43
     └── ≡:0:main[🌳] {1}
@@ -772,8 +767,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     * 3183e43 (origin/main, main) M1
     ");
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
 
     let out =
         but_workspace::branch::apply(r("refs/heads/A1"), &ws, &repo, &mut meta, default_options())?;
@@ -785,8 +779,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     }
     "#);
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A1 on 3183e43 {72}
@@ -816,8 +809,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     }
     "#);
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A2 on 3183e43 {73}
@@ -891,7 +883,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     |/  
     * 3183e43 (main) M1
     ");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓! on 3183e43
     └── ≡:0:anon: on 3183e43 {1}
@@ -910,8 +902,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     }
     "#);
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡📙:2:C on 3183e43 {43}
@@ -951,8 +942,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     * 3183e43 (main) M1
     ");
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:3:B on 3183e43 {42}
@@ -982,8 +972,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:B on 3183e43 {42}
@@ -1026,7 +1015,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     * 85efbe4 (HEAD -> main, origin/main) M
     ");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 85efbe4
     └── ≡:0:main[🌳] {1}
@@ -1044,8 +1033,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     }
     "#);
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:E on 85efbe4 {1}
@@ -1057,8 +1045,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // other stack.
     let out =
         but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())?;
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {43}
@@ -1084,8 +1071,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     // for this to just work as people might intuitively want, even if that means the same commit is used multiple times.
     let out =
         but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:6:B on 7076dee {2}
@@ -1102,8 +1088,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let out =
         but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())
             .unwrap();
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {2}
@@ -1131,7 +1116,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     * 85efbe4 (HEAD -> main, origin/main) M
     ");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓! on 85efbe4
     └── ≡:0:main[🌳] {1}
@@ -1148,8 +1133,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:A on 85efbe4 {41}
@@ -1176,8 +1160,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
 
-    let graph = out.graph;
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:B on 85efbe4 {41}
@@ -1199,7 +1182,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
 
 #[test]
 fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
-    let (_tmp, mut graph, repo, mut meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "various-heads-for-multi-line-merge-conflict",
             |_meta| {},
@@ -1228,7 +1211,9 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             .status()?
             .success()
     );
-    graph = graph.redo_traversal_with_overlay(&repo, &meta, Overlay::default())?;
+    let mut ws = graph
+        .redo_traversal_with_overlay(&repo, &meta, Overlay::default())?
+        .into_workspace()?;
 
     for branch_to_apply in [
         "clean-A",
@@ -1237,7 +1222,6 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         "conflict-F2",
         "clean-C",
     ] {
-        let ws = graph.to_workspace()?;
         let out = but_workspace::branch::apply(
             Category::LocalBranch
                 .to_full_name(branch_to_apply)?
@@ -1248,10 +1232,9 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             default_options(),
         )
         .unwrap_or_else(|err| panic!("{branch_to_apply}: {err}"));
-        graph = out.graph.into_owned();
+        ws = out.workspace.into_owned();
     }
 
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:clean-C on 85efbe4 {273}
@@ -1294,7 +1277,6 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     * 85efbe4 (main) M
     ");
 
-    let ws = graph.to_workspace()?;
     let out = but_workspace::branch::apply(
         r("refs/heads/conflict-hero"),
         &ws,
@@ -1313,8 +1295,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         ],
     }
     "#);
-    let graph = out.graph.into_owned();
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     // By default, it fails and just reports the conflicting stacks, so it's the same as it was before.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
@@ -1373,8 +1354,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     "#);
 
     // Now the other stacks are unapplied.
-    let graph = out.graph.into_owned();
-    let ws = graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:5:conflict-hero on 85efbe4 {52d}
@@ -1517,7 +1497,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
@@ -1543,13 +1523,13 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     "#);
 
     let (b_id, b_ref) = id_at(&repo, "B");
-    let graph = but_graph::Graph::from_commit_traversal(
+    let ws = but_graph::Graph::from_commit_traversal(
         b_id,
         b_ref.clone(),
         &meta,
         standard_traversal_options_with_extra_target(&repo),
-    )?;
-    let ws = graph.to_workspace()?;
+    )?
+    .into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡👉📙:3:B on e5d0542 {2}
@@ -1580,7 +1560,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     "#);
 
     // Now the workspace ref itself is checked out.
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
@@ -1596,14 +1576,15 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 2, "B", StackState::InWorkspace, &["A"]);
 
     let (b_id, b_ref) = id_at(&repo, "B");
-    let graph = but_graph::Graph::from_commit_traversal(
+
+    let ws = but_graph::Graph::from_commit_traversal(
         b_id,
         b_ref.clone(),
         &meta,
         standard_traversal_options_with_extra_target(&repo),
-    )?;
-
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    )?
+    .into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡👉📙:2:B on e5d0542 {2}
         ├── 👉📙:2:B
@@ -1623,16 +1604,16 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // There is no known branch, and adding it will just add metadata.
     meta.data_mut().branches.clear();
-    let graph = but_graph::Graph::from_head(
+    let ws = but_graph::Graph::from_head(
         &repo,
         &meta,
         standard_traversal_options_with_extra_target(&repo),
-    )?;
+    )?
+    .into_workspace()?;
     // There is nothing yet.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542");
 
     // Apply the first branch, it must be independent.
-    let ws = graph.to_workspace()?;
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
     insta::assert_debug_snapshot!(out, @r#"
@@ -1642,8 +1623,8 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         applied_branches: "[refs/heads/A]",
     }
     "#);
-    let graph = out.graph;
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    let ws = out.workspace.into_owned();
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
@@ -1675,7 +1656,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     * 85efbe4 (origin/main, main) M
     ");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
@@ -1698,9 +1679,9 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     "#);
 
     let (b_id, b_ref) = id_at(&repo, "B");
-    let graph =
-        but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?;
-    let ws = graph.to_workspace()?;
+    let ws =
+        but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?
+            .into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡👉📙:0:B on 85efbe4 {2}
@@ -1742,7 +1723,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
@@ -1767,7 +1748,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
         .expect("workspace configured")
         .sha = gix::hash::Kind::Sha1.null();
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
@@ -1808,7 +1789,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     // insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (orphan/main) M1");
 
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -1848,7 +1829,7 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     }
     "#);
 
-    let ws = out.graph.to_workspace()?;
+    let ws = out.workspace.into_owned();
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -50,7 +50,7 @@ mod with_workspace {
                 ..Options::limited()
             },
         )?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         // And even though setting an extra-target works like it should, i.e a simulated target
         // which we can store in absence of a selected target branch…
@@ -63,7 +63,7 @@ mod with_workspace {
             .expect("always set to have workspace")
             .sha = gix::hash::Kind::Sha1.null();
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
         └── ≡:1:main
@@ -100,12 +100,12 @@ mod with_workspace {
         insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, origin/main, main) M1");
 
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43");
 
         let a_ref = r("refs/heads/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             a_ref,
             None, /* anchor */
             &repo,
@@ -115,7 +115,6 @@ mod with_workspace {
             None,
         )
         .expect("it updates the workspace metadata legitimate the new ref at base");
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {41}
@@ -129,7 +128,7 @@ mod with_workspace {
         );
 
         let b_ref = r("refs/heads/B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             b_ref,
             None, /* anchor */
             &repo,
@@ -138,7 +137,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
@@ -148,7 +146,7 @@ mod with_workspace {
         ");
 
         // Idempotency
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             b_ref,
             None, /* anchor */
             &repo,
@@ -157,7 +155,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
@@ -167,7 +164,7 @@ mod with_workspace {
         ");
 
         let above_a = rc("refs/heads/above-A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(a_ref),
@@ -179,7 +176,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
@@ -190,7 +186,7 @@ mod with_workspace {
         ");
 
         let below_b = rc("refs/heads/below-B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_b,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
@@ -202,7 +198,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
@@ -218,7 +213,7 @@ mod with_workspace {
         drop(meta);
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
@@ -246,7 +241,7 @@ mod with_workspace {
         ");
 
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
@@ -258,7 +253,7 @@ mod with_workspace {
 
         let above_bottom_ref = r("refs/heads/above-bottom");
         let bottom_id = id_by_rev(&repo, ":/A1");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_bottom_ref,
             Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
@@ -270,7 +265,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         // It handles this special case, by creating the necessary workspace metadata
         // if for some reason (like manual building) it's not set.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -283,7 +277,7 @@ mod with_workspace {
         ");
 
         let bottom_ref = rc("refs/heads/bottom");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             bottom_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_bottom_ref),
@@ -296,7 +290,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:4:A on bce0c5e {4cf}
@@ -309,7 +302,7 @@ mod with_workspace {
 
         let above_a_commit_ref = r("refs/heads/above-A-commit");
         let a_id = id_by_rev(&repo, ":/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a_commit_ref,
             Anchor::AtCommit {
                 commit_id: a_id.detach(),
@@ -323,7 +316,6 @@ mod with_workspace {
         )?;
 
         // Note how 'Above' *a commit* means directly above, not on top of everything.
-        let ws = graph.to_workspace()?;
         // And as there are now two references on one commit, and one has metadata, the other one doesn't,
         // 'A' is moved to the background.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -338,7 +330,7 @@ mod with_workspace {
 
         // We can, however, restore it simply by putting idempotency.
         let a_ref = rc("refs/heads/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             a_ref,
             Anchor::AtCommit {
                 commit_id: a_id.detach(),
@@ -351,7 +343,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         // And 'A' is back, with the desired order correctly restored.
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
@@ -366,7 +357,7 @@ mod with_workspace {
 
         let above_a_ref = rc("refs/heads/above-A");
         let a_ref = rc("refs/heads/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a_ref,
             Anchor::AtSegment {
                 ref_name: a_ref,
@@ -380,7 +371,6 @@ mod with_workspace {
         )?;
 
         // *Above a segment means what one would expect though.
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
@@ -394,7 +384,7 @@ mod with_workspace {
         ");
 
         let below_a_commit_ref = rc("refs/heads/below-A-commit");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_a_commit_ref,
             Anchor::AtCommit {
                 commit_id: a_id.detach(),
@@ -407,7 +397,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
@@ -422,7 +411,7 @@ mod with_workspace {
         ");
 
         let below_a_ref = rc("refs/heads/below-A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_a_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_a_commit_ref),
@@ -434,7 +423,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
@@ -451,7 +439,7 @@ mod with_workspace {
 
         // create a new stack for good measure.
         let b_ref = r("refs/heads/B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             b_ref,
             None,
             &repo,
@@ -460,7 +448,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:B on bce0c5e {42}
@@ -479,7 +466,7 @@ mod with_workspace {
 
         // create a new dependent branch by segment above (commit can't be done).
         let above_b_ref = rc("refs/heads/above-B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_b_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
@@ -491,7 +478,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
@@ -513,7 +499,7 @@ mod with_workspace {
         // (which somewhat counter-intuitively works here) because it's a completely new
         // independent branch.
         let below_b_ref = rc("refs/heads/below-B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_b_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
@@ -525,7 +511,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
@@ -549,7 +534,7 @@ mod with_workspace {
         drop(meta);
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
@@ -591,7 +576,7 @@ mod with_workspace {
         add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
 
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
@@ -603,7 +588,7 @@ mod with_workspace {
 
         let above_bottom_ref = r("refs/heads/above-bottom");
         let bottom_id = id_by_rev(&repo, ":/A1");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_bottom_ref,
             Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
@@ -615,7 +600,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:4:A on 3183e43 {0}
@@ -626,7 +610,7 @@ mod with_workspace {
         ");
 
         let bottom_ref = rc("refs/heads/bottom");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             bottom_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_bottom_ref),
@@ -639,7 +623,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         // We can create branches that would be on the base.
         // There are
         insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -654,7 +637,7 @@ mod with_workspace {
 
         let above_a_commit_ref = r("refs/heads/above-A-commit");
         let a_id = id_by_rev(&repo, ":/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a_commit_ref,
             Anchor::AtCommit {
                 commit_id: a_id.detach(),
@@ -668,7 +651,6 @@ mod with_workspace {
         )?;
 
         // Note how 'Above' *a commit* means directly above, not on top of everything.
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:A on 3183e43 {0}
@@ -682,7 +664,7 @@ mod with_workspace {
 
         let above_a_ref = rc("refs/heads/above-A");
         let a_ref = rc("refs/heads/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a_ref,
             Anchor::AtSegment {
                 ref_name: a_ref,
@@ -696,7 +678,6 @@ mod with_workspace {
         )?;
 
         // *Above a segment means what one would expect though.
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
@@ -712,7 +693,7 @@ mod with_workspace {
         // Idempotency!
         let above_a_ref = rc("refs/heads/above-A");
         let a_ref = rc("refs/heads/A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_a_ref,
             Anchor::AtSegment {
                 ref_name: a_ref,
@@ -725,7 +706,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
@@ -739,7 +719,7 @@ mod with_workspace {
         ");
 
         let below_a_commit_ref = rc("refs/heads/below-A-commit");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_a_commit_ref,
             Anchor::AtCommit {
                 commit_id: a_id.detach(),
@@ -752,7 +732,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
@@ -767,7 +746,7 @@ mod with_workspace {
         ");
 
         let below_a_ref = rc("refs/heads/below-A");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_a_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_a_commit_ref),
@@ -779,7 +758,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
@@ -796,7 +774,7 @@ mod with_workspace {
 
         // create a new stack for good measure.
         let b_ref = r("refs/heads/B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             b_ref,
             None,
             &repo,
@@ -805,7 +783,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
@@ -824,7 +801,7 @@ mod with_workspace {
 
         // create a new dependent branch by segment above (commit can't be done).
         let above_b_ref = rc("refs/heads/above-B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             above_b_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
@@ -836,7 +813,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
@@ -858,7 +834,7 @@ mod with_workspace {
         // (which somewhat counter-intuitively works here) because it's a completely new
         // independent branch.
         let below_b_ref = rc("refs/heads/below-B");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             below_b_ref,
             Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
@@ -870,7 +846,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
@@ -894,7 +869,7 @@ mod with_workspace {
         drop(meta);
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
@@ -934,7 +909,7 @@ mod with_workspace {
         add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
 
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
@@ -946,7 +921,7 @@ mod with_workspace {
 
         let bottom_ref = rc("refs/heads/bottom");
         let bottom_id = id_by_rev(&repo, ":/A1");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             bottom_ref,
             Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
@@ -959,7 +934,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
@@ -987,7 +961,7 @@ mod with_workspace {
         add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &[]);
 
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
@@ -1001,7 +975,7 @@ mod with_workspace {
 
         let bottom_ref_a = rc("refs/heads/a-bottom");
         let bottom_a_id = id_by_rev(&repo, ":/A1");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             bottom_ref_a,
             Anchor::AtCommit {
                 commit_id: bottom_a_id.detach(),
@@ -1013,7 +987,6 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
@@ -1027,7 +1000,7 @@ mod with_workspace {
 
         let bottom_ref_b = rc("refs/heads/b-bottom");
         let bottom_b_id = id_by_rev(&repo, ":/B1");
-        let graph = but_workspace::branch::create_reference(
+        let ws = but_workspace::branch::create_reference(
             bottom_ref_b,
             Anchor::AtCommit {
                 commit_id: bottom_b_id.detach(),
@@ -1040,7 +1013,6 @@ mod with_workspace {
             None,
         )?;
 
-        let ws = graph.to_workspace()?;
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
@@ -1067,7 +1039,7 @@ mod with_workspace {
         ");
 
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e");
 
@@ -1127,7 +1099,7 @@ mod with_workspace {
         add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
 
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_snapshot!(graph_workspace(&ws), @r"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
@@ -1259,7 +1231,7 @@ mod with_workspace {
 fn errors() -> anyhow::Result<()> {
     let (repo, mut meta) = named_read_only_in_memory_scenario("unborn-empty", "")?;
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -1292,7 +1264,7 @@ fn errors() -> anyhow::Result<()> {
     ");
 
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
@@ -1393,7 +1365,7 @@ fn errors() -> anyhow::Result<()> {
     }
 
     let graph = but_graph::Graph::from_commit_traversal(a_id, a_ref, &*meta, Options::limited())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:A <> ✓!
     └── ≡:0:A {1}
@@ -1445,7 +1417,7 @@ fn errors() -> anyhow::Result<()> {
             ..Options::limited()
         },
     )?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:A <> ✓! on 89cc2d3
     └── ≡:0:A {1}
@@ -1498,7 +1470,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
     ");
 
     let graph = but_graph::Graph::from_head(&repo, &meta, Default::default())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
@@ -1511,7 +1483,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
 
     let (main_id, main_ref) = id_at(&repo, "main");
     let new_name = r("refs/heads/below-main");
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         new_name,
         Anchor::at_segment(main_ref.as_ref(), Below),
         &repo,
@@ -1523,7 +1495,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
     .expect("this works as the branch is unique");
 
     // We always add metadata to new branches.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
@@ -1546,7 +1518,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
     );
 
     // Creating the same reference again is idempotent.
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         new_name,
         Anchor::at_id(main_id, Below),
         &repo,
@@ -1555,7 +1527,6 @@ fn journey_with_commits() -> anyhow::Result<()> {
         stack_id_for_name,
         None,
     )?;
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -1567,7 +1538,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
     ");
 
     // the last possible branch without a workspace.
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         rc("refs/heads/two-below-main"),
         Anchor::at_segment(r("refs/heads/below-main"), Below),
         &repo,
@@ -1576,7 +1547,6 @@ fn journey_with_commits() -> anyhow::Result<()> {
         stack_id_for_name,
         None,
     )?;
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
@@ -1607,7 +1577,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
 
     // branch already exists in the workspace, all good.
     let main_ref = r("refs/heads/main");
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         main_ref,
         None,
         &repo,
@@ -1622,7 +1592,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
         "no data was stored, it wasn't stored before either, for independent branches\
             There should be no benefit doing that."
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡:0:main[🌳] {1}
         ├── :0:main[🌳]
@@ -1634,7 +1604,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
     ");
 
     // However, creating a dependent branch creates metadata as well.
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         main_ref,
         Anchor::AtCommit {
             commit_id: main_id.detach(),
@@ -1652,7 +1622,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
         "Data is created/updated for dependent branches though,
             which is a way to make segments appear if there were not visible before due to ambiguity."
     );
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
     └── ≡📙:0:main[🌳] {1}
         ├── 📙:0:main[🌳]
@@ -1677,7 +1647,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
 
     let id = id_by_rev(&repo, "@~1");
     let graph = but_graph::Graph::from_commit_traversal(id, None, &meta, Default::default())?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓!
@@ -1689,7 +1659,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
 
     let first_ref = rc("refs/heads/first");
     let first_id = id_by_rev(&repo, "@~2");
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         first_ref,
         Anchor::AtCommit {
             commit_id: first_id.detach(),
@@ -1701,7 +1671,6 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         stack_id_for_name,
         None,
     )?;
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:DETACHED <> ✓!
     └── ≡:0:anon: {1}
@@ -1731,7 +1700,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
 
     let second_ref = rc("refs/heads/second");
     let second_id = id_by_rev(&repo, "@~1");
-    let graph = but_workspace::branch::create_reference(
+    let ws = but_workspace::branch::create_reference(
         second_ref,
         Anchor::AtCommit {
             commit_id: second_id.detach(),
@@ -1743,7 +1712,6 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
         stack_id_for_name,
         None,
     )?;
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:second <> ✓!
     └── ≡📙:0:second {1}
@@ -1781,7 +1749,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
             ..Default::default()
         },
     )?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     // And the extra-target serves as base also in single-branch mode.
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:second <> ✓! on 3d57fc1

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[test]
 fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
-    let (_tmp, mut graph, repo, mut meta, desc) =
+    let (_tmp, graph, repo, mut meta, desc) =
         named_writable_scenario_with_args_and_description_and_graph(
             "single-branch-no-ws-commit-no-target",
             ["A", "B"],
@@ -23,7 +23,7 @@ fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
     insta::assert_snapshot!(desc, @"Single commit, no main remote/target, no ws commit, but ws-reference");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, B, A) M1");
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     // the workspace is empty.
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
@@ -59,7 +59,7 @@ fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
 
     // repo and workspace should still look like before.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, B, A) M1");
-    let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 
     Ok(())
@@ -67,13 +67,12 @@ fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
 
 #[test]
 fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, mut graph, repo, mut meta, desc) =
-        named_writable_scenario_with_description_and_graph(
-            "single-branch-3-commits-no-ws-commit-more-branches",
-            |meta| {
-                add_stack_with_segments(meta, 0, "A", StackState::InWorkspace, &[]);
-            },
-        )?;
+    let (_tmp, graph, repo, mut meta, desc) = named_writable_scenario_with_description_and_graph(
+        "single-branch-3-commits-no-ws-commit-more-branches",
+        |meta| {
+            add_stack_with_segments(meta, 0, "A", StackState::InWorkspace, &[]);
+        },
+    )?;
     insta::assert_snapshot!(desc, @"Single commit, target, no ws commit, but ws-reference and a named segment, and branches on each commit");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * c2878fb (HEAD -> gitbutler/workspace, A2, A) A2
@@ -81,7 +80,7 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
     * 3183e43 (origin/main, main) M1
     ");
 
-    let mut ws = graph.to_workspace()?;
+    let mut ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡📙:3:A on 3183e43 {0}
@@ -94,7 +93,7 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
     // It's OK to delete all segment names of a stack
     for name in ["A", "A2", "A1"] {
         let r = Category::LocalBranch.to_full_name(name)?;
-        let new_graph = but_workspace::branch::remove_reference(
+        ws = but_workspace::branch::remove_reference(
             r.as_ref(),
             &repo,
             &ws,
@@ -106,11 +105,9 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
             },
         )?
         .expect("we deleted something");
-        graph = new_graph;
-        ws = graph.to_workspace()?;
     }
 
-    let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡:3:anon: on 3183e43
@@ -124,19 +121,18 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
 
 #[test]
 fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, mut graph, repo, mut meta, desc) =
-        named_writable_scenario_with_description_and_graph(
-            "single-branch-4-commits-more-branches",
-            |meta| {
-                add_stack_with_segments(
-                    meta,
-                    0,
-                    "A",
-                    StackState::InWorkspace,
-                    &["A2-3", "A2-2", "A2-1", "A1-1", "A1-2", "A1-3"],
-                );
-            },
-        )?;
+    let (_tmp, graph, repo, mut meta, desc) = named_writable_scenario_with_description_and_graph(
+        "single-branch-4-commits-more-branches",
+        |meta| {
+            add_stack_with_segments(
+                meta,
+                0,
+                "A",
+                StackState::InWorkspace,
+                &["A2-3", "A2-2", "A2-1", "A1-1", "A1-2", "A1-3"],
+            );
+        },
+    )?;
 
     insta::assert_snapshot!(desc, @"Two commits in main, target setup, ws commit, many more usable branches");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -146,7 +142,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     * bce0c5e (origin/main, main) M2
     * 3183e43 M1
     ");
-    let mut ws = graph.to_workspace()?;
+    let mut ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:5:A on bce0c5e {0}
@@ -164,7 +160,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     // Delete a whole segment to see how it pulls up to the top of the stack a branch from below
     for name in ["A2-1", "A2-3", "A", "A2-2"] {
         let r = Category::LocalBranch.to_full_name(name)?;
-        let new_graph = but_workspace::branch::remove_reference(
+        ws = but_workspace::branch::remove_reference(
             r.as_ref(),
             &repo,
             &ws,
@@ -176,8 +172,6 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
             },
         )?
         .expect("we deleted something");
-        graph = new_graph;
-        ws = graph.to_workspace()?;
     }
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
@@ -191,7 +185,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
 
     for name in ["A1-1", "A1-2"] {
         let r = Category::LocalBranch.to_full_name(name)?;
-        let new_graph = but_workspace::branch::remove_reference(
+        ws = but_workspace::branch::remove_reference(
             r.as_ref(),
             &repo,
             &ws,
@@ -202,8 +196,6 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
             },
         )?
         .expect("we deleted something");
-        graph = new_graph;
-        ws = graph.to_workspace()?;
     }
     // Just one segment left.
     insta::assert_snapshot!(graph_workspace(&ws), @r"
@@ -236,7 +228,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
 
 #[test]
 fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, mut graph, repo, mut meta, desc) =
+    let (_tmp, graph, repo, mut meta, desc) =
         named_writable_scenario_with_args_and_description_and_graph(
             "single-branch-no-ws-commit-no-target",
             ["A", "B", "C", "D", "E"],
@@ -248,7 +240,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     insta::assert_snapshot!(desc, @"Single commit, no main remote/target, no ws commit, but ws-reference");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, E, D, C, B, A) M1");
 
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
@@ -261,7 +253,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     ");
 
     let ref_name = r("refs/heads/A");
-    graph = but_workspace::branch::remove_reference(
+    let ws = but_workspace::branch::remove_reference(
         ref_name,
         &repo,
         &ws,
@@ -273,7 +265,6 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     )?
     .expect("we deleted something");
 
-    let ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
@@ -292,7 +283,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
         "recreate ref to show metadata is present and unchanged",
     )?;
 
-    let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
@@ -304,7 +295,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
         └── 📙:4:C
     ");
 
-    graph = but_workspace::branch::remove_reference(
+    let mut ws = but_workspace::branch::remove_reference(
         ref_name,
         &repo,
         &ws,
@@ -319,7 +310,6 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
         "recreate ref - this time it's not visible as it lacks metadata",
     )?;
 
-    let mut ws = graph.to_workspace()?;
     insta::assert_snapshot!(graph_workspace(&ws), @r"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
@@ -349,7 +339,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     // We can delete everything.
     for name in ["D", "B", "E", "C"] {
         let r = Category::LocalBranch.to_full_name(name)?;
-        let new_graph = but_workspace::branch::remove_reference(
+        ws = but_workspace::branch::remove_reference(
             r.as_ref(),
             &repo,
             &ws,
@@ -361,13 +351,11 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
             },
         )?
         .expect("we deleted something");
-        graph = new_graph;
-        ws = graph.to_workspace()?;
     }
 
     // A remains as we recreated it.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, A) M1");
-    let ws = graph.workspace_of_redone_traversal(&repo, &meta)?;
+    let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
     // The workspace is completely empty.
     insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43");
 

--- a/crates/but-workspace/tests/workspace/ui.rs
+++ b/crates/but-workspace/tests/workspace/ui.rs
@@ -17,7 +17,7 @@ mod changes_in_branch {
         ");
 
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
-        let ws = graph.to_workspace()?;
+        let ws = graph.into_workspace()?;
 
         insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/heads/A"))?, @r#"
         TreeChanges {

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -22,8 +22,7 @@ pub fn worktree_new(
 ) -> Result<NewWorktreeOutcome> {
     let repo = &*ctx.repo.get()?;
 
-    let (_, graph) = ctx.graph_and_meta_from_head(perm)?;
-    let ws = graph.into_workspace()?;
+    let (_, ws) = ctx.workspace_and_meta_from_head(perm)?;
     if !ws.refname_is_segment(refname) {
         bail!("Branch not found in workspace");
     }

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -23,7 +23,7 @@ pub fn worktree_new(
     let repo = &*ctx.repo.get()?;
 
     let (_, graph) = ctx.graph_and_meta_from_head(perm)?;
-    let ws = graph.to_workspace()?;
+    let ws = graph.into_workspace()?;
     if !ws.refname_is_segment(refname) {
         bail!("Branch not found in workspace");
     }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -120,10 +120,11 @@ impl BranchManager<'_> {
         // Assume that this is always about 'apply' and hijack the entire method.
         // That way we'd learn what's missing.
         if self.ctx.settings().feature_flags.apply3 {
-            let (mut meta, graph) = self.ctx.graph_and_meta_from_head(perm.read_permission())?;
+            let (mut meta, ws) = self
+                .ctx
+                .workspace_and_meta_from_head(perm.read_permission())?;
             let repo = self.ctx.repo.get()?;
 
-            let ws = graph.into_workspace()?;
             let target = target.to_string();
             let branch_to_apply = target.as_str().try_into()?;
             let mut out = but_workspace::branch::apply(

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -123,7 +123,7 @@ impl BranchManager<'_> {
             let (mut meta, graph) = self.ctx.graph_and_meta_from_head(perm.read_permission())?;
             let repo = self.ctx.repo.get()?;
 
-            let ws = graph.to_workspace()?;
+            let ws = graph.into_workspace()?;
             let target = target.to_string();
             let branch_to_apply = target.as_str().try_into()?;
             let mut out = but_workspace::branch::apply(
@@ -141,11 +141,11 @@ impl BranchManager<'_> {
                     new_stack_id: None,
                 },
             )?;
-            let ws = out.graph.to_workspace()?;
+            let ws = out.workspace.into_owned();
             let applied_branch_stack_id = ws
                 .find_segment_and_stack_by_refname(out.applied_branches.pop().context("BUG: must mention the actually applied branch last")?.as_ref())
-                .with_context(||
-                    format!("BUG: Can't find the branch to apply in workspace, but the 'apply' function should have failed instead \n{out:?}")
+                .context(
+                    "BUG: Can't find the branch to apply in workspace, but the 'apply' function should have failed instead"
                 )?
                 .0
                 .id


### PR DESCRIPTION
That can be returned from utility functions and facilitate working with it.
This is how code wants to work with it and it will make a lot of it feel more natural.

### Tasks

* [x] get remaining 5 tests green
* [x] Let `Context` return a workspace directly

### Follow-up

* https://github.com/gitbutlerapp/gitbutler/pull/11859