### PR TITLE
e2e: Hunk staging 

### DIFF
--- a/apps/desktop/src/components/ChangedFilesContextMenu.svelte
+++ b/apps/desktop/src/components/ChangedFilesContextMenu.svelte
@@ -380,6 +380,7 @@
 					{#if isUncommitted}
 						<ContextMenuItem
 							label="Discard changes…"
+							testId={TestId.FileListItemContextMenu_DiscardChanges}
 							icon="bin"
 							onclick={() => {
 								confirmationModal?.show(item);
@@ -574,6 +575,7 @@
 	width="small"
 	type="warning"
 	title="Discard changes"
+	testId={TestId.DiscardFileChangesConfirmationModal}
 	bind:this={confirmationModal}
 	onSubmit={(_, item) => isChangedFilesItem(item) && confirmDiscard(item)}
 >
@@ -613,8 +615,17 @@
 		{/if}
 	{/snippet}
 	{#snippet controls(close, item)}
-		<Button kind="outline" onclick={close}>Cancel</Button>
-		<AsyncButton style="danger" type="submit" action={async () => await confirmDiscard(item)}>
+		<Button
+			testId={TestId.DiscardFileChangesConfirmationModal_Cancel}
+			kind="outline"
+			onclick={close}>Cancel</Button
+		>
+		<AsyncButton
+			testId={TestId.DiscardFileChangesConfirmationModal_Discard}
+			style="danger"
+			type="submit"
+			action={async () => await confirmDiscard(item)}
+		>
 			Confirm
 		</AsyncButton>
 	{/snippet}

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -23,7 +23,7 @@
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { isImageFile } from '@gitbutler/shared/utils/file';
-	import { EmptyStatePlaceholder, HunkDiff, TestId } from '@gitbutler/ui';
+	import { EmptyStatePlaceholder, generateHunkId, HunkDiff, TestId } from '@gitbutler/ui';
 	import { DRAG_STATE_SERVICE } from '@gitbutler/ui/drag/dragStateService.svelte';
 	import { parseHunk } from '@gitbutler/ui/utils/diffParsing';
 	import type { FileDependencies } from '$lib/dependencies/dependencies';
@@ -192,9 +192,10 @@
 					}}
 				/>
 			{:else}
-				{#each filter(diff.subject.hunks) as hunk}
+				{#each filter(diff.subject.hunks) as hunk, hunkIndex}
 					{@const selection = uncommittedService.hunkCheckStatus(stackId, change.path, hunk)}
 					{@const [_, lineLocks] = getLineLocks(hunk, fileDependencies?.dependencies ?? [])}
+					{@const hunkId = generateHunkId(change.path, hunkIndex)}
 					<div
 						class="hunk-content"
 						use:draggableChips={{
@@ -214,6 +215,7 @@
 						}}
 					>
 						<HunkDiff
+							id={hunkId}
 							draggingDisabled={!draggable}
 							hideCheckboxes={!isCommitting}
 							filePath={change.path}

--- a/e2e/playwright/fixtures/big-file_after-small-changes.md
+++ b/e2e/playwright/fixtures/big-file_after-small-changes.md
@@ -1,0 +1,70 @@
+# Jurassic Park: A Comprehensive Analysis (of Bad Decision-Making)
+
+## Introduction
+
+Jurassic Park (1993), directed by Steven Spielberg and based on Michael Crichton's novel, revolutionized cinema with its groundbreaking visual effects and bold exploration of what happens when a rich guy decides "safety regulations are for suckers." The film examines themes of scientific hubris, chaos theory, and the shockingly predictable consequences of playing god while severely underpaying your IT staff.
+This is a samll change at the top.
+
+## Plot Summary
+
+The story begins when paleontologists Dr. Alan Grant and Dr. Ellie Sattler are bribed—sorry, "invited"—by billionaire John Hammond to rubber-stamp his totally-not-dangerous theme park on Isla Nublar. The park features living dinosaurs, cloned from prehistoric DNA extracted from mosquitoes preserved in amber, because apparently no one in this universe has seen any horror movie ever.
+
+Alongside mathematician Dr. Ian Malcolm (the only person with functioning brain cells) and Hammond's grandchildren, Tim and Lex, the group tours the facility. Shockingly, the park's security systems fail due to sabotage by disgruntled employee Dennis Nedry, who was apparently the ONLY IT person running this multi-billion dollar death trap and decided corporate espionage was a solid career move. With the electric fences disabled—turns out sparing expenses on backup systems was a bad idea—the dinosaurs escape their enclosures faster than you can say "I told you so."
+
+The visitors must survive encounters with various prehistoric predators while trying to restore the park's systems, because nothing says "fun vacation" like debugging Unix systems while a T-Rex tries to eat you. The film climaxes with the group narrowly escaping the island as Hammond's dream collapses around him, along with his insurance premiums.
+
+## Main Characters
+
+### Dr. Alan Grant (Sam Neill)
+
+A paleontologist specializing in velociraptors, Grant is initially uncomfortable around children (relatable) but develops a protective relationship with Hammond's grandchildren after they nearly die multiple times. His journey represents a shift from studying death (fossils) to confronting living dinosaurs and ultimately embracing life, family, and severe PTSD.
+
+### Dr. Ellie Sattler (Laura Dern)
+
+A paleobotanist and Grant's colleague, Sattler provides the voice of reason throughout the film, which everyone promptly ignores. She combines scientific expertise with compassion and demonstrates remarkable courage during the park's crisis, including voluntarily sticking her arm into dinosaur poop and manually flipping power switches in a raptor-infested maintenance shed. She deserves hazard pay.
+
+### Dr. Ian Malcolm (Jeff Goldblum)
+
+A chaotician who predicts the park's failure through chaos theory, math, and basic common sense. Malcolm serves as the film's philosophical conscience and designated "I told you so" guy, warning that nature cannot be controlled and that scientific achievement without ethical consideration is dangerous. Spoiler alert: he was right. About everything. Did anyone listen? Of course not. Jeff Goldblum's charisma and perfectly unbuttoned shirt carried this man through being mauled by a T-Rex.
+
+### John Hammond (Richard Attenborough)
+
+The park's creator, Hammond embodies both childlike wonder and the business acumen of someone who thinks "spare no expense" means "except on the IT department, cybersecurity, and literally any backup systems." His arc involves recognizing that his pursuit of spectacle has overshadowed safety and ethical considerations, but only after his grandchildren almost become dinosaur snacks. Better late than never, John.
+
+### Tim and Lex Murphy (Joseph Mazzello and Ariana Richards)
+
+Hammond's grandchildren represent innocence thrust into danger by their incredibly irresponsible grandfather. Tim's dinosaur knowledge proves valuable (turns out watching documentaries > million dollar security systems), while Lex's computer skills become crucial to their survival because a 13-year-old knows Unix better than the park's entire adult staff. This is somehow both inspiring and deeply concerning.
+
+### Dennis Nedry (Wayne Knight)
+
+The corporate saboteur whose greed directly causes the park's catastrophic failure, representing what happens when you underpay your sole IT person at a dinosaur park. Seriously, this man had root access to EVERYTHING and Hammond was surprised he went rogue? Maybe offer better benefits next time, John. Nedry's death by Dilophosaurus is karmic justice with a side of venom-induced blindness.
+
+## Featured Dinosaurs
+
+### Tyrannosaurus Rex
+
+The film's most iconic creature, the T-Rex represents raw power, nature's majesty, and what happens when your car's warranty doesn't cover "Acts of Prehistoric Predator." The rain-soaked attack sequence remains one of cinema's most suspenseful moments, showcasing the dinosaur's terrifying presence, the characters' vulnerability, and the audience's collective realization that a flimsy Ford Explorer is not adequate protection against a 7-ton carnivore. Also, fun fact: the T-Rex wasn't supposed to break through the sunroof. The kids' terror is 100% genuine.
+
+### Velociraptors
+
+Perhaps the film's true antagonists, these intelligent pack hunters demonstrate problem-solving abilities that make them particularly dangerous and also way smarter than most of the human characters. The kitchen sequence highlights their cunning nature and creates unbearable tension as two children try to hide from creatures that can open doors. THEY CAN OPEN DOORS, PEOPLE. Who approved this design feature? "Let's make the murder lizards dexterous!" - Some engineer who definitely got eaten later.
+
+### Brachiosaurus
+
+The first dinosaur seen in the park, this gentle giant creates the film's most awe-inspiring moment and the last time anyone felt safe or happy on this island. Its appearance establishes the wonder and scale of Hammond's achievement before everything goes spectacularly, predictably wrong. Enjoy this majestic scene, because it's all downhill from here, folks. At least the Brachiosaurus seems chill.
+
+### Triceratops
+
+Featured in a sick animal sequence, this herbivore allows for a quieter moment examining the reality of caring for living dinosaurs and foreshadows the park's inherent problems. Turns out, resurrecting extinct species comes with extinct diseases and zero veterinary protocols. Who could have predicted this? (Ian Malcolm. Ian Malcolm predicted this.)
+
+### Dilophosaurus
+
+This dinosaur's encounter with Nedry combines horror and dark comedy in what can only be described as "instant karma: dinosaur edition." Its neck frill and venom-spitting abilities (fictional embellishments that paleontologists are still salty about) create a memorable death scene. The cute head-tilt before the kill? Chef's kiss. Nedry deserved it, but also, yikes.
+
+### Gallimimus
+
+Appearing in a stampede sequence, these fast-moving herbivores demonstrate the park's scope before being hunted by the T-Rex, illustrating the food chain dynamics and reminding us that nature is beautiful, brutal, and doesn't care about your feelings. Also, Grant's delivery of "Don't move, he can't see us if we don't move" followed immediately by the T-Rex eating a Gallimimus is _cinema_. The dinosaur could see just fine, Alan.
+
+## Themes and Legacy
+
+This is a small change at the bottom

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -42,7 +42,9 @@ export default defineConfig({
 	projects: projects(),
 
 	/* Run your local dev server before starting the tests */
-	webServer: webServers()
+	webServer: webServers(),
+
+	snapshotPathTemplate: '{testDir}/__snapshots__/{testFilePath}/{arg}{ext}'
 });
 
 function projects() {

--- a/e2e/playwright/src/hunk.ts
+++ b/e2e/playwright/src/hunk.ts
@@ -1,3 +1,5 @@
+import { generateHunkId } from '@gitbutler/ui/utils/hunk';
+
 type HunkLineSelector =
 	| `#hunk-line-${string}\\:R${number} [data-testid="hunk-count-column"]`
 	| `#hunk-line-${string}\\:L${number} [data-testid="hunk-count-column"]`;
@@ -21,4 +23,13 @@ export function getHunkLineSelector(
 		case 'right':
 			return `#hunk-line-${escapedFileName}\\:R${lineNumber} [data-testid="hunk-count-column"]`;
 	}
+}
+
+/**
+ * Get the selector for a hunk header.
+ */
+export function getHunkHeaderSelector(fileName: string, hunkIndex: number): string {
+	const escapedFileName = escapeFileName(fileName);
+	const id = generateHunkId(escapedFileName, hunkIndex);
+	return `#header-${id}`;
 }

--- a/e2e/playwright/tests/__snapshots__/unifiedDiffView.spec.ts/should-unselect-a-complete-hunk-1.txt
+++ b/e2e/playwright/tests/__snapshots__/unifiedDiffView.spec.ts/should-unselect-a-complete-hunk-1.txt
@@ -1,0 +1,69 @@
+# Jurassic Park: A Comprehensive Analysis (of Bad Decision-Making)
+
+## Introduction
+
+Jurassic Park (1993), directed by Steven Spielberg and based on Michael Crichton's novel, revolutionized cinema with its groundbreaking visual effects and bold exploration of what happens when a rich guy decides "safety regulations are for suckers." The film examines themes of scientific hubris, chaos theory, and the shockingly predictable consequences of playing god while severely underpaying your IT staff.
+
+## Plot Summary
+
+The story begins when paleontologists Dr. Alan Grant and Dr. Ellie Sattler are bribed—sorry, "invited"—by billionaire John Hammond to rubber-stamp his totally-not-dangerous theme park on Isla Nublar. The park features living dinosaurs, cloned from prehistoric DNA extracted from mosquitoes preserved in amber, because apparently no one in this universe has seen any horror movie ever.
+
+Alongside mathematician Dr. Ian Malcolm (the only person with functioning brain cells) and Hammond's grandchildren, Tim and Lex, the group tours the facility. Shockingly, the park's security systems fail due to sabotage by disgruntled employee Dennis Nedry, who was apparently the ONLY IT person running this multi-billion dollar death trap and decided corporate espionage was a solid career move. With the electric fences disabled—turns out sparing expenses on backup systems was a bad idea—the dinosaurs escape their enclosures faster than you can say "I told you so."
+
+The visitors must survive encounters with various prehistoric predators while trying to restore the park's systems, because nothing says "fun vacation" like debugging Unix systems while a T-Rex tries to eat you. The film climaxes with the group narrowly escaping the island as Hammond's dream collapses around him, along with his insurance premiums.
+
+## Main Characters
+
+### Dr. Alan Grant (Sam Neill)
+
+A paleontologist specializing in velociraptors, Grant is initially uncomfortable around children (relatable) but develops a protective relationship with Hammond's grandchildren after they nearly die multiple times. His journey represents a shift from studying death (fossils) to confronting living dinosaurs and ultimately embracing life, family, and severe PTSD.
+
+### Dr. Ellie Sattler (Laura Dern)
+
+A paleobotanist and Grant's colleague, Sattler provides the voice of reason throughout the film, which everyone promptly ignores. She combines scientific expertise with compassion and demonstrates remarkable courage during the park's crisis, including voluntarily sticking her arm into dinosaur poop and manually flipping power switches in a raptor-infested maintenance shed. She deserves hazard pay.
+
+### Dr. Ian Malcolm (Jeff Goldblum)
+
+A chaotician who predicts the park's failure through chaos theory, math, and basic common sense. Malcolm serves as the film's philosophical conscience and designated "I told you so" guy, warning that nature cannot be controlled and that scientific achievement without ethical consideration is dangerous. Spoiler alert: he was right. About everything. Did anyone listen? Of course not. Jeff Goldblum's charisma and perfectly unbuttoned shirt carried this man through being mauled by a T-Rex.
+
+### John Hammond (Richard Attenborough)
+
+The park's creator, Hammond embodies both childlike wonder and the business acumen of someone who thinks "spare no expense" means "except on the IT department, cybersecurity, and literally any backup systems." His arc involves recognizing that his pursuit of spectacle has overshadowed safety and ethical considerations, but only after his grandchildren almost become dinosaur snacks. Better late than never, John.
+
+### Tim and Lex Murphy (Joseph Mazzello and Ariana Richards)
+
+Hammond's grandchildren represent innocence thrust into danger by their incredibly irresponsible grandfather. Tim's dinosaur knowledge proves valuable (turns out watching documentaries > million dollar security systems), while Lex's computer skills become crucial to their survival because a 13-year-old knows Unix better than the park's entire adult staff. This is somehow both inspiring and deeply concerning.
+
+### Dennis Nedry (Wayne Knight)
+
+The corporate saboteur whose greed directly causes the park's catastrophic failure, representing what happens when you underpay your sole IT person at a dinosaur park. Seriously, this man had root access to EVERYTHING and Hammond was surprised he went rogue? Maybe offer better benefits next time, John. Nedry's death by Dilophosaurus is karmic justice with a side of venom-induced blindness.
+
+## Featured Dinosaurs
+
+### Tyrannosaurus Rex
+
+The film's most iconic creature, the T-Rex represents raw power, nature's majesty, and what happens when your car's warranty doesn't cover "Acts of Prehistoric Predator." The rain-soaked attack sequence remains one of cinema's most suspenseful moments, showcasing the dinosaur's terrifying presence, the characters' vulnerability, and the audience's collective realization that a flimsy Ford Explorer is not adequate protection against a 7-ton carnivore. Also, fun fact: the T-Rex wasn't supposed to break through the sunroof. The kids' terror is 100% genuine.
+
+### Velociraptors
+
+Perhaps the film's true antagonists, these intelligent pack hunters demonstrate problem-solving abilities that make them particularly dangerous and also way smarter than most of the human characters. The kitchen sequence highlights their cunning nature and creates unbearable tension as two children try to hide from creatures that can open doors. THEY CAN OPEN DOORS, PEOPLE. Who approved this design feature? "Let's make the murder lizards dexterous!" - Some engineer who definitely got eaten later.
+
+### Brachiosaurus
+
+The first dinosaur seen in the park, this gentle giant creates the film's most awe-inspiring moment and the last time anyone felt safe or happy on this island. Its appearance establishes the wonder and scale of Hammond's achievement before everything goes spectacularly, predictably wrong. Enjoy this majestic scene, because it's all downhill from here, folks. At least the Brachiosaurus seems chill.
+
+### Triceratops
+
+Featured in a sick animal sequence, this herbivore allows for a quieter moment examining the reality of caring for living dinosaurs and foreshadows the park's inherent problems. Turns out, resurrecting extinct species comes with extinct diseases and zero veterinary protocols. Who could have predicted this? (Ian Malcolm. Ian Malcolm predicted this.)
+
+### Dilophosaurus
+
+This dinosaur's encounter with Nedry combines horror and dark comedy in what can only be described as "instant karma: dinosaur edition." Its neck frill and venom-spitting abilities (fictional embellishments that paleontologists are still salty about) create a memorable death scene. The cute head-tilt before the kill? Chef's kiss. Nedry deserved it, but also, yikes.
+
+### Gallimimus
+
+Appearing in a stampede sequence, these fast-moving herbivores demonstrate the park's scope before being hunted by the T-Rex, illustrating the food chain dynamics and reminding us that nature is beautiful, brutal, and doesn't care about your feelings. Also, Grant's delivery of "Don't move, he can't see us if we don't move" followed immediately by the T-Rex eating a Gallimimus is _cinema_. The dinosaur could see just fine, Alan.
+
+## Themes and Legacy
+
+This is a small change at the bottom

--- a/e2e/playwright/tests/unifiedDiffView.spec.ts
+++ b/e2e/playwright/tests/unifiedDiffView.spec.ts
@@ -1,4 +1,5 @@
-import { getHunkLineSelector } from '../src/hunk.ts';
+import { discardFile } from '../src/file.ts';
+import { getHunkHeaderSelector, getHunkLineSelector } from '../src/hunk.ts';
 import { getBaseURL, startGitButler, type GitButler } from '../src/setup.ts';
 import { clickByTestId, fillByTestId, getByTestId, waitForTestId } from '../src/util.ts';
 import { expect, Locator, test } from '@playwright/test';
@@ -17,6 +18,10 @@ test.afterEach(async () => {
 
 const BIG_FILE_PATH_BEFORE = resolve(import.meta.dirname, '../fixtures/big-file_before.md');
 const BIG_FILE_PATH_AFTER = resolve(import.meta.dirname, '../fixtures/big-file_after.md');
+const BIG_FILE_PATH_AFTER_SMALL_CHANGES = resolve(
+	import.meta.dirname,
+	'../fixtures/big-file_after-small-changes.md'
+);
 
 test('should be able to select the hunks correctly in a complex file', async ({
 	page,
@@ -108,6 +113,64 @@ test('should be able to select the hunks correctly in a complex file', async ({
 	await expect(commits).toHaveCount(3);
 });
 
+test('should unselect a complete hunk', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	const projectName = 'hunk-unselect-project';
+	const fileName = 'hunk-file.md';
+
+	const projectPath = gitbutler.pathInWorkdir(projectName + '/');
+	const filePath = join(projectPath, fileName);
+
+	const contentBefore = readFileSync(BIG_FILE_PATH_BEFORE, 'utf-8');
+	const contentAfter = readFileSync(BIG_FILE_PATH_AFTER_SMALL_CHANGES, 'utf-8');
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('project-with-remote-branches__commit-file-into-remote-base.sh', [
+		'Initial file for hunk unselect',
+		fileName,
+		contentBefore
+	]);
+	await gitbutler.runScript('project-with-remote-branches__clone-into-new-project.sh', [
+		projectName
+	]);
+	await gitbutler.runScript('project-with-remote-branches__delete-project.sh', ['local-clone']);
+
+	await page.goto('/');
+
+	await waitForTestId(page, 'workspace-view');
+
+	writeFileSync(filePath, contentAfter, 'utf-8');
+
+	await clickByTestId(page, 'commit-to-new-branch-button');
+
+	const uncommittedChangesList = getByTestId(page, 'uncommitted-changes-file-list');
+	const fileItem = uncommittedChangesList
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName });
+	await expect(fileItem).toBeVisible();
+	await fileItem.click();
+
+	const unifiedDiffView = getByTestId(page, 'unified-diff-view');
+	await expect(unifiedDiffView).toBeVisible();
+
+	// Unselect the first hunk (hunkIndex = 0)
+	await unselectHunk(fileName, unifiedDiffView, 0);
+
+	// Commit the changes
+	await fillByTestId(page, 'commit-drawer-title-input', 'Partial commit: Part 1');
+	await clickByTestId(page, 'commit-drawer-action-button');
+
+	// Discard the remaining changes
+	await discardFile(fileName, page);
+
+	// Verify the file has the expected content
+	const finalContent = readFileSync(filePath, 'utf-8');
+	expect(finalContent).toMatchSnapshot();
+});
+
 test('should discard an untracked added file via context menu', async ({
 	page,
 	context
@@ -155,6 +218,13 @@ test('should discard an untracked added file via context menu', async ({
 	await expect(fileItem).toHaveCount(0);
 	await expect(getByTestId(page, 'workspace-view')).toBeVisible();
 });
+
+async function unselectHunk(fileName: string, unifiedDiffView: Locator, hunkIndex: number) {
+	const headerSelector = getHunkHeaderSelector(fileName, hunkIndex);
+	const header = unifiedDiffView.locator(headerSelector).first();
+	await expect(header).toBeVisible();
+	await header.click();
+}
 
 async function unselectHunkLines(
 	fileName: string,

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -21,6 +21,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
+		id?: string;
 		filePath: string;
 		hunkStr: string;
 		tabSize?: number;
@@ -47,6 +48,7 @@
 	}
 
 	const {
+		id,
 		filePath,
 		hunkStr,
 		tabSize = 4,
@@ -106,6 +108,7 @@
 </script>
 
 <div
+	{id}
 	use:focusable={{
 		onKeydown: (e) => {
 			if (e.key === 'Control') {
@@ -129,6 +132,7 @@
 			<thead class="table__title" class:draggable={!draggingDisabled}>
 				<tr>
 					<th
+						id={id ? `header-${id}` : undefined}
 						bind:clientWidth={numberHeaderWidth}
 						class="table__checkbox-container"
 						style="--border-width: {BORDER_WIDTH}px;"

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -1,8 +1,4 @@
 <script lang="ts" module>
-	export function getHunkLineId(rowEncodedId: DiffFileLineId): string {
-		return `hunk-line-${rowEncodedId}`;
-	}
-
 	export type ContextMenuParams = {
 		event?: MouseEvent;
 		target?: HTMLElement;
@@ -20,9 +16,9 @@
 		isDeltaLine,
 		SectionType,
 		type DependencyLock,
-		type DiffFileLineId,
 		type Row
 	} from '$lib/utils/diffParsing';
+	import { getHunkLineId } from '$lib/utils/hunk';
 	import type LineSelection from '$components/hunkDiff/lineSelection.svelte';
 	import type { Snippet } from 'svelte';
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -167,3 +167,5 @@ export type {
 	InputStylingProps,
 	InputStateCallbacks
 } from '$components/inputTypes';
+
+export * from '$lib/utils/hunk';

--- a/packages/ui/src/lib/utils/hunk.ts
+++ b/packages/ui/src/lib/utils/hunk.ts
@@ -1,0 +1,9 @@
+import type { DiffFileLineId } from '$lib/utils/diffParsing';
+
+export function getHunkLineId(rowEncodedId: DiffFileLineId): string {
+	return `hunk-line-${rowEncodedId}`;
+}
+
+export function generateHunkId(changePath: string, hunkIndex: number): string {
+	return `hunk-${changePath}-${hunkIndex}`;
+}

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -158,9 +158,13 @@ export enum TestId {
 	CreateSnapshotModal = 'create-snapshot-modal',
 	CreateSnapshotModal_ActionButton = 'create-snapshot-modal-action-button',
 	FileListItemContextMenu_Absorb = 'file-list-item-context-menu__absorb',
+	FileListItemContextMenu_DiscardChanges = 'file-list-item-context-menu__discard-changes',
 	AbsobModal = 'absorb-modal',
 	AbsorbModal_ActionButton = 'absorb-modal-action-button',
-	AbsorbModal_CommitAbsorption = 'absorb-modal-commit-absorption'
+	AbsorbModal_CommitAbsorption = 'absorb-modal-commit-absorption',
+	DiscardFileChangesConfirmationModal = 'discard-file-changes-confirmation-modal',
+	DiscardFileChangesConfirmationModal_Cancel = 'discard-file-changes-confirmation-modal-cancel',
+	DiscardFileChangesConfirmationModal_Discard = 'discard-file-changes-confirmation-modal-discard'
 }
 
 export enum ElementId {


### PR DESCRIPTION
Summary
- optional id field for hunk
- Add template support for Play snapshots
- file context menu with discard option
- Add e2e tests and utilities to verify hunks can be unselected when committing (including quick discard-by-name helper)