### PR TITLE
Support "branch:filename" format

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1061,6 +1061,7 @@ mod tests {
         CliId::Branch {
             name: "main".to_string(),
             id: "ef".to_string(),
+            stack_id: None,
         }
     }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -192,28 +192,32 @@ impl IdMap {
         let mut branch_auto_id_to_cli_id = HashMap::new();
         let mut workspace_commits = HashMap::new();
         let mut remote_commit_ids = HashMap::new();
-        for segment in stacks.iter().flat_map(|stack| stack.segments.iter()) {
-            if let Some(branch_name) = segment.branch_name() {
-                let cli_id = CliId::Branch {
-                    name: branch_name.to_string(),
-                    id: segment.short_id.clone(),
-                };
-                if segment.is_auto_id {
-                    branch_auto_id_to_cli_id.insert(segment.short_id.clone(), cli_id.clone());
+        for stack in stacks.iter() {
+            for segment in stack.segments.iter() {
+                if let Some(branch_name) = segment.branch_name() {
+                    let cli_id = CliId::Branch {
+                        name: branch_name.to_string(),
+                        id: segment.short_id.clone(),
+                        stack_id: stack.id,
+                    };
+                    if segment.is_auto_id {
+                        branch_auto_id_to_cli_id.insert(segment.short_id.clone(), cli_id.clone());
+                    }
+                    branch_name_to_cli_id.insert(branch_name.to_owned(), cli_id);
                 }
-                branch_name_to_cli_id.insert(branch_name.to_owned(), cli_id);
-            }
-            for workspace_commit in segment.workspace_commits.iter() {
-                workspace_commits.insert(
-                    workspace_commit.short_id.clone(),
-                    WorkspaceCommit {
-                        commit_id: workspace_commit.commit_id(),
-                        first_parent_id: workspace_commit.first_parent_id(),
-                    },
-                );
-            }
-            for remote_commit in segment.remote_commits.iter() {
-                remote_commit_ids.insert(remote_commit.short_id.clone(), remote_commit.commit_id());
+                for workspace_commit in segment.workspace_commits.iter() {
+                    workspace_commits.insert(
+                        workspace_commit.short_id.clone(),
+                        WorkspaceCommit {
+                            commit_id: workspace_commit.commit_id(),
+                            first_parent_id: workspace_commit.first_parent_id(),
+                        },
+                    );
+                }
+                for remote_commit in segment.remote_commits.iter() {
+                    remote_commit_ids
+                        .insert(remote_commit.short_id.clone(), remote_commit.commit_id());
+                }
             }
         }
 
@@ -606,6 +610,8 @@ pub enum CliId {
         name: String,
         /// The short CLI ID for this branch (typically 2 characters)
         id: ShortId,
+        /// The stack ID.
+        stack_id: Option<StackId>,
     },
     /// A commit in the workspace identified by its SHA.
     Commit {

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -108,6 +108,7 @@ fn commit_ids_become_longer_if_ambiguous() -> anyhow::Result<()> {
         Branch {
             name: "not-important",
             id: "no",
+            stack_id: None,
         },
     ]
     "#);
@@ -139,6 +140,7 @@ fn branches_work_with_single_character() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "f".into(),
         id: "g0".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("f")?,
@@ -172,10 +174,12 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
         CliId::Branch {
             name: "foo".into(),
             id: "i0".into(),
+            stack_id: None,
         },
         CliId::Branch {
             name: "foo-bar".into(),
             id: "g0".into(),
+            stack_id: None,
         },
     ];
     assert_eq!(
@@ -187,6 +191,7 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "baz".into(),
         id: "az".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("az")?,
@@ -208,6 +213,7 @@ fn branches_avoid_unassigned_area_id() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "zza".into(),
         id: "za".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("za")?,
@@ -232,6 +238,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "x-yz_/hi".into(),
         id: "yz".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("x-yz")?,
@@ -241,6 +248,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "0ax".into(),
         id: "ax".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("0ax")?,
@@ -265,6 +273,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "ghij".into(),
         id: "ij".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("ghij")?,
@@ -289,6 +298,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "substring".into(),
         id: "g0".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("substring")?,
@@ -298,6 +308,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
     let expected = [CliId::Branch {
         name: "supersubstring".into(),
         id: "up".into(),
+        stack_id: None,
     }];
     assert_eq!(
         id_map.resolve_entity_to_ids("supersubstring")?,
@@ -391,6 +402,9 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         Branch {
             name: "h0",
             id: "h0",
+            stack_id: Some(
+                00000000-0000-0000-0000-000000000001,
+            ),
         },
         Uncommitted(
             UncommittedCliId {
@@ -538,6 +552,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         Branch {
             name: "h0",
             id: "h0",
+            stack_id: None,
         },
     ]
     "#);
@@ -619,6 +634,7 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
         Branch {
             name: "foo",
             id: "fo",
+            stack_id: None,
         },
         Uncommitted(
             UncommittedCliId {


### PR DESCRIPTION
I decided to go with `branch@{stack}`.

Previous description:

Why I'm not automerging: this PR is as I envisioned it before starting, but when I was writing this, I noticed that specifying a branch name when you actually mean its stack is not done throughout `but` - it is done as the target of `rub`, but elsewhere (e.g. `diff`, where I noticed it), it is treated not as a stack but as itself (to specify the stack, you have to look at the `status` output and then get the stack CLI ID from there). I finished writing it anyway and have sent it so that you can see that having these IDs improves scripting for end users, and end users here includes us (writing the tests). But we probably can't have branch mean stack - any ideas? I was thinking of something like in Git, `branch@{stack}` or `branch^{stack}`, or maybe we should think about what's suitable for a durable stack identifier.

