### PR TITLE
Fix CI ignoring specified toolchain

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,4 @@
 name: 'Publish'
-env:
-  RUSTUP_TOOLCHAIN: stable
 on:
   schedule:
     # every day at 1am UTC, 3AM CEST or 2AM CET.

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   RUST_BACKTRACE: full
-  RUSTUP_TOOLCHAIN: stable
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -1,6 +1,4 @@
 name: E2E Blackbox Tests
-env:
-  RUSTUP_TOOLCHAIN: stable
 on:
   push:
     branches:


### PR DESCRIPTION
The `RUSTUP_TOOLCHAIN` takes precedence over anything in our rust-toolchain.toml. This commit removes the environment variables so CI should now build with the expected version of rust