### PR TITLE
fix: `but commit empty` --before and --after flags now work correctly

### DIFF
--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -44,7 +44,13 @@ pub enum Subcommands {
     ///
     /// ## Examples
     ///
-    /// Insert before a commit (default behavior):
+    /// Insert at the top of the first branch (no arguments):
+    ///
+    /// ```text
+    /// but commit empty
+    /// ```
+    ///
+    /// Insert before a commit:
     ///
     /// ```text
     /// but commit empty ab
@@ -66,7 +72,9 @@ pub enum Subcommands {
     #[command(group = clap::ArgGroup::new("position"))]
     Empty {
         /// The target commit or branch to insert relative to.
-        /// If neither --before nor --after is specified, defaults to --before behavior.
+        ///
+        /// If a target is provided without --before or --after, defaults to --before behavior.
+        /// If no arguments are provided at all, inserts at the top of the first branch.
         #[arg(group = "position")]
         target: Option<String>,
         /// Insert the blank commit before this commit or branch

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -44,7 +44,13 @@ pub enum Subcommands {
     ///
     /// ## Examples
     ///
-    /// Insert before a commit:
+    /// Insert before a commit (default behavior):
+    ///
+    /// ```text
+    /// but commit empty ab
+    /// ```
+    ///
+    /// Explicitly insert before a commit:
     ///
     /// ```text
     /// but commit empty --before ab
@@ -57,8 +63,12 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
-    #[command(group = clap::ArgGroup::new("position").required(true))]
+    #[command(group = clap::ArgGroup::new("position"))]
     Empty {
+        /// The target commit or branch to insert relative to.
+        /// If neither --before nor --after is specified, defaults to --before behavior.
+        #[arg(group = "position")]
+        target: Option<String>,
         /// Insert the blank commit before this commit or branch
         #[arg(long, group = "position")]
         before: Option<String>,

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -45,9 +45,11 @@ pub(crate) fn insert_blank_commit(
     let cli_id = &cli_ids[0];
 
     // Determine the position description for the success message
+    // Note: InsertSide::Above inserts as a child (after in time),
+    // InsertSide::Below inserts as a parent (before in time)
     let position_desc = match insert_side {
-        InsertSide::Above => "before",
-        InsertSide::Below => "after",
+        InsertSide::Above => "after",
+        InsertSide::Below => "before",
     };
 
     // Determine target commit ID and use provided insert_side
@@ -73,8 +75,8 @@ pub(crate) fn insert_blank_commit(
                 insert_side,
             )?;
             match insert_side {
-                InsertSide::Below => format!("Created blank commit at the top of stack '{name}'"),
-                InsertSide::Above => {
+                InsertSide::Above => format!("Created blank commit at the top of stack '{name}'"),
+                InsertSide::Below => {
                     format!("Created blank commit at the bottom of stack '{name}'")
                 }
             }

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -337,16 +337,16 @@ Created blank commit after commit 9477ae7
 }
 
 #[test]
-fn commit_empty_requires_target() -> anyhow::Result<()> {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
-    env.setup_metadata(&["A"])?;
+fn commit_empty_without_branches_fails() -> anyhow::Result<()> {
+    // This test uses a scenario with no GitButler branches to verify error handling
+    let env = Sandbox::init_scenario_with_target_and_default_settings("first-commit")?;
 
-    // Try to run without any target
+    // Try to run without any arguments when there are no branches
     env.but("commit empty")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: A target must be specified (either positional argument or --before/--after flag)
+Error: No branches found. Create a branch first or specify a target explicitly.
 
 "#]]);
 


### PR DESCRIPTION
Aslo defaults to "before"
Also, if none provided, new commit is made on above the first commit of the first stack