### PR TITLE
Exclude workspace commit from parent checks

### DIFF
--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -177,7 +177,11 @@ impl GraphExt for Graph {
                     {
                         // The commit has preserved parents, so the parent
                         // connections don't really matter.
-                    } else {
+                        // Further, the but graph does some _fancy_ stuff with
+                        // the workspace commit so we can ignore divergance.
+                        // It will result in the workspace commit getting
+                        // rewritten, but that is _fine_.
+                    } else if Some(c.id) != workspace_commit_id {
                         bail!(
                             "BUG: Parents for commit {} do not match.\n\nFound:{:?}\nExpected:{:?}\n\nThese IDs may be in memory, but may be helpful for debugging.",
                             c.id,


### PR DESCRIPTION
The workspace commit currently has some parents missing because they can be inferred? This causes a disparity between the commit graph and our but-graph.

In the case of the workspace commit we should skip this check and just trust our but-graph.

If some other code has left out a parent, the rebase engine will add it in because it doesn’t try to make assumptions about what is strictly nessesarya, which I think is reasonable behaviour, especially when working with other merge commits where we should preserve the origional graph structure.