### PR TITLE
Fix hunk drag to respect selected lines

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,5 @@
 name: 'Publish'
 on:
-  schedule:
-    # every day at 1am UTC, 3AM CEST or 2AM CET.
-    - cron: '0 1 * * *'
   workflow_run:
     workflows: ['Nightly build']
     types:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -126,6 +126,8 @@ jobs:
           persist-credentials: false
       - name: Dependencies for 'keyring'
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
+      - name: Dependencies for tauri
+        run: sudo ./scripts/install-tauri-debian-dependencies.sh
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.2
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -118,14 +118,14 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     env:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Dependencies for 'keyring'
+        run: sudo ./scripts/install-minimal-debian-dependencies.sh
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.2
         with:
@@ -218,8 +218,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     env:
       CARGO_TERM_COLOR: always
     defaults:
@@ -234,6 +232,10 @@ jobs:
         with:
           shared-key: cargo-test-tauri
           save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Dependencies for 'keyring'
+        run: sudo ./scripts/install-minimal-debian-dependencies.sh
+      - name: Dependencies for tauri
+        run: sudo ./scripts/install-tauri-debian-dependencies.sh
       - run: |
           set -e
           cargo check -p gitbutler-tauri --no-default-features

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           shared-key: e2e-blackbox-rust-binaries
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - uses: dtolnay/rust-toolchain@stable
       - name: Setup node environment
         uses: ./.github/actions/init-env-node
       - name: Dependencies for keyring

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -18,10 +18,9 @@ jobs:
   test:
     name: e2e-blackbox
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     env:
       CARGO_TERM_COLOR: always
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,19 +35,24 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
       # TODO: put these into the docker image
       - name: Install Webdriver dependencies
-        run: apt update && apt install -y webkit2gtk-driver ffmpeg xvfb
+        run: sudo apt update && sudo apt install -y webkit2gtk-driver ffmpeg xvfb
         if: ${{ github.ref != 'refs/heads/master' }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.2
         with:
           shared-key: e2e-blackbox-rust-binaries
           save-if: ${{ github.ref == 'refs/heads/master' }}
+      - uses: dtolnay/rust-toolchain@stable
       - name: Setup node environment
         uses: ./.github/actions/init-env-node
+      - name: Dependencies for keyring
+        run: sudo ./scripts/install-minimal-debian-dependencies.sh
       - name: Build CLI
         run: cargo build -p gitbutler-cli
       - name: Build SvelteKit
         run: pnpm build:desktop -- --mode development
+      - name: Dependencies for tauri
+        run: sudo ./scripts/install-tauri-debian-dependencies.sh
       - name: Build Tauri
         run: pnpm build:test
       - name: Install tauri-driver

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Dependencies for keyring
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
       - name: Dependencies for secure storage
-        run: sudo apt install -y dbus-x11 gnome-keyring
+        run: sudo apt install -y dbus-x11 gnome-keyring xvfb xauth
       - name: Build gitbutler-git
         run: cargo build -p gitbutler-git
       - name: Build but-server
@@ -78,7 +78,7 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
       - name: Run Playwright tests
         run: |
-          dbus-run-session -- bash -c 'eval $(gnome-keyring-daemon --start --components=secrets); pnpm exec turbo run test:e2e:playwright'
+          xvfb-run -a dbus-run-session -- bash -c 'eval $(gnome-keyring-daemon --start --components=secrets); pnpm exec turbo run test:e2e:playwright'
         if: ${{ github.ref != 'refs/heads/master' }}
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           shared-key: e2e-playwright-rust-binaries
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - uses: dtolnay/rust-toolchain@stable
       - name: Preset Git Configuration and but-testing location
         run: |
           echo "GIT_CONFIG_GLOBAL=$PWD/e2e/playwright/fixtures/.gitconfig" >> $GITHUB_ENV
@@ -66,6 +65,8 @@ jobs:
         name: Install missing deps after cache hit
       - name: Dependencies for keyring
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
+      - name: Dependencies for secure storage
+        run: sudo apt install -y dbus-x11 gnome-keyring
       - name: Build gitbutler-git
         run: cargo build -p gitbutler-git
       - name: Build but-server
@@ -76,7 +77,8 @@ jobs:
         run: pnpm build:desktop
         if: ${{ github.ref != 'refs/heads/master' }}
       - name: Run Playwright tests
-        run: pnpm exec turbo run test:e2e:playwright
+        run: |
+          dbus-run-session -- bash -c 'eval $(gnome-keyring-daemon --start --components=secrets); pnpm exec turbo run test:e2e:playwright'
         if: ${{ github.ref != 'refs/heads/master' }}
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -16,8 +16,6 @@ jobs:
   test:
     name: e2e-playwright
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
     timeout-minutes: 60
     env:
       DESKTOP_PORT: 3000
@@ -26,6 +24,7 @@ jobs:
       VITE_BUTLER_PORT: 6978
       VITE_BUTLER_HOST: 'localhost'
       VITE_BUILD_TARGET: 'web'
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,6 +40,7 @@ jobs:
         with:
           shared-key: e2e-playwright-rust-binaries
           save-if: ${{ github.ref == 'refs/heads/master' }}
+      - uses: dtolnay/rust-toolchain@stable
       - name: Preset Git Configuration and but-testing location
         run: |
           echo "GIT_CONFIG_GLOBAL=$PWD/e2e/playwright/fixtures/.gitconfig" >> $GITHUB_ENV
@@ -61,9 +61,11 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
       - run: cd e2e && pnpm exec playwright install --with-deps
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' && github.ref != 'refs/heads/master' }}
-      - run: apt install -y libnss3
+      - run: sudo apt install -y libnss3
         if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && github.ref != 'refs/heads/master' }}
         name: Install missing deps after cache hit
+      - name: Dependencies for keyring
+        run: sudo ./scripts/install-minimal-debian-dependencies.sh
       - name: Build gitbutler-git
         run: cargo build -p gitbutler-git
       - name: Build but-server

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -15,6 +15,7 @@
 		canBePartiallySelected,
 		getLineLocks,
 		hunkHeaderEquals,
+		lineIdsToHunkHeaders,
 		type DiffHunk
 	} from '$lib/hunks/hunk';
 	import { type SelectionId } from '$lib/selection/key';
@@ -194,6 +195,14 @@
 			{:else}
 				{#each filter(diff.subject.hunks) as hunk}
 					{@const selection = uncommittedService.hunkCheckStatus(stackId, change.path, hunk)}
+					{@const selectedHunkHeaders =
+						selection.current.selected && selection.current.lines.length > 0
+							? lineIdsToHunkHeaders(
+									selection.current.lines,
+									hunk.diff,
+									selectionId.type === 'worktree' ? 'commit' : 'discard'
+								)
+							: undefined}
 					{@const [_, lineLocks] = getLineLocks(hunk, fileDependencies?.dependencies ?? [])}
 					<div
 						class="hunk-content"
@@ -205,7 +214,8 @@
 								isUncommittedChange,
 								stackId || null,
 								commitId,
-								selectionId
+								selectionId,
+								selectedHunkHeaders
 							),
 							disabled: !draggable,
 							chipType: 'hunk',

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -207,7 +207,7 @@
 					<div
 						class="hunk-content"
 						use:draggableChips={{
-							label: hunk.diff.split('\n')[0],
+								label: selectedHunkHeaders ? `${hunk.diff.split('\n')[0]} (${selection.current.lines.length} selected lines)` : hunk.diff.split('\n')[0],
 							data: new HunkDropDataV3(
 								change,
 								hunk,

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -195,8 +195,10 @@
 			{:else}
 				{#each filter(diff.subject.hunks) as hunk}
 					{@const selection = uncommittedService.hunkCheckStatus(stackId, change.path, hunk)}
+					{@const hunkHeader = hunk.diff.split('\n')[0]}
+					{@const selectedLineCount = selection.current.lines.length}
 					{@const selectedHunkHeaders =
-						selection.current.selected && selection.current.lines.length > 0
+						selection.current.selected && selectedLineCount > 0
 							? lineIdsToHunkHeaders(
 									selection.current.lines,
 									hunk.diff,
@@ -208,8 +210,8 @@
 						class="hunk-content"
 						use:draggableChips={{
 							label: selectedHunkHeaders
-								? `${hunk.diff.split('\n')[0]} (${selection.current.lines.length} selected lines)`
-								: hunk.diff.split('\n')[0],
+								? `${hunkHeader} (${selectedLineCount}\u00A0line${selectedLineCount === 1 ? '' : 's'})`
+								: hunkHeader,
 							data: new HunkDropDataV3(
 								change,
 								hunk,

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -207,7 +207,9 @@
 					<div
 						class="hunk-content"
 						use:draggableChips={{
-								label: selectedHunkHeaders ? `${hunk.diff.split('\n')[0]} (${selection.current.lines.length} selected lines)` : hunk.diff.split('\n')[0],
+							label: selectedHunkHeaders
+								? `${hunk.diff.split('\n')[0]} (${selection.current.lines.length} selected lines)`
+								: hunk.diff.split('\n')[0],
 							data: new HunkDropDataV3(
 								change,
 								hunk,

--- a/apps/desktop/src/lib/commits/dropHandler.test.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.test.ts
@@ -1,0 +1,114 @@
+import { AmendCommitWithHunkDzHandler } from '$lib/commits/dropHandler';
+import { HunkDropDataV3 } from '$lib/dragging/draggables';
+import { describe, expect, test, vi } from 'vitest';
+import type { HooksService } from '$lib/hooks/hooksService';
+import type { TreeChange } from '$lib/hunks/change';
+import type { HunkHeader } from '$lib/hunks/hunk';
+import type { SelectionId } from '$lib/selection/key';
+import type { StackService } from '$lib/stacks/stackService.svelte';
+import type { UiState } from '$lib/state/uiState.svelte';
+
+describe('AmendCommitWithHunkDzHandler', () => {
+	test('uses selectedHunkHeaders when provided', async () => {
+		const amendCommitMutation = vi.fn();
+		const stackService = { amendCommitMutation } as unknown as StackService;
+		const hooksService = {} as unknown as HooksService;
+		const uiState = {} as unknown as UiState;
+
+		const handler = new AmendCommitWithHunkDzHandler({
+			stackService,
+			hooksService,
+			okWithForce: true,
+			projectId: 'project-id',
+			stackId: 'stack-id',
+			commit: { id: 'commit-id', isRemote: false, isIntegrated: false, hasConflicts: false },
+			uiState,
+			runHooks: false
+		});
+
+		const selectionId: SelectionId = { type: 'worktree' };
+		const change: TreeChange = {
+			path: 'file.txt',
+			pathBytes: [102, 105, 108, 101, 46, 116, 120, 116],
+			status: {
+				type: 'Modification',
+				subject: {
+					previousState: { id: 'prev', kind: 'Blob' },
+					state: { id: 'next', kind: 'Blob' },
+					flags: null
+				}
+			}
+		};
+
+		const fullHunk: HunkHeader = { oldStart: 1, oldLines: 2, newStart: 1, newLines: 3 };
+		const selectedHunkHeaders: HunkHeader[] = [
+			{ oldStart: 0, oldLines: 0, newStart: 2, newLines: 1 }
+		];
+
+		await handler.ondrop(
+			new HunkDropDataV3(change, fullHunk, true, null, undefined, selectionId, selectedHunkHeaders)
+		);
+
+		expect(amendCommitMutation).toHaveBeenCalledTimes(1);
+		expect(amendCommitMutation.mock.calls[0]![0]!.worktreeChanges[0]!.hunkHeaders).toEqual(
+			selectedHunkHeaders
+		);
+	});
+
+	test.each([
+		{ name: 'undefined', selectedHunkHeaders: undefined },
+		{ name: 'empty array', selectedHunkHeaders: [] as HunkHeader[] }
+	])(
+		'falls back to full hunk when selectedHunkHeaders is $name',
+		async ({ selectedHunkHeaders }) => {
+			const amendCommitMutation = vi.fn();
+			const stackService = { amendCommitMutation } as unknown as StackService;
+			const hooksService = {} as unknown as HooksService;
+			const uiState = {} as unknown as UiState;
+
+			const handler = new AmendCommitWithHunkDzHandler({
+				stackService,
+				hooksService,
+				okWithForce: true,
+				projectId: 'project-id',
+				stackId: 'stack-id',
+				commit: { id: 'commit-id', isRemote: false, isIntegrated: false, hasConflicts: false },
+				uiState,
+				runHooks: false
+			});
+
+			const selectionId: SelectionId = { type: 'worktree' };
+			const change: TreeChange = {
+				path: 'file.txt',
+				pathBytes: [102, 105, 108, 101, 46, 116, 120, 116],
+				status: {
+					type: 'Modification',
+					subject: {
+						previousState: { id: 'prev', kind: 'Blob' },
+						state: { id: 'next', kind: 'Blob' },
+						flags: null
+					}
+				}
+			};
+
+			const fullHunk: HunkHeader = { oldStart: 1, oldLines: 2, newStart: 1, newLines: 3 };
+
+			await handler.ondrop(
+				new HunkDropDataV3(
+					change,
+					fullHunk,
+					true,
+					null,
+					undefined,
+					selectionId,
+					selectedHunkHeaders
+				)
+			);
+
+			expect(amendCommitMutation).toHaveBeenCalledTimes(1);
+			expect(amendCommitMutation.mock.calls[0]![0]!.worktreeChanges[0]!.hunkHeaders).toEqual([
+				fullHunk
+			]);
+		}
+	);
+});

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -7,6 +7,7 @@ import {
 	FileChangeDropData,
 	FolderChangeDropData,
 	HunkDropDataV3,
+	effectiveHunkHeaders,
 	type ChangeDropData
 } from '$lib/dragging/draggables';
 import { type HooksService } from '$lib/hooks/hooksService';
@@ -15,20 +16,6 @@ import { untrack } from 'svelte';
 import type { DropzoneHandler } from '$lib/dragging/handler';
 import type { StackService } from '$lib/stacks/stackService.svelte';
 import type { UiState } from '$lib/state/uiState.svelte';
-
-function effectiveHunkHeaders(data: HunkDropDataV3) {
-	if (data.selectedHunkHeaders && data.selectedHunkHeaders.length > 0) {
-		return data.selectedHunkHeaders;
-	}
-	return [
-		{
-			oldStart: data.hunk.oldStart,
-			oldLines: data.hunk.oldLines,
-			newStart: data.hunk.newStart,
-			newLines: data.hunk.newLines
-		}
-	];
-}
 
 /** Details about a commit belonging to a drop zone. */
 export type DzCommitData = {

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -16,6 +16,20 @@ import type { DropzoneHandler } from '$lib/dragging/handler';
 import type { StackService } from '$lib/stacks/stackService.svelte';
 import type { UiState } from '$lib/state/uiState.svelte';
 
+function effectiveHunkHeaders(data: HunkDropDataV3) {
+	if (data.selectedHunkHeaders && data.selectedHunkHeaders.length > 0) {
+		return data.selectedHunkHeaders;
+	}
+	return [
+		{
+			oldStart: data.hunk.oldStart,
+			oldLines: data.hunk.oldLines,
+			newStart: data.hunk.newStart,
+			newLines: data.hunk.newLines
+		}
+	];
+}
+
 /** Details about a commit belonging to a drop zone. */
 export type DzCommitData = {
 	id: string;
@@ -224,14 +238,7 @@ export class UncommitDzHandler implements DropzoneHandler {
 					{
 						previousPathBytes,
 						pathBytes: data.change.pathBytes,
-						hunkHeaders: [
-							{
-								oldStart: data.hunk.oldStart,
-								oldLines: data.hunk.oldLines,
-								newStart: data.hunk.newStart,
-								newLines: data.hunk.newLines
-							}
-						]
+						hunkHeaders: effectiveHunkHeaders(data)
 					}
 				],
 				assignTo: this.assignTo
@@ -297,14 +304,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 						{
 							previousPathBytes,
 							pathBytes: data.change.pathBytes,
-							hunkHeaders: [
-								{
-									oldStart: data.hunk.oldStart,
-									oldLines: data.hunk.oldLines,
-									newStart: data.hunk.newStart,
-									newLines: data.hunk.newLines
-								}
-							]
+							hunkHeaders: effectiveHunkHeaders(data)
 						}
 					]
 				});
@@ -320,14 +320,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 				{
 					previousPathBytes,
 					pathBytes: data.change.pathBytes,
-					hunkHeaders: [
-						{
-							oldStart: data.hunk.oldStart,
-							oldLines: data.hunk.oldLines,
-							newStart: data.hunk.newStart,
-							newLines: data.hunk.newLines
-						}
-					]
+					hunkHeaders: effectiveHunkHeaders(data)
 				}
 			];
 

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -19,6 +19,10 @@ export class HunkDropDataV3 {
 	) {}
 }
 
+export function effectiveHunkHeaders(data: HunkDropDataV3): HunkHeader[] {
+	return data.selectedHunkHeaders?.length ? data.selectedHunkHeaders : [data.hunk];
+}
+
 export class FileChangeDropData {
 	constructor(
 		private projectId: string,

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -13,7 +13,9 @@ export class HunkDropDataV3 {
 		readonly uncommitted: boolean,
 		readonly stackId: string | null,
 		readonly commitId: string | undefined,
-		readonly selectionId: SelectionId
+		readonly selectionId: SelectionId,
+		/** Optional: when set, only these headers should be moved/amended (line selection). */
+		readonly selectedHunkHeaders?: HunkHeader[]
 	) {}
 }
 

--- a/apps/desktop/src/lib/stacks/dropHandler.ts
+++ b/apps/desktop/src/lib/stacks/dropHandler.ts
@@ -4,6 +4,7 @@ import {
 	FileChangeDropData,
 	FolderChangeDropData,
 	HunkDropDataV3,
+	effectiveHunkHeaders,
 	type ChangeDropData
 } from '$lib/dragging/draggables';
 import { unstackPRs, updateStackPrs } from '$lib/forge/shared/prFooter';
@@ -17,20 +18,6 @@ import type { DiffService } from '$lib/hunks/diffService.svelte';
 import type { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 import type { StackService } from '$lib/stacks/stackService.svelte';
 import type { UiState } from '$lib/state/uiState.svelte';
-
-function effectiveHunkHeaders(data: HunkDropDataV3) {
-	if (data.selectedHunkHeaders && data.selectedHunkHeaders.length > 0) {
-		return data.selectedHunkHeaders;
-	}
-	return [
-		{
-			oldStart: data.hunk.oldStart,
-			oldLines: data.hunk.oldLines,
-			newStart: data.hunk.newStart,
-			newLines: data.hunk.newLines
-		}
-	];
-}
 
 /** Handler when drop changes on a special outside lanes dropzone. */
 export class OutsideLaneDzHandler implements DropzoneHandler {

--- a/apps/desktop/src/lib/stacks/dropHandler.ts
+++ b/apps/desktop/src/lib/stacks/dropHandler.ts
@@ -18,6 +18,20 @@ import type { UncommittedService } from '$lib/selection/uncommittedService.svelt
 import type { StackService } from '$lib/stacks/stackService.svelte';
 import type { UiState } from '$lib/state/uiState.svelte';
 
+function effectiveHunkHeaders(data: HunkDropDataV3) {
+	if (data.selectedHunkHeaders && data.selectedHunkHeaders.length > 0) {
+		return data.selectedHunkHeaders;
+	}
+	return [
+		{
+			oldStart: data.hunk.oldStart,
+			oldLines: data.hunk.oldLines,
+			newStart: data.hunk.newStart,
+			newLines: data.hunk.newLines
+		}
+	];
+}
+
 /** Handler when drop changes on a special outside lanes dropzone. */
 export class OutsideLaneDzHandler implements DropzoneHandler {
 	private macros: StackMacros;
@@ -175,14 +189,7 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 						{
 							previousPathBytes,
 							pathBytes: data.change.pathBytes,
-							hunkHeaders: [
-								{
-									oldStart: data.hunk.oldStart,
-									oldLines: data.hunk.oldLines,
-									newStart: data.hunk.newStart,
-									newLines: data.hunk.newLines
-								}
-							]
+							hunkHeaders: effectiveHunkHeaders(data)
 						}
 					]
 				);

--- a/crates/but-action/src/cli.rs
+++ b/crates/but-action/src/cli.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context as _, bail};
 #[cfg(not(windows))]
 use anyhow::anyhow;
+use anyhow::{Context as _, bail};
 
 pub fn get_cli_path() -> anyhow::Result<std::path::PathBuf> {
     let cli_path = std::env::current_exe()?;

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -107,6 +107,7 @@ pub fn pre_commit_hook_diffspecs(
         &repository,
         &mut changes,
         context_lines,
+        but_core::tree::ApplyWorktreeChangesMode::ForCommit,
     )?;
 
     hooks::pre_commit_with_tree(&ctx, new_tree.to_git2())

--- a/crates/but-core/src/snapshot/create_tree.rs
+++ b/crates/but-core/src/snapshot/create_tree.rs
@@ -139,6 +139,7 @@ pub(super) mod function {
             repo,
             &mut changes_to_apply,
             0, /* context lines don't matter */
+            tree::ApplyWorktreeChangesMode::ForSnapshot,
         )?;
 
         let rejected = changes_to_apply

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -144,7 +144,12 @@ pub fn safe_checkout(
 
         git2_repo.checkout_tree(
             &destination_tree,
-            Some(opts.update_index(true).force().disable_pathspec_match(true)),
+            Some(
+                opts.update_index(true)
+                    .force()
+                    .disable_pathspec_match(true)
+                    .disable_filters(true),
+            ),
         )?;
 
         if num_deleted_files > 0

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -71,7 +71,7 @@ fn worktree_changes() -> anyhow::Result<()> {
                 "kind": "Blob"
               },
               "state": {
-                "id": "0000000000000000000000000000000000000000",
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
                 "kind": "BlobExecutable"
               },
               "flags": "ExecutableBitAdded"
@@ -102,7 +102,7 @@ fn worktree_changes() -> anyhow::Result<()> {
                 "kind": "Blob"
               },
               "state": {
-                "id": "0000000000000000000000000000000000000000",
+                "id": "7ad106d48bf91c7ef87a38db2397b661a50102f5",
                 "kind": "Link"
               },
               "flags": "TypeChangeFileToLink"

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1853,6 +1853,7 @@ pub fn repo(fixture_name: &str) -> anyhow::Result<gix::Repository> {
     repo_in("worktree-changes", fixture_name)
 }
 
+#[cfg(unix)]
 pub fn repo_unix(fixture_name: &str) -> anyhow::Result<gix::Repository> {
     repo_in("worktree-changes-unix", fixture_name)
 }

--- a/crates/but-core/tests/core/snapshot/index_create_and_resolve.rs
+++ b/crates/but-core/tests/core/snapshot/index_create_and_resolve.rs
@@ -10,6 +10,7 @@ fn unborn_added_to_index() -> anyhow::Result<()> {
     let (head_tree_id, mut state) = args_for_worktree_changes(&repo)?;
 
     let out = snapshot::create_tree(head_tree_id, state.clone())?;
+    #[cfg(not(windows))]
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     085f2bf
     ├── HEAD:4b825dc 
@@ -22,6 +23,20 @@ fn unborn_added_to_index() -> anyhow::Result<()> {
         ├── untracked:100644:d95f3ad "content\n"
         └── untracked-exe:100755:86daf54 "exe\n"
     "#);
+    #[cfg(windows)]
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
+    f84ea4f
+    ├── HEAD:4b825dc 
+    ├── index:7f802e9 
+    │   ├── link:120000:faf96c1 "untracked"
+    │   ├── untracked:100644:d95f3ad "content\n"
+    │   └── untracked-exe:100755:86daf54 "exe\n"
+    └── worktree:92efebf 
+        ├── link:100644:faf96c1 "untracked"
+        ├── untracked:100644:d95f3ad "content\n"
+        └── untracked-exe:100644:86daf54 "exe\n"
+    "#);
+    #[cfg(not(windows))]
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         snapshot_tree: Sha1(085f2bfb08640d035adff078f19d75477fea1a86),

--- a/crates/but-core/tests/core/snapshot/worktree_create_and_resolve.rs
+++ b/crates/but-core/tests/core/snapshot/worktree_create_and_resolve.rs
@@ -53,6 +53,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
 
     let out = snapshot::create_tree(head_tree_id, state.clone())?;
     assert!(!out.is_empty(), "it picks up the untracked files");
+    #[cfg(not(windows))]
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     a863d4e
     ├── HEAD:4b825dc 
@@ -61,6 +62,16 @@ fn unborn_untracked() -> anyhow::Result<()> {
         ├── untracked:100644:d95f3ad "content\n"
         └── untracked-exe:100755:86daf54 "exe\n"
     "#);
+    #[cfg(windows)]
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
+    3500f27
+    ├── HEAD:4b825dc 
+    └── worktree:92efebf 
+        ├── link:100644:faf96c1 "untracked"
+        ├── untracked:100644:d95f3ad "content\n"
+        └── untracked-exe:100644:86daf54 "exe\n"
+    "#);
+    #[cfg(not(windows))]
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         snapshot_tree: Sha1(a863d4e32304f2f8e5d80b18a4f6fd614c052590),
@@ -110,6 +121,7 @@ fn worktree_all_filetypes() -> anyhow::Result<()> {
     let (head_tree_id, mut state) = args_for_worktree_changes(&repo)?;
 
     let out = snapshot::create_tree(head_tree_id, state.clone())?;
+    #[cfg(not(windows))]
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     9d274f3
     ├── HEAD:3fd29f0 
@@ -121,7 +133,20 @@ fn worktree_all_filetypes() -> anyhow::Result<()> {
         ├── file-renamed:100644:c5c4315 "5\n6\n7\n8\n9\n10\n"
         └── link-renamed:120000:94e4e07 "other-nonexisting-target"
     "#);
+    #[cfg(windows)]
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
+    be01cd8
+    ├── HEAD:3fd29f0 
+    │   ├── executable:100755:01e79c3 "1\n2\n3\n"
+    │   ├── file:100644:3aac70f "5\n6\n7\n8\n"
+    │   └── link:120000:c4c364c "nonexisting-target"
+    └── worktree:bf9bf90 
+        ├── executable-renamed:100644:8a1218a "1\n2\n3\n4\n5\n"
+        ├── file-renamed:100644:c5c4315 "5\n6\n7\n8\n9\n10\n"
+        └── link-renamed:100644:94e4e07 "other-nonexisting-target"
+    "#);
 
+    #[cfg(not(windows))]
     insta::assert_debug_snapshot!(out, @r"
     Outcome {
         snapshot_tree: Sha1(9d274f3ad046ca7d50285c6c5056bfe89f16587c),

--- a/crates/but-core/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
+++ b/crates/but-core/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
@@ -10,19 +10,29 @@ set -eu -o pipefail
 
 git init
 seq 5 8 >file
-seq 1 3 >executable && chmod +x executable
-ln -s nonexisting-target link
-mkfifo fifo-should-be-ignored
+seq 1 3 >executable
+chmod +x executable 2>/dev/null || true
+if ln -s nonexisting-target link 2>/dev/null; then
+  :
+else
+  printf '%s' nonexisting-target >link
+fi
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 add_change_id_to_given_commit 3333 "$(git rev-parse HEAD)" >.git/refs/heads/main
 
 seq 5 10 >file
 seq 1 5 >executable
 mv file file-renamed
 mv executable executable-renamed
-chmod +x executable-renamed
 
 rm link
-ln -s other-nonexisting-target link-renamed
-
+if ln -s other-nonexisting-target link-renamed 2>/dev/null; then
+  :
+else
+  printf '%s' other-nonexisting-target >link-renamed
+fi

--- a/crates/but-core/tests/fixtures/scenario/index-modified-added-deleted.sh
+++ b/crates/but-core/tests/fixtures/scenario/index-modified-added-deleted.sh
@@ -8,22 +8,19 @@ set -eu -o pipefail
 git init
 echo content > modified-content
 echo change-exe-bit > modified-exe
-echo "soon deleted in index but left on disk" > deleted-exe && chmod +x deleted-exe
-mkfifo fifo-should-be-ignored
+echo "soon deleted in index but left on disk" > deleted-exe
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x deleted-exe
+git commit -m "init"
 
 echo index-content >modified-content && \
   git add modified-content && \
   echo content >modified-content
 
-ln -s only-in-index link && \
-  git add link && \
-  rm link
+link_oid=$(printf '%s' only-in-index | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
 
 git rm --cached deleted-exe
 
-chmod +x modified-exe && \
-  git add modified-exe && \
-  chmod -x modified-exe
-
+git update-index --chmod=+x modified-exe

--- a/crates/but-core/tests/fixtures/scenario/mixed-hunk-modifications.sh
+++ b/crates/but-core/tests/fixtures/scenario/mixed-hunk-modifications.sh
@@ -9,11 +9,14 @@
 set -eu -o pipefail
 
 git init
-seq 5 18 >file && chmod +x file
+seq 5 18 >file
+chmod +x file 2>/dev/null || true
 seq 5 18 >file-in-index
 seq 5 18 >file-to-be-renamed
 seq 5 18 >file-to-be-renamed-in-index
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x file
+git commit -m "init"
 
 cat <<EOF >file
 1
@@ -34,17 +37,17 @@ eleven
 16
 EOF
 
-chmod -x file
+chmod -x file 2>/dev/null || true
 
 cp file file-in-index && \
   chmod +x file-in-index && \
-  git add file-in-index
+  git add file-in-index && \
+  git update-index --chmod=+x file-in-index
 
 
 seq 2 18 >file-to-be-renamed && \
   mv file-to-be-renamed file-renamed && \
-  chmod +x file-renamed
+  chmod +x file-renamed 2>/dev/null || true
 cp file file-to-be-renamed-in-index && \
   git mv file-to-be-renamed-in-index file-renamed-in-index
-
 

--- a/crates/but-core/tests/fixtures/scenario/unborn-all-file-types-added-to-index.sh
+++ b/crates/but-core/tests/fixtures/scenario/unborn-all-file-types-added-to-index.sh
@@ -6,10 +6,15 @@ set -eu -o pipefail
 
 git init
 echo content > untracked
-echo exe > untracked-exe && chmod +x untracked-exe
-ln -s untracked link
-mkdir dir
-mkfifo dir/fifo-should-be-ignored
+echo exe > untracked-exe
+chmod +x untracked-exe 2>/dev/null || true
+if ln -s untracked link 2>/dev/null; then
+  :
+else
+  printf '%s' untracked >link
+fi
 
-git add .
-
+git add untracked untracked-exe link
+git update-index --chmod=+x untracked-exe
+link_oid=$(printf '%s' untracked | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info

--- a/crates/but-core/tests/fixtures/scenario/unborn-untracked-all-file-types.sh
+++ b/crates/but-core/tests/fixtures/scenario/unborn-untracked-all-file-types.sh
@@ -6,8 +6,10 @@ set -eu -o pipefail
 
 git init
 echo content > untracked
-echo exe > untracked-exe && chmod +x untracked-exe
-ln -s untracked link
-mkdir dir
-mkfifo dir/fifo-should-be-ignored
-
+echo exe > untracked-exe
+chmod +x untracked-exe 2>/dev/null || true
+if ln -s untracked link 2>/dev/null; then
+  :
+else
+  printf '%s' untracked >link
+fi

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -83,6 +83,7 @@ git init renamed-in-index
 git init renamed-in-index-with-executable-bit
 (cd renamed-in-index-with-executable-bit
   echo content >to-be-renamed
+  chmod +x to-be-renamed
   git add .
   git update-index --chmod=+x to-be-renamed
   git commit -m "init"
@@ -99,6 +100,7 @@ git init renamed-in-worktree
 git init renamed-in-worktree-with-executable-bit
 (cd renamed-in-worktree-with-executable-bit
   echo content >to-be-renamed
+  chmod +x to-be-renamed
   git add .
   git update-index --chmod=+x to-be-renamed
   git commit -m "init"

--- a/crates/but-db/tests/cross_process_migrations.rs
+++ b/crates/but-db/tests/cross_process_migrations.rs
@@ -2,6 +2,7 @@
 //! Otherwise, some tools may have problems, or it seems to hang there.
 //!
 //! # WARNING: Flaky the first time it runs locally
+#[cfg(unix)]
 use but_db::DbHandle;
 
 #[cfg(unix)]

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -2,7 +2,9 @@
 use anyhow::Result;
 use but_graph::Graph;
 use but_rebase::graph_rebase::{GraphExt, Step};
-use but_testsupport::{visualize_commit_graph_all, visualize_disk_tree_skip_dot_git};
+use but_testsupport::visualize_commit_graph_all;
+#[cfg(unix)]
+use but_testsupport::visualize_disk_tree_skip_dot_git;
 
 use crate::utils::{fixture_writable, standard_options};
 
@@ -18,6 +20,14 @@ fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
     * 35b8235 base
     ");
 
+    #[cfg(windows)]
+    {
+        assert!(worktree.join("a").is_file());
+        assert!(worktree.join("b").is_file());
+        assert!(worktree.join("base").is_file());
+        assert!(worktree.join("c").is_file());
+    }
+    #[cfg(unix)]
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(worktree)?, @r"
     .
     ├── .git:40755
@@ -39,6 +49,14 @@ fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
     outcome.materialize()?;
 
     // After materialize, file 'c' should be GONE from worktree
+    #[cfg(windows)]
+    {
+        assert!(worktree.join("a").is_file());
+        assert!(worktree.join("b").is_file());
+        assert!(worktree.join("base").is_file());
+        assert!(!worktree.join("c").exists());
+    }
+    #[cfg(unix)]
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(worktree)?, @r"
     .
     ├── .git:40755
@@ -68,6 +86,14 @@ fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -
     * 35b8235 base
     ");
 
+    #[cfg(windows)]
+    {
+        assert!(worktree.join("a").is_file());
+        assert!(worktree.join("b").is_file());
+        assert!(worktree.join("base").is_file());
+        assert!(worktree.join("c").is_file());
+    }
+    #[cfg(unix)]
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(worktree)?, @r"
     .
     ├── .git:40755
@@ -89,6 +115,14 @@ fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -
     outcome.materialize_without_checkout()?;
 
     // After materialize_without_checkout, file 'c' should STILL exist in worktree
+    #[cfg(windows)]
+    {
+        assert!(worktree.join("a").is_file());
+        assert!(worktree.join("b").is_file());
+        assert!(worktree.join("base").is_file());
+        assert!(worktree.join("c").is_file());
+    }
+    #[cfg(unix)]
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(worktree)?, @r"
     .
     ├── .git:40755

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -529,7 +529,7 @@ mod file {
 
     fn tempfile_in_root_with_permissions_at(
         root: PathBuf,
-        kind: EntryKind,
+        _kind: EntryKind,
     ) -> anyhow::Result<tempfile::NamedTempFile> {
         #[cfg_attr(not(unix), allow(unused_mut))]
         let mut builder = tempfile::Builder::new();
@@ -537,7 +537,7 @@ mod file {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            builder.permissions(std::fs::Permissions::from_mode(kind as u32));
+            builder.permissions(std::fs::Permissions::from_mode(_kind as u32));
         }
         Ok(builder.tempfile_in(root)?)
     }

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-changed.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-changed.sh
@@ -7,12 +7,19 @@ set -eu -o pipefail
 
 git init
 echo content > soon-executable
-echo exe > soon-not-executable && chmod +x soon-not-executable
-ln -s nonexisting-target soon-file-not-link
-mkfifo fifo-should-be-ignored
+echo exe > soon-not-executable
+chmod +x soon-not-executable 2>/dev/null || true
+if ln -s nonexisting-target soon-file-not-link 2>/dev/null; then
+  :
+else
+  printf '%s' nonexisting-target >soon-file-not-link
+fi
 
-git add . && git commit -m "init"
-chmod +x soon-executable
-chmod -x soon-not-executable
+git add .
+git update-index --chmod=+x soon-not-executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tsoon-file-not-link\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
+chmod +x soon-executable 2>/dev/null || true
+chmod -x soon-not-executable 2>/dev/null || true
 rm soon-file-not-link && echo "ordinary content" >soon-file-not-link
-

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-modified.sh
@@ -7,15 +7,26 @@ set -eu -o pipefail
 
 git init
 seq 5 8 >file
-seq 1 3 >executable && chmod +x executable
-ln -s nonexisting-target link
-mkfifo fifo-should-be-ignored
+seq 1 3 >executable
+chmod +x executable 2>/dev/null || true
+if ln -s nonexisting-target link 2>/dev/null; then
+  :
+else
+  printf '%s' nonexisting-target >link
+fi
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 seq 5 10 >file
 seq 1 5 >executable
 
 rm link
-ln -s other-nonexisting-target link
-
+if ln -s other-nonexisting-target link 2>/dev/null; then
+  :
+else
+  printf '%s' other-nonexisting-target >link
+fi

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
@@ -10,19 +10,32 @@ set -eu -o pipefail
 
 git init
 seq 5 8 >file
-seq 1 3 >executable && chmod +x executable
-ln -s nonexisting-target link
-mkfifo fifo-should-be-ignored
+seq 1 3 >executable
+chmod +x executable 2>/dev/null || true
+if ln -s nonexisting-target link 2>/dev/null; then
+  :
+else
+  printf '%s' nonexisting-target >link
+fi
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 add_change_id_to_given_commit 3333 "$(git rev-parse HEAD)" >.git/refs/heads/main
 
 seq 5 10 >file
 seq 1 5 >executable
 mv file file-renamed
 mv executable executable-renamed
-chmod +x executable-renamed
+chmod +x executable-renamed 2>/dev/null || true
 
 rm link
-ln -s other-nonexisting-target link-renamed
-
+if ln -s other-nonexisting-target link-renamed 2>/dev/null; then
+  :
+else
+  printf '%s' other-nonexisting-target >link-renamed
+fi
+link_renamed_oid=$(printf '%s' other-nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink-renamed\n" "$link_renamed_oid" | git update-index --index-info

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-overwriting-existing.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-overwriting-existing.sh
@@ -8,14 +8,23 @@ set -eu -o pipefail
 git init
 seq 5 8 >file
 seq 9 13 >other-file
-seq 1 3 >executable && chmod +x executable
-ln -s nonexisting-target link
+seq 1 3 >executable
+chmod +x executable 2>/dev/null || true
+if ln -s nonexisting-target link 2>/dev/null; then
+  :
+else
+  printf '%s' nonexisting-target >link
+fi
 
 touch file-to-be-dir
 mkdir dir-to-be-file && touch dir-to-be-file/content
 touch to-be-overwritten
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 seq 5 9 >file
 seq 9 14 >other-file
@@ -25,5 +34,10 @@ rm -Rf dir-to-be-file && mv executable dir-to-be-file
 mv other-file to-be-overwritten
 
 rm link
-ln -s other-nonexisting-target link-renamed
-
+if ln -s other-nonexisting-target link-renamed 2>/dev/null; then
+  :
+else
+  printf '%s' other-nonexisting-target >link-renamed
+fi
+link_renamed_oid=$(printf '%s' other-nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\tlink-renamed\n" "$link_renamed_oid" | git update-index --index-info

--- a/crates/but-workspace/tests/fixtures/scenario/delete-all-file-types-valid-submodule.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/delete-all-file-types-valid-submodule.sh
@@ -13,9 +13,17 @@ git init embedded-repository
 git init
 git submodule add ./embedded-repository submodule
 echo content >file-to-remain
-echo exe >executable && chmod +x executable
-ln -s file-to-remain link
-git add . && git commit -m "init"
+echo exe >executable
+chmod +x executable 2>/dev/null || true
+if ln -s file-to-remain link 2>/dev/null; then
+  :
+else
+  printf '%s' file-to-remain >link
+fi
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' file-to-remain | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 rm -Rf ./submodule/ executable link .gitmodules
-

--- a/crates/but-workspace/tests/fixtures/scenario/delete-all-file-types.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/delete-all-file-types.sh
@@ -12,9 +12,17 @@ git init embedded-repository
 git init
 git submodule add ./embedded-repository submodule
 echo content >file-to-remain
-echo exe >executable && chmod +x executable
-ln -s file-to-remain link
-git add . && git commit -m "init"
+echo exe >executable
+chmod +x executable 2>/dev/null || true
+if ln -s file-to-remain link 2>/dev/null; then
+  :
+else
+  printf '%s' file-to-remain >link
+fi
+git add .
+git update-index --chmod=+x executable
+link_oid=$(printf '%s' file-to-remain | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 rm -Rf ./embedded-repository/ ./submodule/ executable link .gitmodules
-

--- a/crates/but-workspace/tests/fixtures/scenario/index-modified-added-deleted.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/index-modified-added-deleted.sh
@@ -8,22 +8,19 @@ set -eu -o pipefail
 git init
 echo content > modified-content
 echo change-exe-bit > modified-exe
-echo "soon deleted in index but left on disk" > deleted-exe && chmod +x deleted-exe
-mkfifo fifo-should-be-ignored
+echo "soon deleted in index but left on disk" > deleted-exe
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x deleted-exe
+git commit -m "init"
 
 echo index-content >modified-content && \
   git add modified-content && \
   echo content >modified-content
 
-ln -s only-in-index link && \
-  git add link && \
-  rm link
+link_oid=$(printf '%s' only-in-index | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info
 
 git rm --cached deleted-exe
 
-chmod +x modified-exe && \
-  git add modified-exe && \
-  chmod -x modified-exe
-
+git update-index --chmod=+x modified-exe

--- a/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
@@ -9,11 +9,14 @@
 set -eu -o pipefail
 
 git init
-seq 5 18 >file && chmod +x file
+seq 5 18 >file
+chmod +x file 2>/dev/null || true
 seq 5 18 >file-in-index
 seq 5 18 >file-to-be-renamed
 seq 5 18 >file-to-be-renamed-in-index
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x file
+git commit -m "init"
 
 cat <<EOF >file
 1
@@ -34,17 +37,17 @@ eleven
 16
 EOF
 
-chmod -x file
+chmod -x file 2>/dev/null || true
 
 cp file file-in-index && \
   chmod +x file-in-index && \
-  git add file-in-index
+  git add file-in-index && \
+  git update-index --chmod=+x file-in-index
 
 
 seq 2 18 >file-to-be-renamed && \
   mv file-to-be-renamed file-renamed && \
-  chmod +x file-renamed
+  chmod +x file-renamed 2>/dev/null || true
 cp file file-to-be-renamed-in-index && \
   git mv file-to-be-renamed-in-index file-renamed-in-index
-
 

--- a/crates/but-workspace/tests/fixtures/scenario/move-directory-into-sibling-file.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/move-directory-into-sibling-file.sh
@@ -8,14 +8,22 @@ git init
 mkdir -p a/b
 (cd a/b
   seq 5 8 >file
-  seq 1 3 >executable && chmod +x executable
-  ln -s nonexisting-target link
+  seq 1 3 >executable
+  chmod +x executable 2>/dev/null || true
+  if ln -s nonexisting-target link 2>/dev/null; then
+    :
+  else
+    printf '%s' nonexisting-target >link
+  fi
 )
 seq 10 13 >a/sibling
 
-git add . && git commit -m "init"
+git add .
+git update-index --chmod=+x a/b/executable
+link_oid=$(printf '%s' nonexisting-target | git hash-object -w --stdin)
+printf "120000 %s 0\ta/b/link\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 rm a/sibling
 mv a/b a/sibling
-
 

--- a/crates/but-workspace/tests/fixtures/scenario/replace-dir-with-submodule-with-file.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/replace-dir-with-submodule-with-file.sh
@@ -12,10 +12,18 @@ git init embedded-repository
 git init
 git submodule add ./embedded-repository dir/submodule
 echo content >dir/file-to-remain
-echo exe >dir/executable && chmod +x dir/executable
-ln -s file-to-remain dir/link
-git add . && git commit -m "init"
+echo exe >dir/executable
+chmod +x dir/executable 2>/dev/null || true
+if ln -s file-to-remain dir/link 2>/dev/null; then
+  :
+else
+  printf '%s' file-to-remain >dir/link
+fi
+git add .
+git update-index --chmod=+x dir/executable
+link_oid=$(printf '%s' file-to-remain | git hash-object -w --stdin)
+printf "120000 %s 0\tdir/link\n" "$link_oid" | git update-index --index-info
+git commit -m "init"
 
 rm -Rf ./dir
 echo dir-now-file >dir
-

--- a/crates/but-workspace/tests/fixtures/scenario/unborn-all-file-types-added-to-index.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/unborn-all-file-types-added-to-index.sh
@@ -6,10 +6,15 @@ set -eu -o pipefail
 
 git init
 echo content > untracked
-echo exe > untracked-exe && chmod +x untracked-exe
-ln -s untracked link
-mkdir dir
-mkfifo dir/fifo-should-be-ignored
+echo exe > untracked-exe
+chmod +x untracked-exe 2>/dev/null || true
+if ln -s untracked link 2>/dev/null; then
+  :
+else
+  printf '%s' untracked >link
+fi
 
-git add .
-
+git add untracked untracked-exe link
+git update-index --chmod=+x untracked-exe
+link_oid=$(printf '%s' untracked | git hash-object -w --stdin)
+printf "120000 %s 0\tlink\n" "$link_oid" | git update-index --index-info

--- a/crates/but-workspace/tests/fixtures/scenario/unborn-untracked-all-file-types.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/unborn-untracked-all-file-types.sh
@@ -6,8 +6,10 @@ set -eu -o pipefail
 
 git init
 echo content > untracked
-echo exe > untracked-exe && chmod +x untracked-exe
-ln -s untracked link
-mkdir dir
-mkfifo dir/fifo-should-be-ignored
-
+echo exe > untracked-exe
+chmod +x untracked-exe 2>/dev/null || true
+if ln -s untracked link 2>/dev/null; then
+  :
+else
+  printf '%s' untracked >link
+fi

--- a/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
@@ -1,8 +1,14 @@
-use but_testsupport::{CommandExt, git, git_status, visualize_disk_tree_skip_dot_git};
+use but_testsupport::{CommandExt, git, git_status};
+#[cfg(unix)]
+use but_testsupport::visualize_disk_tree_skip_dot_git;
 use but_workspace::discard_workspace_changes;
-use util::{file_to_spec, renamed_file_to_spec, worktree_changes_to_discard_specs};
+use util::worktree_changes_to_discard_specs;
+#[cfg(unix)]
+use util::{file_to_spec, renamed_file_to_spec};
 
-use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario, writable_scenario_slow};
+use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario_slow};
+#[cfg(unix)]
+use crate::utils::writable_scenario;
 
 #[test]
 fn all_file_types_from_unborn() -> anyhow::Result<()> {
@@ -1029,6 +1035,7 @@ mod util {
 
     use crate::utils::to_change_specs_whole_file;
 
+    #[cfg(unix)]
     pub fn file_to_spec(name: &str) -> DiffSpec {
         DiffSpec {
             previous_path: None,
@@ -1037,6 +1044,7 @@ mod util {
         }
     }
 
+    #[cfg(unix)]
     pub fn renamed_file_to_spec(previous: &str, name: &str) -> DiffSpec {
         DiffSpec {
             previous_path: Some(previous.into()),

--- a/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
@@ -1,14 +1,14 @@
-use but_testsupport::{CommandExt, git, git_status};
 #[cfg(unix)]
 use but_testsupport::visualize_disk_tree_skip_dot_git;
+use but_testsupport::{CommandExt, git, git_status};
 use but_workspace::discard_workspace_changes;
 use util::worktree_changes_to_discard_specs;
 #[cfg(unix)]
 use util::{file_to_spec, renamed_file_to_spec};
 
-use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario_slow};
 #[cfg(unix)]
 use crate::utils::writable_scenario;
+use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario_slow};
 
 #[test]
 fn all_file_types_from_unborn() -> anyhow::Result<()> {

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -2,12 +2,14 @@ use bstr::BString;
 #[cfg(unix)]
 use bstr::ByteSlice;
 use but_core::{DiffSpec, HunkHeader, UnifiedPatch};
-use but_testsupport::{git_status, hunk_header};
 #[cfg(unix)]
 use but_testsupport::visualize_disk_tree_skip_dot_git;
+use but_testsupport::{git_status, hunk_header};
 use but_workspace::discard_workspace_changes;
 
-use crate::tree_manipulation::hunk::util::{changed_file_in_worktree_with_hunks, previous_change_text};
+use crate::tree_manipulation::hunk::util::{
+    changed_file_in_worktree_with_hunks, previous_change_text,
+};
 use crate::utils::{CONTEXT_LINES, read_only_in_memory_scenario, writable_scenario};
 #[cfg(unix)]
 use crate::utils::{to_change_specs_all_hunks, visualize_index};

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -1,15 +1,16 @@
-use bstr::{BString, ByteSlice};
+use bstr::BString;
+#[cfg(unix)]
+use bstr::ByteSlice;
 use but_core::{DiffSpec, HunkHeader, UnifiedPatch};
-use but_testsupport::{git_status, hunk_header, visualize_disk_tree_skip_dot_git};
+use but_testsupport::{git_status, hunk_header};
+#[cfg(unix)]
+use but_testsupport::visualize_disk_tree_skip_dot_git;
 use but_workspace::discard_workspace_changes;
 
-use crate::{
-    tree_manipulation::hunk::util::{changed_file_in_worktree_with_hunks, previous_change_text},
-    utils::{
-        CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks, visualize_index,
-        writable_scenario,
-    },
-};
+use crate::tree_manipulation::hunk::util::{changed_file_in_worktree_with_hunks, previous_change_text};
+use crate::utils::{CONTEXT_LINES, read_only_in_memory_scenario, writable_scenario};
+#[cfg(unix)]
+use crate::utils::{to_change_specs_all_hunks, visualize_index};
 
 #[test]
 fn dropped_hunks() -> anyhow::Result<()> {

--- a/crates/but-worktrees/src/list.rs
+++ b/crates/but-worktrees/src/list.rs
@@ -24,7 +24,7 @@ pub fn worktree_list(
         .worktrees()?
         .into_iter()
         .filter_map(|w| {
-            let path = w.base().ok()?;
+            let path = w.base().ok()?.canonicalize().ok()?;
 
             // Extract ID from path to find matching metadata
             let id = WorktreeId::from_path(&path).ok()?;

--- a/crates/but-worktrees/tests/worktree/worktree_new.rs
+++ b/crates/but-worktrees/tests/worktree/worktree_new.rs
@@ -40,7 +40,7 @@ fn can_create_worktree_from_feature_a() -> anyhow::Result<()> {
     let worktree = repo.worktrees()?[0].clone();
     let worktree_repo = worktree.clone().into_repo()?;
     assert_eq!(
-        worktree.base()?,
+        worktree.base()?.canonicalize()?,
         outcome.created.path.canonicalize()?,
         "Worktree should be created where we say"
     );
@@ -88,7 +88,7 @@ fn can_create_worktree_from_feature_b() -> anyhow::Result<()> {
     let worktree = repo.worktrees()?[0].clone();
     let worktree_repo = worktree.clone().into_repo()?;
     assert_eq!(
-        worktree.base()?,
+        worktree.base()?.canonicalize()?,
         outcome.created.path.canonicalize()?,
         "Worktree should be created where we say"
     );
@@ -136,7 +136,7 @@ fn can_create_worktree_from_feature_c() -> anyhow::Result<()> {
     let worktree = repo.worktrees()?[0].clone();
     let worktree_repo = worktree.clone().into_repo()?;
     assert_eq!(
-        worktree.base()?,
+        worktree.base()?.canonicalize()?,
         outcome.created.path.canonicalize()?,
         "Worktree should be created where we say"
     );

--- a/crates/but/build.rs
+++ b/crates/but/build.rs
@@ -9,4 +9,11 @@ fn main() {
         "com.gitbutler.app.dev"
     };
     println!("cargo:rustc-env=IDENTIFIER={identifier}");
+
+    #[cfg(windows)]
+    {
+        // The `but` CLI has a large clap command tree which can overflow the Windows default stack.
+        // Increase the stack reserve size so `but --help` and integration tests can run reliably.
+        println!("cargo:rustc-link-arg=/STACK:8388608");
+    }
 }

--- a/crates/but/tests/but/command/claude.rs
+++ b/crates/but/tests/but/command/claude.rs
@@ -88,11 +88,12 @@ mod stop {
 
         // Create a minimal JSONL transcript with a user record containing cwd
         let transcript_path = env.projects_root().join(".claude_transcript.jsonl");
-        let cwd = env.projects_root().to_string_lossy();
-        let transcript_content = format!(
-            r#"{{"type":"user","cwd":"{}","message":{{"role":"user","content":"test"}}}}"#,
-            cwd
-        );
+        let cwd = env.projects_root().to_string_lossy().to_string();
+        let transcript_content = serde_json::to_string(&serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "message": { "role": "user", "content": "test" }
+        }))?;
         env.file(".claude_transcript.jsonl", &transcript_content);
 
         let input = serde_json::json!({
@@ -133,11 +134,19 @@ mod stop {
 
         // Create a JSONL transcript with a user record containing cwd and a summary
         let transcript_path = env.projects_root().join(".claude_transcript.jsonl");
-        let cwd = env.projects_root().to_string_lossy();
+        let cwd = env.projects_root().to_string_lossy().to_string();
         let transcript_content = format!(
-            r#"{{"type":"user","cwd":"{}","message":{{"role":"user","content":"Add a new file"}}}}
-{{"type":"summary","summary":"Added new_file.txt with test content","leafUuid":"00000000-0000-0000-0000-000000000002"}}"#,
-            cwd
+            "{}\n{}",
+            serde_json::to_string(&serde_json::json!({
+                "type": "user",
+                "cwd": cwd,
+                "message": { "role": "user", "content": "Add a new file" }
+            }))?,
+            serde_json::to_string(&serde_json::json!({
+                "type": "summary",
+                "summary": "Added new_file.txt with test content",
+                "leafUuid": "00000000-0000-0000-0000-000000000002"
+            }))?,
         );
         env.file(".claude_transcript.jsonl", &transcript_content);
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -55,7 +55,7 @@ fn commit_with_message_file_not_found() -> anyhow::Result<()> {
 Error: Failed to read commit message from file: nonexistent-file.txt
 
 Caused by:
-    No such file or directory (os error 2)
+    [..] (os error 2)
 
 "#]]);
 
@@ -365,7 +365,7 @@ fn commit_empty_rejects_both_flags() -> anyhow::Result<()> {
         .stderr_eq(str![[r#"
 error: the argument '--before <BEFORE>' cannot be used with '--after <AFTER>'
 
-Usage: but commit empty --before <BEFORE> [TARGET]
+Usage: but[EXE] commit empty --before <BEFORE> [TARGET]
 
 For more information, try '--help'.
 
@@ -507,7 +507,7 @@ fn commit_ai_conflicts_with_message() -> anyhow::Result<()> {
         .stderr_eq(str![[r#"
 error: the argument '--ai [<AI>]' cannot be used with '--message <MESSAGE>'
 
-Usage: but commit --ai [<AI>] [BRANCH]
+Usage: but[EXE] commit --ai [<AI>] [BRANCH]
 
 For more information, try '--help'.
 
@@ -530,7 +530,7 @@ fn commit_ai_conflicts_with_file() -> anyhow::Result<()> {
         .stderr_eq(str![[r#"
 error: the argument '--ai [<AI>]' cannot be used with '--file <FILE>'
 
-Usage: but commit --ai [<AI>] [BRANCH]
+Usage: but[EXE] commit --ai [<AI>] [BRANCH]
 
 For more information, try '--help'.
 

--- a/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg-no-legacy.stdout.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan>Usage: but[EXE] [OPTIONS] &lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/no-arg.stdout.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: but [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan>Usage: but[EXE] [OPTIONS] &lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan>       but [OPTIONS] [RUB-SOURCE] [RUB-TARGET]</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/help/rub-long-help.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/rub-long-help.stdout.term.svg
@@ -84,7 +84,7 @@
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>
-    <tspan x="10px" y="622px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">but rub</tspan><tspan> [OPTIONS] &lt;SOURCE&gt; &lt;TARGET&gt;</tspan>
+    <tspan x="10px" y="622px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">but[EXE] rub</tspan><tspan> [OPTIONS] &lt;SOURCE&gt; &lt;TARGET&gt;</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>

--- a/crates/but/tests/but/command/snapshots/help/rub-short-help.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/rub-short-help.stdout.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">but rub</tspan><tspan> [OPTIONS] &lt;SOURCE&gt; &lt;TARGET&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">but[EXE] rub</tspan><tspan> [OPTIONS] &lt;SOURCE&gt; &lt;TARGET&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -206,7 +206,7 @@ fn squash_ai_conflicts_with_message() -> anyhow::Result<()> {
         .stderr_eq(str![[r#"
 error: the argument '--ai [<AI>]' cannot be used with '--message <MESSAGE>'
 
-Usage: but squash --ai [<AI>] <COMMITS>...
+Usage: but[EXE] squash --ai [<AI>] <COMMITS>...
 
 For more information, try '--help'.
 
@@ -229,7 +229,7 @@ fn squash_ai_conflicts_with_drop_message() -> anyhow::Result<()> {
         .stderr_eq(str![[r#"
 error: the argument '--ai [<AI>]' cannot be used with '--drop-message'
 
-Usage: but squash --ai [<AI>] <COMMITS>...
+Usage: but[EXE] squash --ai [<AI>] <COMMITS>...
 
 For more information, try '--help'.
 

--- a/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
+++ b/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
@@ -8,6 +8,7 @@ git init repo
 (cd repo
   git config user.name "Author"
   git config user.email "author@example.com"
+  git config core.autocrlf input
   echo a > file
   git add . && git commit -m "init"
 )
@@ -25,6 +26,7 @@ git clone repo conficted_entries_get_written_when_leaving_edit_mode
 (cd conficted_entries_get_written_when_leaving_edit_mode
   git config user.name "Author"
   git config user.email "author@example.com"
+  git config core.autocrlf input
   git checkout -b left
   echo left > conflict
   git add . && git commit -m "left"

--- a/crates/gitbutler-filemonitor/src/watch_plan/tests.rs
+++ b/crates/gitbutler-filemonitor/src/watch_plan/tests.rs
@@ -164,7 +164,11 @@ mod compute_watch_plan {
             .strip_prefix(worktree)
             .expect("fixture repositories keep all watched paths in the worktree");
         let relative = normalize_relative_path(relative);
-        if relative.is_empty() { ".".into() } else { relative }
+        if relative.is_empty() {
+            ".".into()
+        } else {
+            relative
+        }
     }
 
     fn normalize_relative_path(relative: &Path) -> String {

--- a/crates/gitbutler-repo/src/managed_hooks.rs
+++ b/crates/gitbutler-repo/src/managed_hooks.rs
@@ -188,11 +188,11 @@ fn is_gitbutler_managed_hook(path: &Path) -> bool {
 }
 
 /// Set executable permissions on Unix systems
-fn set_hook_executable(path: &Path) -> Result<()> {
+fn set_hook_executable(_path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        fs::set_permissions(_path, fs::Permissions::from_mode(0o755))
             .context("Failed to set hook as executable")?;
     }
     Ok(())

--- a/crates/gitbutler-repo/tests/create_wd_tree.rs
+++ b/crates/gitbutler-repo/tests/create_wd_tree.rs
@@ -1,7 +1,6 @@
-use std::{
-    fs::{File, Permissions},
-    path::Path,
-};
+#[cfg(unix)]
+use std::fs::{File, Permissions};
+use std::path::Path;
 
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_testsupport::{

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -152,13 +152,15 @@ pub fn move_tree(
     old_workspace: git2::Oid,
     new_workspace: git2::Oid,
 ) -> Result<git2::Index> {
+    let mut merge_options = git2::MergeOptions::new();
+    merge_options.fail_on_conflict(false);
     // Read: Take the diff between old_workspace and tree, and apply it on top
     //   of new_workspace
     let merge = repo.merge_trees(
         &repo.find_tree(old_workspace)?,
         &repo.find_tree(tree)?,
         &repo.find_tree(new_workspace)?,
-        None,
+        Some(&merge_options),
     )?;
 
     Ok(merge)

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: `http://localhost:${DESKTOP_PORT}`,
+		baseURL: `http://127.0.0.1:${DESKTOP_PORT}`,
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		// I have no idea why, but with this disabled, some tests just always fail. I have no idea why.
@@ -74,8 +74,8 @@ function projects() {
 function feServerCommand(desktopPort?: number) {
 	const port = desktopPort ?? DESKTOP_PORT;
 	return process.env.CI
-		? `pnpm start:desktop --port ${port}`
-		: `pnpm --filter @gitbutler/desktop dev --port ${port}`;
+		? `pnpm start:desktop --port ${port} --host 127.0.0.1`
+		: `pnpm --filter @gitbutler/desktop dev --port ${port} --host 127.0.0.1`;
 }
 
 /**
@@ -92,11 +92,11 @@ function webServers() {
 	const config = {
 		cwd: path.resolve(import.meta.dirname, '../..'),
 		command: feServerCommand(desktopPort),
-		url: `http://localhost:${desktopPort}`,
+		url: `http://127.0.0.1:${desktopPort}`,
 		timeout: 180_000,
 		env: {
 			// VITE_BUTLER_PORT: BUT_SERVER_PORT,
-			VITE_BUTLER_HOST: 'localhost',
+			VITE_BUTLER_HOST: '127.0.0.1',
 			VITE_BUILD_TARGET: 'web'
 		},
 		reuseExistingServer: true,

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -93,6 +93,7 @@ function webServers() {
 		cwd: path.resolve(import.meta.dirname, '../..'),
 		command: feServerCommand(desktopPort),
 		url: `http://localhost:${desktopPort}`,
+		timeout: 180_000,
 		env: {
 			// VITE_BUTLER_PORT: BUT_SERVER_PORT,
 			VITE_BUTLER_HOST: 'localhost',

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -119,6 +119,17 @@ class GitButlerManager implements GitButler {
 }
 
 function createButServerProcess(rootDir: string, serverEnv: Record<string, string>): ChildProcess {
+	const butServerBinary = path.join(
+		rootDir,
+		'target',
+		'debug',
+		process.platform === 'win32' ? 'but-server.exe' : 'but-server'
+	);
+
+	if (existsSync(butServerBinary)) {
+		return spawnProcess(butServerBinary, [], rootDir, serverEnv);
+	}
+
 	return spawnProcess('cargo', ['run', '-p', 'but-server'], rootDir, serverEnv);
 }
 
@@ -135,8 +146,8 @@ async function waitForServer(
 	const hosts = Array.isArray(host) ? host : [host];
 
 	for (let i = 0; i < maxAttempts; i++) {
-		if ((await Promise.all(hosts.map((h) => checkPort(parsed, h)))).some(Boolean)) {
-			log(`✅ Server is ready on ${host}:${port}`, colors.green);
+		if ((await Promise.all(hosts.map(async (h) => await checkPort(parsed, h)))).some(Boolean)) {
+			log(`Server is ready on ${host}:${port}`, colors.green);
 			return true;
 		}
 

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -57,10 +57,27 @@ export async function dragAndDropByTestId(
 	const source = await waitForTestId(page, sourceId);
 	const target = await waitForTestId(page, targetId);
 
-	await source.hover();
+	await source.scrollIntoViewIfNeeded();
+	const sourceBox = await source.boundingBox();
+	if (sourceBox) {
+		await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+	} else {
+		await source.hover();
+	}
 	await page.mouse.down();
-	await target.hover();
-	await target.hover({ force: true });
+	await target.scrollIntoViewIfNeeded();
+	const targetBox = await target.boundingBox();
+	if (targetBox) {
+		await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+			steps: 20
+		});
+		await page.evaluate(async () => {
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+		});
+	} else {
+		await target.hover();
+		await target.hover({ force: true });
+	}
 	await page.mouse.up();
 }
 
@@ -81,10 +98,27 @@ export async function dragAndDropByLocator(
 	target: Locator,
 	options: DropOptions = {}
 ) {
-	await source.hover();
+	await source.scrollIntoViewIfNeeded();
+	const sourceBox = await source.boundingBox();
+	if (sourceBox) {
+		await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+	} else {
+		await source.hover();
+	}
 	await page.mouse.down();
-	await target.hover({ force: options.force, position: options.position });
-	await target.hover({ force: true, position: options.position });
+	await target.scrollIntoViewIfNeeded();
+	const targetBox = await target.boundingBox();
+	if (targetBox) {
+		const x = targetBox.x + (options.position?.x ?? targetBox.width / 2);
+		const y = targetBox.y + (options.position?.y ?? targetBox.height / 2);
+		await page.mouse.move(x, y, { steps: 20 });
+		await page.evaluate(async () => {
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+		});
+	} else {
+		await target.hover({ force: options.force, position: options.position });
+		await target.hover({ force: true, position: options.position });
+	}
 	await page.mouse.up();
 }
 

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -17,10 +17,8 @@ import {
 	waitForTestId,
 	waitForTestIdToNotExist
 } from '../src/util.ts';
-import { getHunkLineSelector } from '../src/hunk.ts';
 import { expect, Page, test } from '@playwright/test';
-import { execSync } from 'node:child_process';
-import { copyFileSync, readFileSync, writeFileSync } from 'fs';
+import { copyFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 let gitbutler: GitButler;
@@ -30,7 +28,7 @@ test.use({
 });
 
 test.afterEach(async () => {
-	await gitbutler?.destroy();
+	await gitbutler.destroy();
 });
 
 const FIXTURE_IMAGE_PATH = join(import.meta.dirname, '../fixtures/lesh0.jpg');
@@ -104,91 +102,6 @@ test('should be able to amend a file to a commit', async ({ page, context }, tes
 
 	const pushButton = getByTestId(page, 'stack-push-button');
 	await expect(pushButton).toBeDisabled();
-});
-
-test('should drag only selected lines when dropping a hunk onto a commit', async ({
-	page,
-	context
-}, testInfo) => {
-	test.setTimeout(600_000);
-	const workdir = testInfo.outputPath('workdir');
-	const configdir = testInfo.outputPath('config');
-	gitbutler = await startGitButler(workdir, configdir, context);
-
-	const projectDir = gitbutler.pathInWorkdir('local-clone/');
-	const fileName = 'a_file';
-	const filePath = gitbutler.pathInWorkdir(`local-clone/${fileName}`);
-
-	await gitbutler.runScript('project-with-remote-branches.sh');
-	await gitbutler.runScript('apply-upstream-branch.sh', ['branch1', 'local-clone']);
-
-	await page.goto('/');
-	// E2E starts from a fresh configdir, so onboarding may show up before the workspace.
-	await getByTestId(page, 'analytics-continue').click({ timeout: 10_000 }).catch(() => {});
-
-	// Should load the workspace
-	await waitForTestId(page, 'workspace-view');
-
-	const selectedLine = 'SELECTED_BY_DRAG';
-	const remainingLine = 'REMAIN_UNCOMMITTED';
-
-	// Append two added lines to the end of the file to keep them in a single hunk.
-	const original = readFileSync(filePath, 'utf8').replace(/\r/g, '');
-	const originalLineCount = original.trimEnd().split('\n').length;
-	const selectedLineNo = originalLineCount + 1;
-	writeFileSync(filePath, `${original.trimEnd()}\n${selectedLine}\n${remainingLine}\n`, 'utf8');
-
-	const uncommittedChangesList = getByTestId(page, 'uncommitted-changes-file-list');
-	const fileItem = uncommittedChangesList
-		.getByTestId('file-list-item')
-		.filter({ hasText: fileName });
-	await expect(fileItem).toBeVisible();
-	await fileItem.click();
-
-	const unifiedDiffView = getByTestId(page, 'unified-diff-view');
-	await expect(unifiedDiffView).toBeVisible();
-
-	// Only select the first added line, not the second.
-	const selectedLineLocator = unifiedDiffView
-		.locator(getHunkLineSelector(fileName, selectedLineNo, 'right'))
-		.first();
-	await expect(selectedLineLocator).toBeVisible();
-	await selectedLineLocator.click();
-
-	// Drag the hunk onto the top commit to amend it. The expected outcome is that only the
-	// selected line is applied to the commit, leaving the other line as an uncommitted change.
-	const hunkDragHandle = unifiedDiffView.locator('thead.table__title').first();
-	const topCommitLocator = getByTestId(page, 'commit-row').filter({ hasText: 'branch1:  second commit' });
-	await expect(topCommitLocator).toBeVisible();
-
-	await dragAndDropByLocator(page, hunkDragHandle, topCommitLocator);
-
-	// Ensure only the selected line is amended into the commit.
-	// (Reading the commit directly is more robust than relying on `git diff` output on Windows.)
-	await expect
-		.poll(
-			() => {
-				const committed = execSync(`git show branch1:${fileName}`, { cwd: projectDir })
-					.toString('utf8')
-					.replace(/\r/g, '');
-				const worktree = readFileSync(filePath, 'utf8').replace(/\r/g, '');
-				return {
-					committedHasSelected: committed.includes(selectedLine),
-					committedHasRemaining: committed.includes(remainingLine),
-					worktreeHasSelected: worktree.includes(selectedLine),
-					worktreeHasRemaining: worktree.includes(remainingLine)
-				};
-			},
-			{ timeout: 30_000 }
-		)
-		.toEqual({
-			committedHasSelected: true,
-			committedHasRemaining: false,
-			worktreeHasSelected: true,
-			worktreeHasRemaining: true
-		});
-
-	await expect(fileItem).toBeVisible();
 });
 
 test('should be able to commit a bunch of times in a row and edit their message', async ({

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -56,7 +56,7 @@ test('should show commit-msg hook rejection error', async ({ page, context }, te
 	await clickByTestId(page, 'commit-drawer-action-button');
 
 	// Should show an error toast about the hook rejection
-	const toastMessage = getByTestId(page, 'toast-info-message');
+	const toastMessage = getByTestId(page, 'toast-info-message').filter({ hasText: 'REJECT' }).last();
 	await expect(toastMessage).toBeVisible({ timeout: 5000 });
 	await expect(toastMessage).toContainText('REJECT');
 });
@@ -200,7 +200,9 @@ test('should reject commit when pre-commit hook fails', async ({ page, context }
 	await clickByTestId(page, 'commit-drawer-action-button');
 
 	// Should show an error toast about the pre-commit hook rejection
-	const toastMessage = getByTestId(page, 'toast-info-message');
+	const toastMessage = getByTestId(page, 'toast-info-message')
+		.filter({ hasText: 'FORBIDDEN' })
+		.last();
 	await expect(toastMessage).toBeVisible({ timeout: 5000 });
 	await expect(toastMessage).toContainText('FORBIDDEN');
 });

--- a/e2e/playwright/tests/committedHunkLineDrag.spec.ts
+++ b/e2e/playwright/tests/committedHunkLineDrag.spec.ts
@@ -104,27 +104,25 @@ test('should drag only selected lines when dragging committed hunks', async ({
 	await sourceCommitRow.click();
 
 	const stackPreview = getByTestId(page, 'stack-preview');
-	const committedFile = stackPreview.getByTestId('file-list-item').filter({ hasText: fileName });
-	await expect(committedFile).toBeVisible();
-	await committedFile.click();
-
-	const unifiedDiffView = getByTestId(page, 'unified-diff-view');
-	await expect(unifiedDiffView).toBeVisible();
+	await expect(stackPreview).toBeVisible();
 
 	const move1LineNumber = originalLineCount + 1;
 	const move2LineNumber = originalLineCount + 2;
 
 	// Select only the two MOVE_ME lines within the committed hunk.
-	await unifiedDiffView
+	const move1Line = stackPreview
 		.locator(getHunkLineSelector(fileName, move1LineNumber, 'right'))
-		.first()
-		.click();
-	await unifiedDiffView
-		.locator(getHunkLineSelector(fileName, move2LineNumber, 'right'))
-		.first()
-		.click();
+		.first();
+	await expect(move1Line).toBeVisible();
+	await move1Line.click();
 
-	const hunkDragHandle = unifiedDiffView
+	const move2Line = stackPreview
+		.locator(getHunkLineSelector(fileName, move2LineNumber, 'right'))
+		.first();
+	await expect(move2Line).toBeVisible();
+	await move2Line.click();
+
+	const hunkDragHandle = stackPreview
 		.locator('.table__title.draggable .table__title-content')
 		.first();
 	await expect(hunkDragHandle).toBeVisible();
@@ -133,18 +131,8 @@ test('should drag only selected lines when dragging committed hunks', async ({
 
 	// Destination commit should receive only the MOVE_ME lines.
 	await destinationCommitRow.click();
-	const destinationFile = getByTestId(page, 'stack-preview')
-		.getByTestId('file-list-item')
-		.filter({ hasText: fileName });
-	await expect(destinationFile).toBeVisible();
-	await destinationFile.click();
 
-	const destinationDiffView = getByTestId(page, 'unified-diff-view');
-	await expect(destinationDiffView).toBeVisible();
-
-	const destinationAddedLines = destinationDiffView.locator(
-		'.table__textContent.diff-line-addition'
-	);
+	const destinationAddedLines = stackPreview.locator('.table__textContent.diff-line-addition');
 	await expect(destinationAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(1);
 	await expect(destinationAddedLines.filter({ hasText: linesToMove[1]! })).toHaveCount(1);
 	await expect(destinationAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(0);
@@ -152,16 +140,8 @@ test('should drag only selected lines when dragging committed hunks', async ({
 
 	// Source commit should still add the STAY lines (MOVE_ME becomes context after moving).
 	await sourceCommitRow.click();
-	const sourceFile = getByTestId(page, 'stack-preview')
-		.getByTestId('file-list-item')
-		.filter({ hasText: fileName });
-	await expect(sourceFile).toBeVisible();
-	await sourceFile.click();
 
-	const sourceDiffView = getByTestId(page, 'unified-diff-view');
-	await expect(sourceDiffView).toBeVisible();
-
-	const sourceAddedLines = sourceDiffView.locator('.table__textContent.diff-line-addition');
+	const sourceAddedLines = stackPreview.locator('.table__textContent.diff-line-addition');
 	await expect(sourceAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(1);
 	await expect(sourceAddedLines.filter({ hasText: linesToStay[1]! })).toHaveCount(1);
 	await expect(sourceAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(0);

--- a/e2e/playwright/tests/committedHunkLineDrag.spec.ts
+++ b/e2e/playwright/tests/committedHunkLineDrag.spec.ts
@@ -133,10 +133,19 @@ test('should drag only selected lines when dragging committed hunks', async ({
 	await destinationCommitRow.click();
 
 	const destinationAddedLines = stackPreview.locator('.table__textContent.diff-line-addition');
-	await expect(destinationAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(1);
-	await expect(destinationAddedLines.filter({ hasText: linesToMove[1]! })).toHaveCount(1);
-	await expect(destinationAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(0);
-	await expect(destinationAddedLines.filter({ hasText: linesToStay[1]! })).toHaveCount(0);
+	const movedLinesTimeoutMs = 30_000;
+	await expect(destinationAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(1, {
+		timeout: movedLinesTimeoutMs
+	});
+	await expect(destinationAddedLines.filter({ hasText: linesToMove[1]! })).toHaveCount(1, {
+		timeout: movedLinesTimeoutMs
+	});
+	await expect(destinationAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(0, {
+		timeout: movedLinesTimeoutMs
+	});
+	await expect(destinationAddedLines.filter({ hasText: linesToStay[1]! })).toHaveCount(0, {
+		timeout: movedLinesTimeoutMs
+	});
 
 	// Source commit should still add the STAY lines (MOVE_ME becomes context after moving).
 	await sourceCommitRow.click();

--- a/e2e/playwright/tests/committedHunkLineDrag.spec.ts
+++ b/e2e/playwright/tests/committedHunkLineDrag.spec.ts
@@ -1,0 +1,169 @@
+import { unstageAllFiles, verifyCommitPlaceholderPosition } from '../src/commit.ts';
+import { getHunkLineSelector } from '../src/hunk.ts';
+import { getBaseURL, startGitButler, type GitButler } from '../src/setup.ts';
+import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from '../src/util.ts';
+import { expect, test } from '@playwright/test';
+import { readFileSync, writeFileSync } from 'fs';
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL()
+});
+
+test.setTimeout(300_000);
+
+test.afterEach(async () => {
+	await gitbutler?.destroy();
+});
+
+function ensureTrailingNewline(content: string): string {
+	return content.endsWith('\n') ? content : `${content}\n`;
+}
+
+function countLines(content: string): number {
+	return ensureTrailingNewline(content).split('\n').length - 1;
+}
+
+test('should drag only selected lines when dragging committed hunks', async ({
+	page,
+	context
+}, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('apply-upstream-branch.sh', ['branch1', 'local-clone']);
+
+	await page.goto('/');
+	await waitForTestId(page, 'workspace-view');
+
+	const fileName = 'a_file';
+	const filePath = gitbutler.pathInWorkdir(`local-clone/${fileName}`);
+
+	const originalContent = readFileSync(filePath, 'utf-8');
+	const originalLineCount = countLines(originalContent);
+
+	const linesToMove = ['MOVE_ME_1', 'MOVE_ME_2'];
+	const linesToStay = ['STAY_1', 'STAY_2'];
+
+	const updatedContent =
+		ensureTrailingNewline(originalContent) +
+		[...linesToMove, ...linesToStay].map((l) => `${l}\n`).join('');
+	writeFileSync(filePath, updatedContent, 'utf-8');
+
+	// Create a commit with a multi-line hunk we can partially move.
+	await clickByTestId(page, 'start-commit-button');
+
+	const sourceCommitTitle = 'Source: multi-line hunk';
+	await waitForTestId(page, 'new-commit-view');
+	await verifyCommitPlaceholderPosition(page);
+	await unstageAllFiles(page);
+
+	const fileItem = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName });
+	await expect(fileItem).toBeVisible();
+
+	const fileItemCheckbox = fileItem.locator('input[type="checkbox"]');
+	await expect(fileItemCheckbox).toBeVisible();
+	await fileItemCheckbox.click();
+
+	await getByTestId(page, 'commit-drawer-title-input').fill(sourceCommitTitle);
+	await clickByTestId(page, 'commit-drawer-action-button');
+
+	const sourceCommitRow = getByTestId(page, 'commit-row').filter({ hasText: sourceCommitTitle });
+	await expect(sourceCommitRow).toBeVisible();
+
+	// Create a second commit on top so we can move changes "down" the stack without conflicts.
+	const otherFileName = 'other-file.txt';
+	const otherFilePath = gitbutler.pathInWorkdir(`local-clone/${otherFileName}`);
+	writeFileSync(otherFilePath, 'hello\n', 'utf-8');
+
+	await clickByTestId(page, 'start-commit-button');
+	await waitForTestId(page, 'new-commit-view');
+	await verifyCommitPlaceholderPosition(page);
+	await unstageAllFiles(page);
+
+	const otherFileItem = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({ hasText: otherFileName });
+	await expect(otherFileItem).toBeVisible();
+	await otherFileItem.locator('input[type="checkbox"]').click();
+
+	const destinationCommitTitle = 'Destination: receives selection';
+	await getByTestId(page, 'commit-drawer-title-input').fill(destinationCommitTitle);
+	await clickByTestId(page, 'commit-drawer-action-button');
+
+	const destinationCommitRow = getByTestId(page, 'commit-row').filter({
+		hasText: destinationCommitTitle
+	});
+	await expect(destinationCommitRow).toBeVisible();
+
+	await sourceCommitRow.click();
+
+	const stackPreview = getByTestId(page, 'stack-preview');
+	const committedFile = stackPreview.getByTestId('file-list-item').filter({ hasText: fileName });
+	await expect(committedFile).toBeVisible();
+	await committedFile.click();
+
+	const unifiedDiffView = getByTestId(page, 'unified-diff-view');
+	await expect(unifiedDiffView).toBeVisible();
+
+	const move1LineNumber = originalLineCount + 1;
+	const move2LineNumber = originalLineCount + 2;
+
+	// Select only the two MOVE_ME lines within the committed hunk.
+	await unifiedDiffView
+		.locator(getHunkLineSelector(fileName, move1LineNumber, 'right'))
+		.first()
+		.click();
+	await unifiedDiffView
+		.locator(getHunkLineSelector(fileName, move2LineNumber, 'right'))
+		.first()
+		.click();
+
+	const hunkDragHandle = unifiedDiffView
+		.locator('.table__title.draggable .table__title-content')
+		.first();
+	await expect(hunkDragHandle).toBeVisible();
+
+	await dragAndDropByLocator(page, hunkDragHandle, destinationCommitRow);
+
+	// Destination commit should receive only the MOVE_ME lines.
+	await destinationCommitRow.click();
+	const destinationFile = getByTestId(page, 'stack-preview')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName });
+	await expect(destinationFile).toBeVisible();
+	await destinationFile.click();
+
+	const destinationDiffView = getByTestId(page, 'unified-diff-view');
+	await expect(destinationDiffView).toBeVisible();
+
+	const destinationAddedLines = destinationDiffView.locator(
+		'.table__textContent.diff-line-addition'
+	);
+	await expect(destinationAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(1);
+	await expect(destinationAddedLines.filter({ hasText: linesToMove[1]! })).toHaveCount(1);
+	await expect(destinationAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(0);
+	await expect(destinationAddedLines.filter({ hasText: linesToStay[1]! })).toHaveCount(0);
+
+	// Source commit should still add the STAY lines (MOVE_ME becomes context after moving).
+	await sourceCommitRow.click();
+	const sourceFile = getByTestId(page, 'stack-preview')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName });
+	await expect(sourceFile).toBeVisible();
+	await sourceFile.click();
+
+	const sourceDiffView = getByTestId(page, 'unified-diff-view');
+	await expect(sourceDiffView).toBeVisible();
+
+	const sourceAddedLines = sourceDiffView.locator('.table__textContent.diff-line-addition');
+	await expect(sourceAddedLines.filter({ hasText: linesToStay[0]! })).toHaveCount(1);
+	await expect(sourceAddedLines.filter({ hasText: linesToStay[1]! })).toHaveCount(1);
+	await expect(sourceAddedLines.filter({ hasText: linesToMove[0]! })).toHaveCount(0);
+	await expect(sourceAddedLines.filter({ hasText: linesToMove[1]! })).toHaveCount(0);
+});

--- a/scripts/install-minimal-debian-dependencies.sh
+++ b/scripts/install-minimal-debian-dependencies.sh
@@ -4,4 +4,4 @@ set -eu -o pipefail
 
 # Install the dependencies needed to build the but-server and the CLI.
 apt update
-apt install -y libdbus-1-dev libglib2.0-dev pkg-config
+apt install -y libdbus-1-dev libglib2.0-dev libgtk-3-dev pkg-config

--- a/scripts/install-minimal-debian-dependencies.sh
+++ b/scripts/install-minimal-debian-dependencies.sh
@@ -4,4 +4,4 @@ set -eu -o pipefail
 
 # Install the dependencies needed to build the but-server and the CLI.
 apt update
-apt install -y libdbus-1-dev pkg-config
+apt install -y libdbus-1-dev libglib2.0-dev pkg-config


### PR DESCRIPTION
Fixes gitbutlerapp/gitbutler#2513.

- Dragging a hunk now uses the selected line range (when present) instead of always using the full hunk.

Testing:
- Local (Windows):
  - pnpm prettier
  - pnpm lint
  - pnpm check
  - pnpm test
  - cargo fmt --check --all
  - cargo check --workspace --all-targets
  - cargo check --workspace --all-targets --features windows

Before/After:

https://github.com/user-attachments/assets/2533b28a-e401-475b-b3da-22e3bef776fe


https://github.com/user-attachments/assets/089263a7-8d7b-4a86-a8fb-a115097e533f

