### PR TITLE
but-llm remove the reference to git2 configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ dependencies = [
  "but-secret",
  "but-tools",
  "futures",
- "git2",
+ "gix",
  "ollama-rs",
  "reqwest 0.12.28",
  "schemars 1.2.0",

--- a/crates/but-llm/Cargo.toml
+++ b/crates/but-llm/Cargo.toml
@@ -25,4 +25,4 @@ anyhow.workspace = true
 strum = { version = "0.27", features = ["derive"] }
 reqwest.workspace = true
 uuid.workspace = true
-git2.workspace = true
+gix.workspace = true

--- a/crates/but-llm/src/anthropic.rs
+++ b/crates/but-llm/src/anthropic.rs
@@ -35,8 +35,8 @@ pub enum CredentialsKind {
 }
 
 impl CredentialsKind {
-    fn from_git_config(config: &git2::Config) -> Option<Self> {
-        let key_option_str = config.get_string(ANTHROPIC_KEY_OPTION).ok()?;
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
+        let key_option_str = config.string(ANTHROPIC_KEY_OPTION).map(|v| v.to_string())?;
         let key_option = CredentialsKeyOption::from_str(&key_option_str)?;
         match key_option {
             CredentialsKeyOption::BringYourOwn => Some(CredentialsKind::OwnAnthropicKey),
@@ -177,12 +177,12 @@ impl AnthropicProvider {
 }
 
 impl LLMClient for AnthropicProvider {
-    fn from_git_config(config: &git2::Config) -> Option<Self>
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self>
     where
         Self: Sized,
     {
         let credentials_kind = CredentialsKind::from_git_config(config)?;
-        let model = config.get_string(ANTHROPIC_MODEL_NAME).ok();
+        let model = config.string(ANTHROPIC_MODEL_NAME).map(|v| v.to_string());
         AnthropicProvider::with(Some(credentials_kind), model)
     }
 

--- a/crates/but-llm/src/client.rs
+++ b/crates/but-llm/src/client.rs
@@ -2,14 +2,13 @@ use std::fmt::Debug;
 
 use anyhow::Result;
 use but_tools::tool::Toolset;
-use git2::Config;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::ChatMessage;
 
 pub trait LLMClient: Debug + Clone {
-    fn from_git_config(config: &Config) -> Option<Self>
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self>
     where
         Self: Sized;
 

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 pub use chat::{ChatMessage, StreamToolCallResult, ToolCall, ToolCallContent, ToolResponseContent};
 
-use git2::Config;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
@@ -119,8 +118,8 @@ impl LLMProvider {
     /// - The `gitbutler.aiModelProvider` setting is not present
     /// - The configured provider is not supported (e.g., LMStudio)
     /// - Provider-specific initialization fails (e.g., missing credentials)
-    pub fn from_git_config(config: &Config) -> Option<Self> {
-        let provider_str = config.get_string(MODEL_PROVIDER).ok()?;
+    pub fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
+        let provider_str = config.string(MODEL_PROVIDER).map(|v| v.to_string())?;
         let provider = LLMProviderKind::from_str(&provider_str);
         match provider {
             Some(LLMProviderKind::OpenAi) => {

--- a/crates/but-llm/src/ollama.rs
+++ b/crates/but-llm/src/ollama.rs
@@ -72,12 +72,15 @@ impl OllamaProvider {
 }
 
 impl LLMClient for OllamaProvider {
-    fn from_git_config(config: &git2::Config) -> Option<Self>
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self>
     where
         Self: Sized,
     {
-        let endpoint = config.get_string(OLLAMA_ENDPOINT).ok().map(Into::into);
-        let model = config.get_string(OLLAMA_MODEL_NAME).ok();
+        let endpoint = config
+            .string(OLLAMA_ENDPOINT)
+            .map(|v| v.to_string())
+            .map(OllamaHostConfig::from);
+        let model = config.string(OLLAMA_MODEL_NAME).map(|v| v.to_string());
         let ollama_config = OllamaConfig {
             host_config: endpoint,
         };

--- a/crates/but-llm/src/openai.rs
+++ b/crates/but-llm/src/openai.rs
@@ -44,8 +44,8 @@ pub enum CredentialsKind {
 }
 
 impl CredentialsKind {
-    fn from_git_config(config: &git2::Config) -> Option<Self> {
-        let key_option_str = config.get_string(OPEN_AI_KEY_OPTION).ok()?;
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
+        let key_option_str = config.string(OPEN_AI_KEY_OPTION).map(|v| v.to_string())?;
         let key_option = CredentialsKeyOption::from_str(&key_option_str)?;
         match key_option {
             CredentialsKeyOption::BringYourOwn => Some(CredentialsKind::OwnOpenAiKey),
@@ -169,13 +169,15 @@ impl OpenAiProvider {
 }
 
 impl LLMClient for OpenAiProvider {
-    fn from_git_config(config: &git2::Config) -> Option<Self>
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self>
     where
         Self: Sized,
     {
         let credentials_kind = CredentialsKind::from_git_config(config)?;
-        let model = config.get_string(OPEN_AI_MODEL_NAME).ok();
-        let custom_endpoint = config.get_string(OPEN_AI_CUSTOM_ENDPOINT).ok();
+        let model = config.string(OPEN_AI_MODEL_NAME).map(|v| v.to_string());
+        let custom_endpoint = config
+            .string(OPEN_AI_CUSTOM_ENDPOINT)
+            .map(|v| v.to_string());
 
         OpenAiProvider::with(Some(credentials_kind), model, custom_endpoint)
     }

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -59,7 +59,7 @@ pub fn show(
 
     // Generate AI summary if requested
     let ai_summary = if generate_ai_summary {
-        let git_config = git2::Config::open_default()?;
+        let git_config = gix::config::File::from_globals()?;
         Some(generate_branch_summary(
             &branch_name,
             &commits,
@@ -528,7 +528,7 @@ struct CommitInfo {
 fn generate_branch_summary(
     branch_name: &str,
     commits: &[CommitInfo],
-    git_config: &git2::Config,
+    git_config: &gix::config::File<'static>,
 ) -> anyhow::Result<String> {
     use but_llm::LLMProvider;
 

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -63,7 +63,9 @@ pub fn auto_commit(
     let changes: Vec<but_core::TreeChange> =
         changes.into_iter().map(|change| change.into()).collect();
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let git_config =
+        gix::config::File::from_globals().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+
     let llm = LLMProvider::from_git_config(&git_config);
 
     let emitter = std::sync::Arc::new(move |name: &str, payload: serde_json::Value| {
@@ -93,7 +95,8 @@ pub fn auto_branch_changes(
     let changes: Vec<but_core::TreeChange> =
         changes.into_iter().map(|change| change.into()).collect();
     let ctx = &mut Context::new_from_legacy_project(project.clone())?;
-    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let git_config =
+        gix::config::File::from_globals().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
     let llm = LLMProvider::from_git_config(&git_config);
 
     let emitter = std::sync::Arc::new(move |name: &str, payload: serde_json::Value| {
@@ -129,7 +132,8 @@ pub fn freestyle(
         });
     });
 
-    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let git_config =
+        gix::config::File::from_globals().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
     let llm = LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_action::freestyle(

--- a/crates/gitbutler-tauri/src/bot.rs
+++ b/crates/gitbutler-tauri/src/bot.rs
@@ -21,7 +21,9 @@ pub fn bot(
         });
     });
 
-    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let git_config =
+        gix::config::File::from_globals().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+
     let llm = but_llm::LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_bot::bot(project_id, message_id, emitter, ctx, &llm, chat_messages)
@@ -51,7 +53,8 @@ pub async fn forge_branch_chat(
         });
     });
 
-    let git_config = git2::Config::open_default().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    let git_config =
+        gix::config::File::from_globals().map_err(|e| Error::from(anyhow::anyhow!(e)))?;
     let llm = but_llm::LLMProvider::from_git_config(&git_config);
     match llm {
         Some(llm) => but_bot::forge_branch_chat(


### PR DESCRIPTION
Prefer using the gix way of reading the git global configuration.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11962 
- <kbd>&nbsp;1&nbsp;</kbd> #11960 👈 
<!-- GitButler Footer Boundary Bottom -->

