### PR TITLE
fix(ui assigned changes): show drop area by default and animate its height

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -792,7 +792,9 @@
 			& .assigned-changes-empty {
 				padding: 20px 8px 20px;
 				background-color: var(--clr-bg-1);
-				will-change: padding;
+				transition:
+					background-color var(--transition-fast),
+					padding var(--transition-fast);
 			}
 
 			& .assigned-changes-empty__text {

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -113,7 +113,12 @@
 	onHovered={onDropzoneHovered}
 >
 	{#snippet overlay({ hovered, activated, handler })}
-		<CardOverlay {hovered} {activated} label={getDropzoneLabel(handler)} />
+		<CardOverlay
+			{hovered}
+			{activated}
+			label={getDropzoneLabel(handler)}
+			visible={mode === 'assigned' && changes.current.length === 0 && !activated}
+		/>
 	{/snippet}
 
 	<div class="uncommitted-changes-wrap">


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/7c30c9b0-fa4e-49ac-98db-8bfa5cf1020a


After:

https://github.com/user-attachments/assets/ad83d7ea-1d4f-421e-8815-5d51f827b241

