### PR TITLE
Make restore an oplog subcommand

### DIFF
--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -253,12 +253,12 @@ Every operation in GitButler is recorded in the oplog (operation log).
 ```bash
 but oplog                      # View history
 but undo                       # Undo last operation
-but restore <snapshot-id>      # Restore to specific point
+but oplog restore <snapshot-id>  # Restore to specific point
 ```
 
 Think of it as "git reflog" but for all GitButler operations, not just branch movements.
 
-**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but restore` to earlier snapshot.
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but oplog restore` to earlier snapshot.
 
 ## Applied vs Unapplied Branches
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -459,7 +459,7 @@ but oplog
 # s1: pull from remote
 
 # Restore to before squash
-but restore s4
+but oplog restore s4
 ```
 
 ### Discard Uncommitted Changes

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -368,12 +368,12 @@ but oplog --json
 
 Shows all operations with snapshot IDs.
 
-### `but restore <snapshot>`
+### `but oplog restore <snapshot>`
 
 Restore to a specific oplog snapshot.
 
 ```bash
-but restore <snapshot-id>
+but oplog restore <snapshot-id>
 ```
 
 ## Setup & Configuration

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -417,29 +417,12 @@ pub enum Subcommands {
     /// This allows you to restore to any previous point in the history of the
     /// project. All state is preserved in operations, including uncommitted changes.
     ///
-    /// You can use `but restore <oplog-sha>` to restore to a specific state.
+    /// You can use `but oplog restore <oplog-sha>` to restore to a specific state.
     ///
     /// By default, shows the last 20 oplog entries (same as `but oplog list`).
     ///
     #[cfg(feature = "legacy")]
     Oplog(oplog::Platform),
-
-    /// Restore to a specific oplog snapshot.
-    ///
-    /// This command allows you to revert the repository to a previous state
-    /// captured in an oplog snapshot.
-    ///
-    /// You need to provide the SHA of the oplog entry you want to restore to,
-    /// which you can find by running `but oplog`.
-    ///
-    #[cfg(feature = "legacy")]
-    Restore {
-        /// Oplog SHA to restore to
-        oplog_sha: String,
-        /// Skip confirmation prompt
-        #[clap(short = 'f', long = "force")]
-        force: bool,
-    },
 
     /// Undo the last operation by reverting to the previous snapshot.
     ///

--- a/crates/but/src/args/oplog.rs
+++ b/crates/but/src/args/oplog.rs
@@ -14,7 +14,7 @@ pub enum Subcommands {
     /// This allows you to restore to any previous point in the history of the
     /// project. All state is preserved in operations, including uncommitted changes.
     ///
-    /// You can use `but restore <oplog-sha>` to restore to a specific state.
+    /// You can use `but oplog restore <oplog-sha>` to restore to a specific state.
     ///
     #[cfg(feature = "legacy")]
     List {
@@ -38,5 +38,22 @@ pub enum Subcommands {
         /// Message to include with the snapshot
         #[clap(short = 'm', long = "message")]
         message: Option<String>,
+    },
+
+    /// Restore to a specific oplog snapshot.
+    ///
+    /// This command allows you to revert the repository to a previous state
+    /// captured in an oplog snapshot.
+    ///
+    /// You need to provide the SHA of the oplog entry you want to restore to,
+    /// which you can find by running `but oplog` or `but oplog list`.
+    ///
+    #[cfg(feature = "legacy")]
+    Restore {
+        /// Oplog SHA to restore to
+        oplog_sha: String,
+        /// Skip confirmation prompt
+        #[clap(short = 'f', long = "force")]
+        force: bool,
     },
 }

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -303,7 +303,7 @@ pub(crate) fn create_snapshot(
 
         writeln!(
             out,
-            "\n{} Use 'but restore {}' to restore to this snapshot later.",
+            "\n{} Use 'but oplog restore {}' to restore to this snapshot later.",
             "💡".bright_blue(),
             &snapshot_id.to_string()[..7]
         )?;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -652,16 +652,14 @@ async fn match_subcommand(
                 Some(args::oplog::Subcommands::Snapshot { message }) => {
                     command::legacy::oplog::create_snapshot(&mut ctx, out, message.as_deref()).emit_metrics(metrics_ctx)
                 }
+                Some(args::oplog::Subcommands::Restore { oplog_sha, force }) => {
+                    command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha, force).emit_metrics(metrics_ctx)
+                }
                 None => {
                     // Default to list when no subcommand is provided
                     command::legacy::oplog::show_oplog(&mut ctx, out, None, None).emit_metrics(metrics_ctx)
                 }
             }
-        }
-        #[cfg(feature = "legacy")]
-        Subcommands::Restore { oplog_sha, force } => {
-            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
-            command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha, force).emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Undo => {

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -105,9 +105,8 @@ impl Subcommands {
                 None => OplogList,
                 Some(crate::args::oplog::Subcommands::List { .. }) => OplogList,
                 Some(crate::args::oplog::Subcommands::Snapshot { .. }) => OplogSnapshot,
+                Some(crate::args::oplog::Subcommands::Restore { .. }) => Restore,
             },
-            #[cfg(feature = "legacy")]
-            Subcommands::Restore { .. } => Restore,
             #[cfg(feature = "legacy")]
             Subcommands::Undo => Undo,
             #[cfg(feature = "legacy")]


### PR DESCRIPTION
Change the CLI and docs so restore is invoked as `but oplog restore`
instead of the top-level `but restore`. This updates help text,
reference docs, examples, argument parsing, command dispatch, legacy
oplog messages, and metrics so that the restore action is nested under
the oplog subcommand and routed to the existing oplog restore
implementation.