### PR TITLE
Re-enable `but` journey test which should now handle concurrent migrations

### DIFF
--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -24,7 +24,6 @@ Error: The reference 'main' did not exist
 // TODO: maybe this should be a non-legacy journey only as we start out without workspace?
 #[cfg(feature = "legacy")]
 #[test]
-#[ignore = "still having 'Failed to run migrations error'"]
 fn from_empty() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
@@ -93,7 +92,7 @@ Caused by:
         .assert()
         .failure()
         .stdout_eq(str![[r#"
-[2mInitiated a background fetch...[0m
+Initiated a background sync...
 
 "#]])
         .stderr_eq(str![[r#"
@@ -109,7 +108,10 @@ Caused by:
     env.but("branch new feat")
         .assert()
         .failure()
-        .stdout_eq(str![""])
+        .stdout_eq(str![[r#"
+Initiated a background sync...
+
+"#]])
         .stderr_eq(str![[r#"
 Error: errors.projects.default_target.not_found
 


### PR DESCRIPTION
Also, reduce friction by testing the actual output less.
