### PR TITLE
Be sure to actually find the lowest merge-base.

### DIFF
--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -283,6 +283,7 @@ impl StackSegment {
             sibling_segment_id,
             commits: _,
             ref metadata,
+            ..
         } = segments_iter
             .next()
             .context("BUG: need one or more segments")?;

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -791,9 +791,6 @@ impl Graph {
     /// ## Note
     ///
     /// This is a **merge-base octopus** effectively, and works without generation numbers.
-    // TODO: actually compute the lowest base, see `first_merge_base()` which should be `lowest_merge_base()` by itself,
-    //       accounting for finding the lowest of all merge-bases which would be assumed to be reachable by all segments
-    //       searching downward, a necessary trait for many search problems.
     fn compute_lowest_base(
         &self,
         tip: ComputeBaseTip,

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -70,12 +70,12 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         }),
         remote_tracking_ref_name: Some("refs/remotes/origin/A".try_into()?),
         sibling_segment_id: Some(SegmentIndex::from(1)),
-        commits: vec![
-            commit(id("a"), Some(init_commit_id), CommitFlags::InWorkspace),
-            commit(init_commit_id, None, CommitFlags::InWorkspace),
-        ],
-        metadata: None,
+        ..Default::default()
     };
+    graph[SegmentIndex::from(3)].commits = vec![
+        commit(id("a"), Some(init_commit_id), CommitFlags::InWorkspace),
+        commit(init_commit_id, None, CommitFlags::InWorkspace),
+    ];
     let branch = graph.connect_new_segment(local_target, None, branch, 0, None);
 
     let remote_to_root_branch = Segment {


### PR DESCRIPTION
Otherwise, the workspace stack traversal may 'sneak' past the lower bound, which all paths should go through, and basically pick up all commits to the beginning of time.

## Tasks

* [x] reproduce
* [ ] prototype fix (find the lowest merge-base, keep searching until all paths are exhausted)
    - Even though it's implemented now, it's not working. Look into this again, fresh
* [ ] test to reproduce the issue without the fix applied

## Problem

This merge-base has paths that go around it, hence the traversal doesn't stop.

<img width="661" height="301" alt="Screenshot 2026-01-23 at 20 40 46" src="https://github.com/user-attachments/assets/53468eb5-9905-4af7-919d-aff63375f24a" />

## Solution

It must find the lowest merge-base, which isn't :34, but :40`.


## While there is no test…

Test it in the real world.

```
 cargo run --bin but-testing -- -C /Users/byron/dev-gb/gitbutler-no-merge-base graph --no-debug-workspace
```

with this patch applied:

```patch
diff --git a/crates/but-graph/src/api.rs b/crates/but-graph/src/api.rs
index c1763bb485..fd7bd475e1 100644
--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -89,7 +89,7 @@ impl Graph {
         //       And yes, let's avoid `gix::Repository::merge_base` as we have free
         //       generation numbers here and can avoid work duplication.
         let mut segments_reachable_by_b = BTreeSet::new();
-        self.visit_all_segments_including_start_until(b, Direction::Outgoing, |s| {
+        self.visit_all_segments_including_start_until(dbg!(b), Direction::Outgoing, |s| {
             segments_reachable_by_b.insert(s.id);
             // Collect everything, keep it simple.
             // This is fast* as completely in memory.
@@ -98,7 +98,7 @@ impl Graph {
         });
 
         let mut candidate = None;
-        self.visit_all_segments_including_start_until(a, Direction::Outgoing, |s| {
+        self.visit_all_segments_including_start_until(dbg!(a), Direction::Outgoing, |s| {
             let prune = true;
             if candidate.is_some() {
                 return prune;
diff --git a/crates/but-graph/src/projection/workspace.rs b/crates/but-graph/src/projection/workspace.rs
index 7ce1bbb1b4..5690bd3bf8 100644
--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -592,7 +592,7 @@ impl Graph {
             }
         };
 
-        let (mut lower_bound, mut lower_bound_segment_id) = ws_lower_bound
+        let (mut lower_bound, mut lower_bound_segment_id) = dbg!(ws_lower_bound)
             .map(|(a, b)| (Some(a), Some(b)))
             .unwrap_or_default();
 
```

The output will be something like 

```
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(9)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(10)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(8)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(7)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(5)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(4)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(1)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/api.rs:92:55] b = NodeIndex(3)
[crates/but-graph/src/api.rs:101:55] a = NodeIndex(34)
[crates/but-graph/src/projection/workspace.rs:595:61] ws_lower_bound = Some(
    (
        Sha1(eb4078b63c3a1fade00796da6ee8830f59bf4cbb),
        NodeIndex(34),
    ),
)
```

And you'd want the `34` become `:40`, to find the longest path by manipulating this portion of the code (probably):

https://github.com/gitbutlerapp/gitbutler/blob/4cbc93746110697d6cad1f5e2f0ea2f1762f9a2c/crates/but-graph/src/api.rs#L101-L111

