### PR TITLE
Add -f short flag for --message-file in commit command

### DIFF
--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -4,7 +4,7 @@ pub struct Platform {
     #[clap(short = 'm', long = "message", conflicts_with = "message_file")]
     pub message: Option<String>,
     /// Read commit message from file
-    #[clap(long = "message-file", value_name = "FILE", conflicts_with = "message")]
+    #[clap(short = 'f', long = "message-file", value_name = "FILE", conflicts_with = "message")]
     pub message_file: Option<std::path::PathBuf>,
     /// Branch CLI ID or name to derive the stack to commit to
     pub branch: Option<String>,

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -39,6 +39,34 @@ fn commit_with_message_from_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn commit_with_message_from_file_short_flag() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.setup_metadata(&["A"])?;
+
+    // Create a change in the worktree
+    env.file("new-file.txt", "test content");
+
+    // Create a file with the commit message
+    env.file("commit-msg.txt", "Commit using short flag -f");
+
+    // Commit with -f short flag for --message-file
+    env.but("commit -f commit-msg.txt")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+✓ Created commit [..] on branch A
+
+"#]]);
+
+    // Verify the commit was created with the correct message
+    let log = env.git_log()?;
+    assert!(log.contains("Commit using short flag -f"));
+
+    Ok(())
+}
+
+#[test]
 fn commit_with_message_file_not_found() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
 


### PR DESCRIPTION
This adds the short flag `-f` as an alias for `--message-file` in the commit command, making it easier to read commit messages from files.

## Changes
- Added `short = 'f'` to the message_file argument in commit args
- Added test case `commit_with_message_from_file_short_flag` to verify the new flag works

## Test plan
- [x] Run `cargo test -p but commit_with_message_from_file_short_flag` - passes
- [x] Run `cargo clippy -p but --all-features --tests` - no warnings
- [x] Run `cargo fmt --check -p but` - formatted correctly