### PR TITLE
Fixes the handling of ChangeId being parsed from old virtual_branhes.toml

### DIFF
--- a/crates/but-meta/tests/fixtures/legacy/legacy-change-id.toml
+++ b/crates/but-meta/tests/fixtures/legacy/legacy-change-id.toml
@@ -1,0 +1,23 @@
+# Test fixture for legacy ChangeId deserialization
+[branch_targets]
+
+[branches.12345678-1234-5678-1234-567812345678]
+id = "12345678-1234-5678-1234-567812345678"
+order = 0
+in_workspace = true
+notes = ""
+ownership = ""
+allow_rebasing = true
+post_commits = false
+tree = "0000000000000000000000000000000000000000"
+created_timestamp_ms = "0"
+updated_timestamp_ms = "0"
+name = "test-branch"
+head = "0000000000000000000000000000000000000000"
+
+[[branches.12345678-1234-5678-1234-567812345678.heads]]
+name = "test-head"
+archived = false
+
+[branches.12345678-1234-5678-1234-567812345678.heads.head]
+ChangeId = "some-legacy-change-id"


### PR DESCRIPTION
In case entries still referring to ChangeId are found set the had value to a null sha

Fixes https://github.com/gitbutlerapp/gitbutler/issues/11921