### PR TITLE
Fix --ai flag consuming positional arguments

### DIFF
--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -19,12 +19,15 @@ pub struct Platform {
     /// Bypass pre-commit hooks
     #[clap(short = 'n', long = "no-hooks", alias = "no-verify")]
     pub no_hooks: bool,
-    /// Generate commit message using AI with optional user summary
+    /// Generate commit message using AI with optional user summary.
+    /// Use --ai by itself or --ai="your instructions" (equals sign required for value)
     #[clap(
         short = 'i',
         long = "ai",
         conflicts_with = "message",
-        conflicts_with = "message_file"
+        conflicts_with = "message_file",
+        num_args = 0..=1,
+        require_equals = true
     )]
     pub ai: Option<Option<String>>,
     /// Uncommitted file or hunk CLI IDs to include in the commit.

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -747,8 +747,9 @@ pub enum Subcommands {
         /// Provide a new commit message for the resulting commit
         #[clap(long, short = 'm', group = "message_opts")]
         message: Option<String>,
-        /// Generate commit message using AI with optional user summary or instructions
-        #[clap(long, short = 'i', group = "message_opts")]
+        /// Generate commit message using AI with optional user summary or instructions.
+        /// Use --ai by itself or --ai="your instructions" (equals sign required for value)
+        #[clap(long, short = 'i', group = "message_opts", num_args = 0..=1, require_equals = true)]
         ai: Option<Option<String>>,
     },
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -496,9 +496,9 @@ fn commit_ai_conflicts_with_message() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-error: the argument '--ai [<AI>]' cannot be used with '--message <MESSAGE>'
+error: the argument '--ai[=<AI>]' cannot be used with '--message <MESSAGE>'
 
-Usage: but commit --ai [<AI>] [BRANCH]
+Usage: but commit --ai[=<AI>] [BRANCH]
 
 For more information, try '--help'.
 
@@ -519,9 +519,9 @@ fn commit_ai_conflicts_with_message_file() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-error: the argument '--ai [<AI>]' cannot be used with '--message-file <FILE>'
+error: the argument '--ai[=<AI>]' cannot be used with '--message-file <FILE>'
 
-Usage: but commit --ai [<AI>] [BRANCH]
+Usage: but commit --ai[=<AI>] [BRANCH]
 
 For more information, try '--help'.
 

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -193,9 +193,9 @@ fn squash_ai_conflicts_with_message() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-error: the argument '--ai [<AI>]' cannot be used with '--message <MESSAGE>'
+error: the argument '--ai[=<AI>]' cannot be used with '--message <MESSAGE>'
 
-Usage: but squash --ai [<AI>] <COMMITS>...
+Usage: but squash --ai[=<AI>] <COMMITS>...
 
 For more information, try '--help'.
 
@@ -216,9 +216,9 @@ fn squash_ai_conflicts_with_drop_message() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-error: the argument '--ai [<AI>]' cannot be used with '--drop-message'
+error: the argument '--ai[=<AI>]' cannot be used with '--drop-message'
 
-Usage: but squash --ai [<AI>] <COMMITS>...
+Usage: but squash --ai[=<AI>] <COMMITS>...
 
 For more information, try '--help'.
 


### PR DESCRIPTION
## Summary
- Fixed `--ai` flag in squash and commit commands consuming the next positional argument as its value
- Added `require_equals = true` so users must use `--ai="prompt"` syntax when providing a value
- `--ai` alone now works correctly without consuming subsequent arguments
