### PR TITLE
Add network status monitoring service and UI

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -10,6 +10,7 @@
 	import { ircEnabled } from '$lib/config/uiFeatureFlags';
 	import { IRC_SERVICE } from '$lib/irc/ircService.svelte';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
+	import NetworkStatus from '$lib/network/NetworkStatus.svelte';
 	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { ircPath, isWorkspacePath, projectPath } from '$lib/routes/routes.svelte';
@@ -262,6 +263,7 @@
 			/>
 		{/if}
 		{#if isOnWorkspacePage}
+			<NetworkStatus />
 			<Button
 				testId={TestId.ChromeHeaderCreateBranchButton}
 				kind="outline"

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -37,6 +37,10 @@ import { DiffService, DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
 import { IrcClient, IRC_CLIENT } from '$lib/irc/ircClient.svelte';
 import { IrcService, IRC_SERVICE } from '$lib/irc/ircService.svelte';
 import { ModeService, MODE_SERVICE } from '$lib/mode/modeService';
+import {
+	NETWORK_STATUS_SERVICE,
+	NetworkStatusService
+} from '$lib/network/networkStatusService.svelte';
 import { ProjectsService, PROJECTS_SERVICE } from '$lib/project/projectsService';
 import { PROMPT_SERVICE, PromptService } from '$lib/prompt/promptService';
 import { REMOTES_SERVICE, RemotesService } from '$lib/remotes/remotesService';
@@ -308,6 +312,7 @@ export function initDependencies(args: {
 	const externalLinkService = {
 		open: async (url) => await urlService.openExternalUrl(url)
 	} satisfies ExternalLinkService;
+	const networkStatusService = new NetworkStatusService();
 
 	// ============================================================================
 	// DEPENDENCY INJECTION REGISTRATION
@@ -378,6 +383,7 @@ export function initDependencies(args: {
 		[USER, userService.user],
 		[USER_SERVICE, userService],
 		[WORKTREE_SERVICE, worktreeService],
-		[EXTERNAL_LINK_SERVICE, externalLinkService]
+		[EXTERNAL_LINK_SERVICE, externalLinkService],
+		[NETWORK_STATUS_SERVICE, networkStatusService]
 	]);
 }

--- a/apps/desktop/src/lib/network/NetworkStatus.svelte
+++ b/apps/desktop/src/lib/network/NetworkStatus.svelte
@@ -1,0 +1,30 @@
+<!--
+	Example component showing how to use the NetworkStatusService
+-->
+<script lang="ts">
+	import { NETWORK_STATUS_SERVICE } from '$lib/network/networkStatusService.svelte';
+	import { inject } from '@gitbutler/core/context';
+
+	const networkStatusService = inject(NETWORK_STATUS_SERVICE);
+
+	// Access the reactive online status
+	const isOnline = $derived(networkStatusService.online.current);
+</script>
+
+{#if !isOnline}
+	<div class="network-status-banner">
+		<span>You are currently offline</span>
+	</div>
+{/if}
+
+<style>
+	.network-status-banner {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 8px;
+		background-color: var(--clr-bg-warn);
+		color: var(--clr-text-1);
+		font-size: 12px;
+	}
+</style>

--- a/apps/desktop/src/lib/network/networkStatusService.svelte.ts
+++ b/apps/desktop/src/lib/network/networkStatusService.svelte.ts
@@ -1,0 +1,52 @@
+import { InjectionToken } from '@gitbutler/core/context';
+import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
+import type { Reactive } from '@gitbutler/shared/storeUtils';
+
+export const NETWORK_STATUS_SERVICE = new InjectionToken<NetworkStatusService>(
+	'NetworkStatusService'
+);
+
+/**
+ * Service that monitors network online/offline status and provides reactive access to it.
+ */
+export class NetworkStatusService {
+	private _online = $state<boolean>(typeof navigator !== 'undefined' ? navigator.onLine : true);
+
+	constructor() {
+		if (typeof window !== 'undefined') {
+			window.addEventListener('online', this.handleOnline);
+			window.addEventListener('offline', this.handleOffline);
+
+			// Log initial status
+			console.log(`Network status: ${this._online ? 'ONLINE' : 'OFFLINE'}`);
+		}
+	}
+
+	private handleOnline = () => {
+		this._online = true;
+		console.log('Network status: ONLINE');
+	};
+
+	private handleOffline = () => {
+		this._online = false;
+		console.log('Network status: OFFLINE');
+	};
+
+	/**
+	 * Reactive getter for online status.
+	 * Returns true when the browser has network connectivity, false otherwise.
+	 */
+	get online(): Reactive<boolean> {
+		return reactive(() => this._online);
+	}
+
+	/**
+	 * Clean up event listeners
+	 */
+	destroy() {
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('online', this.handleOnline);
+			window.removeEventListener('offline', this.handleOffline);
+		}
+	}
+}

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -3,6 +3,7 @@ import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import createBackend from '$lib/backend';
 import { SettingsService } from '$lib/config/appSettingsV2';
+import { NetworkStatusService } from '$lib/network/networkStatusService.svelte';
 import lscache from 'lscache';
 import type { LayoutLoad } from './$types';
 
@@ -12,6 +13,9 @@ lscache.flushExpired();
 export const ssr = false;
 export const prerender = false;
 export const csr = true;
+
+// Initialize network status monitoring
+const networkStatusService = new NetworkStatusService();
 
 // eslint-disable-next-line
 export const load: LayoutLoad = async () => {
@@ -35,6 +39,7 @@ export const load: LayoutLoad = async () => {
 		settingsService,
 		appSettings,
 		posthog,
-		eventContext
+		eventContext,
+		networkStatusService
 	};
 };


### PR DESCRIPTION
Introduce NetworkStatusService that monitors browser online/offline events and exposes reactive network status. Add NetworkStatus component that displays an offline banner when connectivity is lost. This helps users understand when network-dependent features may be unavailable.