### PR TITLE
Ensure read-write guards are used when metadata is altered

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -13,8 +13,8 @@ pub fn apply_only(
     ctx: &but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
-    let guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
     let repo = ctx.repo.get()?;
     let out = but_workspace::branch::apply(
         existing_branch,
@@ -64,7 +64,7 @@ pub fn apply(
 #[instrument(err(Debug))]
 pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges> {
     let guard = ctx.shared_worktree_access();
-    let (_, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let (_, ws) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let reference = repo.find_reference(&branch)?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, reference.name())

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -74,8 +74,8 @@ pub fn create_reference(
         })
         .transpose()?;
 
-    let guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
     let repo = ctx.repo.get()?;
     let ws = but_workspace::branch::create_reference(
         new_ref.clone(),
@@ -104,7 +104,7 @@ pub fn create_branch(
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     use but_workspace::branch::create_reference::Position::Above;
     let mut guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
     let repo = ctx.repo.get()?;
     let stack = ws.try_find_stack_by_id(stack_id)?;
     let new_ref = Category::LocalBranch
@@ -158,7 +158,7 @@ pub fn create_branch(
 pub fn remove_branch(project_id: ProjectId, stack_id: StackId, branch_name: String) -> Result<()> {
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let mut guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
     let repo = ctx.repo.get()?;
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name.as_str())

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -38,8 +38,8 @@ pub fn create_virtual_branch(
 ) -> Result<StackEntryNoOpt> {
     let ctx = Context::new_from_legacy_project_id(project_id)?;
     let stack_entry = {
-        let guard = ctx.exclusive_worktree_access();
-        let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+        let mut guard = ctx.exclusive_worktree_access();
+        let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
         let repo = ctx.repo.get()?;
         let new_ref = Category::LocalBranch
             .to_full_name(

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use but_core::sync::WorktreeWritePermission;
 use but_core::{RepositoryExt, sync::WorktreeReadPermission};
 use but_settings::AppSettings;
 
@@ -229,8 +230,24 @@ impl Context {
     /// Create a new workspace as seen from the current HEAD and return it,
     /// along with read-only metadata.
     ///
-    /// The read-permission is required to obtain a shared metadata instance.
+    /// The write-permission is required to obtain an exclusive metadata instance.
     pub fn workspace_and_meta_from_head(
+        &self,
+        _exclusive_access: &WorktreeWritePermission,
+    ) -> anyhow::Result<(
+        impl but_core::RefMetadata + 'static,
+        but_graph::projection::Workspace,
+    )> {
+        let (meta, graph) =
+            self.graph_and_read_only_meta_from_head(_exclusive_access.read_permission())?;
+        Ok((meta, graph.into_workspace()?))
+    }
+
+    /// Create a new workspace as seen from the current HEAD and return it,
+    /// along with read-only metadata.
+    ///
+    /// The read-permission is required to obtain a shared metadata instance.
+    pub fn workspace_and_read_only_meta_from_head(
         &self,
         _read_only: &WorktreeReadPermission,
     ) -> anyhow::Result<(

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -555,8 +555,8 @@ pub fn remove_reference(
 
 pub fn apply(args: &super::Args, short_name: &str, order: Option<usize>) -> anyhow::Result<()> {
     let ctx = but_ctx::Context::discover(&args.current_dir)?;
-    let guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.read_permission())?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
     let repo = ctx.repo.get()?;
     let branch = repo.find_reference(short_name)?;
     let apply_outcome = but_workspace::branch::apply(

--- a/crates/but-worktrees/src/new.rs
+++ b/crates/but-worktrees/src/new.rs
@@ -22,7 +22,7 @@ pub fn worktree_new(
 ) -> Result<NewWorktreeOutcome> {
     let repo = &*ctx.repo.get()?;
 
-    let (_, ws) = ctx.workspace_and_meta_from_head(perm)?;
+    let (_, ws) = ctx.workspace_and_read_only_meta_from_head(perm)?;
     if !ws.refname_is_segment(refname) {
         bail!("Branch not found in workspace");
     }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -112,9 +112,7 @@ impl BranchManager<'_> {
         // Assume that this is always about 'apply' and hijack the entire method.
         // That way we'd learn what's missing.
         if self.ctx.settings().feature_flags.apply3 {
-            let (mut meta, ws) = self
-                .ctx
-                .workspace_and_meta_from_head(perm.read_permission())?;
+            let (mut meta, ws) = self.ctx.workspace_and_meta_from_head(perm)?;
             let repo = self.ctx.repo.get()?;
 
             let target = target.to_string();


### PR DESCRIPTION
Otherwise metadata changes may race, especially while we have no transactions. Unfortunately this is hard to check for outside of locks as race-checks can only happen ostly reliably in destructors.
