### PR TITLE
Fix journey test isolation

### DIFF
--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -49,15 +49,21 @@ enum InitMetadata {
 
 /// Lifecycle
 impl Sandbox {
-    /// Create a new instance with empty everything.
+    /// Create a new instance with empty everything, except for basic application settings that prevent the app to break out.
+    ///
+    /// Change these if you want to test something specific on top of that.
     pub fn empty() -> anyhow::Result<Sandbox> {
-        Ok(Sandbox {
+        #[cfg_attr(not(feature = "sandbox-but-api"), allow(unused_mut))]
+        let mut sandbox = Sandbox {
             project_root: Some(tempfile::TempDir::new()?),
             #[cfg(feature = "sandbox-but-api")]
             app_root: Some(tempfile::TempDir::new()?),
             #[cfg(feature = "sandbox-but-api")]
             app_settings: None,
-        })
+        };
+        #[cfg(feature = "sandbox-but-api")]
+        sandbox.set_default_settings()?;
+        Ok(sandbox)
     }
 
     /// A utility to init a scenario if the legacy feature is set, or open a repo otherwise.

--- a/crates/but/src/init.rs
+++ b/crates/but/src/init.rs
@@ -119,6 +119,7 @@ pub fn init_ctx(
 }
 
 /// Tracks which background sync operations should be performed.
+#[derive(Debug)]
 struct SyncOperations {
     fetch: bool,
     pr: bool,

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -91,27 +91,21 @@ Caused by:
     env.but("status")
         .assert()
         .failure()
-        .stdout_eq(str![[r#"
-Initiated a background sync...
-
-"#]])
         .stderr_eq(str![[r#"
 Error: errors.projects.default_target.not_found
 
 Caused by:
     there is no default target
 
-"#]]);
+"#]])
+        .stdout_eq(str![""]);
 
     // Single branch mode, does it work?
     // TODO: make this work to get further into a typical workflow.
     env.but("branch new feat")
         .assert()
         .failure()
-        .stdout_eq(str![[r#"
-Initiated a background sync...
-
-"#]])
+        .stdout_eq(str![""])
         .stderr_eq(str![[r#"
 Error: errors.projects.default_target.not_found
 

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -94,6 +94,14 @@ impl Sandbox {
     }
 }
 
+/// Utilities
+impl Sandbox {
+    /// Print the paths to our directories, and keep them.
+    pub fn debug(self) -> ! {
+        self.inner.debug();
+    }
+}
+
 /// Invocations
 impl Sandbox {
     /// Create a command suitable for testing the output of the invocation with `args`. If `args` is empty,


### PR DESCRIPTION
The journey test triggered application updates even though it shouldn't. This was due to not having app-settings, which are now always created.
