### PR TITLE
Remove "Open...Folder" menu items from release build, but decide to use `opener::reveal()` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,6 +3865,7 @@ dependencies = [
  "gix",
  "log",
  "open",
+ "opener",
  "parking_lot",
  "serde",
  "serde_json",
@@ -6871,6 +6872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7441,6 +7451,19 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "opener"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9024962ab91e00c89d2a14352a8d0fc1a64346bf96f1839b45c09149564e47"
+dependencies = [
+ "bstr",
+ "normpath",
+ "url",
+ "windows-sys 0.60.2",
+ "zbus 5.12.0",
 ]
 
 [[package]]

--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -69,10 +69,14 @@ pub fn identifier() -> &'static str {
     })
 }
 
+/// A way to learn about the currently configured compile-time app-channel.
 #[derive(Debug)]
 pub enum AppChannel {
+    /// This is a nightly build.
     Nightly,
+    /// This is a release build.
     Release,
+    /// The fallback if nothing is specified: developer mode.
     Dev,
 }
 

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -70,6 +70,9 @@ tracing-appender = "0.2.4"
 tracing-subscriber.workspace = true
 tracing-forest.workspace = true
 open.workspace = true
+## This is only used on macOS when it's the stable build to open `com.gitbutler.app` folders.
+## Ideally, we could only use the dependency then.
+opener = { version = "0.8.3", features = ["reveal"] }
 url = "2.5.4"
 but-path.workspace = true
 uuid.workspace = true

--- a/crates/gitbutler-tauri/src/debug.rs
+++ b/crates/gitbutler-tauri/src/debug.rs
@@ -53,6 +53,10 @@ fn open_existing(dir: &std::path::Path) -> Result<(), Error> {
 
     let is_macos_stable_build =
         cfg!(target_os = "macos") && matches!(AppChannel::new(), AppChannel::Release);
+    // On macOS stable builds, it would try to open `com.gitbutler.app` and treat it as application,
+    // which would fail. Instead, we reveal, which selects the directory in the finder and users
+    // can right-click it to see the package contents. Better than nothing.
+    // Maybe we can rename the application ID at some point.
     if is_macos_stable_build {
         opener::reveal(dir).map_err(anyhow::Error::from)
     } else {

--- a/crates/gitbutler-tauri/src/debug.rs
+++ b/crates/gitbutler-tauri/src/debug.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context as _, anyhow};
 use but_api::json::Error;
+use but_path::AppChannel;
 use tauri::{AppHandle, Manager, Runtime};
 use tracing::instrument;
 
@@ -49,6 +50,14 @@ fn open_existing(dir: &std::path::Path) -> Result<(), Error> {
         )
         .into());
     }
-    Ok(open::that(dir)
-        .with_context(|| format!("Failed to open directory at '{}'", dir.display()))?)
+
+    let is_macos_stable_build =
+        cfg!(target_os = "macos") && matches!(AppChannel::new(), AppChannel::Release);
+    if is_macos_stable_build {
+        opener::reveal(dir).map_err(anyhow::Error::from)
+    } else {
+        open::that(dir).map_err(anyhow::Error::from)
+    }
+    .with_context(|| format!("Failed to open directory at '{}'", dir.display()))
+    .map_err(Into::into)
 }

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use but_api::json::Error;
 use but_error::Code;
-use but_path::AppChannel;
 use but_settings::AppSettingsWithDiskSync;
 #[cfg(target_os = "macos")]
 use tauri::menu::AboutMetadata;
@@ -208,7 +207,6 @@ pub fn build<R: Runtime>(
         ])
         .build()?;
 
-    let channel = AppChannel::new();
     let help_menu = SubmenuBuilder::new(handle, "Help")
         .text("help/documentation", "Documentation")
         .text("help/debugging-guide", "Debugging Guide")
@@ -217,32 +215,25 @@ pub fn build<R: Runtime>(
         .separator()
         .text("help/share-debug-info", "Share Debug Info…")
         .text("help/report-issue", "Create an Issue")
-        .separator();
-    let is_macos_stable_build = cfg!(target_os = "macos") && matches!(channel, AppChannel::Release);
-    let help_menu = if !is_macos_stable_build {
-        // On macOS, the directories are called `com.gitbutler.app`, which doesn't work with `open`.
-        help_menu
-            .text("help/open-logs-folder", "Open Logs Folder")
-            .text("help/open-config-folder", "Open Config Folder")
-            .text("help/open-cache-folder", "Open Cache Folder")
-            .separator()
-    } else {
-        help_menu
-    }
-    .text("help/discord", "Discord")
-    .text("help/youtube", "YouTube")
-    .text("help/bluesky", "Bluesky")
-    .text("help/x", "X")
-    .separator()
-    .item(
-        &MenuItemBuilder::with_id(
-            "help/version",
-            format!("Version {}", handle.package_info().version),
+        .separator()
+        .text("help/open-logs-folder", "Open Logs Folder")
+        .text("help/open-config-folder", "Open Config Folder")
+        .text("help/open-cache-folder", "Open Cache Folder")
+        .separator()
+        .text("help/discord", "Discord")
+        .text("help/youtube", "YouTube")
+        .text("help/bluesky", "Bluesky")
+        .text("help/x", "X")
+        .separator()
+        .item(
+            &MenuItemBuilder::with_id(
+                "help/version",
+                format!("Version {}", handle.package_info().version),
+            )
+            .enabled(false)
+            .build(handle)?,
         )
-        .enabled(false)
-        .build(handle)?,
-    )
-    .build()?;
+        .build()?;
 
     Menu::with_items(
         handle,

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 use but_api::json::Error;
 use but_error::Code;
+use but_path::AppChannel;
 use but_settings::AppSettingsWithDiskSync;
 #[cfg(target_os = "macos")]
 use tauri::menu::AboutMetadata;
@@ -207,6 +208,7 @@ pub fn build<R: Runtime>(
         ])
         .build()?;
 
+    let channel = AppChannel::new();
     let help_menu = SubmenuBuilder::new(handle, "Help")
         .text("help/documentation", "Documentation")
         .text("help/debugging-guide", "Debugging Guide")
@@ -215,25 +217,32 @@ pub fn build<R: Runtime>(
         .separator()
         .text("help/share-debug-info", "Share Debug Info…")
         .text("help/report-issue", "Create an Issue")
-        .separator()
-        .text("help/open-logs-folder", "Open Logs Folder")
-        .text("help/open-config-folder", "Open Config Folder")
-        .text("help/open-cache-folder", "Open Cache Folder")
-        .separator()
-        .text("help/discord", "Discord")
-        .text("help/youtube", "YouTube")
-        .text("help/bluesky", "Bluesky")
-        .text("help/x", "X")
-        .separator()
-        .item(
-            &MenuItemBuilder::with_id(
-                "help/version",
-                format!("Version {}", handle.package_info().version),
-            )
-            .enabled(false)
-            .build(handle)?,
+        .separator();
+    let is_macos_stable_build = cfg!(target_os = "macos") && matches!(channel, AppChannel::Release);
+    let help_menu = if !is_macos_stable_build {
+        // On macOS, the directories are called `com.gitbutler.app`, which doesn't work with `open`.
+        help_menu
+            .text("help/open-logs-folder", "Open Logs Folder")
+            .text("help/open-config-folder", "Open Config Folder")
+            .text("help/open-cache-folder", "Open Cache Folder")
+            .separator()
+    } else {
+        help_menu
+    }
+    .text("help/discord", "Discord")
+    .text("help/youtube", "YouTube")
+    .text("help/bluesky", "Bluesky")
+    .text("help/x", "X")
+    .separator()
+    .item(
+        &MenuItemBuilder::with_id(
+            "help/version",
+            format!("Version {}", handle.package_info().version),
         )
-        .build()?;
+        .enabled(false)
+        .build(handle)?,
+    )
+    .build()?;
 
     Menu::with_items(
         handle,


### PR DESCRIPTION
The problem is that `open` (CLI) is used by the `open` crate that we use to open a folder, and folders with `.app` suffix are considered applications that should open as applications.

That doesn't work for our folders though.

### Tasks

* [x] Remove menu items in release mode
* [x] Try `opener` crate for this purpose specifically - reveal is good, better to have it than not to have it.

Can be tested with `CHANNEL=release LOG_LEVEL=debug pnpm tauri dev --no-watch`.