### PR TITLE
Move 'but branch apply' to top-level 'but apply' command

### DIFF
--- a/crates/but/skill/TESTING.md
+++ b/crates/but/skill/TESTING.md
@@ -159,7 +159,7 @@ Verify Claude avoids problematic git commands.
 
 - Explains GitButler workspace model
 - Does NOT use `git checkout`
-- Uses `but branch apply/unapply` if needed
+- Uses `but apply`/`but unapply` if needed
 
 ### 6. Edge Case Tests
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -39,7 +39,7 @@ workspace (gitbutler/workspace)
 4. **Applied vs Unapplied**: Control which branches are active:
    - Applied branches: In your working directory
    - Unapplied branches: Exist but not active
-   - Use `but branch apply/unapply` to control
+   - Use `but apply`/`but unapply` to control
 
 ## CLI IDs: Short Identifiers
 
@@ -281,7 +281,7 @@ Branches can be in two states:
 ### Controlling State
 
 ```bash
-but branch apply <id>      # Make branch active
+but apply <id>             # Make branch active
 but unapply <id>           # Make branch inactive
 ```
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -335,8 +335,8 @@ but commit bu --only -m "Complete feature-a"
 but pr new bu
 
 # 5. Reapply other branches
-but branch apply bv
-but branch apply bw
+but apply bv
+but apply bw
 
 # 6. Deal with their conflicts now
 but resolve ...

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -5,7 +5,7 @@ Comprehensive reference for all `but` commands.
 ## Contents
 
 - [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
-- [Branching](#branching) - `branch new`, `branch apply/unapply`, `branch delete`, `pick`
+- [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
 - [Staging](#staging-multiple-staging-areas) - `stage`, `rub`
 - [Committing](#committing) - `commit`, `absorb`
 - [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
@@ -81,12 +81,12 @@ but branch new feature -a <anchor>  # Stacked branch (dependent work)
 
 Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
 
-### `but branch apply <id>`
+### `but apply <id>`
 
 Activate a branch in the workspace.
 
 ```bash
-but branch apply <id>    # Activate branch in workspace
+but apply <id>           # Activate branch in workspace
 ```
 
 Applied branches are merged into `gitbutler/workspace` and visible in working directory.

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -116,7 +116,7 @@ pub enum Subcommands {
         #[clap(long)]
         check: bool,
     },
-    /// Apply a branch to the workspace
+    /// Apply a branch to the workspace (non-legacy path)
     ///
     /// If you want to apply an unapplied branch to your workspace so you
     /// can work on it, you can run `but branch apply <branch-name>`.
@@ -124,6 +124,7 @@ pub enum Subcommands {
     /// This will apply the changes in that branch into your working directory
     /// as a parallel applied branch.
     ///
+    #[cfg(not(feature = "legacy"))]
     #[clap(verbatim_doc_comment)]
     Apply {
         /// Name of the branch to apply

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -304,10 +304,11 @@ pub enum Subcommands {
 
     /// Commands for managing branches.
     ///
-    /// This includes creating, deleting, listing, showing details about, and
-    /// applying and unapplying branches.
+    /// This includes creating, deleting, listing, and showing details about branches.
     ///
     /// By default without a subcommand, it will list the branches.
+    ///
+    /// To apply or unapply branches, use `but apply` and `but unapply`.
     ///
     #[clap(verbatim_doc_comment)]
     Branch(branch::Platform),
@@ -924,6 +925,29 @@ pub enum Subcommands {
         /// Force unapply without confirmation
         #[clap(long, short = 'f')]
         force: bool,
+    },
+
+    /// Apply a branch to the workspace.
+    ///
+    /// If you want to apply an unapplied branch to your workspace so you
+    /// can work on it, you can run `but apply <branch-name>`.
+    ///
+    /// This will apply the changes in that branch into your working directory
+    /// as a parallel applied branch.
+    ///
+    /// ## Examples
+    ///
+    /// Apply by branch name:
+    ///
+    /// ```text
+    /// but apply my-feature-branch
+    /// ```
+    ///
+    #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
+    Apply {
+        /// Name of the branch to apply
+        branch_name: String,
     },
 
     /// Stages a file or hunk to a specific branch.

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::{Confirm, ConfirmDefault, OutputChannel},
 };
 
-mod apply;
+pub mod apply;
 mod json;
 mod list;
 mod show;
@@ -163,7 +163,6 @@ pub fn handle(cmd: Option<Subcommands>, ctx: &mut but_ctx::Context, out: &mut Ou
             }
             Ok(())
         }
-        Some(Subcommands::Apply { branch_name }) => apply::apply(ctx, &branch_name, out),
     }
 }
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -977,6 +977,21 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
+        #[cfg(feature = "legacy")]
+        Subcommands::Apply { branch_name } => {
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
+            command::legacy::branch::apply::apply(&mut ctx, &branch_name, out)
+                .context("Failed to apply branch.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
     }
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -78,12 +78,15 @@ impl Subcommands {
                 Some(branch::Subcommands::New { .. }) => BranchNew,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Delete { .. }) => BranchDelete,
-                Some(branch::Subcommands::Apply { .. }) => BranchApply,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Show { .. }) => BranchShow,
+                #[cfg(not(feature = "legacy"))]
+                Some(branch::Subcommands::Apply { .. }) => BranchApply,
             },
             #[cfg(feature = "legacy")]
             Subcommands::Unapply { .. } => BranchUnapply,
+            #[cfg(feature = "legacy")]
+            Subcommands::Apply { .. } => BranchApply,
             #[cfg(feature = "legacy")]
             Subcommands::Worktree(worktree::Platform { cmd: _ }) => Worktree,
             #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -15,7 +15,7 @@ fn single_branch() -> anyhow::Result<()> {
     * e31e6ca (origin/main, origin/HEAD) add init
     ");
 
-    env.but("branch apply A")
+    env.but("apply A")
         .assert()
         .success()
         .stderr_eq(str![])
@@ -46,7 +46,7 @@ Applied branch 'A' to workspace
     * e31e6ca (origin/main, origin/HEAD) add init
     ");
 
-    env.but("branch apply origin/B")
+    env.but("apply origin/B")
         .assert()
         .success()
         .stdout_eq(str![[r#"
@@ -100,7 +100,7 @@ fn local_branch() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, branch_name);
 
     // Apply the local branch
-    env.but("branch apply")
+    env.but("apply")
         .arg(branch_name)
         .assert()
         .success()
@@ -110,7 +110,7 @@ Applied branch 'feature-branch' to workspace
 
 "#]]);
     // It's idempotent and can produce a shell value.
-    env.but("-f shell branch apply feature-branch")
+    env.but("-f shell apply feature-branch")
         .allow_json()
         .assert()
         .success()
@@ -147,7 +147,7 @@ fn local_branch_with_json_output() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, "feature-branch");
 
     // Apply with JSON output
-    env.but("--json branch apply feature-branch")
+    env.but("--json apply feature-branch")
         .allow_json()
         .assert()
         .success()
@@ -224,7 +224,7 @@ fn remote_branch_creates_local_tracking_branch_automatically() -> anyhow::Result
     );
 
     // Apply the remote branch, by its shortest name only.
-    env.but("branch apply origin/remote-feature")
+    env.but("apply origin/remote-feature")
         .assert()
         .success()
         .stderr_eq(str![])
@@ -251,11 +251,11 @@ fn nonexistent_branch() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
     // Try to apply a branch that doesn't exist
-    env.but("branch apply nonexistent-branch")
+    env.but("apply nonexistent-branch")
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: The reference 'nonexistent-branch' did not exist
+Failed to apply branch. The reference 'nonexistent-branch' did not exist
 
 "#]])
         .stdout_eq(str![""]);
@@ -268,12 +268,12 @@ fn nonexistent_branch_with_json() -> anyhow::Result<()> {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
 
     // Try to apply a branch that doesn't exist with JSON output
-    env.but("--json branch apply nonexistent-branch")
+    env.but("--json apply nonexistent-branch")
         .allow_json()
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: The reference 'nonexistent-branch' did not exist
+Failed to apply branch. The reference 'nonexistent-branch' did not exist
 
 "#]]);
     // Note: Currently the apply function doesn't output anything with JSON when branch not found
@@ -299,7 +299,7 @@ fn multiple_branches_sequentially() -> anyhow::Result<()> {
     create_local_branch_with_commit_with_message(&env, f2, "Add feature 2");
 
     // Apply both branches
-    env.but("branch apply")
+    env.but("apply")
         .arg(f1)
         .assert()
         .success()
@@ -309,7 +309,7 @@ Applied branch 'feature-1' to workspace
 "#]])
         .stderr_eq(str![]);
 
-    env.but("branch apply")
+    env.but("apply")
         .arg(f2)
         .assert()
         .success()

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -18,7 +18,7 @@ fn single_branch() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, branch_name);
 
     // First apply the branch
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     insta::assert_snapshot!(env.git_log()?, @r"
     *   9d5d9e5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
@@ -67,7 +67,7 @@ fn unapply_with_json_output() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, branch_name);
 
     // Apply the branch first
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     // Unapply with JSON output using the new `but unapply` command
     env.but("--json unapply")
@@ -97,7 +97,7 @@ fn unapply_idempotent() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, branch_name);
 
     // Apply then unapply
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     env.but("unapply").arg(branch_name).assert().success();
 
@@ -124,7 +124,7 @@ fn unapply_shell_format() -> anyhow::Result<()> {
     create_local_branch_with_commit(&env, branch_name);
 
     // Apply the branch
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     // Unapply with shell format using the new `but unapply` command
     // Shell format outputs one branch name per line
@@ -216,7 +216,7 @@ fn unapply_remote_tracking_branch() -> anyhow::Result<()> {
     );
 
     // Apply the remote branch
-    env.but("branch apply origin/remote-feature").assert().success();
+    env.but("apply origin/remote-feature").assert().success();
 
     insta::assert_snapshot!(env.git_log()?, @r"
     *   1bb7daf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
@@ -258,7 +258,7 @@ fn unapply_using_cli_branch_id() -> anyhow::Result<()> {
     utils::create_local_branch_with_commit(&env, branch_name);
 
     // Apply the branch
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     // Get the CLI ID from status --json
     let status_output = env.but("status --json").allow_json().output()?;
@@ -320,7 +320,7 @@ fn unapply_using_cli_stack_id() -> anyhow::Result<()> {
     utils::create_local_branch_with_commit(&env, branch_name);
 
     // Apply the branch
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     // Get the stack CLI ID from status --json
     let status_output = env.but("status --json").allow_json().output()?;
@@ -364,7 +364,7 @@ fn unapply_json_output_validation() -> anyhow::Result<()> {
     utils::create_local_branch_with_commit(&env, branch_name);
 
     // Apply the branch
-    env.but("branch apply").arg(branch_name).assert().success();
+    env.but("apply").arg(branch_name).assert().success();
 
     // Unapply with JSON output and validate structure
     let output = env.but("--json unapply").arg(branch_name).allow_json().output()?;


### PR DESCRIPTION
## Summary

- Restructure `but branch apply` to become a top-level `but apply` command
- Follows the same pattern as the recent `but unapply` migration
- Update all tests to use the new command syntax
- Update documentation to direct users to the new command location

## Changes

- **args/mod.rs**: Add new top-level `Apply` subcommand with documentation
- **args/branch.rs**: Remove `Apply` variant from branch subcommands
- **lib.rs**: Add handler for the new `Apply` command
- **command/legacy/branch/mod.rs**: Make `apply` module public, remove old handler
- **utils/metrics.rs**: Update metrics mapping for top-level `Apply`
- **tests**: Update all test invocations and error message expectations

## Usage

```bash
# Old (no longer works)
but branch apply my-feature-branch

# New
but apply my-feature-branch
```