### PR TITLE
Fix Discard change for added/deleted files

### DIFF
--- a/apps/desktop/src/components/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/HunkContextMenu.svelte
@@ -75,13 +75,16 @@
 
 		unselectAllHunkLines(item.hunk);
 
+		const isWholeFileChange =
+			change.status.type === 'Addition' || change.status.type === 'Deletion';
+
 		await stackService.discardChanges({
 			projectId,
 			worktreeChanges: [
 				{
 					previousPathBytes,
 					pathBytes: change.pathBytes,
-					hunkHeaders: [item.hunk]
+					hunkHeaders: isWholeFileChange ? [] : [item.hunk]
 				}
 			]
 		});
@@ -135,7 +138,7 @@
 							contextMenu?.close();
 						}}
 					/>
-					{#if item.selectedLines !== undefined && item.selectedLines.length > 0}
+					{#if item.selectedLines !== undefined && item.selectedLines.length > 0 && change.status.type !== 'Addition' && change.status.type !== 'Deletion'}
 						<ContextMenuItem
 							testId={TestId.HunkContextMenu_DiscardLines}
 							label={getDiscardLineLabel(item)}


### PR DESCRIPTION
## Summary
Fix Discard Change for added/deleted files by treating these as whole-file operations (send empty hunk headers) and hiding the line-selection discard action for those statuses.

## Background
The UI was sending hunk headers for file additions/deletions. The backend expects whole-file discard semantics for these, which can otherwise result in an error and a broken Discard flow.

## Testing
- pnpm prettier .
- pnpm lint
- pnpm check
- pnpm -C apps/desktop test
- pnpm build:desktop
- cd e2e && pnpm exec playwright test --config ./playwright/playwright.config.ts --tsconfig ./playwright/tsconfig.json playwright/tests/unifiedDiffView.spec.ts --workers=1 --timeout=300000
- Fork CI workflow_dispatch: Fork CI (discard fix) on sha ce369e8a28ac0f05c48ff52215aace7efaa53945 (run 21114126403)

## Before vs After


https://github.com/user-attachments/assets/208e7dbf-73ae-4a2a-a7a0-57ee6fe7d06c


https://github.com/user-attachments/assets/21b2e7fc-47ea-4847-bd77-a94d2ea46544


## Issue
Refs #4949
