### PR TITLE
Make `ts-rs` dependency optional

### DIFF
--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "A leaf-crate with core algorithms and types"
 doctest = false
 
 [features]
-export-ts = []
+export-ts = ["dep:ts-rs"]
 ## Make legacy functionality available.
 legacy = []
 
@@ -45,7 +45,7 @@ uuid.workspace = true
 # for `sync`
 fslock = "0.2.1"
 parking_lot = { workspace = true, features = ["arc_lock"] }
-ts-rs.workspace = true
+ts-rs = { workspace = true, optional = true }
 
 # For generating change-ids
 rand.workspace = true

--- a/crates/but-core/src/diff_types.rs
+++ b/crates/but-core/src/diff_types.rs
@@ -1,6 +1,5 @@
 use bstr::BString;
 use serde::{Deserialize, Serialize};
-use ts_rs::TS;
 
 use crate::TreeChange;
 
@@ -44,7 +43,8 @@ impl From<TreeChange> for DiffSpec {
 }
 
 /// The header of a hunk that represents a change to a file.
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash, TS)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./core/diffTypes.ts"))]
 pub struct HunkHeader {

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,5 +1,4 @@
 use gix::refs::FullNameRef;
-use ts_rs::TS;
 use uuid::Uuid;
 
 use crate::Id;
@@ -293,7 +292,8 @@ impl Workspace {
 }
 
 /// Metadata about branches, associated with any Git branch.
-#[derive(serde::Serialize, Clone, Eq, PartialEq, Default, TS)]
+#[derive(serde::Serialize, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -358,7 +358,8 @@ impl<T: std::fmt::Debug> std::fmt::Debug for MaybeDebug<'_, T> {
 ///
 /// It allows keeping track of when it changed, but also if we created it initially, a useful
 /// bit of information.
-#[derive(serde::Serialize, Default, Clone, Eq, PartialEq, TS)]
+#[derive(serde::Serialize, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -366,10 +367,10 @@ impl<T: std::fmt::Debug> std::fmt::Debug for MaybeDebug<'_, T> {
 )]
 pub struct RefInfo {
     /// The time of creation, *if we created the reference*.
-    #[ts(type = "number | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "number | null"))]
     pub created_at: Option<gix::date::Time>,
     /// The time at which the reference was last modified if we modified it.
-    #[ts(type = "number | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "number | null"))]
     pub updated_at: Option<gix::date::Time>,
 }
 
@@ -522,7 +523,8 @@ impl WorkspaceStack {
 }
 
 /// Metadata about branches, associated with any Git branch.
-#[derive(serde::Serialize, Clone, Eq, PartialEq, Default, TS)]
+#[derive(serde::Serialize, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 doctest = false
 
 [features]
-export-ts = []
+export-ts = ["dep:ts-rs", "but-core/export-ts"]
 
 [dependencies]
 but-core.workspace = true
@@ -30,7 +30,7 @@ serde_json.workspace = true
 uuid.workspace = true
 bstr.workspace = true
 tracing.workspace = true
-ts-rs.workspace = true
+ts-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 uuid.workspace = true

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -23,10 +23,10 @@ use itertools::Itertools;
 use reconcile::MultipleOverlapping;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use ts_rs::TS;
 use uuid::Uuid;
 
-#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -37,7 +37,7 @@ pub struct HunkAssignment {
     ///   - When a new hunk is first observed (from the uncommitted changes), it is assigned a new id.
     ///   - If a hunk is modified (i.e. it has gained or lost lines), the UUID remains the same.
     ///   - If two or more hunks become merged (due to edits causing the contexts to overlap), the id of the hunk with the most lines is adopted.
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub id: Option<Uuid>,
     /// The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
     /// If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.
@@ -45,10 +45,10 @@ pub struct HunkAssignment {
     /// The file path of the hunk.
     pub path: String,
     /// The file path of the hunk in bytes.
-    #[ts(type = "number[]")]
+    #[cfg_attr(feature = "export-ts", ts(type = "number[]"))]
     pub path_bytes: BString,
     /// The stack to which the hunk is assigned. If None, the hunk is not assigned to any stack.
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub stack_id: Option<StackId>,
     /// The dependencies(locks) that this hunk has. This determines where the hunk can be assigned.
     /// This field is ignored when HunkAssignment is passed by the UI to create a new assignment.
@@ -135,7 +135,8 @@ impl From<HunkAssignment> for but_core::DiffSpec {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase", tag = "type", content = "subject")]
 #[cfg_attr(
     feature = "export-ts",
@@ -153,7 +154,8 @@ pub enum AbsorptionTarget {
 }
 
 /// Reason why a file is being absorbed to a particular commit
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(
     feature = "export-ts",
@@ -179,7 +181,8 @@ impl AbsorptionReason {
 }
 
 /// Information about a file being absorbed
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -191,16 +194,17 @@ pub struct FileAbsorption {
 }
 
 /// Information about absorptions grouped by commit
-#[derive(Debug, Serialize, Deserialize, TS)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
     ts(export, export_to = "./hunkAssignment/index.ts")
 )]
 pub struct CommitAbsorption {
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub stack_id: but_core::ref_metadata::StackId,
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     #[serde(with = "but_serde::object_id")]
     pub commit_id: gix::ObjectId,
     pub commit_summary: String,

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -19,7 +19,7 @@ legacy = [
     "dep:gitbutler-commit",
     "dep:gitbutler-repo",
 ]
-export-ts = []
+export-ts = ["dep:ts-rs", "but-core/export-ts"]
 
 [dependencies]
 but-core.workspace = true
@@ -50,7 +50,7 @@ tracing.workspace = true
 # For SPMC channel
 flume = "0.11.1"
 tempfile.workspace = true
-ts-rs.workspace = true
+ts-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 # We just want to test everything, with the goal that 'legacy' can one day go away.

--- a/crates/but-workspace/src/legacy/ui.rs
+++ b/crates/but-workspace/src/legacy/ui.rs
@@ -3,10 +3,10 @@ use bstr::{BStr, BString, ByteSlice};
 use but_core::ref_metadata::StackId;
 use gitbutler_stack::Stack;
 use serde::Serialize;
-use ts_rs::TS;
 
 /// The information about the branch inside a stack
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -15,11 +15,11 @@ use ts_rs::TS;
 pub struct StackHeadInfo {
     /// The name of the branch.
     #[serde(with = "but_serde::bstring_lossy")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub name: BString,
     /// The tip of the branch.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub tip: gix::ObjectId,
     /// If `true`, then this head is checked directly so `HEAD` points to it, and this is only ever `true` for a single head.
     /// This is `false` if the worktree is checked out.
@@ -40,7 +40,8 @@ impl StackHeadInfo {
 
 /// Represents a lightweight version of a [`Stack`] for listing.
 /// NOTE: this is a UI type mostly because it's still modeled after the legacy stack with StackId, something that doesn't exist anymore.
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -48,7 +49,7 @@ impl StackHeadInfo {
 )]
 pub struct StackEntry {
     /// The ID of the stack.
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub id: Option<StackId>,
     /// The list of the branch information that are part of the stack.
     /// The list is never empty.
@@ -56,7 +57,7 @@ pub struct StackEntry {
     pub heads: Vec<StackHeadInfo>,
     /// The tip of the top-most branch, i.e., the most recent commit that would become the parent of new commits of the topmost stack branch.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub tip: gix::ObjectId,
     /// The zero-based index for sorting stacks.
     pub order: Option<usize>,

--- a/crates/but-workspace/src/ui/author.rs
+++ b/crates/but-workspace/src/ui/author.rs
@@ -1,9 +1,9 @@
 use bstr::ByteSlice;
 use serde::Serialize;
-use ts_rs::TS;
 
 /// Represents the author of a commit.
-#[derive(Serialize, Hash, Clone, PartialEq, Eq, TS)]
+#[derive(Serialize, Hash, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct Author {
@@ -12,7 +12,7 @@ pub struct Author {
     /// The email from the git commit signature
     pub email: String,
     /// A URL to a gravatar image for the email from the commit signature
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub gravatar_url: url::Url,
 }
 

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -13,7 +13,6 @@ pub use ref_info::inner::RefInfo;
 mod author;
 pub use author::Author;
 use but_core::{CommitOwned, commit};
-use ts_rs::TS;
 
 use crate::{
     ref_info::{LocalCommit, LocalCommitRelation},
@@ -21,7 +20,8 @@ use crate::{
 };
 
 /// Represents the state a commit could be in.
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(tag = "type", content = "subject")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub enum CommitState {
@@ -35,7 +35,7 @@ pub enum CommitState {
     /// This variant carries the remote commit id.
     /// The `remote_commit_id` may be the same as the `id` or it may be different if the local commit has been rebased or updated in another way.
     #[serde(with = "but_serde::object_id")]
-    LocalAndRemote(#[ts(type = "string")] gix::ObjectId),
+    LocalAndRemote(#[cfg_attr(feature = "export-ts", ts(type = "string"))] gix::ObjectId),
     /// The commit is considered integrated.
     /// This should happen when this commit or the contents of this commit is already part of the base.
     Integrated,
@@ -58,21 +58,22 @@ impl CommitState {
 }
 
 /// Commit that is a part of a [`StackBranch`](gitbutler_stack::StackBranch) and, as such, containing state derived in relation to the specific branch.
-#[derive(Clone, Serialize, TS)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct Commit {
     /// The OID of the commit.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub id: gix::ObjectId,
     /// The parent OIDs of the commit.
     #[serde(with = "but_serde::object_id_vec")]
-    #[ts(type = "string[]")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string[]"))]
     pub parent_ids: Vec<gix::ObjectId>,
     /// The message of the commit.
     #[serde(with = "but_serde::bstring_lossy")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub message: BString,
     /// Whether the commit is in a conflicted state.
     /// The Conflicted state of a commit is a GitButler concept.
@@ -147,17 +148,18 @@ impl std::fmt::Debug for Commit {
 
 /// Commit that is only at the remote.
 /// Unlike the `Commit` struct, there is no knowledge of GitButler concepts like conflicted state etc.
-#[derive(Clone, Serialize, TS)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct UpstreamCommit {
     /// The OID of the commit.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub id: gix::ObjectId,
     /// The message of the commit.
     #[serde(with = "but_serde::bstring_lossy")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub message: BString,
     /// Commit creation time in Epoch milliseconds.
     pub created_at: i128,
@@ -177,7 +179,8 @@ impl std::fmt::Debug for UpstreamCommit {
 }
 
 /// Represents the pushable status for the current stack.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub enum PushStatus {
@@ -194,26 +197,27 @@ pub enum PushStatus {
 }
 
 /// Information about the current state of a branch.
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct BranchDetails {
     /// The name of the branch. This is the "given name" IE, just `foo` out of `refs/heads/foo`
     #[serde(with = "but_serde::bstring_lossy")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub name: BString,
     #[serde(with = "but_serde::fullname_lossy")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     /// The full reference of the branch
     pub reference: gix::refs::FullName,
     /// The id of the linked worktree that has the reference of `name` checked out.
     /// Note that we don't list the main worktree here.
     #[serde(with = "but_serde::bstring_opt_lossy")]
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub linked_worktree_id: Option<BString>,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
     #[serde(with = "but_serde::bstring_opt_lossy")]
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub remote_tracking_branch: Option<BString>,
     /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
     pub pr_number: Option<usize>,
@@ -222,13 +226,13 @@ pub struct BranchDetails {
     /// This is the last commit in the branch, aka the tip of the branch.
     /// If this is the only branch in the stack or the top-most branch, this is the tip of the stack.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub tip: gix::ObjectId,
     /// This is the base commit from the perspective of this branch.
     /// If the branch is part of a stack and is on top of another branch, this is the head of the branch below it.
     /// If this branch is at the bottom of the stack, this is the merge base of the stack.
     #[serde(with = "but_serde::object_id")]
-    #[ts(type = "string")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub base_commit: gix::ObjectId,
     /// The pushable status for the branch.
     pub push_status: PushStatus,
@@ -247,7 +251,8 @@ pub struct BranchDetails {
 }
 
 /// Information about the current state of a stack
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "export-ts", ts(export, export_to = "./workspace/index.ts"))]
 pub struct StackDetails {

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -2,7 +2,6 @@ use anyhow::{Context as _, bail};
 use bstr::{BString, ByteSlice};
 use but_core::{ref_metadata, ref_metadata::StackId};
 use gix::refs::Category;
-use ts_rs::TS;
 
 use crate::{
     ref_info::{LocalCommit, LocalCommitRelation},
@@ -11,7 +10,8 @@ use crate::{
 };
 
 /// A reference in `refs/heads`.
-#[derive(serde::Serialize, Debug, Clone, TS)]
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -19,7 +19,7 @@ use crate::{
 )]
 pub struct BranchReference {
     /// The full ref name, like `refs/heads/feat`, for usage with the backend.
-    #[ts(type = "number[]")]
+    #[cfg_attr(feature = "export-ts", ts(type = "number[]"))]
     pub full_name_bytes: BString,
     /// The short version of `full_name_bytes` for display.
     pub display_name: String,
@@ -35,7 +35,8 @@ impl From<gix::refs::FullName> for BranchReference {
 }
 
 /// A reference in `refs/remotes`.
-#[derive(serde::Serialize, Debug, Clone, TS)]
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -43,7 +44,7 @@ impl From<gix::refs::FullName> for BranchReference {
 )]
 pub struct RemoteTrackingReference {
     /// The full ref name, like `refs/remotes/origin/on-remote`, for usage with the backend.
-    #[ts(type = "number[]")]
+    #[cfg_attr(feature = "export-ts", ts(type = "number[]"))]
     pub full_name_bytes: BString,
     /// The short version of `full_name_bytes` for display, like `on-remote`, without the remote name.
     pub display_name: String,
@@ -95,7 +96,8 @@ impl RemoteTrackingReference {
 }
 
 /// Information about the target reference, the one we want to integrate with.
-#[derive(serde::Serialize, Debug, Clone, TS)]
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -125,13 +127,12 @@ impl Target {
 }
 
 pub(crate) mod inner {
-    use ts_rs::TS;
-
     use crate::ui::ref_info::{BranchReference, Stack, Target};
 
     /// The UI-clone of [`crate::RefInfo`].
     /// TODO: should also include base-branch data, see `get_base_branch_data()`.
-    #[derive(serde::Serialize, Debug, Clone, TS)]
+    #[derive(serde::Serialize, Debug, Clone)]
+    #[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
     #[serde(rename_all = "camelCase")]
     #[cfg_attr(
         feature = "export-ts",
@@ -221,7 +222,8 @@ impl inner::RefInfo {
 }
 
 /// The UI-clone of `branch::Stack`.
-#[derive(serde::Serialize, Debug, Clone, TS)]
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -229,14 +231,14 @@ impl inner::RefInfo {
 )]
 pub struct Stack {
     /// Otherwise, it is `None`.
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub id: Option<StackId>,
     /// If there is an integration branch, we know a base commit shared with the integration branch from
     /// which we branched off.
     /// Otherwise, it's the merge-base of all stacks in the current workspace.
     /// It is `None` if this is a stack derived from a branch without relation to any other branch.
     #[serde(with = "but_serde::object_id_opt")]
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub base: Option<gix::ObjectId>,
     /// The branch-name denoted segments of the stack from its tip to the point of reference, typically a merge-base.
     /// This array is never empty.
@@ -257,7 +259,8 @@ impl Stack {
 }
 
 /// A segment of a commit graph, representing a set of commits exclusively.
-#[derive(serde::Serialize, Debug, Clone, TS)]
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(
     feature = "export-ts",
@@ -310,7 +313,7 @@ pub struct Segment {
     /// It is `None` if the stack segment contains the first commit in the history, an orphan without ancestry,
     /// or if the history traversal was stopped early.
     #[serde(with = "but_serde::object_id_opt")]
-    #[ts(type = "string | null")]
+    #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub base: Option<gix::ObjectId>,
 }
 


### PR DESCRIPTION
This makes clear that we don't need it at runtime in the common case.

### Tasks

* [x] make it optional
* [x] fixup

### Hopeful impact

We have been seeing seemingly unnecessary rebuilds, and I'd hope that compiling lest black-magic proc-macros helps. 
This further isolates this crates and makes it easy to remove when there are better alternatives.

### Follow Up

* [ ] If https://github.com/gitbutlerapp/gitbutler/pull/11962 gets merged first, make sure the pattern is introduced there as well.