### PR TITLE
Get the platform and pass it while logging in

### DIFF
--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -104,6 +104,9 @@ export class UserService {
 			const token = await this.httpClient.post<LoginToken>('login/token.json');
 			const url = new URL(token.url);
 			url.host = this.httpClient.apiUrl.host;
+			const buildType = await this.backend.invoke<string>('build_type').catch(() => undefined);
+			if (buildType !== undefined && buildType !== 'development')
+				url.searchParams.set('bt', buildType);
 
 			return url.toString();
 		} catch (err) {

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -25,3 +25,6 @@ pub mod diff;
 /// Types meant to be serialised to JSON, without degenerating information despite the need to be UTF-8 encodable.
 /// EXPERIMENTAL
 pub mod json;
+
+/// Functions releated to platform detection and information.
+pub mod platform;

--- a/crates/but-api/src/platform.rs
+++ b/crates/but-api/src/platform.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+use but_api_macros::but_api;
+
+/// Get the build type of the current GitButler build.
+#[but_api]
+pub fn build_type() -> Result<String> {
+    let build_type = match option_env!("CHANNEL") {
+        Some("release") => "release",
+        Some("nightly") => "nightly",
+        _ => "development",
+    };
+
+    Ok(build_type.to_string())
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -14,7 +14,7 @@ use axum::{
     response::IntoResponse,
     routing::{any, post},
 };
-use but_api::{commit, diff, github, json, legacy};
+use but_api::{commit, diff, github, json, legacy, platform};
 use but_claude::{Broadcaster, Claude};
 use but_settings::AppSettingsWithDiskSync;
 use futures_util::{SinkExt, StreamExt as _};
@@ -694,6 +694,7 @@ pub async fn run() {
             "/commit_uncommit_changes",
             post(json_response(commit::commit_uncommit_changes_cmd)),
         )
+        .route("/build_type", post(json_response(platform::build_type_cmd)))
         // Catch-all for commands that need special handling (app, extra, app_settings_sync)
         .route("/{command}", post(post_handle_command_with_path))
         .route(

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, bail};
-use but_api::{commit, diff, github, legacy};
+use but_api::{commit, diff, github, legacy, platform};
 use but_claude::{Broadcaster, Claude};
 use but_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::{
@@ -393,6 +393,7 @@ fn main() -> anyhow::Result<()> {
                 commit::tauri_commit_insert_blank::commit_insert_blank,
                 commit::tauri_commit_move_changes_between::commit_move_changes_between,
                 commit::tauri_commit_uncommit_changes::commit_uncommit_changes,
+                platform::tauri_build_type::build_type,
             ])
             .menu(move |handle| menu::build(handle, &app_settings_for_menu))
             .on_window_event(|window, event| match event {


### PR DESCRIPTION
While logging in, we retrieve the build type and pass it to the login link, so that we can deeplink correctly

