### PR TITLE
fold-branch-changes

### DIFF
--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -316,9 +316,7 @@
 		flex-direction: column;
 		width: 100%;
 		padding: 14px 0;
-		/* overflow: hidden; */
 		gap: 8px;
-		/* text-overflow: ellipsis; */
 	}
 
 	.branch-header__select-indicator {

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -390,6 +390,7 @@
 										{stackId}
 										draggableFiles
 										autoselect
+										limitPreview
 										selectionId={createBranchSelection({
 											stackId: stackId,
 											branchName,

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -390,7 +390,7 @@
 										{stackId}
 										draggableFiles
 										autoselect
-										limitPreview
+										foldedByDefault
 										selectionId={createBranchSelection({
 											stackId: stackId,
 											branchName,

--- a/apps/desktop/src/components/NestedChangedFiles.svelte
+++ b/apps/desktop/src/components/NestedChangedFiles.svelte
@@ -24,10 +24,8 @@
 		onselect?: (change: TreeChange, index: number) => void;
 		allowUnselect?: boolean;
 		persistId?: string;
-		limitPreview?: boolean;
+		foldedByDefault?: boolean;
 	};
-
-	const INITIAL_VISIBLE_COUNT = 3;
 
 	const {
 		projectId,
@@ -43,7 +41,7 @@
 		onselect,
 		allowUnselect = true,
 		persistId = 'default',
-		limitPreview = false
+		foldedByDefault = false
 	}: Props = $props();
 
 	const idSelection = inject(FILE_SELECTION_MANAGER);
@@ -53,14 +51,9 @@
 	const firstChangePath = $derived(changes.at(0)?.path);
 
 	let listMode: 'list' | 'tree' = $state('tree');
-	let folded = $state(false);
-	let showAll = $state(false);
+	let folded = $state(foldedByDefault);
 
 	const hasConflicts = $derived(conflictEntries && Object.keys(conflictEntries).length > 0);
-	const hasMore = $derived(limitPreview && changes.length > INITIAL_VISIBLE_COUNT);
-	const displayedChanges = $derived(
-		limitPreview && !showAll ? changes.slice(0, INITIAL_VISIBLE_COUNT) : changes
-	);
 
 	$effect(() => {
 		const id = readStableSelectionKey(stringSelectionKey);
@@ -69,13 +62,6 @@
 			idSelection.set(firstChangePath, selectionId, 0);
 		}
 	});
-
-	function handleSelect(change: TreeChange, index: number) {
-		if (hasMore) {
-			showAll = true;
-		}
-		onselect?.(change, index);
-	}
 </script>
 
 <div role="presentation" class="filelist-wrapper">
@@ -131,29 +117,14 @@
 					{selectionId}
 					{projectId}
 					{stackId}
-					changes={displayedChanges}
+					{changes}
 					{listMode}
 					{conflictEntries}
 					{draggableFiles}
 					{ancestorMostConflictedCommitId}
 					{allowUnselect}
-					onselect={handleSelect}
+					{onselect}
 				/>
-				{#if hasMore}
-					<button
-						type="button"
-						class="show-all-button text-11"
-						class:showing-all={showAll}
-						onclick={() => {
-							showAll = !showAll;
-						}}
-					>
-						<span>{showAll ? 'Show less' : 'Show all'}</span>
-						<div class="show-all-button__chevron">
-							<Icon name="chevron-down-small" />
-						</div>
-					</button>
-				{/if}
 			{/if}
 		{/if}
 	</div>
@@ -206,57 +177,5 @@
 		&:hover {
 			color: var(--clr-text-2);
 		}
-	}
-
-	.show-all-button {
-		display: flex;
-		position: relative;
-		align-items: center;
-		justify-content: space-between;
-		width: 100%;
-		margin-top: -12px;
-		padding: 8px 10px;
-		border-top: 1px solid var(--clr-border-2);
-		background: var(--clr-bg-1);
-		color: var(--clr-text-2);
-		transition: color var(--transition-fast);
-		&:hover {
-			color: var(--clr-text-2);
-
-			& .show-all-button__chevron {
-				color: var(--clr-text-2);
-			}
-		}
-
-		&:after {
-			position: absolute;
-			top: -1px;
-			left: 0;
-			width: 100%;
-			height: 24px;
-			transform: translateY(-100%);
-			background: linear-gradient(to top, var(--clr-bg-1), transparent);
-			content: '';
-		}
-
-		&.showing-all {
-			margin-top: 0;
-
-			&::after {
-				display: none;
-			}
-
-			& .show-all-button__chevron {
-				transform: rotate(180deg);
-			}
-		}
-	}
-
-	.show-all-button__chevron {
-		display: flex;
-		color: var(--clr-text-3);
-		transition:
-			transform var(--transition-fast),
-			color var(--transition-fast);
 	}
 </style>


### PR DESCRIPTION


https://github.com/user-attachments/assets/82f7227c-ebaa-411d-b9b6-c45d84e788bf



This pull request introduces an improvement to the handling of file lists in the desktop app by allowing the file list to be folded (collapsed) by default. The main change is the addition of a `foldedByDefault` prop to the `NestedChangedFiles` component, which is then passed and utilized in the `BranchList` component. Additionally, some commented-out CSS in the `BranchHeader` component was cleaned up.

**File list folding improvements:**

* Added a `foldedByDefault` prop to the `NestedChangedFiles` component, allowing the file list to be initially rendered in a folded (collapsed) state. The component's internal `folded` state is now initialized based on this prop. [[1]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bR27) [[2]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bL42-R44) [[3]](diffhunk://#diff-0529bee5c95776379c7771258d44604d0840d076d625d9642d92eae23fb0631bL52-R54)
* Updated the `BranchList` component to pass the new `foldedByDefault` prop to `NestedChangedFiles`, enabling parent components to control the default folding behavior.

**Code cleanup:**

* Removed commented-out CSS lines from the `BranchHeader.svelte` component for better code clarity.