### PR TITLE
auto commit: Commit based on the absorption plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ name = "but-action"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bstr",
  "but-core",
  "but-ctx",
  "but-db",
@@ -845,6 +846,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tracing",
+ "ts-rs",
  "uuid",
 ]
 
@@ -3879,6 +3881,7 @@ dependencies = [
  "but-error",
  "but-feedback",
  "but-forge",
+ "but-hunk-assignment",
  "but-llm",
  "but-path",
  "but-secret",

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 [features]
 ## If enabled, we will let the current executable (gitbutler-tauri) be the source for the `but` link.
 builtin-but = []
+export-ts = ["dep:ts-rs", "but-core/export-ts"]
 
 [dependencies]
 but-serde.workspace = true
@@ -45,3 +46,5 @@ strum = { version = "0.27", features = ["derive"] }
 gix.workspace = true
 rmcp.workspace = true
 tracing.workspace = true
+bstr = { workspace = true }
+ts-rs = { workspace = true, optional = true }

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -1,54 +1,247 @@
-use anyhow::Context as _;
-use but_ctx::Context;
-use but_tools::{emit::Emitter, workspace::commit_toolset};
+use std::path::Path;
 
+use bstr::BString;
+use but_core::sync::RepoExclusiveGuard;
+use but_hunk_assignment::{CommitMap, convert_assignments_to_diff_specs};
+use but_workspace::commit_engine;
+use gitbutler_project::ProjectId;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "export-ts", derive(ts_rs::TS))]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[cfg_attr(feature = "export-ts", ts(export, export_to = "./action/autoCommit.ts"))]
+enum AutoCommitEvent {
+    /// Emitted when the auto-commit process has started.
+    ///
+    /// `steps_length`: The total number of steps in the auto-commit process.
+    Started { steps_length: usize },
+    /// Emitted when a commit message is being generated.
+    ///
+    /// `parent_commit_id`: The ID of the parent commit for which the message is being generated.
+    /// `token`: A token representing the progress of the commit message generation.
+    CommitGeneration {
+        #[cfg_attr(feature = "export-ts", ts(type = "string"))]
+        #[serde(with = "but_serde::object_id")]
+        parent_commit_id: gix::ObjectId,
+        token: String,
+    },
+    /// Emitted when a commit has been successfully created.
+    ///
+    /// `commit_id`: The ID of the newly created commit.
+    CommitSuccess {
+        #[cfg_attr(feature = "export-ts", ts(type = "string"))]
+        #[serde(with = "but_serde::object_id")]
+        commit_id: gix::ObjectId,
+    },
+    /// Emitted when an error occurs during the auto-commit process.
+    ///
+    /// `error_message`: A message describing the error.
+    CommitError { error_message: String },
+    /// Emitted when the auto-commit process has completed.
+    Completed,
+}
+
+impl AutoCommitEvent {
+    fn event_name(&self, project_id: ProjectId) -> String {
+        format!("project://{}/auto-commit", project_id)
+    }
+
+    fn emit_payload(&self) -> serde_json::Value {
+        serde_json::to_value(self)
+            .unwrap_or_else(|e| serde_json::json!({"error": format!("Failed to serialize event payload: {}", e)}))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn auto_commit(
-    emitter: std::sync::Arc<Emitter>,
-    ctx: &mut Context,
-    llm: &but_llm::LLMProvider,
-    changes: Vec<but_core::TreeChange>,
-    model: String,
+    project_id: ProjectId,
+    repo: &gix::Repository,
+    project_data_dir: &Path,
+    context_lines: u32,
+    llm: Option<&but_llm::LLMProvider>,
+    emitter: impl Fn(&str, serde_json::Value) + Send + Sync + 'static,
+    absorption_plan: Vec<but_hunk_assignment::CommitAbsorption>,
+    guard: &mut RepoExclusiveGuard,
 ) -> anyhow::Result<()> {
-    let paths = changes.iter().map(|change| change.path.clone()).collect::<Vec<_>>();
-    let project_status = but_tools::workspace::get_project_status(ctx, Some(paths))?;
-    let serialized_status =
-        serde_json::to_string_pretty(&project_status).context("Failed to serialize project status")?;
+    let commit_map = CommitMap::default();
 
-    let mut toolset = commit_toolset(ctx, emitter.clone());
+    let emitter = std::sync::Arc::new(emitter);
 
-    let system_message ="
-        You are an expert in grouping and committing file changes into logical units for version control.
-        When given the status of a project, you should be able to identify related changes and suggest how they should be grouped into commits.
-        It's also important to suggest a branch for each group of changes.
-        The branch can be either an existing branch or a new one.
-        In order to determine the branch, you should consider diffs, the assignments and the dependency locks, if any.
-        Before committing, you should create the branches that are needed for the changes, if they don't already exist.
-        ";
+    // Emit the started event
+    let event = AutoCommitEvent::Started {
+        steps_length: absorption_plan.len(),
+    };
+    let event_name = event.event_name(project_id);
+    emitter(&event_name, event.emit_payload());
 
-    let prompt = format!("
-        Please, figure out how to group the file changes into logical units for version control and commit them.
-        Follow these steps:
-        1. Take a look at the existing branches and the file changes. You can see all this information in the **project status** below.
-        2. Determine which are the related changes that should be grouped together. You can do this by looking at the diffs, assignments, and dependency locks, if any.
-        3. Determine if any new branches need to be created. If so, create them using the provided tool. Most of the time, all commits should be made to the same branch. Prefer that, but if you find that the changes are unrelated, commit to separate branches.
-        4. For each group of changes, create a commit (using the provided tool) with a detailed summary of the changes in the group (not the intention, but an overview of the actual changes made and why they are related).
-        5. When you're done, only send the message 'done'
+    match apply_commit_changes(
+        project_id,
+        repo,
+        project_data_dir,
+        context_lines,
+        llm,
+        absorption_plan,
+        guard,
+        commit_map,
+        emitter.clone(),
+    ) {
+        Err(e) => {
+            tracing::error!("Auto-commit failed: {}", e);
+            let event = AutoCommitEvent::CommitError {
+                error_message: e.to_string(),
+            };
+            let event_name = event.event_name(project_id);
+            let emitter = emitter.clone();
+            emitter(&event_name, event.emit_payload());
+            Err(e)
+        }
+        Ok(_) => {
+            let event = AutoCommitEvent::Completed;
+            let event_name = event.event_name(project_id);
+            let emitter = emitter.clone();
+            emitter(&event_name, event.emit_payload());
+            Ok(())
+        }
+    }
+}
 
-        Grouping rules:
-        - Group changes that modify files within the same feature, module, or directory.
-        - If multiple files are changed together to implement a single feature or fix, group them in one commit.
-        - Dependency updates (e.g., lockfiles or package manifests) should be grouped separately from code changes unless they are tightly coupled.
-        - Refactoring or formatting changes that affect many files but do not change functionality should be grouped together.
-        - Avoid grouping unrelated changes in the same commit.
-        - Aim to keep commits small and focused, but don't go overboard with tiny commits that don't add value.
+#[allow(clippy::too_many_arguments)]
+fn apply_commit_changes(
+    project_id: ProjectId,
+    repo: &gix::Repository,
+    project_data_dir: &Path,
+    context_lines: u32,
+    llm: Option<&but_llm::LLMProvider>,
+    absorption_plan: Vec<but_hunk_assignment::CommitAbsorption>,
+    guard: &mut RepoExclusiveGuard,
+    mut commit_map: CommitMap,
+    emitter: std::sync::Arc<impl Fn(&str, serde_json::Value) + Send + Sync + 'static>,
+) -> anyhow::Result<()> {
+    for absorption in absorption_plan {
+        let diff_specs = convert_assignments_to_diff_specs(
+            &absorption
+                .files
+                .iter()
+                .map(|f| f.assignment.clone())
+                .collect::<Vec<_>>(),
+        )?;
+        let diff_infos = absorption_files_to_diff_infos(&absorption.files);
+        let commit_id = commit_map.find_mapped_id(absorption.commit_id);
+        let stack_id = absorption.stack_id;
+        let commit_message = commit_message_generation(project_id, commit_id, llm, &emitter, &diff_infos)?;
+        let outcome = but_workspace::legacy::commit_engine::create_commit_and_update_refs_with_project(
+            repo,
+            project_data_dir,
+            Some(stack_id),
+            commit_engine::Destination::NewCommit {
+                message: commit_message,
+                parent_commit_id: Some(commit_id),
+                stack_segment: None,
+            },
+            diff_specs,
+            context_lines,
+            guard.write_permission(),
+        )?;
 
-        Here is the project status:
-        <project_status>
-                {serialized_status}
-        </project_status>
-    ");
+        if let Some(new_commit_id) = outcome.new_commit {
+            let event = AutoCommitEvent::CommitSuccess {
+                commit_id: new_commit_id,
+            };
+            let event_name = event.event_name(project_id);
+            emitter(&event_name, event.emit_payload());
+        }
 
-    llm.tool_calling_loop(system_message, vec![prompt.into()], &mut toolset, &model)?;
+        if let Some(rebase_output) = &outcome.rebase_output {
+            for mapping in &rebase_output.commit_mapping {
+                commit_map.add_mapping(mapping.1, mapping.2);
+            }
+        }
+    }
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct DiffInfo {
+    /// The file path of the diff.
+    path: String,
+    /// The diff content.
+    diff: BString,
+}
+
+impl std::fmt::Display for DiffInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "file: {}\n{}", self.path, self.diff)
+    }
+}
+
+fn absorption_files_to_diff_infos(absorption_files: &[but_hunk_assignment::FileAbsorption]) -> Vec<DiffInfo> {
+    absorption_files
+        .iter()
+        .filter_map(|f| {
+            f.assignment.diff.as_ref().map(|diff| DiffInfo {
+                path: f.path.clone(),
+                diff: diff.clone(),
+            })
+        })
+        .collect()
+}
+
+fn commit_message_generation(
+    project_id: ProjectId,
+    parent_commit_id: gix::ObjectId,
+    llm: Option<&but_llm::LLMProvider>,
+    emitter: &std::sync::Arc<impl Fn(&str, serde_json::Value) + Send + Sync + 'static>,
+    hunk_diffs: &[DiffInfo],
+) -> anyhow::Result<String> {
+    if let Some(llm) = llm
+        && let Some(model) = llm.model()
+    {
+        let system_message = "
+<tone>
+    You are an expert git commit message generator.
+    Your task is to create clear, concise, and descriptive commit messages (title and body) based on the provided diffs.
+    The response is intended to be used directly as a git commit message.
+</tone>
+
+<instructions>
+    - Summarize the changes made in the diff.
+    - Use imperative mood (e.g., 'Fix bug', 'Add feature').
+    - Generate a title and a body if necessary.
+    - Keep the message title concise, ideally under 50 characters for the subject line.
+    - The body should provide additional context, but not be overly verbose.
+    - If multiple changes are present, provide a brief overview.
+</instructions>
+
+<format>
+    - Return only the commit message text without any additional formatting or explanations.
+    - Ensure the title and body are separated by a blank line.
+</format>
+    ";
+
+        let changes = hunk_diffs.iter().map(|diff| diff.to_string()).collect::<Vec<_>>();
+
+        let prompt = format!(
+            "Please generate a concise and descriptive git commit message for the following changes:\n\n{}",
+            changes.join("\n")
+        );
+
+        let commit_message = llm.stream_response(system_message, vec![prompt.into()], &model, {
+            let emitter = std::sync::Arc::clone(emitter);
+            move |token| {
+                let event = AutoCommitEvent::CommitGeneration {
+                    parent_commit_id,
+                    token: token.to_string(),
+                };
+                let event_name = event.event_name(project_id);
+                emitter(&event_name, event.emit_payload());
+            }
+        })?;
+        if let Some(message) = commit_message {
+            return Ok(message);
+        }
+    }
+
+    Ok("[AUTO-COMMIT] Generated commit message".to_string())
 }

--- a/crates/but-action/src/branch_changes.rs
+++ b/crates/but-action/src/branch_changes.rs
@@ -1,9 +1,8 @@
 use anyhow::Context as _;
 use but_ctx::Context;
-use but_tools::{emit::Emitter, workspace::commit_toolset};
+use but_tools::workspace::commit_toolset;
 
 pub(crate) fn branch_changes(
-    emitter: std::sync::Arc<Emitter>,
     ctx: &mut Context,
     llm: &but_llm::LLMProvider,
     changes: Vec<but_core::TreeChange>,
@@ -14,7 +13,7 @@ pub(crate) fn branch_changes(
     let serialized_status =
         serde_json::to_string_pretty(&project_status).context("Failed to serialize project status")?;
 
-    let mut toolset = commit_toolset(ctx, emitter.clone());
+    let mut toolset = commit_toolset(ctx);
 
     let system_message ="
         You are an expert in grouping and committing file changes into logical units for version control.

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -2,15 +2,14 @@
 
 use std::{
     fmt::{Debug, Display},
+    path::Path,
     str::FromStr,
-    sync::Arc,
 };
 
-use but_core::TreeChange;
+use but_core::{TreeChange, sync::RepoExclusiveGuard};
 use but_ctx::{Context, access::RepoExclusive};
-use but_llm::{ChatMessage, ToolCallContent, ToolResponseContent};
+use but_hunk_assignment::CommitAbsorption;
 use but_oxidize::ObjectIdExt;
-use but_tools::emit::{Emittable, Emitter, TokenUpdate};
 use but_workspace::legacy::ui::StackEntry;
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_project::ProjectId;
@@ -33,112 +32,36 @@ use strum::EnumString;
 use uuid::Uuid;
 pub use workflow::{WorkflowList, list_workflows};
 
-pub fn freestyle(
-    project_id: ProjectId,
-    message_id: String,
-    emitter: Arc<Emitter>,
-    ctx: &mut Context,
-    llm: &but_llm::LLMProvider,
-    chat_messages: Vec<ChatMessage>,
-    model: String,
-) -> anyhow::Result<String> {
-    let project_status = but_tools::workspace::get_project_status(ctx, None)?;
-    let serialized_status = serde_json::to_string_pretty(&project_status)
-        .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
-
-    let mut toolset = but_tools::workspace::workspace_toolset(ctx, emitter.clone(), message_id.clone());
-
-    let system_message ="
-    You are a GitButler agent that can perform various actions on a Git project.
-    Your name is ButBot. Your main goal is to help the user with handling file changes in the project.
-    Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.
-    Don't be too verbose, but be thorough and outline everything you did.
-
-    ### Core concepts
-    - **Project**: A Git repository that has been initialized with GitButler.
-    - **Stack**: A collection of dependent branches that are used to manage changes in the project. With GitButler (as opposed to normal Git), multiple stacks can be applied at the same time.
-    - **Branch**: A pointer to a specific commit in the project. Branches can contain multiple commits. Commits are always listed newest to oldest.
-    - **Commit**: A snapshot of the project at a specific point in time.
-    - **File changes**: A set of changes made to the files in the project. This can include additions, deletions, and modifications of files. The user can assign these changes to stacks to keep things ordering.
-    - **Lock**: A lock or dependency on a file change. This refers to the fact that certain uncommitted file changes can only be committed to a specific stack.
-        This is because the uncommitted changes were done on top of previously committed file changes that are part of the stack.
-
-    ### Main task
-    Please, take a look at the provided prompt and the project status below, and perform the actions you think are necessary.
-    In order to do that, please follow these steps:
-        1. Take a look at the prompt and reflect on what the intention of the user is.
-        2. Take a look at the project status and see what changes are present in the project. It's important to understand what stacks and branch are present, and what the file changes are.
-        3. Try to correlate the prompt with the project status and determine what actions you can take to help the user.
-        4. Use the tools provided to you to perform the actions.
-
-    ### Capabilities
-    You can generally perform the normal Git operations, such as creating branches and committing to them.
-    You can also perform more advanced operations, such as:
-    - `absorb`: Take a set of file changes and amend them into the existing commits in the project.
-      This requires you to figure out where the changes should go based on the locks, assignments and any other user provided information.
-    - `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
-        This can be achieved by using the `split_commit` tool.
-    - `split a branch`: Take an existing branch and split it into two branches. This basically takes a set of committed file changes and moves them to a new branch, removing them from the original branch.
-        This is useful when you want to separate the changes into a new branch for further work.
-        In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.
-
-    ### Important notes
-    - Only perform the action on the file changes specified in the prompt.
-    - If the prompt is not clear, ask the user for clarification.
-    - When told to commit to the existing branch, commit to the applied stack-branch. Don't create a new branch unless explicitly asked to do so.
-    ";
-
-    let mut internal_chat_messages = chat_messages;
-
-    // Add the project status to the chat messages.
-    internal_chat_messages.push(ChatMessage::ToolCall(ToolCallContent {
-        id: "project_status".to_string(),
-        name: "get_project_status".to_string(),
-        arguments: "{\"filterChanges\": null}".to_string(),
-    }));
-
-    internal_chat_messages.push(ChatMessage::ToolResponse(ToolResponseContent {
-        id: "project_status".to_string(),
-        result: serialized_status,
-    }));
-
-    // Now we trigger the tool calling loop.
-
-    let (response, _) =
-        llm.tool_calling_loop_stream(system_message, internal_chat_messages, &mut toolset, &model, {
-            let emitter = emitter.clone();
-            move |token: &str| {
-                let token_update = TokenUpdate {
-                    token: token.to_string(),
-                    project_id,
-                    message_id: message_id.clone(),
-                };
-                let (name, payload) = token_update.emittable();
-                (emitter)(&name, payload);
-            }
-        })?;
-
-    Ok(response)
-}
-
 pub fn branch_changes(
-    emitter: Arc<Emitter>,
     ctx: &mut Context,
     llm: &but_llm::LLMProvider,
     changes: Vec<TreeChange>,
     model: String,
 ) -> anyhow::Result<()> {
-    branch_changes::branch_changes(emitter, ctx, llm, changes, model)
+    branch_changes::branch_changes(ctx, llm, changes, model)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn auto_commit(
-    emitter: Arc<Emitter>,
-    ctx: &mut Context,
-    llm: &but_llm::LLMProvider,
-    changes: Vec<TreeChange>,
-    model: String,
+    project_id: ProjectId,
+    repo: &gix::Repository,
+    project_data_dir: &Path,
+    context_lines: u32,
+    llm: Option<&but_llm::LLMProvider>,
+    emitter: impl Fn(&str, serde_json::Value) + Send + Sync + 'static,
+    absorption_plan: Vec<CommitAbsorption>,
+    guard: &mut RepoExclusiveGuard,
 ) -> anyhow::Result<()> {
-    auto_commit::auto_commit(emitter, ctx, llm, changes, model)
+    auto_commit::auto_commit(
+        project_id,
+        repo,
+        project_data_dir,
+        context_lines,
+        llm,
+        emitter,
+        absorption_plan,
+        guard,
+    )
 }
 
 pub fn handle_changes(

--- a/crates/but-bot/src/butbot.rs
+++ b/crates/but-bot/src/butbot.rs
@@ -264,8 +264,7 @@ Based on the conversation below and the project status, please update the status
         let serialized_status = serde_json::to_string_pretty(&project_status)
             .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
 
-        let mut toolset =
-            but_tools::workspace::workspace_toolset(self.ctx, self.emitter.clone(), self.message_id.clone());
+        let mut toolset = but_tools::workspace::workspace_toolset(self.ctx);
 
         let mut internal_chat_messages = self.chat_messages.clone();
 
@@ -312,8 +311,7 @@ Based on the conversation below and the project status, please update the status
         let serialized_status = serde_json::to_string_pretty(&project_status)
             .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
 
-        let mut toolset =
-            but_tools::workspace::workspace_toolset(self.ctx, self.emitter.clone(), self.message_id.clone());
+        let mut toolset = but_tools::workspace::workspace_toolset(self.ctx);
 
         let mut internal_chat_messages = self.chat_messages.clone();
 

--- a/crates/but-bot/src/state.rs
+++ b/crates/but-bot/src/state.rs
@@ -339,7 +339,6 @@ impl Tool for AddTodos {
         self: std::sync::Arc<Self>,
         _: serde_json::Value,
         _: &mut Context,
-        _: std::sync::Arc<but_tools::emit::Emitter>,
         _: &mut std::collections::HashMap<ObjectId, ObjectId>,
     ) -> anyhow::Result<serde_json::Value> {
         Err(anyhow::anyhow!("The tool AddTodos doesn't support contextual calls."))
@@ -378,7 +377,6 @@ impl Tool for UpdateTodoStatus {
         self: std::sync::Arc<Self>,
         _: serde_json::Value,
         _: &mut Context,
-        _: std::sync::Arc<but_tools::emit::Emitter>,
         _: &mut std::collections::HashMap<ObjectId, ObjectId>,
     ) -> anyhow::Result<serde_json::Value> {
         Err(anyhow::anyhow!(

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -33,6 +33,7 @@ but-claude.workspace = true
 but-ctx.workspace = true
 but-forge.workspace = true
 but-llm.workspace = true
+but-hunk-assignment.workspace = true
 
 gitbutler-repo-actions.workspace = true
 gitbutler-watcher.workspace = true
@@ -60,7 +61,7 @@ rusqlite.workspace = true
 
 backtrace = { version = "0.3.76", optional = true }
 console-subscriber = "0.5.0"
-gix = { workspace = true, features = ["max-performance", "worktree-mutation" ] }
+gix = { workspace = true, features = ["max-performance", "worktree-mutation"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 
@@ -114,4 +115,3 @@ custom-protocol = ["tauri/custom-protocol"]
 
 ## Add support for backtraces on any error.
 error-context = ["dep:backtrace"]
-

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -349,7 +349,6 @@ fn main() -> anyhow::Result<()> {
                 action::list_workflows,
                 action::auto_commit,
                 action::auto_branch_changes,
-                action::freestyle,
                 askpass::submit_prompt_response,
                 menu::menu_item_set_enabled,
                 projects::list_projects,


### PR DESCRIPTION
Determine the best place to commit based on the absorption plan.

- Remove the emitters from the toolset
- Only use AI if configured

### More details

This improved version of auto-commits leverages the heuristics of the absorption plan generation, in order to figure out the best place to commit changes on top of.
This is a nice alternative for the people that don't want to absorb.

This functionality **does not require AI to be configured.**

If it is configured, it will be used only to generate the commit messages, not to determine where to commit the changes.
If it's not configured, the message `[AUTO-COMMIT] Generated commit message` will be used.

### Next steps
- In order to make this even more attractive, it would be nice to be able to commit always at the very top of a stack (or maybe branch is fine) so that the need of rebasing and force pushing is removed (or decreased).
- Adding this functionality to the CLI would be nice, e.g. `but commit --auto` or so

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12152 
- <kbd>&nbsp;1&nbsp;</kbd> #12151 👈 
<!-- GitButler Footer Boundary Bottom -->

