### PR TITLE
Add table support to Markdown renderer

### DIFF
--- a/packages/ui/src/lib/components/markdown/MarkdownContent.svelte
+++ b/packages/ui/src/lib/components/markdown/MarkdownContent.svelte
@@ -14,6 +14,7 @@
 	import Paragraph from '$components/markdown/markdownRenderers/Paragraph.svelte';
 	import Separator from '$components/markdown/markdownRenderers/Separator.svelte';
 	import Strong from '$components/markdown/markdownRenderers/Strong.svelte';
+	import Table from '$components/markdown/markdownRenderers/Table.svelte';
 	import Text from '$components/markdown/markdownRenderers/Text.svelte';
 	import type { Token } from 'marked';
 	import type { Component } from 'svelte';
@@ -36,9 +37,11 @@
 		br: Br,
 		strong: Strong,
 		em: Em,
-		hr: Separator
+		hr: Separator,
+		table: Table
 	};
 
+	type TableToken = Extract<Token, { type: 'table' }>;
 	const { type, ...rest }: Props = $props();
 
 	type ListToken = Extract<Token, { type: 'list' }>;
@@ -56,6 +59,34 @@
 			{#each listItems as item}
 				<Self {...item} />
 			{/each}
+		</CurrentComponent>
+	{:else if type === 'table'}
+		{@const tableToken = rest as TableToken}
+		<CurrentComponent {...rest}>
+			<thead>
+				<tr>
+					{#each tableToken.header as headerCell}
+						<th>
+							{#each headerCell.tokens as header}
+								<Self {...header} />
+							{/each}
+						</th>
+					{/each}
+				</tr>
+			</thead>
+			<tbody>
+				{#each tableToken.rows as row}
+					<tr>
+						{#each row as cell}
+							<td>
+								{#each cell.tokens as cellToken}
+									<Self {...cellToken} />
+								{/each}
+							</td>
+						{/each}
+					</tr>
+				{/each}
+			</tbody>
 		</CurrentComponent>
 	{:else}
 		<CurrentComponent {...rest}>

--- a/packages/ui/src/lib/components/markdown/markdownRenderers/Table.svelte
+++ b/packages/ui/src/lib/components/markdown/markdownRenderers/Table.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { type Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	const { children }: Props = $props();
+</script>
+
+<table>
+	{@render children()}
+</table>
+
+<style>
+	table {
+		width: 100%;
+		margin: 1rem 0;
+		border-collapse: collapse;
+	}
+
+	table :global(th),
+	table :global(td) {
+		padding: 0.5rem;
+		border: 1px solid var(--clr-border-2);
+		text-align: left;
+	}
+
+	table :global(th) {
+		background-color: var(--clr-bg-2);
+		font-weight: 600;
+	}
+</style>


### PR DESCRIPTION
- Import and register Table component in MarkdownContent.svelte for handling tables in rendered markdown.
- Add conditional rendering logic for table tokens: render headers and rows with proper nesting.
- Introduce Table.svelte component with table structure and styles for consistent table display.