### PR TITLE
Respect Gitbutler configuration when checking remotes remotes.

### DIFF
--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -126,21 +126,24 @@ pub fn init_ctx(args: &Args, options: InitCtxOptions, out: &mut OutputChannel) -
             };
 
             // Check project setup, prompt for setup if needed
-            let ctx = Context::new_from_legacy_project(project)?;
-            if let Err(e) = check_project_setup(&ctx) {
-                let message = e.to_string();
-                match prompt_for_setup(out, &message) {
-                    SetupPromptResult::RunSetup => {
-                        // Run setup to fix the project configuration
-                        crate::command::legacy::setup::repo(&args.current_dir, out, false)?;
-                        // Re-find and re-check the project after setup
-                        let _project = LegacyProject::find_by_worktree_dir(workdir).map_err(|_| {
-                            anyhow::anyhow!("Setup completed but project still not found at {}", workdir.display())
-                        })?;
-                        check_project_setup(&ctx)?;
-                    }
-                    SetupPromptResult::Declined => {
-                        anyhow::bail!("Setup required: {}", message);
+            let mut ctx = Context::new_from_legacy_project(project)?;
+            {
+                let guard = ctx.exclusive_worktree_access();
+                if let Err(e) = check_project_setup(&ctx, guard.read_permission()) {
+                    let message = e.to_string();
+                    match prompt_for_setup(out, &message) {
+                        SetupPromptResult::RunSetup => {
+                            // Run setup to fix the project configuration
+                            crate::command::legacy::setup::repo(&args.current_dir, out, false)?;
+                            // Re-find and re-check the project after setup
+                            let _project = LegacyProject::find_by_worktree_dir(workdir).map_err(|_| {
+                                anyhow::anyhow!("Setup completed but project still not found at {}", workdir.display())
+                            })?;
+                            check_project_setup(&ctx, guard.read_permission())?;
+                        }
+                        SetupPromptResult::Declined => {
+                            anyhow::bail!("Setup required: {}", message);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously it wouldn't work if there were more than one remotes, and one wasn't named 'origin'.


The old behaviour:

https://github.com/user-attachments/assets/e87cc166-7759-439c-b1e7-eb058796bec6

With this patch it works as long as GB knows the target branch.
