### PR TITLE
Update diff default height to play well with virtual list

### DIFF
--- a/apps/desktop/src/components/MultiDiffView.svelte
+++ b/apps/desktop/src/components/MultiDiffView.svelte
@@ -75,7 +75,7 @@
 			{startIndex}
 			grow
 			items={changes}
-			defaultHeight={140}
+			defaultHeight={102}
 			visibility="scroll"
 			renderDistance={100}
 		>


### PR DESCRIPTION
I need to debug this a bit closer to understand why a misaligned default
height leads to problems in jumpToIndex.

Meanwhile, this fixes the problem for now.