### PR TITLE
Ability to drag changes to start a commit

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -8,7 +8,7 @@
 	import CreateReviewBox from '$components/CreateReviewBox.svelte';
 	import Dropzone from '$components/Dropzone.svelte';
 	import PrNumberUpdater from '$components/PrNumberUpdater.svelte';
-	import { BranchDropData } from '$lib/branches/dropHandler';
+	import { BranchDropData, StartCommitDzHandler } from '$lib/branches/dropHandler';
 	import { MoveCommitDzHandler } from '$lib/commits/dropHandler';
 	import { ReorderCommitDzHandler } from '$lib/dragging/stackingReorderDropzoneManager';
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
@@ -150,6 +150,13 @@
 			});
 		}
 	}
+
+	function getCardOverlayLabel(handler: DropzoneHandler | undefined): string {
+		if (handler instanceof MoveCommitDzHandler) return 'Move here';
+		if (handler instanceof ReorderCommitDzHandler) return 'Reorder here';
+		if (handler instanceof StartCommitDzHandler) return 'Start commit';
+		return 'Drop here';
+	}
 </script>
 
 <div
@@ -171,12 +178,7 @@
 			handlers={args.first ? [moveHandler, ...args.dropzones].filter(isDefined) : args.dropzones}
 		>
 			{#snippet overlay({ hovered, activated, handler })}
-				{@const label =
-					handler instanceof MoveCommitDzHandler
-						? 'Move here'
-						: handler instanceof ReorderCommitDzHandler
-							? 'Reorder here'
-							: 'Start commit'}
+				{@const label = getCardOverlayLabel(handler)}
 				<CardOverlay {hovered} {activated} {label} />
 			{/snippet}
 

--- a/apps/desktop/src/lib/branches/dropHandler.ts
+++ b/apps/desktop/src/lib/branches/dropHandler.ts
@@ -1,7 +1,10 @@
+import { FileChangeDropData, FolderChangeDropData, HunkDropDataV3 } from '$lib/dragging/draggables';
 import { updateStackPrs } from '$lib/forge/shared/prFooter';
 import type { DropzoneHandler } from '$lib/dragging/handler';
 import type { ForgePrService } from '$lib/forge/interface/forgePrService';
+import type { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 import type { StackService } from '$lib/stacks/stackService.svelte';
+import type { UiState } from '$lib/state/uiState.svelte';
 
 export class BranchDropData {
 	constructor(
@@ -60,5 +63,68 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 
 		const branchDetails = await this.stackService.fetchBranches(this.projectId, this.stackId);
 		await updateStackPrs(this.prService, branchDetails, this.baseBranchName);
+	}
+}
+
+export class StartCommitDzHandler implements DropzoneHandler {
+	constructor(
+		private readonly uiState: UiState,
+		private readonly uncommittedService: UncommittedService,
+		private readonly projectId: string,
+		private readonly stackId: string | undefined,
+		private readonly branchName: string
+	) {}
+
+	print(): string {
+		return `StartCommitDzHandler(${this.projectId}, ${this.stackId}, ${this.branchName})`;
+	}
+
+	accepts(data: unknown): boolean {
+		if (data instanceof FileChangeDropData || data instanceof FolderChangeDropData) {
+			// Only accept uncomitted files/folders
+			if (data.isCommitted) return false;
+			// Only accept unassinged files/folders or those assigned to the same stack
+			if (data.stackId !== undefined && data.stackId !== this.stackId) return false;
+			return true;
+		}
+		if (data instanceof HunkDropDataV3) {
+			// Only accept uncommitted hunks
+			if (!data.uncommitted) return false;
+			if (data.selectionId.type !== 'worktree') return false;
+			// Only accept unassigned hunks or those assigned to the same stack
+			if (data.stackId !== undefined && data.stackId !== this.stackId) return false;
+			return true;
+		}
+		return false;
+	}
+
+	private startCommitting() {
+		const projectState = this.uiState.project(this.projectId);
+		projectState.exclusiveAction.set({
+			type: 'commit',
+			stackId: this.stackId,
+			branchName: this.branchName
+		});
+	}
+
+	private async checkDropData(
+		data: FileChangeDropData | FolderChangeDropData | HunkDropDataV3
+	): Promise<true> {
+		if (data instanceof FileChangeDropData || data instanceof FolderChangeDropData) {
+			const changes = await data.treeChanges();
+			const paths = changes.map((c) => c.path);
+			if (paths.length === 0) return true;
+			this.uncommittedService.checkFiles(data.stackId ?? null, paths);
+			return true;
+		}
+
+		// Handle hunk data
+		this.uncommittedService.checkHunk(data.stackId ?? null, data.change.path, data.hunk);
+		return true;
+	}
+
+	async ondrop(data: FileChangeDropData | FolderChangeDropData | HunkDropDataV3): Promise<void> {
+		this.startCommitting();
+		await this.checkDropData(data);
 	}
 }


### PR DESCRIPTION
Add a drop handler that initiates the commit process, staging the
dragged changes.


https://github.com/user-attachments/assets/ce84d385-1c99-4eb8-981a-79361d485db0


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12177 
- <kbd>&nbsp;1&nbsp;</kbd> #12176 👈 
<!-- GitButler Footer Boundary Bottom -->

