### PR TITLE
style/folded-lane-shadow-doubleclick-unfold

### DIFF
--- a/apps/desktop/src/components/CollapseStackButton.svelte
+++ b/apps/desktop/src/components/CollapseStackButton.svelte
@@ -7,9 +7,10 @@
 		projectId: string;
 		disabled?: boolean;
 		isFolded?: boolean;
+		onToggle?: (toggleFn: () => void) => void;
 	}
 
-	const { stackId, projectId, disabled, isFolded }: Props = $props();
+	const { stackId, projectId, disabled, isFolded, onToggle }: Props = $props();
 
 	// Persisted folded stacks state per project (without expiration)
 	const foldedStacks = persisted<string[]>([], `folded-stacks-${projectId}`);
@@ -28,6 +29,13 @@
 			}
 		}
 	}
+
+	// Call onToggle callback with toggleFold function if provided
+	$effect(() => {
+		if (onToggle) {
+			onToggle(toggleFold);
+		}
+	});
 </script>
 
 <Tooltip text={isFolded ? 'Expand stack' : 'Collapse stack'}>

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import CollapseStackButton from '$components/CollapseStackButton.svelte';
-	import { persisted } from '@gitbutler/shared/persisted';
 	import { Icon } from '@gitbutler/ui';
 
 	type Props = {
@@ -11,15 +10,12 @@
 
 	const { stackId, branchNames, projectId }: Props = $props();
 
-	// Persisted folded stacks state per project
-	const foldedStacks = persisted<string[]>([], `folded-stacks-${projectId}`);
+	let toggleFold: (() => void) | undefined = $state();
 
 	function handleDoubleClick() {
-		if (!stackId) return;
-
-		// Unfold: remove from folded list
-		const currentFolded = $foldedStacks;
-		foldedStacks.set(currentFolded.filter((id) => id !== stackId));
+		if (toggleFold) {
+			toggleFold();
+		}
 	}
 </script>
 
@@ -31,7 +27,7 @@
 	draggable="true"
 	ondblclick={handleDoubleClick}
 >
-	<CollapseStackButton {stackId} {projectId} isFolded />
+	<CollapseStackButton {stackId} {projectId} isFolded onToggle={(fn) => (toggleFold = fn)} />
 
 	<div class="drag-handle-icon">
 		<Icon name="draggable-wide" />

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CollapseStackButton from '$components/CollapseStackButton.svelte';
+	import { persisted } from '@gitbutler/shared/persisted';
 	import { Icon } from '@gitbutler/ui';
 
 	type Props = {
@@ -9,6 +10,17 @@
 	};
 
 	const { stackId, branchNames, projectId }: Props = $props();
+
+	// Persisted folded stacks state per project
+	const foldedStacks = persisted<string[]>([], `folded-stacks-${projectId}`);
+
+	function handleDoubleClick() {
+		if (!stackId) return;
+
+		// Unfold: remove from folded list
+		const currentFolded = $foldedStacks;
+		foldedStacks.set(currentFolded.filter((id) => id !== stackId));
+	}
 </script>
 
 <div
@@ -17,6 +29,7 @@
 	data-remove-from-panning
 	data-drag-handle
 	draggable="true"
+	ondblclick={handleDoubleClick}
 >
 	<CollapseStackButton {stackId} {projectId} isFolded />
 

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -67,11 +67,6 @@
 		cursor: grab;
 	}
 
-	/* dark mode */
-	:global(.dark) .folded-lane {
-		box-shadow: inset -5px 0 10px var(--lighter-bg-drop-shadow);
-	}
-
 	.drag-handle-icon {
 		display: flex;
 		margin-top: 4px;

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -47,14 +47,16 @@
 		height: 100%;
 		padding: 2px 9px 18px;
 		border-right: 1px solid var(--clr-border-2);
-		background: linear-gradient(
-			90deg,
-			var(--clr-bg-2) 0%,
-			var(--clr-bg-2) 70%,
-			var(--clr-bg-3) 100%
-		);
+		background: var(--clr-bg-2);
+		--lighter-bg-drop-shadow: color-mix(in srgb, var(--clr-drop-shadow) 50%, var(--clr-bg-2));
+		box-shadow: inset -5px 0 10px var(--lighter-bg-drop-shadow);
 		color: var(--clr-text-3);
 		cursor: grab;
+	}
+
+	/* dark mode */
+	:global(.dark) .folded-lane {
+		box-shadow: inset -5px 0 10px var(--lighter-bg-drop-shadow);
 	}
 
 	.drag-handle-icon {


### PR DESCRIPTION
Changes:
- Softer shadows of the folded lanes (addresses this [issue](https://github.com/gitbutlerapp/gitbutler/issues/11919#issuecomment-3774281685)).
- Enabled double-clicking to unfold the folded lane.

<img width="699" height="789" alt="Screenshot 2026-01-21 at 00 28 15" src="https://github.com/user-attachments/assets/77420b6c-9193-4d8a-99fd-b682d6d24719" />
<img width="687" height="791" alt="Screenshot 2026-01-21 at 00 28 28" src="https://github.com/user-attachments/assets/5ea7e423-c6d2-4211-a408-cd67efb37b9c" />
