### PR TITLE
Remove ok_with_force_push toggle from UI

### DIFF
--- a/apps/desktop/src/components/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/AnalyticsMonitor.svelte
@@ -53,7 +53,6 @@ attached to posthog events.
 		const project = projectQuery.response;
 		if (project) {
 			eventContext.update({
-				forcePushAllowed: project.ok_with_force_push,
 				gitAuthType: gitAuthType(project.preferred_key)
 			});
 		}

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -14,10 +14,6 @@
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const backend = inject(BACKEND);
 
-	async function onForcePushClick(project: Project, value: boolean) {
-		await projectsService.updateProject({ ...project, ok_with_force_push: value });
-	}
-
 	async function onForcePushProtectionClick(project: Project, value: boolean) {
 		await projectsService.updateProject({ ...project, force_push_protection: value });
 	}
@@ -34,22 +30,6 @@
 	<ReduxResult {projectId} result={projectQuery.result}>
 		{#snippet children(project)}
 			<CardGroup>
-				<CardGroup.Item labelFor="allowForcePush">
-					{#snippet title()}
-						Allow force pushing
-					{/snippet}
-					{#snippet caption()}
-						Force pushing allows GitButler to override branches even if they were pushed to remote.
-						GitButler will never force push to the target branch.
-					{/snippet}
-					{#snippet actions()}
-						<Toggle
-							id="allowForcePush"
-							checked={project.ok_with_force_push}
-							onchange={(checked) => onForcePushClick(project, checked)}
-						/>
-					{/snippet}
-				</CardGroup.Item>
 				<CardGroup.Item labelFor="forcePushProtection">
 					{#snippet title()}
 						Force push protection


### PR DESCRIPTION
Remove the obsolete "Allow force pushing" toggle and its handler from the GitForm UI. The project property ok_with_force_push is no longer exposed in the form; only force_push_protection remains. This cleans up unused UI and event handling related to force-push toggling.