### PR TITLE
Reduce log level for playwright e2e tests

### DIFF
--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -44,5 +44,5 @@ serde_json.workspace = true
 uuid.workspace = true
 
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-forest.workspace = true

--- a/crates/but-server/src/main.rs
+++ b/crates/but-server/src/main.rs
@@ -14,15 +14,18 @@ async fn main() -> anyhow::Result<()> {
 
 mod trace {
     use tracing::metadata::LevelFilter;
-    use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
     pub fn init() -> anyhow::Result<()> {
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::default().add_directive(LevelFilter::DEBUG.into()));
+
         tracing_subscriber::registry()
             .with(
                 tracing_forest::ForestLayer::from(
                     tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
                 )
-                .with_filter(LevelFilter::DEBUG),
+                .with_filter(filter),
             )
             .init();
         Ok(())

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -199,6 +199,7 @@ function spawnProcess(
 			VITE_BUILD_TARGET: 'web',
 			BUT_TESTING: BUT_TESTING,
 			VITE_HOST,
+			RUST_LOG: 'error',
 			...env
 		}
 	});


### PR DESCRIPTION
Replace the hardcoded tracing level with an EnvFilter that reads
RUST_LOG (defaulting to DEBUG) so the log level can be controlled
externally.