### PR TITLE
e2e: Test that dragging to start commit

### DIFF
--- a/e2e/playwright/src/commit.ts
+++ b/e2e/playwright/src/commit.ts
@@ -74,27 +74,3 @@ export async function verifyCommitPlaceholderPosition(page: Page) {
 	await expect(commitTargetPosition).toHaveCount(1);
 	await expect(commitTargetPosition).toContainClass('first');
 }
-
-/**
- * Unstage all files in the uncommitted changes list.
- */
-export async function unstageAllFiles(page: Page) {
-	const uncommittedFilesCheckbox = page
-		.getByTestId('uncommitted-changes-header')
-		.locator('input[type="checkbox"]');
-	await expect(uncommittedFilesCheckbox).toBeVisible();
-	await expect(uncommittedFilesCheckbox).toBeChecked();
-	await uncommittedFilesCheckbox.click();
-}
-
-/**
- * Stage the first file in the uncommitted changes list.
- */
-export async function stageFirstFile(page: Page) {
-	const fileItemCheckbox = getByTestId(page, 'uncommitted-changes-file-list')
-		.getByTestId('file-list-item')
-		.first()
-		.locator('input[type="checkbox"]');
-	await expect(fileItemCheckbox).toBeVisible();
-	await fileItemCheckbox.click();
-}

--- a/e2e/playwright/src/file.ts
+++ b/e2e/playwright/src/file.ts
@@ -54,3 +54,71 @@ export async function discardFile(fileName: string, page: Page): Promise<void> {
 		.filter({ hasText: fileName });
 	await expect(fileItem).not.toBeVisible();
 }
+
+/**
+ * Verify that there are no uncommitted changes.
+ */
+export async function assertNoUncommittedChanges(page: Page): Promise<void> {
+	const uncommittedChangesList = getByTestId(page, 'uncommitted-changes-file-list');
+	await expect(uncommittedChangesList).toBeVisible();
+	const fileItems = uncommittedChangesList.getByTestId('file-list-item');
+	await expect(fileItems).toHaveCount(0);
+}
+
+/**
+ * Stage the first file in the uncommitted changes list.
+ */
+export async function stageFirstFile(page: Page) {
+	const fileItemCheckbox = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.first()
+		.locator('input[type="checkbox"]');
+	await expect(fileItemCheckbox).toBeVisible();
+	await fileItemCheckbox.click();
+}
+
+/**
+ * Verify that a file is staged for a commit.
+ */
+export async function assertFileIsStaged(page: Page, fileName: string) {
+	const fileItemCheckbox = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName })
+		.locator('input[type="checkbox"]');
+	await expect(fileItemCheckbox).toBeVisible();
+	await expect(fileItemCheckbox).toBeChecked();
+}
+
+/**
+ * Verify that a file is unstaged for a commit.
+ */
+export async function assertFileIsUnstaged(page: Page, fileName: string) {
+	const fileItemCheckbox = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName })
+		.locator('input[type="checkbox"]');
+	await expect(fileItemCheckbox).toBeVisible();
+	await expect(fileItemCheckbox).not.toBeChecked();
+}
+
+/**
+ * Unstage all files in the uncommitted changes list.
+ */
+export async function unstageAllFiles(page: Page) {
+	const uncommittedFilesCheckbox = page
+		.getByTestId('uncommitted-changes-header')
+		.locator('input[type="checkbox"]');
+	await expect(uncommittedFilesCheckbox).toBeVisible();
+	await expect(uncommittedFilesCheckbox).toBeChecked();
+	await uncommittedFilesCheckbox.click();
+}
+
+/**
+ * Verify that a file is present in the uncommitted changes list.
+ */
+export async function assertFileIsUncommitted(page: Page, fileName: string) {
+	const fileItem = getByTestId(page, 'uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({ hasText: fileName });
+	await expect(fileItem).toBeVisible();
+}

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -1,14 +1,12 @@
 import {
 	openCommitDrawer,
-	stageFirstFile,
 	startEditingCommitMessage,
-	unstageAllFiles,
 	updateCommitMessage,
 	verifyCommitDrawerContent,
 	verifyCommitMessageEditor,
 	verifyCommitPlaceholderPosition
 } from '../src/commit.ts';
-import { writeFiles } from '../src/file.ts';
+import { stageFirstFile, unstageAllFiles, writeFiles } from '../src/file.ts';
 import { getBaseURL, type GitButler, startGitButler } from '../src/setup.ts';
 import {
 	clickByTestId,
@@ -41,31 +39,11 @@ test('should be able to amend a file to a commit', async ({ page, context }, tes
 	const filePath = gitbutler.pathInWorkdir('local-clone/b_file');
 
 	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('apply-upstream-branch.sh', ['branch1', 'local-clone']);
 
 	await page.goto('/');
 
 	// Should load the workspace
-	await waitForTestId(page, 'workspace-view');
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, 'navigation-branches-button');
-	const header = await waitForTestId(page, 'branch-header');
-
-	await expect(header).toContainText('origin/master');
-
-	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(3);
-
-	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, 'branches-view-delete-local-branch-button');
-
-	// Apply the branch
-	await clickByTestId(page, 'branches-view-apply-branch-button');
-	// Should be redirected to the workspace
 	await waitForTestId(page, 'workspace-view');
 
 	// There should be only one stack

--- a/e2e/playwright/tests/dragToCommit.spec.ts
+++ b/e2e/playwright/tests/dragToCommit.spec.ts
@@ -1,0 +1,100 @@
+import { updateCommitMessage, verifyCommitMessageEditor } from '../src/commit.ts';
+import {
+	assertFileContent,
+	assertFileIsStaged,
+	assertFileIsUncommitted,
+	assertFileIsUnstaged
+} from '../src/file.ts';
+import { getBaseURL, type GitButler, startGitButler } from '../src/setup.ts';
+import { clickByTestId, dragAndDropByLocator, getByTestId, waitForTestId } from '../src/util.ts';
+import { expect, test } from '@playwright/test';
+import { writeFileSync } from 'fs';
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL()
+});
+
+test.afterEach(async () => {
+	await gitbutler.destroy();
+});
+
+test('should be able to start a commit by dragging a file', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	const fileName = 'b_file';
+	const filePath = gitbutler.pathInWorkdir('local-clone/' + fileName);
+	const fileContent = 'Hello! this is file b\n';
+	const anotherFileName = 'c_file';
+	const anotherFilePath = gitbutler.pathInWorkdir('local-clone/' + anotherFileName);
+	const anotherFileContent = 'Hello! this is file c\n';
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('apply-upstream-branch.sh', ['branch1', 'local-clone']);
+
+	await page.goto('/');
+
+	// Should load the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// There should be only one stack
+	const stacks = getByTestId(page, 'stack');
+	await expect(stacks).toHaveCount(1);
+	const stack = stacks.first();
+	await expect(stack).toContainText('branch1');
+
+	// The stack should have two commits
+	const commits = getByTestId(page, 'commit-row');
+	await expect(commits).toHaveCount(2);
+
+	// Push the changes to the remote branch
+	// (it's basically a no-op, just makes sure that the same commits after rebasing are on the remote)
+	await clickByTestId(page, 'stack-push-button');
+
+	// Add a two new files to the workdir
+	writeFileSync(filePath, fileContent, { flag: 'w' });
+	writeFileSync(anotherFilePath, anotherFileContent, { flag: 'w' });
+
+	const fileLocator = page
+		.getByTestId('uncommitted-changes-file-list')
+		.getByTestId('file-list-item')
+		.filter({
+			hasText: fileName
+		});
+	await expect(fileLocator).toHaveCount(1);
+	await expect(fileLocator).toBeVisible();
+
+	const branchCardLocators = await waitForTestId(page, 'branch-card');
+	const branchCardLocator = branchCardLocators.filter({
+		hasText: 'branch1'
+	});
+
+	// Drag the new file onto the top commit, to amend it
+	await dragAndDropByLocator(page, fileLocator, branchCardLocator);
+
+	// Verify that the only the dragged file is now staged
+	await assertFileIsStaged(page, fileName);
+	await assertFileIsUnstaged(page, anotherFileName);
+
+	const commitTitle = 'New file added';
+	const commitMessage = `Added ${fileName} to the project`;
+
+	// Fill the commit message
+	await verifyCommitMessageEditor(page, '', '');
+	await updateCommitMessage(page, commitTitle, commitMessage);
+
+	// Submit the commit
+	await clickByTestId(page, 'commit-drawer-action-button');
+	const commitRow = getByTestId(page, 'commit-row').filter({ hasText: commitTitle });
+	await expect(commitRow).toHaveCount(1);
+
+	// Verify that the other file is still uncommitted
+	await assertFileIsUncommitted(page, anotherFileName);
+
+	// Verify the file contents are correct
+	await assertFileContent(filePath, fileContent);
+	await assertFileContent(anotherFilePath, anotherFileContent);
+});


### PR DESCRIPTION
Test the ability to drag a file into the branch header in order to start
a commit.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12177 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12176 
<!-- GitButler Footer Boundary Bottom -->

