### PR TITLE
fix(ui): disable pointer events for readonly branch input

### DIFF
--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -190,5 +190,6 @@
 
 	.branch-name-input[readonly] {
 		cursor: default;
+		pointer-events: none;
 	}
 </style>


### PR DESCRIPTION
This was causing issues on click - the overflow rule didn’t work.

Issue:

https://github.com/user-attachments/assets/65bc479c-870c-48a7-8c70-120818ff6e8e