### PR TITLE
Determine `LocalAndRemote` commit status based on matching remote _and_ matching branch name

### DIFF
--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -80,7 +80,7 @@ pub fn branch_details(
 
     let mut authors = HashSet::new();
     let (mut commits, upstream_commits) = {
-        let commits = local_commits_gix(branch_id, integration_branch_id.detach(), &mut authors)?;
+        let commits = local_commits_gix(branch_id, integration_branch_id.detach(), remote_tracking_branch_id.map(|id| id.detach()), &mut authors)?;
 
         let upstream_commits = if let Some(remote_tracking_branch) = remote_tracking_branch.as_mut()
         {
@@ -206,6 +206,7 @@ fn upstream_commits_gix(
 fn local_commits_gix(
     branch_id: gix::Id<'_>,
     integration_branch_id: gix::ObjectId,
+    remote_tracking_branch_id: Option<gix::ObjectId>,
     authors: &mut HashSet<ui::Author>,
 ) -> anyhow::Result<Vec<ui::Commit>> {
     // TODO(gix): make this work in `gix` or use the Graph traversal for this.
@@ -215,9 +216,21 @@ fn local_commits_gix(
     revwalk.hide(integration_branch_id.to_git2())?;
     revwalk.simplify_first_parent()?;
 
+    // Build a set of commit IDs that are reachable from the remote tracking branch
+    let remote_commits = if let Some(remote_id) = remote_tracking_branch_id {
+        let mut remote_revwalk = git2_repo.revwalk()?;
+        remote_revwalk.push(remote_id.to_git2())?;
+        remote_revwalk.hide(integration_branch_id.to_git2())?;
+        remote_revwalk.simplify_first_parent()?;
+        remote_revwalk.collect::<Result<HashSet<_>, _>>()?
+    } else {
+        HashSet::new()
+    };
+
     let mut out = Vec::new();
     for id in revwalk {
-        let id = id?.to_gix().attach(branch_id.repo);
+        let git2_id = id?;
+        let id = git2_id.to_gix().attach(branch_id.repo);
         let commit = but_core::Commit::from_id(id)?;
 
         let mut buf = TimeBuf::default();
@@ -225,12 +238,20 @@ fn local_commits_gix(
         let committer: ui::Author = commit.committer.to_ref(&mut buf).into();
         authors.insert(author.clone());
         authors.insert(committer);
+
+        // Determine commit state based on whether it's in the remote tracking branch
+        let state = if remote_commits.contains(&git2_id) {
+            CommitState::LocalAndRemote(id.detach())
+        } else {
+            CommitState::LocalOnly
+        };
+
         out.push(ui::Commit {
             id: id.detach(),
             parent_ids: commit.parents.iter().cloned().collect(),
             message: commit.message.clone(),
             has_conflicts: commit.is_conflicted(),
-            state: CommitState::LocalAndRemote(id.detach()),
+            state,
             created_at: i128::from(commit.committer.time.seconds) * 1000,
             author,
             gerrit_review_url: None,
@@ -245,5 +266,5 @@ pub fn local_commits_for_branch(
     integration_branch_id: gix::ObjectId,
 ) -> anyhow::Result<Vec<ui::Commit>> {
     let mut authors = HashSet::new();
-    local_commits_gix(branch_id, integration_branch_id, &mut authors)
+    local_commits_gix(branch_id, integration_branch_id, None, &mut authors)
 }

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -597,7 +597,7 @@ pub(crate) mod function {
                 inner,
                 relation: if flags.contains(StackCommitFlags::Integrated) {
                     LocalCommitRelation::Integrated(id)
-                } else if flags.contains(StackCommitFlags::ReachableByRemote) {
+                } else if flags.contains(StackCommitFlags::ReachableByMatchingRemote) {
                     LocalCommitRelation::LocalAndRemote(id)
                 } else {
                     LocalCommitRelation::LocalOnly

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -64,7 +64,7 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(7f389ed, "add 10 to the beginning", local/remote(identity)),
+                Commit(7f389ed, "add 10 to the beginning", local),
             ],
             upstream_commits: [],
             is_remote_head: false,
@@ -198,8 +198,8 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(89cc2d3, "change in A", local/remote(identity)),
-                Commit(d79bba9, "new file in A", local/remote(identity)),
+                Commit(89cc2d3, "change in A", local),
+                Commit(d79bba9, "new file in A", local),
             ],
             upstream_commits: [],
             is_remote_head: true,
@@ -252,7 +252,7 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(1a265a4, "local change in A", local/remote(identity)),
+                Commit(1a265a4, "local change in A", local),
                 Commit(d79bba9, "new file in A", local/remote(identity)),
             ],
             upstream_commits: [

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
@@ -32,7 +32,7 @@ fn disjoint() -> anyhow::Result<()> {
         ],
         is_conflicted: false,
         commits: [
-            Commit(32791d2, "disjoint init", local/remote(identity)),
+            Commit(32791d2, "disjoint init", local),
         ],
         upstream_commits: [],
         is_remote_head: false,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -1797,7 +1797,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                         ref_name: "►dependent",
                         remote_tracking_ref_name: "None",
                         commits: [
-                            LocalCommit(cbc6713, "change\n", local/remote(identity)),
+                            LocalCommit(cbc6713, "change\n", local),
                         ],
                         commits_on_remote: [],
                         commits_outside: None,


### PR DESCRIPTION
It seems we determine the `LocalAndRemote` status on the commit being reachable by any remote, rather than matching on the specific remote and branch.

I noticed the problem when I had two stacked branches, where the remote bottom branch included the commits of the local only top branch. They were both colored as pushed and matching upstream, and the push button was disabled as a consequence.

*edit: code is 100% generated by Claude, so most likely incorrect.