### PR TITLE
Move 'but branch unapply' to top-level 'but unapply' command

### DIFF
--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -282,7 +282,7 @@ Branches can be in two states:
 
 ```bash
 but branch apply <id>      # Make branch active
-but branch unapply <id>    # Make branch inactive
+but unapply <id>           # Make branch inactive
 ```
 
 **Use cases:**

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -323,8 +323,8 @@ but status --json
 
 # 2. Conflicts between feature-b and feature-c
 # Unapply them temporarily
-but branch unapply bv
-but branch unapply bw
+but unapply bv
+but unapply bw
 
 # 3. Focus on feature-a
 # (make changes, stage, commit)

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -81,16 +81,25 @@ but branch new feature -a <anchor>  # Stacked branch (dependent work)
 
 Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
 
-### `but branch apply/unapply <id>`
+### `but branch apply <id>`
 
-Control which branches are active in workspace.
+Activate a branch in the workspace.
 
 ```bash
 but branch apply <id>    # Activate branch in workspace
-but branch unapply <id>  # Deactivate branch from workspace
 ```
 
 Applied branches are merged into `gitbutler/workspace` and visible in working directory.
+
+### `but unapply <id>`
+
+Deactivate a branch from the workspace.
+
+```bash
+but unapply <id>         # Deactivate branch from workspace
+```
+
+The identifier can be a CLI ID pointing to a stack or branch, or a branch name. If a branch is specified, the entire stack containing that branch will be unapplied.
 
 ### `but branch delete <id>`
 

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -129,24 +129,4 @@ pub enum Subcommands {
         /// Name of the branch to apply
         branch_name: String,
     },
-
-    /// Unapply a branch from the workspace
-    ///
-    /// If you want to unapply an applied branch from your workspace
-    /// (effectively stashing it) so you can work on other branches,
-    /// you can run `but branch unapply <branch-name>`.
-    ///
-    /// This will remove the changes in that branch from your working
-    /// directory and you can re-apply it later when needed. You will then
-    /// see the branch as unapplied in `but branch list`.
-    ///
-    #[cfg(feature = "legacy")]
-    #[clap(verbatim_doc_comment)]
-    Unapply {
-        /// Name of the branch to unapply
-        branch_name: String,
-        /// Force unapply without confirmation
-        #[clap(long, short = 'f')]
-        force: bool,
-    },
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -885,6 +885,47 @@ pub enum Subcommands {
         target_branch: Option<String>,
     },
 
+    /// Unapply a branch from the workspace.
+    ///
+    /// If you want to unapply an applied branch from your workspace
+    /// (effectively stashing it) so you can work on other branches,
+    /// you can run `but unapply <branch-name>`.
+    ///
+    /// This will remove the changes in that branch from your working
+    /// directory and you can re-apply it later when needed. You will then
+    /// see the branch as unapplied in `but branch list`.
+    ///
+    /// The identifier can be:
+    /// - A CLI ID pointing to a stack or branch (e.g., "bu" from `but status`)
+    /// - A branch name
+    ///
+    /// If a branch name (or an identifier pointing to a branch) is provided,
+    /// the entire stack containing that branch will be unapplied.
+    ///
+    /// ## Examples
+    ///
+    /// Unapply by branch name:
+    ///
+    /// ```text
+    /// but unapply my-feature-branch
+    /// ```
+    ///
+    /// Unapply by CLI ID:
+    ///
+    /// ```text
+    /// but unapply bu
+    /// ```
+    ///
+    #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
+    Unapply {
+        /// CLI ID or name of the branch/stack to unapply
+        identifier: String,
+        /// Force unapply without confirmation
+        #[clap(long, short = 'f')]
+        force: bool,
+    },
+
     /// Stages a file or hunk to a specific branch.
     ///
     /// Wrapper for `but rub <file-or-hunk> <branch>`.

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -25,4 +25,5 @@ pub mod setup;
 pub mod show;
 pub mod status;
 pub mod teardown;
+pub mod unapply;
 pub mod worktree;

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -1,0 +1,176 @@
+//! Implementation of the `but unapply` command.
+
+use anyhow::{Context as _, bail};
+use but_core::ref_metadata::StackId;
+use gitbutler_oplog::{
+    OplogExt,
+    entry::{OperationKind, SnapshotDetails, Trailer},
+};
+
+use crate::{
+    CliId, IdMap,
+    utils::{Confirm, ConfirmDefault, OutputChannel},
+};
+
+/// Handle the unapply command.
+///
+/// The identifier can be:
+/// - A CLI ID pointing to a stack
+/// - A CLI ID pointing to a branch
+/// - A branch name
+///
+/// If a branch is specified, the entire stack containing that branch will be unapplied.
+pub fn handle(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    identifier: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    // Fetch stacks once at the start
+    let stacks = but_api::legacy::workspace::stacks(ctx, Some(but_workspace::legacy::StacksFilter::InWorkspace))?;
+
+    let id_map = IdMap::new_from_context(ctx, None)?;
+    let parsed_ids = id_map.parse_using_context(identifier, ctx)?;
+
+    // Try to find the stack to unapply
+    let (stack_id, branches) = if parsed_ids.is_empty() {
+        // No CLI ID match, try to find by branch name directly
+        find_stack_by_branch_name(&stacks, identifier)?
+    } else if parsed_ids.len() == 1 {
+        match &parsed_ids[0] {
+            CliId::Stack { stack_id, .. } => {
+                // Direct stack ID - get the branches for display
+                get_stack_branches(&stacks, *stack_id, identifier)?
+            }
+            CliId::Branch { name, stack_id, .. } => {
+                // Branch ID - use the associated stack
+                if let Some(stack_id) = stack_id {
+                    get_stack_branches(&stacks, *stack_id, name)?
+                } else {
+                    bail!("Branch '{}' does not have an associated stack", name);
+                }
+            }
+            CliId::Commit { .. } => {
+                bail!("Cannot unapply a commit. Please specify a branch or stack identifier.");
+            }
+            CliId::Uncommitted(_) | CliId::CommittedFile { .. } => {
+                bail!("Cannot unapply a file. Please specify a branch or stack identifier.");
+            }
+            CliId::Unassigned { .. } => {
+                bail!("Cannot unapply the unassigned area. Please specify a branch or stack identifier.");
+            }
+        }
+    } else {
+        bail!(
+            "Ambiguous identifier '{}', matches {} items. Please be more specific.",
+            identifier,
+            parsed_ids.len()
+        );
+    };
+
+    confirm_and_unapply_stack(ctx, stack_id, &branches, force, out)
+}
+
+/// Get branches for a stack by ID, validating the stack exists.
+fn get_stack_branches(
+    stacks: &[but_workspace::legacy::ui::StackEntry],
+    stack_id: StackId,
+    identifier: &str,
+) -> anyhow::Result<(StackId, Vec<String>)> {
+    let stack = stacks
+        .iter()
+        .find(|s| s.id == Some(stack_id))
+        .with_context(|| format!("Stack for '{}' not found in workspace", identifier))?;
+
+    let branches: Vec<String> = stack.heads.iter().map(|h| h.name.to_string()).collect();
+
+    if branches.is_empty() {
+        bail!("Stack for '{}' has no branches", identifier);
+    }
+
+    Ok((stack_id, branches))
+}
+
+/// Find a stack by branch name and return the stack ID and branches.
+fn find_stack_by_branch_name(
+    stacks: &[but_workspace::legacy::ui::StackEntry],
+    branch_name: &str,
+) -> anyhow::Result<(StackId, Vec<String>)> {
+    for stack_entry in stacks {
+        if stack_entry.heads.iter().any(|b| b.name == branch_name)
+            && let Some(sid) = stack_entry.id
+        {
+            let branches: Vec<String> = stack_entry.heads.iter().map(|h| h.name.to_string()).collect();
+            return Ok((sid, branches));
+        }
+    }
+
+    bail!("Branch '{}' not found in any applied stack", branch_name);
+}
+
+/// Create a snapshot in the oplog before performing an unapply operation
+fn create_snapshot(ctx: &mut but_ctx::Context, branches: &[String]) {
+    let mut guard = ctx.exclusive_worktree_access();
+
+    // Create trailers with branch names
+    let trailers: Vec<Trailer> = branches
+        .iter()
+        .map(|name| Trailer {
+            key: "branch".to_string(),
+            value: name.clone(),
+        })
+        .collect();
+
+    let details = SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(trailers);
+    let _snapshot = ctx.create_snapshot(details, guard.write_permission()).ok();
+}
+
+/// Confirm with the user and unapply the stack.
+fn confirm_and_unapply_stack(
+    ctx: &mut but_ctx::Context,
+    sid: StackId,
+    branches: &[String],
+    force: bool,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let branches_display = branches.join(", ");
+
+    if !force
+        && let Some(mut inout) = out.prepare_for_terminal_input()
+        && inout.confirm(
+            format!("Are you sure you want to unapply stack with branches '{branches_display}'?"),
+            ConfirmDefault::No,
+        )? == Confirm::No
+    {
+        bail!("Aborted unapply operation.");
+    }
+
+    // Create snapshot before destructive operation
+    create_snapshot(ctx, branches);
+
+    but_api::legacy::virtual_branches::unapply_stack(ctx, sid)?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "Unapplied stack with branches '{}' from workspace",
+            branches_display
+        )?;
+    }
+
+    if let Some(out) = out.for_shell() {
+        // Shell output: one branch per line
+        for branch in branches {
+            writeln!(out, "{}", branch)?;
+        }
+    }
+
+    if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "unapplied": true,
+            "branches": branches
+        }))?;
+    }
+
+    Ok(())
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -962,6 +962,21 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
+        #[cfg(feature = "legacy")]
+        Subcommands::Unapply { identifier, force } => {
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
+            command::legacy::unapply::handle(&mut ctx, out, &identifier, force)
+                .context("Failed to unapply branch.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
     }
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -78,12 +78,12 @@ impl Subcommands {
                 Some(branch::Subcommands::New { .. }) => BranchNew,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Delete { .. }) => BranchDelete,
-                #[cfg(feature = "legacy")]
-                Some(branch::Subcommands::Unapply { .. }) => BranchUnapply,
                 Some(branch::Subcommands::Apply { .. }) => BranchApply,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Show { .. }) => BranchShow,
             },
+            #[cfg(feature = "legacy")]
+            Subcommands::Unapply { .. } => BranchUnapply,
             #[cfg(feature = "legacy")]
             Subcommands::Worktree(worktree::Platform { cmd: _ }) => Worktree,
             #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -29,8 +29,8 @@ fn single_branch() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
 
-    // Now unapply the branch
-    env.but("branch unapply")
+    // Now unapply the branch using the new `but unapply` command
+    env.but("unapply")
         .arg(branch_name)
         .assert()
         .success()
@@ -41,7 +41,7 @@ Unapplied stack with branches 'feature-branch' from workspace
 "#]]);
 
     // Verify the branch is removed from workspace
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log()?, @r"
     * 9f9d5a6 (feature-branch) Add feature
     | * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
@@ -69,16 +69,15 @@ fn unapply_with_json_output() -> anyhow::Result<()> {
     // Apply the branch first
     env.but("branch apply").arg(branch_name).assert().success();
 
-    // Unapply with JSON output
-    env.but("--json branch unapply")
+    // Unapply with JSON output using the new `but unapply` command
+    env.but("--json unapply")
         .arg(branch_name)
         .allow_json()
         .assert()
         .success()
-        .stdout_eq(str![""])
         .stderr_eq(str![]);
 
-    insta::assert_snapshot!(env.git_log()?, @"
+    insta::assert_snapshot!(env.git_log()?, @r"
     * 9f9d5a6 (feature-branch) Add feature
     | * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 9477ae7 (A) add A
@@ -100,18 +99,18 @@ fn unapply_idempotent() -> anyhow::Result<()> {
     // Apply then unapply
     env.but("branch apply").arg(branch_name).assert().success();
 
-    env.but("branch unapply").arg(branch_name).assert().success();
+    env.but("unapply").arg(branch_name).assert().success();
 
-    // Unapplying again should be idempotent (success, no-op)
-    env.but("branch unapply")
+    // Unapplying again should fail because the branch is not in any applied stack
+    env.but("unapply")
         .arg(branch_name)
         .assert()
-        .success()
-        .stdout_eq(str![[r#"
-Branch 'feature-branch' not found in any stack
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
 
 "#]])
-        .stderr_eq(str![]);
+        .stdout_eq(str![]);
 
     Ok(())
 }
@@ -127,14 +126,18 @@ fn unapply_shell_format() -> anyhow::Result<()> {
     // Apply the branch
     env.but("branch apply").arg(branch_name).assert().success();
 
-    // Unapply with shell format
-    env.but("-f shell branch unapply")
+    // Unapply with shell format using the new `but unapply` command
+    // Shell format outputs one branch name per line
+    env.but("-f shell unapply")
         .arg(branch_name)
         .allow_json()
         .assert()
         .success()
         .stderr_eq(str![])
-        .stdout_eq(str![""]);
+        .stdout_eq(str![[r#"
+feature-branch
+
+"#]]);
 
     Ok(())
 }
@@ -143,15 +146,15 @@ fn unapply_shell_format() -> anyhow::Result<()> {
 fn unapply_nonexistent_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
-    // Try to unapply a branch that doesn't exist
-    env.but("branch unapply nonexistent-branch")
+    // Try to unapply a branch that doesn't exist - should fail with the new command
+    env.but("unapply nonexistent-branch")
         .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-Branch 'nonexistent-branch' not found in any stack
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to unapply branch. Branch 'nonexistent-branch' not found in any applied stack
 
-"#]]);
+"#]])
+        .stdout_eq(str![]);
 
     Ok(())
 }
@@ -160,13 +163,11 @@ Branch 'nonexistent-branch' not found in any stack
 fn unapply_nonexistent_branch_with_json() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
-    // Try to unapply a branch that doesn't exist with JSON output
-    env.but("--json branch unapply nonexistent-branch")
+    // Try to unapply a branch that doesn't exist with JSON output - should fail
+    env.but("--json unapply nonexistent-branch")
         .allow_json()
         .assert()
-        .success()
-        .stdout_eq(str![""])
-        .stderr_eq(str![""]);
+        .failure();
 
     Ok(())
 }
@@ -179,16 +180,16 @@ fn unapply_branch_not_in_workspace() -> anyhow::Result<()> {
     let branch_name = "feature-branch";
     create_local_branch_with_commit(&env, branch_name);
 
-    // Try to unapply a branch that exists but wasn't applied
-    env.but("branch unapply")
+    // Try to unapply a branch that exists but wasn't applied - should fail
+    env.but("unapply")
         .arg(branch_name)
         .assert()
-        .success()
-        .stdout_eq(str![[r#"
-Branch 'feature-branch' not found in any stack
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
 
 "#]])
-        .stderr_eq(str![]);
+        .stdout_eq(str![]);
 
     Ok(())
 }
@@ -226,25 +227,157 @@ fn unapply_remote_tracking_branch() -> anyhow::Result<()> {
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
 
-    // Unapply the remote branch
-    env.but("branch unapply origin/remote-feature")
+    // Unapply the remote branch by its local name (remote-feature, not origin/remote-feature)
+    env.but("unapply remote-feature")
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Branch 'origin/remote-feature' not found in any stack
+Unapplied stack with branches 'remote-feature' from workspace
 
 "#]]);
 
     // Verify it was removed from workspace
     insta::assert_snapshot!(env.git_log()?, @r"
-    *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    |\  
+    * 4ee40a2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9477ae7 (A) add A
     | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
-    * | 9477ae7 (A) add A
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
+
+    Ok(())
+}
+
+#[test]
+fn unapply_using_cli_branch_id() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let branch_name = "feature-branch";
+    utils::create_local_branch_with_commit(&env, branch_name);
+
+    // Apply the branch
+    env.but("branch apply").arg(branch_name).assert().success();
+
+    // Get the CLI ID from status --json
+    let status_output = env.but("status --json").allow_json().output()?;
+    let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+
+    // Find the branch's CLI ID - JSON uses camelCase and "branches" not "heads"
+    let stacks = status["stacks"].as_array().expect("stacks should be an array");
+    let mut cli_id = None;
+    for stack in stacks {
+        if let Some(branches) = stack["branches"].as_array() {
+            for branch in branches {
+                if branch["name"].as_str() == Some(branch_name) {
+                    cli_id = Some(branch["cliId"].as_str().unwrap().to_string());
+                    break;
+                }
+            }
+        }
+    }
+    let cli_id = cli_id.expect("should find the branch CLI ID");
+
+    // Unapply using the CLI ID
+    env.but("unapply")
+        .arg(&cli_id)
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Unapplied stack with branches 'feature-branch' from workspace
+
+"#]]);
+
+    // Verify the branch is no longer in workspace
+    let status_output = env.but("status --json").allow_json().output()?;
+    let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+    let stacks = status["stacks"].as_array().expect("stacks should be an array");
+
+    // The feature-branch should no longer be in any stack
+    for stack in stacks {
+        if let Some(branches) = stack["branches"].as_array() {
+            for branch in branches {
+                assert_ne!(
+                    branch["name"].as_str(),
+                    Some(branch_name),
+                    "branch should not be in workspace"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn unapply_using_cli_stack_id() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let branch_name = "feature-branch";
+    utils::create_local_branch_with_commit(&env, branch_name);
+
+    // Apply the branch
+    env.but("branch apply").arg(branch_name).assert().success();
+
+    // Get the stack CLI ID from status --json
+    let status_output = env.but("status --json").allow_json().output()?;
+    let status: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+
+    // Find the stack's CLI ID for the feature-branch - JSON uses camelCase and "branches" not "heads"
+    let stacks = status["stacks"].as_array().expect("stacks should be an array");
+    let mut stack_cli_id = None;
+    for stack in stacks {
+        if let Some(branches) = stack["branches"].as_array() {
+            for branch in branches {
+                if branch["name"].as_str() == Some(branch_name) {
+                    stack_cli_id = Some(stack["cliId"].as_str().unwrap().to_string());
+                    break;
+                }
+            }
+        }
+    }
+    let stack_cli_id = stack_cli_id.expect("should find the stack CLI ID");
+
+    // Unapply using the stack CLI ID
+    env.but("unapply")
+        .arg(&stack_cli_id)
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Unapplied stack with branches 'feature-branch' from workspace
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn unapply_json_output_validation() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    let branch_name = "feature-branch";
+    utils::create_local_branch_with_commit(&env, branch_name);
+
+    // Apply the branch
+    env.but("branch apply").arg(branch_name).assert().success();
+
+    // Unapply with JSON output and validate structure
+    let output = env.but("--json unapply").arg(branch_name).allow_json().output()?;
+
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    // Validate JSON structure
+    assert_eq!(json["unapplied"], serde_json::json!(true));
+    let branches = json["branches"].as_array().expect("branches should be an array");
+    assert_eq!(branches.len(), 1);
+    assert_eq!(branches[0], serde_json::json!("feature-branch"));
 
     Ok(())
 }


### PR DESCRIPTION
Restructure the unapply command from a branch subcommand to a top-level
command for easier access.

Changes:
- Add new Unapply variant to args/mod.rs as top-level subcommand
- Remove Unapply from args/branch.rs
- Create new command/legacy/unapply.rs with implementation that:
  - Accepts CLI ID (stack or branch) or branch name
  - Discovers stack from branch and unapplies entire stack
  - Supports --force and JSON output
- Update lib.rs to wire up the new command
- Update metrics.rs to map to BranchUnapply metric
- Update tests to use new 'but unapply' syntax
- Update skill documentation files
Add explicit error messages for invalid unapply targets and apply rustfmt

- Add clear error messages when user tries to unapply a commit, file, or
  unassigned area instead of a branch/stack
- Apply rustfmt formatting fixes