### PR TITLE
Reduce the usage of VirtualBranchHandles where its types don't leak.

### DIFF
--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -118,6 +118,38 @@ pub type CommitOwnerIndexes = (usize, usize, CommitIndex);
 
 /// Utilities
 impl Workspace {
+    /// Return the commit-id of the merge-base between the `commit_to_merge` and either the [target-branch](Self::target_ref),
+    /// the [extra-target](Self::extra_target) or the [target-commit](Self::target_commit), depending on which is set and encountered
+    /// in this order.
+    /// Return `None` when none of these is set, or if there was no merge-base.
+    ///
+    /// Use this to get the merge-base for test-merges between `commit_to_merge` and the target.
+    pub fn merge_base_with_target_branch(&self, commit_to_merge: gix::ObjectId) -> Option<gix::ObjectId> {
+        // Find the segment containing the commit_to_merge
+        let commit_segment_index = self.graph.node_weights().find_map(|s| {
+            s.commits
+                .first()
+                .is_some_and(|c| c.id == commit_to_merge)
+                .then_some(s.id)
+        })?;
+
+        // Get the target segment in order of precedence: target_ref, extra_target, target_commit
+        let target_segment_index = self
+            .target_ref
+            .as_ref()
+            .map(|t| t.segment_index)
+            .or(self.target_commit.as_ref().map(|t| t.segment_index))
+            .or(self.extra_target)?;
+
+        // Find the merge-base segment between them
+        let merge_base_segment_index = self
+            .graph
+            .find_git_merge_base(commit_segment_index, target_segment_index)?;
+
+        // Get the first commit from the merge-base segment
+        self.graph.tip_skip_empty(merge_base_segment_index).map(|c| c.id)
+    }
+
     /// Return `true` if the workspace itself is where `HEAD` is pointing to.
     /// If `false`, one of the stack-segments is checked out instead.
     pub fn is_entrypoint(&self) -> bool {

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -852,7 +852,7 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
 
 mod with_workspace;
 
-mod utils;
+pub(crate) mod utils;
 pub use utils::{
     StackState, add_stack_with_segments, add_workspace, id_at, id_by_rev, read_only_in_memory_scenario,
     standard_options,

--- a/crates/but-graph/tests/graph/main.rs
+++ b/crates/but-graph/tests/graph/main.rs
@@ -1,2 +1,3 @@
 mod init;
 mod vis;
+mod workspace;

--- a/crates/but-graph/tests/graph/workspace/merge_base_with_target_branch.rs
+++ b/crates/but-graph/tests/graph/workspace/merge_base_with_target_branch.rs
@@ -36,9 +36,10 @@ fn with_target_ref() -> anyhow::Result<()> {
 
     let main_id = repo.rev_parse_single("main")?.detach();
 
-    let merge_base = ws.merge_base_with_target_branch(main_id);
-    let expected = repo.rev_parse_single(":/M2")?;
-    assert_eq!(merge_base, Some(expected.detach()));
+    let res = ws.merge_base_with_target_branch(main_id);
+    let expected_merge_base = repo.rev_parse_single(":/M2")?.detach();
+    let expected_target_id = repo.rev_parse_single("origin/main")?.detach();
+    assert_eq!(res, Some((expected_merge_base, expected_target_id)));
 
     Ok(())
 }
@@ -74,8 +75,9 @@ fn with_extra_target_when_no_target_ref() -> anyhow::Result<()> {
     let a_id = repo.rev_parse_single("A")?.detach();
 
     let merge_base = ws.merge_base_with_target_branch(a_id);
-    let expected = repo.rev_parse_single(":/M2")?;
-    assert_eq!(merge_base, Some(expected.detach()));
+    let expected_merge_base = repo.rev_parse_single(":/M2")?.detach();
+    let expected_target_id = repo.rev_parse_single("main")?.detach();
+    assert_eq!(merge_base, Some((expected_merge_base, expected_target_id)));
 
     Ok(())
 }
@@ -93,8 +95,8 @@ fn returns_none_when_no_target_is_set() -> anyhow::Result<()> {
     assert!(ws.target_commit.is_none(), "should not have target_commit");
 
     let a2_id = repo.rev_parse_single("A")?.detach();
-    let merge_base = ws.merge_base_with_target_branch(a2_id);
-    assert!(merge_base.is_none(), "can't compute merge-base without the other side");
+    let res = ws.merge_base_with_target_branch(a2_id);
+    assert!(res.is_none(), "can't compute merge-base without the other side");
 
     Ok(())
 }
@@ -108,8 +110,8 @@ fn returns_none_when_commit_not_in_graph() -> anyhow::Result<()> {
         .validated()?
         .into_workspace()?;
 
-    let merge_base = ws.merge_base_with_target_branch(repo.object_hash().null());
-    assert!(merge_base.is_none(), "should return None when commit is not in graph");
+    let res = ws.merge_base_with_target_branch(repo.object_hash().null());
+    assert!(res.is_none(), "should return None when commit is not in graph");
 
     Ok(())
 }

--- a/crates/but-graph/tests/graph/workspace/merge_base_with_target_branch.rs
+++ b/crates/but-graph/tests/graph/workspace/merge_base_with_target_branch.rs
@@ -1,0 +1,115 @@
+use but_graph::Graph;
+use but_testsupport::visualize_commit_graph_all;
+
+use crate::init::utils::{
+    add_workspace, add_workspace_without_target, read_only_in_memory_scenario, standard_options,
+    standard_options_with_extra_target,
+};
+
+#[test]
+fn with_target_ref() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/local-target-and-stack")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   59a427f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * a62b0de (A) A2
+    | * 120a217 A1
+    * | 0a415d8 (main) M3
+    | | * 1f5c47b (origin/main) RM1
+    | |/  
+    |/|   
+    * | 73ba99d M2
+    |/  
+    * fafd9d0 init
+    ");
+
+    add_workspace(&mut meta);
+
+    let ws = Graph::from_head(&repo, &*meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+
+    // We have a target_ref but nothing else
+    assert!(ws.target_ref.is_some());
+    assert!(ws.target_commit.is_none());
+    assert!(ws.extra_target.is_none());
+
+    let main_id = repo.rev_parse_single("main")?.detach();
+
+    let merge_base = ws.merge_base_with_target_branch(main_id);
+    let expected = repo.rev_parse_single(":/M2")?;
+    assert_eq!(merge_base, Some(expected.detach()));
+
+    Ok(())
+}
+
+#[test]
+fn with_extra_target_when_no_target_ref() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/two-branches-one-below-base")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   e82dfab (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 6fdab32 (A) A1
+    * | 78b1b59 (B) B1
+    | | * 938e6f2 (origin/main, main) M4
+    | |/  
+    |/|   
+    * | f52fcec M3
+    |/  
+    * bce0c5e M2
+    * 3183e43 M1
+    ");
+
+    add_workspace(&mut meta);
+    meta.data_mut().default_target = None;
+
+    // Use extra_target to set a lower bound
+    let graph = Graph::from_head(&repo, &*meta, standard_options_with_extra_target(&repo, "main"))?.validated()?;
+    let ws = graph.into_workspace()?;
+
+    assert!(ws.target_ref.is_none());
+    assert!(ws.target_commit.is_none());
+    assert!(ws.extra_target.is_some());
+
+    let a_id = repo.rev_parse_single("A")?.detach();
+
+    let merge_base = ws.merge_base_with_target_branch(a_id);
+    let expected = repo.rev_parse_single(":/M2")?;
+    assert_eq!(merge_base, Some(expected.detach()));
+
+    Ok(())
+}
+
+#[test]
+fn returns_none_when_no_target_is_set() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/no-target-without-ws-commit")?;
+
+    add_workspace_without_target(&mut meta);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let ws = graph.into_workspace()?;
+
+    assert!(ws.target_ref.is_none(), "should not have target_ref");
+    assert!(ws.extra_target.is_none(), "should not have extra_target");
+    assert!(ws.target_commit.is_none(), "should not have target_commit");
+
+    let a2_id = repo.rev_parse_single("A")?.detach();
+    let merge_base = ws.merge_base_with_target_branch(a2_id);
+    assert!(merge_base.is_none(), "can't compute merge-base without the other side");
+
+    Ok(())
+}
+
+#[test]
+fn returns_none_when_commit_not_in_graph() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/local-target-and-stack")?;
+
+    add_workspace(&mut meta);
+    let ws = Graph::from_head(&repo, &*meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+
+    let merge_base = ws.merge_base_with_target_branch(repo.object_hash().null());
+    assert!(merge_base.is_none(), "should return None when commit is not in graph");
+
+    Ok(())
+}

--- a/crates/but-graph/tests/graph/workspace/mod.rs
+++ b/crates/but-graph/tests/graph/workspace/mod.rs
@@ -1,0 +1,1 @@
+mod merge_base_with_target_branch;

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -335,6 +335,8 @@ fn get_reviews_json(
     }
 }
 
+// TODO(perf): re-write this to use a graph that includes all branches from the listing, needs a listing that uses
+//             the graph.
 fn check_branches_merge_cleanly(
     ctx: &Context,
     applied_stacks: &[but_workspace::legacy::ui::StackEntry],

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -115,6 +115,8 @@ struct CommitRef {
     timestamp: i64,
 }
 
+// TODO(perf): re-write this to use a graph that includes all branches from the listing, needs a listing that uses
+//             the graph.
 fn check_merge_conflicts(ctx: &Context, branch_name: &str) -> Result<MergeCheck, anyhow::Error> {
     use but_core::RepositoryExt;
 


### PR DESCRIPTION
Often it's just used to lookup a ref, or to figure something out about the target branch.

These instances can easily be served merely by using `ws`, and new code should never instantiate such a handle anyway.

### Tasks

* [x] auto-find candidates and attempt conversion (opus-planning)
* [x] improved workspace API
* [x] review

### Review Notes

Turned out to be a rabbit hole, but also showed what's needed to make the graph truly work.

* Need a way to traverse with a list of all branches to include
    - that could also lead to a better branch listing that uses a one-time traversed graph with all branches of interest.
