### PR TITLE
Handle heredocs when splitting bash commands

### DIFF
--- a/crates/but-claude/src/permissions/bash.rs
+++ b/crates/but-claude/src/permissions/bash.rs
@@ -1,5 +1,5 @@
-/// Splits a bash command string into individual commands, respecting quotes and escape sequences.
-/// Splits on: &&, ||, ;, |, &, and newlines (when not inside quotes)
+/// Splits a bash command string into individual commands, respecting quotes, escape sequences,
+/// and heredocs. Splits on: &&, ||, ;, |, &, and newlines (when not inside quotes or heredocs)
 ///
 /// # Examples
 /// ```
@@ -11,12 +11,63 @@
 /// assert_eq!(result, vec!["git add .", "git commit -m 'test commit'", "git push"]);
 /// ```
 pub(super) fn split_bash_commands(command: &str) -> Vec<String> {
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     enum State {
         Normal,
         InSingleQuote,
         InDoubleQuote,
         Escaped,
+        /// Heredoc state tracking delimiter and current line for efficient matching.
+        /// strip_tabs is true for <<- heredocs where leading tabs on the closing line are ignored.
+        InHeredoc {
+            delimiter: String,
+            strip_tabs: bool,
+            current_line: String,
+        },
+    }
+
+    /// Checks if a line matches the heredoc delimiter, accounting for <<- tab stripping.
+    fn line_matches_delimiter(line: &str, delimiter: &str, strip_tabs: bool) -> bool {
+        let line_to_check = if strip_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line
+        };
+        line_to_check == delimiter
+    }
+
+    /// Parses a heredoc delimiter after `<<` or `<<-`, handling optional quotes.
+    /// Returns the unquoted delimiter string, or None if empty.
+    fn parse_heredoc_delimiter(
+        chars: &mut std::iter::Peekable<std::str::Chars>,
+        current_command: &mut String,
+    ) -> Option<String> {
+        // Skip whitespace before delimiter
+        while matches!(chars.peek(), Some(' ' | '\t')) {
+            current_command.push(chars.next().unwrap());
+        }
+
+        let mut delimiter = String::new();
+        let mut in_quote = false;
+        let mut quote_char = ' ';
+
+        while let Some(&c) = chars.peek() {
+            if !in_quote && matches!(c, '\'' | '"') {
+                in_quote = true;
+                quote_char = c;
+                current_command.push(chars.next().unwrap());
+            } else if in_quote && c == quote_char {
+                in_quote = false;
+                current_command.push(chars.next().unwrap());
+            } else if !in_quote && matches!(c, ' ' | '\t' | '\n' | ';' | '&' | '|') {
+                break;
+            } else {
+                delimiter.push(c);
+                current_command.push(chars.next().unwrap());
+            }
+        }
+
+        (!delimiter.is_empty()).then_some(delimiter)
     }
 
     let mut commands = Vec::new();
@@ -25,9 +76,8 @@ pub(super) fn split_bash_commands(command: &str) -> Vec<String> {
     let mut chars = command.chars().peekable();
 
     while let Some(ch) = chars.next() {
-        match state {
+        match &mut state {
             State::Escaped => {
-                // In escaped state, add the character literally and return to previous state
                 current_command.push(ch);
                 state = State::Normal;
             }
@@ -39,15 +89,38 @@ pub(super) fn split_bash_commands(command: &str) -> Vec<String> {
             }
             State::InDoubleQuote => {
                 current_command.push(ch);
-                if ch == '\\' {
-                    // In double quotes, backslash escapes certain characters
-                    if let Some(&next_ch) = chars.peek()
-                        && matches!(next_ch, '"' | '\\' | '$' | '`' | '\n')
-                    {
-                        current_command.push(chars.next().unwrap());
-                    }
+                if ch == '\\' && matches!(chars.peek(), Some('"' | '\\' | '$' | '`' | '\n')) {
+                    current_command.push(chars.next().unwrap());
                 } else if ch == '"' {
                     state = State::Normal;
+                }
+            }
+            State::InHeredoc {
+                delimiter,
+                strip_tabs,
+                current_line,
+            } => {
+                current_command.push(ch);
+
+                if ch == '\n' {
+                    if line_matches_delimiter(current_line, delimiter, *strip_tabs) {
+                        state = State::Normal;
+                    } else {
+                        current_line.clear();
+                    }
+                } else {
+                    current_line.push(ch);
+
+                    // Check for heredoc terminated by end-of-input or operator (no trailing newline)
+                    if line_matches_delimiter(current_line, delimiter, *strip_tabs) {
+                        // Skip optional whitespace, then check for operator or end
+                        while matches!(chars.peek(), Some(' ' | '\t')) {
+                            current_command.push(chars.next().unwrap());
+                        }
+                        if matches!(chars.peek(), None | Some('&' | '|' | ';')) {
+                            state = State::Normal;
+                        }
+                    }
                 }
             }
             State::Normal => {
@@ -63,6 +136,25 @@ pub(super) fn split_bash_commands(command: &str) -> Vec<String> {
                     '\\' => {
                         current_command.push(ch);
                         state = State::Escaped;
+                    }
+                    '<' => {
+                        current_command.push(ch);
+                        if chars.peek() == Some(&'<') {
+                            current_command.push(chars.next().unwrap());
+                            let strip_tabs = if chars.peek() == Some(&'-') {
+                                current_command.push(chars.next().unwrap());
+                                true
+                            } else {
+                                false
+                            };
+                            if let Some(delimiter) = parse_heredoc_delimiter(&mut chars, &mut current_command) {
+                                state = State::InHeredoc {
+                                    delimiter,
+                                    strip_tabs,
+                                    current_line: String::new(),
+                                };
+                            }
+                        }
                     }
                     // Check for two-character operators
                     '&' => {
@@ -286,5 +378,128 @@ EOF
     fn escaped_newline_in_double_quotes() {
         let result = split_bash_commands("echo \"line1\\nline2\" && echo done");
         assert_eq!(result, vec!["echo \"line1\\nline2\"", "echo done"]);
+    }
+
+    #[test]
+    fn bash_multi_line_string() {
+        let result = split_bash_commands(
+            r#"cat << AStartEndIndicator
+hello world
+what is going on?
+something odd
+AStartEndIndicator"#,
+        );
+
+        assert_eq!(
+            result,
+            vec![
+                r#"cat << AStartEndIndicator
+hello world
+what is going on?
+something odd
+AStartEndIndicator"#,
+            ]
+        );
+    }
+
+    #[test]
+    fn heredoc_strip_tabs() {
+        // <<- allows the closing delimiter to be indented with tabs
+        let result = split_bash_commands("cat <<-EOF\n\thello world\n\tEOF");
+
+        assert_eq!(result, vec!["cat <<-EOF\n\thello world\n\tEOF"]);
+    }
+
+    #[test]
+    fn heredoc_strip_tabs_followed_by_command() {
+        // <<- heredoc followed by another command
+        let result = split_bash_commands("cat <<-EOF\n\tindented content\n\tEOF && echo done");
+
+        assert_eq!(result, vec!["cat <<-EOF\n\tindented content\n\tEOF", "echo done"]);
+    }
+
+    #[test]
+    fn heredoc_simple_eof() {
+        // Basic unquoted heredoc with EOF delimiter
+        let result = split_bash_commands("cat <<EOF\nhello\nEOF");
+        assert_eq!(result, vec!["cat <<EOF\nhello\nEOF"]);
+    }
+
+    #[test]
+    fn heredoc_followed_by_ampersand() {
+        // Heredoc followed by && operator
+        let result = split_bash_commands("cat <<EOF\ndata\nEOF && echo done");
+        assert_eq!(result, vec!["cat <<EOF\ndata\nEOF", "echo done"]);
+    }
+
+    #[test]
+    fn heredoc_followed_by_pipe() {
+        // Heredoc followed by || operator
+        let result = split_bash_commands("cat <<EOF\ndata\nEOF || echo failed");
+        assert_eq!(result, vec!["cat <<EOF\ndata\nEOF", "echo failed"]);
+    }
+
+    #[test]
+    fn heredoc_followed_by_semicolon() {
+        // Heredoc followed by semicolon
+        let result = split_bash_commands("cat <<EOF\ndata\nEOF; echo next");
+        assert_eq!(result, vec!["cat <<EOF\ndata\nEOF", "echo next"]);
+    }
+
+    #[test]
+    fn heredoc_delimiter_not_at_line_start() {
+        // EOF appearing mid-line should not end the heredoc
+        let result = split_bash_commands("cat <<EOF\nthis has EOF in the middle\nEOF");
+        assert_eq!(result, vec!["cat <<EOF\nthis has EOF in the middle\nEOF"]);
+    }
+
+    #[test]
+    fn heredoc_quoted_delimiter() {
+        // Quoted delimiter (disables variable expansion in bash, but delimiter is still unquoted when matching)
+        let result = split_bash_commands("cat <<'END'\n$VAR stays literal\nEND");
+        assert_eq!(result, vec!["cat <<'END'\n$VAR stays literal\nEND"]);
+    }
+
+    #[test]
+    fn heredoc_double_quoted_delimiter() {
+        // Double-quoted delimiter
+        let result = split_bash_commands("cat <<\"END\"\ncontent\nEND");
+        assert_eq!(result, vec!["cat <<\"END\"\ncontent\nEND"]);
+    }
+
+    #[test]
+    fn heredoc_strip_tabs_content_preserved() {
+        // <<- only strips tabs from the closing delimiter line, content tabs are preserved
+        let result = split_bash_commands("cat <<-EOF\n\tline1\n\t\tline2\n\tEOF");
+        assert_eq!(result, vec!["cat <<-EOF\n\tline1\n\t\tline2\n\tEOF"]);
+    }
+
+    #[test]
+    fn heredoc_strip_tabs_non_tab_indent_not_matched() {
+        // <<- only strips tabs, not spaces - delimiter with space indent won't match
+        let result = split_bash_commands("cat <<-EOF\ncontent\n  EOF\nEOF");
+        // The "  EOF" (space-indented) doesn't match, but "EOF" does
+        assert_eq!(result, vec!["cat <<-EOF\ncontent\n  EOF\nEOF"]);
+    }
+
+    #[test]
+    fn heredoc_empty_content() {
+        // Heredoc with no content between start and delimiter
+        let result = split_bash_commands("cat <<EOF\nEOF");
+        assert_eq!(result, vec!["cat <<EOF\nEOF"]);
+    }
+
+    #[test]
+    fn heredoc_at_end_of_input() {
+        // Heredoc that ends exactly at end of input (no trailing newline)
+        let result = split_bash_commands("cat <<EOF\ncontent\nEOF");
+        assert_eq!(result, vec!["cat <<EOF\ncontent\nEOF"]);
+    }
+
+    #[test]
+    fn multiple_heredocs() {
+        // Multiple heredocs in sequence
+        let result = split_bash_commands("cat <<A\nfirst\nA && cat <<B\nsecond\nB");
+        assert_eq!(result, vec!["cat <<A\nfirst\nA", "cat <<B\nsecond\nB"]);
     }
 }


### PR DESCRIPTION
Extend split_bash_commands to recognize << and <<- heredocs, preventing
the parser from incorrectly splitting on newlines or operators within
heredoc content.

The implementation tracks the heredoc delimiter and current line in an
InHeredoc state, matching the closing delimiter at line boundaries or
before operators. For <<- heredocs, leading tabs on the closing line
are stripped when matching.