### PR TITLE
feat(but): add 'but pick' command for cherry-picking commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "bstr",
  "but-action",
  "but-api",
+ "but-cherry-apply",
  "but-claude",
  "but-core",
  "but-ctx",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -29,7 +29,7 @@ legacy = [
     "dep:but-rules",
     "dep:but-gerrit",
     "dep:but-worktrees",
-    "dep:but-worktrees",
+    "dep:but-cherry-apply",
     "dep:gitbutler-project",
     "dep:gitbutler-commit",
     "dep:gitbutler-stack",
@@ -75,6 +75,7 @@ but-tools = { workspace = true, optional = true }
 but-rules = { workspace = true, optional = true }
 but-gerrit = { workspace = true, optional = true }
 but-worktrees = { workspace = true, optional = true }
+but-cherry-apply = { workspace = true, optional = true }
 
 gitbutler-project = { workspace = true, optional = true }
 gitbutler-commit = { workspace = true, optional = true }

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -5,7 +5,7 @@ Comprehensive reference for all `but` commands.
 ## Contents
 
 - [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
-- [Branching](#branching) - `branch new`, `branch apply/unapply`, `branch delete`
+- [Branching](#branching) - `branch new`, `branch apply/unapply`, `branch delete`, `pick`
 - [Staging](#staging-multiple-staging-areas) - `stage`, `rub`
 - [Committing](#committing) - `commit`, `absorb`
 - [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
@@ -108,6 +108,24 @@ Show commits ahead of base for a branch.
 ```bash
 but branch show <id>
 ```
+
+### `but pick <source> [target]`
+
+Cherry-pick commits from unapplied branches into applied branches.
+
+```bash
+but pick <commit-sha> <branch>       # Pick specific commit into branch
+but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "c5")
+but pick <unapplied-branch>          # Interactive commit selection from branch
+but pick <commit-sha>                # Auto-select target if only one branch
+```
+
+The source can be:
+- A commit SHA (full or short)
+- A CLI ID from `but status`
+- An unapplied branch name (shows interactive commit picker)
+
+If no target is specified and multiple branches exist, prompts for selection interactively.
 
 ## Staging (Multiple Staging Areas)
 

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -52,6 +52,7 @@ pub enum CommandName {
     Merge,
     SkillInstall,
     SkillCheck,
+    Pick,
     #[default]
     Unknown,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -801,6 +801,51 @@ pub enum Subcommands {
         after: bool,
     },
 
+    /// Cherry-pick a commit from an unapplied branch into an applied virtual branch.
+    ///
+    /// This command allows you to pick individual commits from unapplied branches
+    /// and apply them to your current workspace branches.
+    ///
+    /// The source can be:
+    /// - A commit SHA (full or short)
+    /// - A CLI ID (e.g., "c5" from `but status`)
+    /// - An unapplied branch name (shows interactive commit selection)
+    ///
+    /// If no target branch is specified:
+    /// - In interactive mode: prompts you to select a target branch
+    /// - If only one branch exists: automatically uses that branch
+    /// - In non-interactive mode: fails with an error
+    ///
+    /// ## Examples
+    ///
+    /// Pick a specific commit into a branch:
+    ///
+    /// ```text
+    /// but pick abc1234 my-feature
+    /// ```
+    ///
+    /// Pick using a CLI ID:
+    ///
+    /// ```text
+    /// but pick c5 my-feature
+    /// ```
+    ///
+    /// Interactively select commits from an unapplied branch:
+    ///
+    /// ```text
+    /// but pick feature-branch
+    /// ```
+    ///
+    #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
+    Pick {
+        /// The commit SHA, CLI ID, or unapplied branch name to cherry-pick from
+        source: String,
+        /// The target virtual branch to apply the commit(s) to
+        #[clap(value_name = "TARGET_BRANCH")]
+        target_branch: Option<String>,
+    },
+
     /// Stages a file or hunk to a specific branch.
     ///
     /// Wrapper for `but rub <file-or-hunk> <branch>`.

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -14,6 +14,7 @@ pub mod mcp;
 pub mod mcp_internal;
 pub mod merge;
 pub mod oplog;
+pub mod pick;
 pub mod pull;
 pub mod push;
 pub mod refresh;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -947,6 +947,21 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
+        #[cfg(feature = "legacy")]
+        Subcommands::Pick { source, target_branch } => {
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
+            command::legacy::pick::handle(&mut ctx, out, &source, target_branch.as_deref())
+                .context("Failed to pick commit.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
     }
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -173,6 +173,8 @@ impl Subcommands {
             Subcommands::Merge { .. } => Merge,
             #[cfg(feature = "legacy")]
             Subcommands::Move { .. } => Rub,
+            #[cfg(feature = "legacy")]
+            Subcommands::Pick { .. } => Pick,
             Subcommands::Skill(skill::Platform { cmd }) => match cmd {
                 skill::Subcommands::Install { .. } => SkillInstall,
                 skill::Subcommands::Check { .. } => SkillCheck,

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -19,6 +19,8 @@ mod merge;
 mod r#move;
 mod onboarding;
 #[cfg(feature = "legacy")]
+mod pick;
+#[cfg(feature = "legacy")]
 mod reword;
 #[cfg(feature = "legacy")]
 mod rub;

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -1,0 +1,169 @@
+use snapbox::str;
+
+use crate::utils::Sandbox;
+
+/// Get commit SHA from a git reference
+fn get_commit_sha(env: &Sandbox, git_ref: &str) -> String {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(env.projects_root())
+        .arg("rev-parse")
+        .arg(git_ref)
+        .output()
+        .expect("git rev-parse failed");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Check if a branch contains a commit with the given message substring
+fn branch_has_commit_message(env: &Sandbox, branch_name: &str, message_contains: &str) -> bool {
+    let result = env.but("status --json").assert().success();
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+    let status: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    status["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap())
+        .filter(|branch| branch["name"] == branch_name)
+        .flat_map(|branch| branch["commits"].as_array().unwrap())
+        .any(|commit| {
+            commit["message"]
+                .as_str()
+                .map(|m| m.contains(message_contains))
+                .unwrap_or(false)
+        })
+}
+
+// === Success cases ===
+
+#[test]
+fn pick_by_full_sha() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
+    env.but(format!("pick {} applied-branch", sha)).assert().success();
+
+    assert!(branch_has_commit_message(
+        &env,
+        "applied-branch",
+        "first pickable commit"
+    ));
+    Ok(())
+}
+
+#[test]
+fn pick_by_short_sha() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    let short_sha = &get_commit_sha(&env, "refs/gitbutler/pickable-first")[..7];
+    env.but(format!("pick {} applied-branch", short_sha)).assert().success();
+
+    assert!(branch_has_commit_message(
+        &env,
+        "applied-branch",
+        "first pickable commit"
+    ));
+    Ok(())
+}
+
+#[test]
+fn pick_by_branch_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    // When picking by branch name in non-interactive mode, picks the head commit
+    env.but("pick unapplied-branch applied-branch").assert().success();
+
+    assert!(branch_has_commit_message(
+        &env,
+        "applied-branch",
+        "second pickable commit"
+    ));
+    Ok(())
+}
+
+#[test]
+fn pick_auto_selects_single_stack() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
+
+    // No target specified - should auto-select the only stack
+    let result = env.but(format!("pick {}", sha)).assert().success();
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+
+    assert!(stdout.contains("into branch applied-branch"));
+    Ok(())
+}
+
+#[test]
+fn pick_target_is_case_insensitive() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
+    env.but(format!("pick {} APPLIED-BRANCH", sha)).assert().success();
+
+    Ok(())
+}
+
+#[test]
+fn pick_json_output() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    let stack_ids = env.setup_metadata(&["applied-branch"])?;
+
+    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
+    let result = env
+        .but(format!("pick {} applied-branch --json", sha))
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())?;
+
+    assert_eq!(json["picked_commit"], sha);
+    assert_eq!(json["target_branch"], "applied-branch");
+    assert_eq!(json["target_stack_id"], stack_ids[0].to_string());
+    Ok(())
+}
+
+// === Error cases ===
+
+#[test]
+fn pick_invalid_source_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    env.but("pick nonexistent-thing applied-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to pick commit. Source 'nonexistent-thing' is not a valid commit ID, CLI ID, or unapplied branch name.
+Run 'but status' to see available CLI IDs, or 'but branch list' to see branches.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn pick_invalid_target_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied")?;
+    env.setup_metadata(&["applied-branch"])?;
+
+    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
+    env.but(format!("pick {} nonexistent-branch", sha))
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to pick commit. Target branch 'nonexistent-branch' not found among applied stacks.
+Available stacks: applied-branch
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/fixtures/scenario/pick-from-unapplied.sh
+++ b/crates/but/tests/fixtures/scenario/pick-from-unapplied.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Scenario for testing `but pick` command
+# Creates:
+# - One applied stack (applied-branch) with a commit
+# - One unapplied branch (unapplied-branch) with two commits that can be picked
+
+git-init-frozen
+tick
+commit-file M
+setup_target_to_match_main
+
+# Create the applied branch
+git checkout -b applied-branch
+tick
+echo "applied content" > applied.txt
+git add applied.txt
+git commit -m "add applied.txt"
+
+# Create an unapplied branch from main with commits to pick
+git checkout -b unapplied-branch main
+tick
+echo "pick me first" > pickable1.txt
+git add pickable1.txt
+git commit -m "first pickable commit"
+
+tick
+echo "pick me second" > pickable2.txt
+git add pickable2.txt
+git commit -m "second pickable commit"
+
+# Store the commit SHAs for easy access in tests
+git update-ref refs/gitbutler/pickable-head HEAD
+git update-ref refs/gitbutler/pickable-first HEAD~1
+
+# Go back to applied-branch and create workspace
+git checkout applied-branch
+create_workspace_commit_once applied-branch


### PR DESCRIPTION
Implement a new 'but pick' command that allows cherry-picking commits
from unapplied branches into applied virtual branches.

Features:
- Accept commit SHA, CLI ID, or unapplied branch name as source
- Interactive commit selection when source is an unapplied branch
- Interactive target branch selection when multiple stacks exist
- Auto-select single stack when only one exists
- Handle CherryApplyStatus constraints (locked to stack, conflicts)
- Support all output formats (human, shell, JSON)

Usage:
  but pick <commit> [target-branch]    # Pick specific commit
  but pick <unapplied-branch>          # Interactive commit selection

The command integrates with the existing cherry_apply API and follows
the established CLI patterns for interactive selection and output.