### PR TITLE
Merge using a recursive-like stratergy

### DIFF
--- a/crates/but-rebase/tests/fixtures/scenario/cherry-pick-recursive-merge.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/cherry-pick-recursive-merge.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+git switch -c base
+echo -e "a\nb\nc" > base-f && git add . && git commit -m "base"
+
+git switch -c a
+echo -e "a\nb\nc" > foo-f && git add . && git commit -m "a"
+
+git switch -c b
+echo -e "a\nx\nc" > foo-f && git add . && git commit -m "b"
+
+git switch -c first-parent
+echo -e "1\nx\nc" > foo-f && git add . && git commit -m "first-parent"
+
+git switch b
+git switch -c second-parent
+echo -e "a\nx\n2" > foo-f && git add . && git commit -m "second-parent"
+
+git switch a
+git switch -c third-parent
+echo -e "a\nx\nc" > base-f && git add . && git commit -m "third-parent"
+
+git switch a
+git switch -c to-pick
+echo -e "a\nx\nc\nd" > base-f && git add . && git commit -m "to-pick"


### PR DESCRIPTION
Longer term we should have one standardized merge function which perhaps also makes use of the but-graph, but looking at the current implementation used in the apply code, it seems to have quite a bit more complexity than what is required here.

Currently this base calculation for the cherry pick doesn’t auto-resolve any conflicts, but thinking it through and talking to Pierre about what mercurial does, this should be safe to do for everything, but perhaps the workspace commit. I’ll make this change in a follow up commit.