### PR TITLE
feat(ui): stack footer columns on tablet viewport

### DIFF
--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -398,6 +398,14 @@
 		}
 	}
 
+	@media (--tablet-viewport) {
+		.footer {
+			flex-direction: column;
+			margin-bottom: 40px;
+			gap: 40px;
+		}
+	}
+
 	@media (max-width: 500px) {
 		.download-links {
 			column-gap: 0;


### PR DESCRIPTION
Add a media query for tablet breakpoint to change the footer layout
from a horizontal row to a vertical column. Update .footer to
column flex-direction, increase bottom margin, and add larger gap
spacing so footer elements have proper separation on tablet devices.

This improves mobile-first responsiveness and fixes cramped footer
appearance on mid-size screens.