### PR TITLE
web: bring back the login buttons

### DIFF
--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import HeaderAuthSection from '$lib/components/HeaderAuthSection.svelte';
 	import ThemeSwitcher from '$lib/components/marketing/ThemeSwitcher.svelte';
 	import * as jsonLinks from '$lib/data/links.json';
 	import osIcons from '$lib/data/os-icons.json';
@@ -117,8 +116,6 @@
 				</li>
 			{/each}
 		</ul>
-
-		<HeaderAuthSection hideIfUserAuthenticated />
 
 		<div class="stack-v gap-20">
 			<div class="meta-links">

--- a/apps/web/src/lib/components/marketing/Header.svelte
+++ b/apps/web/src/lib/components/marketing/Header.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
 	import MobileMenu from '$home/components/MobileMenu.svelte';
 	import GitbutlerLogoLink from '$lib/components/GitbutlerLogoLink.svelte';
-	import NoSSR from '$lib/components/NoSSR.svelte';
-	import UserAuthAvatar from '$lib/components/UserAuthAvatar.svelte';
+	import HeaderAuthSection from '$lib/components/HeaderAuthSection.svelte';
 	import * as jsonLinks from '$lib/data/links.json';
-	import { USER_SERVICE } from '$lib/user/userService';
-	import { inject } from '@gitbutler/core/context';
 	import { Icon } from '@gitbutler/ui';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 
 	interface Props {
 		disableLogoLink?: boolean;
 	}
-
-	const userService = inject(USER_SERVICE);
-	const user = $derived(userService.user);
 
 	const { disableLogoLink }: Props = $props();
 </script>
@@ -66,13 +60,8 @@
 				href: jsonLinks.resources.jobs.url,
 				label: jsonLinks.resources.jobs.label
 			})}
+			<HeaderAuthSection />
 		</section>
-
-		<NoSSR>
-			{#if $user}
-				<UserAuthAvatar user={$user} />
-			{/if}
-		</NoSSR>
 	</nav>
 
 	<MobileMenu />


### PR DESCRIPTION
Display the login buttons in the header and the footer again, even if
there’s someone already logged in.

<img width="802" height="412" alt="Screenshot 2026-01-26 at 15 16 18" src="https://github.com/user-attachments/assets/999c5ec1-9db6-46bb-8837-778c2aa40a2a" />
<img width="802" height="412" alt="Screenshot 2026-01-26 at 15 12 09" src="https://github.com/user-attachments/assets/ba6c3915-dae7-4551-a469-d9b8ec1e7d10" />
