### PR TITLE
Update status message with clearer update actions

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1057,7 +1057,7 @@ impl CliDisplay for but_update::AvailableUpdate {
             format!(
                 "Update available: {} {}",
                 version_info,
-                "(run `but status -v` for link or `but update suppress` to dismiss)".dimmed()
+                "(you can run `but update install` or `but update suppress` to dismiss)".dimmed()
             )
         }
     }


### PR DESCRIPTION
Clarify the status output to suggest running `but update install` or
`but update suppress` instead of the previous wording. This makes the
recommended actions for handling an available update more explicit and
consistent with the update subcommands.