### PR TITLE
Avoid bright white text on light themes

### DIFF
--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -273,7 +273,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             writeln!(
                 out,
                 "\n{} {} upstream commits on {}",
-                "Found".bright_white(),
+                "Found".bold(),
                 base_branch.behind.to_string().bright_yellow(),
                 base_branch.branch_name.bright_cyan()
             )?;
@@ -547,7 +547,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(
                             out,
                             "{} of {} {}",
-                            "Rebase".bright_white(),
+                            "Rebase".bold(),
                             branch_name.as_str().bright_cyan(),
                             "successful".green()
                         )?;
@@ -571,7 +571,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             writeln!(
                                 out,
                                 "{} {} has been integrated upstream and removed locally",
-                                "Branch".bright_white(),
+                                "Branch".bold(),
                                 branch.bright_green()
                             )?;
                         }
@@ -618,7 +618,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
 
                     // Undo instructions
                     writeln!(out)?;
-                    writeln!(out, "{}", "To undo this operation:".bright_white())?;
+                    writeln!(out, "{}", "To undo this operation:".bold())?;
                     writeln!(out, "  Run `but undo`")?;
                 }
 


### PR DESCRIPTION
Replace bright_white() colorization with bold() for several UI strings
in the `but pull` command to improve readability on light themes. The
previous use of bright white made output nearly unreadable for users
with light backgrounds; switching to bold preserves emphasis without
relying on a white foreground color.