### PR TITLE
feat(ui): add fold/unfold toggle to changed-files panel for compact view

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -399,10 +399,6 @@
 										changes={result.changes}
 										stats={result.stats}
 										allowUnselect={false}
-										maxHeight="400px"
-										topBorder
-										bottomBorder={false}
-										transparentHeader
 										onselect={(change, index) => {
 											// Ensure the branch is selected so the preview shows it
 											const currentSelection = laneState.selection.current;


### PR DESCRIPTION

https://github.com/user-attachments/assets/26b3b8d3-dcc3-46aa-9f09-aa61341a3b18

This pull request updates the `NestedChangedFiles.svelte` component to add a collapsible file list feature, improving the usability of the changed files section. The main changes include introducing a fold/unfold toggle with a chevron icon, updating the UI to reflect the folded state, and simplifying component props by removing unused ones.

**UI/UX Improvements:**

* Added a collapsible (fold/unfold) feature to the file list, controlled by a chevron button and double-clicking the header. The list can now be folded to hide its contents, improving navigation in large changesets. [[1]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bR52) [[2]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bL74-R85) [[3]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bR98-R105) [[4]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bR124)
* Updated the file list header to include a chevron icon that rotates when folded, and adjusted padding for the folded state for better visual feedback.

**Code Cleanup:**

* Removed unused props related to resizing and styling (`grow`, `noshrink`, `maxHeight`, `topBorder`, `bottomBorder`, `transparentHeader`, `resizer`, and `ontoggle`) to simplify the component interface.
* Removed the unused `Resizer` import and updated UI imports to include the `Icon` component for the chevron.