### PR TITLE
feat(gitbutler-git): Make askpass-machinery opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,6 +3900,7 @@ dependencies = [
  "console-subscriber",
  "document-features",
  "git2",
+ "gitbutler-git",
  "gitbutler-project",
  "gitbutler-repo-actions",
  "gitbutler-watcher",

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -25,6 +25,7 @@ serde = ["dep:serde"]
 tokio = ["dep:tokio"]
 ## a flag to indicate benchmarks are run
 benches = []
+## a flag to turn on the askpass machinery for Git commands (should be enabled for GUI, disabled for CLI)
 askpass = []
 
 [dependencies]

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -25,6 +25,7 @@ serde = ["dep:serde"]
 tokio = ["dep:tokio"]
 ## a flag to indicate benchmarks are run
 benches = []
+askpass = []
 
 [dependencies]
 tracing.workspace = true

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -38,6 +38,7 @@ but-hunk-assignment.workspace = true
 gitbutler-repo-actions.workspace = true
 gitbutler-watcher.workspace = true
 gitbutler-project.workspace = true
+gitbutler-git = { workspace = true, features = ["askpass"] }
 
 tauri = { version = "^2.9.5", features = ["unstable"] }
 tauri-plugin-single-instance = { version = "2.3.6", features = ["deep-link"] }


### PR DESCRIPTION
Using the askpass machinery for CLI is redundant as the terminal IO can simply be (and is by default) handed over to the child process that requires credentials. So we make it opt-in, s.t. the CLI can be compiled without it, and we can then distribute the CLI as a single, statically linked binary that does not depend on the `gitbutler-git-setsid` and `gitbutler-git-askpass` binaries.

Note to self: I need to double check how Windows uses the CLI, as I recall it doesn't use built-in but.