### PR TITLE
fix(skill): Update GitHub Copilot skill path to correct location

### DIFF
--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -98,7 +98,7 @@ const SKILL_FORMATS: &[SkillFormat] = &[
     SkillFormat {
         name: "GitHub Copilot",
         description: "GitHub Copilot skill format",
-        path: ".github/copilot/skills/gitbutler",
+        path: ".github/skills/gitbutler",
     },
     SkillFormat {
         name: "Cursor",


### PR DESCRIPTION
https://docs.github.com/en/copilot/concepts/agents/about-agent-skills

Adjust the Copilot SKILL installation path to the correct location according to the official documentation.

`.github/copilot/skills/gitbutler` -> `.github/skills/gitbutler`

<img width="444" height="187" src="https://github.com/user-attachments/assets/22e0a609-b098-4946-947d-004dbcca38ec" />
