### PR TITLE
some-ui-fixes

### DIFF
--- a/apps/desktop/src/components/NestedChangedFiles.svelte
+++ b/apps/desktop/src/components/NestedChangedFiles.svelte
@@ -51,9 +51,14 @@
 	const firstChangePath = $derived(changes.at(0)?.path);
 
 	let listMode: 'list' | 'tree' = $state('tree');
+	const hasConflicts = $derived(conflictEntries && Object.keys(conflictEntries).length > 0);
 	let folded = $state(foldedByDefault);
 
-	const hasConflicts = $derived(conflictEntries && Object.keys(conflictEntries).length > 0);
+	$effect(() => {
+		if (changes.length === 0 && !hasConflicts) {
+			folded = true;
+		}
+	});
 
 	$effect(() => {
 		const id = readStableSelectionKey(stringSelectionKey);
@@ -105,8 +110,8 @@
 				<EmptyStatePlaceholder
 					image={emptyFolderSvg}
 					gap={0}
-					topBottomPadding={4}
-					bottomMargin={24}
+					topBottomPadding={14}
+					bottomMargin={20}
 				>
 					{#snippet caption()}
 						No files changed

--- a/apps/desktop/src/components/lib.ts
+++ b/apps/desktop/src/components/lib.ts
@@ -60,7 +60,7 @@ export function getBranchStatusLabelAndColor(pushStatus: PushStatus): {
 } {
 	switch (pushStatus) {
 		case 'completelyUnpushed':
-			return { label: 'Unpushed', color: colorMap.LocalOnly };
+			return { label: 'Unpushed branch', color: colorMap.LocalOnly };
 		case 'nothingToPush':
 			return { label: 'Nothing to push', color: colorMap.LocalAndRemote };
 		case 'unpushedCommits':


### PR DESCRIPTION
This pull request introduces minor UI and usability improvements to the desktop app, focusing on the display and behavior of changed files and branch status labels. The most important changes are:

**UI and Usability Enhancements:**

* The `NestedChangedFiles.svelte` component now automatically folds the file list when there are no changes and no conflicts, improving the default view for empty states.
* Adjusted padding and margin values for the empty state placeholder in `NestedChangedFiles.svelte` to enhance visual consistency.

**Label Improvements:**

* Updated the label for the `'completelyUnpushed'` branch status from `'Unpushed'` to `'Unpushed branch'` in `lib.ts` for greater clarity.