### PR TITLE
Add mock Claude client support for E2E testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "paste",
  "path-absolutize",
  "pin-project",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -327,6 +327,7 @@
 						/>
 						{#if !$codegenDisabled && first && codegenQuery?.response?.length === 0}
 							<Button
+								testId={TestId.BranchHeaderContextMenu_StartCodegenAgent}
 								icon="ai-small"
 								style="gray"
 								size="tag"

--- a/apps/desktop/src/components/codegen/CodegenApprovalToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenApprovalToolCall.svelte
@@ -10,6 +10,7 @@
 		Button,
 		Icon
 	} from '@gitbutler/ui';
+	import { TestId } from '@gitbutler/ui/utils/testIds';
 	import type { PermissionDecision } from '$lib/codegen/types';
 
 	type Props = {
@@ -91,7 +92,7 @@
 	});
 </script>
 
-<div class="tool-call">
+<div class="tool-call" data-testid={TestId.CodegenPermissionApproval}>
 	<div class="tool-call__details">
 		<div class="tool-call__header">
 			<Icon name={getToolIcon(toolCall.name)} color="var(--clr-text-3)" />
@@ -117,6 +118,7 @@
 				kind="outline"
 				icon="select-chevron"
 				shrinkable
+				testId={TestId.CodegenPermissionApproval_WildcardButton}
 				onclick={() => {
 					wildcardContextMenu?.toggle();
 				}}
@@ -145,6 +147,7 @@
 			bind:this={denyDropdownButton}
 			style="danger"
 			kind="outline"
+			testId={TestId.CodegenPermissionApproval_DenyButton}
 			onclick={async () => {
 				await onPermissionDecision(
 					toolCall.id,
@@ -192,6 +195,7 @@
 		<DropdownButton
 			bind:this={allowDropdownButton}
 			style="pop"
+			testId={TestId.CodegenPermissionApproval_AllowButton}
 			onclick={async () => {
 				await onPermissionDecision(
 					toolCall.id,

--- a/apps/desktop/src/components/codegen/CodegenAskUserQuestion.svelte
+++ b/apps/desktop/src/components/codegen/CodegenAskUserQuestion.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { AsyncButton, Icon, Textbox } from '@gitbutler/ui';
+	import { TestId } from '@gitbutler/ui/utils/testIds';
 	import type { AskUserQuestion } from '$lib/codegen/types';
 
 	type Props = {
@@ -106,7 +107,7 @@
 	}
 </script>
 
-<div class="ask-user-question">
+<div class="ask-user-question" data-testid={TestId.CodegenAskUserQuestion}>
 	<div class="ask-user-question__header">
 		<Icon name="ai-small" color="var(--clr-text-3)" />
 		<span class="text-13 header-text">Claude needs your input</span>
@@ -126,6 +127,7 @@
 							type="button"
 							class="option"
 							class:selected={isOptionSelected(q.question, option.label)}
+							data-testid={TestId.CodegenAskUserQuestion_Option}
 							disabled={answered}
 							onclick={() => {
 								if (q.multiSelect) {
@@ -219,7 +221,12 @@
 				Answered
 			</span>
 		{:else}
-			<AsyncButton style="pop" disabled={!allAnswered} action={handleSubmit}>
+			<AsyncButton
+				style="pop"
+				disabled={!allAnswered}
+				testId={TestId.CodegenAskUserQuestion_SubmitButton}
+				action={handleSubmit}
+			>
 				Submit answers
 			</AsyncButton>
 		{/if}

--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -17,6 +17,7 @@
 	import { showError } from '$lib/notifications/toasts';
 	import { inject } from '@gitbutler/core/context';
 	import { Tooltip, AsyncButton, RichTextEditor, FilePlugin, UpDownPlugin } from '@gitbutler/ui';
+	import { TestId } from '@gitbutler/ui/utils/testIds';
 	import { tick, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import type { FileSuggestionUpdate } from '@gitbutler/ui/richText/plugins/FilePlugin.svelte';
@@ -222,6 +223,7 @@
 
 	<div
 		class="text-input dialog-input"
+		data-testid={TestId.CodegenInput}
 		data-remove-from-panning
 		role="button"
 		tabindex="-1"
@@ -330,6 +332,7 @@
 							type="button"
 							class:loading
 							style="pop"
+							data-testid={TestId.CodegenInputSendButton}
 							onclick={handleSubmit}
 							aria-label="Send"
 						>

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -47,6 +47,7 @@
 
 	import VirtualList from '@gitbutler/ui/components/VirtualList.svelte';
 	import { focusable } from '@gitbutler/ui/focus/focusable';
+	import { TestId } from '@gitbutler/ui/utils/testIds';
 	import type {
 		ClaudeMessage,
 		ThinkingLevel,
@@ -409,7 +410,7 @@
 				{/snippet}
 			</PreviewHeader>
 
-			<div class="chat-container">
+			<div class="chat-container" data-testid={TestId.CodegenMessages}>
 				{#if claudeAvailable.status !== 'available' && formattedMessages.length === 0}
 					<ConfigurableScrollableContainer childrenWrapDisplay="contents">
 						<div class="no-agent-placeholder">

--- a/apps/desktop/src/components/codegen/CodegenSidebar.svelte
+++ b/apps/desktop/src/components/codegen/CodegenSidebar.svelte
@@ -2,6 +2,7 @@
 	// import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import Resizer from '$components/Resizer.svelte';
 	import { focusable } from '@gitbutler/ui/focus/focusable';
+	import { TestId } from '@gitbutler/ui/utils/testIds';
 	import type { Snippet } from 'svelte';
 
 	type Props = {
@@ -13,7 +14,12 @@
 	let sidebarViewportRef = $state<HTMLDivElement>();
 </script>
 
-<div class="sidebar" bind:this={sidebarViewportRef} use:focusable={{ vertical: true }}>
+<div
+	class="sidebar"
+	data-testid={TestId.CodegenSidebar}
+	bind:this={sidebarViewportRef}
+	use:focusable={{ vertical: true }}
+>
 	<div class="sidebar-header" use:focusable>
 		<p class="text-14 text-semibold">Current sessions</p>
 		<div class="sidebar-header-actions">

--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -165,6 +165,7 @@ export function formatMessages(
 					} else if (contentBlock.type === 'tool_use') {
 						const content = contentBlock;
 
+						// Handle AskUserQuestion tool calls specially - render as a question UI
 						if (content.name === 'AskUserQuestion') {
 							const input = content.input as { questions: AskUserQuestion[] };
 							const askMessage: Message = {

--- a/crates/but-claude/Cargo.toml
+++ b/crates/but-claude/Cargo.toml
@@ -9,6 +9,13 @@ rust-version.workspace = true
 [lib]
 doctest = false
 
+[features]
+default = []
+# Enable mock client support for E2E testing. With this feature enabled,
+# set CLAUDE_MOCK_SCENARIO env var to a scenario file path to use MockClient.
+# If the env var is not set, the real Claude CLI is used.
+testing = ["claude-agent-sdk-rs/testing"]
+
 [dependencies]
 but-core.workspace = true
 but-action.workspace = true

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -26,6 +26,9 @@ pub mod permissions;
 pub mod prompt_templates;
 mod rules;
 
+#[cfg(feature = "testing")]
+pub mod mock_scenario;
+
 pub use permissions::Permission;
 
 use crate::session::Claudes;

--- a/crates/but-claude/src/mock_scenario.rs
+++ b/crates/but-claude/src/mock_scenario.rs
@@ -1,0 +1,281 @@
+//! Mock scenario support for E2E testing.
+//!
+//! This module provides functionality to load mock scenarios from files and create
+//! mock Claude clients for testing purposes. It is only available when the `testing`
+//! feature is enabled.
+//!
+//! # Usage
+//!
+//! Set the `CLAUDE_MOCK_SCENARIO` environment variable to the path of a JSON scenario file,
+//! then build with `--features testing`. The application will use a mock client that replays
+//! the scenario instead of connecting to the real Claude CLI.
+//!
+//! # Scenario File Format
+//!
+//! The scenario file is a JSON snapshot that can be:
+//! 1. Recorded from a real session using `SnapshotRecorder`
+//! 2. Hand-crafted for specific test cases
+//!
+//! Example scenario structure:
+//! ```json
+//! {
+//!   "version": 1,
+//!   "recorded_at": "1234567890",
+//!   "sdk_version": "0.6.0",
+//!   "cli_version": null,
+//!   "options": null,
+//!   "messages": [
+//!     {"offset_ms": 0, "direction": "Received", "content": {"type": "system", ...}},
+//!     {"offset_ms": 100, "direction": "Received", "content": {"type": "assistant", ...}}
+//!   ]
+//! }
+//! ```
+//!
+//! # Permission Flow Handling
+//!
+//! When a scenario includes a `control_request` with `subtype: "can_use_tool"`, subsequent
+//! messages are automatically configured to be delivered only after the SDK writes back a
+//! `control_response`. This allows proper testing of the permission approval flow where:
+//!
+//! 1. MockTransport delivers the `control_request`
+//! 2. SDK calls the `can_use_tool` callback
+//! 3. Test waits for user to approve/deny
+//! 4. SDK writes `control_response`
+//! 5. MockTransport triggers delivery of remaining messages
+
+use std::path::Path;
+
+use claude_agent_sdk_rs::testing::{
+    MessageDirection, MessageTiming, MockClient, MockTransport, ScheduledMessage, SessionSnapshot, SnapshotPlayer,
+    TimingConfig,
+};
+use claude_agent_sdk_rs::types::config::ClaudeAgentOptions;
+
+/// Environment variable name for specifying the mock scenario file path.
+pub const CLAUDE_MOCK_SCENARIO_ENV: &str = "CLAUDE_MOCK_SCENARIO";
+
+/// Check if mock mode is enabled via environment variable.
+pub fn is_mock_mode_enabled() -> bool {
+    std::env::var(CLAUDE_MOCK_SCENARIO_ENV).is_ok()
+}
+
+/// Get the mock scenario path from environment variable.
+pub fn get_mock_scenario_path() -> Option<String> {
+    std::env::var(CLAUDE_MOCK_SCENARIO_ENV).ok()
+}
+
+/// Load a mock scenario from a file path.
+///
+/// # Arguments
+/// * `path` - Path to the JSON scenario file
+///
+/// # Returns
+/// A `SnapshotPlayer` that can be used to create a mock transport.
+pub fn load_scenario_from_file(path: impl AsRef<Path>) -> std::io::Result<SnapshotPlayer> {
+    SnapshotPlayer::load(path)
+}
+
+/// Create a MockClient from a scenario file with the given options.
+///
+/// # Arguments
+/// * `scenario_path` - Path to the JSON scenario file
+/// * `options` - Claude agent options to use with the mock client
+///
+/// # Returns
+/// A `MockClient` configured with the scenario and options.
+pub fn create_mock_client_from_file(
+    scenario_path: impl AsRef<Path>,
+    options: ClaudeAgentOptions,
+) -> std::io::Result<MockClient> {
+    let player = load_scenario_from_file(scenario_path)?;
+    let transport = player.to_mock_transport();
+    Ok(MockClient::from_transport(transport, options))
+}
+
+/// Create a MockTransport from a scenario file.
+///
+/// This is useful when you need direct access to the transport rather than
+/// going through MockClient.
+///
+/// This function creates a transport that properly handles permission flows:
+/// - Messages before a `control_request` are delivered immediately or with delays
+/// - Messages after a `control_request` with `subtype: "can_use_tool"` are held until
+///   the SDK writes back a `control_response` (i.e., after user approval/denial)
+///
+/// # Arguments
+/// * `scenario_path` - Path to the JSON scenario file
+///
+/// # Returns
+/// A `MockTransport` configured with the scenario.
+pub fn create_mock_transport_from_file(scenario_path: impl AsRef<Path>) -> std::io::Result<MockTransport> {
+    tracing::info!(
+        scenario_path = %scenario_path.as_ref().display(),
+        "Loading mock scenario for permission-aware transport"
+    );
+    let player = load_scenario_from_file(scenario_path)?;
+    tracing::info!(
+        message_count = player.snapshot().messages.len(),
+        "Loaded scenario, creating permission-aware transport"
+    );
+    Ok(create_permission_aware_transport(player.snapshot()))
+}
+
+/// Create a MockTransport that properly handles permission request flows.
+///
+/// Unlike the basic `SnapshotPlayer.to_mock_transport()`, this function:
+/// 1. Identifies `control_request` messages with `subtype: "can_use_tool"`
+/// 2. Configures subsequent messages to wait for `control_response` before delivery
+///
+/// This ensures the permission callback flow works correctly in tests:
+/// - User sees permission popup
+/// - User approves/denies
+/// - SDK sends control_response
+/// - Remaining scenario messages are delivered
+fn create_permission_aware_transport(snapshot: &SessionSnapshot) -> MockTransport {
+    let mut scheduled_messages = Vec::new();
+    let mut waiting_for_control_response = false;
+    let mut pending_request_id: Option<String> = None;
+
+    for msg in &snapshot.messages {
+        // Only process received messages (from "CLI" to SDK)
+        if msg.direction != MessageDirection::Received {
+            continue;
+        }
+
+        let content = &msg.content;
+
+        // Check if this is a control_request with can_use_tool
+        let is_permission_request = content
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(|t| t == "control_request")
+            .unwrap_or(false)
+            && content
+                .get("request")
+                .and_then(|r| r.get("subtype"))
+                .and_then(|v| v.as_str())
+                .map(|s| s == "can_use_tool")
+                .unwrap_or(false);
+
+        if is_permission_request {
+            // Extract request_id for the trigger pattern
+            pending_request_id = content.get("request_id").and_then(|v| v.as_str()).map(String::from);
+
+            tracing::debug!(
+                request_id = ?pending_request_id,
+                "Found permission request in scenario, subsequent messages will wait for control_response"
+            );
+
+            // Deliver the control_request immediately
+            scheduled_messages.push(ScheduledMessage {
+                value: content.clone(),
+                timing: MessageTiming::Immediate,
+            });
+
+            // All subsequent messages should wait for control_response
+            waiting_for_control_response = true;
+        } else if waiting_for_control_response {
+            // This message should wait for the control_response
+            // Use the request_id as the trigger pattern
+            let pattern = pending_request_id
+                .as_ref()
+                .map(|id| format!("\"request_id\":\"{}\"", id))
+                .unwrap_or_else(|| "control_response".to_string());
+
+            scheduled_messages.push(ScheduledMessage {
+                value: content.clone(),
+                timing: MessageTiming::AfterWrite { pattern },
+            });
+
+            // Check if this is a result message (end of session)
+            // If so, we can reset the waiting state for any subsequent exchanges
+            let is_result = content
+                .get("type")
+                .and_then(|v| v.as_str())
+                .map(|t| t == "result")
+                .unwrap_or(false);
+
+            if is_result {
+                waiting_for_control_response = false;
+                pending_request_id = None;
+            }
+        } else {
+            // Normal message - deliver immediately
+            scheduled_messages.push(ScheduledMessage {
+                value: content.clone(),
+                timing: MessageTiming::Immediate,
+            });
+        }
+    }
+
+    MockTransport::new(scheduled_messages, TimingConfig::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_mock_mode_disabled_by_default() {
+        // Note: env var state is shared across tests, so we just check the function works
+        // Don't modify env vars as that could affect parallel tests
+        let _ = is_mock_mode_enabled(); // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_permission_aware_transport_creates_correct_timing() {
+        // Scenario with permission request
+        let scenario_json = r#"{
+            "version": 1,
+            "recorded_at": "1234567890",
+            "sdk_version": "0.6.0",
+            "cli_version": null,
+            "options": null,
+            "messages": [
+                {"offset_ms": 0, "direction": "Received", "content": {"type": "system", "subtype": "init", "session_id": "test-123"}},
+                {"offset_ms": 100, "direction": "Received", "content": {"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello"}]}}},
+                {"offset_ms": 200, "direction": "Received", "content": {"type": "control_request", "request_id": "perm_001", "request": {"subtype": "can_use_tool", "tool_name": "Bash", "input": {"command": "echo test"}}}},
+                {"offset_ms": 300, "direction": "Received", "content": {"type": "assistant", "message": {"content": [{"type": "text", "text": "Done"}]}}},
+                {"offset_ms": 400, "direction": "Received", "content": {"type": "result", "subtype": "success"}}
+            ]
+        }"#;
+
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("test_scenario.json");
+        std::fs::write(&temp_file, scenario_json).unwrap();
+
+        let _transport = create_mock_transport_from_file(&temp_file).unwrap();
+
+        // The transport should have been created with the right timing:
+        // - Messages 0, 1, 2 should be Immediate
+        // - Messages 3, 4 should be AfterWrite (waiting for control_response)
+        //
+        // We can't directly inspect the scheduled messages, but we verified
+        // the transport was created successfully (no panic)
+
+        std::fs::remove_file(&temp_file).ok();
+    }
+
+    #[test]
+    fn test_load_scenario_from_file() {
+        let scenario_json = r#"{
+            "version": 1,
+            "recorded_at": "1234567890",
+            "sdk_version": "0.6.0",
+            "cli_version": null,
+            "options": null,
+            "messages": [
+                {"offset_ms": 0, "direction": "Received", "content": {"type": "system", "session_id": "test-123"}}
+            ]
+        }"#;
+
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("test_scenario_load.json");
+        std::fs::write(&temp_file, scenario_json).unwrap();
+
+        let player = load_scenario_from_file(&temp_file).unwrap();
+        assert_eq!(player.snapshot().messages.len(), 1);
+
+        std::fs::remove_file(&temp_file).ok();
+    }
+}

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -17,6 +17,11 @@ doctest = false
 
 [features]
 
+## Enable mock Claude client for E2E testing.
+## When enabled, set CLAUDE_MOCK_SCENARIO env var to a JSON scenario file path.
+## The mock client replays pre-recorded Claude interactions for deterministic tests.
+claude-testing = ["but-claude/testing"]
+
 [dependencies]
 but-api = { workspace = true, features = ["path-bytes", "legacy"] }
 but-claude.workspace = true

--- a/e2e/playwright/fixtures/claude-scenarios/ask-user-question.json
+++ b/e2e/playwright/fixtures/claude-scenarios/ask-user-question.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "recorded_at": "1706900000",
+  "sdk_version": "0.6.3",
+  "cli_version": null,
+  "options": null,
+  "messages": [
+    {
+      "offset_ms": 0,
+      "direction": "Received",
+      "content": {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "test-session-askuser",
+        "model": "claude-sonnet-4-20250514",
+        "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "AskUserQuestion"],
+        "mcp_servers": [],
+        "cwd": "/tmp/test-project",
+        "permission_mode": "default",
+        "uuid": "sys-001"
+      }
+    },
+    {
+      "offset_ms": 100,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "I have a question before I proceed."
+            },
+            {
+              "type": "tool_use",
+              "id": "tool_askuser_001",
+              "name": "AskUserQuestion",
+              "input": {
+                "questions": [
+                  {
+                    "question": "What testing framework would you like to use?",
+                    "header": "Framework",
+                    "options": [
+                      {
+                        "label": "Jest (Recommended)",
+                        "description": "Popular JavaScript testing framework with great TypeScript support"
+                      },
+                      {
+                        "label": "Vitest",
+                        "description": "Fast Vite-native testing framework"
+                      },
+                      {
+                        "label": "Mocha",
+                        "description": "Flexible testing framework with many plugins"
+                      }
+                    ],
+                    "multiSelect": false
+                  }
+                ]
+              }
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_001",
+          "stop_reason": "tool_use",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 120,
+            "output_tokens": 80,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-askuser",
+        "uuid": "ast-001"
+      }
+    },
+    {
+      "offset_ms": 5000,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "Great choice! I'll set up Jest for your project."
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_002",
+          "stop_reason": "end_turn",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 150,
+            "output_tokens": 25,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-askuser",
+        "uuid": "ast-002"
+      }
+    },
+    {
+      "offset_ms": 5100,
+      "direction": "Received",
+      "content": {
+        "type": "result",
+        "subtype": "success",
+        "total_cost_usd": 0.01,
+        "duration_ms": 5100,
+        "duration_api_ms": 500,
+        "num_turns": 1,
+        "is_error": false,
+        "session_id": "test-session-askuser"
+      }
+    }
+  ]
+}

--- a/e2e/playwright/fixtures/claude-scenarios/permission-bash-echo.json
+++ b/e2e/playwright/fixtures/claude-scenarios/permission-bash-echo.json
@@ -1,0 +1,127 @@
+{
+  "version": 1,
+  "recorded_at": "1706900000",
+  "sdk_version": "0.6.3",
+  "cli_version": null,
+  "options": null,
+  "messages": [
+    {
+      "offset_ms": 0,
+      "direction": "Received",
+      "content": {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "test-session-permission-bash",
+        "model": "claude-sonnet-4-20250514",
+        "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+        "mcp_servers": [],
+        "cwd": "/tmp/test-project",
+        "permission_mode": "default",
+        "uuid": "sys-001"
+      }
+    },
+    {
+      "offset_ms": 100,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "I'll run the echo command for you."
+            },
+            {
+              "type": "tool_use",
+              "id": "tool_bash_echo_001",
+              "name": "Bash",
+              "input": {
+                "command": "echo hello world"
+              }
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_001",
+          "stop_reason": "tool_use",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-permission-bash",
+        "uuid": "ast-001"
+      }
+    },
+    {
+      "offset_ms": 200,
+      "direction": "Received",
+      "content": {
+        "type": "control_request",
+        "request_id": "perm_001",
+        "request": {
+          "subtype": "can_use_tool",
+          "tool_name": "Bash",
+          "tool_use_id": "tool_bash_echo_001",
+          "input": {
+            "command": "echo hello world"
+          }
+        }
+      }
+    },
+    {
+      "offset_ms": 5000,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "tool_result",
+              "tool_use_id": "tool_bash_echo_001",
+              "content": "hello world\n"
+            },
+            {
+              "type": "text",
+              "text": "The command executed successfully and printed \"hello world\"."
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_002",
+          "stop_reason": "end_turn",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 150,
+            "output_tokens": 30,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-permission-bash",
+        "uuid": "ast-002"
+      }
+    },
+    {
+      "offset_ms": 5100,
+      "direction": "Received",
+      "content": {
+        "type": "result",
+        "subtype": "success",
+        "total_cost_usd": 0.01,
+        "duration_ms": 5100,
+        "duration_api_ms": 500,
+        "num_turns": 1,
+        "is_error": false,
+        "session_id": "test-session-permission-bash"
+      }
+    }
+  ]
+}

--- a/e2e/playwright/fixtures/claude-scenarios/permission-wildcard-test.json
+++ b/e2e/playwright/fixtures/claude-scenarios/permission-wildcard-test.json
@@ -1,0 +1,176 @@
+{
+  "version": 1,
+  "recorded_at": "1706900000",
+  "sdk_version": "0.6.3",
+  "cli_version": null,
+  "options": null,
+  "messages": [
+    {
+      "offset_ms": 0,
+      "direction": "Received",
+      "content": {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "test-session-wildcard",
+        "model": "claude-sonnet-4-20250514",
+        "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+        "mcp_servers": [],
+        "cwd": "/tmp/test-project",
+        "permission_mode": "default",
+        "uuid": "sys-001"
+      }
+    },
+    {
+      "offset_ms": 100,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "I'll run two echo commands to demonstrate the permission behavior."
+            },
+            {
+              "type": "tool_use",
+              "id": "tool_bash_001",
+              "name": "Bash",
+              "input": {
+                "command": "echo hello"
+              }
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_001",
+          "stop_reason": "tool_use",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-wildcard",
+        "uuid": "ast-001"
+      }
+    },
+    {
+      "offset_ms": 200,
+      "direction": "Received",
+      "content": {
+        "type": "control_request",
+        "request_id": "perm_001",
+        "request": {
+          "subtype": "can_use_tool",
+          "tool_name": "Bash",
+          "tool_use_id": "tool_bash_001",
+          "input": {
+            "command": "echo hello"
+          }
+        }
+      }
+    },
+    {
+      "offset_ms": 500,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "First command done. Now running the second one."
+            },
+            {
+              "type": "tool_use",
+              "id": "tool_bash_002",
+              "name": "Bash",
+              "input": {
+                "command": "echo world"
+              }
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_002",
+          "stop_reason": "tool_use",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 120,
+            "output_tokens": 60,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-wildcard",
+        "uuid": "ast-002"
+      }
+    },
+    {
+      "offset_ms": 600,
+      "direction": "Received",
+      "content": {
+        "type": "control_request",
+        "request_id": "perm_002",
+        "request": {
+          "subtype": "can_use_tool",
+          "tool_name": "Bash",
+          "tool_use_id": "tool_bash_002",
+          "input": {
+            "command": "echo world"
+          }
+        }
+      }
+    },
+    {
+      "offset_ms": 900,
+      "direction": "Received",
+      "content": {
+        "type": "assistant",
+        "message": {
+          "content": [
+            {
+              "type": "text",
+              "text": "Both echo commands completed successfully. The first printed \"hello\" and the second printed \"world\"."
+            }
+          ],
+          "model": "claude-sonnet-4-20250514",
+          "id": "msg_003",
+          "stop_reason": "end_turn",
+          "role": "assistant",
+          "type": "message",
+          "usage": {
+            "input_tokens": 150,
+            "output_tokens": 30,
+            "cache_creation_input_tokens": null,
+            "cache_read_input_tokens": null,
+            "server_tool_use": null,
+            "service_tier": null
+          }
+        },
+        "session_id": "test-session-wildcard",
+        "uuid": "ast-003"
+      }
+    },
+    {
+      "offset_ms": 1000,
+      "direction": "Received",
+      "content": {
+        "type": "result",
+        "subtype": "success",
+        "total_cost_usd": 0.02,
+        "duration_ms": 1000,
+        "duration_api_ms": 800,
+        "num_turns": 2,
+        "is_error": false,
+        "session_id": "test-session-wildcard"
+      }
+    }
+  ]
+}

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -100,7 +100,7 @@ function webServers() {
 			VITE_BUTLER_HOST: 'localhost',
 			VITE_BUILD_TARGET: 'web'
 		},
-		reuseExistingServer: true,
+		reuseExistingServer: !process.env.CI,
 		stdout: 'pipe'
 	} as const;
 

--- a/e2e/playwright/scripts/project-with-empty-branch.sh
+++ b/e2e/playwright/scripts/project-with-empty-branch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+
+# Setup a remote project with a single commit.
+mkdir remote-with-branch
+pushd remote-with-branch
+git init -b master --object-format=sha1
+echo "foo" >> a_file
+git add a_file
+git commit -am "Initial commit"
+popd
+
+# Clone the remote and add the project to GitButler.
+# This creates a workspace with an empty branch (no applied stacks).
+git clone remote-with-branch local-clone
+pushd local-clone
+  git checkout master
+  $BUT_TESTING add-project --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+popd

--- a/e2e/playwright/tests/claudePermissions.spec.ts
+++ b/e2e/playwright/tests/claudePermissions.spec.ts
@@ -1,0 +1,227 @@
+import { getBaseURL, type GitButler, startGitButler } from '../src/setup.ts';
+import { clickByTestId, getByTestId, waitForTestId } from '../src/util.ts';
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+
+/**
+ * Claude permission flow E2E tests.
+ *
+ * These tests require the application to be built with the `claude-testing` feature:
+ *   cargo build -p gitbutler-tauri --features claude-testing
+ *
+ * Each test specifies its own mock scenario file via CLAUDE_MOCK_SCENARIO env var
+ * passed to the but-server process at startup.
+ */
+
+let gitbutler: GitButler;
+
+// Path to the mock scenario files
+const SCENARIO_DIR = path.resolve(import.meta.dirname, '../fixtures/claude-scenarios');
+
+test.use({
+	baseURL: getBaseURL(),
+	// These tests spawn their own but-server process which may need to compile,
+	// so we need a longer timeout than the default 30 seconds
+	actionTimeout: 60_000
+});
+
+// Set a longer test timeout to account for but-server startup/compilation
+test.setTimeout(120_000);
+
+test.afterEach(async () => {
+	await gitbutler?.destroy();
+});
+
+test.describe('Claude permission approval flow', () => {
+	test('should show permission popup when Claude requests Bash tool use', async ({
+		page,
+		context
+	}, testInfo) => {
+		const workdir = testInfo.outputPath('workdir');
+		const configdir = testInfo.outputPath('config');
+
+		// Start GitButler with the mock scenario
+		gitbutler = await startGitButler(workdir, configdir, context, {
+			CLAUDE_MOCK_SCENARIO: path.join(SCENARIO_DIR, 'permission-bash-echo.json'),
+			RUST_LOG: 'but_claude=debug,claude_agent_sdk_rs=debug,error'
+		});
+
+		// Set up a project with a stack to work with
+		await gitbutler.runScript('project-with-remote-branches.sh');
+
+		await page.goto('/');
+
+		// Should load the workspace directly (project already set up by script)
+		await waitForTestId(page, 'workspace-view');
+
+		// Click the AI button on the existing stack to open codegen view
+		await clickByTestId(page, 'branch-header-context-menu-start-codegen-agent');
+
+		// Wait for input to appear
+		await waitForTestId(page, 'codegen-input');
+
+		// Type a message to Claude
+		const input = getByTestId(page, 'codegen-input');
+		await input.locator('div[contenteditable="true"]').fill('Please run echo hello world');
+
+		// Send the message
+		await clickByTestId(page, 'codegen-input-send-button');
+
+		// Wait for the permission approval popup to appear (with timeout for backend processing)
+		const permissionPopup = await waitForTestId(page, 'codegen-permission-approval');
+		await expect(permissionPopup).toBeVisible();
+
+		// Verify the popup shows the Bash tool
+		await expect(permissionPopup).toContainText('Bash');
+		await expect(permissionPopup).toContainText('echo hello world');
+
+		// Click the Allow button
+		await clickByTestId(page, 'codegen-permission-approval-allow-button');
+
+		// Verify the popup disappears
+		await expect(permissionPopup).not.toBeVisible();
+	});
+
+	test('should allow changing permission scope before approval', async ({
+		page,
+		context
+	}, testInfo) => {
+		const workdir = testInfo.outputPath('workdir');
+		const configdir = testInfo.outputPath('config');
+
+		gitbutler = await startGitButler(workdir, configdir, context, {
+			CLAUDE_MOCK_SCENARIO: path.join(SCENARIO_DIR, 'permission-wildcard-test.json')
+		});
+
+		// Set up a project with a stack to work with
+		await gitbutler.runScript('project-with-remote-branches.sh');
+
+		await page.goto('/');
+		await waitForTestId(page, 'workspace-view');
+
+		// Click the AI button on the existing stack to open codegen view
+		await clickByTestId(page, 'branch-header-context-menu-start-codegen-agent');
+		await waitForTestId(page, 'codegen-input');
+
+		const input = getByTestId(page, 'codegen-input');
+		await input.locator('div[contenteditable="true"]').fill('Please run echo hello world');
+		await clickByTestId(page, 'codegen-input-send-button');
+
+		const permissionPopup = await waitForTestId(page, 'codegen-permission-approval');
+		await expect(permissionPopup).toBeVisible();
+
+		// Click the wildcard button to change scope
+		const wildcardButton = getByTestId(page, 'codegen-permission-approval-wildcard-button');
+		await expect(wildcardButton).toBeVisible();
+
+		// Initially should show "This command"
+		await expect(wildcardButton).toContainText('This command');
+
+		// Click to open the dropdown
+		await wildcardButton.click();
+
+		// Select "Any subcommands or flags" option
+		await page.getByText('Any subcommands or flags').click();
+
+		// Verify the button now shows the new selection
+		await expect(wildcardButton).toContainText('Any subcommands or flags');
+
+		// Now approve - the mock scenario sends a second command after this
+		await clickByTestId(page, 'codegen-permission-approval-allow-button');
+
+		// Wait for the second permission request to appear (echo world)
+		// This tests that the permission flow continues for additional tool uses
+		await expect(permissionPopup.getByText('echo world')).toBeVisible({ timeout: 5000 });
+
+		// Approve the second command as well
+		await clickByTestId(page, 'codegen-permission-approval-allow-button');
+
+		// Now the popup should finally disappear
+		await expect(permissionPopup).not.toBeVisible();
+	});
+
+	test('should allow denying permission', async ({ page, context }, testInfo) => {
+		const workdir = testInfo.outputPath('workdir');
+		const configdir = testInfo.outputPath('config');
+
+		gitbutler = await startGitButler(workdir, configdir, context, {
+			CLAUDE_MOCK_SCENARIO: path.join(SCENARIO_DIR, 'permission-bash-echo.json')
+		});
+
+		// Set up a project with a stack to work with
+		await gitbutler.runScript('project-with-remote-branches.sh');
+
+		await page.goto('/');
+		await waitForTestId(page, 'workspace-view');
+
+		// Click the AI button on the existing stack to open codegen view
+		await clickByTestId(page, 'branch-header-context-menu-start-codegen-agent');
+		await waitForTestId(page, 'codegen-input');
+
+		const input = getByTestId(page, 'codegen-input');
+		await input.locator('div[contenteditable="true"]').fill('Please run echo hello world');
+		await clickByTestId(page, 'codegen-input-send-button');
+
+		const permissionPopup = await waitForTestId(page, 'codegen-permission-approval');
+		await expect(permissionPopup).toBeVisible();
+
+		// Click the Deny button
+		await clickByTestId(page, 'codegen-permission-approval-deny-button');
+
+		// Verify the popup disappears
+		await expect(permissionPopup).not.toBeVisible();
+	});
+});
+
+test.describe('Claude AskUserQuestion flow', () => {
+	test('should show question UI and allow user to answer', async ({ page, context }, testInfo) => {
+		const workdir = testInfo.outputPath('workdir');
+		const configdir = testInfo.outputPath('config');
+
+		gitbutler = await startGitButler(workdir, configdir, context, {
+			CLAUDE_MOCK_SCENARIO: path.join(SCENARIO_DIR, 'ask-user-question.json')
+		});
+
+		// Set up a project with a stack to work with
+		await gitbutler.runScript('project-with-remote-branches.sh');
+
+		await page.goto('/');
+
+		// Should load the workspace directly (project already set up by script)
+		await waitForTestId(page, 'workspace-view');
+
+		// Click the AI button on the existing stack to open codegen view
+		await clickByTestId(page, 'branch-header-context-menu-start-codegen-agent');
+
+		// Type a message to Claude that will trigger AskUserQuestion
+		const input = getByTestId(page, 'codegen-input');
+		await input.locator('div[contenteditable="true"]').fill('Please set up testing');
+
+		// Send the message
+		await clickByTestId(page, 'codegen-input-send-button');
+
+		// Wait for the AskUserQuestion UI to appear
+		const askUserQuestion = await waitForTestId(page, 'codegen-ask-user-question');
+		await expect(askUserQuestion).toBeVisible();
+
+		// Verify the question text is shown
+		await expect(askUserQuestion).toContainText('What testing framework would you like to use?');
+		await expect(askUserQuestion).toContainText('Jest (Recommended)');
+
+		// Select an option (clicking the first option - Jest)
+		const options = page.getByTestId('codegen-ask-user-question-option');
+		await options.first().click();
+
+		// Click the Submit button
+		await clickByTestId(page, 'codegen-ask-user-question-submit-button');
+
+		// Verify Claude responds with confirmation (this proves the answer was submitted and processed)
+		await expect(
+			page
+				.getByTestId('codegen-messages')
+				.getByText("Great choice! I'll set up Jest for your project.")
+		).toBeVisible({
+			timeout: 10000
+		});
+	});
+});

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -165,7 +165,19 @@ export enum TestId {
 	AbsorbModal_CommitAbsorption = 'absorb-modal-commit-absorption',
 	DiscardFileChangesConfirmationModal = 'discard-file-changes-confirmation-modal',
 	DiscardFileChangesConfirmationModal_Cancel = 'discard-file-changes-confirmation-modal-cancel',
-	DiscardFileChangesConfirmationModal_Discard = 'discard-file-changes-confirmation-modal-discard'
+	DiscardFileChangesConfirmationModal_Discard = 'discard-file-changes-confirmation-modal-discard',
+	// Codegen / Claude
+	CodegenSidebar = 'codegen-sidebar',
+	CodegenInput = 'codegen-input',
+	CodegenInputSendButton = 'codegen-input-send-button',
+	CodegenMessages = 'codegen-messages',
+	CodegenPermissionApproval = 'codegen-permission-approval',
+	CodegenPermissionApproval_AllowButton = 'codegen-permission-approval-allow-button',
+	CodegenPermissionApproval_DenyButton = 'codegen-permission-approval-deny-button',
+	CodegenPermissionApproval_WildcardButton = 'codegen-permission-approval-wildcard-button',
+	CodegenAskUserQuestion = 'codegen-ask-user-question',
+	CodegenAskUserQuestion_Option = 'codegen-ask-user-question-option',
+	CodegenAskUserQuestion_SubmitButton = 'codegen-ask-user-question-submit-button'
 }
 
 export enum ElementId {


### PR DESCRIPTION
Introduces a testing framework for Claude integration that allows Playwright
tests to run with deterministic, pre-recorded Claude interactions instead of
the real Claude CLI. This enables reliable, fast E2E testing of permission
flows and user interactions without requiring an actual Claude API connection.

Key components:

- Mock scenario loader (mock_scenario.rs) that reads session snapshots from
  JSON files and creates mock transports for the Claude Agent SDK
- Three initial test scenarios covering common permission flows:
  * permission-bash-echo.json - Basic Bash tool approval
  * permission-wildcard-test.json - Wildcard permission scoping
  * ask-user-question.json - AskUserQuestion tool interaction
- Integration in session.rs via `testing` feature flag and CLAUDE_MOCK_SCENARIO
  environment variable
- E2E test suite (claudePermissions.spec.ts) demonstrating permission approval
  UI interactions
- Improved test stability with process cleanup and RUST_LOG passthrough

The mock scenarios use the SDK's SessionSnapshot format and handle permission
callback timing automatically - when a control_request appears in the scenario,
subsequent messages are held until the SDK responds with control_response.

Each test specifies its own scenario by passing CLAUDE_MOCK_SCENARIO to
startGitButler(), which spawns a fresh but-server process with that env
var.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12220 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12132 
<!-- GitButler Footer Boundary Bottom -->

