### PR TITLE
but absorb: dry run

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -452,7 +452,6 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     Undo,
-
     /// Amends changes into the appropriate commits where they belong.
     ///
     /// The semantic for finding "the appropriate commit" is as follows:
@@ -468,12 +467,18 @@ pub enum Subcommands {
     /// - If a Branch (stack) id is provided, absorb will be performed for all changes staged to that stack
     /// - If no source is provided, absorb is performed for all uncommitted changes
     ///
+    /// If `--dry-run` is specified, no changes will be made; instead, the absorption plan
+    /// (what changes would be absorbed by which commits) will be shown.
+    ///
     #[cfg(feature = "legacy")]
     Absorb {
         /// If the Source is an uncommitted change - the change will be absorbed.
         /// If the Source is a stack - anything staged to the stack will be absorbed accordingly.
         /// If not provided, everything that is uncommitted will be absorbed.
         source: Option<String>,
+        /// Show the absorption plan without making any changes.
+        #[clap(long = "dry-run")]
+        dry_run: bool,
     },
 
     /// Discard uncommitted changes from the worktree.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -536,9 +536,9 @@ async fn match_subcommand(
             command::legacy::oplog::undo_last_operation(&mut ctx, out).emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Absorb { source } => {
+        Subcommands::Absorb { source, dry_run } => {
             let mut ctx = init::init_ctx(&args, BackgroundSync::Enabled, out)?;
-            command::legacy::absorb::handle(&mut ctx, out, source.as_deref())
+            command::legacy::absorb::handle(&mut ctx, out, source.as_deref(), dry_run)
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -384,3 +384,74 @@ Hint: run `but help` for all commands
 
     Ok(())
 }
+
+#[test]
+fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    // Get initial status
+    let initial_status = env.but("--json status -f").allow_json().output()?.stdout;
+
+    // Run absorb with dry-run flag
+    env.but("absorb i0 --dry-run")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Found 2 changed files to absorb:
+
+Absorbed to commit: f4ea7f8 a.txt
+  (files locked to commit due to hunk range overlap)
+    a.txt @1,4 +1,4
+    a.txt @6,4 +6,4
+
+Dry run complete. No changes were made.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Verify that no changes were actually made - status should be unchanged
+    let post_dry_run_status = env.but("--json status -f").allow_json().output()?.stdout;
+    assert_eq!(
+        initial_status, post_dry_run_status,
+        "Status should be unchanged after dry-run"
+    );
+
+    // Verify the file content wasn't actually changed
+    let repo = env.open_repo()?;
+    let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
+    insta::assert_snapshot!(blob.data.as_bstr(), @r"
+    first
+    line
+    line
+    line
+    line
+    line
+    line
+    line
+    last
+    ");
+
+    // Verify there are still uncommitted changes
+    env.but("--json status -f")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+{
+  "unassignedChanges": [
+    {
+      "cliId": "i0",
+      "filePath": "a.txt",
+      "changeType": "modified"
+    }
+  ],
+...
+
+"#]]);
+
+    Ok(())
+}


### PR DESCRIPTION
Add the ability to dry run the absorb, to see the plan before executing it.

### Things that would be nicer
It would be nicer if we could actually see if there would be any conflicts if we were to absorb