### PR TITLE
Avoid extra file sort in the UI

### DIFF
--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -402,7 +402,7 @@ export class UncommittedService {
 	}
 
 	changesByStackId(stackId: string | null): Reactive<TreeChange[]> {
-		const changes = $derived(sortLikeFileTree(this.getChangesByStackId(stackId)));
+		const changes = $derived(this.getChangesByStackId(stackId));
 		return reactive(() => changes);
 	}
 


### PR DESCRIPTION
It's already sorted by the function it calls.