### PR TITLE
Refactor legacy settings migration to get a better understanding

### DIFF
--- a/crates/but-settings/src/legacy_settings.rs
+++ b/crates/but-settings/src/legacy_settings.rs
@@ -304,11 +304,13 @@ mod parse_legacy_settings_to_overrides {
 mod read_legacy_overrides {
     use crate::legacy_settings::read_legacy_overrides;
     use serde_json::json;
+    use tempfile::TempDir;
 
     #[test]
     fn read_from_nonexistent_path() -> anyhow::Result<()> {
-        let path = std::path::Path::new("/nonexistent/path/settings.json");
-        let result = read_legacy_overrides(path);
+        let temp_dir = TempDir::new()?;
+        let path = temp_dir.path().join("nonexistent-settings.json");
+        let result = read_legacy_overrides(&path);
         assert!(result.is_none());
         Ok(())
     }

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -37,6 +37,9 @@ impl AppSettings {
 
         // Migrate legacy settings from Tauri store (only if not already migrated)
         if let Some(legacy_overrides) = maybe_migrate_legacy_settings(config_path, &settings) {
+            // Note that by now, it has written back the `customizations` as freshly read from `config_path`,
+            // back to `config_path`, after merging them with the legacy settings.
+            // We now repeat this merging step with the in-memory settings to bring it up-to date.
             merge_non_null_json_value(legacy_overrides, &mut settings);
         }
 

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -37,9 +37,9 @@ impl AppSettings {
 
         // Migrate legacy settings from Tauri store (only if not already migrated)
         if let Some(legacy_overrides) = maybe_migrate_legacy_settings(config_path, &settings) {
-            // Note that by now, it has written back the `customizations` as freshly read from `config_path`,
-            // back to `config_path`, after merging them with the legacy settings.
-            // We now repeat this merging step with the in-memory settings to bring it up-to date.
+            // At this point, `maybe_migrate_legacy_settings` has attempted to write the `customizations`
+            // as freshly read from `config_path` back to `config_path`, after merging them with the legacy settings.
+            // We now repeat this merging step with the in-memory settings to bring it up-to date with those overrides.
             merge_non_null_json_value(legacy_overrides, &mut settings);
         }
 


### PR DESCRIPTION
Even though I initially set out to make clear in code that the migration also writes changes to the settings.json, I decided against it in favor of a simple comment that makes clear why this is alright here.

After all, the code will be deleted at some point.

CC @krlvi 