### PR TITLE
fix(ui): truncate long remote/local labels in branches card

### DIFF
--- a/apps/desktop/src/components/branchesPage/BranchListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchListCard.svelte
@@ -137,16 +137,17 @@
 			{/if}
 
 			{#each branchListing.remotes as remote}
-				<span>{remote}</span>
+				<span class="truncate">{remote}</span>
 				<span class="sidebar-entry__divider">•</span>
 			{/each}
+
 			{#if branchListing.hasLocal}
-				<span>local</span>
+				<span class="truncate">local</span>
 				<span class="sidebar-entry__divider">•</span>
 			{/if}
+
 			{#if branchListing.remotes.length === 0 && !branchListing.hasLocal}
-				<span class="sidebar-entry__divider">•</span>
-				<span>No remotes</span>
+				<span class="truncate">No remotes</span>
 			{/if}
 		</div>
 	{/snippet}


### PR DESCRIPTION
- Truncate long remote and local branch labels in the branches card to prevent overflow and improve layout consistency.

Before:
<img width="361" height="362" alt="Screenshot 2026-02-04 at 22 32 32" src="https://github.com/user-attachments/assets/9290e93b-8a8b-4485-8866-0d17c6545495" />

After:
<img width="390" height="242" alt="Screenshot 2026-02-04 at 22 44 11" src="https://github.com/user-attachments/assets/b4655064-e050-4a46-820b-723653d51d61" />
