### PR TITLE
fix manpage generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "but-clap"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "but",
+ "clap",
+]
+
+[[package]]
 name = "but-claude"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,8 @@ members = [
     "crates/but-testing",
     # GitButler installation binary
     "crates/but-installer",
+    # Documentation binary
+    "crates/but-clap",
 
     ##
     ### Legacy

--- a/crates/but-clap/src/generator.rs
+++ b/crates/but-clap/src/generator.rs
@@ -30,10 +30,7 @@ pub fn generate_command_mdx(cmd: &Command) -> String {
     output.push_str(&format!("**Usage:** `{}`\n\n", usage));
 
     // Add subcommands section if there are any
-    let subcommands: Vec<_> = cmd
-        .get_subcommands()
-        .filter(|sub| !sub.is_hide_set())
-        .collect();
+    let subcommands: Vec<_> = cmd.get_subcommands().filter(|sub| !sub.is_hide_set()).collect();
 
     if !subcommands.is_empty() {
         output.push_str("## Subcommands\n\n");
@@ -54,10 +51,7 @@ pub fn generate_command_mdx(cmd: &Command) -> String {
             output.push_str(&format!("**Usage:** `{}`\n\n", sub_usage));
 
             // Add subcommand arguments
-            let args: Vec<_> = subcmd
-                .get_positionals()
-                .filter(|arg| !arg.is_hide_set())
-                .collect();
+            let args: Vec<_> = subcmd.get_positionals().filter(|arg| !arg.is_hide_set()).collect();
             if !args.is_empty() {
                 output.push_str("**Arguments:**\n\n");
                 for arg in args {
@@ -79,10 +73,7 @@ pub fn generate_command_mdx(cmd: &Command) -> String {
     }
 
     // Add arguments for the main command (if it has no subcommands or also accepts args)
-    let args: Vec<_> = cmd
-        .get_positionals()
-        .filter(|arg| !arg.is_hide_set())
-        .collect();
+    let args: Vec<_> = cmd.get_positionals().filter(|arg| !arg.is_hide_set()).collect();
     if !args.is_empty() && subcommands.is_empty() {
         output.push_str("## Arguments\n\n");
         for arg in args {

--- a/crates/but-clap/src/main.rs
+++ b/crates/but-clap/src/main.rs
@@ -23,12 +23,8 @@ fn main() -> Result<()> {
         let file_path = docs_dir.join(format!("but-{}.mdx", subcommand_name));
 
         let mdx_content = generator::generate_command_mdx(subcommand);
-        fs::write(&file_path, mdx_content).with_context(|| {
-            format!(
-                "Failed to write subcommand documentation to {:?}",
-                file_path
-            )
-        })?;
+        fs::write(&file_path, mdx_content)
+            .with_context(|| format!("Failed to write subcommand documentation to {:?}", file_path))?;
         println!("Generated: {:?}", file_path);
     }
 

--- a/crates/but-clap/tests/mdx_generation.rs
+++ b/crates/but-clap/tests/mdx_generation.rs
@@ -4,12 +4,7 @@ use clap::{Arg, ArgAction, Command};
 fn create_simple_command() -> Command {
     Command::new("test")
         .about("A test command")
-        .arg(
-            Arg::new("input")
-                .help("Input file to process")
-                .required(true)
-                .index(1),
-        )
+        .arg(Arg::new("input").help("Input file to process").required(true).index(1))
         .arg(
             Arg::new("verbose")
                 .short('v')
@@ -177,9 +172,7 @@ fn test_command_with_subcommands_mdx_generation() {
 
     // Check frontmatter
     assert!(mdx.contains("title: \"`but git`\""));
-    assert!(mdx.contains(
-        "description: \"Git is a free and open source distributed version control system\""
-    ));
+    assert!(mdx.contains("description: \"Git is a free and open source distributed version control system\""));
 
     // Check long description
     assert!(mdx.contains("Git is a free and open source distributed version control system"));
@@ -308,8 +301,7 @@ fn test_command_with_long_help() {
 
 #[test]
 fn test_frontmatter_only_first_line() {
-    let cmd = Command::new("multiline")
-        .long_about("First line of description\nSecond line of description\nThird line");
+    let cmd = Command::new("multiline").long_about("First line of description\nSecond line of description\nThird line");
 
     let mdx = but_clap::generator::generate_command_mdx(&cmd);
 

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -16,6 +16,7 @@ pub enum Subcommands {
     /// the new branch from. This allows you to create stacked branches.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     New {
         /// Name of the new branch
         branch_name: Option<String>,
@@ -32,6 +33,7 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     #[clap(short_flag = 'd')]
+    #[clap(verbatim_doc_comment)]
     Delete {
         /// Name of the branch to delete
         branch_name: String,
@@ -63,6 +65,7 @@ pub enum Subcommands {
     /// make the command faster.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     List {
         /// Filter branches by name (case-insensitive substring match)
         filter: Option<String>,
@@ -116,11 +119,12 @@ pub enum Subcommands {
     /// Apply a branch to the workspace
     ///
     /// If you want to apply an unapplied branch to your workspace so you
-    /// can work on it, you can run `but branch apply <branch-name>`.`
+    /// can work on it, you can run `but branch apply <branch-name>`.
     ///
     /// This will apply the changes in that branch into your working directory
     /// as a parallel applied branch.
     ///
+    #[clap(verbatim_doc_comment)]
     Apply {
         /// Name of the branch to apply
         branch_name: String,
@@ -137,6 +141,7 @@ pub enum Subcommands {
     /// see the branch as unapplied in `but branch list`.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Unapply {
         /// Name of the branch to unapply
         branch_name: String,

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -72,6 +72,7 @@ pub enum Subcommands {
     /// ```
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     #[command(group = clap::ArgGroup::new("position"))]
     Empty {
         /// The target commit or branch to insert relative to.

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -279,6 +279,7 @@ pub enum Subcommands {
     /// merged into the target branch before running the update.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Pull {
         /// Only check the status without updating (equivalent to the old `but base check`)
         #[clap(long, short = 'c')]
@@ -368,6 +369,7 @@ pub enum Subcommands {
     /// commit that you can amend changes into later using `but mark`, `but rub` or `but absorb`.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Commit(commit::Platform),
 
     /// Push changes in a branch to remote.
@@ -398,6 +400,7 @@ pub enum Subcommands {
     /// You can also use `but reword <branch-id>` to rename the branch.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Reword {
         /// Commit ID to edit the message for, or branch ID to rename
         target: String,
@@ -422,6 +425,7 @@ pub enum Subcommands {
     /// By default, shows the last 20 oplog entries (same as `but oplog list`).
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Oplog(oplog::Platform),
 
     /// Undo the last operation by reverting to the previous snapshot.
@@ -660,6 +664,7 @@ pub enum Subcommands {
     /// When in resolution mode, `but status` will also show that you're resolving conflicts.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Resolve {
         /// Subcommand to run (defaults to entering resolution mode)
         #[clap(subcommand)]
@@ -683,6 +688,7 @@ pub enum Subcommands {
     /// 3. Using a branch name: `but squash <branch>`
     ///    - Squashes all commits in the branch into the bottom-most commit
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Squash {
         /// Commit identifiers, a range (commit1..commit2), or a branch name
         commits: Vec<String>,
@@ -701,6 +707,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <source> zz`.
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Uncommit {
         /// Commit ID or file-in-commit ID to uncommit
         source: String,
@@ -710,6 +717,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <file> <commit>`.
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Amend {
         /// File ID to amend
         file: String,
@@ -738,6 +746,7 @@ pub enum Subcommands {
     /// but merge my-feature-branch
     /// ```
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Merge {
         /// Branch ID or name to merge
         branch: String,
@@ -784,6 +793,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <file-or-hunk> <branch>`.
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Stage {
         /// File or hunk ID to stage
         file_or_hunk: String,
@@ -795,6 +805,7 @@ pub enum Subcommands {
     ///
     /// Wrapper for `but rub <file-or-hunk> zz`.
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     #[clap(hide = true)]
     Unstage {
         /// File or hunk ID to unstage
@@ -825,6 +836,7 @@ pub enum Subcommands {
     /// ```text
     /// but skill install --global
     /// ```
+    #[clap(verbatim_doc_comment)]
     Skill(skill::Platform),
 
     /// Show help information grouped by category.
@@ -834,6 +846,7 @@ pub enum Subcommands {
     ///
     /// This is equivalent to running `but -h` to see the command overview.
     #[clap(hide = true)]
+    #[clap(verbatim_doc_comment)]
     Help,
 }
 

--- a/crates/but/src/args/oplog.rs
+++ b/crates/but/src/args/oplog.rs
@@ -17,6 +17,7 @@ pub enum Subcommands {
     /// You can use `but oplog restore <oplog-sha>` to restore to a specific state.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     List {
         /// Start from this oplog SHA instead of the head
         #[clap(long)]
@@ -49,6 +50,7 @@ pub enum Subcommands {
     /// which you can find by running `but oplog` or `but oplog list`.
     ///
     #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
     Restore {
         /// Oplog SHA to restore to
         oplog_sha: String,


### PR DESCRIPTION
In order to generate the manpages from the comments, we need the `but-clap` binary in Cargo and in order for the output to be valid MDX content, anything with backticks needs to be verbatium flagged.