### PR TITLE
feat(ui): made "scroll to bottom" optional

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -459,6 +459,7 @@
 						bind:this={virtualList}
 						grow
 						stickToBottom
+						showBottomButton
 						items={formattedMessages}
 						visibility={$userSettings.scrollbarVisibilityState}
 						padding={{ left: 20, right: 20, top: 12, bottom: 12 }}

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -92,6 +92,11 @@
 		 */
 		startIndex?: number;
 		renderDistance?: number;
+		/**
+		 * Whether to show the "Scroll to bottom" button when user scrolls up.
+		 * Defaults to false.
+		 */
+		showBottomButton?: boolean;
 	};
 
 	const SCROLL_DOWN_THRESHOLD = 600;
@@ -111,7 +116,8 @@
 		defaultHeight,
 		stickToBottom,
 		startIndex,
-		renderDistance = 0
+		renderDistance = 0,
+		showBottomButton = false
 	}: Props = $props();
 
 	let viewport = $state<HTMLDivElement>();
@@ -535,7 +541,7 @@
 				New unread
 			</button>
 		{/if}
-		{#if previousDistance > SCROLL_DOWN_THRESHOLD}
+		{#if showBottomButton && previousDistance > SCROLL_DOWN_THRESHOLD}
 			<div class="feed-actions__scroll-to-bottom" transition:fade={{ duration: 150 }}>
 				<Button
 					kind="outline"


### PR DESCRIPTION
<img width="2482" height="1562" alt="image" src="https://github.com/user-attachments/assets/07812b4a-ad6b-472a-a06f-3276bca5ef24" />

---

The "Scroll to bottom" should be enabled only for chats. In other places the button is a distraction that disrupts the natural reading flow. and we also usually have the list for navigation.