### PR TITLE
Fix push to fork remote instead of origin (#10583)

### DIFF
--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -44,6 +44,9 @@ mod stack {
         /// Upstream tracking branch reference, added when creating a stack from a branch.
         /// Used e.g. when listing commits from a fork.
         pub upstream: Option<RemoteRefname>,
+        /// Per-stack push remote override.
+        #[serde(default)]
+        pub push_remote_name: Option<String>,
         // order is the number by which UI should sort branches
         pub order: usize,
         /// This is the new metric for determining whether the branch is in the workspace, which means it's applied
@@ -149,6 +152,7 @@ mod stack {
                 // Don't keep redundant information
                 source_refname: None,
                 upstream: None,
+                push_remote_name: None,
 
                 // Unused - everything is defined by the top-most branch name.
                 // unclear, obsolete


### PR DESCRIPTION


## 🧢 Changes

Added per-stack `push_remote_name` field that overrides the global default when set. When creating a branch from a fork PR, this field is automatically set to the fork's remote.

- **`gitbutler-stack/src/stack.rs`**
  - Added `push_remote_name: Option<String>` field to `Stack` struct
  - Added `effective_push_remote_name()` method that returns the stack-level override if set (and valid), otherwise falls back to default
  - Updated `push_details()` to use `effective_push_remote_name()`

- **`but-meta/src/virtual_branches_legacy_types.rs`**
  - Added `push_remote_name` field with `#[serde(default)]` for backward compatibility

- **`gitbutler-branch-actions/src/branch_manager/branch_creation.rs`**
  - Set `push_remote_name` when upstream is from a different remote than the default

- **`gitbutler-branch-actions/src/stack.rs`**
  - Updated `push_stack()` to use effective push remote for fetch, result, and hooks
  - 
## ☕️ Reasoning

When applying a PR from a fork and pushing, the branch incorrectly pushes to `origin` instead of the fork remote. This happens because push destination is determined globally at the project level, not per-branch.

**Root cause**: `push_details()` in `stack.rs` always uses `default_target.push_remote_name()`, ignoring the branch's upstream remote.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:  
## 🎫 Affected issues



-->
Fixes: #10583

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
