### PR TITLE
fix(but-github): fetch up to 20 most recently updated PRs

### DIFF
--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -115,7 +115,12 @@ impl GitHubClient {
         let response = self
             .client
             .get(&url)
-            .query(&[("state", "open"), ("sort", "created")])
+            .query(&[
+                ("state", "open"),
+                ("sort", "updated"),
+                ("direction", "desc"),
+                ("per_page", "20"),
+            ])
             .send()
             .await?;
 


### PR DESCRIPTION
The list_open_pulls function was only fetching the first 30 PRs
(GitHub API default) sorted by creation date ascending. This meant
that only the 30 oldest open PRs were cached, causing newer PRs
to not show up in `but status`.

Changes:
- Add per_page=20 to get the 20 most recently updated PRs (faster API calls)
- Change sort from "created" to "updated" for relevance
- Add direction=desc to get most recently updated PRs first

This ensures that the most relevant (recently active) PRs are
always included in the cache, fixing the issue where PR info
and CI status were not showing for newer PRs.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>