### PR TITLE
`but commit` improvements

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -329,7 +329,14 @@ pub(crate) fn commit(
             Some(id) => id.to_hex_with_len(7).to_string(),
             None => "unknown".to_string(),
         };
-        writeln!(out, "Created commit {} on branch {}", commit_short, target_branch.name)?;
+        writeln!(
+            out,
+            "{} {} {} {}",
+            "✓ Created commit".green(),
+            commit_short.magenta(),
+            "on branch".green(),
+            target_branch.name.to_str_lossy().yellow()
+        )?;
     }
 
     // Run post-commit hook unless --no-hooks was specified

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -174,6 +174,11 @@ pub(crate) fn commit(
         })
         .collect();
 
+    // In JSON mode with multiple branches, require branch specification
+    if out.for_json().is_some() && stacks.len() > 1 && branch_hint.is_none() {
+        bail!("Multiple branches found. Specify a branch to commit to using the branch argument");
+    }
+
     let (target_stack_id, target_stack) = select_stack(&id_map, ctx, &stacks, branch_hint, create_branch, out)?;
 
     // Get changes and assignments using but-api
@@ -247,6 +252,11 @@ pub(crate) fn commit(
     } else if let Some(msg) = message {
         msg.to_string()
     } else {
+        // In JSON mode, we should have already validated that a message was provided
+        // This is a safeguard in case the validation was missed
+        if out.for_json().is_some() {
+            bail!("In JSON mode, a commit message must be provided via --message (-m) or --file (-f)");
+        }
         get_commit_message_from_editor(&files_to_commit, &changes)?
     };
 
@@ -337,6 +347,13 @@ pub(crate) fn commit(
             "on branch".green(),
             target_branch.name.to_str_lossy().yellow()
         )?;
+    } else if let Some(json_out) = out.for_json() {
+        let commit_data = serde_json::json!({
+            "commit_id": outcome.new_commit.map(|id| id.to_string()),
+            "branch": target_branch.name.to_str_lossy(),
+            "branch_tip": outcome.new_commit.map(|id| id.to_string()),
+        });
+        json_out.write_value(commit_data)?;
     }
 
     // Run post-commit hook unless --no-hooks was specified

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -592,6 +592,18 @@ async fn match_subcommand(
                 }
                 None => {
                     // Handle the regular `but commit` command
+
+                    // In JSON mode, require either -m or -f to be specified
+                    if args.json
+                        && commit_args.message.is_none()
+                        && commit_args.file.is_none()
+                        && commit_args.ai.is_none()
+                    {
+                        anyhow::bail!(
+                            "In JSON mode, either --message (-m), --file (-f), or --ai (-i) must be specified"
+                        );
+                    }
+
                     // Read message from file if provided, otherwise use message option
                     let commit_message =
                         match &commit_args.file {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -18,7 +18,7 @@ fn outputs_branch_name() -> anyhow::Result<()> {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Created branch my-feature
+✓ Created branch my-feature
 
 "#]]);
 
@@ -27,7 +27,7 @@ Created branch my-feature
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Created branch my-anchored-feature
+✓ Created branch my-anchored-feature stacked on [..]
 
 "#]]);
     Ok(())

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -27,7 +27,7 @@ fn commit_with_message_from_file() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created commit [..] on branch A
+✓ Created commit [..] on branch A
 
 "#]]);
 
@@ -81,7 +81,7 @@ fn commit_with_message_flag() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created commit [..] on branch A
+✓ Created commit [..] on branch A
 
 "#]]);
 
@@ -114,7 +114,7 @@ fn commit_with_branch_hint() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created commit [..] on branch B
+✓ Created commit [..] on branch B
 
 "#]]);
 
@@ -173,7 +173,7 @@ fn commit_with_create_flag_creates_new_branch() -> anyhow::Result<()> {
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
 Created new independent branch 'feature-x'
-Created commit [..] on branch feature-x
+✓ Created commit [..] on branch feature-x
 
 "#]]);
 


### PR DESCRIPTION
This adds much better json support to `but commit`, plus nicer coloring on the commit and branch output

<img width="1046" height="176" alt="CleanShot 2026-02-02 at 11 40 35@2x" src="https://github.com/user-attachments/assets/c8463cf4-adb9-4235-8cc7-cce1c82982ea" />

<img width="1152" height="278" alt="CleanShot 2026-02-02 at 11 41 03@2x" src="https://github.com/user-attachments/assets/2744922e-25f9-418f-929a-710da0861d85" />

<img width="818" height="180" alt="CleanShot 2026-02-02 at 11 41 39@2x" src="https://github.com/user-attachments/assets/5ebdaba6-5895-44d3-a15e-325ef897f390" />

<img width="774" height="232" alt="CleanShot 2026-02-02 at 11 41 53@2x" src="https://github.com/user-attachments/assets/20bd6eb5-07c3-424b-8db7-cc4ad2346033" />
