### PR TITLE
fix: restore remote tracking branch check in canned_branch_name

### DIFF
--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -14,7 +14,7 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 use gitbutler_reference::{LocalRefname, Refname};
-use gitbutler_stack::{StackId, VirtualBranchesHandle};
+use gitbutler_stack::{Stack, StackId, VirtualBranchesHandle};
 use tracing::instrument;
 
 use crate::json::HexHash;
@@ -593,11 +593,14 @@ pub fn stash_into_branch(
 
 /// Returns a new available branch name based on a simple template - user_initials-branch-count
 /// The main point of this is to be able to provide branch names that are not already taken.
+/// This checks local branches, remote tracking branches, and GitButler patch references.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn canned_branch_name(ctx: &Context) -> Result<String> {
-    let rn = but_core::branch::unique_canned_refname(&*ctx.repo.get()?)?;
-    Ok(rn.shorten().to_string())
+    let repo = ctx.repo.get()?;
+    let base_name = but_core::branch::canned_refname(&repo)?.shorten().to_string();
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    Stack::next_available_name(&repo, &vb_state, base_name, false)
 }
 
 #[but_api]


### PR DESCRIPTION
The canned_branch_name function was changed in 3b84179150 to use
but_core::branch::unique_canned_refname which only checks local
refs. This caused collisions with branches that exist on the remote.

This restores the original behavior by using Stack::next_available_name
which properly checks:
- GitButler patch references
- Local git references  
- Remote tracking branches

Also adds a test to prevent this regression in the future.