### PR TITLE
Provide SKILL.md for the `but` CLI as well as a `but skill install` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "cli-prompts",
  "colored",
  "command-group",
+ "dirs 6.0.0",
  "git2",
  "gitbutler-branch",
  "gitbutler-branch-actions",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -123,6 +123,7 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 tracing-forest.workspace = true
 cli-prompts = "0.1.0"
+dirs.workspace = true
 minus = { version = "5.6.1", default-features = false, features = [
     "static_output",
     "search",

--- a/crates/but/agents.md
+++ b/crates/but/agents.md
@@ -27,3 +27,8 @@ Usable output goes to `out: &mut OutputChannel`
 
 * use `cargo fmt --check --all` to check for formatting issues.
 * use `cargo clippy --all-targets --fix --allow-dirty` to auto-fix clippy errors.
+
+### CLI Skills
+
+* After changing CLI commands or workflows, update the skill files in `crates/but/skill/` so AI agents stay current
+* Users update their skills with `but skill install --infer` (auto-detects installation location)

--- a/crates/but/skill/README.md
+++ b/crates/but/skill/README.md
@@ -1,0 +1,150 @@
+# GitButler CLI Skill
+
+Claude Code skill for working with the GitButler CLI (`but` command) in workspace mode.
+
+## Installation
+
+Install this skill using the GitButler CLI:
+
+```bash
+but skill install    # Prompts for installation location
+```
+
+The command will prompt you to select a skill format (Claude Code, OpenCode, GitHub Copilot, Cursor, or Windsurf) and install to the appropriate location.
+
+**Options:**
+- `--path <path>` - Install to a custom path
+- `--global` - Install globally (in home directory) instead of current repository
+- `--infer` - Auto-detect installation location from existing installation (useful for updates)
+
+**Requirements:**
+- **GitButler CLI** installed: `curl -sSL https://gitbutler.com/install.sh | sh`
+- **Claude Code, OpenCode, GitHub Copilot, Cursor, or Windsurf**
+- Repository initialized with GitButler: `but setup`
+
+**Updating:**
+
+To update the skill to the latest version, use the `--infer` flag to automatically detect and update your existing installation:
+
+```bash
+but skill install --infer
+```
+
+Alternatively, re-run the install command and select the same location:
+
+```bash
+but skill install
+```
+
+This will overwrite the existing skill files with the latest version.
+
+## Skill Structure
+
+The skill directory contains both distributable skill files and development documentation:
+
+```text
+crates/but/skill/
+├── SKILL.md                   ← Main skill entry point (INSTALLED)
+├── README.md                  ← This file - development docs (NOT installed)
+├── TESTING.md                 ← Testing guidelines (NOT installed)
+└── references/                ← Additional skill documentation (INSTALLED)
+    ├── reference.md          (393 lines) - Command reference
+    ├── concepts.md           (317 lines) - Deep concepts
+    └── examples.md           (494 lines) - Workflow examples
+```
+
+**What gets installed:**
+The `but skill install` command only copies the distributable files to the user's system:
+- `SKILL.md` - Main skill entry point
+- `references/` - All reference documentation files
+
+**What stays in the repository:**
+Development documentation remains in the source tree and is not installed:
+- `README.md` - This file (development and maintenance docs)
+- `TESTING.md` - Testing guidelines for contributors
+
+## When This Skill Is Invoked
+
+Claude automatically invokes this skill when:
+
+- Checking version control state (status, diffs, commits)
+- Starting new work (should create branch/stack for each task)
+- After making code changes (should stage files to branches)
+- Committing work (when logical units complete)
+- Editing history (amend, squash, move changes)
+- Any git-like operation
+
+## Progressive Disclosure
+
+Claude loads files on-demand:
+
+1. **SKILL.md** - Always loaded when skill activates (lean overview)
+2. **references/reference.md** - Loaded when detailed command syntax needed
+3. **references/concepts.md** - Loaded when deeper understanding required
+4. **references/examples.md** - Loaded when workflow examples needed
+
+Files in `references/` directory are only loaded when explicitly referenced, keeping context lean while providing comprehensive documentation when needed.
+
+## Key Design Principles
+
+### Trigger-Rich Description
+
+The YAML `description` field contains all triggering information so Claude knows when to use this skill before loading the body.
+
+### Lean Entry Point
+
+SKILL.md is kept under 150 lines as a "table of contents" that points to detailed materials.
+
+### Domain Separation
+
+Separate files by domain (commands, concepts, examples) so Claude only loads relevant context.
+
+### Active Language
+
+Uses directive language ("do this") rather than passive ("this might happen").
+
+## Maintaining This Skill
+
+### When to Update SKILL.md
+
+- New high-level workflow patterns
+- Changes to core concepts
+- Updates to quick reference commands
+
+### When to Update REFERENCE.md
+
+- New `but` commands
+- Changed command syntax
+- New flags or options
+
+### When to Update CONCEPTS.md
+
+- New conceptual models
+- Changes to workspace behavior
+- New architectural patterns
+
+### When to Update EXAMPLES.md
+
+- New workflow patterns
+- Common user questions
+- Real-world scenarios
+
+### Line Count Guideline
+
+Keep SKILL.md under 500 lines (currently 137). Split content into other files if approaching limit.
+
+## Testing the Skill
+
+Test that Claude:
+
+1. Invokes skill when starting new work
+2. Creates branches before making changes
+3. Stages changes after edits
+4. Commits at logical points
+5. Uses `but` commands instead of `git`
+
+## References
+
+- [Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
+- [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
+- [GitButler CLI Documentation](https://docs.gitbutler.com/cli-overview)

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -13,21 +13,22 @@ Help users work with GitButler CLI (`but` command) in workspace mode.
 
 **CRITICAL:** Follow this pattern for EVERY task involving code changes:
 
-1. **Start work** → `but branch new <task-name>` (create stack for this work theme)
-2. **Make changes** → Edit files as needed
-3. **Stage changes IMMEDIATELY** → `but stage <file> <branch>` (after EVERY Write/Edit tool use)
-4. **Commit work** → `but commit <branch> -m "message"` (preserve logical units)
-5. **Refine** → Use `but absorb` or `but squash` to clean up history
+1. **Check state** → `but status --json` (always use `--json` for structured output)
+2. **Start work** → `but branch new <task-name>` (create stack for this work theme)
+3. **Make changes** → Edit files as needed
+4. **Stage changes IMMEDIATELY** → `but stage <file> <branch>` (after EVERY Write/Edit tool use)
+5. **Commit work** → `but commit <branch> -m "message"` (preserve logical units)
+6. **Refine** → Use `but absorb` or `but squash` to clean up history
 
-**Step 3 is required immediately after any file modification** - do not skip or delay staging.
+**Step 4 is required immediately after any file modification** - do not skip or delay staging.
 
 ## After Using Write/Edit Tools
 
 **ALWAYS do this immediately:**
 
-1. Run `but status` to see the new changes
+1. Run `but status --json` to see the new changes (use `--json` for structured output)
 2. Stage the modified files: `but stage <file-id> <branch-id>`
-3. Verify with `but status` again
+3. Verify with `but status --json` again
 
 Do not proceed to other tasks until changes are staged.
 
@@ -54,12 +55,14 @@ but setup                          # Initialize in your repo
 but skill install --path <path>    # Install/update skill (agents use --path with known location)
 ```
 
-**Note for AI agents:** When installing or updating this skill programmatically, always use `--path` to specify the exact installation directory. The `--infer` flag requires user interaction if multiple installations exist.
+**Note for AI agents:**
+- When installing or updating this skill programmatically, always use `--path` to specify the exact installation directory. The `--infer` flag requires user interaction if multiple installations exist.
+- **Use `--json` flag for all commands** to get structured, parseable output. This is especially important for `but status --json` to reliably parse workspace state.
 
 **Core workflow:**
 
 ```bash
-but status              # Always start here - shows workspace state
+but status --json       # Always start here - shows workspace state (JSON for agents)
 but branch new feature  # Create new stack for work
 but stage <file> <id>   # Stage changes to branch
 but commit <id> -m "…"  # Commit to branch
@@ -70,10 +73,12 @@ but push <id>           # Push to remote
 
 For detailed command syntax and all available options, see [references/reference.md](references/reference.md).
 
+**IMPORTANT for AI agents:** Add `--json` flag to all commands for structured, parseable output.
+
 **Understanding state:**
 
-- `but status [-f]` - Overview (START HERE)
-- `but show <id>` - Details about commit/branch
+- `but status --json [-f]` - Overview (START HERE, always use --json for agents, add -f to include file lists)
+- `but show <id> --json` - Details about commit/branch
 - `but diff <id>` - Show diff
 
 **Organizing work:**
@@ -151,11 +156,11 @@ but resolve finish      # Complete resolution
 
 ## Guidelines
 
-1. Always start with `but status` to understand current state
+1. Always start with `but status --json` to understand current state (agents should always use `--json`)
 2. Create a new stack for each independent work theme
 3. Stage changes after making edits (especially after formatters/linters)
 4. Commit at logical units of work
-5. Use `--json` flag when parsing output programmatically
+5. **Use `--json` flag for ALL commands** when running as an agent - this provides structured, parseable output instead of human-readable text
 6. Use `--dry-run` flags (push, absorb) when unsure
 7. Run `but pull` regularly to stay updated with upstream
 8. When updating this skill, use `but skill install --path <known-path>` to avoid prompts

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: but
+version: 0.0.0
+description: Manage GitButler CLI workspace with multiple parallel branches. ALWAYS invoke immediately after Write/Edit tools to stage changes. Use when checking version control state, starting new work (create branch/stack first), after ANY file modifications (stage to branches), committing work, editing history, or any git operation. Uses 'but' commands not 'git' for writes.
+author: GitButler Team
+---
+
+# GitButler CLI Skill
+
+Help users work with GitButler CLI (`but` command) in workspace mode.
+
+## Proactive Agent Workflow
+
+**CRITICAL:** Follow this pattern for EVERY task involving code changes:
+
+1. **Start work** → `but branch new <task-name>` (create stack for this work theme)
+2. **Make changes** → Edit files as needed
+3. **Stage changes IMMEDIATELY** → `but stage <file> <branch>` (after EVERY Write/Edit tool use)
+4. **Commit work** → `but commit <branch> -m "message"` (preserve logical units)
+5. **Refine** → Use `but absorb` or `but squash` to clean up history
+
+**Step 3 is required immediately after any file modification** - do not skip or delay staging.
+
+## After Using Write/Edit Tools
+
+**ALWAYS do this immediately:**
+
+1. Run `but status` to see the new changes
+2. Stage the modified files: `but stage <file-id> <branch-id>`
+3. Verify with `but status` again
+
+Do not proceed to other tasks until changes are staged.
+
+## Critical Concept: Workspace Model
+
+**GitButler ≠ Traditional Git**
+
+- **Traditional Git**: One branch at a time, switch with `git checkout`
+- **GitButler**: Multiple stacks simultaneously in one workspace, changes assigned to stacks
+
+**This means:**
+
+- ❌ Don't use `git status`, `git commit`, `git checkout`
+- ✅ Use `but status`, `but commit`, `but` commands
+- ✅ Read-only git commands are fine (`git log`, `git diff`)
+
+## Quick Start
+
+**Installation:**
+
+```bash
+curl -sSL https://gitbutler.com/install.sh | sh
+but setup                          # Initialize in your repo
+but skill install --path <path>    # Install/update skill (agents use --path with known location)
+```
+
+**Note for AI agents:** When installing or updating this skill programmatically, always use `--path` to specify the exact installation directory. The `--infer` flag requires user interaction if multiple installations exist.
+
+**Core workflow:**
+
+```bash
+but status              # Always start here - shows workspace state
+but branch new feature  # Create new stack for work
+but stage <file> <id>   # Stage changes to branch
+but commit <id> -m "…"  # Commit to branch
+but push <id>           # Push to remote
+```
+
+## Essential Commands
+
+For detailed command syntax and all available options, see [references/reference.md](references/reference.md).
+
+**Understanding state:**
+
+- `but status [-f]` - Overview (START HERE)
+- `but show <id>` - Details about commit/branch
+- `but diff <id>` - Show diff
+
+**Organizing work:**
+
+- `but branch new <name>` - Independent branch
+- `but branch new <name> -a <anchor>` - Stacked branch (dependent)
+- `but stage <file> <branch>` - Assign file to branch
+
+**Making changes:**
+
+- `but commit <branch> -m "msg"` - Create commit
+- `but absorb` - Auto-amend into existing commits
+
+**Editing history:**
+
+- `but rub <source> <dest>` - Universal edit (stage/amend/squash/move)
+- `but squash <commits>` - Combine commits
+- `but reword <id>` - Change commit message/branch name
+
+**Remote operations:**
+
+- `but pull` - Update with upstream
+- `but push [branch]` - Push to remote
+- `but pr new <branch>` - Create pull request
+
+## Key Concepts
+
+For deeper understanding of the workspace model, dependency tracking, and philosophy, see [references/concepts.md](references/concepts.md).
+
+**CLI IDs**: Every object gets a short ID (e.g., `c5` for commit, `bu` for branch). Use these as arguments.
+
+**Multiple staging areas**: Each stack has its own staging area. Stage files with `but stage <file> <branch>`.
+
+**Parallel vs Stacked branches**:
+
+- Parallel: Independent work that doesn't depend on each other
+- Stacked: Dependent work where one feature builds on another
+
+**The `but rub` primitive**: Core operation that does different things based on what you combine:
+
+- File + Branch → Stage
+- File + Commit → Amend
+- Commit + Commit → Squash
+- Commit + Branch → Move
+
+## Workflow Examples
+
+For complete step-by-step workflows and real-world scenarios, see [references/examples.md](references/examples.md).
+
+**Starting independent work:**
+
+```bash
+but status
+but branch new api-endpoint
+but branch new ui-update
+# Make changes, then stage to appropriate branches
+but stage <api-file> <api-branch>
+but commit <api-branch> -m "Add endpoint"
+```
+
+**Cleaning up commits:**
+
+```bash
+but absorb              # Auto-amend changes
+but squash <branch>     # Squash all commits in branch
+```
+
+**Resolving conflicts:**
+
+```bash
+but resolve <commit>    # Enter resolution mode
+# Fix conflicts in editor
+but resolve finish      # Complete resolution
+```
+
+## Guidelines
+
+1. Always start with `but status` to understand current state
+2. Create a new stack for each independent work theme
+3. Stage changes after making edits (especially after formatters/linters)
+4. Commit at logical units of work
+5. Use `--json` flag when parsing output programmatically
+6. Use `--dry-run` flags (push, absorb) when unsure
+7. Run `but pull` regularly to stay updated with upstream
+8. When updating this skill, use `but skill install --path <known-path>` to avoid prompts

--- a/crates/but/skill/TESTING.md
+++ b/crates/but/skill/TESTING.md
@@ -1,0 +1,305 @@
+# GitButler Skill Testing Plan
+
+This document outlines tests to evaluate the skill's performance in real-world usage.
+
+## Test Categories
+
+### 1. Trigger Accuracy Tests
+
+Verify the skill is invoked at the right times.
+
+#### Test 1.1: Version Control State Query
+
+**User says:** "What files have I changed?"
+**Expected:**
+
+- Skill is invoked
+- Runs `but status` to show changes
+- Does NOT use `git status`
+
+#### Test 1.2: Starting New Work
+
+**User says:** "Add a dark mode feature"
+**Expected:**
+
+- Skill is invoked proactively
+- Creates branch FIRST: `but branch new dark-mode`
+- Then proceeds with implementation
+
+#### Test 1.3: After Code Edits
+
+**Agent action:** Edits 3 files (via Write/Edit tools)
+**Expected:**
+
+- Skill is invoked after edits
+- Stages changes: `but stage <files> <branch>`
+- Without user prompting
+
+#### Test 1.4: Commit Request
+
+**User says:** "Commit my changes"
+**Expected:**
+
+- Skill is invoked
+- Uses `but commit <branch> -m "message"`
+- Does NOT use `git commit`
+
+#### Test 1.5: History Editing
+
+**User says:** "Squash my last 3 commits"
+**Expected:**
+
+- Skill is invoked
+- Uses `but squash` or `but rub`
+- Provides correct syntax
+
+### 2. Command Selection Tests
+
+Verify Claude picks the right commands.
+
+#### Test 2.1: Status Check
+
+**Context:** User wants to see changes
+**Expected:** Uses `but status` not `git status`
+
+#### Test 2.2: Branch Creation
+
+**Context:** Starting independent features
+**Expected:** Uses `but branch new <name>` for parallel work
+
+#### Test 2.3: Stacked Branch Creation
+
+**Context:** Feature depends on another
+**Expected:** Uses `but branch new <name> -a <anchor>`
+
+#### Test 2.4: Staging Files
+
+**Context:** Multiple branches, need to organize changes
+**Expected:** Uses `but stage <file> <branch>`
+
+### 3. Workflow Compliance Tests
+
+Verify Claude follows the 5-step proactive workflow.
+
+#### Test 3.1: Complete Feature Implementation
+
+**User says:** "Implement user authentication"
+**Expected workflow:**
+
+1. ✓ Creates branch: `but branch new user-auth`
+2. ✓ Makes code changes
+3. ✓ Stages changes: `but stage <files> <branch>`
+4. ✓ Commits: `but commit <branch> -m "..."`
+5. ✓ (Optional) Refines with `but absorb` or `but squash`
+
+#### Test 3.2: Multiple Independent Features
+
+**User says:** "Add API endpoint and update UI styling"
+**Expected workflow:**
+
+1. ✓ Creates two parallel branches
+2. ✓ Makes changes
+3. ✓ Stages files to appropriate branches
+4. ✓ Commits each independently
+
+### 4. Progressive Loading Tests
+
+Verify Claude loads reference files when needed.
+
+#### Test 4.1: Basic Command Usage
+
+**User says:** "Create a new branch called feature-x"
+**Expected:**
+
+- Works from SKILL.md alone
+- Does NOT load reference.md (has enough info)
+
+#### Test 4.2: Detailed Command Syntax
+
+**User says:** "What are all the options for but commit?"
+**Expected:**
+
+- Loads references/reference.md
+- Provides detailed syntax with all flags
+
+#### Test 4.3: Conceptual Questions
+
+**User says:** "Explain how dependency tracking works in GitButler"
+**Expected:**
+
+- Loads references/concepts.md
+- Provides detailed explanation
+
+#### Test 4.4: Workflow Examples
+
+**User says:** "Show me how to work with stacked branches"
+**Expected:**
+
+- Loads references/examples.md
+- Walks through complete example
+
+### 5. Avoidance Tests
+
+Verify Claude avoids problematic git commands.
+
+#### Test 5.1: Git Status Avoidance
+
+**User says:** "What's the status?"
+**Expected:** Uses `but status` NOT `git status`
+
+#### Test 5.2: Git Commit Avoidance
+
+**User says:** "Commit these changes"
+**Expected:** Uses `but commit` NOT `git commit`
+
+#### Test 5.3: Git Checkout Avoidance
+
+**User says:** "Switch to the feature branch"
+**Expected:**
+
+- Explains GitButler workspace model
+- Does NOT use `git checkout`
+- Uses `but branch apply/unapply` if needed
+
+### 6. Edge Case Tests
+
+#### Test 6.1: Conflict Resolution
+
+**Scenario:** Conflicts after `but pull`
+**Expected:**
+
+- Guides through `but resolve` workflow
+- Does not try to use git merge tools
+
+#### Test 6.2: Multiple Branches Active
+
+**Scenario:** 3 branches applied in workspace
+**Expected:**
+
+- Correctly stages files to appropriate branches
+- Understands which changes belong where
+
+#### Test 6.3: Empty Repository
+
+**User says:** "Set up GitButler in this repo"
+**Expected:**
+
+- Runs `but setup`
+- Explains workspace model
+
+## Success Criteria
+
+### Must Have (P0)
+
+- ✅ Skill invokes on version control queries
+- ✅ Creates branches before starting work
+- ✅ Uses `but` commands not `git` for writes
+- ✅ Follows proactive 5-step workflow
+
+### Should Have (P1)
+
+- ✅ Stages changes after code edits
+- ✅ Loads reference files when needed
+- ✅ Provides correct command syntax
+- ✅ Explains workspace model when confused
+
+### Nice to Have (P2)
+
+- ✅ Proactively suggests `but absorb` for cleanup
+- ✅ Recommends parallel vs stacked branches appropriately
+- ✅ Uses CLI IDs from `but status` output
+
+## Performance Metrics
+
+### Token Efficiency
+
+- **SKILL.md size:** 151 lines, ~4.6KB, ~1,150 tokens
+- **Target:** Load reference files <20% of the time for basic operations
+- **Measure:** Count how many times references/ files are loaded
+
+### Response Quality
+
+- **Command accuracy:** 100% correct `but` command selection
+- **Workflow compliance:** Follows 5-step pattern >80% of time
+- **Avoidance:** 0% use of prohibited git commands
+
+### User Experience
+
+- **Time to first action:** Claude should start work within 1-2 messages
+- **Clarity:** Explanations should reference workspace model when needed
+- **Completeness:** All steps in workflow should be followed
+
+## Running Tests
+
+### Manual Testing
+
+1. Start fresh Claude Code session
+2. Navigate to GitButler repository
+3. Run each test scenario
+4. Record observations in format:
+
+```
+   Test: [Test Name]
+   Result: PASS/FAIL
+   Observations: [What happened]
+   Token usage: [If measurable]
+   ```
+
+### Automated Testing (Future)
+
+- Create test harness that simulates user inputs
+- Measure skill invocation rates
+- Track token consumption
+- Verify command selection
+
+## Test Results Log
+
+```
+Date: [YYYY-MM-DD]
+Tester: [Name]
+Session: [Session ID]
+
+Test 1.1 - Version Control State Query
+Result: [PASS/FAIL]
+Notes:
+
+Test 1.2 - Starting New Work
+Result: [PASS/FAIL]
+Notes:
+
+[... etc ...]
+```
+
+## Iteration Plan
+
+Based on test results:
+
+### If trigger accuracy <80%
+
+- Refine description field
+- Add more trigger keywords
+- Consider more explicit "when to use" language
+
+### If command selection incorrect
+
+- Strengthen "don't use git" messaging in SKILL.md
+- Add more examples of correct commands
+- Clarify workspace model differences
+
+### If workflow not followed
+
+- Make 5-step workflow more prominent
+- Add more directive language ("always do X before Y")
+- Consider simplified workflow section
+
+### If too many reference loads
+
+- Add more command quick reference to SKILL.md
+- Compress key concepts into smaller snippets
+- Evaluate if references/ split is optimal
+
+### If token consumption too high
+
+- Move Essential Commands section to reference.md
+- Remove code examples from SKILL.md
+- Implement ultra-lean Option A structure

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -1,0 +1,333 @@
+# GitButler CLI Key Concepts
+
+Deep dive into GitButler's conceptual model and philosophy.
+
+## The Workspace Model
+
+### Traditional Git: Serial Branching
+
+```
+main ──┬── feature-a (checkout here, work, commit, checkout back)
+       └── feature-b (checkout here, work, commit, checkout back)
+```
+
+- Work on ONE branch at a time
+- Switch contexts with `git checkout`
+- Changes are isolated by branch
+
+### GitButler: Parallel Stacks
+
+```
+workspace (gitbutler/workspace)
+  ├─ feature-a (applied, merged into workspace)
+  ├─ feature-b (applied, merged into workspace)
+  └─ feature-c (unapplied, not in workspace)
+```
+
+- Work on MULTIPLE branches simultaneously
+- No context switching - all applied branches merged in working directory
+- Changes are ASSIGNED to branches, not isolated by checkout
+
+### Key Implications
+
+1. **No `git checkout`**: You don't switch between branches. All applied branches exist simultaneously in your workspace.
+
+2. **Multiple staging areas**: Each branch is like having its own `git add` staging area. You stage files to specific branches.
+
+3. **The `gitbutler/workspace` branch**: A merge commit containing all applied stacks. Don't interact with it directly - use `but` commands.
+
+4. **Applied vs Unapplied**: Control which branches are active:
+   - Applied branches: In your working directory
+   - Unapplied branches: Exist but not active
+   - Use `but branch apply/unapply` to control
+
+## CLI IDs: Short Identifiers
+
+Every object gets a short, human-readable CLI ID shown in `but status`:
+
+```
+Commits:    c1, c2, c3, c4, c5
+Branches:   bu, bv, bw
+Files:      a1, a2, a3
+Hunks:      h1, h2, h3
+```
+
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short (2-3 chars) and unique within your current workspace context.
+
+**Usage:** Pass these IDs as arguments to commands:
+
+```bash
+but commit bu -m "message"     # Commit to branch 'bu'
+but stage a1 bu                # Stage file 'a1' to branch 'bu'
+but rub c2 c3                  # Squash commits 'c2' and 'c3'
+```
+
+## Parallel vs Stacked Branches
+
+### Parallel Branches (Independent Work)
+
+Create with `but branch new <name>`:
+
+```
+main ──┬── api-endpoint (independent)
+       └── ui-update    (independent)
+```
+
+Use when:
+
+- Tasks don't depend on each other
+- Can be merged independently
+- No shared code between them
+
+Example: Adding a new API endpoint and updating button styles are independent.
+
+### Stacked Branches (Dependent Work)
+
+Create with `but branch new <name> -a <anchor>`:
+
+```
+main ── authentication ── user-profile ── settings-page
+        (base)            (stacked)       (stacked)
+```
+
+Use when:
+
+- Feature B needs code from Feature A
+- Building incrementally on previous work
+- Creating a series of related changes
+
+Example: User profile page needs authentication to be implemented first.
+
+**Dependency tracking:** GitButler automatically tracks which changes depend on which commits. You can't stage dependent changes to the wrong branch.
+
+## Multiple Staging Areas
+
+Traditional git has ONE staging area:
+
+```bash
+git add file1.js    # Stage to THE staging area
+git add file2.js    # Stage to THE staging area
+git commit          # Commit from THE staging area
+```
+
+GitButler has MULTIPLE staging areas (one per branch):
+
+```bash
+but stage file1.js api-branch    # Stage to api-branch's staging area
+but stage file2.js ui-branch     # Stage to ui-branch's staging area
+but commit api-branch -m "..."   # Commit from api-branch's staging area
+but commit ui-branch -m "..."    # Commit from ui-branch's staging area
+```
+
+**Unstaged changes:** Files not staged to any branch yet. Use `but status` to see them, then `but stage` to assign them.
+
+**Auto-assignment:** If only one branch is applied, changes may auto-assign to it.
+
+## The `but rub` Philosophy
+
+`but rub` is the core primitive operation: "rub two things together" to perform an action.
+
+### What Happens Based on Types
+
+The operation performed depends on what you combine:
+
+| Source | Target | Operation | Example |
+|--------|--------|-----------|---------|
+| File | Branch | Stage file to branch | `but rub a1 bu` |
+| File | Commit | Amend file into commit | `but rub a1 c3` |
+| Commit | Commit | Squash commits | `but rub c2 c3` |
+| Commit | Branch | Move commit to branch | `but rub c2 bu` |
+
+### Higher-Level Conveniences
+
+These commands are wrappers around `but rub`:
+
+- `but stage <file> <branch>` = `but rub <file> <branch>`
+- `but amend <file> <commit>` = `but rub <file> <commit>`
+- `but squash` = Multiple `but rub <commit> <commit>` operations
+- `but move` = `but rub <commit> <target>` with position control
+
+**Why this design?** One powerful primitive is easier to understand and maintain than many specialized commands. Once you understand `but rub`, you understand the editing model.
+
+## Dependency Tracking
+
+GitButler tracks dependencies between changes automatically.
+
+### How It Works
+
+```
+Commit C1: Added function foo()
+Commit C2: Added function bar()
+Uncommitted: Call to foo() in new code
+```
+
+The uncommitted change **depends on** C1 (because it calls `foo()`).
+
+**Implications:**
+
+1. Can't stage this change to a branch that doesn't have C1
+2. `but absorb` will automatically amend it into C1 (or a commit after C1)
+3. If you try to move the change, GitButler prevents invalid operations
+
+### Why This Matters
+
+Prevents you from creating broken states:
+
+- Can't move dependent code away from its dependencies
+- Can't stage changes to wrong branches
+- Ensures each branch remains independently functional
+
+## Empty Commits as Placeholders
+
+You can create empty commits:
+
+```bash
+but commit empty --before c3
+but commit empty --after c3
+```
+
+**Use cases:**
+
+1. **Mark future work:** Create empty commit as placeholder for changes you'll make
+2. **Mark targets:** Use with `but mark <empty-commit-id>` so future changes auto-amend into it
+3. **Organize history:** Add semantic markers in commit history
+
+Example workflow:
+
+```bash
+but commit empty -m "TODO: Add error handling" --before c5
+but mark <empty-commit-id>
+# Now work on error handling, changes auto-amend into the placeholder
+```
+
+## Auto-Staging and Auto-Commit (Marks)
+
+Set a "mark" on a branch or commit to automatically organize new changes.
+
+### Mark a Branch
+
+```bash
+but mark <branch-id>
+```
+
+New unstaged changes automatically stage to this branch. Useful when focused on one feature.
+
+### Mark a Commit
+
+```bash
+but mark <commit-id>
+```
+
+New changes automatically amend into this commit. Useful for iterative refinement.
+
+### Remove Marks
+
+```bash
+but mark <id> --delete    # Remove specific mark
+but unmark                # Remove all marks
+```
+
+**Example workflow:**
+
+```bash
+but branch new refactor
+but mark <refactor-branch-id>
+# Make lots of changes - they all auto-stage to refactor branch
+but unmark
+```
+
+## Operation History (Oplog)
+
+Every operation in GitButler is recorded in the oplog (operation log).
+
+### What Gets Recorded
+
+- Branch creation/deletion
+- Commits
+- Stage operations
+- Rub/squash/move operations
+- Push/pull operations
+
+### Using Oplog
+
+```bash
+but oplog                      # View history
+but undo                       # Undo last operation
+but restore <snapshot-id>      # Restore to specific point
+```
+
+Think of it as "git reflog" but for all GitButler operations, not just branch movements.
+
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but restore` to earlier snapshot.
+
+## Applied vs Unapplied Branches
+
+Branches can be in two states:
+
+### Applied Branches
+
+- Active in your workspace
+- Merged into `gitbutler/workspace`
+- Changes visible in working directory
+- Can make changes, commit, stage files
+
+### Unapplied Branches
+
+- Exist but not active
+- Not in working directory
+- Can't make changes (must apply first)
+- Useful for temporarily setting aside work
+
+### Controlling State
+
+```bash
+but branch apply <id>      # Make branch active
+but branch unapply <id>    # Make branch inactive
+```
+
+**Use cases:**
+
+- Unapply branches causing conflicts
+- Focus on subset of work (unapply others)
+- Temporarily set aside work without deleting
+
+## Conflict Resolution Mode
+
+When `but pull` causes conflicts, affected commits are marked as conflicted.
+
+### Resolution Workflow
+
+1. **Identify:** `but status` shows conflicted commits
+2. **Enter mode:** `but resolve <commit-id>`
+3. **Fix conflicts:** Edit files, remove conflict markers
+4. **Check:** `but resolve status` shows remaining conflicts
+5. **Finalize:** `but resolve finish` or `but resolve cancel`
+
+### During Resolution
+
+- You're in a special mode focused on that commit
+- Other GitButler operations are limited
+- `but status` shows you're in resolution mode
+- Must finish or cancel before continuing normal work
+
+## Read-Only Git Commands
+
+Git commands that don't modify state are safe to use:
+
+**Safe (read-only):**
+
+- `git log` - View history
+- `git diff` - See changes
+- `git show` - View commits
+- `git blame` - See line history
+- `git reflog` - View reference log
+
+**Unsafe (modifying):**
+
+- `git status` - Shows merged workspace, not individual stacks
+- `git commit` - Commits to wrong place
+- `git checkout` - Breaks workspace model
+- `git rebase` - Conflicts with GitButler's management
+- `git merge` - Use `but merge` instead
+
+**Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -1,0 +1,494 @@
+# GitButler CLI Workflow Examples
+
+Real-world examples of common workflows.
+
+## Example 1: Starting Independent Parallel Work
+
+**Scenario:** Need to work on two independent features: a new API endpoint and UI styling updates.
+
+```bash
+# 1. Check current state
+but status
+
+# 2. Create two independent (parallel) branches
+but branch new api-endpoint
+but branch new ui-styling
+
+# 3. Make changes to multiple files
+# (edit api/users.js and components/Button.svelte)
+
+# 4. Check what's unstaged
+but status
+
+# 5. Stage files to appropriate branches
+but stage a1 bu    # api/users.js → api-endpoint branch
+but stage a2 bv    # Button.svelte → ui-styling branch
+
+# 6. Commit each branch
+but commit bu -m "Add user details endpoint"
+but commit bv -m "Update button hover styles"
+
+# 7. Push branches independently
+but push bu
+but push bv
+
+# 8. Create pull requests
+but pr new bu
+but pr new bv
+```
+
+**Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
+
+## Example 2: Building Stacked Features
+
+**Scenario:** Need to add authentication, then build a user profile page that requires auth.
+
+```bash
+# 1. Check current state and update
+but pull
+but status
+
+# 2. Create base branch for authentication
+but branch new add-authentication
+
+# 3. Implement auth and commit
+# (edit auth/login.js, auth/middleware.js)
+but status
+but commit bu -m "Add JWT authentication"
+
+# 4. Create stacked branch anchored on authentication
+but branch new user-profile -a bu
+
+# 5. Implement profile page (depends on auth)
+# (edit pages/profile.js)
+but status
+but commit bv -m "Add user profile page"
+
+# 6. Push both branches (maintains stack relationship)
+but push
+```
+
+**Result:** Two PRs where user-profile PR depends on authentication PR. GitHub/GitLab shows the dependency.
+
+## Example 3: Using Absorb Instead of New Commits
+
+**Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
+
+```bash
+# 1. Check current commits
+but status
+
+# Output shows:
+# Branch: feature-x (bu)
+# Commits:
+#   c3: Implement feature logic
+#   c2: Add feature tests
+# Unstaged:
+#   a1: fix-typo.js (staged to bu)
+
+# 2. Absorb the change into appropriate commit
+but absorb
+
+# GitButler analyzes the change and amends it into c3
+# (because the typo is in code from c3)
+
+# Alternative: Preview first with dry-run
+but absorb --dry-run    # Shows what would happen
+but absorb              # Actually do it
+```
+
+**Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
+
+## Example 4: Reorganizing Commit History
+
+### Scenario A: Squashing Commits
+
+**Situation:** Made 5 small WIP commits, want to combine into one logical commit.
+
+```bash
+# Before:
+# c5: More tweaks
+# c4: Fix another thing
+# c3: Fix tests
+# c2: Adjust logic
+# c1: Initial implementation
+
+# Squash all commits in branch
+but squash bu
+
+# Or squash specific range
+but squash c2..c5    # Squashes c2, c3, c4, c5 into one
+
+# Or squash specific commits
+but squash c2 c3 c4    # Squashes these three
+```
+
+### Scenario B: Moving Files Between Commits
+
+**Situation:** A file was committed in the wrong commit, need to move it.
+
+```bash
+# 1. See which files are in which commits
+but status --file
+
+# Output shows:
+# c3: api.js, utils.js
+# c2: config.js
+
+# 2. Move utils.js from c3 to c2
+but rub a2 c2    # File a2 (utils.js) → commit c2
+```
+
+### Scenario C: Moving Commit to Different Branch
+
+**Situation:** Committed to wrong branch, need to move commit.
+
+```bash
+# 1. Check current state
+but status
+
+# Output:
+# Branch: feature-a (bu)
+#   c3: This should be in feature-b!
+#   c2: Correct commit
+
+# 2. Create or identify target branch
+but branch new feature-b    # Creates branch bv
+
+# 3. Move the commit
+but move c3 bv    # Move c3 to top of branch bv
+```
+
+## Example 5: Using Marks for Focused Work
+
+**Scenario:** Working on a large refactor, want all changes to automatically stage to that branch.
+
+```bash
+# 1. Create refactor branch
+but branch new refactor
+
+# 2. Mark it for auto-staging
+but mark bu    # Branch bu (refactor) is now marked
+
+# 3. Make changes across many files
+# (edit 20 different files)
+
+# 4. All changes automatically staged to refactor branch
+but status    # Shows all changes staged to bu
+
+# 5. Commit everything
+but commit bu -m "Refactor error handling across app"
+
+# 6. Remove mark
+but unmark
+```
+
+**Alternative: Mark a commit for auto-amend**
+
+```bash
+# 1. Create empty commit as placeholder
+but commit empty -m "TODO: Add error handling"
+
+# 2. Mark it
+but mark c5    # Commit c5 is now marked
+
+# 3. Make changes - they auto-amend into c5
+# (edit files)
+
+# 4. Check result
+but show c5    # Shows accumulated changes
+
+# 5. Remove mark when done
+but unmark
+```
+
+## Example 6: Conflict Resolution
+
+**Scenario:** After `but pull`, conflicts appear in a commit.
+
+```bash
+# 1. Pull updates
+but pull
+
+# Output:
+# Conflict in commit c3 on branch feature-x
+
+# 2. Check status
+but status
+
+# Output:
+# Branch: feature-x (bu)
+#   c3: Add validation (CONFLICTED)
+
+# 3. Enter resolution mode
+but resolve c3
+
+# Output:
+# Entering resolution mode for commit c3
+# Fix conflicts in: api/users.js, api/validation.js
+
+# 4. Edit files to resolve conflicts
+# (open files, remove <<< === >>> markers)
+
+# 5. Check progress
+but resolve status
+
+# Output:
+# Remaining conflicts:
+#   api/validation.js
+
+# 6. Continue fixing...
+# (resolve last conflict)
+
+# 7. Finalize
+but resolve finish
+
+# Back to normal workspace mode
+```
+
+## Example 7: Complete Feature Development Workflow
+
+**Scenario:** Building a complete feature from start to finish.
+
+```bash
+# 1. Update to latest
+but pull
+
+# 2. Create branch for feature
+but branch new user-dashboard
+
+# 3. Make initial changes
+# (create dashboard.js, add routes)
+
+# 4. Check and stage
+but status
+# If only one branch applied, files auto-stage
+# Otherwise: but stage <files> bu
+
+# 5. First commit
+but commit bu -m "Add dashboard route and basic layout"
+
+# 6. Continue iterating
+# (add widgets, styling)
+but commit bu -m "Add dashboard widgets"
+but commit bu -m "Style dashboard components"
+
+# 7. Make small fix
+# (fix typo in widget)
+but absorb    # Amends into appropriate commit
+
+# 8. Review history
+but status
+
+# 9. Clean up if needed
+but squash bu    # Combine all commits (optional)
+
+# 10. Push to remote
+but push bu
+
+# 11. Create pull request
+but pr new bu
+
+# Output:
+# Created PR #123: https://github.com/org/repo/pull/123
+
+# 12. After PR is merged, update
+but pull
+```
+
+## Example 8: Working with Applied/Unapplied Branches
+
+**Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
+
+```bash
+# 1. Check active branches
+but status
+
+# Output:
+# Applied branches:
+#   bu: feature-a
+#   bv: feature-b
+#   bw: feature-c
+
+# 2. Conflicts between feature-b and feature-c
+# Unapply them temporarily
+but branch unapply bv
+but branch unapply bw
+
+# 3. Focus on feature-a
+# (make changes, commit)
+but commit bu -m "Complete feature-a"
+
+# 4. Push and create PR for feature-a
+but push bu
+but pr new bu
+
+# 5. Reapply other branches
+but branch apply bv
+but branch apply bw
+
+# 6. Deal with their conflicts now
+but resolve ...
+```
+
+## Example 9: Fixing History Before Pushing
+
+**Scenario:** Made several commits, realized you need to reword messages and reorder.
+
+```bash
+# 1. Current state
+but status
+
+# Output:
+# Branch: feature-x (bu)
+#   c5: final commit
+#   c4: WIP
+#   c3: Fix stuff
+#   c2: Another fix
+#   c1: Initial
+
+# 2. Reword commit messages
+but reword c4 -m "Add validation logic"
+but reword c3 -m "Fix edge case in parser"
+but reword c2 -m "Update error messages"
+
+# 3. Move c5 to be earlier
+but move c5 c3    # Move c5 before c3
+
+# 4. Squash similar commits
+but squash c2 c3    # Combine error handling commits
+
+# 5. Review final state
+but status
+
+# Output:
+# Branch: feature-x (bu)
+#   c4: Add validation logic
+#   c3: final commit
+#   c2: Fix edge case in parser and update error messages
+#   c1: Initial
+
+# 6. Push clean history
+but push bu
+```
+
+## Example 10: Daily Development Workflow
+
+**Typical day working with GitButler:**
+
+```bash
+# Morning: Start day
+but pull                          # Get latest from team
+
+# Start new task
+but branch new fix-auth-bug       # Create branch for today's work
+
+# Work and commit iteratively
+# (make changes)
+but commit bu -m "Identify auth bug source"
+# (make more changes)
+but commit bu -m "Fix token expiration handling"
+# (small fix)
+but absorb                        # Amend into previous commit
+
+# Mid-day: Start urgent fix on different branch
+but branch new hotfix-login       # Parallel branch for urgent work
+# (make fix)
+but commit bv -m "Fix login redirect loop"
+but push bv                       # Push urgent fix
+but pr new bv                     # Create PR immediately
+
+# Back to original work
+# (continue working on bu, auth bug fix)
+but commit bu -m "Add tests for token handling"
+
+# End of day: Clean up and push
+but squash bu                     # Combine into clean history
+but push bu                       # Push work
+but pr new bu                     # Create PR
+
+# After PR review: Make requested changes
+# (make changes based on feedback)
+but absorb                        # Amend into existing commits
+but push bu --with-force          # Force push updated history
+```
+
+## Example 11: Recovering from Mistakes
+
+**Scenario:** Made changes you didn't mean to, need to undo.
+
+### Undo Last Operation
+
+```bash
+# Made a mistake
+but squash bu    # Oops! Didn't mean to squash
+
+# Undo it
+but undo         # Reverts the squash
+```
+
+### Restore to Earlier Point
+
+```bash
+# View operation history
+but oplog
+
+# Output:
+# s5: squash branch bu
+# s4: commit bu "message"
+# s3: stage files to bu
+# s2: create branch bu
+# s1: pull from remote
+
+# Restore to before squash
+but restore s4
+```
+
+### Discard Uncommitted Changes
+
+```bash
+# Changed a file but want to discard
+but status
+
+# Output:
+# Unstaged:
+#   a1: bad-changes.js
+
+# Discard it
+but discard a1
+```
+
+## Tips and Tricks
+
+### Quick Status Check
+
+```bash
+but status -f    # File-centric view for quick overview
+```
+
+### Preview Before Doing
+
+```bash
+but absorb --dry-run    # See what would happen
+but push --dry-run      # See what would be pushed
+```
+
+### JSON for Scripting
+
+```bash
+but status --json | jq '.branches[] | .name'    # List branch names
+```
+
+### Auto-completion
+
+```bash
+eval "$(but completions zsh)"     # Add to ~/.zshrc
+eval "$(but completions bash)"    # Add to ~/.bashrc
+```
+
+### Viewing History
+
+```bash
+but show bu              # Show all commits in branch
+git log bu               # Traditional git log (read-only, still works)
+```

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -1,0 +1,434 @@
+# GitButler CLI Command Reference
+
+Comprehensive reference for all `but` commands.
+
+## Inspection (Understanding State)
+
+### `but status`
+
+Overview of workspace state - this is your entry point.
+
+```bash
+but status              # Human-readable view
+but status -f           # File-centric view (shows which files in which commits)
+but status --json       # Structured output for parsing
+but status --verbose    # Detailed information
+but status --upstream   # Show upstream relationship
+```
+
+Shows:
+
+- Applied/unapplied branches in workspace
+- Uncommitted changes (unstaged files)
+- Commits on each stack
+- CLI IDs to use in other commands
+
+### `but show <id>`
+
+Details about a commit or branch.
+
+```bash
+but show <id>           # Show details
+but show <id> --verbose # More detailed information
+but show <id> --json    # Structured output
+```
+
+### `but diff [target]`
+
+Display diff for file, branch, stack, or commit.
+
+```bash
+but diff <file-id>      # Diff for specific file
+but diff <branch-id>    # Diff for all changes in branch
+but diff <commit-id>    # Diff for specific commit
+but diff                # Diff for entire workspace
+```
+
+## Branching
+
+### `but branch`
+
+List all branches (default when no subcommand).
+
+```bash
+but branch              # List branches
+but branch --json       # JSON output
+```
+
+### `but branch new <name>`
+
+Create a new branch.
+
+```bash
+but branch new feature              # Independent branch (parallel work)
+but branch new feature -a <anchor>  # Stacked branch (dependent work)
+```
+
+Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
+
+### `but branch apply/unapply <id>`
+
+Control which branches are active in workspace.
+
+```bash
+but branch apply <id>    # Activate branch in workspace
+but branch unapply <id>  # Deactivate branch from workspace
+```
+
+Applied branches are merged into `gitbutler/workspace` and visible in working directory.
+
+### `but branch delete <id>`
+
+Delete a branch.
+
+```bash
+but branch delete <id>
+but branch -d <id>      # Short form
+```
+
+### `but branch show <id>`
+
+Show commits ahead of base for a branch.
+
+```bash
+but branch show <id>
+```
+
+## Staging (Multiple Staging Areas)
+
+GitButler has multiple staging areas - one per stack.
+
+### `but stage <file> <branch>`
+
+Stage file to a specific branch.
+
+```bash
+but stage <file-id> <branch-id>
+```
+
+Alias for `but rub <file> <branch>`. You can't stage changes that depend on branch A to branch B.
+
+### `but rub <file> <branch>`
+
+Core primitive for staging (see Editing History for other `but rub` uses).
+
+```bash
+but rub <file-id> <branch-id>    # Stage file to branch
+```
+
+## Committing
+
+### `but commit [branch]`
+
+Commit changes to a branch.
+
+```bash
+but commit <branch> -m "message"         # Commit with message
+but commit <branch> --only               # Only commit already-staged files
+but commit <branch> -i                   # AI-generated commit message
+but commit empty --before <target>       # Insert empty commit before target
+but commit empty --after <target>        # Insert empty commit after target
+```
+
+If only one branch is applied, you can omit the branch ID.
+
+### `but absorb [source]`
+
+Automatically amend uncommitted changes into existing commits.
+
+```bash
+but absorb                    # Amend all changes
+but absorb <file-id>          # Amend only this file
+but absorb <branch-id>        # Amend only changes staged to this branch
+but absorb --dry-run          # Preview without making changes
+```
+
+Logic:
+
+- Changes amended into topmost commit of their branch
+- Changes depending on specific commit amended into that commit
+- Uses smart matching to find appropriate commits
+
+## Editing History
+
+### `but rub <source> <dest>`
+
+Universal editing primitive that does different operations based on types.
+
+```bash
+but rub <file> <branch>      # Stage file to branch
+but rub <file> <commit>      # Amend file into commit
+but rub <commit> <commit>    # Squash commits together
+but rub <commit> <branch>    # Move commit to branch
+```
+
+The core "rub two things together" operation.
+
+### `but squash <commits>`
+
+Squash commits together.
+
+```bash
+but squash <c1> <c2> <c3>    # Squash multiple commits (into last)
+but squash <c1>..<c4>        # Squash a range
+but squash <branch>          # Squash all commits in branch into bottom-most
+```
+
+### `but amend <file> <commit>`
+
+Amend file into a specific commit.
+
+```bash
+but amend <file-id> <commit-id>
+```
+
+Alias for `but rub <file> <commit>`.
+
+### `but move <commit> <target>`
+
+Move a commit to a different location.
+
+```bash
+but move <source> <target>           # Move before target
+but move <source> <target> --after   # Move after target
+but move <commit> <branch>           # Move to top of branch
+```
+
+### `but uncommit <source>`
+
+Uncommit changes back to unstaged area.
+
+```bash
+but uncommit <commit-id>      # Uncommit entire commit
+but uncommit <file-id>        # Uncommit specific file from its commit
+```
+
+### `but reword <id>`
+
+Reword commit message or rename branch.
+
+```bash
+but reword <id>               # Interactive editor
+but reword <id> -m "new"      # Non-interactive
+but reword <id> --format      # Format to 72-char wrapping
+```
+
+### `but discard <id>`
+
+Discard uncommitted changes.
+
+```bash
+but discard <file-id>         # Discard file changes
+but discard <hunk-id>         # Discard hunk changes
+```
+
+## Conflict Resolution
+
+When commits have conflicts (shown in `but status`):
+
+### `but resolve <commit>`
+
+Enter resolution mode for a conflicted commit.
+
+```bash
+but resolve <commit-id>
+```
+
+### `but resolve status`
+
+Show remaining conflicted files.
+
+```bash
+but resolve status
+```
+
+### `but resolve finish`
+
+Finalize conflict resolution.
+
+```bash
+but resolve finish
+```
+
+### `but resolve cancel`
+
+Cancel conflict resolution and return to workspace mode.
+
+```bash
+but resolve cancel
+```
+
+**Workflow:**
+
+1. `but resolve <commit>` - Enter mode
+2. Edit files to resolve conflicts
+3. `but resolve status` - Check progress
+4. `but resolve finish` - Complete
+
+## Remote Operations
+
+### `but push [branch]`
+
+Push branches to remote.
+
+```bash
+but push                      # Push all branches with unpushed commits
+but push <branch-id>          # Push specific branch
+but push --dry-run            # Preview what would be pushed
+but push --with-force         # Force push (use carefully!)
+```
+
+### `but pull`
+
+Update all branches with target branch changes.
+
+```bash
+but pull                      # Fetch and rebase all branches
+but pull --check              # Check if can merge cleanly (no changes)
+```
+
+Run regularly to stay up to date with main development line.
+
+### `but pr`
+
+Create and manage pull requests.
+
+```bash
+but pr                        # Create PR (prompts for branch)
+but pr new <branch-id>        # Create PR for specific branch
+but pr template               # Configure PR description template
+```
+
+Requires GitHub CLI (`gh`) to be installed and authenticated.
+
+### `but merge <branch>`
+
+Merge branch into local target branch.
+
+```bash
+but merge <branch-id>
+```
+
+Merges into local target branch, then runs `but pull` to update.
+
+## Automation
+
+### `but mark <target>`
+
+Auto-stage or auto-commit new changes.
+
+```bash
+but mark <branch-id>          # New unstaged changes auto-stage to this branch
+but mark <commit-id>          # New changes auto-amend into this commit
+but mark <id> --delete        # Remove the mark
+```
+
+### `but unmark`
+
+Remove all marks.
+
+```bash
+but unmark
+```
+
+Use marks when working on a focused area to automatically organize changes.
+
+## History & Undo
+
+### `but undo`
+
+Undo last operation.
+
+```bash
+but undo
+```
+
+Reverts to previous oplog snapshot.
+
+### `but oplog`
+
+View operation history.
+
+```bash
+but oplog
+but oplog --json
+```
+
+Shows all operations with snapshot IDs.
+
+### `but restore <snapshot>`
+
+Restore to a specific oplog snapshot.
+
+```bash
+but restore <snapshot-id>
+```
+
+## Setup & Configuration
+
+### `but setup`
+
+Initialize GitButler in current git repository.
+
+```bash
+but setup
+```
+
+Converts regular git repo to use GitButler workspace model.
+
+### `but teardown`
+
+Exit GitButler mode and return to normal git workflow.
+
+```bash
+but teardown
+```
+
+### `but config`
+
+View and manage GitButler configuration.
+
+```bash
+but config
+```
+
+### `but gui`
+
+Open GitButler GUI for current project.
+
+```bash
+but gui
+```
+
+### `but update`
+
+Manage GitButler CLI and app updates.
+
+```bash
+but update
+```
+
+### `but alias`
+
+Manage command aliases.
+
+```bash
+but alias
+```
+
+## Global Options
+
+Available on most commands:
+
+- `-j, --json` - Output in JSON format for parsing
+- `-C, --current-dir <PATH>` - Run as if started in different directory
+- `-h, --help` - Show help for command
+
+## Getting More Help
+
+```bash
+but --help                    # List all commands
+but <subcommand> --help       # Detailed help for specific command
+```
+
+Full documentation: <https://docs.gitbutler.com/cli-overview>

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -50,6 +50,7 @@ pub enum CommandName {
     Resolve,
     Update,
     Merge,
+    SkillInstall,
     #[default]
     Unknown,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -819,6 +819,29 @@ pub enum Subcommands {
         branch: Option<String>,
     },
 
+    /// Manage Claude AI skills for GitButler.
+    ///
+    /// Skills provide enhanced AI capabilities for working with GitButler through
+    /// Claude Code and other AI assistants.
+    ///
+    /// Use `but skill install` to install the GitButler skill files into your
+    /// repository or globally.
+    ///
+    /// ## Examples
+    ///
+    /// Install the skill in the current repository:
+    ///
+    /// ```text
+    /// but skill install
+    /// ```
+    ///
+    /// Install the skill globally:
+    ///
+    /// ```text
+    /// but skill install --global
+    /// ```
+    Skill(skill::Platform),
+
     /// Show help information grouped by category.
     ///
     /// Displays all available commands organized into functional categories
@@ -832,6 +855,7 @@ pub enum Subcommands {
 pub mod alias;
 pub mod commit;
 pub mod config;
+pub mod skill;
 pub mod update;
 
 pub mod actions {

--- a/crates/but/src/args/skill.rs
+++ b/crates/but/src/args/skill.rs
@@ -1,0 +1,55 @@
+/// Arguments for skill management commands
+#[derive(Debug, clap::Parser)]
+pub struct Platform {
+    #[clap(subcommand)]
+    pub cmd: Subcommands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+    /// Install the Claude skill files into the repository
+    ///
+    /// By default, installs the skill into the current repository. The command
+    /// will prompt you to select a skill folder format (Claude Code, GitHub Copilot, etc.)
+    /// unless you specify a custom path with --path.
+    ///
+    /// Use --global to install the skill in a global location instead of the
+    /// current repository.
+    ///
+    /// ## Examples
+    ///
+    /// Install in current repository (prompts for format):
+    ///
+    /// ```text
+    /// but skill install
+    /// ```
+    ///
+    /// Install globally (prompts for format):
+    ///
+    /// ```text
+    /// but skill install --global
+    /// ```
+    ///
+    /// Install to a custom path:
+    ///
+    /// ```text
+    /// but skill install --path .claude/skills/gitbutler
+    /// ```
+    ///
+    /// Auto-detect installation location (update existing installation):
+    ///
+    /// ```text
+    /// but skill install --infer
+    /// ```
+    Install {
+        /// Install the skill globally instead of in the current repository
+        #[clap(long, short = 'g')]
+        global: bool,
+        /// Custom path where to install the skill (relative to repository root or absolute)
+        #[clap(long, short = 'p')]
+        path: Option<String>,
+        /// Automatically infer where to install by detecting existing installation
+        #[clap(long, short = 'i')]
+        infer: bool,
+    },
+}

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -10,4 +10,5 @@ pub mod config;
 pub mod gui;
 pub mod help;
 pub mod push;
+pub mod skill;
 pub mod update;

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -1,0 +1,733 @@
+use crate::{args::skill, utils::OutputChannel};
+use anyhow::{Context as _, Result};
+use but_ctx::Context;
+use cli_prompts::DisplayPrompt;
+use colored::Colorize;
+use std::{fmt::Write as _, path::PathBuf};
+
+// Embedded skill files
+const SKILL_MD: &[u8] = include_bytes!("../../skill/SKILL.md");
+const CONCEPTS_MD: &[u8] = include_bytes!("../../skill/references/concepts.md");
+const EXAMPLES_MD: &[u8] = include_bytes!("../../skill/references/examples.md");
+const REFERENCE_MD: &[u8] = include_bytes!("../../skill/references/reference.md");
+
+/// Metadata for a skill file to be installed
+struct SkillFile {
+    /// Relative path from install directory (e.g., "SKILL.md" or "references/concepts.md")
+    path: &'static str,
+    /// Embedded content
+    content: &'static [u8],
+    /// Display name for output
+    display_name: &'static str,
+}
+
+/// All skill files to be installed
+const SKILL_FILES: &[SkillFile] = &[
+    SkillFile {
+        path: "SKILL.md",
+        content: SKILL_MD,
+        display_name: "SKILL.md",
+    },
+    SkillFile {
+        path: "references/concepts.md",
+        content: CONCEPTS_MD,
+        display_name: "concepts.md",
+    },
+    SkillFile {
+        path: "references/examples.md",
+        content: EXAMPLES_MD,
+        display_name: "examples.md",
+    },
+    SkillFile {
+        path: "references/reference.md",
+        content: REFERENCE_MD,
+        display_name: "reference.md",
+    },
+];
+
+/// Represents a skill installation location format
+#[derive(Debug, Clone)]
+struct SkillFormat {
+    /// Display name of the format
+    name: &'static str,
+    /// Description of where this format is used
+    description: &'static str,
+    /// Path relative to repository root (for local) or home directory (for global)
+    path: &'static str,
+}
+
+impl SkillFormat {
+    /// Get the actual installation path given a base directory
+    fn get_install_path(&self, base_dir: &std::path::Path) -> PathBuf {
+        base_dir.join(self.path)
+    }
+}
+
+// Common skill folder formats
+const SKILL_FORMATS: &[SkillFormat] = &[
+    SkillFormat {
+        name: "Claude Code",
+        description: "Claude Code CLI skill format",
+        path: ".claude/skills/gitbutler",
+    },
+    SkillFormat {
+        name: "OpenCode",
+        description: "OpenCode AI skill format",
+        path: ".opencode/skills/gitbutler",
+    },
+    SkillFormat {
+        name: "GitHub Copilot",
+        description: "GitHub Copilot skill format",
+        path: ".github/copilot/skills/gitbutler",
+    },
+    SkillFormat {
+        name: "Cursor",
+        description: "Cursor AI skill format",
+        path: ".cursor/skills/gitbutler",
+    },
+    SkillFormat {
+        name: "Windsurf",
+        description: "Windsurf skill format",
+        path: ".windsurf/skills/gitbutler",
+    },
+];
+
+/// Handle skill subcommands
+pub fn handle(
+    ctx: Option<&mut Context>,
+    out: &mut OutputChannel,
+    cmd: skill::Subcommands,
+) -> Result<()> {
+    match cmd {
+        skill::Subcommands::Install {
+            global,
+            path,
+            infer,
+        } => install_skill(ctx, out, global, path, infer),
+    }
+}
+
+/// Expand tilde in path to home directory
+fn expand_tilde(path_str: &str) -> Option<PathBuf> {
+    if path_str == "~" || path_str.starts_with("~/") || path_str.starts_with("~\\") {
+        dirs::home_dir().map(|home| {
+            if path_str == "~" {
+                home
+            } else {
+                home.join(&path_str[2..])
+            }
+        })
+    } else {
+        None
+    }
+}
+
+/// Get the base directory for installation (repo root or home directory)
+fn get_base_dir(ctx: Option<&mut Context>, global: bool) -> Result<PathBuf> {
+    if global {
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
+    } else {
+        let ctx = ctx.ok_or_else(|| {
+            anyhow::anyhow!("Not in a git repository. Use --global to install globally, or run from within a repository.")
+        })?;
+        let repo = ctx.repo.get()?;
+        repo.workdir()
+            .ok_or_else(|| anyhow::anyhow!("Not in a Git repository"))
+            .map(|p| p.to_path_buf())
+    }
+}
+
+/// Replace version in SKILL.md content
+fn inject_version(content: &str, version: &str) -> String {
+    // Handle different line endings (Unix \n, Windows \r\n, or old Mac \r)
+    let frontmatter_end = content
+        .find("---\n\n")
+        .or_else(|| content.find("---\r\n\r\n"))
+        .or_else(|| content.find("---\r\r"));
+
+    if let Some(end_pos) = frontmatter_end {
+        let frontmatter = &content[..end_pos];
+        let rest = &content[end_pos..];
+        let updated_frontmatter =
+            frontmatter.replace("version: 0.0.0", &format!("version: {}", version));
+        format!("{}{}", updated_frontmatter, rest)
+    } else {
+        // Fallback if frontmatter format is unexpected
+        content.replace("version: 0.0.0", &format!("version: {}", version))
+    }
+}
+
+/// Resolve custom path with tilde expansion and relative path handling
+fn resolve_custom_path(custom: &str, ctx: Option<&mut Context>, global: bool) -> Result<PathBuf> {
+    let path = std::path::Path::new(custom);
+
+    // Try tilde expansion first
+    let expanded_path = expand_tilde(custom).unwrap_or_else(|| path.to_path_buf());
+
+    if expanded_path.is_absolute() {
+        Ok(expanded_path)
+    } else {
+        // Relative path - join with base directory
+        let base_dir = get_base_dir(ctx, global)?;
+        Ok(base_dir.join(expanded_path))
+    }
+}
+
+/// Validate that a SKILL.md file is actually a GitButler skill
+fn is_gitbutler_skill(skill_md_path: &std::path::Path) -> bool {
+    if let Ok(content) = std::fs::read_to_string(skill_md_path) {
+        // Check for GitButler-specific markers with proper context
+        // Look for YAML frontmatter with "name: but" or the specific header
+        let has_frontmatter_name = content.lines().any(|line| line.trim() == "name: but");
+
+        let has_gitbutler_header = content.lines().any(|line| {
+            line.contains("# GitButler CLI Skill") || line.contains("GitButler CLI (`but` command)")
+        });
+
+        has_frontmatter_name || has_gitbutler_header
+    } else {
+        false
+    }
+}
+
+/// Infer installation path by detecting existing skill installation
+fn infer_install_path(ctx: Option<&mut Context>, global: bool) -> Result<PathBuf> {
+    // Determine which base directories to check
+    let base_dirs: Vec<(PathBuf, &str)> = if global {
+        // Only check global locations
+        vec![(
+            dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?,
+            "global",
+        )]
+    } else if let Some(ctx) = ctx {
+        // Check local repo first, then fall back to global
+        let repo = ctx.repo.get()?;
+        let local_dir = repo
+            .workdir()
+            .ok_or_else(|| anyhow::anyhow!("Not in a Git repository"))?
+            .to_path_buf();
+        let global_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        vec![(local_dir, "local"), (global_dir, "global")]
+    } else {
+        // No repo context, only check global
+        vec![(
+            dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?,
+            "global",
+        )]
+    };
+
+    // Check each scope in priority order (local before global)
+    // Return the first scope that has installations, erroring only if multiple in same scope
+    for (base_dir, scope) in &base_dirs {
+        let mut scope_installations: Vec<(PathBuf, &str)> = Vec::new();
+
+        for format in SKILL_FORMATS {
+            let potential_path = format.get_install_path(base_dir);
+            let skill_md_path = potential_path.join("SKILL.md");
+            if skill_md_path.exists() && is_gitbutler_skill(&skill_md_path) {
+                scope_installations.push((potential_path, format.name));
+            }
+        }
+
+        match scope_installations.len() {
+            0 => {
+                // No installations in this scope, try next scope
+                continue;
+            }
+            1 => {
+                // Exactly one installation in this scope - use it
+                return Ok(scope_installations[0].0.clone());
+            }
+            _ => {
+                // Multiple installations in the same scope - error
+                let installations_list = scope_installations
+                    .iter()
+                    .map(|(path, format)| {
+                        format!("  • {} - {} ({})", format, path.display(), scope)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                anyhow::bail!(
+                    "Multiple skill installations found in {} scope. Please use --path to specify which one to update:\n{}",
+                    scope,
+                    installations_list
+                )
+            }
+        }
+    }
+
+    // No installations found in any scope
+    let checked_locations = base_dirs
+        .iter()
+        .flat_map(|(base_dir, scope)| {
+            SKILL_FORMATS
+                .iter()
+                .map(move |f| format!("  • {} ({})", f.get_install_path(base_dir).display(), scope))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    anyhow::bail!(
+        "Could not infer installation location. No existing skill found in:\n{}",
+        checked_locations
+    )
+}
+
+/// Prompt user to select installation format
+fn prompt_for_install_path(
+    ctx: Option<&mut Context>,
+    global: bool,
+    out: &mut OutputChannel,
+    progress: &mut impl std::io::Write,
+) -> Result<PathBuf> {
+    if out.for_human().is_none() {
+        anyhow::bail!(
+            "In non-interactive mode, you must specify --path. Use --path <path> to specify where to install the skill."
+        );
+    }
+
+    let base_dir = get_base_dir(ctx, global)?;
+
+    writeln!(progress)?;
+    writeln!(progress, "{}", "Select a skill folder format:".bold())?;
+    writeln!(progress)?;
+
+    let options: Vec<String> = SKILL_FORMATS
+        .iter()
+        .map(|format| {
+            let full_path = format.get_install_path(&base_dir);
+            format!(
+                "{} - {} ({})",
+                format.name,
+                format.description,
+                full_path.display().to_string().dimmed()
+            )
+        })
+        .collect();
+
+    let prompt = cli_prompts::prompts::Selection::new(
+        "Which format would you like to use?",
+        options.into_iter(),
+    );
+
+    let selection: String = match prompt.display() {
+        Ok(s) => s,
+        Err(_) => {
+            // User cancelled the prompt (e.g., pressed Escape)
+            writeln!(progress)?;
+            writeln!(progress, "Installation cancelled.")?;
+            std::process::exit(0);
+        }
+    };
+
+    // Find the format that matches the selection
+    let selected_format = SKILL_FORMATS
+        .iter()
+        .find(|format| {
+            let expected_prefix = format!("{} - {}", format.name, format.description);
+            selection.starts_with(&expected_prefix)
+        })
+        .ok_or_else(|| anyhow::anyhow!("Invalid selection"))?;
+
+    Ok(selected_format.get_install_path(&base_dir))
+}
+
+/// Prepare SKILL.md content with version injection and validate all files
+fn prepare_skill_content(version: &str) -> Result<String> {
+    // Validate all embedded files are valid UTF-8
+    let skill_content = std::str::from_utf8(SKILL_MD).context("SKILL.md is not valid UTF-8")?;
+    std::str::from_utf8(CONCEPTS_MD).context("concepts.md is not valid UTF-8")?;
+    std::str::from_utf8(EXAMPLES_MD).context("examples.md is not valid UTF-8")?;
+    std::str::from_utf8(REFERENCE_MD).context("reference.md is not valid UTF-8")?;
+
+    // Inject version into SKILL.md
+    Ok(inject_version(skill_content, version))
+}
+
+/// Write a skill file with proper error context
+fn write_skill_file(path: &std::path::Path, content: &[u8], name: &str) -> Result<()> {
+    std::fs::write(path, content).with_context(|| {
+        format!(
+            "Failed to write {} to {}. Check write permissions.",
+            name,
+            path.parent()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| path.display().to_string())
+        )
+    })
+}
+
+/// Install the skill files
+fn install_skill(
+    ctx: Option<&mut Context>,
+    out: &mut OutputChannel,
+    global: bool,
+    custom_path: Option<String>,
+    infer: bool,
+) -> Result<()> {
+    // Validate that embedded files are not empty (catches build issues)
+    if SKILL_FILES.iter().any(|f| f.content.is_empty()) {
+        anyhow::bail!(
+            "Skill files were not properly embedded at build time. Please report this as a bug."
+        );
+    }
+
+    // Validate SKILL_FORMATS configuration (catches development errors)
+    debug_assert!(
+        !SKILL_FORMATS.is_empty(),
+        "SKILL_FORMATS must contain at least one format"
+    );
+    debug_assert!(
+        SKILL_FORMATS
+            .iter()
+            .all(|f| !f.name.is_empty() && !f.path.is_empty()),
+        "SkillFormat name and path must not be empty"
+    );
+
+    let mut progress = out.progress_channel();
+
+    // Validate flags
+    if infer && custom_path.is_some() {
+        anyhow::bail!("Cannot use both --infer and --path options together");
+    }
+
+    // Determine installation path
+    let install_path = if let Some(custom) = custom_path {
+        resolve_custom_path(&custom, ctx, global)?
+    } else if infer {
+        infer_install_path(ctx, global)?
+    } else {
+        prompt_for_install_path(ctx, global, out, &mut progress)?
+    };
+
+    // Validate installation path
+    if install_path.exists() && install_path.is_file() {
+        anyhow::bail!(
+            "Installation path {} is a file, not a directory. Please specify a directory path.",
+            install_path.display()
+        );
+    }
+
+    // Check if files already exist and warn user
+    let skill_md_path = install_path.join("SKILL.md");
+    if skill_md_path.exists() && out.for_human().is_some() {
+        writeln!(progress)?;
+        writeln!(
+            progress,
+            "{} Skill files already exist at {}",
+            "⚠".yellow(),
+            install_path.display().to_string().cyan()
+        )?;
+        writeln!(progress, "  Overwriting existing files...")?;
+        writeln!(progress)?;
+    }
+
+    // Prepare all content before writing (validate UTF-8 and inject version)
+    let version = option_env!("VERSION").unwrap_or("dev");
+    let skill_md_content = prepare_skill_content(version)?;
+
+    // Create the directory structure
+    let references_dir = install_path.join("references");
+    std::fs::create_dir_all(&references_dir).with_context(|| {
+        format!(
+            "Failed to create skill directory at {}. Check that you have write permissions for this location.",
+            install_path.display()
+        )
+    })?;
+
+    // Write all files
+    for file in SKILL_FILES {
+        let file_path = install_path.join(file.path);
+        let content = if file.path == "SKILL.md" {
+            // Use the version-injected content for SKILL.md
+            skill_md_content.as_bytes()
+        } else {
+            file.content
+        };
+        write_skill_file(&file_path, content, file.display_name)?;
+    }
+
+    // Output success message
+    if out.for_human().is_some() {
+        writeln!(progress)?;
+        writeln!(
+            progress,
+            "{} GitButler skill installed successfully!",
+            "✓".green().bold()
+        )?;
+        writeln!(progress)?;
+        writeln!(
+            progress,
+            "  Location: {}",
+            install_path.display().to_string().cyan()
+        )?;
+        writeln!(progress)?;
+        writeln!(progress, "  Files installed:")?;
+        for file in SKILL_FILES {
+            writeln!(progress, "    • {}", file.path)?;
+        }
+        writeln!(progress)?;
+    } else if let Some(out) = out.for_json() {
+        let file_paths: Vec<&str> = SKILL_FILES.iter().map(|f| f.path).collect();
+        let result = serde_json::json!({
+            "success": true,
+            "version": version,
+            "path": install_path.display().to_string(),
+            "files": file_paths
+        });
+        out.write_value(result)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tilde_handles_home_only() {
+        let result = expand_tilde("~");
+        assert!(result.is_some());
+        let expanded = result.unwrap();
+        assert!(expanded.is_absolute());
+        assert!(!expanded.to_string_lossy().contains('~'));
+    }
+
+    #[test]
+    fn expand_tilde_handles_unix_path() {
+        let result = expand_tilde("~/Documents/test");
+        assert!(result.is_some());
+        let expanded = result.unwrap();
+        assert!(expanded.is_absolute());
+        assert!(expanded.ends_with("Documents/test"));
+    }
+
+    #[test]
+    fn expand_tilde_handles_windows_path() {
+        let result = expand_tilde("~\\Documents\\test");
+        assert!(result.is_some());
+        let expanded = result.unwrap();
+        assert!(expanded.is_absolute());
+    }
+
+    #[test]
+    fn expand_tilde_returns_none_for_non_tilde_path() {
+        let result = expand_tilde("/absolute/path");
+        assert!(result.is_none());
+
+        let result = expand_tilde("relative/path");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn inject_version_replaces_in_frontmatter() {
+        let content = "---\nname: Test\nversion: 0.0.0\n---\n\nContent here with version: 0.0.0";
+        let result = inject_version(content, "1.2.3");
+
+        // Should replace the first occurrence in frontmatter
+        assert!(result.contains("version: 1.2.3"));
+        // The second occurrence should NOT be replaced
+        assert!(result.contains("Content here with version: 0.0.0"));
+    }
+
+    #[test]
+    fn inject_version_handles_windows_line_endings() {
+        let content = "---\r\nname: Test\r\nversion: 0.0.0\r\n---\r\n\r\nContent here";
+        let result = inject_version(content, "1.2.3");
+
+        assert!(result.contains("version: 1.2.3"));
+    }
+
+    #[test]
+    fn inject_version_handles_old_mac_line_endings() {
+        let content = "---\rname: Test\rversion: 0.0.0\r---\r\rContent here";
+        let result = inject_version(content, "1.2.3");
+
+        assert!(result.contains("version: 1.2.3"));
+    }
+
+    #[test]
+    fn inject_version_fallback_without_frontmatter() {
+        let content = "Just some content with version: 0.0.0 in it";
+        let result = inject_version(content, "2.0.0");
+
+        assert!(result.contains("version: 2.0.0"));
+        assert!(!result.contains("version: 0.0.0"));
+    }
+
+    #[test]
+    fn inject_version_handles_missing_version_field() {
+        let content = "---\nname: Test\n---\n\nContent";
+        let result = inject_version(content, "1.0.0");
+
+        // Should not crash, and content should be unchanged
+        assert_eq!(content, result);
+    }
+
+    #[test]
+    fn prepare_skill_content_validates_utf8() {
+        // This tests that the function checks UTF-8 validity
+        // The actual embedded files should be valid, so this should succeed
+        let result = prepare_skill_content("1.0.0");
+        assert!(result.is_ok());
+        assert!(!result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn prepare_skill_content_injects_version() {
+        let result = prepare_skill_content("9.9.9").unwrap();
+        assert!(result.contains("version: 9.9.9"));
+    }
+
+    #[test]
+    fn skill_formats_are_valid() {
+        // Validate that all SKILL_FORMATS have non-empty fields
+        assert!(!SKILL_FORMATS.is_empty(), "Must have at least one format");
+
+        for format in SKILL_FORMATS {
+            assert!(!format.name.is_empty(), "Format name cannot be empty");
+            assert!(
+                !format.description.is_empty(),
+                "Format description cannot be empty"
+            );
+            assert!(!format.path.is_empty(), "Format path cannot be empty");
+            assert!(
+                !format.path.starts_with('/'),
+                "Format path should be relative"
+            );
+        }
+    }
+
+    #[test]
+    fn skill_format_get_install_path_joins_correctly() {
+        let format = SkillFormat {
+            name: "Test",
+            description: "Test format",
+            path: ".test/skills/foo",
+        };
+
+        let base = PathBuf::from("/home/user");
+        let result = format.get_install_path(&base);
+
+        assert_eq!(result, PathBuf::from("/home/user/.test/skills/foo"));
+    }
+
+    #[test]
+    fn embedded_files_are_not_empty() {
+        // This catches build issues where files aren't properly embedded
+        for file in SKILL_FILES {
+            assert!(!file.content.is_empty(), "{} should be embedded", file.path);
+        }
+    }
+
+    #[test]
+    fn embedded_files_are_valid_utf8() {
+        // Ensure all embedded files are valid UTF-8
+        for file in SKILL_FILES {
+            assert!(
+                std::str::from_utf8(file.content).is_ok(),
+                "{} should be valid UTF-8",
+                file.path
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_custom_path_handles_absolute_path() {
+        let result = resolve_custom_path("/absolute/path", None, false);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("/absolute/path"));
+    }
+
+    #[test]
+    fn resolve_custom_path_expands_tilde() {
+        let result = resolve_custom_path("~/test/path", None, true);
+        assert!(result.is_ok());
+        let expanded = result.unwrap();
+        assert!(expanded.is_absolute());
+        assert!(!expanded.to_string_lossy().contains('~'));
+        assert!(expanded.ends_with("test/path"));
+    }
+
+    #[test]
+    fn get_base_dir_global_returns_home() {
+        let result = get_base_dir(None, true);
+        assert!(result.is_ok());
+        let dir = result.unwrap();
+        assert!(dir.is_absolute());
+    }
+
+    #[test]
+    fn get_base_dir_local_without_context_fails() {
+        let result = get_base_dir(None, false);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Not in a git repository")
+        );
+    }
+
+    // NOTE: infer_install_path is difficult to test in isolation because it depends on
+    // dirs::home_dir() and git repository context. It's tested indirectly through
+    // integration tests and manual testing. The core logic (is_gitbutler_skill validation
+    // and scope prioritization) is tested separately.
+
+    #[test]
+    fn is_gitbutler_skill_validates_correct_skill() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let skill_path = temp_dir.path().join("SKILL.md");
+
+        // Test with valid GitButler skill content (frontmatter)
+        fs::write(
+            &skill_path,
+            "---\nname: but\nversion: 1.0.0\n---\n# Content",
+        )
+        .unwrap();
+        assert!(
+            is_gitbutler_skill(&skill_path),
+            "Should recognize valid GitButler skill with frontmatter"
+        );
+
+        // Test with valid GitButler skill content (header)
+        fs::write(&skill_path, "# GitButler CLI Skill\n\nContent here").unwrap();
+        assert!(
+            is_gitbutler_skill(&skill_path),
+            "Should recognize valid GitButler skill with header"
+        );
+
+        // Test with invalid content that contains the strings but not as exact matches
+        fs::write(
+            &skill_path,
+            "I was reading about the GitButler CLI and the name: but that's not right",
+        )
+        .unwrap();
+        assert!(
+            !is_gitbutler_skill(&skill_path),
+            "Should reject content with strings in wrong context"
+        );
+
+        // Test with random content
+        fs::write(&skill_path, "Some random content").unwrap();
+        assert!(
+            !is_gitbutler_skill(&skill_path),
+            "Should reject non-GitButler content"
+        );
+
+        // Test with nonexistent file
+        let nonexistent = temp_dir.path().join("nonexistent.md");
+        assert!(
+            !is_gitbutler_skill(&nonexistent),
+            "Should return false for nonexistent file"
+        );
+    }
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -250,6 +250,27 @@ async fn match_subcommand(
                 }
             }
         }
+        Subcommands::Skill(args::skill::Platform { cmd }) => {
+            // For global installs or absolute paths, we don't need to be in a git repository
+            // For --infer without --global, we try to get repo context but don't require it
+            let needs_repo = match &cmd {
+                args::skill::Subcommands::Install {
+                    global,
+                    path,
+                    infer,
+                } => {
+                    !global
+                        && !infer
+                        && path
+                            .as_ref()
+                            .is_none_or(|p| !std::path::Path::new(p).is_absolute())
+                }
+            };
+
+            let ctx = but_ctx::Context::discover(&args.current_dir);
+            let mut ctx = if needs_repo { Some(ctx?) } else { ctx.ok() };
+            command::skill::handle(ctx.as_mut(), out, cmd).emit_metrics(metrics_ctx)
+        }
         Subcommands::Branch(branch::Platform { cmd }) => {
             cfg_if! {
                 if #[cfg(feature = "legacy")]  {

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -56,7 +56,7 @@ impl Subcommands {
     fn to_metrics_command(&self) -> CommandName {
         use CommandName::*;
 
-        use crate::args::{alias as alias_args, branch, claude, cursor, forge, worktree};
+        use crate::args::{alias as alias_args, branch, claude, cursor, forge, skill, worktree};
         match self {
             #[cfg(feature = "legacy")]
             Subcommands::Status { .. } => Status,
@@ -176,6 +176,9 @@ impl Subcommands {
             Subcommands::Merge { .. } => Merge,
             #[cfg(feature = "legacy")]
             Subcommands::Move { .. } => Rub,
+            Subcommands::Skill(skill::Platform { cmd }) => match cmd {
+                skill::Subcommands::Install { .. } => SkillInstall,
+            },
         }
     }
 }


### PR DESCRIPTION
The idea here is to have a coding agent skill that we can keep up to date as the CLI evolves with new commands. 
The `crates/but/skill` folder should contain everything one needs to get started manually, but also for convenience, the app provides a `but skill install` command which installs the most up-to-date skill.

@aheritier i saw your project here https://github.com/aheritier/boost-your-ai/ (really cool btw ❤️) and wanted to give you a ping on this PR. 

I am not fully sure what the exact good practices are for creating a good `SKILL` - feedback is appreciated. By doing it here, we will be able to keep it up to date. Feel free to pull code from here for https://github.com/aheritier/boost-your-ai if it is useful and let me know if we can do things in a better way