### PR TITLE
but llm: Use the AI provider from the git config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "but-secret",
  "but-tools",
  "futures",
+ "git2",
  "ollama-rs",
  "reqwest 0.12.28",
  "schemars 1.2.0",

--- a/crates/but-llm/Cargo.toml
+++ b/crates/but-llm/Cargo.toml
@@ -25,3 +25,4 @@ anyhow.workspace = true
 strum = { version = "0.27", features = ["derive"] }
 reqwest.workspace = true
 uuid.workspace = true
+git2.workspace = true

--- a/crates/but-llm/src/client.rs
+++ b/crates/but-llm/src/client.rs
@@ -2,12 +2,19 @@ use std::fmt::Debug;
 
 use anyhow::Result;
 use but_tools::tool::Toolset;
+use git2::Config;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::ChatMessage;
 
 pub trait LLMClient: Debug + Clone {
+    fn from_git_config(config: &Config) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn model(&self) -> Option<String>;
+
     fn tool_calling_loop_stream(
         &self,
         system_message: &str,

--- a/crates/but-llm/src/key.rs
+++ b/crates/but-llm/src/key.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CredentialsKeyOption {
+    BringYourOwn,
+    #[serde(rename = "butlerAPI")]
+    ButlerApi,
+}
+
+impl CredentialsKeyOption {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "bringYourOwn" => Some(CredentialsKeyOption::BringYourOwn),
+            "butlerAPI" => Some(CredentialsKeyOption::ButlerApi),
+            _ => None,
+        }
+    }
+}

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -63,7 +63,8 @@ pub fn auto_commit(
     let changes: Vec<but_core::TreeChange> =
         changes.into_iter().map(|change| change.into()).collect();
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let llm = LLMProvider::default_openai();
+    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let llm = LLMProvider::from_git_config(&git_config);
 
     let emitter = std::sync::Arc::new(move |name: &str, payload: serde_json::Value| {
         app_handle.emit(name, payload).unwrap_or_else(|e| {
@@ -92,7 +93,8 @@ pub fn auto_branch_changes(
     let changes: Vec<but_core::TreeChange> =
         changes.into_iter().map(|change| change.into()).collect();
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let llm = LLMProvider::default_openai();
+    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let llm = LLMProvider::from_git_config(&git_config);
 
     let emitter = std::sync::Arc::new(move |name: &str, payload: serde_json::Value| {
         app_handle.emit(name, payload).unwrap_or_else(|e| {
@@ -127,7 +129,8 @@ pub fn freestyle(
         });
     });
 
-    let llm = LLMProvider::default_openai();
+    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let llm = LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_action::freestyle(
             project_id,

--- a/crates/gitbutler-tauri/src/bot.rs
+++ b/crates/gitbutler-tauri/src/bot.rs
@@ -21,7 +21,8 @@ pub fn bot(
         });
     });
 
-    let llm = but_llm::LLMProvider::default_openai();
+    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let llm = but_llm::LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_bot::bot(project_id, message_id, emitter, ctx, &llm, chat_messages)
             .map_err(|e| Error::from(anyhow::anyhow!(e))),
@@ -50,7 +51,8 @@ pub async fn forge_branch_chat(
         });
     });
 
-    let llm = but_llm::LLMProvider::default_openai();
+    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let llm = but_llm::LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_bot::forge_branch_chat(
             project_id,


### PR DESCRIPTION
Read the global git config and use the LLM provider specified in there.

This allows the user to use the same configuration of LLM provider in the frontend and the backend