### PR TITLE
Enter API key

### DIFF
--- a/apps/desktop/src/components/GeneralSettingsModalContent.svelte
+++ b/apps/desktop/src/components/GeneralSettingsModalContent.svelte
@@ -30,7 +30,7 @@
 	const user = userService.user;
 	const urlService = inject(URL_SERVICE);
 
-	let currentSelectedId = $state(data.selectedId || generalSettingsPages[0]!.id);
+	let currentSelectedId = $derived(data.selectedId || generalSettingsPages[0]!.id);
 
 	function selectPage(pageId: GeneralSettingsPageId) {
 		currentSelectedId = pageId;
@@ -40,7 +40,7 @@
 <SettingsModalLayout
 	title="Global settings"
 	pages={generalSettingsPages}
-	selectedId={data.selectedId}
+	selectedId={currentSelectedId}
 	isAdmin={$user?.role === 'admin'}
 	onSelectPage={selectPage}
 >

--- a/apps/desktop/src/components/GeneralSettingsModalContent.svelte
+++ b/apps/desktop/src/components/GeneralSettingsModalContent.svelte
@@ -10,11 +10,14 @@
 	import OrganisationSettings from '$components/profileSettings/OrganisationSettings.svelte';
 	import TelemetrySettings from '$components/profileSettings/TelemetrySettings.svelte';
 	import AppearanceSettings from '$components/projectSettings/AppearanceSettings.svelte';
+	import {
+		generalSettingsPages,
+		type GeneralSettingsPageId
+	} from '$lib/settings/generalSettingsPages';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { URL_SERVICE } from '$lib/utils/url';
 	import { inject } from '@gitbutler/core/context';
 	import { Icon } from '@gitbutler/ui';
-	import iconsJson from '@gitbutler/ui/data/icons.json';
 	import type { GeneralSettingsModalState } from '$lib/state/uiState.svelte';
 
 	type Props = {
@@ -27,65 +30,16 @@
 	const user = userService.user;
 	const urlService = inject(URL_SERVICE);
 
-	const pages = [
-		{
-			id: 'general',
-			label: 'General',
-			icon: 'settings' as keyof typeof iconsJson
-		},
-		{
-			id: 'appearance',
-			label: 'Appearance',
-			icon: 'appearance' as keyof typeof iconsJson
-		},
-		{
-			id: 'lanes-and-branches',
-			label: 'Lanes & branches',
-			icon: 'lanes' as keyof typeof iconsJson
-		},
-		{
-			id: 'git',
-			label: 'Git stuff',
-			icon: 'git' as keyof typeof iconsJson
-		},
-		{
-			id: 'integrations',
-			label: 'Integrations',
-			icon: 'integrations' as keyof typeof iconsJson
-		},
-		{
-			id: 'ai',
-			label: 'AI Options',
-			icon: 'ai' as keyof typeof iconsJson
-		},
-		{
-			id: 'telemetry',
-			label: 'Telemetry',
-			icon: 'stat' as keyof typeof iconsJson
-		},
-		{
-			id: 'experimental',
-			label: 'Experimental',
-			icon: 'idea' as keyof typeof iconsJson
-		},
-		{
-			id: 'organizations',
-			label: 'Organizations',
-			icon: 'idea' as keyof typeof iconsJson,
-			adminOnly: true
-		}
-	];
+	let currentSelectedId = $state(data.selectedId || generalSettingsPages[0]!.id);
 
-	let currentSelectedId = $state(data.selectedId || pages[0]!.id);
-
-	function selectPage(pageId: string) {
+	function selectPage(pageId: GeneralSettingsPageId) {
 		currentSelectedId = pageId;
 	}
 </script>
 
 <SettingsModalLayout
 	title="Global settings"
-	{pages}
+	pages={generalSettingsPages}
 	selectedId={data.selectedId}
 	isAdmin={$user?.role === 'admin'}
 	onSelectPage={selectPage}

--- a/apps/desktop/src/components/LoginButtons.svelte
+++ b/apps/desktop/src/components/LoginButtons.svelte
@@ -3,65 +3,18 @@
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
 	import { Button } from '@gitbutler/ui';
-	import { writable } from 'svelte/store';
 
 	const userService = inject(USER_SERVICE);
-	const loading = userService.loading;
 	const posthog = inject(POSTHOG_WRAPPER);
-
-	const aborted = writable(false);
-
-	let showAbort = $state(false);
-	let abortTimer: ReturnType<typeof setTimeout> | null = null;
-
-	// Watch for loading state changes
-	$effect(() => {
-		if ($loading) {
-			// Start timer when loading begins
-			abortTimer = setTimeout(() => {
-				showAbort = true;
-			}, 7000);
-		} else {
-			// Clear timer and hide abort button when loading stops
-			if (abortTimer) {
-				clearTimeout(abortTimer);
-				abortTimer = null;
-			}
-			showAbort = false;
-		}
-
-		// Cleanup function
-		return () => {
-			if (abortTimer) {
-				clearTimeout(abortTimer);
-				abortTimer = null;
-			}
-		};
-	});
 </script>
 
-{#if !showAbort}
-	<Button
-		style="pop"
-		loading={$loading}
-		icon="signin"
-		onclick={async () => {
-			$aborted = false;
-			posthog.captureOnboarding(OnboardingEvent.LoginGitButler);
-			await userService.login(aborted);
-		}}
-	>
-		Sign up or Log in
-	</Button>
-{:else}
-	<Button
-		kind="outline"
-		onclick={() => {
-			$aborted = true;
-			posthog.captureOnboarding(OnboardingEvent.CancelLoginGitButler);
-		}}
-		loading={$aborted}
-	>
-		Cancel login
-	</Button>
-{/if}
+<Button
+	style="pop"
+	icon="signin"
+	onclick={async () => {
+		posthog.captureOnboarding(OnboardingEvent.LoginGitButler);
+		await userService.openLoginPage();
+	}}
+>
+	Sign up or Log in
+</Button>

--- a/apps/desktop/src/components/LoginButtons.svelte
+++ b/apps/desktop/src/components/LoginButtons.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
-	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
-	import { USER_SERVICE } from '$lib/user/userService';
-	import { inject } from '@gitbutler/core/context';
+	import { useSettingsModal } from '$lib/settings/settingsModal.svelte';
 	import { Button } from '@gitbutler/ui';
 
-	const userService = inject(USER_SERVICE);
-	const posthog = inject(POSTHOG_WRAPPER);
+	const { openGeneralSettings } = useSettingsModal();
 </script>
 
 <Button
 	style="pop"
 	icon="signin"
 	onclick={async () => {
-		posthog.captureOnboarding(OnboardingEvent.LoginGitButler);
-		await userService.openLoginPage();
+		openGeneralSettings('general');
 	}}
 >
-	Sign up or Log in
+	Go to Settings
 </Button>

--- a/apps/desktop/src/components/ProjectSettingsModalContent.svelte
+++ b/apps/desktop/src/components/ProjectSettingsModalContent.svelte
@@ -6,7 +6,10 @@
 	import AgentSettings from '$components/projectSettings/AgentSettings.svelte';
 	import GeneralSettings from '$components/projectSettings/GeneralSettings.svelte';
 	import { projectDisableCodegen } from '$lib/config/config';
-	import iconsJson from '@gitbutler/ui/data/icons.json';
+	import {
+		projectSettingsPages,
+		type ProjectSettingsPageId
+	} from '$lib/settings/projectSettingsPages';
 	import type { ProjectSettingsModalState } from '$lib/state/uiState.svelte';
 
 	type Props = {
@@ -16,41 +19,13 @@
 	const { data }: Props = $props();
 
 	const codegenDisabled = $derived(projectDisableCodegen(data.projectId));
-
-	const allPages = [
-		{
-			id: 'project',
-			label: 'Project',
-			icon: 'profile' as keyof typeof iconsJson
-		},
-		{
-			id: 'git',
-			label: 'Git stuff',
-			icon: 'git' as keyof typeof iconsJson
-		},
-		{
-			id: 'ai',
-			label: 'AI options',
-			icon: 'ai' as keyof typeof iconsJson
-		},
-		{
-			id: 'agent',
-			label: 'Agent',
-			icon: 'ai-agent' as keyof typeof iconsJson,
-			requireCodegen: true
-		},
-		{
-			id: 'experimental',
-			label: 'Experimental',
-			icon: 'idea' as keyof typeof iconsJson
-		}
-	];
-
-	const pages = $derived(allPages.filter((page) => !page.requireCodegen || !$codegenDisabled));
+	const pages = $derived(
+		projectSettingsPages.filter((page) => page.id !== 'agent' || !$codegenDisabled)
+	);
 
 	let currentSelectedId = $derived(data.selectedId || pages.at(0)?.id);
 
-	function selectPage(pageId: string) {
+	function selectPage(pageId: ProjectSettingsPageId) {
 		currentSelectedId = pageId;
 	}
 </script>

--- a/apps/desktop/src/components/ProjectSettingsModalContent.svelte
+++ b/apps/desktop/src/components/ProjectSettingsModalContent.svelte
@@ -33,7 +33,7 @@
 <SettingsModalLayout
 	title="Project settings"
 	{pages}
-	selectedId={data.selectedId}
+	selectedId={currentSelectedId}
 	onSelectPage={selectPage}
 >
 	{#snippet content({ currentPage })}

--- a/apps/desktop/src/components/SettingsModalLayout.svelte
+++ b/apps/desktop/src/components/SettingsModalLayout.svelte
@@ -21,7 +21,7 @@
 	type Props = {
 		title: string;
 		pages: readonly T[];
-		selectedId?: string;
+		selectedId?: PageId;
 		isAdmin?: boolean;
 		onSelectPage: (pageId: PageId) => void;
 		content: Snippet<[{ currentPage: Page | undefined }]>;
@@ -30,7 +30,7 @@
 
 	const { title, pages, selectedId, isAdmin, onSelectPage, content, footer }: Props = $props();
 
-	let currentSelectedId = $state(selectedId || pages[0]?.id || '');
+	let currentSelectedId = $derived(selectedId || pages[0]?.id || '');
 	const currentPage = $derived(pages.find((p) => p.id === currentSelectedId));
 	let scrollableContainer: ConfigurableScrollableContainer;
 

--- a/apps/desktop/src/components/SettingsModalLayout.svelte
+++ b/apps/desktop/src/components/SettingsModalLayout.svelte
@@ -1,24 +1,29 @@
-<script lang="ts">
-	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
-	import { Icon } from '@gitbutler/ui';
+<script lang="ts" module>
 	import iconsJson from '@gitbutler/ui/data/icons.json';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
-	import { type Snippet } from 'svelte';
-
-	type Page = {
+	// This module script is necessary to make Svelte recognize the generics in the component
+	export type Page = {
 		id: string;
 		label: string;
 		icon: keyof typeof iconsJson;
 		adminOnly?: boolean;
 		[key: string]: any; // Allow additional properties for flexibility
 	};
+</script>
+
+<script lang="ts" generics="T extends Page">
+	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
+	import { Icon } from '@gitbutler/ui';
+	import { focusable } from '@gitbutler/ui/focus/focusable';
+	import { type Snippet } from 'svelte';
+
+	type PageId = T['id'];
 
 	type Props = {
 		title: string;
-		pages: Page[];
+		pages: readonly T[];
 		selectedId?: string;
 		isAdmin?: boolean;
-		onSelectPage: (pageId: string) => void;
+		onSelectPage: (pageId: PageId) => void;
 		content: Snippet<[{ currentPage: Page | undefined }]>;
 		footer?: Snippet;
 	};

--- a/apps/desktop/src/components/WelcomeSigninAction.svelte
+++ b/apps/desktop/src/components/WelcomeSigninAction.svelte
@@ -2,102 +2,76 @@
 	import signinSvg from '$lib/assets/signin.svg?raw';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
-	import { AsyncButton, Button, CardGroup } from '@gitbutler/ui';
-
-	import { writable } from 'svelte/store';
-
-	const aborted = writable(false);
-	let cancelClicked = $state(false);
-	let showCancel = $state(false);
+	import { Button, CardGroup, Textbox } from '@gitbutler/ui';
 
 	const userService = inject(USER_SERVICE);
-	const loading = userService.loading;
 	const user = userService.user;
+
+	let accessToken = $state('');
 </script>
 
 {#if !$user}
 	<CardGroup>
-		<section class="welcome-signin-action">
-			<div class="stack-v gap-8">
-				<h3 class="text-18 text-bold">Log in or Sign up</h3>
+		<CardGroup.Item>
+			{#snippet title()}
+				<h3 class="text-18 text-bold">Access Token</h3>
+			{/snippet}
+			<p class="text-12 text-body clr-text-2">
+				An access token is required to use GitButler's smart automation features, including
+				intelligent branch creation and commit message generation.
+			</p>
+			<Textbox
+				size="large"
+				type="password"
+				value={accessToken}
+				placeholder="************************"
+				oninput={(value) => (accessToken = value)}
+			/>
+			<Button
+				style="pop"
+				disabled={accessToken.trim().length === 0}
+				onclick={async () => {
+					await userService.setUserAccessToken(accessToken.trim());
+					accessToken = '';
+				}}>Save Access Token</Button
+			>
+		</CardGroup.Item>
+		<CardGroup.Item>
+			{#snippet title()}
+				<h3 class="text-18 text-bold">Get an Access Token</h3>
+			{/snippet}
+			{#snippet caption()}
 				<p class="text-12 text-body clr-text-2">
-					Log in to access smart automation features, including intelligent branch creation and
-					commit message generation.
+					No Access Token? No problem! Sign up or log in to GitButler to generate your personal
+					access token and unlock
 				</p>
-
 				<div class="flex gap-8 m-t-8">
-					{#if !showCancel}
-						<Button
-							style="pop"
-							loading={$loading}
-							onclick={async () => {
-								$aborted = false;
-								cancelClicked = false;
-								showCancel = false;
+					<Button
+						style="pop"
+						onclick={async () => {
+							await userService.openLoginPage();
+						}}>Log in / Sign up</Button
+					>
 
-								// Show cancel button after 3 seconds
-								setTimeout(() => {
-									if ($loading) {
-										showCancel = true;
-									}
-								}, 6000);
-
-								// TODO: Track login calls
-								await userService.login(aborted);
-							}}>Log in / Sign up</Button
-						>
-					{/if}
-
-					{#if $loading && showCancel}
-						<AsyncButton
-							icon="spinner"
-							kind="outline"
-							disabled={cancelClicked}
-							action={async () => {
-								if (cancelClicked) return;
-								cancelClicked = true;
-								showCancel = false;
-								$aborted = true;
-							}}>Cancel</AsyncButton
-						>
-					{/if}
 					<Button
 						kind="outline"
 						icon="copy-small"
-						disabled={$loading}
 						onclick={async () => {
-							$aborted = false;
-							cancelClicked = false;
-							showCancel = false;
-
-							// Show cancel button after 3 seconds
-							setTimeout(() => {
-								if ($loading) {
-									showCancel = true;
-								}
-							}, 3000);
-
-							await userService.loginAndCopyLink(aborted);
+							await userService.copyLoginPageLink();
 						}}>Copy login link</Button
 					>
 				</div>
-			</div>
-
-			<div class="signin-svg">
-				{@html signinSvg}
-			</div>
-		</section>
+			{/snippet}
+			{#snippet actions()}
+				<div class="signin-svg">
+					{@html signinSvg}
+				</div>
+			{/snippet}
+		</CardGroup.Item>
 	</CardGroup>
 {/if}
 
 <style lang="postcss">
-	.welcome-signin-action {
-		display: flex;
-		flex-direction: row;
-		padding: 16px;
-		gap: 20px;
-	}
-
 	.signin-svg {
 		flex-shrink: 0;
 		width: 100px;

--- a/apps/desktop/src/components/WelcomeSigninAction.svelte
+++ b/apps/desktop/src/components/WelcomeSigninAction.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import signinSvg from '$lib/assets/signin.svg?raw';
+	import signinSvg from '$lib/assets/token.svg?raw';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
-	import { Button, CardGroup, Textbox } from '@gitbutler/ui';
+	import { Button, CardGroup, Textbox, Spacer } from '@gitbutler/ui';
 
 	const userService = inject(USER_SERVICE);
 	const user = userService.user;
@@ -11,43 +11,24 @@
 </script>
 
 {#if !$user}
-	<CardGroup>
-		<CardGroup.Item>
-			{#snippet title()}
-				<h3 class="text-18 text-bold">Access Token</h3>
-			{/snippet}
-			<p class="text-12 text-body clr-text-2">
-				An access token is required to use GitButler's smart automation features, including
-				intelligent branch creation and commit message generation.
-			</p>
-			<Textbox
-				size="large"
-				type="password"
-				value={accessToken}
-				placeholder="************************"
-				oninput={(value) => (accessToken = value)}
-			/>
-			<Button
-				style="pop"
-				disabled={accessToken.trim().length === 0}
-				onclick={async () => {
-					await userService.setUserAccessToken(accessToken.trim());
-					accessToken = '';
-				}}>Save Access Token</Button
-			>
-		</CardGroup.Item>
-		<CardGroup.Item>
-			{#snippet title()}
-				<h3 class="text-18 text-bold">Get an Access Token</h3>
-			{/snippet}
-			{#snippet caption()}
+	<!-- <CardGroup> -->
+	<CardGroup.Item standalone>
+		<div class="token-content">
+			<div class="token-svg">
+				{@html signinSvg}
+			</div>
+
+			<div class="info-section">
+				<h2 class="text-15 text-bold m-b-6">Access token</h2>
+
 				<p class="text-12 text-body clr-text-2">
-					No Access Token? No problem! Sign up or log in to GitButler to generate your personal
-					access token and unlock
+					Sign in to GitButler to get your personal access token.
 				</p>
-				<div class="flex gap-8 m-t-8">
+
+				<div class="flex gap-8 m-t-12">
 					<Button
 						style="pop"
+						icon="signin"
 						onclick={async () => {
 							await userService.openLoginPage();
 						}}>Log in / Sign up</Button
@@ -61,22 +42,62 @@
 						}}>Copy login link</Button
 					>
 				</div>
-			{/snippet}
-			{#snippet actions()}
-				<div class="signin-svg">
-					{@html signinSvg}
+
+				<Spacer dotted margin={16} />
+
+				<div class="token-fields">
+					<Textbox
+						size="large"
+						type="password"
+						value={accessToken}
+						placeholder="•••••••••••••••••••••••••"
+						oninput={(value) => (accessToken = value)}
+					/>
+					<Button
+						style="pop"
+						disabled={accessToken.trim().length === 0}
+						onclick={async () => {
+							await userService.setUserAccessToken(accessToken.trim());
+							accessToken = '';
+						}}>Authorize access token</Button
+					>
 				</div>
-			{/snippet}
-		</CardGroup.Item>
-	</CardGroup>
+
+				<p class="text-12 text-body clr-text-2 m-t-16">
+					An access token is required to use GitButler's smart automation features, including
+					intelligent branch creation and commit message generation.
+				</p>
+			</div>
+		</div>
+	</CardGroup.Item>
 {/if}
 
 <style lang="postcss">
-	.signin-svg {
+	.token-svg {
+		display: flex;
 		flex-shrink: 0;
-		width: 100px;
-		height: 70px;
+		align-items: center;
+		justify-content: center;
+		width: 110px;
+		height: 100px;
 		border-radius: var(--radius-m);
 		background-color: var(--clr-art-scene-bg);
+	}
+
+	.token-content {
+		display: flex;
+		gap: 24px;
+	}
+
+	.info-section {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+	}
+
+	.token-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
 	}
 </style>

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -120,8 +120,7 @@
 		try {
 			await settingsService.deleteAllData();
 			projectsService.unsetLastOpenedProject();
-			await userService.logout();
-			// TODO: Delete user from observable!!!
+			await userService.forgetUserCredentials();
 			chipToasts.success('All data deleted');
 			goto('/', { replaceState: true, invalidateAll: true });
 		} catch (err: any) {
@@ -159,18 +158,18 @@
 	<CardGroup>
 		<CardGroup.Item>
 			{#snippet title()}
-				Signing out
+				Forget credentials and log out
 			{/snippet}
 			{#snippet caption()}
-				Ready to take a break? Click here to log out and unwind.
+				Ready to take a break? Click here to clear your credentials and unwind.
 			{/snippet}
 			{#snippet actions()}
 				<Button
 					kind="outline"
 					icon="signout"
 					onclick={async () => {
-						await userService.logout();
-					}}>Log out</Button
+						await userService.forgetUserCredentials();
+					}}>Forget credentials</Button
 				>
 			{/snippet}
 		</CardGroup.Item>

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -161,7 +161,7 @@
 				Forget credentials and log out
 			{/snippet}
 			{#snippet caption()}
-				Ready to take a break? Click here to clear your credentials and unwind.
+				Click here to clear your credentials and unwind.
 			{/snippet}
 			{#snippet actions()}
 				<Button

--- a/apps/desktop/src/lib/assets/token.svg
+++ b/apps/desktop/src/lib/assets/token.svg
@@ -1,0 +1,20 @@
+<svg width="81" height="51" viewBox="0 0 81 51" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M59.7 0.600342C70.8009 0.600342 79.7996 9.59903 79.7996 20.7C79.7996 31.8009 70.8009 40.7996 59.7 40.7996H20.7C9.59909 40.7996 0.600403 31.8009 0.600403 20.7C0.600403 9.59903 9.59909 0.600342 20.7 0.600342H59.7Z"
+    fill="var(--clr-art-scene-fill)" stroke="var(--clr-art-scene-outline)" stroke-width="1.2" />
+  <path opacity="0.4"
+    d="M13.9333 26.2L18.7 19.9241M18.7 19.9241L23.4667 26.2M18.7 19.9241L25.2 18.131M18.7 19.9241L12.2 18.131M18.7 19.9241V13.2"
+    stroke="var(--clr-art-scene-outline)" stroke-width="3" />
+  <path opacity="0.4"
+    d="M31.9333 26.2L36.7 19.9241M36.7 19.9241L41.4667 26.2M36.7 19.9241L43.2 18.131M36.7 19.9241L30.2 18.131M36.7 19.9241V13.2"
+    stroke="var(--clr-art-scene-outline)" stroke-width="3" />
+  <path opacity="0.4" d="M49.9333 26.2L54.7 19.9241M54.7 19.9241L48.2 18.131M54.7 19.9241V13.2"
+    stroke="var(--clr-art-scene-outline)" stroke-width="3" />
+  <path d="M72.2 35.2V27.2C72.2 23.334 69.066 20.2 65.2 20.2C61.334 20.2 58.2 23.334 58.2 27.2V35.2"
+    stroke="var(--clr-art-scene-outline)" stroke-width="4" />
+  <rect x="50.6" y="31.6" width="29.2" height="18.2" fill="var(--clr-art-scene-fill)"
+    stroke="var(--clr-art-scene-outline)" stroke-width="1.2" />
+  <path fill-rule="evenodd" clip-rule="evenodd"
+    d="M64.5478 36.2C63.2512 36.2 62.2 37.2666 62.2 38.5823C62.2 39.6734 62.9228 40.5932 63.9091 40.8754L62.9826 45.2H67.4174L66.4909 40.8754C67.4772 40.5932 68.2 39.6734 68.2 38.5823C68.2 37.2666 67.1489 36.2 65.8522 36.2H64.5478Z"
+    fill="var(--clr-art-scene-outline)" />
+</svg>

--- a/apps/desktop/src/lib/settings/generalSettingsPages.ts
+++ b/apps/desktop/src/lib/settings/generalSettingsPages.ts
@@ -1,0 +1,53 @@
+import iconsJson from '@gitbutler/ui/data/icons.json';
+
+export const generalSettingsPages = [
+	{
+		id: 'general',
+		label: 'General',
+		icon: 'settings' as keyof typeof iconsJson
+	},
+	{
+		id: 'appearance',
+		label: 'Appearance',
+		icon: 'appearance' as keyof typeof iconsJson
+	},
+	{
+		id: 'lanes-and-branches',
+		label: 'Lanes & branches',
+		icon: 'lanes' as keyof typeof iconsJson
+	},
+	{
+		id: 'git',
+		label: 'Git stuff',
+		icon: 'git' as keyof typeof iconsJson
+	},
+	{
+		id: 'integrations',
+		label: 'Integrations',
+		icon: 'integrations' as keyof typeof iconsJson
+	},
+	{
+		id: 'ai',
+		label: 'AI Options',
+		icon: 'ai' as keyof typeof iconsJson
+	},
+	{
+		id: 'telemetry',
+		label: 'Telemetry',
+		icon: 'stat' as keyof typeof iconsJson
+	},
+	{
+		id: 'experimental',
+		label: 'Experimental',
+		icon: 'idea' as keyof typeof iconsJson
+	},
+	{
+		id: 'organizations',
+		label: 'Organizations',
+		icon: 'idea' as keyof typeof iconsJson,
+		adminOnly: true
+	}
+] as const;
+
+export type GeneralSettingsPage = (typeof generalSettingsPages)[number];
+export type GeneralSettingsPageId = GeneralSettingsPage['id'];

--- a/apps/desktop/src/lib/settings/projectSettingsPages.ts
+++ b/apps/desktop/src/lib/settings/projectSettingsPages.ts
@@ -1,0 +1,32 @@
+import iconsJson from '@gitbutler/ui/data/icons.json';
+
+export const projectSettingsPages = [
+	{
+		id: 'project',
+		label: 'Project',
+		icon: 'profile' as keyof typeof iconsJson
+	},
+	{
+		id: 'git',
+		label: 'Git stuff',
+		icon: 'git' as keyof typeof iconsJson
+	},
+	{
+		id: 'ai',
+		label: 'AI options',
+		icon: 'ai' as keyof typeof iconsJson
+	},
+	{
+		id: 'agent',
+		label: 'Agent',
+		icon: 'ai-agent' as keyof typeof iconsJson
+	},
+	{
+		id: 'experimental',
+		label: 'Experimental',
+		icon: 'idea' as keyof typeof iconsJson
+	}
+] as const;
+
+export type ProjectSettingsPage = (typeof projectSettingsPages)[number];
+export type ProjectSettingsPageId = ProjectSettingsPage['id'];

--- a/apps/desktop/src/lib/settings/settingsModal.svelte.ts
+++ b/apps/desktop/src/lib/settings/settingsModal.svelte.ts
@@ -1,5 +1,7 @@
 import { UI_STATE } from '$lib/state/uiState.svelte';
 import { inject } from '@gitbutler/core/context';
+import type { GeneralSettingsPageId } from '$lib/settings/generalSettingsPages';
+import type { ProjectSettingsPageId } from '$lib/settings/projectSettingsPages';
 import type {
 	GeneralSettingsModalState,
 	ProjectSettingsModalState
@@ -8,7 +10,7 @@ import type {
 export function useSettingsModal() {
 	const uiState = inject(UI_STATE);
 
-	function openGeneralSettings(selectedId?: string) {
+	function openGeneralSettings(selectedId?: GeneralSettingsPageId) {
 		const modalState: GeneralSettingsModalState = {
 			type: 'general-settings',
 			selectedId
@@ -16,7 +18,7 @@ export function useSettingsModal() {
 		uiState.global.modal.set(modalState);
 	}
 
-	function openProjectSettings(projectId: string, selectedId?: string) {
+	function openProjectSettings(projectId: string, selectedId?: ProjectSettingsPageId) {
 		const modalState: ProjectSettingsModalState = {
 			type: 'project-settings',
 			projectId,

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -11,6 +11,8 @@ import {
 	type UnknownAction
 } from '@reduxjs/toolkit';
 import type { ThinkingLevel, ModelType, PermissionMode } from '$lib/codegen/types';
+import type { GeneralSettingsPageId } from '$lib/settings/generalSettingsPages';
+import type { ProjectSettingsPageId } from '$lib/settings/projectSettingsPages';
 import type { StackDetails } from '$lib/stacks/stack';
 import type { RejectionReason } from '$lib/stacks/stackService.svelte';
 
@@ -93,13 +95,13 @@ export type AuthorMissingModalState = BaseGlobalModalState & {
 
 export type GeneralSettingsModalState = BaseGlobalModalState & {
 	type: 'general-settings';
-	selectedId?: string;
+	selectedId?: GeneralSettingsPageId;
 };
 
 export type ProjectSettingsModalState = BaseGlobalModalState & {
 	type: 'project-settings';
 	projectId: string;
-	selectedId?: string;
+	selectedId?: ProjectSettingsPageId;
 };
 
 export type GlobalModalState =


### PR DESCRIPTION
Replace the device flow with a simple ‘enter API key’ flow.

- Display an input field for entering the API key
- Auth banner in the AI settings redirects to the general settings page
- Update log out copy to ‘forget’ copy

Also:
- Strongly type the modal settings page IDs
- Fix an issue regarding the update of the selected page for modals

![Screenshot 2026-01-27 at 13.49.03.png](https://app.gitbutler.com/uploads/daa9ebdf-2998-4b65-ac83-8fcf95bfbb9c)
![Screenshot 2026-01-27 at 14.29.17.png](https://app.gitbutler.com/uploads/14712677-16ca-4acb-bc63-18635b207354)
![Screenshot 2026-01-27 at 14.29.00.png](https://app.gitbutler.com/uploads/e12a5f32-c4d8-4ed4-b3bb-698694acdfdc)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #12063 
- <kbd>&nbsp;3&nbsp;</kbd> #12061 
- <kbd>&nbsp;2&nbsp;</kbd> #12062 
- <kbd>&nbsp;1&nbsp;</kbd> #12048 👈 
<!-- GitButler Footer Boundary Bottom -->

