### PR TITLE
update workspace commit message

### DIFF
--- a/apps/desktop/src/components/NotOnGitButlerBranch.svelte
+++ b/apps/desktop/src/components/NotOnGitButlerBranch.svelte
@@ -83,9 +83,7 @@
 				<p class="switchrepo__message text-13 text-body">
 					Due to GitButler managing multiple virtual branches, you cannot switch back and forth
 					between git branches and virtual branches easily.
-					<Link href="https://docs.gitbutler.com/features/branch-management/integration-branch">
-						Learn more
-					</Link>
+					<Link href="https://docs.gitbutler.com/workspace-branch">Learn more</Link>
 				</p>
 
 				{#if uncommittedChanges.length > 0}

--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -203,9 +203,7 @@
 					automatically manages a special branch <span class="text-bold">gitbutler/workspace</span>.
 					You can always switch back and forth as needed between normal git branches and the
 					Gitbutler workspace.
-					<Link href="https://docs.gitbutler.com/features/branch-management/integration-branch"
-						>Learn more</Link
-					>
+					<Link href="https://docs.gitbutler.com/workspace-branch">Learn more</Link>
 				</p>
 			{/if}
 		</div>

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -529,11 +529,11 @@ impl<'repo> WorkspaceCommit<'repo> {
             message
                 .push_str("This is placeholder commit and will be replaced by a merge of your virtual branches.\n\n");
         }
-        message.push_str("Due to GitButler managing multiple virtual branches, you cannot switch back and\n");
-        message.push_str("forth between git branches and virtual branches easily. \n\n");
 
-        message.push_str("If you switch to another branch, GitButler will need to be reinitialized.\n");
-        message.push_str("If you commit on this branch, GitButler will throw it away.\n\n");
+        message.push_str("For GitButler to manage multiple parallel branches, we maintain this commit\n");
+        message.push_str("automatically so other tooling works properly.\n\n");
+
+        message.push_str("If you switch to another branch, GitButler will need to be reinitialized.\n\n");
         if !stacks.is_empty() {
             message.push_str("Here are the branches that are currently applied:\n");
             for branch in &stacks {
@@ -548,8 +548,8 @@ impl<'repo> WorkspaceCommit<'repo> {
                 message.push('\n');
             }
         }
-        message.push_str("For more information about what we're doing here, check out our docs:\n");
-        message.push_str("https://docs.gitbutler.com/features/branch-management/integration-branch\n");
+        message.push_str("\nFor more information about what we're doing here, check out our docs:\n");
+        message.push_str("https://docs.gitbutler.com/workspace-branch\n");
 
         let author = commit_signature(commit_time("GIT_COMMITTER_DATE"));
         gix::objs::Commit {

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -163,7 +163,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
 
     // the new local tracking ref actually exists, and is in the right spot.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   e00cf08 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   3b41190 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * 6b40b15 (origin/feature, feature) without-local-tracking
     |/  
@@ -403,7 +403,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     )?;
     // A workspace commit was created, even though it does nothing.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 6277161 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * d65d226 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e5d0542 (origin/main, main, B, A) A
     ");
 
@@ -428,7 +428,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
 
     // It's idempotent, but has to update the workspace commit nonetheless for the comment, which depends on the stacks.
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 452772e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 0bb6993 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\
     * e5d0542 (origin/main, main, B, A) A
     ");
@@ -610,7 +610,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   d87b903 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   fa6fb28 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * bf53300 (A) add A
     * | b1540e5 (main) M
@@ -644,7 +644,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   7bcf528 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   633f384 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * 0e391b2 (origin/B, B) add B
     | * | bf53300 (A) add A
@@ -690,7 +690,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * f1889e7 (A2) add A2
     * 7de99e1 (A1) add A1
-    | * 6848743 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 82aeec3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 53ad0c2 (unrelated) add U1
     |/  
     * 3183e43 (origin/main, main) M1
@@ -855,7 +855,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     "#);
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 49d4b34 (A) A1
-    | *   fdec130 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | *   5922bde (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | |\  
     | | * f57c528 (B) B1
     | |/  
@@ -910,7 +910,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *-.   951ff29 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *-.   5447673 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\ \  
     | | * f57c528 (B) B1
     | * | aaa195b (C) C1
@@ -975,7 +975,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     ");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    *   78f3659 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   f1b9a85 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * f084d61 (C, B, A) A2
     |/  
@@ -1053,7 +1053,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             └── ·7076dee (🏘️) ►D, ►E
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 773e030 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 1c948ed (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (origin/main, main) M
@@ -1080,7 +1080,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             └── ·7076dee (🏘️) ►D, ►E
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 094bf37 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (origin/main, main) M
@@ -1157,7 +1157,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 4bbb93c (conflict-hero) add conflicting-F2
     * 98519e9 add conflicting-F1
-    | *-----.   e13e11a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | *-----.   a62be91 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |/|\ \ \ \  
     | | | | | * 34c4591 (clean-C) add C
     | |_|_|_|/  
@@ -1267,7 +1267,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     * bf09eae (conflict-F1) add F1
     | * f2ce66d (conflict-F2) add F2
     |/  
-    | *---.   c51f37c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | *---.   2603d89 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |/|\ \ \  
     | | | | * 4bbb93c (conflict-hero) add conflicting-F2
     | | | | * 98519e9 add conflicting-F1

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -45,21 +45,21 @@ mod from_new_merge_with_metadata {
 
         This is a merge commit of the virtual branches in your workspace.
 
-        Due to GitButler managing multiple virtual branches, you cannot switch back and
-        forth between git branches and virtual branches easily. 
+        For GitButler to manage multiple parallel branches, we maintain this commit
+        automatically so other tooling works properly.
 
         If you switch to another branch, GitButler will need to be reinitialized.
-        If you commit on this branch, GitButler will throw it away.
 
         Here are the branches that are currently applied:
          - add-A
            branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
+
         For more information about what we're doing here, check out our docs:
-        https://docs.gitbutler.com/features/branch-management/integration-branch
+        https://docs.gitbutler.com/workspace-branch
         ");
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(31f3d99d4b12a57c1c21053ab3ae5da160247044),
+            workspace_commit_id: Sha1(8f0d04add2efa2f20fe0b7b63a836c4e377d7116),
             stacks: [
                 Stack { tip: d3cce74, name: "add-A" },
             ],
@@ -85,7 +85,7 @@ mod from_new_merge_with_metadata {
         // It retains order.
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(391a453230c141ac5f81d7203ac90c7e66ea9acf),
+            workspace_commit_id: Sha1(ce26844c9477149218f6ecd2e2a81ccaeea1cdf2),
             stacks: [
                 Stack { tip: 27ab782, name: "add-D" },
                 Stack { tip: d3cce74, name: "add-A" },
@@ -112,11 +112,10 @@ mod from_new_merge_with_metadata {
 
         This is a merge commit of the virtual branches in your workspace.
 
-        Due to GitButler managing multiple virtual branches, you cannot switch back and
-        forth between git branches and virtual branches easily. 
+        For GitButler to manage multiple parallel branches, we maintain this commit
+        automatically so other tooling works properly.
 
         If you switch to another branch, GitButler will need to be reinitialized.
-        If you commit on this branch, GitButler will throw it away.
 
         Here are the branches that are currently applied:
          - add-D
@@ -127,8 +126,9 @@ mod from_new_merge_with_metadata {
            branch head: 34c4591eac5ade7cdf094c4fc48dea798ab73bbb
          - add-B
            branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+
         For more information about what we're doing here, check out our docs:
-        https://docs.gitbutler.com/features/branch-management/integration-branch
+        https://docs.gitbutler.com/workspace-branch
         ");
         // Order isn't visible in the merged tree.
         insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
@@ -181,7 +181,7 @@ mod from_new_merge_with_metadata {
         )?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(b8ba7bd37ac1a1f9a0e7f29ddf83acc249d7b866),
+            workspace_commit_id: Sha1(4772c5b3286bc7b7365becfd007a309b5d53aaec),
             stacks: [
                 Stack { tip: d3cce74, name: "clean-A" },
                 Stack { tip: 115e41b, name: "clean-B" },
@@ -220,7 +220,7 @@ mod from_new_merge_with_metadata {
         let out = WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), None, &graph, &repo, None)?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(e444bfa38570217271f5df56c3fe26ed57a7e023),
+            workspace_commit_id: Sha1(d72f0053dd8b22ffee806578496920f10134ce58),
             stacks: [
                 Stack { tip: d3cce74, name: "clean-A" },
                 Stack { tip: bf09eae, name: "conflict-F1" },
@@ -288,7 +288,7 @@ mod from_new_merge_with_metadata {
         let out = WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), None, &graph, &repo, None)?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(e25b36b3a4192701e5e91a00d1c2fe07b9888338),
+            workspace_commit_id: Sha1(fc3c368e69b7fdaa7b8f310e4a27ce1202eec83c),
             stacks: [
                 Stack { tip: 8450331, name: "tip-conflicted" },
                 Stack { tip: 8ab1c4d, name: "unrelated" },
@@ -332,7 +332,7 @@ mod from_new_merge_with_metadata {
         let out = WorkspaceCommit::from_new_merge_with_metadata(&to_stacks(stacks), None, &graph, &repo, None)?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(4aede0de89327f3afde3db1ed9f83f368f67d501),
+            workspace_commit_id: Sha1(2a1810b129025491563f7bff43e249766ffd54e2),
             stacks: [
                 Stack { tip: d3cce74, name: "clean-A" },
                 Stack { tip: 6777bd8, name: "conflict-C1" },
@@ -364,11 +364,10 @@ mod from_new_merge_with_metadata {
 
         This is a merge commit of the virtual branches in your workspace.
 
-        Due to GitButler managing multiple virtual branches, you cannot switch back and
-        forth between git branches and virtual branches easily. 
+        For GitButler to manage multiple parallel branches, we maintain this commit
+        automatically so other tooling works properly.
 
         If you switch to another branch, GitButler will need to be reinitialized.
-        If you commit on this branch, GitButler will throw it away.
 
         Here are the branches that are currently applied:
          - clean-A
@@ -377,8 +376,9 @@ mod from_new_merge_with_metadata {
            branch head: 6777bd8aff28a87a07739e2f309d3699d93685f9
          - clean-B
            branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
+
         For more information about what we're doing here, check out our docs:
-        https://docs.gitbutler.com/features/branch-management/integration-branch
+        https://docs.gitbutler.com/workspace-branch
         ");
         insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
         fc2bf71
@@ -397,7 +397,7 @@ mod from_new_merge_with_metadata {
         // TODO: make clean-B show up!
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(fd9723d257cd09656a2f8bb24d3dd2138f88b343),
+            workspace_commit_id: Sha1(344e784aa31edbfcd7a356c081247141b97cf60a),
             stacks: [
                 Stack { tip: d3cce74, name: "clean-A" },
                 Stack { tip: 115e41b, name: "clean-B" },
@@ -428,11 +428,10 @@ mod from_new_merge_with_metadata {
 
         This is a merge commit of the virtual branches in your workspace.
 
-        Due to GitButler managing multiple virtual branches, you cannot switch back and
-        forth between git branches and virtual branches easily. 
+        For GitButler to manage multiple parallel branches, we maintain this commit
+        automatically so other tooling works properly.
 
         If you switch to another branch, GitButler will need to be reinitialized.
-        If you commit on this branch, GitButler will throw it away.
 
         Here are the branches that are currently applied:
          - clean-A
@@ -441,8 +440,9 @@ mod from_new_merge_with_metadata {
            branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea
          - conflict-C2
            branch head: f8392d239500de94b23f42c8ab5508dae1b3b657
+
         For more information about what we're doing here, check out our docs:
-        https://docs.gitbutler.com/features/branch-management/integration-branch
+        https://docs.gitbutler.com/workspace-branch
         ");
         insta::assert_snapshot!(visualize_tree(commit.peel_to_tree()?.id()), @r#"
         39ba522
@@ -460,7 +460,7 @@ mod from_new_merge_with_metadata {
         )?;
         insta::assert_debug_snapshot!(out, @r#"
         Outcome {
-            workspace_commit_id: Sha1(e297aee321879eb991bb5360859cbddb5891a316),
+            workspace_commit_id: Sha1(6f3992eec39eb29e413eab59bb30fe3f78f16bc7),
             stacks: [
                 Stack { tip: 6777bd8, name: "conflict-C1" },
                 Stack { tip: d3cce74, name: "clean-A" },

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -295,7 +295,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     write_vrbranches_to_refs(&vb, &repo)?;
     // head was updated to point to the new workspace commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    *   48b7ef5 (HEAD -> main) GitButler Workspace Commit
+    *   256f609 (HEAD -> main) GitButler Workspace Commit
     |\  
     | * 5e3da89 (s2/top) new file with 15 lines
     * | b451685 (s1/top, feat1) insert 5 lines to the top

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -95,11 +95,10 @@ pub fn update_workspace_commit(
         message.push_str("This is placeholder commit and will be replaced by a merge of your ");
         message.push_str("virtual branches.\n\n");
     }
-    message.push_str("Due to GitButler managing multiple virtual branches, you cannot switch back and\n");
-    message.push_str("forth between git branches and virtual branches easily. \n\n");
+    message.push_str("For GitButler to manage multiple parallel branches, we maintain this commit\n");
+    message.push_str("automatically so other tooling works properly.\n\n");
 
-    message.push_str("If you switch to another branch, GitButler will need to be reinitialized.\n");
-    message.push_str("If you commit on this branch, GitButler will throw it away.\n\n");
+    message.push_str("If you switch to another branch, GitButler will need to be reinitialized.\n\n");
     if !virtual_branches.is_empty() {
         message.push_str("Here are the branches that are currently applied:\n");
         for branch in &virtual_branches {
@@ -123,8 +122,8 @@ pub fn update_workspace_commit(
         message.push_str(&prev_branch.sha);
         message.push_str("\n\n");
     }
-    message.push_str("For more information about what we're doing here, check out our docs:\n");
-    message.push_str("https://docs.gitbutler.com/features/branch-management/integration-branch\n");
+    message.push_str("\nFor more information about what we're doing here, check out our docs:\n");
+    message.push_str("https://docs.gitbutler.com/features/workspace-branch\n");
 
     let committer = gitbutler_repo::signature(SignaturePurpose::Committer)?;
     let author = gitbutler_repo::signature(SignaturePurpose::Author)?;


### PR DESCRIPTION
The workspace commit message is quite old and a little out of date.
Mainly we want to update the URL at the bottom, but I updated the
general text of the message as well. Now it reads like this:

```
GitButler Workspace Commit

This is is a merge commit of the virtual branches in your workspace.

For GitButler to manage multiple parallel branches, we maintain
this commit automatically so other tooling works properly.

If you switch to another branch, GitButler will need to be
reinitialized.

Here are the branches that are currently applied:
- clean-A 
  branch head: d3cce74a69ee3b0e1cbea65b53908d602d6bda26
- conflict-C1 
  branch head: 6777bd8aff28a87a07739e2f309d3699d93685f9
- clean-B 
  branch head: 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea

For more information about what we're doing here, check out our docs:
https://docs.gitbutler.com/workspace-branch
```