### PR TITLE
refactor(branches): simplify renderCommitRow signature and use commit state type

### DIFF
--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -64,17 +64,12 @@
 	/>
 {/snippet}
 
-{#snippet renderCommitRow(
-	commit: Commit,
-	idx: number,
-	totalLocal: number,
-	branchFirstCommitType: string | undefined
-)}
+{#snippet renderCommitRow(commit: Commit, idx: number, totalLocal: number)}
 	{#snippet menu({ rightClickTrigger }: { rightClickTrigger: HTMLElement })}
 		{@render commitMenu(rightClickTrigger, commit.id)}
 	{/snippet}
 	{@const localCommit = commit}
-	{@const commitType: 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = (branchFirstCommitType as 'LocalOnly' | 'LocalAndRemote' | 'Integrated') ?? 'LocalOnly'}
+	{@const commitType: 'LocalOnly' | 'LocalAndRemote' | 'Integrated' = commit.state.type}
 	{@const isDiverged =
 		localCommit.state.type === 'LocalAndRemote' && commit.id !== localCommit.state.subject}
 	{@const shouldShowMenu = !(
@@ -111,7 +106,6 @@
 		branchesSelection.current.branchName === branch.name &&
 		branchesSelection.current.stackId === env.stackId &&
 		!branchesSelection.current.commitId}
-	{@const branchFirstCommitType = branch.commits?.at(0)?.state.type}
 	<BranchCard
 		type="normal-branch"
 		first={isTopBranch}
@@ -148,7 +142,7 @@
 			{#if hasCommits}
 				<div class="branch-commits">
 					{#each branch.commits ?? [] as commit, idx}
-						{@render renderCommitRow(commit, idx, localCount, branchFirstCommitType)}
+						{@render renderCommitRow(commit, idx, localCount)}
 					{/each}
 				</div>
 			{/if}


### PR DESCRIPTION
This pull request simplifies how commit types are determined and passed in the `BranchesViewBranch.svelte` component. Instead of calculating the first commit type for a branch and passing it through multiple function calls, the code now directly uses each commit's own state to determine its type. This reduces complexity and improves maintainability.

**Refactoring commit type handling:**

* The `renderCommitRow` snippet no longer receives `branchFirstCommitType` as a parameter; instead, it uses `commit.state.type` directly for determining the commit type.
* The calculation and usage of `branchFirstCommitType` have been removed from the component logic, streamlining the code.
* The invocation of `renderCommitRow` within the commits loop has been updated to remove the now-unnecessary `branchFirstCommitType` argument.