### PR TITLE
Turn exception into warning in virtual list

### DIFF
--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -312,7 +312,11 @@
 			await tick(); // Wait for element to be added
 			const element = visibleRowElements?.[i - startingAt];
 			if (!element) {
-				throw new Error('Expected to find element');
+				// Most likely cause for this is that something else made `visibleRange.end = 0`
+				// during the tick(). This needs debugging, but is not severe enough to warrant
+				// immediate attention.
+				console.warn('Invariant violation - root cause not yet determined.');
+				return;
 			}
 			heightMap[i] = element.clientHeight;
 			if (calculateHeightSum(startingAt, visibleRange.end) > viewportHeight + renderDistance) {
@@ -329,7 +333,8 @@
 			await tick(); // Wait for element to be added
 			const element = visibleRowElements?.[0];
 			if (!element) {
-				throw new Error('Expected to find element');
+				console.warn('Invariant violation - root cause not yet determined.');
+				return;
 			}
 			const heightDiff = element.clientHeight - (lockedHeights[i] || defaultHeight);
 			if (heightDiff !== 0) {


### PR DESCRIPTION
This condition does not happen in normal circumstances, but I haven't
located the root cause. There should not be any negative consequence
from simply logging a warning for now as it likely happens in some weird
manner during unmount.