### PR TITLE
Improve bases merge failure message

### DIFF
--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -196,7 +196,19 @@ fn single_parent_to_multiple_parents_parents_conflict() -> Result<()> {
 
     let result = cherry_pick(&repo, target, &[onto, onto2], true)?;
 
-    insta::assert_debug_snapshot!(result, @"FailedToMergeBases");
+    insta::assert_debug_snapshot!(result, @r"
+    FailedToMergeBases {
+        base_merge_failed: false,
+        bases: None,
+        onto_merge_failed: true,
+        ontos: Some(
+            [
+                Sha1(cc8998caa25bc039884eb893ec89b4880c6bd232),
+                Sha1(16cfd2c3707e064337a80ba66fc0f6d2171d6ddb),
+            ],
+        ),
+    }
+    ");
 
     Ok(())
 }
@@ -291,7 +303,19 @@ fn multiple_parents_to_single_parent_parents_conflict() -> Result<()> {
 
     let result = cherry_pick(&repo, target, &[onto], true)?;
 
-    insta::assert_debug_snapshot!(result, @"FailedToMergeBases");
+    insta::assert_debug_snapshot!(result, @r"
+    FailedToMergeBases {
+        base_merge_failed: true,
+        bases: Some(
+            [
+                Sha1(5183ac6942d0fc2fc0cca84e1a8ad06370f2952c),
+                Sha1(a3e84fbc36af1f7f48f9b8e3c61f71db360d6b7c),
+            ],
+        ),
+        onto_merge_failed: false,
+        ontos: None,
+    }
+    ");
 
     Ok(())
 }
@@ -392,7 +416,19 @@ fn multiple_parents_to_multiple_parents_base_parents_conflict() -> Result<()> {
 
     let result = cherry_pick(&repo, target, &[onto, onto2], true)?;
 
-    insta::assert_debug_snapshot!(result, @"FailedToMergeBases");
+    insta::assert_debug_snapshot!(result, @r"
+    FailedToMergeBases {
+        base_merge_failed: true,
+        bases: Some(
+            [
+                Sha1(5183ac6942d0fc2fc0cca84e1a8ad06370f2952c),
+                Sha1(a3e84fbc36af1f7f48f9b8e3c61f71db360d6b7c),
+            ],
+        ),
+        onto_merge_failed: false,
+        ontos: None,
+    }
+    ");
 
     Ok(())
 }
@@ -407,7 +443,19 @@ fn multiple_parents_to_multiple_parents_target_parents_conflict() -> Result<()> 
 
     let result = cherry_pick(&repo, target, &[onto, onto2], true)?;
 
-    insta::assert_debug_snapshot!(result, @"FailedToMergeBases");
+    insta::assert_debug_snapshot!(result, @r"
+    FailedToMergeBases {
+        base_merge_failed: false,
+        bases: None,
+        onto_merge_failed: true,
+        ontos: Some(
+            [
+                Sha1(cc8998caa25bc039884eb893ec89b4880c6bd232),
+                Sha1(16cfd2c3707e064337a80ba66fc0f6d2171d6ddb),
+            ],
+        ),
+    }
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
The error message now explicitly states that it encountered a conflict when merging the things together. It mentions whether it was the original bases or the new ones.

It also lists out the IDs of the bases it was trying to merge since they might be helpful for debugging. The error message states that they might be inaccessable through the git CLI due to the chance that they may be from an in-memory repository

```
command: commit_insert_blank
params: {"projectId":"1a3bb94f-7cd9-4aa6-aa5f-ab491d9ddd88","relativeTo":{"type":"reference","subject":"refs/heads/st-branch-54"},"side":"below"})

Failed to merge bases while cherry picking commit ac7a5ecc5cc62ca0531e37b18677faa79ab00feb.
Encountered a conflict while merging the commit's new bases: be6c99654d822b43c26b0f2f20fe832555b2c8a1, 0cd0f2640f8b6244c5b489e70514e9e7db08a867, 4b7e31f1a6acd21fb2a5bb81cea1d261302d328e, 2c23ee8700c251fa90651b680b10880bf3cc01dc.
Any ids mentioned may be in-memory and inaccessable through the git CLI
```