### PR TITLE
Unify paths in the backend via `but-path`, avoiding `AppHandle::path()`

### DIFF
--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -32,7 +32,7 @@ pub fn app_log_dir() -> anyhow::Result<PathBuf> {
 
 /// The directory to store application-wide settings in, **shared for all channels**.
 ///
-/// > ⚠️Keep in sync with `tauri::AppHandle::path().app_log_dir().`
+/// > ⚠️Keep in sync with `tauri::AppHandle::path().app_config_dir().`
 pub fn app_config_dir() -> anyhow::Result<PathBuf> {
     if let Ok(test_dir) = std::env::var("E2E_TEST_APP_DATA_DIR") {
         return Ok(PathBuf::from(test_dir).join("gitbutler"));

--- a/crates/gitbutler-tauri/src/debug.rs
+++ b/crates/gitbutler-tauri/src/debug.rs
@@ -1,41 +1,33 @@
 use anyhow::{Context as _, anyhow};
 use but_api::json::Error;
 use but_path::AppChannel;
-use tauri::{AppHandle, Manager, Runtime};
+use std::path::Path;
 use tracing::instrument;
 
 /// Opens the logs folder in the system file manager
-#[instrument(skip(handle), err(Debug))]
-pub fn open_logs_folder<R: Runtime>(handle: &AppHandle<R>) -> Result<(), Error> {
-    let dir = handle
-        .path()
-        .app_log_dir()
-        .context("Failed to get app log directory")?;
-    open_existing(&dir)
+#[instrument(err(Debug))]
+pub fn open_logs_folder() -> Result<(), Error> {
+    open_existing(but_path::app_log_dir()?)
 }
 
 /// Opens the config/settings folder in the system file manager
-#[instrument(skip(handle), err(Debug))]
-pub fn open_config_folder<R: Runtime>(handle: &AppHandle<R>) -> Result<(), Error> {
-    let dir = handle
-        .path()
-        .app_config_dir()
-        .context("Failed to get app config directory")?;
-    open_existing(&dir)
+#[instrument(err(Debug))]
+pub fn open_config_folder() -> Result<(), Error> {
+    open_existing(but_path::app_config_dir()?)
 }
 
 /// Opens the cache folder in the system file manager
 #[instrument(err(Debug))]
 pub fn open_cache_folder() -> Result<(), Error> {
-    let dir = but_path::app_cache_dir()?;
-    open_existing(&dir)
+    open_existing(but_path::app_cache_dir()?)
 }
 
 /// Open `dir` but refuse to do so if that would definitely fail as it's not a directory,
 /// or it doesn't exist.
 ///
 /// We can assume the directories exist.
-fn open_existing(dir: &std::path::Path) -> Result<(), Error> {
+fn open_existing(dir: impl AsRef<Path>) -> Result<(), Error> {
+    let dir = dir.as_ref();
     if !dir.exists() {
         return Err(anyhow!(
             "Cannot attempt to open non-existing directory: '{}'",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -87,8 +87,8 @@ fn main() -> anyhow::Result<()> {
         but_path::app_log_dir()?,
     );
     std::fs::create_dir_all(&app_data_dir).context("failed to create app data dir")?;
-    std::fs::create_dir_all(&app_cache_dir).context("failed to create cache dir")?;
-    std::fs::create_dir_all(&app_log_dir).context("failed to create cache dir")?;
+    std::fs::create_dir_all(&app_cache_dir).context("failed to create app cache dir")?;
+    std::fs::create_dir_all(&app_log_dir).context("failed to create app log dir")?;
 
     let app_settings_for_menu = app_settings.clone();
     runtime.block_on(async {

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -252,7 +252,6 @@ pub fn build<R: Runtime>(
     )
 }
 
-/// `handle` is needed to access the undo queue, and buttons for that are only available when the `undo` feature is enabled.
 pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
     if event.id() == "edit/undo" {
         eprintln!("use app undo queue to undo.");

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -253,7 +253,7 @@ pub fn build<R: Runtime>(
 }
 
 /// `handle` is needed to access the undo queue, and buttons for that are only available when the `undo` feature is enabled.
-pub fn handle_event<R: Runtime>(handle: &AppHandle<R>, webview: &WebviewWindow, event: &MenuEvent) {
+pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
     if event.id() == "edit/undo" {
         eprintln!("use app undo queue to undo.");
         return;
@@ -360,14 +360,14 @@ pub fn handle_event<R: Runtime>(handle: &AppHandle<R>, webview: &WebviewWindow, 
     }
 
     if event.id() == "help/open-logs-folder" {
-        if let Err(err) = crate::debug::open_logs_folder(handle) {
+        if let Err(err) = crate::debug::open_logs_folder() {
             tracing::error!(error = ?err, "failed to open logs folder");
         }
         return;
     }
 
     if event.id() == "help/open-config-folder" {
-        if let Err(err) = crate::debug::open_config_folder(handle) {
+        if let Err(err) = crate::debug::open_config_folder() {
             tracing::error!(error = ?err, "failed to open config folder");
         }
         return;


### PR DESCRIPTION
The respective tauri functions are aligned with `but-path`, but that's not a given over time, particularly because `but-path` doesn't document such dependency.

Instead, let's opt for using `but-path` everywhere, while noting that the `app_cache_dir` should be remain aligned with `tauri` for convenience.

### Tasks

* [x] unify paths
* [x] check and double-check everything, also in UI
