### PR TITLE
Implement `but stack`

### DIFF
--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -50,6 +50,7 @@ pub enum CommandName {
     Resolve,
     Update,
     Merge,
+    Stack,
     #[default]
     Unknown,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -814,6 +814,31 @@ pub enum Subcommands {
         branch: Option<String>,
     },
 
+    /// Rebase a branch onto another branch to create a stacked branch.
+    ///
+    /// This command rebases the source branch onto the target branch,
+    /// creating a stacked branch relationship where the source branch
+    /// depends on the target branch.
+    ///
+    /// ## Examples
+    ///
+    /// Stack a feature branch onto another branch:
+    ///
+    /// ```text
+    /// but stack my-feature base-feature
+    /// ```
+    ///
+    /// Stack using CLI IDs:
+    ///
+    /// ```text
+    /// but stack bu bv
+    /// ```
+    #[cfg(feature = "legacy")]
+    Stack {
+        source_branch: String,
+        target_branch: String,
+    },
+
     /// Show help information grouped by category.
     ///
     /// Displays all available commands organized into functional categories

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -21,6 +21,7 @@ pub mod reword;
 pub mod rub;
 pub mod setup;
 pub mod show;
+pub mod stack;
 pub mod status;
 pub mod teardown;
 pub mod worktree;

--- a/crates/but/src/command/legacy/stack.rs
+++ b/crates/but/src/command/legacy/stack.rs
@@ -1,0 +1,186 @@
+use anyhow::{Context as _, bail};
+use but_ctx::Context;
+use colored::Colorize;
+use gix::refs::Category;
+
+use crate::{CliId, IdMap, utils::OutputChannel};
+
+/// Stack a branch onto another branch by rebasing it.
+///
+/// This command rebases the source branch onto the target branch, creating
+/// a stacked branch relationship where the source branch depends on the target.
+pub fn handle(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    source_str: &str,
+    target_str: &str,
+) -> anyhow::Result<()> {
+    let id_map = IdMap::new_from_context(ctx, None)?;
+
+    // Resolve source branch
+    let source_matches = id_map.resolve_entity_to_ids(source_str)?;
+    if source_matches.is_empty() {
+        bail!(
+            "Source branch '{}' not found. If you just performed a Git operation, try running 'but status' to refresh.",
+            source_str
+        );
+    }
+    if source_matches.len() > 1 {
+        bail!(
+            "Source '{}' is ambiguous. Try using more characters to disambiguate.",
+            source_str
+        );
+    }
+
+    let source_id = &source_matches[0];
+    let source_branch_name = match source_id {
+        CliId::Branch { name, .. } => name,
+        _ => {
+            bail!(
+                "Source '{}' must be a branch, but got {}",
+                source_str,
+                source_id.kind_for_humans()
+            );
+        }
+    };
+
+    // Resolve target branch
+    let target_matches = id_map.resolve_entity_to_ids(target_str)?;
+    if target_matches.is_empty() {
+        bail!(
+            "Target branch '{}' not found. If you just performed a Git operation, try running 'but status' to refresh.",
+            target_str
+        );
+    }
+    if target_matches.len() > 1 {
+        bail!(
+            "Target '{}' is ambiguous. Try using more characters to disambiguate.",
+            target_str
+        );
+    }
+
+    let target_id = &target_matches[0];
+    let target_branch_name = match target_id {
+        CliId::Branch { name, .. } => name,
+        _ => {
+            bail!(
+                "Target '{}' must be a branch, but got {}",
+                target_str,
+                target_id.kind_for_humans()
+            );
+        }
+    };
+
+    // Validate that source and target are different
+    if source_branch_name == target_branch_name {
+        bail!("Source and target branches cannot be the same");
+    }
+
+    // Perform the stacking operation
+    stack_branch_onto_target(ctx, source_branch_name, target_branch_name)?;
+
+    // Output results
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{} Stacked branch {} onto {}",
+            "✓".green().bold(),
+            source_branch_name.blue(),
+            target_branch_name.blue()
+        )?;
+    } else if let Some(out) = out.for_shell() {
+        writeln!(out, "{}", source_branch_name)?;
+    } else if let Some(out) = out.for_json() {
+        let value = serde_json::json!({
+            "source_branch": source_branch_name,
+            "target_branch": target_branch_name,
+            "success": true
+        });
+        out.write_value(value)?;
+    }
+
+    Ok(())
+}
+
+/// Performs the actual stacking operation by removing and recreating the source branch
+/// with an anchor at the target branch.
+fn stack_branch_onto_target(
+    ctx: &mut Context,
+    source_branch_name: &str,
+    target_branch_name: &str,
+) -> anyhow::Result<()> {
+    // Get repository and workspace
+    let mut guard = ctx.exclusive_worktree_access();
+    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
+    let repo = ctx.repo.get()?;
+
+    // Convert branch names to full reference names
+    let source_ref = Category::LocalBranch
+        .to_full_name(source_branch_name)
+        .map_err(anyhow::Error::from)?;
+    let target_ref = Category::LocalBranch
+        .to_full_name(target_branch_name)
+        .map_err(anyhow::Error::from)?;
+
+    // Verify both branches exist
+    repo.try_find_reference(&source_ref)?
+        .with_context(|| format!("Source branch '{}' does not exist", source_branch_name))?;
+    repo.try_find_reference(&target_ref)?
+        .with_context(|| format!("Target branch '{}' does not exist", target_branch_name))?;
+
+    // Find the source branch's stack
+    let (source_stack, _source_segment) = ws
+        .find_segment_and_stack_by_refname(source_ref.as_ref())
+        .with_context(|| format!("Could not find stack for branch '{}'", source_branch_name))?;
+
+    // Check if it's safe to remove the branch
+    // If this is the last branch in the stack, we can't remove it without leaving anonymous segments
+    let is_last_branch_in_stack = source_stack
+        .segments
+        .iter()
+        .filter(|seg| seg.ref_info.is_some())
+        .count()
+        == 1;
+
+    if is_last_branch_in_stack {
+        bail!(
+            "Cannot stack '{}' as it is the only named branch in its stack. \
+             Use 'but branch new --anchor {}' to create a new branch stacked on '{}' instead.",
+            source_branch_name,
+            target_branch_name,
+            target_branch_name
+        );
+    }
+
+    // Remove the old branch reference
+    but_workspace::branch::remove_reference(
+        source_ref.as_ref(),
+        &repo,
+        &ws,
+        &mut meta,
+        but_workspace::branch::remove_reference::Options {
+            avoid_anonymous_stacks: true,
+            keep_metadata: true, // Keep metadata so we preserve commit history
+        },
+    )?;
+
+    // Recreate the branch with the target as anchor
+    let anchor = but_workspace::branch::create_reference::Anchor::AtSegment {
+        ref_name: std::borrow::Cow::Borrowed(target_ref.as_ref()),
+        position: but_workspace::branch::create_reference::Position::Above,
+    };
+
+    let stack_id = source_stack.id.unwrap_or_else(but_core::ref_metadata::StackId::generate);
+
+    but_workspace::branch::create_reference(
+        source_ref.as_ref(),
+        Some(anchor),
+        &repo,
+        &ws,
+        &mut meta,
+        |_| stack_id,
+        None,
+    )?;
+
+    Ok(())
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -825,6 +825,24 @@ async fn match_subcommand(
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
         #[cfg(feature = "legacy")]
+        Subcommands::Stack {
+            source_branch,
+            target_branch,
+        } => {
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
+            command::legacy::stack::handle(&mut ctx, out, &source_branch, &target_branch)
+                .context("Failed to stack branch.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Squash {
             commits,
             drop_message,

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -176,6 +176,8 @@ impl Subcommands {
             Subcommands::Merge { .. } => Merge,
             #[cfg(feature = "legacy")]
             Subcommands::Move { .. } => Rub,
+            #[cfg(feature = "legacy")]
+            Subcommands::Stack { .. } => Stack,
         }
     }
 }

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -26,6 +26,8 @@ mod setup;
 #[cfg(feature = "legacy")]
 mod squash;
 #[cfg(feature = "legacy")]
+mod stack;
+#[cfg(feature = "legacy")]
 mod status;
 #[cfg(feature = "legacy")]
 mod teardown;

--- a/crates/but/tests/but/command/stack.rs
+++ b/crates/but/tests/but/command/stack.rs
@@ -1,0 +1,91 @@
+use snapbox::str;
+
+use crate::utils::Sandbox;
+
+#[test]
+fn error_when_stacking_only_branch_in_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    
+    // Try to stack B (the only branch in its stack) onto A - should fail
+    // This is the expected behavior since B is a single-branch stack
+    env.but("stack B A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to stack branch. Cannot stack 'B' as it is the only named branch in its stack. Use 'but branch new --anchor A' to create a new branch stacked on 'A' instead.
+
+"#]]);
+    
+    Ok(())
+}
+
+#[test]
+fn error_when_source_not_found() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    
+    env.setup_metadata(&["A"])?;
+    
+    env.but("stack nonexistent A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to stack branch. Source branch 'nonexistent' not found. If you just performed a Git operation, try running 'but status' to refresh.
+
+"#]]);
+    
+    Ok(())
+}
+
+#[test]
+fn error_when_target_not_found() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    
+    env.setup_metadata(&["A"])?;
+    
+    env.but("stack A nonexistent")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to stack branch. Target branch 'nonexistent' not found. If you just performed a Git operation, try running 'but status' to refresh.
+
+"#]]);
+    
+    Ok(())
+}
+
+#[test]
+fn error_when_source_is_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    
+    env.setup_metadata(&["A"])?;
+    
+    // Try to use a commit ID as source (should be a branch)
+    env.but("stack 9477ae7 A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to stack branch. Source '9477ae7' must be a branch, but got a commit
+
+"#]]);
+    
+    Ok(())
+}
+
+#[test]
+fn error_when_same_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    
+    env.setup_metadata(&["A"])?;
+    
+    env.but("stack A A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to stack branch. Source and target branches cannot be the same
+
+"#]]);
+    
+    Ok(())
+}


### PR DESCRIPTION
## 🧢 Changes

- Added `but stack` command to stack one branch onto another
- Implemented `stack_branch_onto_target` function that removes and recreates a branch with a new anchor
- Added validation to prevent stacking a branch onto itself
- Added a check to prevent stacking the last-named branch in a stack (to avoid anonymous segments)
- Preserved commit metadata when recreating the stacked branch

## ☕️ Reasoning

The `but stack` command provides a way to reorganize branch hierarchies by changing which branch another branch is stacked on top of. This is useful when you want to reorder your work or change dependencies between branches. The implementation safely removes the old branch reference while preserving its metadata, then recreates it with the target branch as its new anchor point. The validation ensures we don't create invalid states like anonymous stacks or circular dependencies.

## 🎫 Affected issues

Fixes: #11318 

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
