### PR TITLE
Bug fix and increased type safety for `status` remote committed file CLI ID output

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -850,15 +850,19 @@ fn print_commit(
     }
     if show_files {
         for change in &commit_details.diff_with_first_parent {
-            let cid = id_map
-                .resolve_file_changed_in_commit_or_unassigned(
-                    commit_details.commit.id,
-                    change.path.as_ref(),
-                )
-                .to_short_string()
-                .blue()
-                .underline();
-            writeln!(out, "┊│     {cid} {}", change.display_cli(false))?;
+            if upstream_commit {
+                writeln!(out, "┊│     {}", change.display_cli(false))?;
+            } else {
+                let cid = id_map
+                    .resolve_file_changed_in_commit_or_unassigned(
+                        commit_details.commit.id,
+                        change.path.as_ref(),
+                    )
+                    .to_short_string()
+                    .blue()
+                    .underline();
+                writeln!(out, "┊│     {cid} {}", change.display_cli(false))?;
+            }
         }
     }
     Ok(())

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -907,7 +907,7 @@ fn display_cli_commit_details(
 
     if verbose {
         // No message when verbose since it goes to the next line
-        let created_at = commit_details.commit.inner.committer.time;
+        let created_at = commit_details.commit.inner.author.time;
         let formatted_time = created_at.format_or_unix(CLI_DATE);
         format!(
             "{}{} {} {}{}{}",

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -24,6 +24,7 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 .map(|commit| WorkspaceCommitWithId {
                     short_id: ShortId::default(),
                     inner: commit,
+                    tree_changes: Vec::new(),
                 })
                 .collect::<Vec<_>>();
             let remote_commits = std::mem::take(&mut segment.commits_on_remote)

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -293,20 +293,20 @@ k0 a.txt│
 ┊
 ┊╭┄g0 [A]  
 ┊●   a7aa4ef partial change to a.txt 3  
-┊│     q0 M a.txt
-┊●   889385c partial change to a.txt 2  
 ┊│     n0 M a.txt
-┊●   8dc39e0 partial change to a.txt 1  
+┊●   889385c partial change to a.txt 2  
 ┊│     o0 M a.txt
+┊●   8dc39e0 partial change to a.txt 1  
+┊│     p0 M a.txt
 ┊●   f4ea7f8 a.txt  
-┊│     s0 A a.txt
+┊│     q0 A a.txt
 ┊●   9477ae7 add A  
-┊│     p0 A A
+┊│     r0 A A
 ├╯
 ┊
 ┊╭┄h0 [B]  
 ┊●   d3e2ba3 add B  
-┊│     r0 A B
+┊│     s0 A B
 ├╯
 ┊
 ┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 
@@ -345,20 +345,20 @@ Hint: you can run `but undo` to undo these changes
 ┊
 ┊╭┄g0 [A]  
 ┊●   4822140 partial change to a.txt 3  
-┊│     l0 M a.txt
-┊●   4593422 partial change to a.txt 2  
 ┊│     k0 M a.txt
+┊●   4593422 partial change to a.txt 2  
+┊│     l0 M a.txt
 ┊●   8dc39e0 partial change to a.txt 1  
 ┊│     m0 M a.txt
 ┊●   f4ea7f8 a.txt  
-┊│     p0 A a.txt
+┊│     n0 A a.txt
 ┊●   9477ae7 add A  
-┊│     n0 A A
+┊│     o0 A A
 ├╯
 ┊
 ┊╭┄h0 [B]  
 ┊●   d3e2ba3 add B  
-┊│     o0 A B
+┊│     p0 A B
 ├╯
 ┊
 ┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -120,14 +120,29 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "m0",
+                  "cliId": "k0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "n0",
+                  "cliId": "l0",
                   "filePath": "b.txt",
                   "changeType": "modified"
+                }
+              ]
+            },
+            {
+...
+              "changes": [
+                {
+                  "cliId": "m0",
+                  "filePath": "a.txt",
+                  "changeType": "added"
+                },
+                {
+                  "cliId": "n0",
+                  "filePath": "b.txt",
+                  "changeType": "added"
                 }
               ]
             },
@@ -136,21 +151,6 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
               "changes": [
                 {
                   "cliId": "o0",
-                  "filePath": "a.txt",
-                  "changeType": "added"
-                },
-                {
-                  "cliId": "p0",
-                  "filePath": "b.txt",
-                  "changeType": "added"
-                }
-              ]
-            },
-            {
-...
-              "changes": [
-                {
-                  "cliId": "k0",
                   "filePath": "A",
                   "changeType": "added"
                 }
@@ -160,7 +160,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("p0 zz")
+    env.but("n0 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -207,7 +207,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "o0",
+                  "cliId": "n0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 }
@@ -217,7 +217,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "n0",
+                  "cliId": "o0",
                   "filePath": "A",
                   "changeType": "added"
                 }

--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -1,0 +1,68 @@
+<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-cyan { fill: #00AAAA }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .italic { font-style: italic; }
+    .underline { text-decoration-line: underline; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>┊┊</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">28</tspan><tspan class="dimmed">baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan><tspan>  </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>┊│     A </tspan><tspan class="fg-green">only-on-remote</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>┊-</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="underline">j0</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>├╯</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>┊</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan>┴ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> (common base) [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M </tspan>
+</tspan>
+    <tspan x="10px" y="334px">
+</tspan>
+    <tspan x="10px" y="352px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="370px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -35,13 +35,13 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊│     </tspan><tspan class="dimmed">A-remote </tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     A </tspan>
 </tspan>
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>┊│     B </tspan>
 </tspan>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -75,6 +75,27 @@ Error: No push remote set
 }
 
 #[test]
+fn remote_and_local_files() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("remote-local-divergence")?;
+
+    // Must set metadata to match the scenario, or else the old APIs used here won't deliver.
+    env.setup_metadata(&["main", "A"])?;
+
+    // Under branch A, remote-only and local-only commits and files are shown.
+    // CLI IDs are shown only for local-only files.
+    env.but("status --files")
+        .with_color_for_svg()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::file![
+            "snapshots/status/remote-and-local-files.stdout.term.svg"
+        ]);
+
+    Ok(())
+}
+
+#[test]
 fn json_shows_paths_as_strings() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊│     add A </tspan>
 </tspan>
@@ -40,7 +40,7 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-02 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     add B </tspan>
 </tspan>

--- a/crates/but/tests/fixtures/scenario/remote-local-divergence.sh
+++ b/crates/but/tests/fixtures/scenario/remote-local-divergence.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+commit-file only-on-remote
+git update-ref refs/remotes/origin/A HEAD
+git reset --hard @~1
+
+commit-file only-on-local
+git branch A
+git reset --hard @~1
+create_workspace_commit_once main A
+


### PR DESCRIPTION
As I was investigating eliminating the need for another "00" fallback in `IdMap`, I saw a bug in `but status` where "00" was being output for files in remote commits. This PR contains a fix and also the elimination of the "00" fallback.

Thanks to Byron for pointing out how to setup the `status` test case.