### PR TITLE
Fix but graph not matching commit graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "insta",
  "itertools",
  "petgraph",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -23,8 +23,9 @@ tracing.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-but-meta = { workspace = true, features = ["legacy"]}
+but-meta = { workspace = true, features = ["legacy"] }
 but-testsupport.workspace = true
+tempfile.workspace = true
 
 gitbutler-reference.workspace = true
 

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -594,7 +594,6 @@ impl Graph {
             &ctx.worktree_by_branch,
         )?;
         max_commits_recharge_location.sort();
-        let mut no_duplicate_parents = gix::hashtable::HashSet::default();
         let mut points_of_interest_to_traverse_first = next.iter().count();
         while let Some((info, mut propagated_flags, instruction, mut limit)) = next.pop_front() {
             points_of_interest_to_traverse_first = points_of_interest_to_traverse_first.saturating_sub(1);
@@ -698,7 +697,6 @@ impl Graph {
             let propagated_flags = propagated_flags | maybe_make_id_a_goal_so_remote_can_find_local;
             let hard_limit_hit = queue_parents(
                 &mut next,
-                &mut no_duplicate_parents,
                 &info.parent_ids,
                 propagated_flags,
                 segment_idx_for_id,

--- a/crates/but-graph/tests/fixtures/scenario/single-commit.sh
+++ b/crates/but-graph/tests/fixtures/scenario/single-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"

--- a/crates/but-graph/tests/fixtures/scenario/single-commit.sh
+++ b/crates/but-graph/tests/fixtures/scenario/single-commit.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu -o pipefail
-
-git init
-
-echo "base" >base && git add . && git commit -m "base"

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -850,6 +850,32 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn commit_with_two_parents() -> anyhow::Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("single-commit")?;
+
+    let base = repo.rev_parse_single("HEAD")?;
+    let base = base.object()?.into_commit();
+    repo.commit("HEAD", "a", base.tree_id()?, vec![base.id(), base.id()])?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * d70d863 (HEAD -> main) a
+    |\
+    * 35b8235 base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:main[🌳]
+        └── ·d70d863 (⌂|1)
+            ├── ►:1[1]:anon:
+            │   └── ·35b8235 (⌂|1)
+            └── →:1:
+    ");
+    Ok(())
+}
+
 mod with_workspace;
 
 mod utils;
@@ -858,4 +884,4 @@ pub use utils::{
     standard_options,
 };
 
-use crate::init::utils::standard_options_with_extra_target;
+use crate::init::utils::{fixture_writable, standard_options_with_extra_target};

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -27,6 +27,20 @@ pub fn read_only_in_memory_scenario_named(script_name: &str, dirname: &str) -> a
     Ok(repo)
 }
 
+/// Returns a fixture that may be written to.
+pub fn fixture_writable(
+    fixture_name: &str,
+) -> anyhow::Result<(
+    gix::Repository,
+    tempfile::TempDir,
+    std::mem::ManuallyDrop<VirtualBranchesTomlMetadata>,
+)> {
+    // TODO: remove the need for this, impl everything in `gitoxide`, allowing this to be in-memory entirely.
+    let (repo, tmp) = but_testsupport::writable_scenario(fixture_name);
+    let meta = VirtualBranchesTomlMetadata::from_path(repo.path().join(".git").join("should-never-be-written.toml"))?;
+    Ok((repo, tmp, std::mem::ManuallyDrop::new(meta)))
+}
+
 pub enum StackState {
     InWorkspace,
     Inactive,

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -267,8 +267,6 @@ fn find_segment_edge_commits(graph: &but_graph::Graph, sidx: SegmentIndex) -> Ve
         })
         .collect::<Vec<_>>();
 
-    let mut seen = potential_parents.iter().map(|e| e.sidx).collect::<HashSet<_>>();
-
     let mut parents = vec![];
 
     while let Some(candidate) = potential_parents.pop() {
@@ -282,12 +280,10 @@ fn find_segment_edge_commits(graph: &but_graph::Graph, sidx: SegmentIndex) -> Ve
         };
 
         for edge in graph.edges_directed(candidate.sidx, Direction::Outgoing) {
-            if seen.insert(edge.target()) {
-                potential_parents.push(SegmentViaReference {
-                    sidx: edge.target(),
-                    via_reference: candidate.via_reference || graph[edge.target()].ref_name().is_some(),
-                });
-            }
+            potential_parents.push(SegmentViaReference {
+                sidx: edge.target(),
+                via_reference: candidate.via_reference || graph[edge.target()].ref_name().is_some(),
+            });
         }
     }
 

--- a/crates/but-rebase/tests/fixtures/scenario/single-commit.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/single-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"


### PR DESCRIPTION
The but-graph ought to accurately represent the commit graph. Not doing so should probably be considered a bug.

It seems like there was some code that tried to de-duplicate parents, which git also tries to do, but this really isn’t the place to try and do this.

Perhaps when we are rewriting commits we could consider it, but it most likely should be left as something for manual user intervention.