### PR TITLE
Add ability to specify uncommitted files by CLI ID when committing

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -90,13 +90,17 @@ For detailed command syntax and all available options, see [references/reference
 
 **Making changes:**
 
-- `but commit <branch> -m "msg" --files <id>,<id>` - Commit specific files by CLI ID (recommended)
+- `but commit <branch> -m "msg" --files <id>,<id>` - Commit specific files or hunks by CLI ID (recommended)
 - `but commit <branch> -m "msg"` - Commit ALL uncommitted changes to branch
 - `but commit <branch> --only -m "msg"` - Commit only pre-staged changes
 - `but amend <file-id> <commit-id>` - Amend file into specific commit (explicit control)
 - `but absorb <file-id>` - Absorb file into auto-detected commit (smart matching)
 - `but absorb <branch-id>` - Absorb all changes staged to a branch
 - `but absorb` - Absorb ALL uncommitted changes (use with caution)
+
+**Getting IDs for --files:**
+- File IDs: `but status --json` - shows file-level IDs
+- Hunk IDs: `but diff --json` - shows hunk-level IDs for fine-grained commits
 
 **Editing history:**
 
@@ -116,7 +120,9 @@ For deeper understanding of the workspace model, dependency tracking, and philos
 
 **CLI IDs**: Every object gets a short ID (e.g., `c5` for commit, `bu` for branch). Use these as arguments.
 
-**Direct commit with file IDs**: Use `--files` to commit specific files directly without staging: `but commit <branch> -m "msg" --files <id>,<id>`
+**Direct commit with file/hunk IDs**: Use `--files` to commit specific files or hunks directly:
+- File IDs from `but status --json` - commit entire files
+- Hunk IDs from `but diff --json` - commit individual hunks for fine-grained control
 
 **Parallel vs Stacked branches**:
 

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: but
 version: 0.0.0
-description: Manage GitButler CLI workspace with multiple parallel branches. ALWAYS invoke immediately after Write/Edit tools to stage changes. Use when checking version control state, starting new work (create branch/stack first), after ANY file modifications (stage to branches), committing work, editing history, or any git operation. Uses 'but' commands not 'git' for writes.
+description: Manage GitButler CLI workspace with multiple parallel branches. Use when checking version control state, starting new work (create branch first), committing work, editing history, or any git operation. Uses 'but' commands not 'git' for writes.
 author: GitButler Team
 ---
 
@@ -16,21 +16,17 @@ Help users work with GitButler CLI (`but` command) in workspace mode.
 1. **Check state** → `but status --json` (always use `--json` for structured output)
 2. **Start work** → `but branch new <task-name>` (create stack for this work theme)
 3. **Make changes** → Edit files as needed
-4. **Stage changes IMMEDIATELY** → `but stage <file> <branch>` (after EVERY Write/Edit tool use)
-5. **Commit work** → `but commit <branch> --only -m "message"` (commit only staged changes)
-6. **Refine** → Use `but absorb` or `but squash` to clean up history
-
-**Step 4 is required immediately after any file modification** - do not skip or delay staging.
+4. **Commit work** → `but commit <branch> -m "message" --files <id>,<id>` (commit specific files by CLI ID)
+5. **Refine** → Use `but absorb` or `but squash` to clean up history
 
 ## After Using Write/Edit Tools
 
-**ALWAYS do this immediately:**
+When ready to commit:
 
-1. Run `but status --json` to see the new changes (use `--json` for structured output)
-2. Stage the modified files: `but stage <file-id> <branch-id>`
-3. Verify with `but status --json` again
+1. Run `but status --json` to see uncommitted changes and get their CLI IDs
+2. Commit the relevant files directly: `but commit <branch> -m "message" --files <id>,<id>`
 
-Do not proceed to other tasks until changes are staged.
+You can batch multiple file edits before committing - no need to commit after every single change.
 
 ## Critical Concept: Workspace Model
 
@@ -64,9 +60,9 @@ but skill install --path <path>    # Install/update skill (agents use --path wit
 ```bash
 but status --json       # Always start here - shows workspace state (JSON for agents)
 but branch new feature  # Create new stack for work
-but stage <file> <id>   # Stage changes to branch
-but commit <id> --only -m "…"  # Commit only staged changes
-but push <id>           # Push to remote
+# Make changes...
+but commit <branch> -m "…" --files <id>,<id>  # Commit specific files by CLI ID
+but push <branch>       # Push to remote
 ```
 
 ## Essential Commands
@@ -90,12 +86,13 @@ For detailed command syntax and all available options, see [references/reference
 
 - `but branch new <name>` - Independent branch
 - `but branch new <name> -a <anchor>` - Stacked branch (dependent)
-- `but stage <file> <branch>` - Assign file to branch
+- `but stage <file> <branch>` - Pre-assign file to branch (optional, for organizing before commit)
 
 **Making changes:**
 
-- `but commit <branch> --only -m "msg"` - Commit only staged changes
+- `but commit <branch> -m "msg" --files <id>,<id>` - Commit specific files by CLI ID (recommended)
 - `but commit <branch> -m "msg"` - Commit ALL uncommitted changes to branch
+- `but commit <branch> --only -m "msg"` - Commit only pre-staged changes
 - `but amend <file-id> <commit-id>` - Amend file into specific commit (explicit control)
 - `but absorb <file-id>` - Absorb file into auto-detected commit (smart matching)
 - `but absorb <branch-id>` - Absorb all changes staged to a branch
@@ -119,7 +116,7 @@ For deeper understanding of the workspace model, dependency tracking, and philos
 
 **CLI IDs**: Every object gets a short ID (e.g., `c5` for commit, `bu` for branch). Use these as arguments.
 
-**Multiple staging areas**: Each stack has its own staging area. Stage files with `but stage <file> <branch>`.
+**Direct commit with file IDs**: Use `--files` to commit specific files directly without staging: `but commit <branch> -m "msg" --files <id>,<id>`
 
 **Parallel vs Stacked branches**:
 
@@ -143,10 +140,10 @@ For complete step-by-step workflows and real-world scenarios, see [references/ex
 but status --json
 but branch new api-endpoint
 but branch new ui-update
-# Make changes, then stage to appropriate branches
-but stage <api-file> <api-branch>
-but status --json  # Verify staging
-but commit <api-branch> --only -m "Add endpoint"
+# Make changes, then commit specific files to appropriate branches
+but status --json  # Get file CLI IDs
+but commit api-endpoint -m "Add endpoint" --files <api-file-id>
+but commit ui-update -m "Update UI" --files <ui-file-id>
 ```
 
 **Cleaning up commits:**
@@ -169,7 +166,7 @@ but resolve finish      # Complete resolution
 
 1. Always start with `but status --json` to understand current state (agents should always use `--json`)
 2. Create a new stack for each independent work theme
-3. Stage changes after making edits (especially after formatters/linters)
+3. Use `--files` to commit specific files directly - no need to stage first
 4. Commit at logical units of work
 5. **Use `--json` flag for ALL commands** when running as an agent - this provides structured, parseable output instead of human-readable text
 6. Use `--dry-run` flags (push, absorb) when unsure

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -125,12 +125,15 @@ Commit changes to a branch.
 ```bash
 but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
 but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
+but commit <branch> -m "message" --files <id>,<id>  # Commit specific files by CLI ID
 but commit <branch> -i                   # AI-generated commit message
 but commit empty --before <target>       # Insert empty commit before target
 but commit empty --after <target>        # Insert empty commit after target
 ```
 
 **Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
+
+**Committing specific files:** Use `--files` (or `-F`) with comma-separated CLI IDs to commit only those files. Get file IDs from `but status`. Example: `but commit my-branch -m "Fix bug" --files ab,cd` commits only files `ab` and `cd`.
 
 If only one branch is applied, you can omit the branch ID.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -134,8 +134,10 @@ but commit empty --after <target>        # Insert empty commit after target
 **Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
 
 **Committing specific files or hunks:** Use `--files` (or `-F`) with comma-separated CLI IDs to commit only those files or hunks:
-- **File IDs** from `but status`: commits entire files
+- **File IDs** from `but status --json`: commits entire files
 - **Hunk IDs** from `but diff --json`: commits individual hunks
+
+**Note:** `--files` and `--only` are mutually exclusive.
 
 Example: `but commit my-branch -m "Fix bug" --files ab,cd` commits files/hunks `ab` and `cd`.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -125,7 +125,7 @@ Commit changes to a branch.
 ```bash
 but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
 but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
-but commit <branch> -m "message" --files <id>,<id>  # Commit specific files by CLI ID
+but commit <branch> -m "message" --files <id>,<id>  # Commit specific files or hunks by CLI ID
 but commit <branch> -i                   # AI-generated commit message
 but commit empty --before <target>       # Insert empty commit before target
 but commit empty --after <target>        # Insert empty commit after target
@@ -133,7 +133,13 @@ but commit empty --after <target>        # Insert empty commit after target
 
 **Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
 
-**Committing specific files:** Use `--files` (or `-F`) with comma-separated CLI IDs to commit only those files. Get file IDs from `but status`. Example: `but commit my-branch -m "Fix bug" --files ab,cd` commits only files `ab` and `cd`.
+**Committing specific files or hunks:** Use `--files` (or `-F`) with comma-separated CLI IDs to commit only those files or hunks:
+- **File IDs** from `but status`: commits entire files
+- **Hunk IDs** from `but diff --json`: commits individual hunks
+
+Example: `but commit my-branch -m "Fix bug" --files ab,cd` commits files/hunks `ab` and `cd`.
+
+To commit specific hunks from a file with multiple changes, use `but diff --json` to see hunk IDs, then specify them individually.
 
 If only one branch is applied, you can omit the branch ID.
 

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -22,6 +22,11 @@ pub struct Platform {
     /// Generate commit message using AI with optional user summary
     #[clap(short = 'i', long = "ai", conflicts_with = "message", conflicts_with = "file")]
     pub ai: Option<Option<String>>,
+    /// Uncommitted file or hunk CLI IDs to include in the commit.
+    /// Can be specified multiple times or as comma-separated values.
+    /// If not specified, all uncommitted changes (or changes staged to the target branch) are committed.
+    #[clap(long = "files", short = 'F', value_delimiter = ',', num_args = 1..)]
+    pub files: Vec<String>,
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,
 }

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -25,7 +25,7 @@ pub struct Platform {
     /// Uncommitted file or hunk CLI IDs to include in the commit.
     /// Can be specified multiple times or as comma-separated values.
     /// If not specified, all uncommitted changes (or changes staged to the target branch) are committed.
-    #[clap(long = "files", short = 'F', value_delimiter = ',', num_args = 1..)]
+    #[clap(long = "files", short = 'F', value_delimiter = ',', num_args = 1.., conflicts_with = "only")]
     pub files: Vec<String>,
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -531,6 +531,8 @@ async fn match_subcommand(
                     if commit_args.ai.is_some() {
                         anyhow::bail!("--ai cannot be used with 'commit empty'.");
                     }
+                    // Note: --files with commit empty is rejected by clap at parse time
+                    // because --files is not a flag on the empty subcommand
 
                     // Handle the `but commit empty` subcommand
                     // Determine target and insert side based on which argument was provided
@@ -618,6 +620,7 @@ async fn match_subcommand(
                         out,
                         commit_message.as_deref(),
                         commit_args.branch.as_deref(),
+                        &commit_args.files,
                         commit_args.only,
                         commit_args.create,
                         commit_args.no_hooks,

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -546,6 +546,25 @@ Error: --ai cannot be used with 'commit empty'.
 }
 
 #[test]
+fn commit_empty_rejects_files_flag() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Try to use --files with empty subcommand
+    // --files is not a valid flag for the empty subcommand, so clap rejects it
+    let output = env.but("commit empty --before A --files ab").assert().failure();
+
+    let stderr = std::str::from_utf8(&output.get_output().stderr)?;
+    assert!(
+        stderr.contains("unexpected argument"),
+        "Expected clap to reject --files with empty subcommand, got: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+#[test]
 fn commit_json_mode_requires_message_or_file() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     env.setup_metadata(&["A"])?;
@@ -650,6 +669,299 @@ fn commit_json_mode_multiple_branches_with_branch_succeeds() -> anyhow::Result<(
     assert!(json["commit_id"].is_string(), "commit_id should be a string");
     assert!(json["branch"].is_string(), "branch should be a string");
     assert_eq!(json["branch"].as_str().unwrap(), "B");
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_specific_file_ids() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create two files
+    env.file("file1.txt", "content 1");
+    env.file("file2.txt", "content 2");
+
+    // Get file IDs from status
+    let status_output = env.but("status --json").assert().success();
+    let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
+    let status: serde_json::Value = serde_json::from_str(stdout)?;
+
+    // Find the CLI ID for file1.txt from unassignedChanges
+    let file1_id = status["unassignedChanges"]
+        .as_array()
+        .and_then(|changes| {
+            changes.iter().find_map(|c| {
+                if c["filePath"].as_str() == Some("file1.txt") {
+                    c["cliId"].as_str().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+        })
+        .expect("file1.txt should have a CLI ID");
+
+    // Commit only file1.txt using its CLI ID
+    env.but(format!("commit -m 'Add file1 only' --files {}", file1_id))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+✓ Created commit [..] on branch A
+
+"#]]);
+
+    // Verify file1 was committed
+    let log = env.git_log()?;
+    assert!(log.contains("Add file1 only"));
+
+    // Verify file2 is still uncommitted
+    let status_after = env.but("status --json").assert().success();
+    let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
+    let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
+
+    let has_file2 = status_after["unassignedChanges"]
+        .as_array()
+        .map(|changes| changes.iter().any(|c| c["filePath"].as_str() == Some("file2.txt")))
+        .unwrap_or(false);
+    assert!(has_file2, "file2.txt should still be uncommitted");
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_multiple_file_ids() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create three files
+    env.file("file1.txt", "content 1");
+    env.file("file2.txt", "content 2");
+    env.file("file3.txt", "content 3");
+
+    // Get file IDs from status
+    let status_output = env.but("status --json").assert().success();
+    let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
+    let status: serde_json::Value = serde_json::from_str(stdout)?;
+
+    // Find CLI IDs for file1 and file2
+    let changes = status["unassignedChanges"].as_array().expect("should have changes");
+    let file1_id = changes
+        .iter()
+        .find(|c| c["filePath"].as_str() == Some("file1.txt"))
+        .and_then(|c| c["cliId"].as_str())
+        .expect("file1 should have ID");
+    let file2_id = changes
+        .iter()
+        .find(|c| c["filePath"].as_str() == Some("file2.txt"))
+        .and_then(|c| c["cliId"].as_str())
+        .expect("file2 should have ID");
+
+    // Commit file1 and file2, leaving file3 uncommitted
+    env.but(format!("commit -m 'Add two files' --files {},{}", file1_id, file2_id))
+        .assert()
+        .success();
+
+    // Verify file3 is still uncommitted
+    let status_after = env.but("status --json").assert().success();
+    let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
+    let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
+
+    let remaining: Vec<&str> = status_after["unassignedChanges"]
+        .as_array()
+        .map(|changes| changes.iter().filter_map(|c| c["filePath"].as_str()).collect())
+        .unwrap_or_default();
+
+    assert_eq!(remaining, vec!["file3.txt"], "Only file3 should remain uncommitted");
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_invalid_file_id_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create a file so we have something to potentially commit
+    env.file("file.txt", "content");
+
+    // Try to commit with a nonexistent file ID
+    env.but("commit -m 'test' --files zq")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Invalid file ID(s):
+  'zq' not found. Run 'but status' to see available file IDs.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_wrong_entity_type_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create a file
+    env.file("file.txt", "content");
+
+    // Try to commit using a branch ID instead of file ID
+    // "A" is a branch name which should fail
+    env.but("commit -m 'test' --files A")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Invalid file ID(s):
+  'A' is a branch but must be an uncommitted file or hunk
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_file_assigned_to_different_stack_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+
+    // Create a file
+    env.file("file.txt", "content");
+
+    // Get file ID from status
+    let status_output = env.but("status --json").assert().success();
+    let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
+    let status: serde_json::Value = serde_json::from_str(stdout)?;
+
+    let file_id = status["unassignedChanges"]
+        .as_array()
+        .and_then(|changes| {
+            changes.iter().find_map(|c| {
+                if c["filePath"].as_str() == Some("file.txt") {
+                    c["cliId"].as_str().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+        })
+        .expect("file.txt should have a CLI ID");
+
+    // Stage the file to branch A
+    env.but(format!("stage {} A", file_id)).assert().success();
+
+    // Try to commit the file to branch B (should fail because it's staged to A)
+    let output = env
+        .but(format!("commit -m 'test' B --files {}", file_id))
+        .assert()
+        .failure();
+
+    // Verify error message contains the expected text
+    let stderr = std::str::from_utf8(&output.get_output().stderr)?;
+    assert!(
+        stderr.contains("is assigned to a different stack"),
+        "Expected error about different stack assignment, got: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_empty_file_list_uses_all_files() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create two files
+    env.file("file1.txt", "content 1");
+    env.file("file2.txt", "content 2");
+
+    // Commit without specifying files (should include both)
+    env.but("commit -m 'Add both files'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+✓ Created commit [..] on branch A
+
+"#]]);
+
+    // Verify both files were committed (no uncommitted files left)
+    let status_after = env.but("status --json").assert().success();
+    let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
+    let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
+
+    let unassigned = status_after["unassignedChanges"].as_array();
+    assert!(
+        unassigned.map(|f| f.is_empty()).unwrap_or(true),
+        "All files should be committed"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_with_multiple_hunk_ids_from_same_file() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create a file with content that will result in multiple hunks when modified
+    env.file(
+        "multi-hunk.txt",
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    );
+
+    // Commit initial file
+    env.but("commit -m 'Initial file'").assert().success();
+
+    // Modify the file in two non-adjacent places to create two hunks
+    env.file(
+        "multi-hunk.txt",
+        "MODIFIED1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nMODIFIED10\n",
+    );
+
+    // Get hunk IDs from status
+    let status_output = env.but("status --json -f").assert().success();
+    let stdout = std::str::from_utf8(&status_output.get_output().stdout)?;
+    let status: serde_json::Value = serde_json::from_str(stdout)?;
+
+    // Find all hunk IDs for multi-hunk.txt
+    let hunk_ids: Vec<String> = status["unassignedChanges"]
+        .as_array()
+        .map(|changes| {
+            changes
+                .iter()
+                .filter(|c| c["filePath"].as_str() == Some("multi-hunk.txt"))
+                .filter_map(|c| c["cliId"].as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // If we have multiple hunks, test that specifying both works
+    if hunk_ids.len() >= 2 {
+        let ids_arg = hunk_ids.join(",");
+        env.but(format!("commit -m 'Both hunks' --files {}", ids_arg))
+            .assert()
+            .success();
+
+        // Verify no uncommitted changes left
+        let status_after = env.but("status --json").assert().success();
+        let stdout_after = std::str::from_utf8(&status_after.get_output().stdout)?;
+        let status_after: serde_json::Value = serde_json::from_str(stdout_after)?;
+
+        let remaining: Vec<&str> = status_after["unassignedChanges"]
+            .as_array()
+            .map(|changes| changes.iter().filter_map(|c| c["filePath"].as_str()).collect())
+            .unwrap_or_default();
+
+        assert!(
+            !remaining.contains(&"multi-hunk.txt"),
+            "All hunks from multi-hunk.txt should be committed"
+        );
+    } else {
+        // If only one hunk was created (due to context lines merging them),
+        // just verify commit works with that single ID
+        env.but(format!("commit -m 'Single hunk' --files {}", hunk_ids[0]))
+            .assert()
+            .success();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Users can now pass specific file CLI IDs to commit only those files:

  but commit -m 'message' --files ab,cd,ef
  but commit -m 'message' -F ab,cd

This adds:
- New 'files' argument with --files / -F flag accepting comma-separated IDs
- resolve_file_ids() helper to validate and convert CLI IDs to FileAssignments
- Proper error handling for invalid/ambiguous IDs and wrong entity types
- Tests for the new functionality and backward compatibility
- Updated skill docs to recommend direct commit with --files instead of staging