### PR TITLE
Use `ctx.project_dir` in oplog more consistently.

### DIFF
--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -648,10 +648,7 @@ fn restore_snapshot(
 
     // Update virtual_branches.toml with the state from the snapshot
     fs::write(
-        git2_repo
-            .path()
-            .join("gitbutler")
-            .join("virtual_branches.toml"),
+        ctx.project_data_dir().join("virtual_branches.toml"),
         vb_toml_blob.content(),
     )?;
 


### PR DESCRIPTION
Follow-up on https://github.com/gitbutlerapp/gitbutler/pull/12086#discussion_r2744501270
