### PR TITLE
refactor(ui/avatar): remove unused reactive logic and helpers

### DIFF
--- a/apps/desktop/src/components/GithubUserLoginState.svelte
+++ b/apps/desktop/src/components/GithubUserLoginState.svelte
@@ -29,7 +29,7 @@
 	<CardGroup.Item>
 		{#snippet iconSide()}
 			<div class="avatar">
-				<Avatar size="large" username={account.info.username} srcUrl={undefined} />
+				<Avatar size="large" username={account.info.username} srcUrl={null} />
 			</div>
 		{/snippet}
 
@@ -76,7 +76,7 @@
 					</svg>
 				{/if}
 
-				<Avatar size="large" username={account.info.username} srcUrl={user?.avatarUrl} />
+				<Avatar size="large" username={account.info.username} srcUrl={user?.avatarUrl ?? null} />
 			</div>
 		{/snippet}
 

--- a/packages/ui/src/lib/components/avatar/Avatar.svelte
+++ b/packages/ui/src/lib/components/avatar/Avatar.svelte
@@ -22,26 +22,6 @@
 		tooltipPosition,
 		size = 'small'
 	}: Props = $props();
-
-	const shouldShowImage = $derived(!!srcUrl && !hasError);
-
-	// Reset error state when srcUrl changes
-	$effect(() => {
-		if (srcUrl) {
-			hasError = false;
-			isLoaded = false;
-		}
-	});
-
-	// Extract initials from name (first letter of each word, max 2 letters)
-	function getInitials(name: string): string {
-		if (!name) return '';
-		return name
-			.split(' ')
-			.map((word) => word.charAt(0).toUpperCase())
-			.join('')
-			.slice(0, 2);
-	}
 </script>
 
 <Tooltip text={tooltip ?? username} align={tooltipAlign} position={tooltipPosition}>

--- a/packages/ui/src/lib/components/avatar/Avatar.svelte
+++ b/packages/ui/src/lib/components/avatar/Avatar.svelte
@@ -3,16 +3,13 @@
 	import { stringToColor } from '$lib/utils/stringToColor';
 
 	interface Props {
-		srcUrl?: string | null;
+		srcUrl: string | null;
 		username: string;
 		tooltip?: string;
 		tooltipAlign?: TooltipAlign;
 		tooltipPosition?: TooltipPosition;
 		size?: 'small' | 'medium' | 'large';
 	}
-
-	let isLoaded = $state(false);
-	let hasError = $state(false);
 
 	const {
 		srcUrl,
@@ -29,19 +26,8 @@
 		class="image-wrapper {size}"
 		style:background-color={stringToColor(username || srcUrl || undefined)}
 	>
-		{#if shouldShowImage}
-			<img
-				class="avatar"
-				alt={tooltip}
-				src={srcUrl}
-				loading="lazy"
-				onload={() => (isLoaded = true)}
-				onerror={() => (hasError = true)}
-				class:show={isLoaded}
-			/>
-		{/if}
-		{#if !shouldShowImage}
-			<span class="initials">{getInitials(username)}</span>
+		{#if srcUrl}
+			<img class="avatar" alt={tooltip} src={srcUrl} loading="lazy" />
 		{/if}
 	</div>
 </Tooltip>
@@ -85,26 +71,5 @@
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		opacity: 0;
-	}
-
-	.show {
-		opacity: 1;
-	}
-
-	.initials {
-		font-weight: 500;
-		font-size: 8px;
-		line-height: 1;
-		text-align: center;
-		user-select: none;
-	}
-
-	.medium .initials {
-		font-size: 10px;
-	}
-
-	.large .initials {
-		font-size: 14px;
 	}
 </style>


### PR DESCRIPTION
Remove obsolete reactive variables and helper functions from the Avatar
component:
- delete shouldShowImage derived boolean
- remove effect that reset hasError/isLoaded on srcUrl changes
- remove getInitials helper that computed initials from name

These pieces were unused in the current component implementation and
removed to simplify the component, reduce unnecessary reactivity, and
improve maintainability.