### PR TITLE
move git hooks config to "Git Stuff"

### DIFF
--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { projectRunCommitHooks } from '$lib/config/config';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
-	import { CardGroup, Spacer, Textarea, Textbox, Toggle } from '@gitbutler/ui';
+	import { CardGroup, Spacer, Textarea, Textbox } from '@gitbutler/ui';
 
 	const { projectId }: { projectId: string } = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectQuery = $derived(projectsService.getProject(projectId));
-
-	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
 </script>
 
 <CardGroup>
@@ -44,23 +41,6 @@
 			</div>
 		{/snippet}
 	</ReduxResult>
-</CardGroup>
-
-<Spacer />
-
-<CardGroup>
-	<CardGroup.Item labelFor="runHooks">
-		{#snippet title()}
-			Run Git hooks
-		{/snippet}
-		{#snippet caption()}
-			Enabling this will run git pre-push, pre and post commit, and commit-msg hooks you have
-			configured in your repository.
-		{/snippet}
-		{#snippet actions()}
-			<Toggle id="runHooks" bind:checked={$runCommitHooks} />
-		{/snippet}
-	</CardGroup.Item>
 </CardGroup>
 
 <Spacer />

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CommitSigningForm from '$components/CommitSigningForm.svelte';
+	import GitHooksForm from '$components/GitHooksForm.svelte';
 	import KeysForm from '$components/KeysForm.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import SettingsSection from '$components/SettingsSection.svelte';
@@ -20,6 +21,7 @@
 </script>
 
 <SettingsSection>
+	<GitHooksForm {projectId} />
 	<CommitSigningForm {projectId} />
 	{#if backend.platformName !== 'windows'}
 		<Spacer />

--- a/apps/desktop/src/components/GitHooksForm.svelte
+++ b/apps/desktop/src/components/GitHooksForm.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import SettingsSection from '$components/SettingsSection.svelte';
+	import { projectRunCommitHooks } from '$lib/config/config';
+	import { CardGroup, Toggle } from '@gitbutler/ui';
+
+	const { projectId }: { projectId: string } = $props();
+
+	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
+</script>
+
+<SettingsSection>
+	<CardGroup>
+		<CardGroup.Item labelFor="runHooks">
+			{#snippet title()}
+				Run Git hooks
+			{/snippet}
+			{#snippet caption()}
+				Enabling this will run git pre-push, pre and post commit, and commit-msg hooks you have
+				configured in your repository.
+			{/snippet}
+			{#snippet actions()}
+				<Toggle id="runHooks" bind:checked={$runCommitHooks} />
+			{/snippet}
+		</CardGroup.Item>
+	</CardGroup>
+</SettingsSection>


### PR DESCRIPTION
extract this form logic into it’s own component and move it to “Git Stuff”, which seems to make more sense to me.

before:

<img width="1474" height="1562" alt="CleanShot 2026-01-23 at 11 23 56@2x" src="https://github.com/user-attachments/assets/4a4e3131-b0d6-49e4-ae1d-692f982d0dd6" />

after:

<img width="1472" height="1118" alt="CleanShot 2026-01-23 at 11 24 06@2x" src="https://github.com/user-attachments/assets/3f910192-cfb3-4f3e-9f98-052e38870313" />
