### PR TITLE
Use improved `gix-testtools` and finally banish `git2::Repository` based traversals.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -326,7 +326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1735,7 +1735,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2639,7 +2639,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2876,7 +2876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3012,14 +3012,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3507,7 +3506,7 @@ checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
 dependencies = [
  "getset",
  "nom 8.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -3536,7 +3535,7 @@ dependencies = [
  "gix-path 0.10.22",
  "log",
  "shellexpand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3702,7 +3701,7 @@ dependencies = [
  "serde",
  "snapbox",
  "sysinfo",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "windows 0.62.2",
@@ -3803,7 +3802,7 @@ dependencies = [
  "git2",
  "gix",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3840,7 +3839,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.10+spec-1.1.0",
  "tracing",
 ]
@@ -3987,7 +3986,7 @@ name = "gitbutler-url"
 version = "0.0.0"
 dependencies = [
  "bstr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -4047,82 +4046,68 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-actor",
+ "gix-attributes",
  "gix-command",
- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-commitgraph",
  "gix-config",
  "gix-credentials",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-date",
  "gix-diff",
  "gix-dir",
- "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
  "gix-mailmap",
  "gix-merge",
  "gix-negotiate",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-ref",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-revwalk",
+ "gix-sec",
  "gix-shallow",
  "gix-status",
  "gix-submodule",
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-tempfile",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-transport",
- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-traverse",
  "gix-url",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils",
+ "gix-validate 0.11.0",
+ "gix-worktree",
  "gix-worktree-state",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-actor"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "thiserror 2.0.17",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-date",
+ "gix-error",
  "serde",
  "winnow 0.7.14",
 ]
@@ -4130,79 +4115,44 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f868f013fee0ebb5c85fae848c34a0b9ef7438acfbaec0c82a3cdbd5eac730a0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-quote 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "kstring",
- "smallvec",
- "thiserror 2.0.17",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-glob",
+ "gix-path 0.11.0",
+ "gix-quote",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "kstring",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-bitmap"
 version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-chunk"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
+ "gix-quote",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "shell-words",
 ]
@@ -4210,25 +4160,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-chunk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
  "memmap2",
  "serde",
 ]
@@ -4236,18 +4173,18 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
+ "gix-glob",
+ "gix-path 0.11.0",
+ "gix-ref",
+ "gix-sec",
  "memchr",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-bom",
  "winnow 0.7.14",
 ]
@@ -4255,53 +4192,40 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "libc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-credentials"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-date",
+ "gix-path 0.11.0",
  "gix-prompt",
- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-sec",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-url",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-date"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "jiff",
- "smallvec",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-error",
  "itoa",
  "jiff",
  "serde",
@@ -4311,87 +4235,63 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-attributes",
  "gix-command",
  "gix-filter",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
  "gix-pathspec",
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-tempfile",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-traverse",
+ "gix-worktree",
  "imara-diff",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
  "gix-pathspec",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-discover"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ref 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-sec 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-fs",
+ "gix-path 0.11.0",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-error"
 version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dffc9ca4dfa4f519a3d2cf1c038919160544923577ac60f45bcb602a24d82c6"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
 ]
@@ -4399,33 +4299,19 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a407957e21dc5e6c87086e50e5114a2f9240f9cb11699588a6d900d53cb6c70"
-dependencies = [
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "prodash",
- "walkdir",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils",
  "libc",
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
  "zlib-rs",
 ]
@@ -4433,115 +4319,66 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-attributes",
  "gix-command",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-hash",
+ "gix-object",
  "gix-packetline",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
+ "gix-quote",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-fs"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba74fa163d3b2ba821d5cd207d55fe3daac3d1099613a8559c812d2b15b3c39a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-features",
+ "gix-path 0.11.0",
+ "gix-utils",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bitflags 2.10.0",
- "bstr",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
+ "gix-path 0.11.0",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8e11ea6bbd0fd4ab4a1c66812dd3cc25921a41315b120f352997725a4c79d6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "faster-hex",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1-checked",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "faster-hex",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
  "serde",
  "sha1-checked",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-hashtable"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-hash",
  "hashbrown 0.16.1",
  "parking_lot",
 ]
@@ -4549,24 +4386,11 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8953d87c13267e296d547f0fc7eaa8aa8fa5b2a9a34ab1cd5857f25240c7d299"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-glob",
+ "gix-path 0.11.0",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "serde",
  "unicode-bom",
@@ -4575,49 +4399,21 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31c6b3664efe5916c539c50e610f9958f2993faf8e29fa5a40fb80b6ac8486a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-traverse 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.16.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix 1.1.3",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bitflags 2.10.0",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap 0.2.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate 0.11.0",
  "hashbrown 0.16.1",
  "itoa",
  "libc",
@@ -4625,174 +4421,142 @@ dependencies = [
  "rustix 1.1.3",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-lock"
 version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d406220ef9df105645a9ddcaa42e8c882ba920344ace866d0403570aea599"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-lock"
-version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-mailmap"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-actor",
+ "gix-date",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-merge"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-diff",
  "gix-filter",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
+ "gix-quote",
  "gix-revision",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-revwalk",
+ "gix-tempfile",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-worktree",
  "imara-diff",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-negotiate"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-object"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-actor 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "smallvec",
- "thiserror 2.0.17",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path 0.11.0",
+ "gix-utils",
+ "gix-validate 0.11.0",
  "itoa",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "winnow 0.7.14",
 ]
 
 [[package]]
 name = "gix-odb"
 version = "0.75.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "arc-swap",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-pack",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
+ "gix-quote",
  "parking_lot",
  "serde",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pack"
 version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "clru",
- "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path 0.11.0",
+ "gix-tempfile",
  "memmap2",
  "parking_lot",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uluru",
 ]
 
 [[package]]
 name = "gix-packetline"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4804,176 +4568,132 @@ dependencies = [
  "bstr",
  "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-validate 0.10.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-path"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c3cd795cad18c7acbc6bafe34bfb34ac7273ee81133793f9d1516dd9faf922"
-dependencies = [
- "bstr",
- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-validate 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pathspec"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-attributes",
  "gix-config-value",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-glob",
+ "gix-path 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
  "rustix 1.1.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-protocol"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
  "gix-negotiate",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-object",
+ "gix-ref",
  "gix-refspec",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-revwalk",
  "gix-shallow",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-transport",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils",
  "maybe-async",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "winnow 0.7.14",
 ]
 
 [[package]]
 name = "gix-quote"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "thiserror 2.0.17",
+ "gix-utils",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-ref"
 version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-actor 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
- "thiserror 2.0.17",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path 0.11.0",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate 0.11.0",
  "memmap2",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "winnow 0.7.14",
 ]
 
 [[package]]
 name = "gix-refspec"
 version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
  "gix-revision",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-validate 0.11.0",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-revision"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
  "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "serde",
 ]
@@ -4981,53 +4701,25 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
- "gix-commitgraph 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-sec"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beeb3bc63696cf7acb5747a361693ebdbcaf25b5d27d2308f38e9782983e7bce"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bitflags 2.10.0",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -5036,92 +4728,79 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-hash",
+ "gix-lock",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-status"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
  "gix-pathspec",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-submodule"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-tempfile"
 version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d280bba7c547170e42d5228fc6e76c191fb5a7c88808ff61af06460404d1fd91"
-dependencies = [
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "parking_lot",
- "signal-hook 0.4.1",
- "signal-hook-registry",
- "tempfile",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "21.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "dashmap",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
  "libc",
  "parking_lot",
+ "signal-hook 0.4.3",
+ "signal-hook-registry",
  "tempfile",
 ]
 
 [[package]]
 name = "gix-testtools"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a12c424a4be945e77b1381b4ffc1a01f6d0b8901f988991451ac69c4b46f1c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "crc",
  "fastrand",
  "fs_extra",
- "gix-discover 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-worktree 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-discover",
+ "gix-fs",
+ "gix-lock",
+ "gix-tempfile",
+ "gix-worktree",
  "io-close",
  "is_ci",
  "parking_lot",
@@ -5139,7 +4818,7 @@ checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
 [[package]]
 name = "gix-trace"
 version = "0.1.17"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "tracing",
 ]
@@ -5147,81 +4826,54 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "gix-command",
  "gix-credentials",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
  "gix-packetline",
- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote",
+ "gix-sec",
  "gix-url",
  "reqwest 0.13.1",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-traverse"
 version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bitflags 2.10.0",
- "gix-commitgraph 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-revwalk 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bitflags 2.10.0",
- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-url"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.0",
  "percent-encoding",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5235,22 +4887,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
 dependencies = [
  "bstr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
 ]
@@ -5258,54 +4901,36 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-attributes 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ignore 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-index 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
-dependencies = [
- "bstr",
- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
+ "gix-validate 0.11.0",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.25.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a3e7b6eb7330e2d83df492b301ac4975d17c1fd2"
 dependencies = [
  "bstr",
- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path 0.11.0",
+ "gix-worktree",
  "io-close",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5824,12 +5449,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -6140,7 +5765,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6215,7 +5840,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6804,7 +6429,7 @@ dependencies = [
  "once_cell",
  "png 0.17.16",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -7006,7 +6631,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7466,7 +7091,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -7613,7 +7238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7627,7 +7252,7 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8254,8 +7879,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -8277,7 +7902,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8292,9 +7917,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8462,7 +8087,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8771,7 +8396,7 @@ dependencies = [
  "schemars 1.2.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8905,7 +8530,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8984,7 +8609,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9586,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a37d01603c37b5466f808de79f845c7116049b0579adb70a6b7d47c1fa3a952"
+checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -9771,7 +9396,7 @@ dependencies = [
  "cc",
  "hashbrown 0.16.1",
  "js-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
 ]
 
@@ -10095,7 +9720,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tray-icon",
  "url",
@@ -10147,7 +9772,7 @@ dependencies = [
  "sha2",
  "syn 2.0.112",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -10197,7 +9822,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10214,7 +9839,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "windows-registry 0.5.3",
@@ -10235,7 +9860,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -10256,7 +9881,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.10+spec-1.1.0",
  "url",
 ]
@@ -10279,7 +9904,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
  "urlpattern",
@@ -10303,7 +9928,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -10322,7 +9947,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10352,7 +9977,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -10366,7 +9991,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin-deep-link",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
  "zbus 5.12.0",
@@ -10383,7 +10008,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10423,7 +10048,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -10443,7 +10068,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10464,7 +10089,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -10528,7 +10153,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.10+spec-1.1.0",
  "url",
  "urlpattern",
@@ -10554,7 +10179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
 ]
@@ -10569,7 +10194,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10628,11 +10253,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -10648,9 +10273,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11046,7 +10671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -11079,7 +10704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92bdb3c949c9e81b71f78ba782f956b896019d82cc2f31025d21e04adab4d695"
 dependencies = [
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
@@ -11131,7 +10756,7 @@ dependencies = [
  "once_cell",
  "png 0.17.16",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -11158,7 +10783,7 @@ version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs-macros",
 ]
 
@@ -11187,7 +10812,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -11728,7 +11353,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -11761,7 +11386,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12367,7 +11992,7 @@ dependencies = [
  "os_pipe",
  "rustix 0.38.44",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -12415,7 +12040,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,11 +1200,9 @@ dependencies = [
  "but-testsupport",
  "gitbutler-reference",
  "gix",
- "gix-testtools",
  "insta",
  "itertools",
  "petgraph",
- "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,10 +194,10 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
 backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { version = "0.78.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
-] }
+gix = { version = "0.78.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [] }
+gix-testtools = { version = "0.18.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main" }
+
 ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
-gix-testtools = "0.18.0"
 insta = { version = "1.45.1", features = ["json"] }
 git2 = { version = "0.20.3", features = [
     "vendored-openssl",

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -25,9 +25,6 @@ itertools.workspace = true
 [dev-dependencies]
 but-meta = { workspace = true, features = ["legacy"] }
 but-testsupport.workspace = true
-tempfile.workspace = true
 
 gitbutler-reference.workspace = true
-
-gix-testtools.workspace = true
 insta = "1.45.1"

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -3,6 +3,7 @@ use but_meta::{
     VirtualBranchesTomlMetadata,
     virtual_branches_legacy_types::{Stack, StackBranch, Target},
 };
+use but_testsupport::gix_testtools::scripted_fixture_read_only;
 
 pub fn read_only_in_memory_scenario(
     name: &str,
@@ -28,8 +29,7 @@ pub fn in_memory_meta(
 
 /// Provide a scenario but assure the returned repository will write objects to memory, in a subdirectory `dirname`.
 pub fn read_only_in_memory_scenario_named(script_name: &str, dirname: &str) -> anyhow::Result<gix::Repository> {
-    let root =
-        gix_testtools::scripted_fixture_read_only(format!("{script_name}.sh")).map_err(anyhow::Error::from_boxed)?;
+    let root = scripted_fixture_read_only(format!("{script_name}.sh")).map_err(anyhow::Error::from_boxed)?;
     let repo = gix::open_opts(root.join(dirname), gix::open::Options::isolated())?.with_object_memory();
     Ok(repo)
 }

--- a/crates/but-oxidize/src/lib.rs
+++ b/crates/but-oxidize/src/lib.rs
@@ -9,7 +9,7 @@ pub fn gix_time_to_git2(time: gix::date::Time) -> git2::Time {
     git2::Time::new(time.seconds, time.offset / 60)
 }
 
-pub fn git2_to_gix_object_id(id: git2::Oid) -> gix::ObjectId {
+fn git2_to_gix_object_id(id: git2::Oid) -> gix::ObjectId {
     gix::ObjectId::try_from(id.as_bytes()).expect("git2 oid is always valid")
 }
 
@@ -23,7 +23,7 @@ impl OidExt for git2::Oid {
     }
 }
 
-pub fn gix_to_git2_oid(id: impl Into<gix::ObjectId>) -> git2::Oid {
+fn gix_to_git2_oid(id: impl Into<gix::ObjectId>) -> git2::Oid {
     git2::Oid::from_bytes(id.into().as_bytes()).expect("always valid")
 }
 

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -8,7 +8,7 @@ use anyhow::Context as _;
 use bstr::BString;
 use but_core::{TreeChange, UnifiedPatch, ref_metadata::StackId};
 use but_ctx::Context;
-use but_oxidize::{ObjectIdExt, OidExt, git2_to_gix_object_id};
+use but_oxidize::{ObjectIdExt, OidExt};
 use but_workspace::legacy::{CommmitSplitOutcome, ui::StackEntryNoOpt};
 use gitbutler_branch_actions::{BranchManagerExt, update_workspace_commit};
 use gitbutler_oplog::{
@@ -984,7 +984,7 @@ pub fn squash_commits(
     // Update the commit mapping with the new commit id.
     commit_mapping.insert(destination_id.to_gix(), new_commit_id.to_gix());
 
-    Ok(git2_to_gix_object_id(new_commit_id))
+    Ok(new_commit_id.to_gix())
 }
 
 pub struct SplitBranch;

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -5,7 +5,7 @@ use bstr::ByteSlice;
 use but_core::{Reference, RepositoryExt};
 use but_ctx::{Context, access::RepoExclusive};
 use but_meta::VirtualBranchesTomlMetadata;
-use but_oxidize::{ObjectIdExt, OidExt, git2_to_gix_object_id, gix_to_git2_oid};
+use but_oxidize::{ObjectIdExt, OidExt};
 use but_rebase::{RebaseOutput, RebaseStep};
 use but_serde::BStringForFrontend;
 use but_workspace::{legacy::stack_ext::StackDetailsExt, ref_info::Options};
@@ -232,7 +232,7 @@ fn get_stack_status(
     review_map: &HashMap<String, but_forge::ForgeReview>,
     ctx: &Context,
 ) -> Result<StackStatus> {
-    let mut last_head: git2::Oid = gix_to_git2_oid(new_target_commit_id);
+    let mut last_head: git2::Oid = new_target_commit_id.to_git2();
 
     let mut branch_statuses: Vec<NameAndStatus> = vec![];
 
@@ -395,13 +395,7 @@ pub fn upstream_integration_statuses(context: &UpstreamIntegrationContext) -> Re
         .map(|stack| {
             Ok((
                 stack.id,
-                get_stack_status(
-                    &repo_in_memory,
-                    git2_to_gix_object_id(*new_target),
-                    stack.id,
-                    review_map,
-                    context.ctx,
-                )?,
+                get_stack_status(&repo_in_memory, new_target.to_gix(), stack.id, review_map, context.ctx)?,
             ))
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -7,7 +7,7 @@ use but_ctx::{
     Context,
     access::{RepoExclusive, RepoShared},
 };
-use but_oxidize::{ObjectIdExt, OidExt, RepoExt, git2_to_gix_object_id, gix_to_git2_index};
+use but_oxidize::{ObjectIdExt, OidExt, RepoExt, gix_to_git2_index};
 use but_workspace::legacy::stack_ext::StackExt;
 use git2::build::CheckoutBuilder;
 use gitbutler_branch_actions::update_workspace_commit;
@@ -51,9 +51,9 @@ fn get_commit_index(ctx: &Context, commit: &git2::Commit) -> Result<git2::Index>
         let gix_repo = repo.clone().for_tree_diffing()?;
         // Merge without favoring a side this time to get a tree containing the actual conflicts.
         let mut merge_result = gix_repo.merge_trees(
-            git2_to_gix_object_id(base),
-            git2_to_gix_object_id(ours),
-            git2_to_gix_object_id(theirs),
+            base.to_gix(),
+            ours.to_gix(),
+            theirs.to_gix(),
             gix_repo.default_merge_labels(),
             gix_repo.tree_merge_options()?,
         )?;

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -1,7 +1,9 @@
 pub const VAR_NO_CLEANUP: &str = "GITBUTLER_TESTS_NO_CLEANUP";
 
 use but_ctx::Context;
+use but_oxidize::OidExt;
 use but_workspace::{legacy::StacksFilter, ui::StackDetails};
+use gitbutler_stack::StackId;
 use gix::bstr::BStr;
 /// Direct access to lower-level utilities for cases where this is enough.
 ///
@@ -183,7 +185,7 @@ pub fn visualize_gix_tree(tree_id: gix::Id<'_>) -> termtree::Tree<String> {
 /// Visualize a git2 tree, otherwise just like [`visualize_gix_tree()`].
 pub fn visualize_git2_tree(tree_id: git2::Oid, repo: &git2::Repository) -> termtree::Tree<String> {
     let repo = gix::open_opts(repo.path(), gix::open::Options::isolated()).unwrap();
-    visualize_gix_tree(git2_to_gix_object_id(tree_id).attach(&repo))
+    visualize_gix_tree(tree_id.to_gix().attach(&repo))
 }
 
 pub fn stack_details(ctx: &Context) -> Vec<(StackId, StackDetails)> {
@@ -274,8 +276,6 @@ pub mod read_only {
 
 use std::path::{Path, PathBuf};
 
-use but_oxidize::git2_to_gix_object_id;
-use gitbutler_stack::StackId;
 use gix::{bstr::ByteSlice, prelude::ObjectIdExt};
 use once_cell::sync::Lazy;
 

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -1,6 +1,6 @@
 use std::{fs, path, path::PathBuf};
 
-use but_oxidize::{git2_to_gix_object_id, gix_to_git2_oid};
+use but_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_repo::RepositoryExt;
 use tempfile::TempDir;
@@ -226,8 +226,8 @@ impl TestProject {
         let merge_tree = {
             use but_core::RepositoryExt;
             let mut merge_result = gix_repo.merge_commits(
-                git2_to_gix_object_id(master_branch_commit.id()),
-                git2_to_gix_object_id(branch.get().peel_to_commit()?.id()),
+                master_branch_commit.id().to_gix(),
+                branch.get().peel_to_commit()?.id().to_gix(),
                 gix_repo.default_merge_labels(),
                 gix::merge::commit::Options::default(),
             )?;
@@ -236,7 +236,7 @@ impl TestProject {
                 "test-merges should have non-conflicting trees"
             );
             let tree_id = merge_result.tree_merge.tree.write()?;
-            self.remote_repo.find_tree(gix_to_git2_oid(tree_id))?
+            self.remote_repo.find_tree(tree_id.to_git2())?
         };
 
         let repo: &git2::Repository = &self.remote_repo;

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use but_core::{ChangeId, commit::Headers};
-use but_oxidize::git2_to_gix_object_id;
+use but_oxidize::OidExt;
 use gitbutler_repo::RepositoryExt;
 use gix_testtools::bstr::ByteSlice as _;
 use tempfile::{TempDir, tempdir};
@@ -203,7 +203,7 @@ pub fn assert_tree_matches_with_mode(
 ) {
     let gix_repository = gix::open(repository.path()).unwrap();
 
-    let tree = gix_repository.find_tree(git2_to_gix_object_id(tree)).unwrap();
+    let tree = gix_repository.find_tree(tree.to_gix()).unwrap();
 
     for (path, content, entry_attributes) in files {
         let tree_entry = tree.lookup_entry_by_path(path).unwrap().unwrap();


### PR DESCRIPTION
With the recent improvements to `gix`, we can create fixtures with Rust, and are able to do commit-graph traversals correctly with hidden tips.

### Tasks

* [x] upgrade `gix`
* [x] upgrade `gix-testtools` with https://github.com/GitoxideLabs/gitoxide/pull/2413
* [x] ~~use latest `gix-testtools` where we used `tempfile::TempDir` manually before.~~ - just show one example.
     - This will be valuable once more but commands are modernised, but that requires sandbox support and I don't feel it right now.
* [x] Use native `gix` traversals
