### PR TITLE
Check remote tracking branches when generating canned names

### DIFF
--- a/crates/but-core/src/branch/mod.rs
+++ b/crates/but-core/src/branch/mod.rs
@@ -6,7 +6,10 @@ mod normalize;
 pub use normalize::normalize_short_name;
 
 mod generate;
-pub use generate::{canned_refname, find_unique_refname, unique_canned_refname};
+pub use generate::{
+    canned_refname, find_unique_refname, find_unique_refname_with_remote_check, unique_canned_refname,
+    unique_canned_refname_with_remote_check,
+};
 
 /// A way to safely delete branches, which is only the case it's checked out nowhere.
 pub mod safe_delete;

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -17,6 +17,7 @@ but-graph.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-hunk-dependency.workspace = true
 but-ctx.workspace = true
+gitbutler-stack.workspace = true
 
 anyhow.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
Ensure generated canned branch names avoid conflicts with remote
tracking refs as well as local branches. Add new functions in but-core
to find unique refnames with an explicit remote check and a canned-ref
wrapper that uses it. Update but-api to consult the project's default
push remote and use the remote-aware generation when available. Include
tests covering remote-aware behavior to ensure names that exist on
remotes are skipped.