### PR TITLE
deduplicate storage of access token

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -152,7 +152,7 @@ const exampleDiffs: DiffInput[] = [hunk1, hunk2];
 function buildDefaultServices() {
 	const gitConfig = new DummyGitConfigService(structuredClone(defaultGitConfig));
 	const secretsService = new DummySecretsService(structuredClone(defaultSecretsConfig));
-	const tokenMemoryService = new TokenMemoryService(secretsService);
+	const tokenMemoryService = new TokenMemoryService();
 	const fetchMock = vi.fn();
 	const cloud = new HttpClient(fetchMock, 'https://www.example.com', tokenMemoryService.token);
 	return {
@@ -186,7 +186,7 @@ describe('AIService', () => {
 				[GitAIConfigKey.OpenAIKeyOption]: KeyOption.BringYourOwn
 			});
 			const secretsService = new DummySecretsService({ [AISecretHandle.OpenAIKey]: 'sk-asdfasdf' });
-			const tokenMemoryService = new TokenMemoryService(secretsService);
+			const tokenMemoryService = new TokenMemoryService();
 			const fetchMock = vi.fn();
 			const cloud = new HttpClient(fetchMock, 'https://www.example.com', tokenMemoryService.token);
 			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
@@ -200,7 +200,7 @@ describe('AIService', () => {
 				[GitAIConfigKey.OpenAIKeyOption]: KeyOption.BringYourOwn
 			});
 			const secretsService = new DummySecretsService();
-			const tokenMemoryService = new TokenMemoryService(secretsService);
+			const tokenMemoryService = new TokenMemoryService();
 			const fetchMock = vi.fn();
 			const cloud = new HttpClient(fetchMock, 'https://www.example.com', tokenMemoryService.token);
 			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
@@ -221,7 +221,7 @@ describe('AIService', () => {
 			const secretsService = new DummySecretsService({
 				[AISecretHandle.AnthropicKey]: 'test-key'
 			});
-			const tokenMemoryService = new TokenMemoryService(secretsService);
+			const tokenMemoryService = new TokenMemoryService();
 			const fetchMock = vi.fn();
 			const cloud = new HttpClient(fetchMock, 'https://www.example.com', tokenMemoryService.token);
 			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
@@ -236,7 +236,7 @@ describe('AIService', () => {
 				[GitAIConfigKey.AnthropicKeyOption]: KeyOption.BringYourOwn
 			});
 			const secretsService = new DummySecretsService();
-			const tokenMemoryService = new TokenMemoryService(secretsService);
+			const tokenMemoryService = new TokenMemoryService();
 			const fetchMock = vi.fn();
 			const cloud = new HttpClient(fetchMock, 'https://www.example.com', tokenMemoryService.token);
 			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -117,7 +117,7 @@ export function initDependencies(args: {
 	// ============================================================================
 
 	const secretsService = new RustSecretService(backend);
-	const tokenMemoryService = new TokenMemoryService(secretsService);
+	const tokenMemoryService = new TokenMemoryService();
 	const httpClient = new HttpClient(window.fetch, PUBLIC_API_BASE_URL, tokenMemoryService.token);
 	const userService = new UserService(backend, httpClient, tokenMemoryService, posthog);
 

--- a/apps/desktop/src/lib/stores/tokenMemoryService.ts
+++ b/apps/desktop/src/lib/stores/tokenMemoryService.ts
@@ -4,7 +4,7 @@ import type { UserService as _UserService } from '$lib/user/userService';
 /**
  * Holds the logged in user's token in memory
  *
- * Persistance is handled by the login process.
+ * Persistence is handled by the login process.
  * @see _UserService#setUser for more details.
  */
 export class TokenMemoryService {

--- a/apps/desktop/src/lib/stores/tokenMemoryService.ts
+++ b/apps/desktop/src/lib/stores/tokenMemoryService.ts
@@ -1,28 +1,16 @@
-import { persisted } from '@gitbutler/shared/persisted';
-import { get, writable, type Readable } from 'svelte/store';
-import type { SecretsService } from '$lib/secrets/secretsService';
+import { writable, type Readable } from 'svelte/store';
+import type { UserService as _UserService } from '$lib/user/userService';
 
-// Exported for testing :D
-export const tokenKey = 'TokenMemoryService-authToken';
-
-const oldToken = persisted<string | undefined>(undefined, tokenKey);
-
-/** Holds the logged in user's token in memory */
+/**
+ * Holds the logged in user's token in memory
+ *
+ * Persistance is handled by the login process.
+ * @see _UserService#setUser for more details.
+ */
 export class TokenMemoryService {
-	constructor(private readonly secretsService: SecretsService) {}
+	constructor() {}
 
-	#token = writable<string | undefined>(undefined, (set) => {
-		const old = get(oldToken);
-		if (old) {
-			set(old);
-
-			this.secretsService.set(tokenKey, old).then(() => {
-				oldToken.set(undefined);
-			});
-		} else {
-			this.secretsService.get(tokenKey).then(set);
-		}
-	});
+	#token = writable<string | undefined>(undefined, () => {});
 
 	get token(): Readable<string | undefined> {
 		return this.#token;
@@ -30,10 +18,5 @@ export class TokenMemoryService {
 
 	async setToken(data: string | undefined) {
 		this.#token.set(data);
-		if (data !== undefined) {
-			await this.secretsService.set(tokenKey, data);
-		} else {
-			await this.secretsService.delete(tokenKey);
-		}
 	}
 }


### PR DESCRIPTION
The token is already set by the login process, so there’s no need to store it twice