### PR TITLE
Fix cmd/ctrl + a

### DIFF
--- a/apps/desktop/src/lib/selection/fileSelectionUtils.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionUtils.ts
@@ -6,7 +6,6 @@
  */
 import { type SelectedFile, type SelectionId } from '$lib/selection/key';
 import { getSelectionDirection } from '$lib/utils/getSelectionDirection';
-import { KeyName } from '@gitbutler/ui/utils/hotkeys';
 import { get } from 'svelte/store';
 import type { TreeChange } from '$lib/hunks/change';
 import type { FileSelectionManager } from '$lib/selection/fileSelectionManager.svelte';
@@ -133,7 +132,7 @@ export function updateSelection({
 			}
 			break;
 		case 'k':
-		case KeyName.Up:
+		case 'ArrowUp':
 			preventDefault();
 			if (shiftKey && allowMultiple) {
 				// Handle case if only one file is selected
@@ -158,7 +157,7 @@ export function updateSelection({
 			break;
 
 		case 'j':
-		case KeyName.Down:
+		case 'ArrowDown':
 			preventDefault();
 			if (shiftKey && allowMultiple) {
 				// Handle case if only one file is selected
@@ -182,7 +181,7 @@ export function updateSelection({
 				}
 			}
 			break;
-		case KeyName.Escape:
+		case 'Escape':
 			preventDefault();
 			fileIdSelection.clearPreview(selectionId);
 			targetElement.blur();

--- a/packages/ui/src/lib/components/select/SearchItem.svelte
+++ b/packages/ui/src/lib/components/select/SearchItem.svelte
@@ -33,9 +33,6 @@
 			// but don't stop propagation so parent can handle navigation
 			return;
 		}
-
-		// Stop other keys from bubbling up to prevent interference
-		event.stopPropagation();
 	}
 </script>
 

--- a/packages/ui/src/lib/components/select/Select.svelte
+++ b/packages/ui/src/lib/components/select/Select.svelte
@@ -47,7 +47,6 @@
 	import ScrollableContainer from '$components/scroll/ScrollableContainer.svelte';
 	import OptionsGroup from '$components/select/OptionsGroup.svelte';
 	import SearchItem from '$components/select/SearchItem.svelte';
-	import { KeyName } from '$lib/utils/hotkeys';
 	import { portal } from '$lib/utils/portal';
 	import { pxToRem } from '$lib/utils/pxToRem';
 	import { resizeObserver } from '$lib/utils/resizeObserver';
@@ -261,39 +260,16 @@
 
 	function handleKeyDown(e: KeyboardEvent) {
 		const { key } = e;
+		if (!['Enter', 'Escape', 'ArrowUp', 'ArrowDown'].includes(key)) return;
 
-		if (!listOpen) {
-			// When list is closed, handle keys to open it
-			if (key === KeyName.Enter || key === KeyName.Down || key === KeyName.Up) {
-				e.preventDefault();
-				e.stopPropagation();
-				openList();
-				if (key === KeyName.Up) {
-					highlightedIndex = selectableOptions.length - 1;
-				} else if (key === KeyName.Down) {
-					highlightedIndex = 0;
-				}
-			}
-			return;
-		}
-
-		// When list is open, handle navigation
+		e.stopPropagation();
 		e.preventDefault();
 
-		switch (key) {
-			case KeyName.Escape:
-				closeList();
-				break;
-			case KeyName.Up:
-				handleArrowUp();
-				break;
-			case KeyName.Down:
-				handleArrowDown();
-				break;
-			case KeyName.Enter:
-				handleEnter(e);
-				break;
-		}
+		if (key === 'Escape') closeList();
+		else if (!listOpen) openList();
+		else if (key === 'ArrowUp') handleArrowUp();
+		else if (key === 'ArrowDown') handleArrowDown();
+		else if (key === 'Enter') handleEnter(e);
 	}
 
 	function getTopStyle() {

--- a/packages/ui/src/lib/utils/hotkeys.ts
+++ b/packages/ui/src/lib/utils/hotkeys.ts
@@ -15,18 +15,3 @@ export function keysStringToArr(keys: string): string[] {
 		return key;
 	});
 }
-
-export enum KeyName {
-	Space = ' ',
-	Meta = 'Meta',
-	Alt = 'Alt',
-	Ctrl = 'Ctrl',
-	Enter = 'Enter',
-	Escape = 'Escape',
-	Tab = 'Tab',
-	Up = 'ArrowUp',
-	Down = 'ArrowDown',
-	Left = 'ArrowLeft',
-	Right = 'ArrowRight',
-	Delete = 'Backspace'
-}


### PR DESCRIPTION
Refactor handleKeyDown to centralize key checks and reduce nesting. Also
fixes an oversight where `stopPropagation()` prevented cmd/ctrl + a from
working as expected.

Removes keyboard key name enum since it's not widely used, so it's
better to be consistent.