### PR TITLE
Improve the but-llm crate: On token callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anthropic-api"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ef729ad2443434e6509070cf37086329f1fa41d3ed57ae2ebbe84d62013358"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "futures-util",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1264,7 @@ dependencies = [
 name = "but-llm"
 version = "0.1.0"
 dependencies = [
+ "anthropic-api",
  "anyhow",
  "async-openai",
  "but-secret",

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -51,7 +51,7 @@ pub(crate) fn auto_commit(
         </project_status>
     ");
 
-    llm.tool_calling_loop(system_message, vec![prompt.into()], &mut toolset, model)?;
+    llm.tool_calling_loop(system_message, vec![prompt.into()], &mut toolset, &model)?;
 
     Ok(())
 }

--- a/crates/but-action/src/branch_changes.rs
+++ b/crates/but-action/src/branch_changes.rs
@@ -47,7 +47,7 @@ pub(crate) fn branch_changes(
         </project_status>
     ");
 
-    llm.tool_calling_loop(system_message, vec![prompt.into()], &mut toolset, model)?;
+    llm.tool_calling_loop(system_message, vec![prompt.into()], &mut toolset, &model)?;
 
     Ok(())
 }

--- a/crates/but-action/src/generate.rs
+++ b/crates/but-action/src/generate.rs
@@ -31,11 +31,7 @@ unified diff:
 
     let chat_messages = vec![ChatMessage::User(user_message)];
     let response = llm
-        .structured_output::<StructuredOutput>(
-            &system_message,
-            chat_messages,
-            "gpt-5-mini".to_string(),
-        )?
+        .structured_output::<StructuredOutput>(&system_message, chat_messages, "gpt-5-mini")?
         .context("Failed to generate structured content for commit message")?;
 
     Ok(response.commit_message)
@@ -91,7 +87,7 @@ pub fn branch_name(
         .structured_output::<GenerateBranchNameOutput>(
             &system_message,
             chat_messages,
-            "gpt-5-mini".to_string(),
+            "gpt-5-mini",
         )?
         .context("Failed to generate structured content for commit message")?;
 

--- a/crates/but-llm/Cargo.toml
+++ b/crates/but-llm/Cargo.toml
@@ -27,3 +27,4 @@ anyhow.workspace = true
 strum = { version = "0.27", features = ["derive"] }
 reqwest.workspace = true
 uuid.workspace = true
+anthropic-api = "0.0.5"

--- a/crates/but-llm/src/client.rs
+++ b/crates/but-llm/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use anyhow::Result;
 use but_tools::tool::Toolset;
@@ -13,8 +13,8 @@ pub trait LLMClient: Debug + Clone {
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl Toolset,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<(String, Vec<ChatMessage>)>;
 
     fn tool_calling_loop(
@@ -22,22 +22,22 @@ pub trait LLMClient: Debug + Clone {
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl Toolset,
-        model: String,
+        model: &str,
     ) -> Result<String>;
 
     fn stream_response(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<Option<String>>;
 
     fn response(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> Result<Option<String>>;
 
     fn structured_output<
@@ -46,6 +46,6 @@ pub trait LLMClient: Debug + Clone {
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> Result<Option<T>>;
 }

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -7,11 +7,10 @@ use std::sync::Arc;
 
 pub use chat::{ChatMessage, StreamToolCallResult, ToolCall, ToolCallContent, ToolResponseContent};
 
-pub use openai::CredentialsKind;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
-use crate::client::LLMClient;
+use crate::{client::LLMClient, openai::CredentialsKind};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum LLMProviderConfig {
@@ -27,39 +26,98 @@ pub enum LLMClientType {
 
 #[derive(Debug, Clone)]
 pub struct LLMProvider {
-    pub kind: LLMProviderConfig,
     client: LLMClientType,
 }
 
 /// The top-level LLM provider that wraps specific implementations.
 ///
 /// This struct provides a unified interface to interact with different LLM providers
+/// (currently OpenAI and Ollama). It abstracts away the differences between providers,
+/// allowing callers to work with a consistent API regardless of which underlying
+/// LLM service is being used. The provider handles authentication, request formatting,
+/// response parsing, and tool calling orchestration for all supported backends.
 impl LLMProvider {
+    /// Creates a new LLM provider based on the specified configuration.
+    ///
+    /// This method initializes the appropriate underlying client (OpenAI or Ollama)
+    /// based on the provided configuration. For OpenAI, it will attempt to use
+    /// the provided credentials or fall back to environment variables. For Ollama,
+    /// it will use the provided host configuration or default to localhost.
+    ///
+    /// # Arguments
+    ///
+    /// * `kind` - The provider configuration specifying which LLM backend to use
+    ///   and any associated credentials or settings.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(LLMProvider)` if the provider was successfully initialized,
+    /// or `None` if initialization failed (e.g., missing required credentials).
     pub fn new(kind: LLMProviderConfig) -> Option<Self> {
-        let client = match &kind {
-            LLMProviderConfig::OpenAi(creds) => openai::OpenAiProvider::with(creds.clone())
-                .map(|p| LLMClientType::OpenAi(Arc::new(p)))?,
+        let client = match kind {
+            LLMProviderConfig::OpenAi(creds) => {
+                openai::OpenAiProvider::with(creds).map(|p| LLMClientType::OpenAi(Arc::new(p)))?
+            }
             LLMProviderConfig::Ollama(config) => {
-                let config = config
-                    .clone()
-                    .unwrap_or(ollama::OllamaConfig { host_config: None });
+                let config = config.unwrap_or_default();
                 LLMClientType::Ollama(Arc::new(ollama::OllamaProvider::new(config)))
             }
         };
-        Some(Self { kind, client })
+        Some(Self { client })
     }
+
+    /// Creates a default OpenAI LLM provider using environment-based credentials.
+    ///
+    /// This is a convenience method that attempts to create an OpenAI provider
+    /// by reading credentials from environment variables (typically GB credentials or `OPENAI_API_KEY`).
+    /// It's the recommended way to create an OpenAI provider when you want to use
+    /// the default configuration without explicitly passing credentials.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(LLMProvider)` if OpenAI credentials are found in the environment
+    /// and the provider was successfully initialized, or `None` if credentials are
+    /// missing or initialization failed.
     pub fn default_openai() -> Option<Self> {
         Self::new(LLMProviderConfig::OpenAi(None))
     }
 
-    /// Streams a tool-calling loop using the selected LLM provider.
+    /// Executes an interactive tool-calling loop with streaming output.
+    ///
+    /// This method orchestrates a conversation with the LLM where the model can call
+    /// tools (functions) to gather information or perform actions. The LLM's text output
+    /// is streamed token-by-token via the provided callback, enabling real-time display
+    /// of the assistant's responses. The loop continues until the LLM produces a final
+    /// response without tool calls.
+    ///
+    /// The tool-calling loop works as follows:
+    /// 1. Send messages to the LLM with available tools
+    /// 2. If the LLM requests tool calls, execute them and add results to the conversation
+    /// 3. Continue until the LLM provides a final text response
+    /// 4. Stream all text output through the `on_token` callback as it's generated
+    ///
+    /// # Arguments
+    ///
+    /// * `system_message` - The system prompt that defines the assistant's behavior and context
+    /// * `chat_messages` - The conversation history including user and assistant messages
+    /// * `tool_set` - A mutable reference to the toolset containing available functions the LLM can call
+    /// * `model` - The model identifier (e.g., "gpt-4", "llama2") to use for generation
+    /// * `on_token` - A callback function that receives each token as it's generated, enabling streaming display
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok((final_response, updated_messages))` where:
+    /// - `final_response` is the complete text response from the LLM
+    /// - `updated_messages` is the full conversation history including all tool calls and responses
+    ///
+    /// Returns `Err` if the LLM request fails or tool execution encounters an error.
     pub fn tool_calling_loop_stream(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl but_tools::tool::Toolset,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> anyhow::Result<(String, Vec<ChatMessage>)> {
         match &self.client {
             LLMClientType::OpenAi(client) => client.tool_calling_loop_stream(
@@ -79,13 +137,36 @@ impl LLMProvider {
         }
     }
 
-    /// Executes a tool-calling loop using the selected LLM provider.
+    /// Executes an interactive tool-calling loop without streaming.
+    ///
+    /// Similar to `tool_calling_loop_stream`, but returns the complete final response
+    /// only after the entire conversation is finished, without streaming intermediate tokens.
+    /// This is useful when you don't need real-time output and prefer to wait for the
+    /// complete response before processing it.
+    ///
+    /// The tool-calling loop works as follows:
+    /// 1. Send messages to the LLM with available tools
+    /// 2. If the LLM requests tool calls, execute them and add results to the conversation
+    /// 3. Continue until the LLM provides a final text response
+    /// 4. Return only the final complete response
+    ///
+    /// # Arguments
+    ///
+    /// * `system_message` - The system prompt that defines the assistant's behavior and context
+    /// * `chat_messages` - The conversation history including user and assistant messages
+    /// * `tool_set` - A mutable reference to the toolset containing available functions the LLM can call
+    /// * `model` - The model identifier (e.g., "gpt-4", "llama2") to use for generation
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(final_response)` containing the complete text response from the LLM
+    /// after all tool calls have been resolved, or `Err` if the request or tool execution fails.
     pub fn tool_calling_loop(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl but_tools::tool::Toolset,
-        model: String,
+        model: &str,
     ) -> anyhow::Result<String> {
         match &self.client {
             LLMClientType::OpenAi(client) => {
@@ -97,13 +178,30 @@ impl LLMProvider {
         }
     }
 
-    /// Streams a response using the selected LLM provider.
+    /// Generates a streaming text response without tool calling capability.
+    ///
+    /// This method sends a conversation to the LLM and streams the response token-by-token
+    /// through the provided callback. Unlike the tool-calling methods, this is a simple
+    /// request-response interaction without the ability for the model to call functions.
+    /// Use this when you want a straightforward chat completion with streaming output.
+    ///
+    /// # Arguments
+    ///
+    /// * `system_message` - The system prompt that defines the assistant's behavior and context
+    /// * `chat_messages` - The conversation history including user and assistant messages
+    /// * `model` - The model identifier (e.g., "gpt-4", "llama2") to use for generation
+    /// * `on_token` - A callback function that receives each token as it's generated, enabling streaming display
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Some(response))` containing the complete text response if successful,
+    /// `Ok(None)` if the model produced no output, or `Err` if the request failed.
     pub fn stream_response(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> anyhow::Result<Option<String>> {
         match &self.client {
             LLMClientType::OpenAi(client) => {
@@ -115,14 +213,38 @@ impl LLMProvider {
         }
     }
 
-    /// Gets a response using the selected LLM provider in the provided format.
+    /// Generates a structured response conforming to a specific schema.
+    ///
+    /// This method requests the LLM to produce output in a specific structured format
+    /// defined by a Rust type. The response is automatically validated against the
+    /// JSON schema derived from the type and deserialized into the requested structure.
+    /// This is useful for extracting structured data (like configuration, JSON objects,
+    /// or specific data models) from LLM responses with type safety.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The type that defines the expected structure. Must implement
+    ///   `Serialize`, `Deserialize`, and `JsonSchema` to enable schema generation
+    ///   and validation.
+    ///
+    /// # Arguments
+    ///
+    /// * `system_message` - The system prompt that defines the assistant's behavior and context
+    /// * `chat_messages` - The conversation history including user and assistant messages
+    /// * `model` - The model identifier (e.g., "gpt-4", "llama2") to use for generation
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Some(value))` containing the parsed structured response if successful,
+    /// `Ok(None)` if the model produced no output, or `Err` if the request failed or
+    /// the response didn't conform to the expected schema.
     pub fn structured_output<
         T: serde::Serialize + DeserializeOwned + JsonSchema + std::marker::Send + 'static,
     >(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> anyhow::Result<Option<T>> {
         match &self.client {
             LLMClientType::OpenAi(client) => {
@@ -134,12 +256,28 @@ impl LLMProvider {
         }
     }
 
-    /// Gets a response using the selected LLM provider.
+    /// Generates a simple text response without streaming or tool calling.
+    ///
+    /// This is the most basic interaction method that sends a conversation to the LLM
+    /// and waits for the complete response. The entire response is returned at once
+    /// without streaming. Use this for simple request-response scenarios where you
+    /// don't need real-time output or function calling capabilities.
+    ///
+    /// # Arguments
+    ///
+    /// * `system_message` - The system prompt that defines the assistant's behavior and context
+    /// * `chat_messages` - The conversation history including user and assistant messages
+    /// * `model` - The model identifier (e.g., "gpt-4", "llama2") to use for generation
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Some(response))` containing the complete text response if successful,
+    /// `Ok(None)` if the model produced no output, or `Err` if the request failed.
     pub fn response(
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> anyhow::Result<Option<String>> {
         match &self.client {
             LLMClientType::OpenAi(client) => client.response(system_message, chat_messages, model),

--- a/crates/but-llm/src/ollama.rs
+++ b/crates/but-llm/src/ollama.rs
@@ -27,7 +27,7 @@ pub struct OllamaHostConfig {
     pub port: u16,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct OllamaConfig {
     pub host_config: Option<OllamaHostConfig>,
 }
@@ -61,8 +61,8 @@ impl LLMClient for OllamaProvider {
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl Toolset,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<(String, Vec<ChatMessage>)> {
         tool_calling_loop_stream(
             self,
@@ -79,7 +79,7 @@ impl LLMClient for OllamaProvider {
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
         tool_set: &mut impl Toolset,
-        model: String,
+        model: &str,
     ) -> Result<String> {
         tool_calling_loop(self, system_message, chat_messages, tool_set, model)
     }
@@ -88,8 +88,8 @@ impl LLMClient for OllamaProvider {
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
-        on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<Option<String>> {
         stream_response_blocking(self, system_message, chat_messages, model, on_token)
     }
@@ -100,7 +100,7 @@ impl LLMClient for OllamaProvider {
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> Result<Option<T>> {
         structured_output_blocking(self, system_message, chat_messages, model)
     }
@@ -109,7 +109,7 @@ impl LLMClient for OllamaProvider {
         &self,
         system_message: &str,
         chat_messages: Vec<ChatMessage>,
-        model: String,
+        model: &str,
     ) -> Result<Option<String>> {
         response_blocking(self, system_message, chat_messages, model)
     }
@@ -120,8 +120,8 @@ pub fn tool_calling_loop_stream(
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
     tool_set: &mut impl Toolset,
-    model: String,
-    on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+    model: &str,
+    on_token: impl Fn(&str) + Send + Sync + 'static,
 ) -> Result<(String, Vec<ChatMessage>)> {
     let mut messages: Vec<ollama_rs::generation::chat::ChatMessage> =
         vec![ollama_rs::generation::chat::ChatMessage::system(
@@ -140,25 +140,23 @@ pub fn tool_calling_loop_stream(
         .map(|t| t.deref().try_into())
         .collect::<Result<Vec<ollama_rs::generation::tools::ToolInfo>, _>>()?;
 
-    let on_token_cb = {
-        let on_token = on_token.clone();
-        Box::new(move |token: &str| on_token(token)) as Box<dyn Fn(&str) + Send + Sync + 'static>
-    };
+    // Needs to be Arc to be cloned into async closures
+    let on_token = Arc::new(on_token);
 
     let mut response = tool_calling_stream_blocking(
         provider,
         messages.clone(),
         ollama_tool_infos.clone(),
-        model.clone(),
-        on_token_cb,
+        model,
+        {
+            let on_token = Arc::clone(&on_token);
+            move |s: &str| on_token(s)
+        },
     )?;
 
     let mut text_response_buffer = vec![];
-    if let Some(text_response) = response.1.clone() {
-        text_response_buffer.push(text_response.clone());
-        messages.push(ollama_rs::generation::chat::ChatMessage::assistant(
-            text_response,
-        ));
+    if let Some(text_response) = &response.1 {
+        handle_text_response(&mut messages, &mut text_response_buffer, text_response);
     }
 
     while let Some(tool_calls) = response.0 {
@@ -191,24 +189,19 @@ pub fn tool_calling_loop_stream(
             ));
         }
 
-        let on_token_cb = {
-            let on_token = on_token.clone();
-            Box::new(move |token: &str| on_token(token))
-                as Box<dyn Fn(&str) + Send + Sync + 'static>
-        };
         response = tool_calling_stream_blocking(
             provider,
             messages.clone(),
             ollama_tool_infos.clone(),
-            model.clone(),
-            on_token_cb,
+            model,
+            {
+                let on_token = Arc::clone(&on_token);
+                move |s: &str| on_token(s)
+            },
         )?;
 
-        if let Some(text_response) = response.1.clone() {
-            text_response_buffer.push(text_response.clone());
-            messages.push(ollama_rs::generation::chat::ChatMessage::assistant(
-                text_response,
-            ));
+        if let Some(text_response) = &response.1 {
+            handle_text_response(&mut messages, &mut text_response_buffer, text_response);
         }
     }
 
@@ -223,14 +216,26 @@ pub fn tool_calling_loop_stream(
     Ok((text_response, chat_messages))
 }
 
+fn handle_text_response(
+    messages: &mut Vec<ollama_rs::generation::chat::ChatMessage>,
+    text_response_buffer: &mut Vec<String>,
+    text_response: &str,
+) {
+    text_response_buffer.push(text_response.to_string());
+    messages.push(ollama_rs::generation::chat::ChatMessage::assistant(
+        text_response.to_string(),
+    ));
+}
+
 fn tool_calling_stream_blocking(
     provider: &OllamaProvider,
     messages: Vec<ollama_rs::generation::chat::ChatMessage>,
     tool_infos: Vec<ollama_rs::generation::tools::ToolInfo>,
-    model: String,
+    model: &str,
     on_token: impl Fn(&str) + Send + Sync + 'static,
 ) -> Result<StreamToolCallResult> {
     let provider = provider.clone();
+    let model = model.to_string();
 
     std::thread::spawn(move || {
         tokio::runtime::Runtime::new()
@@ -256,24 +261,31 @@ async fn tool_calling_stream(
     let request = ChatMessageRequest::new(model, messages).tools(tool_infos);
 
     let mut resp = ollama
-        .send_chat_messages_with_history_stream(history.clone(), request)
+        .send_chat_messages_with_history_stream(history, request)
         .await?;
 
     let mut response_text: Option<String> = None;
     let mut tool_call_results: Option<Vec<ToolCall>> = None;
 
+    let on_token = Arc::new(on_token);
+
+    // The streaming implementation of ollama_rs returns chunks as they come, and then the complete response at the end.
+    // This is annoying, but we can work around it by collecting the content from each chunk and only emitting if the content is new.
     while let Some(chunk) = resp.next().await {
         match chunk {
             Ok(part) => {
                 let content = part.message.content;
-                on_token(&content);
-                if let Some(ref mut text) = response_text {
-                    text.push_str(&content);
-                } else {
-                    response_text = Some(content);
-                }
+                let is_last_chunk = process_token_response(
+                    {
+                        let on_token = Arc::clone(&on_token);
+                        move |s: &str| on_token(s)
+                    },
+                    &mut response_text,
+                    content,
+                );
 
-                if !part.message.tool_calls.is_empty() {
+                // If it's the last chunk (e.g. the full response), we don't need to process tool calls again.
+                if !part.message.tool_calls.is_empty() && !is_last_chunk {
                     for tool_call in part.message.tool_calls {
                         let tool_call_result = ToolCall {
                             id: generate_tool_id(),
@@ -301,10 +313,11 @@ fn stream_response_blocking(
     provider: &OllamaProvider,
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
-    model: String,
-    on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
+    model: &str,
+    on_token: impl Fn(&str) + Send + Sync + 'static,
 ) -> Result<Option<String>> {
     let provider = provider.clone();
+    let model = model.to_string();
     let mut messages: Vec<ollama_rs::generation::chat::ChatMessage> =
         vec![ollama_rs::generation::chat::ChatMessage::system(
             system_message.to_string(),
@@ -316,14 +329,10 @@ fn stream_response_blocking(
             .map(ollama_rs::generation::chat::ChatMessage::from),
     );
 
-    let on_token_cb = {
-        let on_token = on_token.clone();
-        Box::new(move |token: &str| on_token(token)) as Box<dyn Fn(&str) + Send + Sync + 'static>
-    };
     std::thread::spawn(move || {
         tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(stream_response(&provider, messages, model, on_token_cb))
+            .block_on(stream_response(&provider, messages, model, on_token))
     })
     .join()
     .unwrap()
@@ -346,16 +355,22 @@ async fn stream_response(
 
     let mut response_text: Option<String> = None;
 
+    let on_token = Arc::new(on_token);
+
+    // The streaming implementation of ollama_rs returns chunks as they come, and then the complete response at the end.
+    // This is annoying, but we can work around it by collecting the content from each chunk and only emitting if the content is new.
     while let Some(chunk) = resp.next().await {
         match chunk {
             Ok(part) => {
                 let content = part.message.content;
-                on_token(&content);
-                if let Some(ref mut text) = response_text {
-                    text.push_str(&content);
-                } else {
-                    response_text = Some(content);
-                }
+                process_token_response(
+                    {
+                        let on_token = Arc::clone(&on_token);
+                        move |s: &str| on_token(s)
+                    },
+                    &mut response_text,
+                    content,
+                );
             }
             Err(_) => {
                 bail!("Error during Ollama streaming response",);
@@ -366,13 +381,37 @@ async fn stream_response(
     Ok(response_text)
 }
 
+/// Processes a token response chunk, emitting it if it's new.
+///
+/// Returns true if the processed content was the determined to be the last one.
+fn process_token_response(
+    on_token: impl Fn(&str) + Send + Sync + 'static,
+    response_text: &mut Option<String>,
+    content: String,
+) -> bool {
+    let last_chunk = Some(content.clone()) == *response_text;
+    // Don't emit empty strings or the last chunk containing the full response again.
+    // We can tell that it's the last chunk because it will be equal to the accumulated response_text.
+    if !content.is_empty() && !last_chunk {
+        on_token(&content);
+        if let Some(ref mut text) = *response_text {
+            text.push_str(&content);
+        } else {
+            *response_text = Some(content);
+        }
+    }
+
+    last_chunk
+}
+
 fn response_blocking(
     provider: &OllamaProvider,
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
-    model: String,
+    model: &str,
 ) -> anyhow::Result<Option<String>> {
     let provider = provider.clone();
+    let model = model.to_string();
     let mut messages: Vec<ollama_rs::generation::chat::ChatMessage> =
         vec![ollama_rs::generation::chat::ChatMessage::system(
             system_message.to_string(),
@@ -420,9 +459,10 @@ fn structured_output_blocking<
     provider: &OllamaProvider,
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
-    model: String,
+    model: &str,
 ) -> anyhow::Result<Option<T>> {
     let provider = provider.clone();
+    let model = model.to_string();
     let mut messages: Vec<ollama_rs::generation::chat::ChatMessage> =
         vec![ollama_rs::generation::chat::ChatMessage::system(
             system_message.to_string(),
@@ -470,7 +510,7 @@ fn tool_calling_loop(
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
     tool_set: &mut impl Toolset,
-    model: String,
+    model: &str,
 ) -> Result<String> {
     let mut messages: Vec<ollama_rs::generation::chat::ChatMessage> =
         vec![ollama_rs::generation::chat::ChatMessage::system(
@@ -489,12 +529,8 @@ fn tool_calling_loop(
         .map(|t| t.deref().try_into())
         .collect::<Result<Vec<ollama_rs::generation::tools::ToolInfo>, _>>()?;
 
-    let mut response = tool_calling_blocking(
-        provider,
-        messages.clone(),
-        ollama_tool_infos.clone(),
-        model.clone(),
-    )?;
+    let mut response =
+        tool_calling_blocking(provider, messages.clone(), ollama_tool_infos.clone(), model)?;
 
     let mut text_response_buffer = vec![];
     if !response.message.content.is_empty() {
@@ -531,12 +567,8 @@ fn tool_calling_loop(
             ));
         }
 
-        response = tool_calling_blocking(
-            provider,
-            messages.clone(),
-            ollama_tool_infos.clone(),
-            model.clone(),
-        )?;
+        response =
+            tool_calling_blocking(provider, messages.clone(), ollama_tool_infos.clone(), model)?;
 
         if !response.message.content.is_empty() {
             let text_response = response.message.content.clone();
@@ -560,9 +592,10 @@ fn tool_calling_blocking(
     provider: &OllamaProvider,
     messages: Vec<ollama_rs::generation::chat::ChatMessage>,
     tool_infos: Vec<ollama_rs::generation::tools::ToolInfo>,
-    model: String,
+    model: &str,
 ) -> Result<ollama_rs::generation::chat::ChatMessageResponse> {
     let provider = provider.clone();
+    let model = model.to_string();
     std::thread::spawn(move || {
         tokio::runtime::Runtime::new()
             .unwrap()

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -558,9 +558,8 @@ fn generate_branch_summary(branch_name: &str, commits: &[CommitInfo]) -> anyhow:
 
     let system_message = "You are a helpful assistant that summarizes Git branch changes.";
     let chat_messages = vec![ChatMessage::User(prompt)];
-    let model = "gpt-5-mini".to_string();
 
-    let response = llm.response(system_message, chat_messages, model)?;
+    let response = llm.response(system_message, chat_messages, "gpt-5-mini")?;
 
     let summary = response.unwrap_or_default().trim().to_string();
 


### PR DESCRIPTION
- Improve the on-token callback signature so that the caller doesn’t
  have to care about creating an arc
- Move the ChatMessage-specific functions to the chat module
- Improve documentation

### Follow-ups
- Further pretty-fication of the code and documentation of the inner-workings of this
- Anthropic implementation
- LLM Studio implementation
- Read from the git config