### PR TITLE
fix: enable selection during commit

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -675,7 +675,7 @@
 								bind:this={multiDiffView}
 								projectId={stableProjectId}
 								draggable={true}
-								selectable={false}
+								selectable={isCommitting}
 								onclose={onclosePreview}
 								startIndex={$activeLastAdded.index}
 							/>

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -9,6 +9,7 @@
 	import { createWorktreeSelection } from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
+	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { TestId } from '@gitbutler/ui';
 
@@ -23,6 +24,7 @@
 	const stackService = inject(STACK_SERVICE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
+	const uiState = inject(UI_STATE);
 
 	const selectionId = createWorktreeSelection({ stackId: undefined });
 	const worktreeSelection = $derived(idSelection.getById(selectionId));
@@ -33,6 +35,9 @@
 
 	// Transform unassigned changes to SelectedFile[] format
 	const unassignedChanges = $derived(uncommittedService.getChangesByStackId(null));
+	const projectState = $derived(uiState.project(projectId));
+	const exclusiveAction = $derived(projectState.exclusiveAction.current);
+	const isCommitting = $derived(exclusiveAction?.type === 'commit');
 
 	let multiDiffView = $state<MultiDiffView>();
 	let startIndex = $state(0);
@@ -47,7 +52,7 @@
 		changes={unassignedChanges}
 		bind:this={multiDiffView}
 		draggable={true}
-		selectable={false}
+		selectable={isCommitting}
 		showBorder={false}
 		showRoundedEdges={false}
 		onclose={() => {

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
@@ -169,9 +169,6 @@
 	<tbody
 		onmouseenter={() => (hoveringOverTable = true)}
 		onmouseleave={() => (hoveringOverTable = false)}
-		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
-		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
-		ontouchend={() => lineSelection.onEnd()}
 		use:clickOutside={{
 			handler: handleClearSelection,
 			excludeElement: clickOutsideExcludeElements


### PR DESCRIPTION
Re-enable selecting diffs in multi-diff views when a commit is in
progress, and simplify hunk diff touch handling.

- Make selectable controlled by project commit state:
  - Inject UI_STATE and derive project/exclusiveAction in WorkspaceView
    and StackView, and pass isCommitting to MultiDiffView selectable prop.
  - This allows selecting files/lines while committing and prevents
    selection when not committing.

- Remove manual touch event handlers from HunkDiffBody:
  - Remove ontouchstart, ontouchmove and ontouchend handlers and rely on
    existing lineSelection logic and clickOutside behavior to manage
    touch interactions, reducing duplicate/fragile touch handling.