### PR TITLE
Context with simplified workspace retrieval and caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,6 @@ dependencies = [
  "anyhow",
  "bstr",
  "but-core",
- "but-ctx",
  "but-db",
  "but-graph",
  "but-hunk-dependency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2627,7 +2627,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2864,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4118,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 ]
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "dunce",
@@ -4391,7 +4391,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
 ]
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "faster-hex",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.16.1",
@@ -4562,7 +4562,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4652,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4745,7 +4745,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.75.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "arc-swap",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "clru",
  "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4822,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4833,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4927,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5024,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5036,7 +5036,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "filetime",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "dashmap",
  "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5139,7 +5139,7 @@ checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
 [[package]]
 name = "gix-trace"
 version = "0.1.17"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "tracing",
 ]
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5183,7 +5183,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5221,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
 ]
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5294,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#ea9e2b9bfc520b33eda0a02767ffb76c569ea7ca"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 dependencies = [
  "bstr",
  "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5824,12 +5824,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -6140,7 +6140,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6215,7 +6215,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7022,7 +7022,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7658,7 +7658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8320,7 +8320,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8358,9 +8358,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8971,7 +8971,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9050,7 +9050,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10649,7 +10649,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11836,7 +11836,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
     "crates/but-oplog",             # 📄A sketch of a modern `gitbutler-oplog`
     # 👉mostly powered by legacy, but will help to transition to `but-db` backing.
     "crates/but-meta",              # 📄An interface to support Git-entity metadata;
-    # 👉uses `but-ctx`, and lacks tests.
+    # 👉lacks tests
     "crates/but-hunk-assignment",   # 📄Assign uncommitted changes to stacks/lanes.
     # 👉uses `but-ctx`.
     "crates/but-hunk-dependency",   # 📄Assuming it works, it feels close to 'Exemplary',

--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -34,7 +34,7 @@ pub fn rename_branch(
     let changes =
         but_core::diff::ui::commit_changes_with_line_stats_by_worktree_dir(repo, commit_id)?;
     let diff = changes
-        .try_to_unidiff(repo, ctx.settings().context_lines)?
+        .try_to_unidiff(repo, ctx.settings.context_lines)?
         .to_string();
     let diffs = vec![diff];
 

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -32,7 +32,7 @@ pub fn commit(
         )?;
         (
             changes
-                .try_to_unidiff(repo, ctx.settings().context_lines)?
+                .try_to_unidiff(repo, ctx.settings.context_lines)?
                 .to_string(),
             ctx.into_sync(),
         )

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -101,12 +101,13 @@ fn handle_changes_simple_inner(
     let repo = ctx.repo.get()?.clone();
     let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(perm.read_permission())?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
-        ctx,
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
         &repo,
         &workspace,
         true,
         None::<Vec<but_core::TreeChange>>,
         None,
+        ctx.settings.context_lines,
     )
     .map_err(|err| serde_error::Error::new(&*err))?;
     if assignments.is_empty() {

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -13,8 +13,7 @@ pub fn apply_only(
     ctx: &but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let (mut meta, ws) = ctx.workspace_and_meta_from_head(guard.write_permission())?;
+    let (_guard, mut meta, ws) = ctx.workspace_and_meta_from_head_for_editing()?;
     let repo = ctx.repo.get()?;
     let out = but_workspace::branch::apply(
         existing_branch,

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -98,7 +98,7 @@ pub fn pre_commit_hook_diffspecs(
         .head_tree_id_or_empty()
         .context("Failed to get head tree")?;
 
-    let context_lines = ctx.settings().context_lines;
+    let context_lines = ctx.settings.context_lines;
 
     let mut changes = changes.into_iter().map(Ok).collect::<Vec<_>>();
 

--- a/crates/but-claude/src/mcp.rs
+++ b/crates/but-claude/src/mcp.rs
@@ -124,7 +124,7 @@ impl Mcp {
 
         // Send notification for permission request
         if let Err(e) =
-            crate::notifications::notify_permission_request(ctx.settings(), &req.tool_name)
+            crate::notifications::notify_permission_request(&ctx.settings, &req.tool_name)
         {
             tracing::warn!("Failed to send permission request notification: {}", e);
         }

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -96,6 +96,7 @@ pub fn shared_worktree_access(git_dir: impl Into<PathBuf>) -> WorkspaceReadGuard
 }
 
 /// A utility that drops an exclusive lock on drop.
+#[must_use]
 pub struct WorkspaceWriteGuard {
     inner: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
     perm: WorktreeWritePermission,
@@ -136,6 +137,7 @@ impl WorkspaceWriteGuard {
 }
 
 /// A utility that drops a shared lock on drop.
+#[must_use]
 pub struct WorkspaceReadGuard(Option<parking_lot::ArcRwLockReadGuard<RawRwLock, ()>>);
 
 impl WorkspaceReadGuard {

--- a/crates/but-ctx/Cargo.toml
+++ b/crates/but-ctx/Cargo.toml
@@ -13,7 +13,7 @@ test = true
 
 [features]
 # Support for a built-in legacy project.
-legacy = ["dep:gitbutler-project", "dep:tracing"]
+legacy = ["dep:gitbutler-project"]
 
 [dependencies]
 but-path.workspace = true
@@ -26,7 +26,7 @@ but-graph.workspace = true
 
 gitbutler-project = { workspace = true, optional = true }
 
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
 anyhow.workspace = true
 gix.workspace = true
 git2.workspace = true

--- a/crates/but-ctx/src/access.rs
+++ b/crates/but-ctx/src/access.rs
@@ -13,7 +13,7 @@ impl Context {
     ///
     /// Note that the lock is automatically released on `Drop`, or when the process quits for any reason,
     /// so it can't go stale.
-    pub fn try_exclusive_access(&self) -> anyhow::Result<but_core::sync::LockFile> {
+    pub fn try_exclusive_access(&self) -> anyhow::Result<LockFile> {
         but_core::sync::try_exclusive_inter_process_access(&self.gitdir, AllOperations)
     }
     /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for someone else,
@@ -22,14 +22,14 @@ impl Context {
     ///
     /// Note that this in-process locking works only under the assumption that no two instances of
     /// GitButler are able to read or write the same repository.
-    pub fn exclusive_worktree_access(&self) -> but_core::sync::WorkspaceWriteGuard {
+    pub fn exclusive_worktree_access(&self) -> WorkspaceWriteGuard {
         but_core::sync::exclusive_worktree_access(&self.gitdir)
     }
 
     /// Return a guard for shared (read) worktree access, and block while waiting for writers to disappear.
     /// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
     /// thus block readers to prevent writer starvation.
-    pub fn shared_worktree_access(&self) -> but_core::sync::WorkspaceReadGuard {
+    pub fn shared_worktree_access(&self) -> WorkspaceReadGuard {
         but_core::sync::shared_worktree_access(&self.gitdir)
     }
 }

--- a/crates/but-db/src/cache/handle.rs
+++ b/crates/but-db/src/cache/handle.rs
@@ -1,5 +1,6 @@
 use crate::AppCacheHandle;
 use std::path::{Path, PathBuf};
+use tracing::instrument;
 
 /// Lifecycle
 impl AppCacheHandle {
@@ -11,6 +12,7 @@ impl AppCacheHandle {
     }
 
     /// Create a new instance at `path`.
+    #[instrument(name = "AppCacheHandle::new_at_path", level = "debug", skip(path))]
     pub fn new_at_path(path: impl Into<PathBuf>) -> Self {
         let path = path.into();
         let (conn, path) = crate::cache::open_with_migrations_infallible(

--- a/crates/but-db/src/handle.rs
+++ b/crates/but-db/src/handle.rs
@@ -29,7 +29,12 @@ impl DbHandle {
     }
 
     /// A new instance connecting to the project database at the given `path`.
-    #[instrument(level = "debug", skip(path), err(Debug))]
+    #[instrument(
+        name = "DbHandle::new_at_path",
+        level = "debug",
+        skip(path),
+        err(Debug)
+    )]
     pub fn new_at_path(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
         let path = path.into();
         let mut conn = rusqlite::Connection::open(&path)?;

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -60,7 +60,7 @@ pub mod migration;
 use std::path::PathBuf;
 #[rustfmt::skip]
 pub use table::{
-    hunk_assignments::HunkAssignment,
+    hunk_assignments::{HunkAssignmentsHandleMut, HunkAssignmentsHandle, HunkAssignment},
     butler_actions::ButlerAction,
     workflows::Workflow,
     claude::{ClaudeMessage, ClaudePermissionRequest, ClaudeSession},

--- a/crates/but-db/src/migration.rs
+++ b/crates/but-db/src/migration.rs
@@ -24,7 +24,12 @@ pub fn ours() -> impl Iterator<Item = M<'static>> {
 /// for an intermediate failure related to databases.
 ///
 /// Currently, either all migrations succeed, or all fail.
-#[instrument(level = "debug", skip(conn, migrations), err(Debug))]
+#[instrument(
+    name = "run_migration",
+    level = "trace",
+    skip(conn, migrations),
+    err(Debug)
+)]
 pub fn run<'m>(
     conn: &mut rusqlite::Connection,
     migrations: impl IntoIterator<Item = M<'m>>,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -242,7 +242,7 @@ impl Graph {
     /// * The traversal is cut short when there is only tips which are integrated
     /// * The traversal is always as long as it needs to be to fully reconcile possibly disjoint branches, despite
     ///   this sometimes costing some time when the remote is far ahead in a huge repository.
-    #[instrument(level = "debug", skip_all, fields(tip = ?tip, options = ?options, ref_name), err(Debug))]
+    #[instrument(name = "Graph::from_commit_traversal", level = "trace", skip_all, fields(tip = ?tip, ref_name), err(Debug))]
     pub fn from_commit_traversal(
         tip: gix::Id<'_>,
         ref_name: impl Into<Option<gix::refs::FullName>>,

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -44,22 +44,7 @@ impl Context<'_> {
 impl Graph {
     /// Now that the graph is complete, perform additional structural improvements with
     /// the requirement of them to be computationally cheap.
-    #[instrument(
-        level = "trace",
-        skip(
-            self,
-            meta,
-            refs_by_id,
-            repo,
-            symbolic_remote_names,
-            configured_remote_tracking_branches,
-            inserted_proxy_segments,
-            hard_limit,
-            dangerously_skip_postprocessing_for_debugging,
-            worktree_by_branch
-        ),
-        err(Debug)
-    )]
+    #[instrument(level = "trace", skip_all, fields(tip), err(Debug))]
     pub(super) fn post_processed<T: RefMetadata>(
         mut self,
         meta: &OverlayMetadata<'_, T>,

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -466,7 +466,12 @@ impl Graph {
     /// that target as base. The same is true for [target commit ids](but_core::ref_metadata::Workspace::target_commit_id).
     /// This affects what we consider to be the part of the workspace.
     /// Typically, that's a previous location of the target segment.
-    #[instrument(level = "trace", skip(self), err(Debug))]
+    #[instrument(
+        name = "Graph::into_workspace",
+        level = "debug",
+        skip(self),
+        err(Debug)
+    )]
     pub fn into_workspace(self) -> anyhow::Result<Workspace> {
         let state = self.to_workspace_state(workspace::Downgrade::Allow)?;
         Ok(Workspace::from_state(self, state))

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -18,7 +18,6 @@ but-graph.workspace = true
 but-hunk-dependency.workspace = true
 but-db.workspace = true
 but-serde.workspace = true
-but-ctx.workspace = true
 
 gix.workspace = true
 

--- a/crates/but-hunk-assignment/src/state.rs
+++ b/crates/but-hunk-assignment/src/state.rs
@@ -1,12 +1,11 @@
 /// The name of the file holding our state, useful for watching for changes.
 use anyhow::Result;
-use but_db::DbHandle;
+use but_db::{HunkAssignmentsHandle, HunkAssignmentsHandleMut};
 
 use crate::HunkAssignment;
 
-pub fn assignments(db: &DbHandle) -> Result<Vec<HunkAssignment>> {
+pub fn assignments(db: HunkAssignmentsHandle) -> Result<Vec<HunkAssignment>> {
     let assignments = db
-        .hunk_assignments()
         .list_all()?
         .into_iter()
         .map(|a| a.try_into())
@@ -14,13 +13,14 @@ pub fn assignments(db: &DbHandle) -> Result<Vec<HunkAssignment>> {
     Ok(assignments)
 }
 
-pub fn set_assignments(db: &mut DbHandle, assignments: Vec<HunkAssignment>) -> Result<()> {
+pub fn set_assignments(
+    db: HunkAssignmentsHandleMut,
+    assignments: Vec<HunkAssignment>,
+) -> Result<()> {
     let assignments: Vec<but_db::HunkAssignment> = assignments
         .into_iter()
         .map(|a| a.try_into())
         .collect::<Result<Vec<but_db::HunkAssignment>>>(
     )?;
-    db.hunk_assignments_mut()?
-        .set_all(assignments)
-        .map_err(Into::into)
+    db.set_all(assignments).map_err(Into::into)
 }

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -121,7 +121,7 @@ fn handle_amend(
             new_message: None,
         },
         changes,
-        ctx.settings().context_lines,
+        ctx.settings.context_lines,
         guard.write_permission(),
     )?;
     Ok(())
@@ -191,12 +191,14 @@ fn handle_assign(
     deps: Option<&HunkDependencies>,
 ) -> anyhow::Result<usize> {
     let len = assignments.len();
+    let context_lines = ctx.settings.context_lines;
     if assign(
-        ctx,
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
         repo,
         workspace,
         assignments_to_requests(assignments),
         deps,
+        context_lines,
     )
     .is_ok()
     {

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -318,12 +318,13 @@ pub fn process_rules(
     )?;
 
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
-        ctx,
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
         repo,
         workspace,
         false,
         Some(wt_changes.changes),
         Some(&dependencies),
+        ctx.settings.context_lines,
     )
     .map_err(|e| anyhow::anyhow!("Failed to get assignments: {}", e))?;
 

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -83,9 +83,7 @@ impl ActiveProjects {
                     },
                 };
 
-                println!("Sending event");
                 broadcaster.blocking_lock().send(frontend_event);
-                println!("Sent event");
                 Ok(())
             }
         });

--- a/crates/but-workspace/src/legacy/commit_engine/mod.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/mod.rs
@@ -82,7 +82,7 @@ pub fn create_commit_simple(
             }),
         },
         worktree_changes,
-        ctx.settings().context_lines,
+        ctx.settings.context_lines,
         perm,
     );
 

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -45,17 +45,7 @@ pub fn handle(
         }) => {
             let ahead = !no_ahead; // Invert the flag
             let check = !no_check; // Invert the flag
-            list::list(
-                &ctx.legacy_project,
-                local,
-                remote,
-                all,
-                ahead,
-                review,
-                filter,
-                out,
-                check,
-            )?;
+            list::list(ctx, local, remote, all, ahead, review, filter, out, check)?;
             Ok(())
         }
         Some(Subcommands::Show {
@@ -74,9 +64,9 @@ pub fn handle(
         }) => {
             let id_map = IdMap::new_from_context(ctx, None)?;
             // Get branch name or use canned name
-            let branch_name = branch_name.map(Ok).unwrap_or_else(|| {
-                but_api::legacy::workspace::canned_branch_name(ctx.legacy_project.id)
-            })?;
+            let branch_name = branch_name
+                .map(Ok)
+                .unwrap_or_else(|| but_api::legacy::workspace::canned_branch_name(ctx))?;
 
             // Store anchor string for JSON output
             let anchor_for_json = anchor.clone();
@@ -124,7 +114,7 @@ pub fn handle(
                 None
             };
             but_api::legacy::stack::create_reference(
-                ctx.legacy_project.id,
+                ctx,
                 but_api::legacy::stack::create_reference::Request {
                     new_name: branch_name.clone(),
                     anchor,
@@ -146,7 +136,7 @@ pub fn handle(
         }
         Some(Subcommands::Delete { branch_name, force }) => {
             let stacks = but_api::legacy::workspace::stacks(
-                ctx.legacy_project.id,
+                ctx,
                 Some(but_workspace::legacy::StacksFilter::InWorkspace),
             )?;
 
@@ -178,7 +168,7 @@ pub fn handle(
         }
         Some(Subcommands::Unapply { branch_name, force }) => {
             let stacks = but_api::legacy::workspace::stacks(
-                ctx.legacy_project.id,
+                ctx,
                 Some(but_workspace::legacy::StacksFilter::InWorkspace),
             )?;
 

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -55,9 +55,8 @@ fn mark_commit(
         return Ok(());
     }
 
-    let guard = ctx.shared_worktree_access();
     let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, ws) = ctx.workspace_from_head()?;
 
     let req = {
         let commit = repo.find_commit(oid)?;
@@ -73,7 +72,7 @@ fn mark_commit(
             action,
         }
     };
-    but_rules::create_rule(ctx, &repo, &workspace, req)?;
+    but_rules::create_rule(ctx, &repo, &ws, req)?;
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -104,9 +103,8 @@ fn mark_branch(
         return Ok(());
     }
 
-    let guard = ctx.shared_worktree_access();
     let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, ws) = ctx.workspace_from_head()?;
 
     // TODO: if there are other marks of this kind, get rid of them
     let stack_id = stack_id.expect("Cannot find stack for this branch");
@@ -120,7 +118,7 @@ fn mark_branch(
         )?)],
         action,
     };
-    but_rules::create_rule(ctx, &repo, &workspace, req)?;
+    but_rules::create_rule(ctx, &repo, &ws, req)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Changes will be assigned to → {branch_name}")?;
     }

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -30,9 +30,8 @@ pub async fn handle(
     };
 
     // Get the base branch data to find the target
-    let base_branch =
-        but_api::legacy::virtual_branches::get_base_branch_data(ctx.legacy_project.id)?
-            .ok_or_else(|| anyhow::anyhow!("No base branch configured"))?;
+    let base_branch = but_api::legacy::virtual_branches::get_base_branch_data(ctx)?
+        .ok_or_else(|| anyhow::anyhow!("No base branch configured"))?;
 
     let target_remote = base_branch.remote_name;
 

--- a/crates/but/src/command/legacy/refresh.rs
+++ b/crates/but/src/command/legacy/refresh.rs
@@ -23,27 +23,23 @@ pub fn handle(
 
     if fetch {
         out.write_str("\nFetching from remotes...")?;
-        let fetch_result = but_api::legacy::virtual_branches::fetch_from_remotes(
-            ctx.legacy_project.id,
-            Some("auto".to_string()),
-        );
+        let fetch_result =
+            but_api::legacy::virtual_branches::fetch_from_remotes(ctx, Some("auto".to_string()));
         if fetch_result.is_err() {
             out.write_str("Failed to fetch from the remote repository.")?;
         }
     }
     if prs {
         out.write_str("\nGetting PR data...")?;
-        let pr_result = but_api::legacy::forge::list_reviews(
-            ctx.legacy_project.id,
-            Some(but_forge::CacheConfig::NoCache),
-        );
+        let pr_result =
+            but_api::legacy::forge::list_reviews(ctx, Some(but_forge::CacheConfig::NoCache));
         if pr_result.is_err() {
             out.write_str("Failed to refresh pull request data.")?;
         }
     }
     if ci {
         out.write_str("\nGetting CI checks...")?;
-        let ci_result = but_api::legacy::forge::warm_ci_checks_cache(ctx.legacy_project.id);
+        let ci_result = but_api::legacy::forge::warm_ci_checks_cache(ctx);
         if ci_result.is_err() {
             out.write_str("Failed to refresh CI data.")?;
         }

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -91,7 +91,7 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     }
 
     // Find which stack this commit belongs to
-    let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
+    let stacks = but_api::legacy::workspace::stacks(ctx, None)?;
     let mut found_stack_id = None;
     for stack in &stacks {
         // Check if this commit is in any of the stack's heads
@@ -470,7 +470,7 @@ fn check_for_new_conflicts_after_rebase(
 
 /// Find all conflicted commits across all stacks, grouped by branch
 fn find_conflicted_commits(ctx: &mut Context) -> Result<BTreeMap<String, Vec<ConflictedCommit>>> {
-    let stacks = but_api::legacy::workspace::stacks(ctx.legacy_project.id, None)?;
+    let stacks = but_api::legacy::workspace::stacks(ctx, None)?;
     let git2_repo = ctx.git2_repo.get()?;
     let repo = ctx.repo.get()?;
     let mut conflicts_by_branch: BTreeMap<String, Vec<ConflictedCommit>> = BTreeMap::new();

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -80,16 +80,16 @@ fn wt_assignments(ctx: &mut Context) -> anyhow::Result<Vec<HunkAssignment>> {
         ctx.legacy_project.worktree_dir()?.into(),
     )?
     .changes;
-    let guard = ctx.shared_worktree_access();
     let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, ws) = ctx.workspace_from_head()?;
     let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-        ctx,
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
         &repo,
-        &workspace,
+        &ws,
         false,
         Some(changes.clone()),
         None,
+        ctx.settings.context_lines,
     )?;
     Ok(assignments)
 }
@@ -110,7 +110,7 @@ fn amend_diff_specs(
             new_message: None,
         },
         but_workspace::flatten_diff_specs(diff_specs),
-        ctx.settings().context_lines,
+        ctx.settings.context_lines,
         perm,
     )
 }

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -14,16 +14,14 @@ pub(crate) fn assign_uncommitted_to_branch(
 ) -> anyhow::Result<()> {
     let description = uncommitted_cli_id.describe();
 
-    let guard = ctx.shared_worktree_access();
-    let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, ws) = ctx.workspace_from_head()?;
 
     let assignments = uncommitted_cli_id
         .hunk_assignments
         .into_iter()
         .map(|hunk_assignment| (hunk_assignment.hunk_header, hunk_assignment.path_bytes));
     let reqs = to_assignment_request(ctx, assignments, Some(branch_name))?;
-    do_assignments(ctx, &repo, &workspace, reqs, out)?;
+    do_assignments(ctx, &ws, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -43,9 +41,7 @@ pub(crate) fn assign_uncommitted_to_stack(
 ) -> anyhow::Result<()> {
     let description = uncommitted_cli_id.describe();
 
-    let guard = ctx.shared_worktree_access();
-    let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, workspace) = ctx.workspace_from_head()?;
 
     let assignments = uncommitted_cli_id
         .hunk_assignments
@@ -58,7 +54,7 @@ pub(crate) fn assign_uncommitted_to_stack(
             req
         })
         .collect();
-    do_assignments(ctx, &repo, &workspace, reqs, out)?;
+    do_assignments(ctx, &workspace, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -77,16 +73,14 @@ pub(crate) fn unassign_uncommitted(
 ) -> anyhow::Result<()> {
     let description = uncommitted_cli_id.describe();
 
-    let guard = ctx.shared_worktree_access();
-    let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
+    let (_guard, ws) = ctx.workspace_from_head()?;
 
     let assignments = uncommitted_cli_id
         .hunk_assignments
         .into_iter()
         .map(|hunk_assignment| (hunk_assignment.hunk_header, hunk_assignment.path_bytes));
     let reqs = to_assignment_request(ctx, assignments, None)?;
-    do_assignments(ctx, &repo, &workspace, reqs, out)?;
+    do_assignments(ctx, &ws, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Unstaged {description}")?;
     }
@@ -148,17 +142,15 @@ fn assign_all_inner(
     )?
     .changes;
 
-    let guard = ctx.shared_worktree_access();
-    let repo = ctx.repo.get()?.clone();
-    let (_, workspace) = ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
-
+    let (_, ws) = ctx.workspace_from_head()?;
     let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
-        ctx,
-        &repo,
-        &workspace,
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
+        &*ctx.repo.get()?,
+        &ws,
         false,
         Some(changes),
         None,
+        ctx.settings.context_lines,
     )?;
 
     let mut reqs = Vec::new();
@@ -171,7 +163,7 @@ fn assign_all_inner(
             });
         }
     }
-    do_assignments(ctx, &repo, &workspace, reqs, out)?;
+    do_assignments(ctx, &ws, reqs, out)?;
     if let Some(out) = out.for_human() {
         if to_branch.is_some() {
             writeln!(
@@ -199,12 +191,19 @@ fn assign_all_inner(
 
 fn do_assignments(
     ctx: &mut Context,
-    repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
     reqs: Vec<HunkAssignmentRequest>,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let rejections = but_hunk_assignment::assign(ctx, repo, workspace, reqs, None)?;
+    let repo = &*ctx.repo.get()?;
+    let rejections = but_hunk_assignment::assign(
+        ctx.db.get_mut()?.hunk_assignments_mut()?,
+        repo,
+        workspace,
+        reqs,
+        None,
+        ctx.settings.context_lines,
+    )?;
     if !rejections.is_empty()
         && let Some(out) = out.for_human()
     {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -121,10 +121,7 @@ pub(crate) async fn worktree(
     } else {
         but_forge::CacheConfig::CacheOnly
     };
-    let review_map = crate::command::legacy::forge::review::get_review_map(
-        &ctx.legacy_project,
-        Some(cache_config.clone()),
-    )?;
+    let review_map = review::get_review_map(ctx, Some(cache_config.clone()))?;
 
     let worktree_changes = but_api::legacy::diff::changes_in_worktree(ctx)?;
 
@@ -181,7 +178,7 @@ pub(crate) async fn worktree(
 
         // Get cached upstream state information (without fetching)
         let (upstream_state, last_fetched_ms, base_branch) =
-            but_api::legacy::virtual_branches::get_base_branch_data(ctx.legacy_project.id)
+            but_api::legacy::virtual_branches::get_base_branch_data(ctx)
                 .ok()
                 .flatten()
                 .map(|base_branch| {
@@ -1072,11 +1069,9 @@ async fn compute_branch_merge_statuses(
     use gitbutler_branch_actions::upstream_integration::StackStatuses;
 
     // Get upstream integration statuses using the public API
-    let statuses = but_api::legacy::virtual_branches::upstream_integration_statuses(
-        ctx.legacy_project.id,
-        None,
-    )
-    .await?;
+    let statuses =
+        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
+            .await?;
 
     let mut result = BTreeMap::new();
 

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -81,18 +81,13 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
     }
 
     // Get stacks filtered to only those in workspace, sorted by order to find the leftmost
-    let mut stacks = match but_api::legacy::workspace::stacks(
-        ctx.legacy_project.id,
-        Some(StacksFilter::InWorkspace),
-    ) {
+    let mut stacks = match but_api::legacy::workspace::stacks(ctx, Some(StacksFilter::InWorkspace))
+    {
         Ok(stacks) => stacks,
         Err(_e) => {
             try_stack_fixes(ctx, out)?;
-            but_api::legacy::workspace::stacks(
-                ctx.legacy_project.id,
-                Some(StacksFilter::InWorkspace),
-            )
-            .context("Failed to retrieve stacks after attempting fixes")?
+            but_api::legacy::workspace::stacks(ctx, Some(StacksFilter::InWorkspace))
+                .context("Failed to retrieve stacks after attempting fixes")?
         }
     };
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -364,12 +364,13 @@ impl IdMap {
                     let (_, workspace) =
                         ctx.workspace_and_read_only_meta_from_head(guard.read_permission())?;
                     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
-                        ctx,
+                        ctx.db.get_mut()?.hunk_assignments_mut()?,
                         &repo,
                         &workspace,
                         false,
                         Some(changes),
                         None,
+                        ctx.settings.context_lines,
                     )?;
                     assignments
                 } else {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -595,8 +595,7 @@ async fn match_subcommand(
                         // No arguments provided - default to inserting at top of first branch
                         use but_api::legacy::workspace;
 
-                        let project_id = ctx.legacy_project.id;
-                        let stack_entries = workspace::stacks(project_id, None)?;
+                        let stack_entries = workspace::stacks(&ctx, None)?;
                         let stacks: Vec<(
                             but_core::ref_metadata::StackId,
                             but_workspace::ui::StackDetails,
@@ -604,7 +603,7 @@ async fn match_subcommand(
                             .iter()
                             .filter_map(|s| {
                                 s.id.and_then(|id| {
-                                    workspace::stack_details(project_id, Some(id))
+                                    workspace::stack_details(&ctx, Some(id))
                                         .ok()
                                         .map(|details| (id, details))
                                 })

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -130,21 +130,22 @@ pub fn init_ctx(
             };
 
             // Check project setup, prompt for setup if needed
-            if let Err(e) = check_project_setup(&project) {
+            let ctx = Context::new_from_legacy_project(project)?;
+            if let Err(e) = check_project_setup(&ctx) {
                 let message = e.to_string();
                 match prompt_for_setup(out, &message) {
                     SetupPromptResult::RunSetup => {
                         // Run setup to fix the project configuration
                         crate::command::legacy::setup::repo(&args.current_dir, out, false)?;
                         // Re-find and re-check the project after setup
-                        let project =
+                        let _project =
                             LegacyProject::find_by_worktree_dir(workdir).map_err(|_| {
                                 anyhow::anyhow!(
                                     "Setup completed but project still not found at {}",
                                     workdir.display()
                                 )
                             })?;
-                        check_project_setup(&project)?;
+                        check_project_setup(&ctx)?;
                     }
                     SetupPromptResult::Declined => {
                         anyhow::bail!("Setup required: {}", message);
@@ -152,7 +153,6 @@ pub fn init_ctx(
                 }
             }
 
-            let ctx = Context::new_from_legacy_project(project)?;
             let fetch_interval_minutes = ctx.settings.fetch.auto_fetch_interval_minutes;
             let last_fetch = ctx
                 .legacy_project

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -198,7 +198,7 @@ pub fn unapply_stack(
         perm,
         false,
         assigned_diffspec,
-        ctx.settings().feature_flags.cv3,
+        ctx.settings.feature_flags.cv3,
     )?;
     Ok(branch_name)
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -68,7 +68,7 @@ pub fn get_base_branch_data(ctx: &Context) -> Result<BaseBranch> {
 #[instrument(skip(ctx), err(Debug))]
 fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<BaseBranch> {
     let gix_repo = ctx.clone_repo_for_merging()?;
-    if ctx.settings().feature_flags.cv3 {
+    if ctx.settings.feature_flags.cv3 {
         let workspace_commit_to_checkout =
             but_workspace::legacy::remerged_workspace_commit_v2(ctx)?;
         let tree_to_checkout_to_avoid_ref_update = gix_repo

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -111,7 +111,8 @@ impl BranchManager<'_> {
 
         // Assume that this is always about 'apply' and hijack the entire method.
         // That way we'd learn what's missing.
-        if self.ctx.settings().feature_flags.apply3 {
+        if self.ctx.settings.feature_flags.apply3 {
+            #[allow(deprecated)] // should have no need for this in modern code anymore
             let (mut meta, ws) = self.ctx.workspace_and_meta_from_head(perm)?;
             let repo = self.ctx.repo.get()?;
 
@@ -162,7 +163,7 @@ impl BranchManager<'_> {
                 conflicted_stack_short_names_for_display,
             ));
         }
-        let old_cwd = (!self.ctx.settings().feature_flags.cv3)
+        let old_cwd = (!self.ctx.settings.feature_flags.cv3)
             .then(|| {
                 self.ctx
                     .git2_repo

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -575,7 +575,7 @@ pub(crate) fn integrate_upstream(
                 permission,
                 false,
                 Vec::new(),
-                ctx.settings().feature_flags.cv3,
+                ctx.settings.feature_flags.cv3,
             )?;
         }
 

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -630,7 +630,7 @@ fn restore_snapshot(
     git2_repo.ignore_large_files_in_diffs(AUTO_TRACK_LIMIT_BYTES)?;
 
     // Define the checkout builder
-    if ctx.settings().feature_flags.cv3 {
+    if ctx.settings.feature_flags.cv3 {
         but_core::worktree::safe_checkout_from_head(
             workdir_tree.id().to_gix(),
             &gix_repo,

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -235,12 +235,13 @@ fn assignments_and_errors(
 ) -> Result<(Vec<HunkAssignment>, Option<serde_error::Error>)> {
     let (assignments, assignments_error) = match &dependencies {
         Ok(dependencies) => but_hunk_assignment::assignments_with_fallback(
-            ctx,
+            ctx.db.get_mut()?.hunk_assignments_mut()?,
             repo,
             workspace,
             false,
             Some(tree_changes),
             Some(dependencies),
+            ctx.settings.context_lines,
         )?,
         Err(e) => (
             vec![],

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -80,7 +80,7 @@ pub fn update_uncommitted_changes(
     perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
-    let uncommitted_changes = (!ctx.settings().feature_flags.cv3)
+    let uncommitted_changes = (!ctx.settings.feature_flags.cv3)
         .then(|| repo.create_wd_tree(0).map(|tree| tree.id()))
         .transpose()?;
 

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -17,7 +17,7 @@ test.afterEach(async () => {
 test('should show commit-msg hook rejection error', async ({ page, context }, testInfo) => {
 	const workdir = testInfo.outputPath('workdir');
 	const configdir = testInfo.outputPath('config');
-	gitbutler = await startGitButler(workdir, configdir, context);
+	gitbutler = await startGitButler(workdir, configdir, context, { RUST_LOG: 'debug' });
 
 	await gitbutler.runScript('project-with-commit-hooks.sh');
 


### PR DESCRIPTION
Follow-up on #12046.

### Tasks

* [x] error chain for json error
* [x] !! rebase onto master before merging.
* [x] fix E2E and merge
    - which commit is it? probably the last (and biggest) one. `gix-upgrade` also fails! And the error change. So must be the error change? It's the error change!
    - the commit that changes what goes into the error toast has nothing to do with the failure, as that is looking for an error toast which is UI generated. So there is no change in the way the error is displayed and both are the same.
    - [x] skip the problematic commit: postpone to another day


### Follow-up

* Context with workspace caching (enabled by owned Workspace)
* let editor users re-use the graph from workspace
* optimise uncached usage for convenience
* [figure out error toast issue](https://github.com/gitbutlerapp/gitbutler/pull/12073)

