### PR TITLE
feat: Replace "assign" terminology with "stage" across codebase

### DIFF
--- a/apps/desktop/src/components/NewRuleMenu.svelte
+++ b/apps/desktop/src/components/NewRuleMenu.svelte
@@ -69,7 +69,7 @@
 	</ContextMenuSection>
 	{#if addEmpty}
 		<ContextMenuSection>
-			<ContextMenuItem icon="arrow-right" label="Assign all to branch" onclick={handleAddEmpty} />
+			<ContextMenuItem icon="arrow-right" label="Stage all to branch" onclick={handleAddEmpty} />
 		</ContextMenuSection>
 	{/if}
 </ContextMenu>

--- a/apps/desktop/src/components/Rule.svelte
+++ b/apps/desktop/src/components/Rule.svelte
@@ -218,7 +218,7 @@
 					<span class="text-12 truncate">*. All changes</span>
 				</div>
 			{/if}
-			<Tooltip text="Assign to branch">
+			<Tooltip text="Stage to branch">
 				<Icon name="arrow-right" color="var(--clr-text-3)" />
 			</Tooltip>
 			{@render stackTarget(target)}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -427,7 +427,7 @@
 								class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
 							>
 								<WorktreeChanges
-									title="Assigned"
+									title="Staged"
 									projectId={stableProjectId}
 									stackId={stableStackId}
 									mode="assigned"
@@ -447,7 +447,7 @@
 										{#if !isCommitting}
 											<div class="assigned-changes-empty">
 												<p class="text-12 text-body assigned-changes-empty__text">
-													Drop files to assign or commit directly
+													Drop files to stage or commit directly
 												</p>
 											</div>
 										{/if}

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -105,7 +105,7 @@
 		<div class="unassigned-wrap">
 			<div role="presentation" class="unassigned-files-wrapper" onclick={unselectFiles}>
 				<WorktreeChanges
-					title="Unassigned"
+					title="Unstaged"
 					{projectId}
 					stackId={undefined}
 					mode="unassigned"

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -130,8 +130,8 @@ pub enum SemanticType {
 }
 
 /// Represents an action that can be taken based on the rule evaluation.
-/// An action can be either explicit, meaning the user defined something like "Assign in Lane A" or "Amend into Commit X"
-/// or it is implicit, meaning the action was determined by heuristics or AI, such as "Assign to appropriate branch" or "Absorb in dependent commit".
+/// An action can be either explicit, meaning the user defined something like "Stage to Lane A" or "Amend into Commit X"
+/// or it is implicit, meaning the action was determined by heuristics or AI, such as "Stage to appropriate branch" or "Absorb in dependent commit".
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", tag = "type", content = "subject")]
 pub enum Action {

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -719,7 +719,7 @@ fn output_human(
     if !unassigned_files.is_empty() {
         writeln!(buf)?;
         writeln!(buf)?;
-        writeln!(buf, "{}", "Unassigned Files:".bold())?;
+        writeln!(buf, "{}", "Unstaged Files:".bold())?;
         for file in unassigned_files {
             writeln!(buf, "  {}", file.yellow())?;
         }

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -27,7 +27,7 @@ pub(crate) fn assign_uncommitted_to_branch(
     if let Some(out) = out.for_human() {
         writeln!(
             out,
-            "Assigned {} → {}.",
+            "Staged {} → {}.",
             description,
             format!("[{branch_name}]").green()
         )?;
@@ -62,7 +62,7 @@ pub(crate) fn assign_uncommitted_to_stack(
     if let Some(out) = out.for_human() {
         writeln!(
             out,
-            "Assigned {} → stack {}.",
+            "Staged {} → stack {}.",
             description,
             format!("[{}]", stack_id).green()
         )?;
@@ -88,7 +88,7 @@ pub(crate) fn unassign_uncommitted(
     let reqs = to_assignment_request(ctx, assignments, None)?;
     do_assignments(ctx, &repo, &workspace, reqs, out)?;
     if let Some(out) = out.for_human() {
-        writeln!(out, "Unassigned {description}")?;
+        writeln!(out, "Unstaged {description}")?;
     }
     Ok(())
 }
@@ -176,21 +176,21 @@ fn assign_all_inner(
         if to_branch.is_some() {
             writeln!(
                 out,
-                "Assigned all {} changes to {}.",
+                "Staged all {} changes to {}.",
                 from_branch
                     .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "unassigned".to_string().bold()),
+                    .unwrap_or_else(|| "unstaged".to_string().bold()),
                 to_branch
                     .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "unassigned".to_string().bold())
+                    .unwrap_or_else(|| "unstaged".to_string().bold())
             )?;
         } else {
             writeln!(
                 out,
-                "Unassigned all {} changes.",
+                "Unstaged all {} changes.",
                 from_branch
                     .map(|b| format!("[{b}]").green())
-                    .unwrap_or_else(|| "unassigned".to_string().bold())
+                    .unwrap_or_else(|| "unstaged".to_string().bold())
             )?;
         }
     }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -61,7 +61,7 @@ fn uncommitted_file_to_unassigned() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Unassigned the only hunk in a.txt in a stack
+Unstaged the only hunk in a.txt in a stack
 
 "#]])
         .stderr_eq(str![""]);
@@ -92,7 +92,7 @@ fn uncommitted_file_to_branch() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Assigned all hunks in a.txt in the unassigned area → [A].
+Staged all hunks in a.txt in the unassigned area → [A].
 
 "#]])
         .stderr_eq(str![""]);
@@ -317,7 +317,7 @@ k0 a.txt│
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Unassigned a hunk in a.txt in a stack
+Unstaged a hunk in a.txt in a stack
 
 "#]])
         .stderr_eq(str![""]);
@@ -396,7 +396,7 @@ k0 a.txt│
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Assigned a hunk in a.txt in the unassigned area → [A].
+Staged a hunk in a.txt in the unassigned area → [A].
 
 "#]])
         .stderr_eq(str![""]);


### PR DESCRIPTION
While working on the CLI and also when talking to developers, it seems like it's been more helpful to talk about "staging" changes to a lane or a stack, rather than assigning. It is a familiar term, and we often describe that the app has multiple staging areas (for the multiple branches).

This begins the process of renaming stuff, at least with regards to what is visible by users.

cc @PavelLaptev for updating the copy in figma