### PR TITLE
docs: add Skills section to claude.md

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -3,3 +3,7 @@
 When asked about general development workflow, project structure, building, testing, or contributing to GitButler, please read `@.github/copilot-instructions.md` for context.
 
 When working on the `but` CLI (Rust command-line tool in `crates/but`), please read `@crates/but/agents.md` for context on API usage patterns, output formatting, and testing conventions.
+
+## Skills
+
+If you have access to it, load the `gitbutler` skill for any and all version control tasks.


### PR DESCRIPTION
Document that the `gitbutler` skill should be loaded for version
control tasks. This clarifies recommended tooling for assistants and
provides guidance to users with access to that skill when working on
GitButler-related tasks.