### PR TITLE
Inline target in prettier script

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ pnpm fix
 pnpm format
 
 # Check formatting
-pnpm prettier --check .
+pnpm prettier
 
 # Shortcut to check everything
 pnpm isgood

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/init-env-node
-      - run: pnpm prettier .
+      - run: pnpm prettier
 
   generate-ts-definitions:
     needs: changes

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"tauri-for-release": "tauri",
 		"lint": "turbo run //#globallint --no-daemon",
 		"globallint": "prettier --check . && eslint .",
-		"prettier": "prettier --check",
+		"prettier": "prettier --check .",
 		"format": "prettier --write .",
 		"fix": "eslint --fix .",
 		"prepare": "pnpm --filter @gitbutler/desktop run prepare",


### PR DESCRIPTION
## 🧢 Changes
Inlines the target of the `prettier` command into the script itself to conform with the rest of the TypeScript tooling scripts. Also updates outdated Copilot instructions for using the script.

See discussion in https://github.com/gitbutlerapp/gitbutler/pull/11826#discussion_r2692875038
