### PR TITLE
POC: Workspace comparison and events

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -206,8 +206,12 @@
 	// FEED & UPDATES MANAGEMENT
 	// =============================================================================
 
-	const headResponse = $derived(modeService.head(projectId));
+	const headResponse = $derived(modeService.workspaceUpdates(projectId));
 	const head = $derived(headResponse.response);
+	const debouncedInvalidateStacks = debounce((value: string) => {
+		console.log('Head changed, invalidating stacks and details', value);
+		stackService.invalidateStacksAndDetails();
+	}, 300);
 
 	// If the head changes, invalidate stacks and details
 	// We need to track the previous head value to avoid infinite loops
@@ -216,7 +220,7 @@
 		if (head && head !== previousHead) {
 			untrack(() => {
 				previousHead = head;
-				stackService.invalidateStacksAndDetails();
+				debouncedInvalidateStacks(head);
 			});
 		}
 	});

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -41,7 +41,7 @@ pub struct Overlay {
 pub(super) type PetGraph = petgraph::stable_graph::StableGraph<Segment, Edge>;
 
 /// Options for use in [`Graph::from_head()`] and [`Graph::from_commit_traversal()`].
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Options {
     /// Associate tag references with commits.
     ///

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -240,6 +240,27 @@ pub struct Graph {
     /// Public to be able to change it before calling [Graph::redo_traversal_with_overlay()].
     pub options: init::Options,
 }
+impl PartialEq for Graph {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.node_count() == other.inner.node_count()
+            && self.inner.edge_count() == other.inner.edge_count()
+            && self
+                .inner
+                .node_indices()
+                .all(|nidx| self.inner[nidx] == other.inner[nidx])
+            && self
+                .inner
+                .edge_indices()
+                .all(|eidx| self.inner[eidx] == other.inner[eidx])
+            && self.entrypoint == other.entrypoint
+            && self.entrypoint_ref == other.entrypoint_ref
+            && self.extra_target == other.extra_target
+            && self.hard_limit_hit == other.hard_limit_hit
+            && self.options == other.options
+    }
+}
+
+impl Eq for Graph {}
 
 /// A resolved entry point into the graph for easy access to the segment, commit,
 /// and the respective indices for later traversal.
@@ -264,7 +285,7 @@ pub struct EntryPoint<'graph> {
 /// doesn't yet have a commit.
 /// The idea is to write code that keeps edge information consistent, and our visualization tools highlights
 /// issues with the inherent invariants.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Edge {
     /// `None` if the source segment has no commit.
     src: Option<CommitIndex>,

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -8,7 +8,7 @@ use petgraph::Direction;
 use crate::{CommitFlags, Graph, SegmentIndex, SegmentMetadata, init::PetGraph};
 
 /// A list of segments that together represent a list of dependent branches, stacked on top of each other.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Stack {
     /// If the stack belongs to a managed workspace, the `id` will be set and persist.
     /// Otherwise, it is `None`.
@@ -143,7 +143,7 @@ impl std::fmt::Debug for Stack {
 /// As it stands, we may 'doctor' the `ref_name`, `remote_tracking_ref_name` and `metadata` *if* `commits_outside` is not
 /// `None`. This is to help with visualisation, but makes this data much less usable in algorithms, at least if
 /// these fields are significant.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StackSegment {
     /// The unambiguous or disambiguated name of the branch at the tip of the segment, i.e. at the first commit,
     /// along with its worktree information.

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// A workspace reference is a list of [Stacks](Stack), with a reference to the underlying [`Graph`].
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Workspace {
     /// The underlying graph for providing simplified access to data.
     pub graph: Graph,
@@ -292,7 +292,7 @@ impl Workspace {
 }
 
 /// A classifier for the workspace.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkspaceKind {
     /// The `HEAD` is pointing to a dedicated workspace reference, like `refs/heads/gitbutler/workspace`.
     /// This also means that we have a workspace commit that `ref_name` points to directly, which is also owned
@@ -349,7 +349,7 @@ impl WorkspaceKind {
 }
 
 /// Information about the target reference.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetRef {
     /// The name of the target branch, i.e. the branch that all [Stacks](Stack) want to get merged into.
     /// Typically, this is `refs/remotes/origin/main`.
@@ -361,7 +361,7 @@ pub struct TargetRef {
 }
 
 /// Information about the target commit.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetCommit {
     /// The hash of the commit that was once included in the [target ref](TargetRef), and that we remember to expand
     /// the reach of the workspace.

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -81,6 +81,10 @@ impl ActiveProjects {
                         name: format!("project://{project_id}/worktree_changes"),
                         payload: serde_json::json!(&changes),
                     },
+                    Change::WorkspaceChanges { project_id } => FrontendEvent {
+                        name: format!("project://{project_id}/workspace_changes"),
+                        payload: serde_json::json!({}),
+                    },
                 };
 
                 println!("Sending event");

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -60,6 +60,11 @@ pub(crate) mod state {
                         payload: serde_json::json!(&changes),
                         project_id,
                     },
+                    Change::WorkspaceChanges { project_id } => ChangeForFrontend {
+                        name: format!("project://{project_id}/workspace_changes"),
+                        payload: serde_json::json!({}),
+                        project_id,
+                    },
                 }
             }
         }

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -19,4 +19,7 @@ pub enum Change {
         project_id: ProjectId,
         changes: but_hunk_assignment::WorktreeChanges,
     },
+    WorkspaceChanges {
+        project_id: ProjectId,
+    },
 }

--- a/crates/gitbutler-watcher/src/lib.rs
+++ b/crates/gitbutler-watcher/src/lib.rs
@@ -91,7 +91,7 @@ pub fn watch_in_background(
     };
     let handle_event =
         move |event: InternalEvent, app_settings: AppSettingsWithDiskSync| -> Result<()> {
-            let handler = handler.clone();
+            let mut handler = handler.clone();
             // NOTE: Traditional parallelization (blocking) is required as `tokio::spawn()` on
             //       the `handler.handle()` future isn't `Send` as it keeps non-Send things
             //       across await points. Further, there is a fair share of `sync` IO happening


### PR DESCRIPTION
Concept of emitting events from the backend for whenever the workspace changes.

## Missing: 
### A better way of propagating the update.
Currently, I just added the ISO datetime of whenever the event was emitted, but I’m not sure this is the best approach.

### A fine-grained update
We could propagate information about what changed, i.e number of stacks, content of single stacks, etc
