### PR TITLE
logged in page

### DIFF
--- a/apps/web/src/routes/(app)/loggedin/+page.svelte
+++ b/apps/web/src/routes/(app)/loggedin/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import FullscreenUtilityCard from '$lib/components/service/FullscreenUtilityCard.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { LOGIN_SERVICE } from '@gitbutler/shared/login/loginService';
@@ -7,6 +8,10 @@
 	import { copyToClipboard } from '@gitbutler/ui/utils/clipboard';
 
 	const loginService = inject(LOGIN_SERVICE);
+	const BUILD_TYPE_PARAM = 'bt';
+
+	const searchParams = $derived(page.url.searchParams);
+	const buildType = $derived(mapBuiltType(searchParams.get(BUILD_TYPE_PARAM)));
 
 	async function copyAccessToken() {
 		const response = await loginService.token();
@@ -14,6 +19,33 @@
 			copyToClipboard(response.data);
 		} else {
 			chipToasts.error('Failed to get token');
+		}
+	}
+
+	function mapBuiltType(buildType: string | null): 'but' | 'but-nightly' | null {
+		switch (buildType) {
+			case 'release':
+				return 'but';
+			case 'nightly':
+				return 'but-nightly';
+			default:
+				return null;
+		}
+	}
+
+	async function followDeeplink() {
+		if (!buildType) {
+			chipToasts.error('Unknown built type');
+			return;
+		}
+
+		const response = await loginService.token();
+		if (response.type !== 'success' || !response.data) {
+			chipToasts.error('Failed to get token');
+		} else {
+			const accessToken = response.data;
+			const deeplink = `${buildType}://login?access_token=${accessToken}&t=${Date.now()}`;
+			window.location.href = deeplink;
 		}
 	}
 </script>
@@ -32,9 +64,15 @@
 	<div class="loggedin__success-card-content">
 		<p class="text-13">You can now close this window and return to your client.</p>
 		<div class="flex gap-8 m-t-8">
-			<AsyncButton style="gray" kind="outline" icon="copy-small" action={copyAccessToken}
-				>Copy Access Token</AsyncButton
-			>
+			{#if buildType !== null}
+				<AsyncButton style="gray" kind="outline" icon="open-editor" action={followDeeplink}
+					>Open client</AsyncButton
+				>
+			{:else}
+				<AsyncButton style="gray" kind="outline" icon="copy-small" action={copyAccessToken}
+					>Copy Access Token</AsyncButton
+				>
+			{/if}
 			<Button style="gray" kind="ghost" onclick={() => goto('/profile')} icon="profile"
 				>Profile page</Button
 			>

--- a/apps/web/src/routes/(app)/loggedin/+page.svelte
+++ b/apps/web/src/routes/(app)/loggedin/+page.svelte
@@ -62,13 +62,14 @@
 	}}
 >
 	<div class="loggedin__success-card-content">
-		<p class="text-13">You can now close this window and return to your client.</p>
 		<div class="flex gap-8 m-t-8">
 			{#if buildType !== null}
-				<AsyncButton style="gray" kind="outline" icon="open-editor" action={followDeeplink}
+				<p class="text-13">Click below to open your client and complete sign-in.</p>
+				<AsyncButton style="gray" kind="outline" icon="open-editor-small" action={followDeeplink}
 					>Open client</AsyncButton
 				>
 			{:else}
+				<p class="text-13">Copy the access token and paste it in your client.</p>
 				<AsyncButton style="gray" kind="outline" icon="copy-small" action={copyAccessToken}
 					>Copy Access Token</AsyncButton
 				>


### PR DESCRIPTION
If there’s a build type provided, allow the user to directly open their
client through deeplinks, removing the need to copy the access token.

The button is only shown when logging in from the Release or Nightly clients. If that's not the case, the 'Copy access token' button is shown

![Screenshot 2026-01-28 at 10.30.39.png](https://app.gitbutler.com/uploads/3f72d8d3-58d7-49ec-80fb-9f1491e0363c)

