### PR TITLE
Provide full error chain in JSON error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "gitbutler-stack",
  "gitbutler-user",
  "gix",
+ "insta",
  "itertools",
  "open",
  "schemars 1.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ gix = { version = "0.78.0", git = "https://github.com/GitoxideLabs/gitoxide", br
 ] }
 ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
 gix-testtools = "0.18.0"
-insta = "1.45.1"
+insta = { version = "1.45.1", features = ["json"] }
 git2 = { version = "0.20.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -20,7 +20,7 @@ const E2E_MESSAGES_TO_IGNORE = [
 function shouldIgnoreError(error: unknown): boolean {
 	const { message } = parseError(error);
 	if (import.meta.env.VITE_E2E === 'true') {
-		return E2E_MESSAGES_TO_IGNORE_DURING_E2E.includes(message);
+		return E2E_MESSAGES_TO_IGNORE_DURING_E2E.some((entry) => message.includes(entry));
 	}
 
 	return E2E_MESSAGES_TO_IGNORE.includes(message);

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -116,3 +116,6 @@ git2.workspace = true
 open.workspace = true
 url = { version = "2.5", optional = true }
 uuid.workspace = true
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/but-oplog/Cargo.toml
+++ b/crates/but-oplog/Cargo.toml
@@ -20,4 +20,4 @@ but-oxidize.workspace = true
 gitbutler-oplog = { workspace = true, optional = true }
 
 gix.workspace = true
-anyhow = "1.0.100"
+anyhow.workspace = true

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -322,6 +322,8 @@ pnpm exec playwright show-trace e2e/test-results/path-to-trace.zip
 ls e2e/blackbox/videos/
 ```
 
+You can also download them from the respective E2E Job on CI, or find a link in the "Upload Artifact" job log.
+
 ## Test Structure
 
 ```


### PR DESCRIPTION
This improvement is to help with all errors, but also for [this PR](https://github.com/gitbutlerapp/gitbutler/pull/11878) specifically.

### Problem

There is a permanent secrets issue that isn't clicked away that seems to distract it (but only there):

<img width="652" height="320" alt="Screenshot 2026-01-29 at 04 48 13" src="https://github.com/user-attachments/assets/99cb0b3a-ac77-4364-8590-94957e2d71d1" />

I assume this always happens, but that it is clicked away beforehand. That automation might not work anymore.
The ignoring happens in the normal client, and apparently that fails now.

The offending test looks like this:

<img width="1103" height="650" alt="Screenshot 2026-01-29 at 05 01 05" src="https://github.com/user-attachments/assets/6920a182-11d0-4306-84ba-71fd4abd1447" />

And I am pretty sure it sees the wrong toast.

### Solution

Make the standard error disappear like before.

And it turns out that the message must match specifically, even though a substring search would probably also be specific enough.

### Tasks

* [x] try playwright locally, but see it succeed
* [x] see why CI is failing
     - [x] make sense of the artefact that can be downloaded


### Research

The failing test doesn't find a toast message, but they look identical in nightly and in dev.

<img width="491" height="218" alt="Screenshot 2026-01-28 at 21 48 51" src="https://github.com/user-attachments/assets/58742378-2083-4fc4-beba-7ff7576b74f0" />

<img width="557" height="228" alt="Screenshot 2026-01-28 at 21 51 11" src="https://github.com/user-attachments/assets/e0cf70c8-a570-43aa-909e-bcaaf513e559" />
