### PR TITLE
Remove lastUpdatedAt from BranchDetails and related code

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -16,7 +16,6 @@
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { ReviewBadge, TestId } from '@gitbutler/ui';
-	import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
 	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 	import type { DropzoneHandler } from '$lib/dragging/handler';
 	import type { PushStatus } from '$lib/stacks/stack';
@@ -38,7 +37,6 @@
 		iconName: keyof typeof iconsJson;
 		selected: boolean;
 		trackingBranch?: string;
-		lastUpdatedAt?: number;
 		isTopBranch?: boolean;
 		isNewBranch?: boolean;
 		roundedBottom?: boolean;
@@ -59,7 +57,6 @@
 		allOtherPrNumbersInStack: number[];
 		reviewId?: string;
 		pushStatus: PushStatus;
-		lastUpdatedAt?: number;
 		isConflicted: boolean;
 		applied?: boolean;
 		contextMenu?: typeof BranchHeaderContextMenu;
@@ -80,7 +77,6 @@
 		type: 'pr-branch';
 		selected: boolean;
 		trackingBranch: string;
-		lastUpdatedAt: number;
 	}
 
 	type Props = NormalBranchProps | StackBranchProps | PrBranchProps;
@@ -242,14 +238,6 @@
 				{#snippet content()}
 					<BranchBadge pushStatus={args.pushStatus} unstyled />
 
-					<span class="branch-header__divider">•</span>
-
-					{#if args.lastUpdatedAt}
-						<span class="branch-header__item">
-							{getTimeAgo(new Date(args.lastUpdatedAt))}
-						</span>
-					{/if}
-
 					{#if args.reviewId || args.prNumber}
 						<span class="branch-header__divider">•</span>
 						<div class="branch-header__review-badges">
@@ -304,13 +292,6 @@
 				<span class="branch-header__empty-state-span">There are no commits yet on this branch.</span
 				>
 			{/snippet}
-			{#snippet content()}
-				{#if args.lastUpdatedAt}
-					<span class="branch-header__item">
-						{getTimeAgo(new Date(args.lastUpdatedAt))}
-					</span>
-				{/if}
-			{/snippet}
 		</BranchHeader>
 	{:else if args.type === 'pr-branch'}
 		<BranchHeader
@@ -325,15 +306,7 @@
 			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
 			readonly
 			isPushed
-		>
-			{#snippet content()}
-				{#if args.lastUpdatedAt}
-					<span class="branch-header__item">
-						{getTimeAgo(new Date(args.lastUpdatedAt))}
-					</span>
-				{/if}
-			{/snippet}
-		</BranchHeader>
+		/>
 	{/if}
 
 	{#if args.type === 'stack-branch' && args.hasCodegenRow && args.codegenRow}
@@ -357,11 +330,6 @@
 		position: relative;
 		flex-direction: column;
 		width: 100%;
-	}
-
-	.branch-header__item {
-		color: var(--clr-text-2);
-		white-space: nowrap;
 	}
 
 	.branch-header__divider {

--- a/apps/desktop/src/components/BranchDetails.svelte
+++ b/apps/desktop/src/components/BranchDetails.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import BranchBadge from '$components/BranchBadge.svelte';
-	import { branchLastUpdatedAtDate, type BranchDetails } from '$lib/stacks/stack';
-	import { AvatarGroup, TimeAgo, Button } from '@gitbutler/ui';
+	import { type BranchDetails } from '$lib/stacks/stack';
+	import { AvatarGroup, Button } from '@gitbutler/ui';
 	import type { Snippet } from 'svelte';
 
 	type Props = {
@@ -12,7 +12,6 @@
 	};
 
 	const { branch, children, conflictedCommits, onResolveConflicts }: Props = $props();
-	const lastUpdatedAtDate = $derived(branchLastUpdatedAtDate(branch));
 </script>
 
 <div class="branch-view">
@@ -31,14 +30,7 @@
 					srcUrl: a.gravatarUrl
 				}))}
 			/>
-			<span class="branch-view__details-divider">•</span>
 		</div>
-
-		{#if lastUpdatedAtDate}
-			<div class="factoid-wrap">
-				<TimeAgo date={lastUpdatedAtDate} />
-			</div>
-		{/if}
 	</div>
 
 	{@render children?.()}

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -20,7 +20,7 @@
 	import { editPatch } from '$lib/editMode/editPatchUtils';
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
-	import { branchLastUpdatedAt, type BranchDetails } from '$lib/stacks/stack';
+	import { type BranchDetails } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { combineResults } from '$lib/state/helpers';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -174,7 +174,6 @@
 					!selection?.current.codegen}
 				{@const pushStatus = branchDetails.pushStatus}
 				{@const isConflicted = branchDetails.isConflicted}
-				{@const lastUpdatedAt = branchLastUpdatedAt(branchDetails) ?? undefined}
 				{@const reviewId = branch.reviewId || undefined}
 				{@const prNumber = branch.prNumber || undefined}
 				{@const allOtherPrNumbersInStack = branches
@@ -219,7 +218,6 @@
 						stackId !== undefined &&
 						codegenQuery?.response &&
 						codegenQuery.response.length > 0}
-					{lastUpdatedAt}
 					{reviewId}
 					{prNumber}
 					{allOtherPrNumbersInStack}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -112,7 +112,6 @@
 		branchesSelection.current.stackId === env.stackId &&
 		!branchesSelection.current.commitId}
 	{@const branchFirstCommitType = branch.commits?.at(0)?.state.type}
-
 	<BranchCard
 		type="normal-branch"
 		first={isTopBranch}

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -142,20 +142,6 @@ export function pushStatusToIcon(pushStatus: PushStatus): keyof typeof iconsJson
 }
 
 export type BranchDetails = Workspace.BranchDetails;
-
-/** Safely extract the time of the last update to a given branch */
-export function branchLastUpdatedAt(branch: BranchDetails): number | null {
-	if (branch.lastUpdatedAt === null) return null;
-	return Number(branch.lastUpdatedAt);
-}
-
-/** Safely extract the date of the last update to a given branch */
-export function branchLastUpdatedAtDate(branch: BranchDetails): Date | null {
-	const ts = branchLastUpdatedAt(branch);
-	if (ts === null) return null;
-	return new Date(ts);
-}
-
 export type StackDetails = Workspace.StackDetails;
 
 export function stackRequiresForcePush(stack: StackDetails): boolean {

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -32,7 +32,6 @@ const BRANCH_DETAILS_A: BranchDetails = {
 	name: 'branch-a',
 	reference: 'refs/heads/branch-a',
 	pushStatus: 'nothingToPush',
-	lastUpdatedAt: BigInt(1672531200000), // Example timestamp
 	authors: [MOCK_AUTHOR_A],
 	isConflicted: false,
 	commits: [MOCK_COMMIT_A],
@@ -43,7 +42,8 @@ const BRANCH_DETAILS_A: BranchDetails = {
 	tip: 'tip-commit-a',
 	baseCommit: 'base-commit-a',
 	isRemoteHead: false,
-	linkedWorktreeId: null
+	linkedWorktreeId: null,
+	lastUpdatedAt: BigInt(1672531200000)
 };
 
 export function getStackServiceMock() {

--- a/crates/but-workspace/bindings/workspace/index.ts
+++ b/crates/but-workspace/bindings/workspace/index.ts
@@ -61,11 +61,7 @@ baseCommit: string,
 /**
  * The pushable status for the branch.
  */
-pushStatus: PushStatus, 
-/**
- * Last time, the branch was updated in Epoch milliseconds.
- */
-lastUpdatedAt: bigint | null, 
+pushStatus: PushStatus,
 /**
  * All authors of the commits in the branch.
  */


### PR DESCRIPTION
Eliminates the lastUpdatedAt property from BranchDetails in type definitions, mock data, and all Svelte components. Associated utility functions and UI references to last updated time have been removed to reflect this data model change.