### PR TITLE
secrets: fail silently if the error is not found while deleting it

### DIFF
--- a/crates/but-secret/src/secret.rs
+++ b/crates/but-secret/src/secret.rs
@@ -71,7 +71,17 @@ fn annotate_linux_keychain(err: anyhow::Error) -> anyhow::Error {
 
 /// Delete the secret at `handle` permanently from `namespace`.
 pub fn delete(handle: &str, namespace: Namespace) -> Result<()> {
-    Ok(entry_for(handle, namespace)?.delete_credential()?)
+    match entry_for(handle, namespace)
+        .map_err(annotate_linux_keychain)?
+        .delete_credential()
+    {
+        Ok(_) => Ok(()),
+        Err(keyring::Error::NoEntry) => {
+            // Fail silently if it doesn't exist.
+            Ok(())
+        }
+        Err(err) => Err(annotate_linux_keychain(err.into())),
+    }
 }
 
 /// Use this `identifier` as 'namespace' for identifying secrets.


### PR DESCRIPTION
If a secret is not found while deleting it, fail silently.