### PR TITLE
Don't perform auto-fixes if we are in an ad-hoc workspace!

### DIFF
--- a/crates/but-meta/src/legacy.rs
+++ b/crates/but-meta/src/legacy.rs
@@ -254,6 +254,10 @@ impl Snapshot {
         )?;
 
         let ws = graph.into_workspace()?;
+        if !ws.kind.has_managed_commit() {
+            tracing::debug!("Avoiding workspace->vb-toml reconciliation in unmanaged workspace");
+            return Ok(());
+        }
         let mut seen = BTreeSet::new();
 
         if let Some((computed_lower_bound, target)) =


### PR DESCRIPTION
This is dangerous, and could cause all kinds of bugs.

Related to #11921.
