### PR TITLE
fix(ui): adjust drawer outline radius to outer radius

### DIFF
--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -220,7 +220,7 @@
 				width: 100%;
 				height: 100%;
 				border: 2px solid var(--clr-theme-pop-element);
-				border-radius: var(--radius-ml);
+				border-radius: calc(var(--radius-m) + 2px);
 				content: '';
 				pointer-events: none;
 			}


### PR DESCRIPTION

<img width="713" height="489" alt="image" src="https://github.com/user-attachments/assets/0241655f-668a-48cb-9e00-1062222e3c0e" />

- Update drawer pseudo-element border-radius from var(--radius-ml) to calc(var(--radius-m) + 2px)
- Prevent subtle mismatch introduced by the previous larger radius value