### PR TITLE
fix(ui): adjust badge padding and remove default info icon

### DIFF
--- a/apps/desktop/src/components/ChecksPolling.svelte
+++ b/apps/desktop/src/components/ChecksPolling.svelte
@@ -58,7 +58,7 @@
 		if (!checksService && isFork) {
 			return {
 				style: 'gray',
-				icon: 'info',
+				icon: undefined,
 				text: 'No PR checks',
 				reducedText: 'No checks',
 				tooltip: 'Checks for forked repos only available on the web.'

--- a/packages/ui/src/lib/components/Badge.svelte
+++ b/packages/ui/src/lib/components/Badge.svelte
@@ -182,6 +182,11 @@
 					padding-right: 0;
 					padding-left: 2px;
 				}
+
+				/* When no icon, use equal padding */
+				&:not(:has(.badge__icon)) .badge__label {
+					padding: 0 5px;
+				}
 			}
 
 			&.tag-size {
@@ -192,6 +197,11 @@
 				& .badge__icon {
 					padding-right: 0;
 					padding-left: 4px;
+				}
+
+				/* When no icon, use equal padding */
+				&:not(:has(.badge__icon)) .badge__label {
+					padding: 0 8px;
 				}
 			}
 		}

--- a/packages/ui/src/lib/components/Badge.svelte
+++ b/packages/ui/src/lib/components/Badge.svelte
@@ -15,6 +15,7 @@
 		icon?: keyof typeof iconsJson | undefined;
 		tooltip?: string;
 		skeleton?: boolean;
+		skeletonWidth?: string;
 		children?: Snippet;
 		onclick?: (e: MouseEvent) => void;
 		reversedDirection?: boolean;
@@ -29,6 +30,7 @@
 		icon,
 		tooltip,
 		skeleton,
+		skeletonWidth,
 		children,
 		onclick,
 		reversedDirection
@@ -38,7 +40,7 @@
 {#if skeleton}
 	<SkeletonBone
 		radius="3rem"
-		width={size === 'icon' ? 'var(--size-icon)' : 'var(--size-tag)'}
+		width={skeletonWidth ?? (size === 'icon' ? 'var(--size-icon)' : 'var(--size-tag)')}
 		height={size === 'icon' ? 'var(--size-icon)' : 'var(--size-tag)'}
 	/>
 {:else}

--- a/packages/ui/src/stories/components/Badge.stories.svelte
+++ b/packages/ui/src/stories/components/Badge.stories.svelte
@@ -32,6 +32,12 @@
 			icon: {
 				options: Object.keys(iconsJson),
 				control: { type: 'select' }
+			},
+			reversedDirection: {
+				control: { type: 'boolean' }
+			},
+			skeleton: {
+				control: { type: 'boolean' }
 			}
 		}
 	});
@@ -39,7 +45,14 @@
 
 <Story name="default">
 	{#snippet template(args)}
-		<Badge style={args.style} kind={args.kind} icon={args.icon} size={args.size}>
+		<Badge
+			style={args.style}
+			kind={args.kind}
+			icon={args.icon}
+			size={args.size}
+			reversedDirection={args.reversedDirection}
+			skeleton={args.skeleton}
+		>
 			{args.text}
 		</Badge>
 	{/snippet}


### PR DESCRIPTION
This pull request improves the visual consistency of badges and updates the checks status icon for forked repositories. The most important changes are grouped below:

Badge styling improvements:

* Updated the `Badge.svelte` component to ensure equal horizontal padding for badge labels when no icon is present, improving alignment and appearance. [[1]](diffhunk://#diff-ac04917671203e45f25d09f2c6187c494847f3054de015b9fda932a546e7c64fR185-R189) [[2]](diffhunk://#diff-ac04917671203e45f25d09f2c6187c494847f3054de015b9fda932a546e7c64fR201-R205)

Checks status icon update:

* Changed the checks status icon for forked repositories in `ChecksPolling.svelte` to display no icon instead of the info icon, clarifying the UI for users.

Before:
<img width="365" height="133" alt="image" src="https://github.com/user-attachments/assets/c95f3a9c-f6f9-4ca4-a8c3-9058a8968969" />

After:
<img width="365" height="133" alt="Screenshot 2026-01-21 at 01 32 37" src="https://github.com/user-attachments/assets/ac9ebf9f-cc5a-4aed-9ded-2d5ae098a05c" />
