### PR TITLE
Make cmd/ctrl + a work in input fields

### DIFF
--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -60,10 +60,7 @@
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
-		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
-			e.stopPropagation();
-			inputEl?.select();
-		} else if (e.key === 'Enter' || e.key === 'Escape') {
+		if (e.key === 'Enter' || e.key === 'Escape') {
 			e.stopPropagation();
 			inputEl?.blur();
 		}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -125,8 +125,25 @@
 	const uiState = inject(UI_STATE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
 
+	function handleKeyDown(e: KeyboardEvent) {
+		// Explicitly detect cmd/ctrl + A since Tauri gets in the way of default behavior.
+		// To get default behavior you can add a "Select All" predefined menu item to the
+		// Edit menu, but that prevents the event from reaching the webview.
+		if (
+			(e.metaKey || e.ctrlKey) &&
+			e.key === 'a' &&
+			e.target &&
+			e.target instanceof HTMLInputElement
+		) {
+			e.target.select();
+			e.preventDefault();
+		} else {
+			handleKeyBind(e);
+		}
+	}
+
 	// Debug keyboard shortcuts
-	const handleKeyDown = createKeybind({
+	const handleKeyBind = createKeybind({
 		// Toggle next-gen safe checkout.
 		'c o 3': () => {
 			settingsService.updateFeatureFlags({ cv3: !$settingsStore?.featureFlags.cv3 });

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -110,17 +110,6 @@
 	$effect(() => {
 		if (measureElHeight < minHeight) measureElHeight = minHeight;
 	});
-
-	function handleKeydown(e: KeyboardEvent & { currentTarget: HTMLTextAreaElement }) {
-		// Handle cmd+a (Mac) or ctrl+a (Windows/Linux) to select all text
-		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
-			e.preventDefault();
-			e.currentTarget.select();
-		}
-
-		// Call the original onkeydown handler if provided
-		onkeydown?.(e);
-	}
 </script>
 
 <div
@@ -175,7 +164,7 @@
 		{oninput}
 		{onchange}
 		{onblur}
-		onkeydown={handleKeydown}
+		{onkeydown}
 		{onfocus}
 		rows={minRows}
 	></textarea>

--- a/packages/ui/src/lib/components/Textbox.svelte
+++ b/packages/ui/src/lib/components/Textbox.svelte
@@ -130,17 +130,6 @@
 			htmlInput.select();
 		}
 	}
-
-	function handleKeydown(e: KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement }) {
-		// Handle cmd+a (Mac) or ctrl+a (Windows/Linux) to select all text
-		if ((e.metaKey || e.ctrlKey) && e.key === 'a') {
-			e.preventDefault();
-			e.currentTarget.select();
-		}
-
-		// Call the original onkeydown handler if provided
-		onkeydown?.(e);
-	}
 </script>
 
 <div
@@ -218,7 +207,7 @@
 			onchange={(e) => {
 				onchange?.(e.currentTarget.value);
 			}}
-			onkeydown={handleKeydown}
+			{onkeydown}
 		/>
 
 		{#if type === 'number' && showCountActions}


### PR DESCRIPTION
Looks like the Edit -> Select All menu item is necessary for supporting
select all in text boxes.