### PR TITLE
Add PR message flags for non-interactive use

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -116,6 +116,9 @@ For detailed command syntax and all available options, see [references/reference
 - `but pull` - Update with upstream
 - `but push [branch]` - Push to remote
 - `but pr new <branch>` - Push and create pull request (auto-pushes, no need to push first)
+- `but pr new <branch> -m "Title..."` - Inline PR message (first line is title, rest is description)
+- `but pr new <branch> -F pr_message.txt` - PR message from file (first line is title, rest is description)
+- For stacked branches, the custom message (`-m` or `-F`) only applies to the selected branch; dependent branches use defaults
 
 ## Key Concepts
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -330,12 +330,17 @@ Create and manage pull requests.
 
 ```bash
 but pr new <branch-id>        # Push branch and create PR (recommended)
-but pr new <branch-id> -m "Title" -m "Body"  # With title and description
+but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
+but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
 but pr                        # Create PR (prompts for branch)
 but pr template               # Configure PR description template
 ```
 
 **Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first.
+
+In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts.
+
+**Note:** For stacked branches, the custom message (`-m` or `-F`) only applies to the selected branch. Dependent branches in the stack will use default messages (commit title/description).
 
 Requires forge integration to be configured via `but config forge auth`.
 

--- a/crates/but/src/args/forge.rs
+++ b/crates/but/src/args/forge.rs
@@ -13,6 +13,12 @@ pub mod pr {
             /// The branch to create a PR for.
             #[clap(value_name = "BRANCH")]
             branch: Option<String>,
+            /// PR title and description. The first line is the title, the rest is the description.
+            #[clap(short = 'm', long = "message", conflicts_with_all = &["file", "default"])]
+            message: Option<String>,
+            /// Read PR title and description from file. The first line is the title, the rest is the description.
+            #[clap(short = 'F', long = "file", value_name = "FILE", conflicts_with_all = &["message", "default"])]
+            file: Option<std::path::PathBuf>,
             /// Force push even if it's not fast-forward (defaults to true).
             #[clap(long, short = 'f', default_value_t = true)]
             with_force: bool,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -733,22 +733,51 @@ async fn match_subcommand(
             match cmd {
                 Some(forge::pr::Subcommands::New {
                     branch,
+                    message,
+                    file,
                     skip_force_push_protection,
                     with_force,
                     run_hooks,
                     default,
-                }) => command::legacy::forge::review::create_pr(
-                    &mut ctx,
-                    branch,
-                    skip_force_push_protection,
-                    with_force,
-                    run_hooks,
-                    default,
-                    out,
-                )
-                .await
-                .context("Failed to create PR for branch.")
-                .emit_metrics(metrics_ctx),
+                }) => {
+                    // Read message content from file or inline
+                    let message_content = match &file {
+                        Some(path) => Some(
+                            std::fs::read_to_string(path)
+                                .with_context(|| format!("Failed to read PR message from file: {}", path.display()))?,
+                        ),
+                        None => message.clone(),
+                    };
+                    // Parse early to fail fast on invalid content
+                    let pr_message = match message_content {
+                        Some(content) => Some(command::legacy::forge::review::parse_pr_message(&content)?),
+                        None => None,
+                    };
+                    // Check for non-interactive environment
+                    if !out.can_prompt() {
+                        if branch.is_none() {
+                            anyhow::bail!("Non-interactive environment detected. Please specify a branch.");
+                        }
+                        if pr_message.is_none() && !default {
+                            anyhow::bail!(
+                                "Non-interactive environment detected. Provide one of: --message (-m), --file (-F), or --default (-t)."
+                            );
+                        }
+                    }
+                    command::legacy::forge::review::create_pr(
+                        &mut ctx,
+                        branch,
+                        skip_force_push_protection,
+                        with_force,
+                        run_hooks,
+                        default,
+                        pr_message,
+                        out,
+                    )
+                    .await
+                    .context("Failed to create PR for branch.")
+                    .emit_metrics(metrics_ctx)
+                }
                 Some(forge::pr::Subcommands::Template { template_path }) => {
                     command::legacy::forge::review::set_review_template(&mut ctx, template_path, out)
                         .context("Failed to set PR template.")
@@ -756,7 +785,7 @@ async fn match_subcommand(
                 }
                 None => {
                     // Default to `pr new` when no subcommand is provided
-                    command::legacy::forge::review::create_pr(&mut ctx, None, false, true, true, false, out)
+                    command::legacy::forge::review::create_pr(&mut ctx, None, false, true, true, false, None, out)
                         .await
                         .context("Failed to create PR for branch.")
                         .emit_metrics(metrics_ctx)


### PR DESCRIPTION
Update PR message docs in skill references
Limit custom PR message to selected branch