### PR TITLE
id: use `<commit>:<index|filename>` for committed files

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -34,8 +34,7 @@ pub(crate) fn handle(
     source: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
     let source: Option<CliId> = source
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -72,8 +72,7 @@ pub fn handle(
             branch_name,
             anchor,
         }) => {
-            let mut id_map = IdMap::new_from_context(ctx, None)?;
-            id_map.add_committed_file_info_from_context(ctx)?;
+            let id_map = IdMap::new_from_context(ctx, None)?;
             // Get branch name or use canned name
             let branch_name = branch_name.map(Ok).unwrap_or_else(|| {
                 but_api::legacy::workspace::canned_branch_name(ctx.legacy_project.id)
@@ -86,7 +85,7 @@ pub fn handle(
                 // Use the new create_reference API when anchor is provided
 
                 // Resolve the anchor string to a CliId
-                let anchor_ids = id_map.resolve_entity_to_ids(&anchor_str)?;
+                let anchor_ids = id_map.parse_using_context(&anchor_str, ctx)?;
                 if anchor_ids.is_empty() {
                     return Err(anyhow::anyhow!("Could not find anchor: {}", anchor_str));
                 }

--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -14,12 +14,11 @@ pub fn handle(
     target_str: Option<&str>,
 ) -> anyhow::Result<()> {
     let wt_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
-    let mut id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
 
     if let Some(entity) = target_str {
         let id = id_map
-            .resolve_entity_to_ids(entity)? // TODO: look up plain names
+            .parse_using_context(entity, ctx)? // TODO: look up plain names
             .first() // TODO: handle ambiguity
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("No ID found for entity"))?;

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -20,8 +20,7 @@ use crate::{CliId, IdMap, command::legacy::rub::parse_sources, utils::OutputChan
 /// The ID should be a file or hunk ID as shown in `but status`.
 pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()> {
     // Build ID map to resolve the user's ID
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve the ID to get file information
     let resolved_ids = parse_sources(ctx, &id_map, id)

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -154,10 +154,9 @@ fn get_branches_without_prs(
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let mut id_map = IdMap::new_from_context(&mut ctx, None)?;
-    id_map.add_committed_file_info_from_context(&mut ctx)?;
+    let id_map = IdMap::new_from_context(&mut ctx, None)?;
     let branch_ids = id_map
-        .resolve_entity_to_ids(branch_id)?
+        .parse_using_context(branch_id, &mut ctx)?
         .iter()
         .filter_map(|clid| match clid {
             CliId::Branch { name, .. } => Some(name.clone()),

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -14,9 +14,8 @@ pub(crate) fn handle(
     target_str: &str,
     delete: bool,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
-    let target_result = id_map.resolve_entity_to_ids(target_str)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
+    let target_result = id_map.parse_using_context(target_str, ctx)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(
             "Target {} is ambiguous: {:?}",

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -12,11 +12,10 @@ pub async fn handle(
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
 
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve the branch ID
-    let resolved_ids = id_map.resolve_entity_to_ids(branch_id)?;
+    let resolved_ids = id_map.parse_using_context(branch_id, ctx)?;
     if resolved_ids.is_empty() {
         bail!("Could not find branch: {}", branch_id);
     }

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -45,8 +45,7 @@ pub fn handle(
     ctx: &mut Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Check gerrit mode early
     let gerrit_mode = {
@@ -168,8 +167,7 @@ fn handle_dry_run(
     // Filter based on branch_id if provided
     let branches_to_show: Vec<_> = if let Some(branch_id) = branch_id {
         // Resolve branch name
-        let mut id_map = IdMap::new_from_context(ctx, None)?;
-        id_map.add_committed_file_info_from_context(ctx)?;
+        let id_map = IdMap::new_from_context(ctx, None)?;
         let branch_name = resolve_branch_name(ctx, &id_map, branch_id)?;
 
         branches_with_info
@@ -1043,7 +1041,7 @@ fn resolve_branch_name(
     branch_id: &str,
 ) -> anyhow::Result<String> {
     // Try to resolve as CliId first
-    let cli_ids = id_map.resolve_entity_to_ids(branch_id)?;
+    let cli_ids = id_map.parse_using_context(branch_id, ctx)?;
 
     if cli_ids.is_empty() {
         // If no CliId matches, treat as literal branch name but validate it exists

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -54,7 +54,7 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve the commit ID using the IdMap
-    let matches = id_map.resolve_entity_to_ids(commit_id_str)?;
+    let matches = id_map.parse_using_context(commit_id_str, ctx)?;
 
     if matches.is_empty() {
         bail!(

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -14,11 +14,10 @@ pub(crate) fn reword_target(
     message: Option<&str>,
     format: bool,
 ) -> Result<()> {
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve the commit ID
-    let cli_ids = id_map.resolve_entity_to_ids(target)?;
+    let cli_ids = id_map.parse_using_context(target, ctx)?;
 
     if cli_ids.is_empty() {
         bail!("ID '{}' not found", target);

--- a/crates/but/src/command/legacy/rub/move.rs
+++ b/crates/but/src/command/legacy/rub/move.rs
@@ -105,7 +105,7 @@ pub(crate) fn handle(
     let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve source
-    let source_matches = id_map.resolve_entity_to_ids(source_str)?;
+    let source_matches = id_map.parse_using_context(source_str, ctx)?;
     if source_matches.is_empty() {
         bail!(
             "Source '{}' not found. If you just performed a Git operation, try running 'but status' to refresh.",
@@ -122,7 +122,7 @@ pub(crate) fn handle(
     let source_id = &source_matches[0];
 
     // Resolve target
-    let target_matches = id_map.resolve_entity_to_ids(target_str)?;
+    let target_matches = id_map.parse_using_context(target_str, ctx)?;
     if target_matches.is_empty() {
         bail!(
             "Target '{}' not found. If you just performed a Git operation, try running 'but status' to refresh.",

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -46,10 +46,9 @@ pub(crate) fn show_commit(
 
     // Not a branch, proceed with commit logic
     // Try to resolve the commit ID through the IdMap
-    let mut id_map = IdMap::new_from_context(ctx, None)?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new_from_context(ctx, None)?;
 
-    let cli_ids = id_map.resolve_entity_to_ids(commit_id_str)?;
+    let cli_ids = id_map.parse_using_context(commit_id_str, ctx)?;
 
     let commit_id = if cli_ids.is_empty() {
         // If not found in IdMap, try to parse as a git commit ID directly

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -128,8 +128,7 @@ pub(crate) async fn worktree(
 
     let worktree_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
 
-    let mut id_map = IdMap::new(head_info.stacks, worktree_changes.assignments.clone())?;
-    id_map.add_committed_file_info_from_context(ctx)?;
+    let id_map = IdMap::new(head_info.stacks, worktree_changes.assignments.clone())?;
 
     let stacks = &id_map.stacks;
     // Store the count of stacks for hint logic later
@@ -702,7 +701,7 @@ pub fn print_group(
                 print_commit(
                     commit.short_id.clone(),
                     &commit.inner.inner,
-                    CommitChanges::Workspace(&commit.tree_changes),
+                    CommitChanges::Workspace(&commit.tree_changes_using_repo(&repo)?),
                     classification,
                     marked,
                     show_files,

--- a/crates/but/src/id/file_info.rs
+++ b/crates/but/src/id/file_info.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use bstr::BString;
 
@@ -10,34 +10,19 @@ pub(crate) struct FileInfo {
     // filename) pair even though it's not supposed to happen. (This is why
     // there's a Vec in the definition of `changes` below.) Make sure that this
     // does not happen (possibly by tightening the types involved).
-    /// Tree changes indexed by commit ID then filename.
-    pub(crate) changes: HashMap<gix::ObjectId, BTreeMap<BString, Vec<but_core::TreeChange>>>,
+    /// Tree changes indexed by filename.
+    pub(crate) changes: BTreeMap<BString, Vec<but_core::TreeChange>>,
 }
 
 impl FileInfo {
-    /// Extracts file information from workspace commits and worktree status.
-    ///
-    /// This function processes workspace commits to find all changed files in each commit.
-    pub(crate) fn from_workspace_commits_and_status<'a, F>(
-        workspace_commit_and_first_parent_ids: impl Iterator<
-            Item = (&'a gix::ObjectId, &'a Option<gix::ObjectId>),
-        >,
-        mut changes_fn: F,
-    ) -> anyhow::Result<Self>
-    where
-        F: FnMut(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<but_core::TreeChange>>,
-    {
-        let mut changes: HashMap<gix::ObjectId, BTreeMap<BString, Vec<but_core::TreeChange>>> =
-            HashMap::new();
-        for (commit_id, parent_id) in workspace_commit_and_first_parent_ids {
-            let paths_to_changes = changes.entry(*commit_id).or_default();
+    /// Extracts file information from tree changes.
+    pub(crate) fn from_tree_changes(
+        tree_changes: Vec<but_core::TreeChange>,
+    ) -> anyhow::Result<Self> {
+        let mut changes: BTreeMap<BString, Vec<but_core::TreeChange>> = BTreeMap::new();
 
-            for change in changes_fn(*commit_id, *parent_id)? {
-                paths_to_changes
-                    .entry(change.path.clone())
-                    .or_default()
-                    .push(change);
-            }
+        for change in tree_changes {
+            changes.entry(change.path.clone()).or_default().push(change);
         }
         Ok(Self { changes })
     }

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -24,7 +24,6 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 .map(|commit| WorkspaceCommitWithId {
                     short_id: ShortId::default(),
                     inner: commit,
-                    tree_changes: Vec::new(),
                 })
                 .collect::<Vec<_>>();
             let remote_commits = std::mem::take(&mut segment.commits_on_remote)

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -293,20 +293,20 @@ k0 a.txt│
 ┊
 ┊╭┄g0 [A]  
 ┊●   a7aa4ef partial change to a.txt 3  
-┊│     n0 M a.txt
+┊│     a7:0 M a.txt
 ┊●   889385c partial change to a.txt 2  
-┊│     o0 M a.txt
+┊│     88:0 M a.txt
 ┊●   8dc39e0 partial change to a.txt 1  
-┊│     p0 M a.txt
+┊│     8d:0 M a.txt
 ┊●   f4ea7f8 a.txt  
-┊│     q0 A a.txt
+┊│     f4:0 A a.txt
 ┊●   9477ae7 add A  
-┊│     r0 A A
+┊│     94:0 A A
 ├╯
 ┊
 ┊╭┄h0 [B]  
 ┊●   d3e2ba3 add B  
-┊│     s0 A B
+┊│     d3:0 A B
 ├╯
 ┊
 ┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 
@@ -345,20 +345,20 @@ Hint: you can run `but undo` to undo these changes
 ┊
 ┊╭┄g0 [A]  
 ┊●   4822140 partial change to a.txt 3  
-┊│     k0 M a.txt
+┊│     48:0 M a.txt
 ┊●   4593422 partial change to a.txt 2  
-┊│     l0 M a.txt
+┊│     45:0 M a.txt
 ┊●   8dc39e0 partial change to a.txt 1  
-┊│     m0 M a.txt
+┊│     8d:0 M a.txt
 ┊●   f4ea7f8 a.txt  
-┊│     n0 A a.txt
+┊│     f4:0 A a.txt
 ┊●   9477ae7 add A  
-┊│     o0 A A
+┊│     94:0 A A
 ├╯
 ┊
 ┊╭┄h0 [B]  
 ┊●   d3e2ba3 add B  
-┊│     p0 A B
+┊│     d3:0 A B
 ├╯
 ┊
 ┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -130,12 +130,12 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "k0",
+                  "cliId": "e8:0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "l0",
+                  "cliId": "e8:1",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -145,12 +145,12 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "m0",
+                  "cliId": "fc:0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "n0",
+                  "cliId": "fc:1",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -160,7 +160,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "o0",
+                  "cliId": "94:0",
                   "filePath": "A",
                   "changeType": "added"
                 }
@@ -170,7 +170,7 @@ fn committed_file_to_unassigned() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("n0 zz")
+    env.but("fc:1 zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -207,7 +207,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "m0",
+                  "cliId": "1e:0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }
@@ -217,7 +217,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "n0",
+                  "cliId": "99:0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 }
@@ -227,7 +227,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "o0",
+                  "cliId": "94:0",
                   "filePath": "A",
                   "changeType": "added"
                 }
@@ -245,7 +245,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "p0",
+                  "cliId": "d3:0",
                   "filePath": "B",
                   "changeType": "added"
                 }

--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -49,7 +49,7 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="underline">j0</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
+    <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="underline">64:0</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -252,12 +252,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "p0",
+                  "cliId": "44:0",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "q0",
+                  "cliId": "44:1",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -267,12 +267,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 ...
               "changes": [
                 {
-                  "cliId": "r0",
+                  "cliId": "49:0",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "s0",
+                  "cliId": "49:1",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }


### PR DESCRIPTION
This improves performance when not all files of all workspace commits need their CLI IDs computed.
