### PR TITLE
but-gitlab

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -148,7 +148,6 @@ jobs:
           cargo check -p but-meta --all-targets
           cargo check -p but-graph --all-targets
           cargo check -p but-workspace --all-targets
-          cargo check -p but-github --all-targets
           cargo check -p but-api --all-targets
           cargo check -p but --all-targets
         name: Special `cargo check` runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "but-forge-storage",
  "but-gerrit",
  "but-github",
+ "but-gitlab",
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
@@ -1165,11 +1166,26 @@ dependencies = [
  "but-forge-storage",
  "but-secret",
  "but-settings",
- "gitbutler-user",
  "http 1.4.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "but-gitlab"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "but-error",
+ "but-forge-storage",
+ "but-secret",
+ "but-settings",
+ "http 1.4.0",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "urlencoding",
 ]
 
 [[package]]
@@ -11304,6 +11320,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,10 @@ members = [
     "crates/but-tools",             # 📄TBD
     # 👉No tests, lacks top-level docs, purpose somewhat unclear.
     "crates/but-llm",               # 📄TBD
-    # 👉lacks top-level docs and docs, purpose somewhat unclear. Uses legacy crate.
-    "crates/but-github",            # 📄Retrieve information using the GitHub API.
+    # 👉lacks top-level docs and docs.
+    "crates/but-github",            # 📄A thin wrapper of the GitHub API, for authentication and resource access.
+    # 👉lacks top-level docs and docs.
+    "crates/but-gitlab",            # 📄A thin wrapper of the GitLab API, for authentication and resource access.
     # 👉No tests, lacks top-level docs, purpose somewhat unclear.
     "crates/but-cursor",            # 📄Integration with Cursor
     # 👉Kind of no docs, no tests, and unclear purpose.
@@ -151,6 +153,7 @@ but-cursor = { path = "crates/but-cursor" }
 but-gerrit = { path = "crates/but-gerrit" }
 but-cherry-apply = { path = "crates/but-cherry-apply" }
 but-github = { path = "crates/but-github" }
+but-gitlab = { path = "crates/but-gitlab" }
 but-error = { path = "crates/but-error" }
 but-serde = { path = "crates/but-serde" }
 but-update = { path = "crates/but-update" }

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -211,14 +211,14 @@ function injectBackendEndpoints(api: BackendApi) {
 			}),
 			initDeviceOauth: build.mutation<Verification, void>({
 				extraOptions: {
-					command: 'init_device_oauth',
+					command: 'init_github_device_oauth',
 					actionName: 'Init GitHub Device OAuth'
 				},
 				query: () => ({})
 			}),
 			checkAuthStatus: build.mutation<AuthStatusResponse, { deviceCode: string }>({
 				extraOptions: {
-					command: 'check_auth_status',
+					command: 'check_github_auth_status',
 					actionName: 'Check GitHub Auth Status'
 				},
 				query: (args) => args,

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -65,9 +65,9 @@ but-forge.workspace = true
 but-forge-storage.workspace = true
 but-hunk-assignment.workspace = true
 but-hunk-dependency.workspace = true
+but-github.workspace = true
+but-gitlab.workspace = true
 
-# needs `gitbutler_user::User`, which can probably be ported over.
-but-github = { workspace = true, features = ["legacy"] }
 # 'legacy' is needed while we only have `virtual-branches.toml`
 but-meta = { workspace = true, features = ["legacy"] }
 # 'legacy' is needed while this is only a sketch of what the oplog could be.

--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -1,22 +1,33 @@
-// TODO: everything should be fully documented.
-#![allow(missing_docs)]
 use anyhow::Result;
 use but_api_macros::but_api;
 use but_github::{AuthStatusResponse, AuthenticatedUser, Verification};
 use but_secret::Sensitive;
 use tracing::instrument;
 
+/// JSON serialization types for GitHub API responses.
+///
+/// This module contains serializable versions of GitHub authentication types
+/// that expose sensitive data (like access tokens) as plain strings for API responses.
 pub mod json {
     use but_github::{AuthStatusResponse, AuthenticatedUser};
     use serde::Serialize;
 
+    /// Serializable version of [`AuthStatusResponse`] with exposed access token.
+    ///
+    /// This struct is used for API responses where the access token needs to be
+    /// sent as a plain string. Field names are converted to camelCase for JSON.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct AuthStatusResponseSensitive {
+        /// The GitHub access token as a plain string (sensitive data).
         pub access_token: String,
+        /// The GitHub username/login.
         pub login: String,
+        /// The user's display name, if available.
         pub name: Option<String>,
+        /// The user's email address, if available.
         pub email: Option<String>,
+        /// The GitHub Enterprise host, if this is an enterprise account.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub host: Option<String>,
     }
@@ -41,13 +52,22 @@ pub mod json {
         }
     }
 
+    /// Serializable version of [`AuthenticatedUser`] with exposed access token.
+    ///
+    /// This struct represents an authenticated GitHub user with their credentials
+    /// exposed as plain strings for API responses. Field names are converted to camelCase for JSON.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct AuthenticatedUserSensitive {
+        /// The GitHub access token as a plain string (sensitive data).
         pub access_token: String,
+        /// The GitHub username/login.
         pub login: String,
+        /// The URL to the user's avatar image, if available.
         pub avatar_url: Option<String>,
+        /// The user's display name, if available.
         pub name: Option<String>,
+        /// The user's email address, if available.
         pub email: Option<String>,
     }
 
@@ -72,19 +92,55 @@ pub mod json {
     }
 }
 
+/// Initiates the GitHub device OAuth flow.
+///
+/// This starts the OAuth device authorization flow, which allows users to authenticate
+/// by visiting a URL and entering a code. Returns verification details including the
+/// user code and verification URL.
+///
+/// # Returns
+///
+/// * `Ok(Verification)` - Contains the user code, device code, and verification URL
+/// * `Err(_)` - If the OAuth initialization request fails
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn init_device_oauth() -> Result<Verification> {
-    but_github::init_device_oauth().await
+pub async fn init_github_device_oauth() -> Result<Verification> {
+    but_github::init_github_device_oauth().await
 }
 
+/// Checks the status of a GitHub device OAuth authorization.
+///
+/// Polls the GitHub API to check if the user has completed the device authorization flow.
+/// If successful, stores the access token and returns the authenticated user information.
+///
+/// # Arguments
+///
+/// * `device_code` - The device code received from [`init_github_device_oauth`]
+///
+/// # Returns
+///
+/// * `Ok(AuthStatusResponse)` - User is authenticated, contains access token and user details
+/// * `Err(_)` - If the authorization is pending, denied, or the request fails
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
-pub async fn check_auth_status(device_code: String) -> Result<AuthStatusResponse> {
+pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
-    but_github::check_auth_status(device_code, &storage).await
+    but_github::check_github_auth_status(device_code, &storage).await
 }
 
+/// Stores a GitHub Personal Access Token (PAT) for github.com.
+///
+/// Validates and stores the provided PAT, then retrieves and returns the authenticated
+/// user information. The token is securely stored in the application's data directory.
+///
+/// # Arguments
+///
+/// * `access_token` - The GitHub PAT to store (wrapped in Sensitive to prevent logging)
+///
+/// # Returns
+///
+/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+/// * `Err(_)` - If the token is invalid or storage fails
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
@@ -92,6 +148,20 @@ pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthSta
     but_github::store_pat(&access_token, &storage).await
 }
 
+/// Stores a GitHub Personal Access Token (PAT) for a GitHub Enterprise instance.
+///
+/// Validates and stores the provided PAT for a specific GitHub Enterprise host,
+/// then retrieves and returns the authenticated user information.
+///
+/// # Arguments
+///
+/// * `access_token` - The GitHub Enterprise PAT to store
+/// * `host` - The GitHub Enterprise hostname (e.g., "github.company.com")
+///
+/// # Returns
+///
+/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details and host
+/// * `Err(_)` - If the token is invalid, host is unreachable, or storage fails
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_github_enterprise_pat(access_token: Sensitive<String>, host: String) -> Result<AuthStatusResponse> {
@@ -99,6 +169,18 @@ pub async fn store_github_enterprise_pat(access_token: Sensitive<String>, host: 
     but_github::store_enterprise_pat(&host, &access_token, &storage).await
 }
 
+/// Removes stored credentials for a specific GitHub account.
+///
+/// Deletes the access token associated with the specified GitHub account identifier.
+/// This is used when users want to sign out or remove an account.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the GitHub account (github.com or enterprise)
+///
+/// # Returns
+///
+/// * `Ok(())` - Always succeeds, even if no token was found
 #[but_api]
 #[instrument(err(Debug))]
 pub fn forget_github_account(account: but_github::GithubAccountIdentifier) -> Result<()> {
@@ -107,6 +189,15 @@ pub fn forget_github_account(account: but_github::GithubAccountIdentifier) -> Re
     Ok(())
 }
 
+/// Removes all stored GitHub credentials.
+///
+/// Deletes all stored GitHub access tokens for both github.com and enterprise instances.
+/// This is a destructive operation that signs out all GitHub accounts.
+///
+/// # Returns
+///
+/// * `Ok(())` - All tokens successfully cleared
+/// * `Err(_)` - If storage cleanup fails
 #[but_api]
 #[instrument(err(Debug))]
 pub fn clear_all_github_tokens() -> Result<()> {
@@ -114,6 +205,20 @@ pub fn clear_all_github_tokens() -> Result<()> {
     but_github::clear_all_github_tokens(&storage)
 }
 
+/// Retrieves the authenticated user information for a GitHub account.
+///
+/// Fetches the stored credentials and current user profile for the specified GitHub account.
+/// Returns `None` if no credentials are stored for the account.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the GitHub account to query
+///
+/// # Returns
+///
+/// * `Ok(Some(AuthenticatedUser))` - User information with access token
+/// * `Ok(None)` - No credentials stored for this account
+/// * `Err(_)` - If the API request fails or credentials are invalid
 #[but_api(json::AuthenticatedUserSensitive)]
 #[instrument(err(Debug))]
 pub async fn get_gh_user(account: but_github::GithubAccountIdentifier) -> Result<Option<AuthenticatedUser>> {
@@ -121,6 +226,15 @@ pub async fn get_gh_user(account: but_github::GithubAccountIdentifier) -> Result
     but_github::get_gh_user(&account, &storage).await
 }
 
+/// Lists all GitHub accounts with stored credentials.
+///
+/// Returns identifiers for all GitHub accounts (github.com and enterprise) that have
+/// stored access tokens in the application.
+///
+/// # Returns
+///
+/// * `Ok(Vec<GithubAccountIdentifier>)` - List of all known accounts
+/// * `Err(_)` - If storage access fails
 #[but_api]
 #[instrument(err(Debug))]
 pub async fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdentifier>> {
@@ -128,6 +242,19 @@ pub async fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccoun
     but_github::list_known_github_accounts(&storage).await
 }
 
+/// Validates stored GitHub credentials.
+///
+/// Checks if the stored credentials for the specified account are still valid by
+/// making a test API request. This helps detect expired or revoked tokens.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the GitHub account to validate
+///
+/// # Returns
+///
+/// * `Ok(CredentialCheckResult)` - Result indicating if credentials are valid or not
+/// * `Err(_)` - If the validation request fails
 #[instrument(err(Debug))]
 pub async fn check_github_credentials(
     account: but_github::GithubAccountIdentifier,

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(feature = "legacy")]
 pub mod legacy;
 
+/// Functions for GitHub authentication.
 pub mod github;
 
 /// Functions that take a branch as input.

--- a/crates/but-forge-storage/src/settings.rs
+++ b/crates/but-forge-storage/src/settings.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct ForgeSettings {
     /// GitHub-specific settings.
     pub github: GitHubSettings,
+    /// GitLab-specific settings.
+    #[serde(default)]
+    pub gitlab: GitLabSettings,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -98,6 +101,79 @@ impl PartialEq for GitHubAccount {
             (GitHubAccount::OAuth { .. }, GitHubAccount::Enterprise { .. }) => false,
             (GitHubAccount::Pat { .. }, GitHubAccount::Enterprise { .. }) => false,
             (GitHubAccount::Enterprise { .. }, GitHubAccount::Pat { .. }) => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GitLabSettings {
+    /// GitLab-specific settings.
+    pub known_accounts: Vec<GitLabAccount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum GitLabAccount {
+    Pat {
+        // Username associated with the PAT account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+    SelfHosted {
+        // Hostname of the self-hosted GitLab instance.
+        host: String,
+        // Username associated with the PAT account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+}
+
+impl GitLabAccount {
+    pub fn access_token_key(&self) -> &str {
+        match self {
+            GitLabAccount::Pat { access_token_key, .. } => access_token_key,
+            GitLabAccount::SelfHosted { access_token_key, .. } => access_token_key,
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        match self {
+            GitLabAccount::Pat { username, .. } => username,
+            GitLabAccount::SelfHosted { host, .. } => host,
+        }
+    }
+}
+
+impl PartialEq for GitLabAccount {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                GitLabAccount::Pat {
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GitLabAccount::Pat {
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => u1 == u2 && k1 == k2,
+            (
+                GitLabAccount::SelfHosted {
+                    host: h1,
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GitLabAccount::SelfHosted {
+                    host: h2,
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => h1 == h2 && u1 == u2 && k1 == k2,
+            (GitLabAccount::Pat { .. }, GitLabAccount::SelfHosted { .. }) => false,
+            (GitLabAccount::SelfHosted { .. }, GitLabAccount::Pat { .. }) => false,
         }
     }
 }

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Verification {
     pub device_code: String,
 }
 
-pub async fn init_device_oauth() -> Result<Verification> {
+pub async fn init_github_device_oauth() -> Result<Verification> {
     let mut req_body = HashMap::new();
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
     let client_id = app_settings.github_oauth_app.oauth_client_id.clone();
@@ -56,7 +56,7 @@ pub struct AuthStatusResponse {
     pub host: Option<String>,
 }
 
-pub async fn check_auth_status(
+pub async fn check_github_auth_status(
     device_code: String,
     storage: &but_forge_storage::Controller,
 ) -> Result<AuthStatusResponse> {

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -278,21 +278,7 @@ pub async fn check_credentials(
 pub async fn list_known_github_accounts(
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<token::GithubAccountIdentifier>> {
-    let known_accounts = token::list_known_github_accounts(storage).context("Failed to list known GitHub usernames")?;
-    // Migrate the users from the previous storage method.
-    #[cfg(feature = "legacy")]
-    if let Some(stored_gh_access_token) = gitbutler_user::forget_github_login_for_user()?
-        && known_accounts.is_empty()
-    {
-        fetch_and_persist_oauth_user_data(&stored_gh_access_token, storage)
-            .await
-            .ok();
-
-        let known_accounts =
-            token::list_known_github_accounts(storage).context("Failed to list known GitHub usernames")?;
-        return Ok(known_accounts);
-    }
-    Ok(known_accounts)
+    token::list_known_github_accounts(storage).context("Failed to list known GitHub usernames")
 }
 
 pub fn clear_all_github_tokens(storage: &but_forge_storage::Controller) -> Result<()> {

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "but-github"
+name = "but-gitlab"
 version = "0.0.0"
 edition.workspace = true
 repository.workspace = true
 license-file = "../../LICENSE.md"
-description = "The GitButler GitHub integration"
+description = "The GitButler GitLab integration"
 authors.workspace = true
 readme = "../../README.md"
 publish = false
@@ -23,6 +23,7 @@ serde.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+urlencoding = "2.1"
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -1,0 +1,354 @@
+use anyhow::{Result, bail};
+use but_secret::Sensitive;
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use serde::{Deserialize, Serialize};
+
+const GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
+
+pub struct GitLabClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl GitLabClient {
+    pub fn new(access_token: &Sensitive<String>) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("gb-gitlab-integration"));
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", access_token.0))?,
+        );
+
+        let client = reqwest::Client::builder().default_headers(headers).build()?;
+
+        Ok(Self {
+            client,
+            base_url: GITLAB_API_BASE_URL.to_string(),
+        })
+    }
+
+    pub fn from_storage(
+        storage: &but_forge_storage::Controller,
+        preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    ) -> anyhow::Result<Self> {
+        let account_id = resolve_account(preferred_account, storage)?;
+        if let Some(access_token) = crate::token::get_gl_access_token(&account_id, storage)? {
+            account_id.client(&access_token)
+        } else {
+            Err(anyhow::anyhow!(
+                "No GitLab access token found for account '{}'.\nPlease, try to re-authenticate with this account.",
+                account_id
+            ))
+        }
+    }
+
+    pub fn new_with_host_override(access_token: &Sensitive<String>, host: &str) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("gb-gitlab-integration"));
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", access_token.0))?,
+        );
+
+        let client = reqwest::Client::builder().default_headers(headers).build()?;
+
+        let base_url = if host.ends_with("/api/v4") {
+            host.to_string()
+        } else if host.ends_with('/') {
+            format!("{}api/v4", host)
+        } else {
+            format!("{}/api/v4", host)
+        };
+
+        Ok(Self { client, base_url })
+    }
+
+    pub async fn get_authenticated(&self) -> Result<AuthenticatedUser> {
+        #[derive(Deserialize)]
+        struct User {
+            username: String,
+            name: Option<String>,
+            email: Option<String>,
+            avatar_url: Option<String>,
+        }
+
+        let url = format!("{}/user", self.base_url);
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to get authenticated user: {}", response.status());
+        }
+
+        let user: User = response.json().await?;
+
+        Ok(AuthenticatedUser {
+            username: user.username,
+            avatar_url: user.avatar_url,
+            name: user.name,
+            email: user.email,
+        })
+    }
+
+    pub async fn list_open_mrs(&self, project: &str) -> Result<Vec<MergeRequest>> {
+        let url = format!(
+            "{}/projects/{}/merge_requests",
+            self.base_url,
+            urlencoding::encode(project)
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("state", "opened"), ("sort", "created_at")])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to list open merge requests: {}", response.status());
+        }
+
+        let mrs: Vec<GitLabMergeRequest> = response.json().await?;
+        Ok(mrs.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn list_mrs_for_target(&self, project: &str, target_branch: &str) -> Result<Vec<MergeRequest>> {
+        let url = format!(
+            "{}/projects/{}/merge_requests",
+            self.base_url,
+            urlencoding::encode(project)
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("state", "all"),
+                ("target_branch", target_branch),
+                ("order_by", "updated_at"),
+                ("sort", "desc"),
+                ("per_page", "100"),
+            ])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to list merge requests for target branch: {}", response.status());
+        }
+
+        let mrs: Vec<GitLabMergeRequest> = response.json().await?;
+        Ok(mrs.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn create_merge_request(&self, params: &CreateMergeRequestParams<'_>) -> Result<MergeRequest> {
+        #[derive(Serialize)]
+        struct CreateMergeRequestBody<'a> {
+            title: &'a str,
+            description: &'a str,
+            source_branch: &'a str,
+            target_branch: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            target_project_id: Option<i64>,
+        }
+
+        let url = format!(
+            "{}/projects/{}/merge_requests",
+            self.base_url,
+            urlencoding::encode(params.project)
+        );
+
+        let body = CreateMergeRequestBody {
+            title: params.title,
+            description: params.body,
+            source_branch: params.source_branch,
+            target_branch: params.target_branch,
+            target_project_id: None,
+        };
+
+        let response = self.client.post(&url).json(&body).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            bail!("Failed to create merge request: {} - {}", status, error_text);
+        }
+
+        let mr: GitLabMergeRequest = response.json().await?;
+        Ok(mr.into())
+    }
+
+    pub async fn get_merge_request(&self, project: &str, mr_iid: i64) -> Result<MergeRequest> {
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}",
+            self.base_url,
+            urlencoding::encode(project),
+            mr_iid
+        );
+
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to get merge request: {}", response.status());
+        }
+
+        let mr: GitLabMergeRequest = response.json().await?;
+        Ok(mr.into())
+    }
+}
+
+pub struct CreateMergeRequestParams<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+    pub source_branch: &'a str,
+    pub target_branch: &'a str,
+    pub project: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthenticatedUser {
+    pub username: String,
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GitLabUser {
+    pub id: i64,
+    pub username: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub avatar_url: Option<String>,
+    pub is_bot: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabApiUser {
+    id: i64,
+    username: String,
+    name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    avatar_url: Option<String>,
+    #[serde(default)]
+    bot: bool,
+}
+
+impl From<GitLabApiUser> for GitLabUser {
+    fn from(user: GitLabApiUser) -> Self {
+        GitLabUser {
+            id: user.id,
+            username: user.username,
+            name: user.name,
+            email: user.email,
+            avatar_url: user.avatar_url,
+            is_bot: user.bot,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GitLabLabel {
+    pub id: i64,
+    pub name: String,
+    pub description: Option<String>,
+    pub color: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MergeRequest {
+    pub web_url: String,
+    pub iid: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub author: Option<GitLabUser>,
+    pub labels: Vec<String>,
+    pub draft: bool,
+    pub source_branch: String,
+    pub target_branch: String,
+    pub sha: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub merged_at: Option<String>,
+    pub closed_at: Option<String>,
+    pub project_id: i64,
+    pub assignees: Vec<GitLabUser>,
+    pub reviewers: Vec<GitLabUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabMergeRequest {
+    web_url: String,
+    iid: i64,
+    title: String,
+    description: Option<String>,
+    author: Option<GitLabApiUser>,
+    labels: Vec<String>,
+    draft: bool,
+    source_branch: String,
+    target_branch: String,
+    sha: String,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    merged_at: Option<String>,
+    closed_at: Option<String>,
+    project_id: i64,
+    #[serde(default)]
+    assignees: Vec<GitLabApiUser>,
+    #[serde(default)]
+    reviewers: Vec<GitLabApiUser>,
+}
+
+impl From<GitLabMergeRequest> for MergeRequest {
+    fn from(mr: GitLabMergeRequest) -> Self {
+        let author = mr.author.map(Into::into);
+
+        let assignees = mr.assignees.into_iter().map(Into::into).collect();
+        let reviewers = mr.reviewers.into_iter().map(Into::into).collect();
+
+        MergeRequest {
+            web_url: mr.web_url,
+            iid: mr.iid,
+            title: mr.title,
+            description: mr.description,
+            author,
+            labels: mr.labels,
+            draft: mr.draft,
+            source_branch: mr.source_branch,
+            target_branch: mr.target_branch,
+            sha: mr.sha,
+            created_at: mr.created_at,
+            updated_at: mr.updated_at,
+            merged_at: mr.merged_at,
+            closed_at: mr.closed_at,
+            project_id: mr.project_id,
+            assignees,
+            reviewers,
+        }
+    }
+}
+
+pub(crate) fn resolve_account(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::GitlabAccountIdentifier, anyhow::Error> {
+    let known_accounts = crate::token::list_known_gitlab_accounts(storage)?;
+    let Some(default_account) = known_accounts.first() else {
+        bail!("No authenticated GitLab users found. Please authenticate with GitLab first.");
+    };
+    let account = if let Some(account) = preferred_account {
+        if known_accounts.contains(account) {
+            account
+        } else {
+            bail!(
+                "Preferred GitLab account '{}' has not authenticated yet. Please choose another account or authenticate with the desired account first.",
+                account
+            );
+        }
+    } else {
+        default_account
+    };
+
+    Ok(account.to_owned())
+}

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -1,0 +1,225 @@
+use anyhow::{Context as _, Result};
+use but_secret::Sensitive;
+
+mod client;
+pub mod mr;
+pub use client::{CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabUser, MergeRequest};
+mod token;
+pub use token::GitlabAccountIdentifier;
+
+#[derive(Debug, Clone)]
+pub struct AuthStatusResponse {
+    /// The access token.
+    /// This is only shared with the FrontEnd temporarily as we undergo the migration to having all API calls
+    /// made to the forges from the Rustend.
+    pub access_token: Sensitive<String>,
+    pub username: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub host: Option<String>,
+}
+
+/// Store a PAT access token and fetch the associated user data.
+pub async fn store_pat(
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<AuthStatusResponse> {
+    let user = fetch_and_persist_pat_user_data(access_token, storage).await?;
+    Ok(AuthStatusResponse {
+        access_token: access_token.clone(),
+        username: user.username,
+        name: user.name,
+        email: user.email,
+        host: None,
+    })
+}
+
+/// Fetch the authenticated user data from GitLab and persist the access token. (PAT)
+async fn fetch_and_persist_pat_user_data(
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<client::AuthenticatedUser, anyhow::Error> {
+    let gl = client::GitLabClient::new(access_token).context("Failed to create GitLab client")?;
+    let user = gl
+        .get_authenticated()
+        .await
+        .context("Failed to get authenticated user")?;
+    token::persist_gl_access_token(
+        &token::GitlabAccountIdentifier::pat(&user.username),
+        access_token,
+        storage,
+    )
+    .context("Failed to persist access token")?;
+    Ok(user)
+}
+
+/// Store a self-hosted GitLab access token and fetch the associated user data.
+pub async fn store_selfhosted_pat(
+    host: &str,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<AuthStatusResponse> {
+    let user = fetch_and_persist_selfhosted_user_data(host, access_token, storage).await?;
+    Ok(AuthStatusResponse {
+        access_token: access_token.clone(),
+        username: user.username,
+        name: user.name,
+        email: user.email,
+        host: Some(host.to_owned()),
+    })
+}
+
+/// Fetch the authenticated user data from GitLab and persist the access token. (Self-hosted)
+async fn fetch_and_persist_selfhosted_user_data(
+    host: &str,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<client::AuthenticatedUser, anyhow::Error> {
+    let gl =
+        client::GitLabClient::new_with_host_override(access_token, host).context("Failed to create GitLab client")?;
+    let user = gl
+        .get_authenticated()
+        .await
+        .context("Failed to get authenticated user")?;
+    token::persist_gl_access_token(
+        &token::GitlabAccountIdentifier::selfhosted(&user.username, host),
+        access_token,
+        storage,
+    )
+    .context("Failed to persist access token")?;
+    Ok(user)
+}
+
+pub fn forget_gl_access_token(
+    account: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    token::delete_gl_access_token(account, storage).context("Failed to delete access token")
+}
+
+pub async fn get_gl_user(
+    account: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<AuthenticatedUser>> {
+    if let Some(access_token) = token::get_gl_access_token(account, storage)? {
+        let gl = account
+            .client(&access_token)
+            .context("Failed to create GitLab client")?;
+        let user = match gl.get_authenticated().await {
+            Ok(user) => user,
+            Err(client_err) => {
+                // Check if this is a network error
+                if let Some(reqwest_err) = client_err.downcast_ref::<reqwest::Error>()
+                    && is_network_error(reqwest_err)
+                {
+                    return Err(client_err.context(but_error::Context::new_static(
+                        but_error::Code::NetworkError,
+                        "Unable to connect to GitLab.",
+                    )));
+                }
+                return Err(client_err.context("Failed to get authenticated user"));
+            }
+        };
+        Ok(Some(AuthenticatedUser {
+            username: user.username,
+            name: user.name,
+            email: user.email,
+            avatar_url: user.avatar_url,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Check if an error is a network connectivity error.
+///
+/// This includes DNS resolution failures, connection timeouts, connection refused, etc.
+fn is_network_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialCheckResult {
+    Valid,
+    Invalid,
+    NoCredentials,
+}
+
+/// Check the validity of the stored credentials for the given GitLab account.
+pub async fn check_credentials(
+    account: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<CredentialCheckResult> {
+    if let Some(access_token) = token::get_gl_access_token(account, storage)? {
+        let gl = account
+            .client(&access_token)
+            .context("Failed to create GitLab client")?;
+        match gl.get_authenticated().await {
+            Ok(_) => Ok(CredentialCheckResult::Valid),
+            Err(_) => Ok(CredentialCheckResult::Invalid),
+        }
+    } else {
+        Ok(CredentialCheckResult::NoCredentials)
+    }
+}
+
+pub async fn list_known_gitlab_accounts(
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<token::GitlabAccountIdentifier>> {
+    token::list_known_gitlab_accounts(storage).context("Failed to list known GitLab usernames")
+}
+
+pub fn clear_all_gitlab_tokens(storage: &but_forge_storage::Controller) -> Result<()> {
+    token::clear_all_gitlab_accounts(storage).context("Failed to clear all GitLab tokens")
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub username: String,
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_network_error_with_reqwest_timeout() {
+        // Create a reqwest error by making an actual HTTP request that will timeout
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .unwrap();
+
+        // Try to connect to a non-routable IP address (should timeout)
+        let result = client.get("http://192.0.2.1:80").send();
+
+        if let Err(reqwest_err) = result {
+            assert!(
+                is_network_error(&reqwest_err),
+                "Should detect timeout/connection errors"
+            );
+        } else {
+            panic!("Expected a network error but request succeeded");
+        }
+    }
+
+    #[test]
+    fn test_is_network_error_with_connection_error() {
+        // Create a reqwest error
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .unwrap();
+
+        let result = client.get("http://192.0.2.1:80").send();
+
+        if let Err(reqwest_err) = result {
+            assert!(is_network_error(&reqwest_err), "Should detect reqwest network errors");
+        } else {
+            panic!("Expected a network error but request succeeded");
+        }
+    }
+}

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -1,0 +1,58 @@
+use anyhow::{Context as _, Result};
+
+use crate::client::GitLabClient;
+
+pub async fn list(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<crate::client::MergeRequest>> {
+    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
+        gl.list_open_mrs(project)
+            .await
+            .context("Failed to list open merge requests")
+    } else {
+        Ok(vec![])
+    }
+}
+
+pub async fn list_all_for_target(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project: &str,
+    target_branch: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<crate::client::MergeRequest>> {
+    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
+        gl.list_mrs_for_target(project, target_branch)
+            .await
+            .context("Failed to list merge requests for target branch")
+    } else {
+        Ok(vec![])
+    }
+}
+
+pub async fn create(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    params: crate::client::CreateMergeRequestParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::MergeRequest> {
+    let mr = GitLabClient::from_storage(storage, preferred_account)?
+        .create_merge_request(&params)
+        .await
+        .context("Failed to create merge request")?;
+    Ok(mr)
+}
+
+pub async fn get(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project: &str,
+    mr_iid: usize,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::MergeRequest> {
+    let mr_iid = mr_iid.try_into().context("MR number is too large")?;
+    let mr = GitLabClient::from_storage(storage, preferred_account)?
+        .get_merge_request(project, mr_iid)
+        .await
+        .context("Failed to get merge request")?;
+    Ok(mr)
+}

--- a/crates/but-gitlab/src/token.rs
+++ b/crates/but-gitlab/src/token.rs
@@ -1,0 +1,260 @@
+use std::sync::Mutex;
+
+use anyhow::Result;
+use but_secret::{Sensitive, secret};
+use serde::{Deserialize, Serialize};
+
+use crate::client::GitLabClient;
+
+/// Persist GitLab account access tokens securely.
+pub fn persist_gl_access_token(
+    account_id: &GitlabAccountIdentifier,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let oauth_account = GitLabAccount::new(account_id, access_token.clone());
+    persist_gitlab_account(&oauth_account, storage)
+}
+
+/// Delete a GitLab account access token for a given username.
+pub fn delete_gl_access_token(
+    account_id: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let account = find_gitlab_account(account_id, storage)?;
+    if let Some(account) = account {
+        delete_gitlab_account(&account, storage)
+    } else {
+        Ok(())
+    }
+}
+
+/// Retrieve a GitLab account access token for a given username.
+pub fn get_gl_access_token(
+    account_id: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<Sensitive<String>>> {
+    let account = find_gitlab_account(account_id, storage)?;
+    Ok(account.map(|acct| acct.access_token()))
+}
+
+pub fn list_known_gitlab_accounts(storage: &but_forge_storage::Controller) -> Result<Vec<GitlabAccountIdentifier>> {
+    Ok(storage
+        .gitlab_accounts()?
+        .iter()
+        .map(|account| account.into())
+        .collect::<Vec<_>>())
+}
+
+pub fn clear_all_gitlab_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
+    delete_all_gitlab_accounts(storage)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type", content = "info")]
+pub enum GitlabAccountIdentifier {
+    PatUsername { username: String },
+    SelfHosted { username: String, host: String },
+}
+
+impl GitlabAccountIdentifier {
+    pub fn pat(username: &str) -> Self {
+        GitlabAccountIdentifier::PatUsername {
+            username: username.to_string(),
+        }
+    }
+    pub fn selfhosted(username: &str, host: &str) -> Self {
+        GitlabAccountIdentifier::SelfHosted {
+            username: username.to_string(),
+            host: host.to_string(),
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        match self {
+            GitlabAccountIdentifier::PatUsername { username } => username,
+            GitlabAccountIdentifier::SelfHosted { username, .. } => username,
+        }
+    }
+
+    pub fn client(&self, access_token: &Sensitive<String>) -> Result<GitLabClient> {
+        match self {
+            GitlabAccountIdentifier::PatUsername { .. } => GitLabClient::new(access_token),
+            GitlabAccountIdentifier::SelfHosted { host, .. } => {
+                GitLabClient::new_with_host_override(access_token, host)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for GitlabAccountIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GitlabAccountIdentifier::PatUsername { username } => write!(f, "PAT: {}", username),
+            GitlabAccountIdentifier::SelfHosted { username, host } => {
+                write!(f, "Self-hosted {}@{}", username, host)
+            }
+        }
+    }
+}
+
+pub enum GitLabAccount {
+    #[allow(dead_code)]
+    Pat {
+        username: String,
+        access_token: Sensitive<String>,
+    },
+    #[allow(dead_code)]
+    SelfHosted {
+        username: String,
+        host: String,
+        access_token: Sensitive<String>,
+    },
+}
+
+impl From<&GitLabAccount> for but_forge_storage::settings::GitLabAccount {
+    fn from(account: &GitLabAccount) -> Self {
+        let access_token_key = account.secret_key();
+        match account {
+            GitLabAccount::Pat { username, .. } => but_forge_storage::settings::GitLabAccount::Pat {
+                username: username.to_owned(),
+                access_token_key,
+            },
+            GitLabAccount::SelfHosted { host, username, .. } => {
+                but_forge_storage::settings::GitLabAccount::SelfHosted {
+                    username: username.to_owned(),
+                    host: host.to_owned(),
+                    access_token_key,
+                }
+            }
+        }
+    }
+}
+
+impl From<&but_forge_storage::settings::GitLabAccount> for GitlabAccountIdentifier {
+    fn from(account: &but_forge_storage::settings::GitLabAccount) -> Self {
+        match account {
+            but_forge_storage::settings::GitLabAccount::Pat { username, .. } => GitlabAccountIdentifier::PatUsername {
+                username: username.to_owned(),
+            },
+            but_forge_storage::settings::GitLabAccount::SelfHosted { host, username, .. } => {
+                GitlabAccountIdentifier::SelfHosted {
+                    username: username.to_owned(),
+                    host: host.to_owned(),
+                }
+            }
+        }
+    }
+}
+
+impl GitLabAccount {
+    pub fn new(account_id: &GitlabAccountIdentifier, access_token: Sensitive<String>) -> Self {
+        match account_id {
+            GitlabAccountIdentifier::PatUsername { username } => GitLabAccount::Pat {
+                username: username.to_owned(),
+                access_token,
+            },
+            GitlabAccountIdentifier::SelfHosted { username, host } => GitLabAccount::SelfHosted {
+                username: username.to_owned(),
+                host: host.to_owned(),
+                access_token,
+            },
+        }
+    }
+
+    fn secret_key(&self) -> String {
+        match self {
+            GitLabAccount::Pat { username, .. } => format!("gitlab_pat_{}", username),
+            GitLabAccount::SelfHosted { host, .. } => format!("gitlab_selfhosted_{}", host),
+        }
+    }
+
+    fn secret_value(&self) -> Result<Sensitive<String>> {
+        Ok(self.access_token())
+    }
+
+    fn access_token(&self) -> Sensitive<String> {
+        match self {
+            GitLabAccount::Pat { access_token, .. } => access_token.clone(),
+            GitLabAccount::SelfHosted { access_token, .. } => access_token.clone(),
+        }
+    }
+}
+
+fn retrieve_gitlab_secret(account_secret_key: &str) -> Result<Option<Sensitive<String>>> {
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::retrieve(account_secret_key, secret::Namespace::BuildKind)
+}
+
+fn persist_gitlab_account(account: &GitLabAccount, storage: &but_forge_storage::Controller) -> Result<()> {
+    let secret_key = account.secret_key();
+    storage.add_gitlab_account(&account.into())?;
+
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::persist(&secret_key, &account.secret_value()?, secret::Namespace::BuildKind)
+}
+
+fn delete_gitlab_account(account: &GitLabAccount, storage: &but_forge_storage::Controller) -> Result<()> {
+    let secret_key = account.secret_key();
+    storage.remove_gitlab_account(&account.into())?;
+
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::delete(&secret_key, secret::Namespace::BuildKind)
+}
+
+fn delete_all_gitlab_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
+    let keys_to_delete = storage.clear_all_gitlab_accounts()?;
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    for key in keys_to_delete {
+        secret::delete(&key, secret::Namespace::BuildKind)?;
+    }
+    Ok(())
+}
+
+fn find_gitlab_account(
+    account_id: &GitlabAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<GitLabAccount>> {
+    let accounts = storage.gitlab_accounts()?;
+    let result = match account_id {
+        GitlabAccountIdentifier::PatUsername { username } => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GitLabAccount::Pat {
+                username: acct_username,
+                access_token_key,
+            } = account
+                && acct_username == username
+                && let Some(access_token) = retrieve_gitlab_secret(access_token_key).ok().flatten()
+            {
+                return Some(GitLabAccount::Pat {
+                    username: acct_username.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+        GitlabAccountIdentifier::SelfHosted { username, host } => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GitLabAccount::SelfHosted {
+                username: acct_username,
+                host: acct_host,
+                access_token_key,
+            } = account
+                && acct_host == host
+                && acct_username == username
+                && let Some(access_token) = retrieve_gitlab_secret(access_token_key).ok().flatten()
+            {
+                return Some(GitLabAccount::SelfHosted {
+                    username: acct_username.clone(),
+                    host: acct_host.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+    };
+    Ok(result)
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -815,15 +815,15 @@ async fn handle_command(
             }
         }
         // GitHub commands (async, not yet migrated)
-        "init_device_oauth" => {
-            let result = github::init_device_oauth().await;
+        "init_github_device_oauth" => {
+            let result = github::init_github_device_oauth().await;
             result.map(|r| json!(r))
         }
-        "check_auth_status" => {
+        "check_github_auth_status" => {
             let params = deserialize_json(request.params);
             match params {
                 Ok(params) => {
-                    let result = github::check_auth_status_cmd(params).await;
+                    let result = github::check_github_auth_status_cmd(params).await;
                     result.map(|r| json!(r))
                 }
                 Err(e) => Err(e),

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -549,7 +549,7 @@ async fn github_enterprise(mut inout: InputOutputChannel<'_>) -> Result<()> {
 
 /// Authenticate with GitHub using the device OAuth flow
 async fn github_oauth(mut inout: InputOutputChannel<'_>) -> Result<()> {
-    let code = but_api::github::init_device_oauth().await?;
+    let code = but_api::github::init_github_device_oauth().await?;
     writeln!(
         inout,
         "Device authorization initiated. Please visit the following URL and enter the code:\n\nhttps://github.com/login/device\n\nCode: {}\n\n",
@@ -562,7 +562,7 @@ async fn github_oauth(mut inout: InputOutputChannel<'_>) -> Result<()> {
         anyhow::bail!("Authorization process aborted by user.")
     }
 
-    let status = but_api::github::check_auth_status(code.device_code)
+    let status = but_api::github::check_github_auth_status(code.device_code)
         .await
         .map_err(|err| err.context("Authentication failed"))?;
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -208,8 +208,8 @@ fn main() -> anyhow::Result<()> {
             .plugin(tauri_plugin_store::Builder::default().build())
             .plugin(log.build())
             .invoke_handler(tauri::generate_handler![
-                github::tauri_init_device_oauth::init_device_oauth,
-                github::tauri_check_auth_status::check_auth_status,
+                github::tauri_init_github_device_oauth::init_github_device_oauth,
+                github::tauri_check_github_auth_status::check_github_auth_status,
                 github::tauri_store_github_pat::store_github_pat,
                 github::tauri_store_github_enterprise_pat::store_github_enterprise_pat,
                 github::tauri_get_gh_user::get_gh_user,


### PR DESCRIPTION
Create a crate for GitLab API interactions.

This PR only introduces the new crate, and renames some function on the but-github side in order to differentiate the forge-specific authentication methods

### Next steps (for the following PRs)
- Hook it up to the FE
- Add the forge handlers for gitlab
- Migrate the existing secrets into the new storage
- Test the beejezus out of this integration migration 🐝🙏

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12193 
- <kbd>&nbsp;1&nbsp;</kbd> #12182 👈 
<!-- GitButler Footer Boundary Bottom -->

