### PR TITLE
Optimise `but-graph` in debug builds for performance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,6 +293,7 @@ incremental = false
 [profile.dev.package]
 foldhash = { opt-level = 3 }
 imara-diff = { opt-level = 3 }
+but-graph = { opt-level = 3 }
 gix = { opt-level = 3 }
 gix-diff = { opt-level = 3 }
 gix-object = { opt-level = 3 }


### PR DESCRIPTION
Otherwise our graph traversals are too slow, and time changes from 1.66s to <0.1 seconds.
