### PR TITLE
fix: Confirmation message for but unapply and restore

### DIFF
--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -233,11 +233,7 @@ fn confirm_unapply_stack(
         }
     }
 
-    if force {
-        but_api::legacy::virtual_branches::unapply_stack(project.id, sid)?;
-    } else {
-        bail!("Refusing to unapply stack without --force");
-    }
+    but_api::legacy::virtual_branches::unapply_stack(project.id, sid)?;
 
     if let Some(out) = out.for_human() {
         writeln!(
@@ -256,9 +252,9 @@ fn confirm_branch_deletion(
     force: bool,
     out: &mut OutputChannel,
 ) -> Result<(), anyhow::Error> {
-    if !force && let Some(mut inout) = out.prepare_for_terminal_input() {
+    if !force && let Some(mut input) = out.prepare_for_terminal_input() {
         let abort_msg = "Aborted branch deletion.";
-        let input = inout
+        let input = input
             .prompt(format!(
                 "Are you sure you want to delete branch '{}'? [y/N]:",
                 branch_name
@@ -271,14 +267,7 @@ fn confirm_branch_deletion(
         }
     }
 
-    if force {
-        but_api::legacy::stack::remove_branch(project.id, sid, branch_name.to_owned())?;
-    } else {
-        bail!(
-            "Refusing to remove branch '{}' from workspace without --force",
-            branch_name
-        );
-    }
+    but_api::legacy::stack::remove_branch(project.id, sid, branch_name.to_owned())?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Deleted branch {branch_name}")?;

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, bail};
+use anyhow::Context;
 use but_oxidize::TimeExt;
 use colored::Colorize;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
@@ -231,11 +231,7 @@ pub(crate) fn restore_to_oplog(
     }
 
     // Restore to the target snapshot using the but-api crate
-    if force {
-        but_api::legacy::oplog::restore_snapshot(ctx.legacy_project.id, commit_sha_string)?;
-    } else {
-        bail!("Unable to possibly overwrite changes in the worktree without --force");
-    }
+    but_api::legacy::oplog::restore_snapshot(ctx.legacy_project.id, commit_sha_string)?;
 
     if let Some(out) = out.for_human() {
         writeln!(


### PR DESCRIPTION
Respect user’s confirmation when unapplying and restoring commands