### PR TITLE
Remove redundant padding-top from file list style

### DIFF
--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -416,7 +416,6 @@
 		flex-direction: column;
 		justify-content: center;
 		padding: 12px;
-		padding-top: 4px;
 		gap: 12px;
 		border-bottom: 1px solid var(--clr-border-2);
 	}


### PR DESCRIPTION
Eliminated the extra padding-top property from the file list container's CSS to streamline spacing and avoid conflicting padding values.

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
