### PR TITLE
Delete GitButler branches upon `teardown`

### DIFF
--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -4,6 +4,7 @@ use crate::utils::{CommandExt, Sandbox};
 
 /// Test 1: Simple case of a single branch
 /// - Teardown should return HEAD to that branch
+/// - All gitbutler branches cleaned up
 #[test]
 fn single_branch_simple_teardown() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
@@ -39,6 +40,15 @@ To return to GitButler mode, run:
         .arg("HEAD")
         .output()?;
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "A");
+
+    // Verify that there are no gitbutler branches
+    for reference in env.open_repo()?.references()?.local_branches()? {
+        let reference = reference.expect("could not read reference");
+        let branch_name = reference.name().shorten();
+        if branch_name != b"A" && branch_name != b"main" {
+            panic!("unexpected branch `{}`", branch_name);
+        }
+    }
 
     Ok(())
 }

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -21,19 +21,7 @@ fn single_branch_simple_teardown() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Exiting GitButler mode...
-
-→ Creating snapshot...
-  ✓ Snapshot created: [..]
-
-→ Finding active branch to check out...
-  ✓ Will check out: A
-
-→ Checking out A...
-  ✓ Checked out: A
-
-✓ Successfully exited GitButler mode!
-
+...
 You are now on branch: A
 
 To return to GitButler mode, run:
@@ -79,19 +67,7 @@ fn multiple_branches_preserves_state() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Exiting GitButler mode...
-
-→ Creating snapshot...
-  ✓ Snapshot created: [..]
-
-→ Finding active branch to check out...
-  ✓ Will check out: A
-
-→ Checking out A...
-  ✓ Checked out: A
-
-✓ Successfully exited GitButler mode!
-
+...
 You are now on branch: A
 
 To return to GitButler mode, run:
@@ -153,35 +129,11 @@ fn dangling_commit_on_workspace() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Exiting GitButler mode...
-
-→ Creating snapshot...
-  ✓ Snapshot created: [..]
-
-→ Finding active branch to check out...
-
-Attempting to fix workspace stacks...
-→ Checking for dangling commits...
-→ Resetting gitbutler/workspace to [..]
-  ✓ gitbutler/workspace reset to [..]
-
+...
   ⚠ Non-GitButler created commits found.
   ⚠ Undoing these commits but keeping the changes in your working directory.
   ⚠ Uncommitted 1 dangling commit(s):
 ...
-
-  ✓ Will check out: A
-
-→ Checking out A...
-  ✓ Checked out: A
-
-✓ Successfully exited GitButler mode!
-
-You are now on branch: A
-
-To return to GitButler mode, run:
-  but setup
-
 
 "#]]);
 
@@ -251,38 +203,17 @@ fn dangling_commit_spanning_multiple_branches() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Exiting GitButler mode...
-
-→ Creating snapshot...
-  ✓ Snapshot created: [..]
-
-→ Finding active branch to check out...
-
-Attempting to fix workspace stacks...
-→ Checking for dangling commits...
-→ Resetting gitbutler/workspace to [..]
-  ✓ gitbutler/workspace reset to [..]
-
+...
   ⚠ Non-GitButler created commits found.
   ⚠ Undoing these commits but keeping the changes in your working directory.
   ⚠ Uncommitted 1 dangling commit(s):
     [..]: User commit touching both branches
-
-  ✓ Will check out: A
-
-→ Checking out A...
+...
   ⚠ Checkout failed, trying soft reset...
   ⚠ This will leave changes from multiple branches in your working directory.
   ⚠ You will have to manually remove, stash or re-commit the changes.
   ✓ Checked out: A
-
-✓ Successfully exited GitButler mode!
-
-You are now on branch: A
-
-To return to GitButler mode, run:
-  but setup
-
+...
 
 "#]]);
 
@@ -341,36 +272,11 @@ fn two_dangling_commits_different_branches() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Exiting GitButler mode...
-
-→ Creating snapshot...
-  ✓ Snapshot created: [..]
-
-→ Finding active branch to check out...
-
-Attempting to fix workspace stacks...
-→ Checking for dangling commits...
-→ Resetting gitbutler/workspace to c128bce
-  ✓ gitbutler/workspace reset to c128bce
-
+...
   ⚠ Non-GitButler created commits found.
   ⚠ Undoing these commits but keeping the changes in your working directory.
   ⚠ Uncommitted 2 dangling commit(s):
-    [..]
-    [..]
-
-  ✓ Will check out: A
-
-→ Checking out A...
-  ✓ Checked out: A
-
-✓ Successfully exited GitButler mode!
-
-You are now on branch: A
-
-To return to GitButler mode, run:
-  but setup
-
+...
 
 "#]]);
 


### PR DESCRIPTION
Why I'm not automerging: this might be a workflow change, although I think it's misleading for the `gitbutler/workspace` and `gitbutler/target` branches to stick around, so I think it's better for them to be removed. (I've included a test to show that `setup` after `teardown` still works even if we remove the branches.)

This is a followup from #12074