### PR TITLE
Update `gix` to the latest version for better logging.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2626,7 +2626,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2863,7 +2863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4117,14 +4117,12 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "itoa",
+ "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "serde",
- "thiserror 2.0.17",
  "winnow 0.7.14",
 ]
 
@@ -4148,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4174,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4191,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 ]
@@ -4199,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4224,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4237,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4256,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4268,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4299,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4312,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4335,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4369,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "dunce",
@@ -4392,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
 ]
@@ -4414,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4434,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4468,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4493,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4517,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "faster-hex",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4540,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.16.1",
@@ -4563,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4604,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4643,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4653,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4665,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4689,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4725,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4746,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.75.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "arc-swap",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4766,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "clru",
  "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4788,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4823,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4834,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4848,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4860,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4897,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4928,7 +4926,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4949,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4964,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4998,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5025,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5037,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5049,7 +5047,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "filetime",
@@ -5071,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5099,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "dashmap",
  "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5140,12 +5138,15 @@ checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
 [[package]]
 name = "gix-trace"
 version = "0.1.17"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "gix-transport"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5181,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5197,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5219,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5248,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
 ]
@@ -5274,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5292,7 +5293,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#766ab10104c5f3a2edfe5550791a8d5e78479b3b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
 dependencies = [
  "bstr",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5822,12 +5823,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -6138,7 +6139,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6213,7 +6214,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7020,7 +7021,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7656,7 +7657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8318,7 +8319,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8356,9 +8357,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8969,7 +8970,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9048,7 +9049,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10647,7 +10648,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11834,7 +11835,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12822,9 +12823,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -44,7 +44,22 @@ impl Context<'_> {
 impl Graph {
     /// Now that the graph is complete, perform additional structural improvements with
     /// the requirement of them to be computationally cheap.
-    #[instrument(level = "trace", skip(self, meta, repo, refs_by_id), err(Debug))]
+    #[instrument(
+        level = "trace",
+        skip(
+            self,
+            meta,
+            refs_by_id,
+            repo,
+            symbolic_remote_names,
+            configured_remote_tracking_branches,
+            inserted_proxy_segments,
+            hard_limit,
+            dangerously_skip_postprocessing_for_debugging,
+            worktree_by_branch
+        ),
+        err(Debug)
+    )]
     pub(super) fn post_processed<T: RefMetadata>(
         mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[clap(name = "gitbutler-cli", about = "A CLI for GitButler", version = option_env!("GIX_VERSION"))]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
-    #[clap(short = 'd', long, hide = true, action = clap::ArgAction::Count,)]
+    #[clap(short = 't', long, action = clap::ArgAction::Count)]
     pub trace: u8,
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[clap(name = "gitbutler-cli", about = "A CLI for GitButler", version = option_env!("GIX_VERSION"))]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
-    #[clap(short = 'd', long, action = clap::ArgAction::Count,)]
+    #[clap(short = 'd', long, hide = true, action = clap::ArgAction::Count,)]
     pub trace: u8,
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -111,7 +111,7 @@ regex.workspace = true
 anyhow.workspace = true
 rmcp.workspace = true
 command-group = { version = "5.0.1", features = ["with-tokio"] }
-gix.workspace = true
+gix = { workspace = true, features = ["tracing", "tracing-detail"] }
 colored = "3.0.0"
 serde_json.workspace = true
 terminal_size = "0.4.3"

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 )]
 pub struct Args {
     /// Enable tracing for debug and performance information printed to stderr.
+    ///
+    /// Repeat up to 4 times for increasingly verbose output.
     #[clap(short = 't', long, action = clap::ArgAction::Count, hide = true, env = "BUT_TRACE")]
     pub trace: u8,
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.

--- a/crates/but/src/trace.rs
+++ b/crates/but/src/trace.rs
@@ -15,14 +15,23 @@ pub fn init(level: u8) -> anyhow::Result<()> {
         if *meta.level() > level_t {
             return false;
         }
-        if level_t < Level::DEBUG
-            && !meta
-                .module_path()
-                .is_some_and(|p| p == "but" || p.starts_with("but::") || p.starts_with("but_"))
-        {
-            return false;
+        if level_t > Level::DEBUG {
+            return true;
         }
-        true
+        if level_t > Level::INFO
+            && meta
+                .module_path()
+                .is_some_and(|p| p.starts_with("gitbutler_"))
+        {
+            return true;
+        }
+        if meta
+            .module_path()
+            .is_some_and(|p| p == "but" || p.starts_with("but::") || p.starts_with("but_"))
+        {
+            return true;
+        }
+        false
     });
 
     if level >= 4 {

--- a/crates/but/src/trace.rs
+++ b/crates/but/src/trace.rs
@@ -18,7 +18,7 @@ pub fn init(level: u8) -> anyhow::Result<()> {
         if level_t < Level::DEBUG
             && !meta
                 .module_path()
-                .is_some_and(|p| p.starts_with("but::") || p.starts_with("but_"))
+                .is_some_and(|p| p == "but" || p.starts_with("but::") || p.starts_with("but_"))
         {
             return false;
         }


### PR DESCRIPTION
Previously, `gix` didn't implement its usage of `tracing` correctly and misbehaved. Now this is fixed and one can disable it like any other tracing client, using filters.

#### -t

```
INFO     CLI [ 202ms | 19.04% / 100.00% ]
INFO     ┝━ setup [ 10.8ms | 5.33% ]
INFO     ┝━ get_base_branch_data [ 153ms | 75.62% ] project_id: 6f2d364f-0b4a-4352-886b-430afb012841
WARN     ┕━ 🚧 [warn]: Ignoring stack None (NodeIndex(3)) as it is pruned
```

#### -tt

```
INFO     CLI [ 199ms | 1.96% / 100.00% ]
INFO     ┝━ setup [ 9.34ms | 0.20% / 4.70% ]
INFO     │  ┕━ gix_path::git::install_config_path() [ 8.94ms | 4.50% ]
DEBUG    │     ┕━ 🐛 [debug]: invoking git for installation config path | cmd: cd "/" && env -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_CONFIG -u GIT_DISCOVERY_ACROSS_FILESYSTEM -u GIT_OBJECT_DIRECTORY GIT_DIR="/dev/null" GIT_WORK_TREE="/dev/null" "git" "config" "-lz" "--show-origin" "--name-only"
INFO     ┝━ ThreadSafeRepository::discover() [ 1.90ms | 0.21% / 0.96% ]
INFO     │  ┕━ open_from_paths() [ 1.49ms | 0.41% / 0.75% ]
INFO     │     ┕━ gix_odb::Store::at() [ 667µs | 0.34% ]
INFO     ┝━ get_base_branch_data [ 151ms | 0.88% / 76.04% ] project_id: 6f2d364f-0b4a-4352-886b-430afb012841
INFO     │  ┕━ get_base_branch_data [ 150ms | 74.86% / 75.16% ]
INFO     │     ┕━ ThreadSafeRepository::open() [ 608µs | 0.03% / 0.31% ]
INFO     │        ┕━ open_from_paths() [ 544µs | 0.08% / 0.27% ]
INFO     │           ┕━ gix_odb::Store::at() [ 393µs | 0.20% ]
INFO     ┝━ ThreadSafeRepository::open() [ 576µs | 0.04% / 0.29% ]
INFO     │  ┕━ open_from_paths() [ 506µs | 0.08% / 0.25% ]
INFO     │     ┕━ gix_odb::Store::at() [ 351µs | 0.18% ]
INFO     ┝━ ThreadSafeRepository::open() [ 389µs | 0.02% / 0.20% ]
INFO     │  ┕━ open_from_paths() [ 353µs | 0.05% / 0.18% ]
INFO     │     ┕━ gix_odb::Store::at() [ 252µs | 0.13% ]
DEBUG    ┕━ from_commit_traversal [ 31.6ms | 15.87% ] tip: Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) | options: Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false } | ref_name: "refs/heads/gitbutler/workspace"
WARN        ┕━ 🚧 [warn]: Ignoring stack None (NodeIndex(3)) as it is pruned
```

#### -ttt

```
INFO     CLI [ 194ms | 2.00% / 100.00% ]
INFO     ┝━ setup [ 9.28ms | 0.20% / 4.78% ]
INFO     │  ┕━ gix_path::git::install_config_path() [ 8.90ms | 4.58% ]
DEBUG    │     ┕━ 🐛 [debug]: invoking git for installation config path | cmd: cd "/" && env -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_CONFIG -u GIT_DISCOVERY_ACROSS_FILESYSTEM -u GIT_OBJECT_DIRECTORY GIT_DIR="/dev/null" GIT_WORK_TREE="/dev/null" "git" "config" "-lz" "--show-origin" "--name-only"
INFO     ┝━ ThreadSafeRepository::discover() [ 1.48ms | 0.18% / 0.76% ]
INFO     │  ┕━ open_from_paths() [ 1.13ms | 0.31% / 0.58% ]
INFO     │     ┕━ gix_odb::Store::at() [ 520µs | 0.27% ]
INFO     ┝━ get_base_branch_data [ 148ms | 0.88% / 75.97% ] project_id: 6f2d364f-0b4a-4352-886b-430afb012841
INFO     │  ┕━ get_base_branch_data [ 146ms | 74.79% / 75.09% ]
INFO     │     ┕━ ThreadSafeRepository::open() [ 579µs | 0.03% / 0.30% ]
INFO     │        ┕━ open_from_paths() [ 516µs | 0.08% / 0.27% ]
INFO     │           ┕━ gix_odb::Store::at() [ 367µs | 0.19% ]
INFO     ┝━ ThreadSafeRepository::open() [ 598µs | 0.04% / 0.31% ]
INFO     │  ┕━ open_from_paths() [ 524µs | 0.09% / 0.27% ]
INFO     │     ┕━ gix_odb::Store::at() [ 348µs | 0.18% ]
INFO     ┝━ ThreadSafeRepository::open() [ 425µs | 0.02% / 0.22% ]
INFO     │  ┕━ open_from_paths() [ 380µs | 0.06% / 0.20% ]
INFO     │     ┕━ gix_odb::Store::at() [ 264µs | 0.14% ]
DEBUG    ┝━ from_commit_traversal [ 31.0ms | 15.24% / 15.96% ] tip: Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) | options: Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false } | ref_name: "refs/heads/gitbutler/workspace"
TRACE    │  ┕━ post_processed [ 1.40ms | 0.72% ] tip: Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) | symbolic_remote_names: ["origin", "origin"] | configured_remote_tracking_branches: {FullName("refs/remotes/nathan/node-gyp-server-repro-backup"), FullName("refs/remotes/origin/main")} | inserted_proxy_segments: [] | hard_limit: false | dangerously_skip_postprocessing_for_debugging: false | worktree_by_branch: {FullName("HEAD"): [Main], FullName("refs/heads/gitbutler/workspace"): [Main]}
WARN     │     ┕━ 🚧 [warn]: Ignoring stack None (NodeIndex(3)) as it is pruned
TRACE    ┕━ into_workspace [ 31.3µs | 0.02% ]
TRACE    📍 [trace]:  | op_name: "poll_recv" | is_ready: false
TRACE    📍 [trace]:  | tx_dropped: true | tx_dropped.op: "override"
TRACE    📍 [trace]:  | op_name: "poll_recv" | is_ready: true
```

#### -tttt

```
2026-01-27T18:23:53.694387Z DEBUG CLI:setup:gix_path::git::install_config_path(): gix_path::env::git: invoking git for installation config path cmd=cd "/" && env -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_CONFIG -u GIT_DISCOVERY_ACROSS_FILESYSTEM -u GIT_OBJECT_DIRECTORY GIT_DIR="/dev/null" GIT_WORK_TREE="/dev/null" "git" "config" "-lz" "--show-origin" "--name-only"
2026-01-27T18:23:53.703660Z  INFO CLI:setup:gix_path::git::install_config_path(): gix_path::env::git: close time.busy=9.34ms time.idle=5.71µs
2026-01-27T18:23:53.703988Z  INFO CLI:setup: but_secret::secret::git_credentials: close time.busy=9.93ms time.idle=4.00µs
2026-01-27T18:23:53.705829Z  INFO CLI:ThreadSafeRepository::discover():open_from_paths():gix_odb::Store::at(): gix_odb::store_impls::dynamic::init: close time.busy=653µs time.idle=2.08µs
2026-01-27T18:23:53.705857Z  INFO CLI:ThreadSafeRepository::discover():open_from_paths(): gix::open::repository: close time.busy=1.34ms time.idle=1.83µs
2026-01-27T18:23:53.705867Z  INFO CLI:ThreadSafeRepository::discover(): gix::discover: close time.busy=1.76ms time.idle=2.08µs
2026-01-27T18:23:53.724573Z  INFO CLI:get_base_branch_data:get_base_branch_data:ThreadSafeRepository::open():open_from_paths():gix_odb::Store::at(): gix_odb::store_impls::dynamic::init: close time.busy=375µs time.idle=2.79µs project_id=6f2d364f-0b4a-4352-886b-430afb012841
2026-01-27T18:23:53.724613Z  INFO CLI:get_base_branch_data:get_base_branch_data:ThreadSafeRepository::open():open_from_paths(): gix::open::repository: close time.busy=580µs time.idle=2.46µs project_id=6f2d364f-0b4a-4352-886b-430afb012841
2026-01-27T18:23:53.724627Z  INFO CLI:get_base_branch_data:get_base_branch_data:ThreadSafeRepository::open(): gix::open::repository: close time.busy=665µs time.idle=3.17µs project_id=6f2d364f-0b4a-4352-886b-430afb012841
2026-01-27T18:23:53.857212Z  INFO CLI:get_base_branch_data:get_base_branch_data: gitbutler_branch_actions::base: close time.busy=148ms time.idle=3.83µs project_id=6f2d364f-0b4a-4352-886b-430afb012841
2026-01-27T18:23:53.858404Z  INFO CLI:get_base_branch_data: but_api::legacy::virtual_branches: close time.busy=150ms time.idle=2.38µs project_id=6f2d364f-0b4a-4352-886b-430afb012841
2026-01-27T18:23:53.859029Z  INFO CLI:ThreadSafeRepository::open():open_from_paths():gix_odb::Store::at(): gix_odb::store_impls::dynamic::init: close time.busy=334µs time.idle=1.75µs
2026-01-27T18:23:53.859042Z  INFO CLI:ThreadSafeRepository::open():open_from_paths(): gix::open::repository: close time.busy=524µs time.idle=1.58µs
2026-01-27T18:23:53.859053Z  INFO CLI:ThreadSafeRepository::open(): gix::open::repository: close time.busy=626µs time.idle=2.08µs
2026-01-27T18:23:53.859948Z  INFO CLI:ThreadSafeRepository::open():open_from_paths():gix_odb::Store::at(): gix_odb::store_impls::dynamic::init: close time.busy=230µs time.idle=1.42µs
2026-01-27T18:23:53.859961Z  INFO CLI:ThreadSafeRepository::open():open_from_paths(): gix::open::repository: close time.busy=346µs time.idle=1.38µs
2026-01-27T18:23:53.859970Z  INFO CLI:ThreadSafeRepository::open(): gix::open::repository: close time.busy=391µs time.idle=1.58µs
2026-01-27T18:23:53.890468Z  WARN CLI:from_commit_traversal:post_processed: but_graph::projection::workspace: Ignoring stack None (NodeIndex(3)) as it is pruned tip=Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) options=Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false } ref_name="refs/heads/gitbutler/workspace" tip=Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) symbolic_remote_names=["origin", "origin"] configured_remote_tracking_branches={FullName("refs/remotes/nathan/node-gyp-server-repro-backup"), FullName("refs/remotes/origin/main")} inserted_proxy_segments=[] hard_limit=false dangerously_skip_postprocessing_for_debugging=false worktree_by_branch={FullName("HEAD"): [Main], FullName("refs/heads/gitbutler/workspace"): [Main]}
2026-01-27T18:23:53.891695Z TRACE CLI:from_commit_traversal:post_processed: but_graph::init::post: close time.busy=1.35ms time.idle=3.75µs tip=Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) options=Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false } ref_name="refs/heads/gitbutler/workspace" tip=Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) symbolic_remote_names=["origin", "origin"] configured_remote_tracking_branches={FullName("refs/remotes/nathan/node-gyp-server-repro-backup"), FullName("refs/remotes/origin/main")} inserted_proxy_segments=[] hard_limit=false dangerously_skip_postprocessing_for_debugging=false worktree_by_branch={FullName("HEAD"): [Main], FullName("refs/heads/gitbutler/workspace"): [Main]}
2026-01-27T18:23:53.891727Z DEBUG CLI:from_commit_traversal: but_graph::init: close time.busy=31.2ms time.idle=2.00µs tip=Sha1(3f1d8c392ab6abea3d2472dd6e5e6914c33dceaf) options=Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false } ref_name="refs/heads/gitbutler/workspace"
2026-01-27T18:23:53.891785Z TRACE CLI:into_workspace: but_graph::projection::workspace: close time.busy=40.0µs time.idle=1.96µs
```