### PR TITLE
Questions about teardown and setup workflows

### DIFF
--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -596,3 +596,91 @@ More info: https://docs.gitbutler.com/workspace-branch
 
     Ok(())
 }
+
+#[test]
+fn setup_after_teardown_and_new_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+
+    // Run teardown
+    env.but("teardown").assert().success();
+
+    // Create a new commit on branch A, and verify that the commit graph is what
+    // we expect
+    std::process::Command::new("git")
+        .env("GIT_AUTHOR_DATE", "1675176957 +0100")
+        .env("GIT_COMMITTER_DATE", "1675176957 +0100")
+        .arg("-C")
+        .arg(env.projects_root())
+        .arg("commit")
+        .arg("--allow-empty")
+        .arg("-m")
+        .arg("New commit on branch A")
+        .output()?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    * 3b447f7 (HEAD -> A) New commit on branch A
+    | *   c128bce (gitbutler/workspace) GitButler Workspace Commit
+    | |\  
+    | |/  
+    |/|   
+    * | 9477ae7 add A
+    | * d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
+
+    // Verify that setup works
+    env.but("setup")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Setting up GitButler project...
+
+→ Adding repository to GitButler project registry
+  ✓ Repository added to project registry
+
+GitButler project is already set up!
+Target branch: origin/main
+
+
+Setting up your project for GitButler tooling. Some things to note:
+
+- Switching you to a special `gitbutler/workspace` branch to enable parallel branches
+- Installing Git hooks to help manage commits on the workspace branch
+
+To undo these changes and return to normal Git mode, either:
+
+    - Directly checkout a branch (`git checkout A`)
+    - Run `but teardown`
+
+More info: https://docs.gitbutler.com/workspace-branch                    
+
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   3b447f7 New commit on branch A (no changes)  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 (common base) [origin/main] 2000-01-02 add M 
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -59,6 +59,7 @@ To return to GitButler mode, run:
 /// - Picks the first branch and returns HEAD to it
 /// - Removes other branches' work from working directory
 /// - Preserves virtual branch state
+/// - Preserves all branches
 #[test]
 fn multiple_branches_preserves_state() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
@@ -120,6 +121,16 @@ To return to GitButler mode, run:
         !file_b.exists(),
         "File B should not exist in working directory after teardown"
     );
+
+    // Verify that all branches still exist in Git
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   c128bce (gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (HEAD -> A) add A
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
I was looking at teardown and setup workflows and have these questions:

 - Is it correct to have `gitbutler/workspace` and `gitbutler/target` refs still around even after teardown? See `multiple_branches_preserves_state`. I was expecting them to disappear. (All the other branches still exist, which is good.)
 - When running setup after teardown, a message "GitButler project is already set up!" is printed. See `setup_after_teardown_and_new_commit`. Is this expected? There was a change to the `gitbutler/workspace` branch incorporating the new commit  (which was what I hoped for, which is good).

I can take a look at fixing any of these if need be.