### PR TITLE
logout updates the settings correctly

### DIFF
--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -74,7 +74,7 @@ export class PostHogWrapper {
 			email,
 			name
 		});
-		this.settingsService.updateTelemetryDistinctId(distinctId);
+		await this.settingsService.updateTelemetryDistinctId(distinctId);
 	}
 
 	setAnonymousPostHogUser() {


### PR DESCRIPTION
- Treat null as deletion when merging JSON objects: source null values remove the corresponding key from the target instead of being ignored.
- Update merge logic to recurse for non-null values and continue to avoid merging arrays.
- Add tests: new test it_unsets_values_into_null and updated existing test to reflect deletion behavior.
- Ensure logging out deletes user data (removes user id from storage).

### What changed
- merge_non_null_json_value now:
  - removes target keys when source value is null
  - performs recursive merging for non-null object values
  - still does not merge arrays
- Tests updated/added to assert null unsets target fields.
- Logout flow now deletes stored user id (telemetry cleanup).

### Risk and migration
- Behavior change: null in incoming JSON now deletes keys in target; callers relying on previous "ignore null" behavior must be aware.