### PR TITLE
feat: add support to open project in terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -2964,6 +2965,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -11635,6 +11642,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.3",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12244,6 +12262,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -54,6 +54,8 @@
 				await fileService.showFileInFolder(project.path);
 			}),
 			shortcutService.on('open-in-terminal', async () => {
+				// TODO: once projectId is a project handle, it can be sent to the
+				// backend directly and we don't need to fetch.
 				const project = await projectsService.fetchProject(projectId);
 				if (!project) {
 					throw new Error(`Project not found: ${projectId}`);

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { BACKEND } from '$lib/backend';
 	import { FILE_SERVICE } from '$lib/files/fileService';
+	import { showError } from '$lib/notifications/toasts';
 	import { vscodePath } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { historyPath } from '$lib/routes/routes.svelte';
@@ -13,6 +15,7 @@
 
 	const { projectId }: { projectId: string } = $props();
 
+	const backend = inject(BACKEND);
 	const projectsService = inject(PROJECTS_SERVICE);
 	const urlService = inject(URL_SERVICE);
 	const { openProjectSettings } = useSettingsModal();
@@ -49,6 +52,20 @@
 				}
 				// Show the project directory in the default file manager (cross-platform)
 				await fileService.showFileInFolder(project.path);
+			}),
+			shortcutService.on('open-in-terminal', async () => {
+				const project = await projectsService.fetchProject(projectId);
+				if (!project) {
+					throw new Error(`Project not found: ${projectId}`);
+				}
+				try {
+					await backend.invoke('open_in_terminal', {
+						terminalId: $userSettings.defaultTerminal.identifier,
+						path: project.path
+					});
+				} catch (err: unknown) {
+					showError('Failed to open terminal', err);
+				}
 			})
 		)
 	);

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -7,7 +7,11 @@
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { showError } from '$lib/notifications/toasts';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { SETTINGS, type CodeEditorSettings } from '$lib/settings/userSettings';
+	import {
+		SETTINGS,
+		type CodeEditorSettings,
+		type TerminalSettings
+	} from '$lib/settings/userSettings';
 	import { UPDATER_SERVICE } from '$lib/updater/updater';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
@@ -63,6 +67,36 @@
 	const editorOptionsForSelect = editorOptions.map((option) => ({
 		label: option.displayName,
 		value: option.schemeIdentifer
+	}));
+
+	const allTerminalOptions: TerminalSettings[] = [
+		// macOS
+		{ identifier: 'terminal', displayName: 'Terminal', platform: 'macos' },
+		{ identifier: 'iterm2', displayName: 'iTerm2', platform: 'macos' },
+		{ identifier: 'ghostty', displayName: 'Ghostty', platform: 'macos' },
+		{ identifier: 'warp', displayName: 'Warp', platform: 'macos' },
+		{ identifier: 'alacritty-mac', displayName: 'Alacritty', platform: 'macos' },
+		{ identifier: 'wezterm-mac', displayName: 'WezTerm', platform: 'macos' },
+		{ identifier: 'hyper', displayName: 'Hyper', platform: 'macos' },
+		// Windows
+		{ identifier: 'wt', displayName: 'Windows Terminal', platform: 'windows' },
+		{ identifier: 'powershell', displayName: 'PowerShell', platform: 'windows' },
+		{ identifier: 'cmd', displayName: 'Command Prompt', platform: 'windows' },
+		// Linux
+		{ identifier: 'gnome-terminal', displayName: 'GNOME Terminal', platform: 'linux' },
+		{ identifier: 'konsole', displayName: 'Konsole', platform: 'linux' },
+		{ identifier: 'xfce4-terminal', displayName: 'XFCE Terminal', platform: 'linux' },
+		{ identifier: 'alacritty', displayName: 'Alacritty', platform: 'linux' },
+		{ identifier: 'ghostty', displayName: 'Ghostty', platform: 'linux' },
+		{ identifier: 'warp', displayName: 'Warp', platform: 'linux' },
+		{ identifier: 'hyper', displayName: 'Hyper', platform: 'linux' },
+		{ identifier: 'wezterm', displayName: 'WezTerm', platform: 'linux' }
+	];
+
+	const terminalOptions = allTerminalOptions.filter((t) => t.platform === platformName);
+	const terminalOptionsForSelect = terminalOptions.map((option) => ({
+		label: option.displayName,
+		value: option.identifier
 	}));
 
 	$effect(() => {
@@ -199,6 +233,32 @@
 				{#snippet itemSnippet({ item, highlighted })}
 					<SelectItem
 						selected={item.value === $userSettings.defaultCodeEditor.schemeIdentifer}
+						{highlighted}
+					>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		{/snippet}
+	</CardGroup.Item>
+	<CardGroup.Item alignment="center">
+		{#snippet title()}
+			Default terminal
+		{/snippet}
+		{#snippet actions()}
+			<Select
+				value={$userSettings.defaultTerminal.identifier}
+				options={terminalOptionsForSelect}
+				onselect={(value) => {
+					const selected = terminalOptions.find((option) => option.identifier === value);
+					if (selected) {
+						userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
+					}
+				}}
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem
+						selected={item.value === $userSettings.defaultTerminal.identifier}
 						{highlighted}
 					>
 						{item.label}

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -241,32 +241,34 @@
 			</Select>
 		{/snippet}
 	</CardGroup.Item>
-	<CardGroup.Item alignment="center">
-		{#snippet title()}
-			Default terminal
-		{/snippet}
-		{#snippet actions()}
-			<Select
-				value={$userSettings.defaultTerminal.identifier}
-				options={terminalOptionsForSelect}
-				onselect={(value) => {
-					const selected = terminalOptions.find((option) => option.identifier === value);
-					if (selected) {
-						userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
-					}
-				}}
-			>
-				{#snippet itemSnippet({ item, highlighted })}
-					<SelectItem
-						selected={item.value === $userSettings.defaultTerminal.identifier}
-						{highlighted}
-					>
-						{item.label}
-					</SelectItem>
-				{/snippet}
-			</Select>
-		{/snippet}
-	</CardGroup.Item>
+	{#if platformName !== 'web'}
+		<CardGroup.Item alignment="center">
+			{#snippet title()}
+				Default terminal
+			{/snippet}
+			{#snippet actions()}
+				<Select
+					value={$userSettings.defaultTerminal.identifier}
+					options={terminalOptionsForSelect}
+					onselect={(value) => {
+						const selected = terminalOptions.find((option) => option.identifier === value);
+						if (selected) {
+							userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
+						}
+					}}
+				>
+					{#snippet itemSnippet({ item, highlighted })}
+						<SelectItem
+							selected={item.value === $userSettings.defaultTerminal.identifier}
+							{highlighted}
+						>
+							{item.label}
+						</SelectItem>
+					{/snippet}
+				</Select>
+			{/snippet}
+		</CardGroup.Item>
+	{/if}
 </CardGroup>
 
 <CardGroup>

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -105,7 +105,7 @@ export function initDependencies(args: {
 	// FOUNDATION LAYER - Core services that others depend on
 	// ============================================================================
 
-	const userSettings = loadUserSettings();
+	const userSettings = loadUserSettings(backend.platformName);
 	const appState = new AppState();
 
 	// ============================================================================

--- a/apps/desktop/src/lib/error/knownErrors.ts
+++ b/apps/desktop/src/lib/error/knownErrors.ts
@@ -9,7 +9,8 @@ export enum Code {
 	SecretKeychainNotFound = 'errors.secret.keychain_notfound',
 	MissingLoginKeychain = 'errors.secret.missing_login_keychain',
 	GitHubTokenExpired = 'errors.github.expired_token',
-	ProjectDatabaseIncompatible = 'errors.projectdb.migration'
+	ProjectDatabaseIncompatible = 'errors.projectdb.migration',
+	DefaultTerminalNotFound = 'errors.terminal.not_found'
 }
 
 export const KNOWN_ERRORS: Record<string, string> = {
@@ -37,6 +38,9 @@ With \`seahorse\` or equivalent, create a \`Login\` password store, right click 
 Your GitHub token appears expired. Please log out and back in to refresh it. (Settings -> Integrations -> Forget) 
 	`,
 	[Code.ProjectDatabaseIncompatible]: `
-The database was changed by a more recent version of GitButler - cannot safely open it anymore. 
+The database was changed by a more recent version of GitButler - cannot safely open it anymore.
+	`,
+	[Code.DefaultTerminalNotFound]: `
+Your default terminal was not found. Please select your preferred terminal in Settings > General.
 	`
 };

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -89,9 +89,8 @@ export function loadUserSettings(): Writable<Settings> {
 		obj = {};
 	}
 
-	// If no terminal was persisted, or the persisted one is the old 'auto' sentinel,
-	// resolve to the platform default.
-	if (!obj.defaultTerminal || obj.defaultTerminal.identifier === 'auto') {
+	// If no terminal was persisted, resolve to the platform default.
+	if (!obj.defaultTerminal) {
 		obj.defaultTerminal = defaultTerminalForPlatform();
 	}
 

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -1,6 +1,5 @@
 import { InjectionToken } from '@gitbutler/core/context';
 import { type ScrollbarVisilitySettings } from '@gitbutler/ui';
-import { platform } from '@tauri-apps/plugin-os';
 import { get, writable, type Writable } from 'svelte/store';
 
 const SETTINGS_KEY = 'settings-json';
@@ -17,8 +16,8 @@ export type TerminalSettings = {
 	platform: 'macos' | 'windows' | 'linux';
 };
 
-function defaultTerminalForPlatform(): TerminalSettings {
-	switch (platform()) {
+function defaultTerminalForPlatform(platformName: string): TerminalSettings {
+	switch (platformName) {
 		case 'windows':
 			return { identifier: 'powershell', displayName: 'PowerShell', platform: 'windows' };
 		case 'linux':
@@ -81,8 +80,8 @@ const defaults: Settings = {
 	singleDiffView: false
 };
 
-export function loadUserSettings(): Writable<Settings> {
-	let obj: any;
+export function loadUserSettings(platformName: string): Writable<Settings> {
+	let obj: Partial<Settings>;
 	try {
 		obj = JSON.parse(localStorage.getItem(SETTINGS_KEY) || '');
 	} catch {
@@ -91,7 +90,7 @@ export function loadUserSettings(): Writable<Settings> {
 
 	// If no terminal was persisted, resolve to the platform default.
 	if (!obj.defaultTerminal) {
-		obj.defaultTerminal = defaultTerminalForPlatform();
+		obj.defaultTerminal = defaultTerminalForPlatform(platformName);
 	}
 
 	const store = writable<Settings>({ ...defaults, ...obj });

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -116,6 +116,7 @@ git2.workspace = true
 open.workspace = true
 url = { version = "2.5", optional = true }
 uuid.workspace = true
+which = "8.0.0"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -99,6 +99,318 @@ pub fn open_url(url: String) -> Result<()> {
     open_that(&url)
 }
 
+/// Opens a terminal application at the specified directory path.
+///
+/// # Parameters
+/// - `terminal_id`: Identifier for the terminal application to open.
+/// - `path`: The directory path where the terminal should open.
+///
+/// # Supported Terminals
+///
+/// **macOS:**
+/// - `terminal` - Terminal.app
+/// - `iterm2` - iTerm2
+/// - `ghostty` - Ghostty
+/// - `warp` - Warp
+/// - `alacritty-mac` - Alacritty
+/// - `wezterm-mac` - WezTerm
+/// - `hyper` - Hyper
+///
+/// **Windows:**
+/// - `wt` - Windows Terminal
+/// - `powershell` - PowerShell
+/// - `cmd` - Command Prompt
+///
+/// **Linux:**
+/// - `gnome-terminal` - GNOME Terminal
+/// - `konsole` - KDE Konsole
+/// - `xfce4-terminal` - XFCE Terminal
+/// - `alacritty` - Alacritty
+/// - `ghostty` - Ghostty
+/// - `warp` - Warp
+/// - `hyper` - Hyper
+/// - `wezterm` - WezTerm
+///
+/// # Errors
+/// Returns an error if:
+/// - The terminal application is not installed or not found in PATH
+/// - The specified path does not exist or is not accessible
+/// - The terminal_id is not recognized for the current platform
+/// - The terminal fails to launch
+///   - On macOS/Linux, this includes the terminal process exiting immediately with a non-zero status code
+///   - On Windows, only spawn failures are detected; the terminal's later exit status is not checked
+#[but_api]
+#[instrument(err(Debug))]
+pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
+    use std::process::Command;
+
+    #[cfg(target_os = "macos")]
+    {
+        /// Helper to run a command and check its exit status
+        /// Used for macOS terminals that are launched via `open` or direct commands.
+        /// These typically return immediately (async launch), so we only check if the launch succeeded.
+        fn run_terminal_command(mut cmd: Command, terminal_name: &str, path: &str) -> Result<()> {
+            tracing::info!(?cmd, "terminal command");
+            let output = cmd
+                .output()
+                .with_context(|| format!("Failed to launch {terminal_name} at '{path}'"))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr = stderr.trim();
+                if stderr.is_empty() {
+                    bail!(
+                        "{terminal_name} exited with non-zero status: {}",
+                        output.status.code().map_or("unknown".to_string(), |c| c.to_string())
+                    );
+                } else {
+                    bail!("Failed to open {terminal_name}: {stderr}");
+                }
+            }
+            Ok(())
+        }
+        /// Check if a macOS application is installed using `open -Ra`.
+        fn ensure_app_installed(app_name: &str, terminal_id: &str, path: &str) -> Result<()> {
+            let status = std::process::Command::new("open")
+                .arg("-Ra")
+                .arg(app_name)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .context("Failed to run 'open -Ra' to check application availability")?;
+            if !status.success() {
+                return Err(anyhow::anyhow!(
+                    "command: open_in_terminal\n\
+                     params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
+                     '{app_name}' was not found."
+                )
+                .context(but_error::Code::DefaultTerminalNotFound));
+            }
+            Ok(())
+        }
+
+        match terminal_id.as_str() {
+            // These terminals support `open -a <app> <path>` as folder handlers
+            "terminal" => {
+                ensure_app_installed("Terminal", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-a").arg("Terminal").arg(&path);
+                run_terminal_command(cmd, "Terminal", &path)?;
+            }
+            "iterm2" => {
+                ensure_app_installed("iTerm", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-a").arg("iTerm").arg(&path);
+                run_terminal_command(cmd, "iTerm2", &path)?;
+            }
+            "warp" => {
+                ensure_app_installed("Warp", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-a").arg("Warp").arg(&path);
+                run_terminal_command(cmd, "Warp", &path)?;
+            }
+            "ghostty" => {
+                ensure_app_installed("Ghostty", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-a").arg("Ghostty").arg(&path);
+                run_terminal_command(cmd, "Ghostty", &path)?;
+            }
+            "alacritty-mac" => {
+                ensure_app_installed("Alacritty", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-n")
+                    .arg("-a")
+                    .arg("Alacritty")
+                    .arg("--args")
+                    .arg("--working-directory")
+                    .arg(&path);
+                run_terminal_command(cmd, "Alacritty", &path)?;
+            }
+            // WezTerm does not support `open -a WezTerm <path>`. Their docs state you have to use their CLI.
+            // https://wezterm.org/config/launch.html#specifying-the-current-working-directory
+            "wezterm-mac" => {
+                let cli_found = Command::new("which")
+                    .arg("wezterm")
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                if !cli_found {
+                    return Err(anyhow::anyhow!(
+                        "command: open_in_terminal\n\
+                         params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
+                         'wezterm' CLI was not found on PATH."
+                    )
+                    .context(but_error::Code::DefaultTerminalNotFound));
+                }
+                let mut cmd = Command::new("wezterm");
+                cmd.arg("start").arg("--cwd").arg(&path);
+                run_terminal_command(cmd, "WezTerm", &path)?;
+            }
+            "hyper" => {
+                ensure_app_installed("Hyper", &terminal_id, &path)?;
+                let mut cmd = Command::new("open");
+                cmd.arg("-a").arg("Hyper").arg(&path);
+                run_terminal_command(cmd, "Hyper", &path)?;
+            }
+            _ => bail!("Unknown terminal: {}", terminal_id),
+        };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        use std::path::Path;
+
+        // Validate path exists and canonicalize it to proper Windows format
+        let path_buf = Path::new(&path);
+        if !path_buf.exists() {
+            bail!("Path does not exist: {}", path);
+        }
+        if !path_buf.is_dir() {
+            bail!("Path is not a directory: {}", path);
+        }
+
+        // Canonicalize to get the absolute, properly formatted Windows path
+        // This converts forward slashes to backslashes and resolves . and ..
+        let canonical_path = path_buf
+            .canonicalize()
+            .with_context(|| format!("Failed to canonicalize path: {}", path))?;
+
+        // Strip the \\?\ prefix that canonicalize adds on Windows
+        // CMD.exe and some terminals don't support UNC paths with this prefix
+        let path_str = canonical_path.to_str().context("Path contains invalid UTF-8")?;
+        let cleaned_path = path_str.strip_prefix(r"\\?\").unwrap_or(path_str);
+
+        // Check if the terminal binary exists in PATH before attempting to launch.
+        let binary_found = Command::new("where")
+            .arg(&terminal_id)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !binary_found {
+            return Err(anyhow::anyhow!(
+                "command: open_in_terminal\n\
+                 params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
+                 '{terminal_id}' was not found."
+            )
+            .context(but_error::Code::DefaultTerminalNotFound));
+        }
+
+        // CREATE_NEW_CONSOLE: Creates a new console for the process (0x00000010)
+        // This allows the terminal to run independently without blocking our thread
+        const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+
+        match terminal_id.as_str() {
+            "wt" => {
+                let mut cmd = Command::new("wt");
+                cmd.arg("-d").arg(cleaned_path);
+                cmd.creation_flags(CREATE_NEW_CONSOLE);
+                // Windows Terminal detaches automatically, just check if it launches
+                cmd.spawn().with_context(|| {
+                    format!(
+                        "command: open_in_terminal\n\
+                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
+                         Failed to launch Windows Terminal at '{cleaned_path}'"
+                    )
+                })?;
+            }
+            "powershell" => {
+                let mut cmd = Command::new("powershell");
+                // Set the working directory directly instead of using cd command
+                cmd.current_dir(cleaned_path);
+                cmd.arg("-NoExit"); // Keep the window open
+                cmd.creation_flags(CREATE_NEW_CONSOLE);
+                cmd.spawn().with_context(|| {
+                    format!(
+                        "command: open_in_terminal\n\
+                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
+                         Failed to launch PowerShell at '{cleaned_path}'"
+                    )
+                })?;
+            }
+            "cmd" => {
+                let mut cmd = Command::new("cmd");
+                // Set the working directory directly - OS handles path format
+                cmd.current_dir(cleaned_path);
+                cmd.arg("/K"); // Keep the window open
+                cmd.creation_flags(CREATE_NEW_CONSOLE);
+                cmd.spawn().with_context(|| {
+                    format!(
+                        "command: open_in_terminal\n\
+                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
+                         Failed to launch Command Prompt at '{cleaned_path}'"
+                    )
+                })?;
+            }
+            _ => bail!("Unknown terminal: {}", terminal_id),
+        };
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Resolve the actual binary name (some terminals use a different binary than their ID)
+        let binary = match terminal_id.as_str() {
+            "warp" => "warp-terminal",
+            other => other,
+        };
+
+        // Check if the terminal binary exists in PATH before attempting to launch.
+        // This lets us give a clear error directing users to Settings, rather than
+        // a vague launch failure (which could be confused with path issues).
+        let binary_found = Command::new("which")
+            .arg(binary)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !binary_found {
+            return Err(anyhow::anyhow!(
+                "command: open_in_terminal\n\
+                 params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
+                 '{binary}' was not found."
+            )
+            .context(but_error::Code::DefaultTerminalNotFound));
+        }
+
+        // Use spawn() (fire-and-forget) rather than output() for Linux terminals.
+        // Most terminal emulators return immediately after spawning a window, so output()
+        // doesn't provide meaningful post-launch diagnostics — only spawn failures matter.
+        match terminal_id.as_str() {
+            // Terminals that inherit parent process CWD (no explicit flags needed).
+            // Note: `binary` is used instead of the terminal ID because some terminals
+            // have a different binary name (e.g. "warp" launches "warp-terminal").
+            "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "ghostty" | "warp" => {
+                let mut cmd = Command::new(binary);
+                cmd.current_dir(&path);
+                cmd.spawn()
+                    .with_context(|| format!("Failed to launch {binary} at '{path}'"))?;
+            }
+            // Hyper accepts path as argument (Electron app doesn't use parent CWD)
+            "hyper" => {
+                let mut cmd = Command::new("hyper");
+                cmd.arg(&path);
+                cmd.spawn()
+                    .with_context(|| format!("Failed to launch hyper at '{path}'"))?;
+            }
+            // WezTerm does not respect parent CWD and requires explicit --cwd
+            "wezterm" => {
+                let mut cmd = Command::new("wezterm");
+                cmd.arg("start").arg("--cwd").arg(&path);
+                cmd.spawn()
+                    .with_context(|| format!("Failed to launch wezterm at '{path}'"))?;
+            }
+            _ => bail!("Unknown terminal: {}", terminal_id),
+        };
+    }
+
+    Ok(())
+}
+
 #[but_api]
 #[instrument(err(Debug))]
 pub fn show_in_finder(path: String) -> Result<()> {

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -104,6 +104,7 @@ pub fn open_url(url: String) -> Result<()> {
 /// # Parameters
 /// - `terminal_id`: Identifier for the terminal application to open.
 /// - `path`: The directory path where the terminal should open.
+///   It's a string as it's passed from the frontend, but ideally we'd manage to keep the original bytes.
 ///
 /// # Supported Terminals
 ///
@@ -144,79 +145,67 @@ pub fn open_url(url: String) -> Result<()> {
 pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
     use std::process::Command;
 
-    #[cfg(target_os = "macos")]
-    {
+    if cfg!(target_os = "macos") {
+        use std::process::Stdio;
+
         /// Helper to run a command and check its exit status
         /// Used for macOS terminals that are launched via `open` or direct commands.
         /// These typically return immediately (async launch), so we only check if the launch succeeded.
         fn run_terminal_command(mut cmd: Command, terminal_name: &str, path: &str) -> Result<()> {
+            use bstr::ByteSlice;
+
             tracing::info!(?cmd, "terminal command");
             let output = cmd
                 .output()
                 .with_context(|| format!("Failed to launch {terminal_name} at '{path}'"))?;
 
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stderr = stderr.trim();
-                if stderr.is_empty() {
-                    bail!(
-                        "{terminal_name} exited with non-zero status: {}",
-                        output.status.code().map_or("unknown".to_string(), |c| c.to_string())
-                    );
-                } else {
-                    bail!("Failed to open {terminal_name}: {stderr}");
-                }
+            if output.status.success() {
+                return Ok(());
             }
-            Ok(())
+
+            let stderr = output.stderr.to_str_lossy();
+            let stderr = stderr.trim();
+            let status_code = output.status.code().map_or("unknown".to_string(), |c| c.to_string());
+            if stderr.is_empty() {
+                bail!("{terminal_name} exited with non-zero status: {status_code}",);
+            } else {
+                bail!("Failed to open {terminal_name} ({status_code}): {stderr}");
+            }
         }
+
         /// Check if a macOS application is installed using `open -Ra`.
-        fn ensure_app_installed(app_name: &str, terminal_id: &str, path: &str) -> Result<()> {
-            let status = std::process::Command::new("open")
+        fn ensure_app_installed(app_name: &str) -> Result<()> {
+            let status = Command::new("open")
                 .arg("-Ra")
                 .arg(app_name)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .context("Failed to run 'open -Ra' to check application availability")?;
             if !status.success() {
-                return Err(anyhow::anyhow!(
-                    "command: open_in_terminal\n\
-                     params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
-                     '{app_name}' was not found."
-                )
-                .context(but_error::Code::DefaultTerminalNotFound));
+                return Err(
+                    anyhow::anyhow!("'{app_name}' was not found.").context(but_error::Code::DefaultTerminalNotFound)
+                );
             }
             Ok(())
         }
 
+        let open_with_path = |app_name: &str, alt_app_name: Option<&str>| {
+            ensure_app_installed(app_name)?;
+            let mut cmd = Command::new("open");
+            cmd.arg("-a").arg(app_name).arg(&path);
+            run_terminal_command(cmd, alt_app_name.unwrap_or(app_name), &path)
+        };
+
         match terminal_id.as_str() {
             // These terminals support `open -a <app> <path>` as folder handlers
-            "terminal" => {
-                ensure_app_installed("Terminal", &terminal_id, &path)?;
-                let mut cmd = Command::new("open");
-                cmd.arg("-a").arg("Terminal").arg(&path);
-                run_terminal_command(cmd, "Terminal", &path)?;
-            }
-            "iterm2" => {
-                ensure_app_installed("iTerm", &terminal_id, &path)?;
-                let mut cmd = Command::new("open");
-                cmd.arg("-a").arg("iTerm").arg(&path);
-                run_terminal_command(cmd, "iTerm2", &path)?;
-            }
-            "warp" => {
-                ensure_app_installed("Warp", &terminal_id, &path)?;
-                let mut cmd = Command::new("open");
-                cmd.arg("-a").arg("Warp").arg(&path);
-                run_terminal_command(cmd, "Warp", &path)?;
-            }
-            "ghostty" => {
-                ensure_app_installed("Ghostty", &terminal_id, &path)?;
-                let mut cmd = Command::new("open");
-                cmd.arg("-a").arg("Ghostty").arg(&path);
-                run_terminal_command(cmd, "Ghostty", &path)?;
-            }
+            "terminal" => open_with_path("Terminal", None)?,
+            "iterm2" => open_with_path("iTerm", Some("iTerm2"))?,
+            "warp" => open_with_path("Warp", None)?,
+            "ghostty" => open_with_path("Ghostty", None)?,
+            "hyper" => open_with_path("Hyper", None)?,
             "alacritty-mac" => {
-                ensure_app_installed("Alacritty", &terminal_id, &path)?;
+                ensure_app_installed("Alacritty")?;
                 let mut cmd = Command::new("open");
                 cmd.arg("-n")
                     .arg("-a")
@@ -229,129 +218,18 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
             // WezTerm does not support `open -a WezTerm <path>`. Their docs state you have to use their CLI.
             // https://wezterm.org/config/launch.html#specifying-the-current-working-directory
             "wezterm-mac" => {
-                let cli_found = Command::new("which")
-                    .arg("wezterm")
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status()
-                    .map(|s| s.success())
-                    .unwrap_or(false);
+                let cli_found = which::which("wezterm").is_ok();
                 if !cli_found {
-                    return Err(anyhow::anyhow!(
-                        "command: open_in_terminal\n\
-                         params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
-                         'wezterm' CLI was not found on PATH."
-                    )
-                    .context(but_error::Code::DefaultTerminalNotFound));
+                    return Err(anyhow::anyhow!("'wezterm' CLI was not found on PATH.")
+                        .context(but_error::Code::DefaultTerminalNotFound));
                 }
                 let mut cmd = Command::new("wezterm");
                 cmd.arg("start").arg("--cwd").arg(&path);
                 run_terminal_command(cmd, "WezTerm", &path)?;
             }
-            "hyper" => {
-                ensure_app_installed("Hyper", &terminal_id, &path)?;
-                let mut cmd = Command::new("open");
-                cmd.arg("-a").arg("Hyper").arg(&path);
-                run_terminal_command(cmd, "Hyper", &path)?;
-            }
-            _ => bail!("Unknown terminal: {}", terminal_id),
+            _ => bail!("Unknown terminal: {terminal_id}"),
         };
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        use std::path::Path;
-
-        // Validate path exists and canonicalize it to proper Windows format
-        let path_buf = Path::new(&path);
-        if !path_buf.exists() {
-            bail!("Path does not exist: {}", path);
-        }
-        if !path_buf.is_dir() {
-            bail!("Path is not a directory: {}", path);
-        }
-
-        // Canonicalize to get the absolute, properly formatted Windows path
-        // This converts forward slashes to backslashes and resolves . and ..
-        let canonical_path = path_buf
-            .canonicalize()
-            .with_context(|| format!("Failed to canonicalize path: {}", path))?;
-
-        // Strip the \\?\ prefix that canonicalize adds on Windows
-        // CMD.exe and some terminals don't support UNC paths with this prefix
-        let path_str = canonical_path.to_str().context("Path contains invalid UTF-8")?;
-        let cleaned_path = path_str.strip_prefix(r"\\?\").unwrap_or(path_str);
-
-        // Check if the terminal binary exists in PATH before attempting to launch.
-        let binary_found = Command::new("where")
-            .arg(&terminal_id)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if !binary_found {
-            return Err(anyhow::anyhow!(
-                "command: open_in_terminal\n\
-                 params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
-                 '{terminal_id}' was not found."
-            )
-            .context(but_error::Code::DefaultTerminalNotFound));
-        }
-
-        // CREATE_NEW_CONSOLE: Creates a new console for the process (0x00000010)
-        // This allows the terminal to run independently without blocking our thread
-        const CREATE_NEW_CONSOLE: u32 = 0x00000010;
-
-        match terminal_id.as_str() {
-            "wt" => {
-                let mut cmd = Command::new("wt");
-                cmd.arg("-d").arg(cleaned_path);
-                cmd.creation_flags(CREATE_NEW_CONSOLE);
-                // Windows Terminal detaches automatically, just check if it launches
-                cmd.spawn().with_context(|| {
-                    format!(
-                        "command: open_in_terminal\n\
-                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
-                         Failed to launch Windows Terminal at '{cleaned_path}'"
-                    )
-                })?;
-            }
-            "powershell" => {
-                let mut cmd = Command::new("powershell");
-                // Set the working directory directly instead of using cd command
-                cmd.current_dir(cleaned_path);
-                cmd.arg("-NoExit"); // Keep the window open
-                cmd.creation_flags(CREATE_NEW_CONSOLE);
-                cmd.spawn().with_context(|| {
-                    format!(
-                        "command: open_in_terminal\n\
-                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
-                         Failed to launch PowerShell at '{cleaned_path}'"
-                    )
-                })?;
-            }
-            "cmd" => {
-                let mut cmd = Command::new("cmd");
-                // Set the working directory directly - OS handles path format
-                cmd.current_dir(cleaned_path);
-                cmd.arg("/K"); // Keep the window open
-                cmd.creation_flags(CREATE_NEW_CONSOLE);
-                cmd.spawn().with_context(|| {
-                    format!(
-                        "command: open_in_terminal\n\
-                         params: terminal=\"{terminal_id}\", path=\"{cleaned_path}\"\n\n\
-                         Failed to launch Command Prompt at '{cleaned_path}'"
-                    )
-                })?;
-            }
-            _ => bail!("Unknown terminal: {}", terminal_id),
-        };
-    }
-
-    #[cfg(target_os = "linux")]
-    {
+    } else if cfg!(target_os = "linux") {
         // Resolve the actual binary name (some terminals use a different binary than their ID)
         let binary = match terminal_id.as_str() {
             "warp" => "warp-terminal",
@@ -361,20 +239,9 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
         // Check if the terminal binary exists in PATH before attempting to launch.
         // This lets us give a clear error directing users to Settings, rather than
         // a vague launch failure (which could be confused with path issues).
-        let binary_found = Command::new("which")
-            .arg(binary)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        let binary_found = which::which(binary).is_ok();
         if !binary_found {
-            return Err(anyhow::anyhow!(
-                "command: open_in_terminal\n\
-                 params: terminal=\"{terminal_id}\", path=\"{path}\"\n\n\
-                 '{binary}' was not found."
-            )
-            .context(but_error::Code::DefaultTerminalNotFound));
+            return Err(anyhow::anyhow!("'{binary}' was not found.").context(but_error::Code::DefaultTerminalNotFound));
         }
 
         // Use spawn() (fire-and-forget) rather than output() for Linux terminals.
@@ -385,27 +252,97 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
             // Note: `binary` is used instead of the terminal ID because some terminals
             // have a different binary name (e.g. "warp" launches "warp-terminal").
             "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "ghostty" | "warp" => {
-                let mut cmd = Command::new(binary);
-                cmd.current_dir(&path);
-                cmd.spawn()
+                Command::new(binary)
+                    .current_dir(&path)
+                    .spawn()
                     .with_context(|| format!("Failed to launch {binary} at '{path}'"))?;
             }
             // Hyper accepts path as argument (Electron app doesn't use parent CWD)
             "hyper" => {
-                let mut cmd = Command::new("hyper");
-                cmd.arg(&path);
-                cmd.spawn()
+                Command::new("hyper")
+                    .arg(&path)
+                    .spawn()
                     .with_context(|| format!("Failed to launch hyper at '{path}'"))?;
             }
             // WezTerm does not respect parent CWD and requires explicit --cwd
             "wezterm" => {
-                let mut cmd = Command::new("wezterm");
-                cmd.arg("start").arg("--cwd").arg(&path);
-                cmd.spawn()
+                Command::new("wezterm")
+                    .args(["start", "--cwd"])
+                    .arg(&path)
+                    .spawn()
                     .with_context(|| format!("Failed to launch wezterm at '{path}'"))?;
             }
-            _ => bail!("Unknown terminal: {}", terminal_id),
+            _ => bail!("Unknown terminal: {terminal_id}"),
         };
+    } else if cfg!(windows) {
+        #[cfg(windows)]
+        fn create_new_console(cmd: &mut Command) -> &mut Command {
+            use std::os::windows::process::CommandExt;
+            // CREATE_NEW_CONSOLE: Creates a new console for the process (0x00000010)
+            // This allows the terminal to run independently without blocking our thread
+            const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+            cmd.creation_flags(CREATE_NEW_CONSOLE)
+        }
+        #[cfg(not(windows))]
+        fn create_new_console(cmd: &mut Command) -> &mut Command {
+            cmd
+        }
+
+        use std::path::Path;
+
+        // Validate path exists and canonicalize it to proper Windows format
+        let path_buf = Path::new(&path);
+        if !path_buf.exists() {
+            bail!("Path does not exist: {path}");
+        }
+        if !path_buf.is_dir() {
+            bail!("Path is not a directory: {path}");
+        }
+
+        // Canonicalize to get the absolute, properly formatted Windows path
+        // This converts forward slashes to backslashes and resolves . and ..
+        let canonical_path = gix::path::realpath(path_buf)
+            .with_context(|| format!("Failed to canonicalize path: {path}"))?
+            .to_str()
+            .context("BUG: input path is String, should be able to convert back to it")?
+            .to_owned();
+        let canonical_path = &canonical_path;
+
+        // Check if the terminal binary exists in PATH before attempting to launch.
+        let binary_found = which::which(&terminal_id).is_ok();
+        if !binary_found {
+            return Err(
+                anyhow::anyhow!("'{terminal_id}' was not found.").context(but_error::Code::DefaultTerminalNotFound)
+            );
+        }
+
+        match terminal_id.as_str() {
+            "wt" => {
+                // Windows Terminal detaches automatically, just check if it launches
+                create_new_console(Command::new("wt").arg("-d").arg(canonical_path))
+                    .spawn()
+                    .with_context(|| format!("Failed to launch Windows Terminal at '{canonical_path}'"))?;
+            }
+            "powershell" => {
+                // Set the working directory directly instead of using cd command
+                create_new_console(Command::new("powershell").current_dir(canonical_path))
+                    // Keep the window open
+                    .arg("-NoExit")
+                    .spawn()
+                    .with_context(|| format!("Failed to launch PowerShell at '{canonical_path}'"))?;
+            }
+            "cmd" => {
+                // Set the working directory directly - OS handles path format
+                create_new_console(Command::new("cmd").current_dir(canonical_path))
+                    // Keep the window open
+                    .arg("/K")
+                    .spawn()
+                    .with_context(|| format!("Failed to launch Command Prompt at '{canonical_path}'"))?;
+            }
+            _ => bail!("Unknown terminal: {terminal_id}"),
+        };
+    } else {
+        bail!("Unsupported platform");
     }
 
     Ok(())

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -137,6 +137,7 @@ pub enum Code {
     GitForcePushProtection,
     NetworkError,
     ProjectDatabaseIncompatible,
+    DefaultTerminalNotFound,
 }
 
 impl std::fmt::Display for Code {
@@ -157,6 +158,7 @@ impl std::fmt::Display for Code {
             Code::GitForcePushProtection => "errors.git.force_push_protection",
             Code::NetworkError => "errors.network",
             Code::ProjectDatabaseIncompatible => "errors.projectdb.migration",
+            Code::DefaultTerminalNotFound => "errors.terminal.not_found",
         };
         f.write_str(code)
     }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -619,6 +619,10 @@ pub async fn run() {
         .route("/cli_path", post(json_response(legacy::cli::cli_path_cmd)))
         .route("/open_url", post(json_response(legacy::open::open_url_cmd)))
         .route(
+            "/open_in_terminal",
+            post(json_response(legacy::open::open_in_terminal_cmd)),
+        )
+        .route(
             "/show_in_finder",
             post(json_response(legacy::open::show_in_finder_cmd)),
         )

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -307,6 +307,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::modes::tauri_edit_initial_index_state::edit_initial_index_state,
                 legacy::modes::tauri_edit_changes_from_initial::edit_changes_from_initial,
                 legacy::open::tauri_open_url::open_url,
+                legacy::open::tauri_open_in_terminal::open_in_terminal,
                 legacy::open::tauri_show_in_finder::show_in_finder,
                 legacy::forge::tauri_pr_templates::pr_templates,
                 legacy::forge::tauri_pr_template::pr_template,

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -165,7 +165,8 @@ pub fn build<R: Runtime>(
                 .build(handle)?,
         )
         .separator()
-        .text("project/open-in-vscode", "Open in Editor");
+        .text("project/open-in-vscode", "Open in Editor")
+        .text("project/open-in-terminal", "Open in Terminal");
 
     #[cfg(target_os = "macos")]
     {
@@ -322,6 +323,11 @@ pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
 
     if event.id() == "project/open-in-vscode" {
         emit(webview, SHORTCUT_EVENT, "open-in-vscode");
+        return;
+    }
+
+    if event.id() == "project/open-in-terminal" {
+        emit(webview, SHORTCUT_EVENT, "open-in-terminal");
         return;
     }
 


### PR DESCRIPTION
## 🧢 Changes

- Implement open_in_terminal based on #9719 
- Add additional terminals for different OSes to be supported
- Add check if Open in Terminal command was successful using helper
  function open_in_terminal
- Sets the default terminal per platform to handle cases where user has
  not yet opted for a specific terminal.
- Fix issue where output from terminal sent to stderr was not captured
  and checked. We now use this message to provide helpful error to the
  user

**MacOS Support**

- Add custom launch logic for each MacOS terminal option. Wezterm uses a PATH binary instead of `open` because it does not work well with the  “open -a” notation to open specific directories. 
- Add check to see if app is installed before attempting launch, so we
  can give more helpful error to users.
- Fix for issue Alacritty is installed in Applications but not PATH on
  MacOS by using “open -a” instead of direct binary reference. The
  `—working-directory` flag continues working with this variant
- Fix issue where Alacritty will hijack existing terminal sessions if present, by using `-n` flag to force a new window.
- Implement custom opening logic and is-installed check for Wezterm since its the only emulator that only opens with CLI

**Windows Support**

- Detaches the Windows terminal processes from main thread in GB using
  0x00000010 flag. This fixes an issue where we couldn’t report success
  until the user actually closed or crashed their terminal.
- Implement Windows-specific path handling and path validation with path escaping for special symbols
- Force Windows-style path parsing for cmd
- Fix Windows Cmd and Powershell escaping to be more secure and handle path names with spaces and other characters. 

**Linux Support**

- Condense the terminal opening logic for most linux terminals, as they
  support launching in the parent process cwd
- Condense UI identifiers for common MacOS/Linux emulators. 
- Adds more terminals for Linux, particularily ones that are already
  supported on MacOS
- Use spawn() for terminals on Linux, as some of the terminals will be blocking their launch thread

**Error handling**
- Implement DefaultTerminalNotFound error for Linux, MacOS and Windows
- Enrich DefaultTerminalNotFound error message on all platforms
- Display attempted command, params and resulting error message to user as copyable error
**UI stuff**
- Add default terminal option in settings panel. Only displays terminals available for current platform.
- Add logic to ensure default terminal is valid for
current os on first load
- Expose open in terminal action in menu
- Show error if opening terminal fails
- Register open in terminal action for but server
- Replace default terminal with sentinel value to trigger OS-specific selection
- Fix issue where “Open in Terminal” will fail if you open without ever
visiting the settings panel
- Add platform detection one-liner to userSettings.ts to determine default terminal

**UI stuff**

- Add default terminal option in settings panel. Only displays terminals available for current platform.
- Add logic to ensure default terminal is valid for
current os on first load
- Expose open in terminal action in menu
- Show error if opening terminal fails
- Register open in terminal action for but server
- Replace default terminal with sentinel value to trigger OS-specific selection
- Fix issue where “Open in Terminal” will fail if you open without ever
visiting the settings panel
- Add platform detection one-liner to userSettings.ts to determine default terminal

## ☕️ Reasoning

- Seems like there was interest in the suggested additions from #9719, but PR went stale. There has been a bunch of changes since then (August 2025)

**Validation checklist**

MacOS (Tested on MacOS 15.7.3)
- [x] Terminal (default)
- [x] iTerm2
- [x] Ghostty
- [x] Warp
- [x] Alacritty
- [x] WezTerm
- [x] Hyper

Windows (Windows 11 25H2)
- [x] Terminal (default)
- [x] Powershell
- [x] cmd

Linux (Ubuntu 24 LTS)
- [x] Gnome
- [x] Konsole
- [x] Xfce4-terminal
- [x] Alacritty
- [x] WezTerm
- [x] Hyper
- [x] Warp
- [x] Ghostty

## ✨ Future Enhancements

- Add “Select Custom App” option in Terminal selector inside settings. This would let us drop the hard-coded list and allow user to select their desired terminal. However, this should also require a change in the “Default Code Editor” selector, which is also hard-coded currently.

<img width="534" height="334" alt="image" src="https://github.com/user-attachments/assets/f94cd8cc-3860-4251-b9c6-282651f16004" />

# PR-revival in action on latest nightly:

**Windows**

<img width="1160" height="745" alt="image" src="https://github.com/user-attachments/assets/3377dbca-7887-45d6-977e-ef45c801fe07" />

<img width="1159" height="750" alt="image" src="https://github.com/user-attachments/assets/da51612e-ad48-444f-abb4-87a875a8ecd7" />

Tested with Terminal app, Powershell app and cmd app. Note that a plain Windows install will launch all three options in the Terminal app unless configured to do otherwise.

**Macos**

<img width="1000" height="625" alt="image" src="https://github.com/user-attachments/assets/c58782a3-3b85-4dfd-8803-43a28c06bff5" />

<img width="997" height="624" alt="image" src="https://github.com/user-attachments/assets/94493bb2-602a-4ab9-9bdf-7e667e36c514" />

Tested with Terminal and Warp.

**Settings menu**
<img width="785" height="524" alt="image" src="https://github.com/user-attachments/assets/a2a23114-f27c-4cad-b7d9-314455d05ed1" />

**Linux (Ubuntu)**

<img width="1158" height="722" alt="Screenshot from 2026-01-20 15-25-08" src="https://github.com/user-attachments/assets/b81e5aa8-b936-49cc-b4c0-80ce6c931950" />

<img width="1161" height="723" alt="Screenshot from 2026-01-20 15-30-51" src="https://github.com/user-attachments/assets/5ee25c78-775e-491a-b9dd-279d85edacdc" />
