### PR TITLE
project: Resolve the path

### DIFF
--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -347,7 +347,7 @@ fn already_setup() -> anyhow::Result<()> {
 Setting up GitButler project...
 
 → Adding repository to GitButler project registry
-  ✓ Repository added to project registry
+  ✓ Repository already in project registry
 
 GitButler project is already set up!
 Target branch: origin/main
@@ -417,7 +417,7 @@ fn json_output_already_setup() -> anyhow::Result<()> {
         .stdout_eq(snapbox::str![[r#"
 {
   "repositoryPath": "[..]",
-  "projectStatus": "added",
+  "projectStatus": "alreadyexists",
   "target": {
     "branchName": "origin/main",
     "remoteName": "origin",

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -113,7 +113,7 @@ Learn more at https://docs.gitbutler.com/cli-overview
 Setting up GitButler project...
 
 → Adding repository to GitButler project registry
-  ✓ Repository added to project registry
+  ✓ Repository already in project registry
 
 GitButler project is already set up!
 Target branch: gb-local/main


### PR DESCRIPTION
Before comparing the path of the incoming project, we should resolve it
in order to know for certain which is the path we’re about to add

This fixes the condition in which running `but setup` mutltiple times would add duplicate projects.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12175 
- <kbd>&nbsp;1&nbsp;</kbd> #12172 👈 
<!-- GitButler Footer Boundary Bottom -->

