### PR TITLE
unique branch names prevent auto-association with stale remote tracking branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typed-builder",

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -597,6 +597,9 @@ pub fn stash_into_branch(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn canned_branch_name(ctx: &Context) -> Result<String> {
+    // TODO: should be this:
+    // let rn = but_core::branch::unique_canned_refname(&*ctx.repo.get()?)?;
+    // Ok(rn.shorten().to_string())
     let repo = ctx.repo.get()?;
     let base_name = but_core::branch::canned_refname(&repo)?.shorten().to_string();
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -50,7 +50,7 @@ use std::{
     path::PathBuf,
 };
 
-use bstr::BString;
+use bstr::{BString, ByteSlice};
 use gix::{object::tree::EntryKind, refs::FullNameRef, status::plumbing::index_as_worktree::ConflictIndexEntry};
 use serde::Serialize;
 
@@ -119,21 +119,51 @@ pub fn is_workspace_ref_name(ref_name: &FullNameRef) -> bool {
     ref_name.as_bstr() == "refs/heads/gitbutler/workspace" || ref_name.as_bstr() == "refs/heads/gitbutler/integration"
 }
 
-/// A utility to extra the name of the remote from a remote tracking ref with `ref_name`.
+/// A utility to extract the name of the remote from a remote tracking ref with `ref_name`.
 /// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,
 /// `None` is returned.
+/// `remote_names` are expected to be returned by [`gix::Repository::remote_names()`],
+/// and as such are sorted in ascending order by length.
 pub fn extract_remote_name(ref_name: &gix::refs::FullNameRef, remote_names: &gix::remote::Names<'_>) -> Option<String> {
+    extract_remote_name_and_short_name(ref_name, remote_names).map(|(remote_name, _)| remote_name)
+}
+
+/// A utility to extract the name of the remote from a remote tracking ref with `ref_name`,
+/// along with the short name of the branch that remains after stripping the remote name.
+/// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,
+/// `None` is returned.
+/// `remote_names` are expected to be returned by [`gix::Repository::remote_names()`],
+/// and as such are sorted in ascending order by length.
+pub fn extract_remote_name_and_short_name(
+    ref_name: &gix::refs::FullNameRef,
+    remote_names: &gix::remote::Names<'_>,
+) -> Option<(String, BString)> {
     let (category, shorthand_name) = ref_name.category_and_short_name()?;
     if !matches!(category, gix::refs::Category::RemoteBranch) {
         return None;
     }
 
-    let longest_remote = remote_names
+    let (longest_remote, short_name) = remote_names
         .iter()
-        .rfind(|reference_name| shorthand_name.starts_with(reference_name))
-        .ok_or(anyhow::anyhow!("Failed to find remote branch's corresponding remote"))
-        .ok()?;
-    Some(longest_remote.to_string())
+        .rev()
+        .filter_map(|remote_name| {
+            let stripped = shorthand_name.strip_prefix(remote_name.iter().as_slice())?;
+            let short_name = stripped.strip_prefix(b"/")?;
+            Some((remote_name.as_bstr(), short_name.as_bstr()))
+        })
+        .next()
+        .or_else(|| {
+            // it's a stray RTB, without registered remote name. Let's not risk it and assume a nanme without slashes.
+            let rtb_short_name = ref_name.shorten();
+            let pos = rtb_short_name.find_byte(b'/')?;
+            let remote_name = rtb_short_name[..pos].as_bstr();
+            let short_name = rtb_short_name[pos + 1..].as_bstr();
+            if short_name.find_byte(b'/').is_some() {
+                return None;
+            }
+            Some((remote_name, short_name))
+        })?;
+    Some((longest_remote.to_string(), short_name.to_owned()))
 }
 
 /// A trait to associate arbitrary metadata with any *Git reference name*.

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -144,7 +144,7 @@ pub fn extract_remote_name_and_short_name(
         })
         .next()
         .or_else(|| {
-            // it's a stray RTB, without registered remote name. Let's not risk it and assume a nanme without slashes.
+            // it's a stray RTB, without registered remote name. Let's not risk it and assume a name without slashes.
             let rtb_short_name = ref_name.shorten();
             let pos = rtb_short_name.find_byte(b'/')?;
             let remote_name = rtb_short_name[..pos].as_bstr();

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -119,15 +119,6 @@ pub fn is_workspace_ref_name(ref_name: &FullNameRef) -> bool {
     ref_name.as_bstr() == "refs/heads/gitbutler/workspace" || ref_name.as_bstr() == "refs/heads/gitbutler/integration"
 }
 
-/// A utility to extract the name of the remote from a remote tracking ref with `ref_name`.
-/// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,
-/// `None` is returned.
-/// `remote_names` are expected to be returned by [`gix::Repository::remote_names()`],
-/// and as such are sorted in ascending order by length.
-pub fn extract_remote_name(ref_name: &gix::refs::FullNameRef, remote_names: &gix::remote::Names<'_>) -> Option<String> {
-    extract_remote_name_and_short_name(ref_name, remote_names).map(|(remote_name, _)| remote_name)
-}
-
 /// A utility to extract the name of the remote from a remote tracking ref with `ref_name`,
 /// along with the short name of the branch that remains after stripping the remote name.
 /// If it's not a remote tracking ref, or no remote in `remote_names` (like `origin`) matches,

--- a/crates/but-core/tests/core/branch/find_unique_refname.rs
+++ b/crates/but-core/tests/core/branch/find_unique_refname.rs
@@ -1,17 +1,24 @@
 use bstr::ByteSlice;
 use but_core::branch::find_unique_refname;
-use but_testsupport::writable_scenario;
+use but_testsupport::{
+    read_only_in_memory_scenario, read_only_in_memory_scenario_named_with_post, visualize_commit_graph_all,
+};
 use gix::refs::{self, Category, transaction::PreviousValue};
 
 #[test]
 fn with_existing_numerical_suffix() -> anyhow::Result<()> {
-    let (repo, _tmp) = writable_scenario("unborn-empty");
+    let (repo, (branch_1, branch_2)) =
+        read_only_in_memory_scenario_named_with_post("unborn-empty", "", 1, |fixture| {
+            let repo = but_testsupport::open_repo(fixture.path())?;
 
-    let id = repo.object_hash().null();
-    let branch_1 = refs::Category::LocalBranch.to_full_name("branch-1".as_bytes().as_bstr())?;
-    repo.reference(branch_1.as_ref(), id, PreviousValue::Any, "test")?;
-    let branch_2 = refs::Category::LocalBranch.to_full_name("branch-2".as_bytes().as_bstr())?;
-    repo.reference(branch_2.as_ref(), id, PreviousValue::Any, "test")?;
+            let id = repo.object_hash().null();
+            let branch_1 = refs::Category::LocalBranch.to_full_name("branch-1".as_bytes().as_bstr())?;
+            repo.reference(branch_1.as_ref(), id, PreviousValue::Any, "test")?;
+            let branch_2 = refs::Category::LocalBranch.to_full_name("branch-2".as_bytes().as_bstr())?;
+            repo.reference(branch_2.as_ref(), id, PreviousValue::Any, "test")?;
+
+            Ok((branch_1, branch_2))
+        })?;
 
     let unique = find_unique_refname(&repo, branch_1.as_ref())?;
     assert_eq!(unique.category(), Some(Category::LocalBranch));
@@ -25,14 +32,68 @@ fn with_existing_numerical_suffix() -> anyhow::Result<()> {
 }
 
 #[test]
+fn it_considers_remote_tracking_branches_even_if_unregistered() -> anyhow::Result<()> {
+    // The problem is us picking up remote tracking branches for local tracking branches automatically,
+    // even without Git configuration.
+    // That way, a newly created branch can wrongly be associated with an old and stale remote tracking branch,
+    // causing all kinds of funkiness.
+    let (repo, _) = read_only_in_memory_scenario_named_with_post("unborn-empty", "", 1, |fixture| {
+        let repo = but_testsupport::open_repo(fixture.path())?;
+
+        // Create a remote tracking branch for 'feature'
+        let id = repo.object_hash().null();
+        let rtb: &gix::refs::FullNameRef = "refs/remotes/non-existing-remote/a".try_into()?;
+        repo.reference(rtb, id, PreviousValue::Any, "test")?;
+        let rtb: &gix::refs::FullNameRef = "refs/remotes/non-existing-remote/a-1".try_into()?;
+        repo.reference(rtb, id, PreviousValue::Any, "test")?;
+
+        Ok(())
+    })?;
+
+    let unique = find_unique_refname(&repo, "refs/heads/a".try_into()?)?;
+    assert_eq!(
+        unique.as_bstr(),
+        "refs/heads/a-2",
+        "it looks through all remote tracking branches and avoids RBTs from matching, for now.
+        This also works if the RTB is stray, and has no remote configured."
+    );
+    Ok(())
+}
+
+#[test]
+fn registered_remotes_help_deal_with_slashed_remote_names() -> anyhow::Result<()> {
+    let repo = read_only_in_memory_scenario("multiple-remotes-with-tracking-branches")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, 
+        @"* fafd9d0 (origin/normal-remote, origin/main, origin/HEAD, nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init");
+
+    let unique = find_unique_refname(&repo, "refs/heads/in-nested-remote".try_into()?)?;
+    assert_eq!(
+        unique.as_bstr(),
+        "refs/heads/in-nested-remote-1",
+        "it deduplicates correctly even if symbolic remote names have slashes in them"
+    );
+
+    let unique = find_unique_refname(&repo, "refs/heads/normal-remote".try_into()?)?;
+    assert_eq!(
+        unique.as_bstr(),
+        "refs/heads/normal-remote-1",
+        "registered remotes without slashes also work"
+    );
+    Ok(())
+}
+
+#[test]
 fn without_numerical_suffix_it_appends_one() -> anyhow::Result<()> {
-    let (repo, _tmp) = writable_scenario("unborn-empty");
+    let (repo, feature) = read_only_in_memory_scenario_named_with_post("unborn-empty", "", 1, |fixture| {
+        let repo = but_testsupport::open_repo(fixture.path())?;
 
-    let id = repo.object_hash().null();
+        // Create a branch named "feature"
+        let id = repo.object_hash().null();
+        let feature = refs::Category::Note.to_full_name("feature".as_bytes().as_bstr())?;
+        repo.reference(feature.as_ref(), id, PreviousValue::Any, "test")?;
 
-    // Create a branch named "feature"
-    let feature = refs::Category::Note.to_full_name("feature".as_bytes().as_bstr())?;
-    repo.reference(feature.as_ref(), id, PreviousValue::Any, "test")?;
+        Ok(feature)
+    })?;
 
     let unique = find_unique_refname(&repo, feature.as_ref())?;
     assert_eq!(unique.category(), Some(Category::Note));
@@ -47,7 +108,7 @@ fn without_numerical_suffix_it_appends_one() -> anyhow::Result<()> {
 
 #[test]
 fn returns_original_if_unique() -> anyhow::Result<()> {
-    let (repo, _tmp) = writable_scenario("unborn-empty");
+    let repo = read_only_in_memory_scenario("unborn-empty")?;
 
     let branch_1 = refs::Category::LocalBranch.to_full_name("branch-1".as_bytes().as_bstr())?;
     let unique = find_unique_refname(&repo, branch_1.as_ref())?;

--- a/crates/but-core/tests/core/branch/find_unique_refname.rs
+++ b/crates/but-core/tests/core/branch/find_unique_refname.rs
@@ -40,7 +40,8 @@ fn it_considers_remote_tracking_branches_even_if_unregistered() -> anyhow::Resul
     let (repo, _) = read_only_in_memory_scenario_named_with_post("unborn-empty", "", 1, |fixture| {
         let repo = but_testsupport::open_repo(fixture.path())?;
 
-        // Create a remote tracking branch for 'feature'
+        // Create a remote tracking branch for 'a' in a non-existing remote.
+        // It's a stale branch basically.
         let id = repo.object_hash().null();
         let rtb: &gix::refs::FullNameRef = "refs/remotes/non-existing-remote/a".try_into()?;
         repo.reference(rtb, id, PreviousValue::Any, "test")?;
@@ -64,7 +65,11 @@ fn it_considers_remote_tracking_branches_even_if_unregistered() -> anyhow::Resul
 fn registered_remotes_help_deal_with_slashed_remote_names() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("multiple-remotes-with-tracking-branches")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, 
-        @"* fafd9d0 (origin/normal-remote, origin/main, origin/HEAD, nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init");
+        @"
+    * 14f7926 (nested/remote-b/main, nested/remote-b/in-nested-remote-b, nested/remote-b/HEAD) init-c
+    * 5efb67f (nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init-b
+    * 263500f (origin/normal-remote, origin/main, origin/HEAD) init-a
+    ");
 
     let unique = find_unique_refname(&repo, "refs/heads/in-nested-remote".try_into()?)?;
     assert_eq!(

--- a/crates/but-core/tests/core/extract_remote_name_and_short_name.rs
+++ b/crates/but-core/tests/core/extract_remote_name_and_short_name.rs
@@ -5,7 +5,11 @@ use but_testsupport::{read_only_in_memory_scenario, visualize_commit_graph_all};
 fn journey() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("multiple-remotes-with-tracking-branches")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, 
-            @"* fafd9d0 (origin/normal-remote, origin/main, origin/HEAD, nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init");
+            @"
+    * 14f7926 (nested/remote-b/main, nested/remote-b/in-nested-remote-b, nested/remote-b/HEAD) init-c
+    * 5efb67f (nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init-b
+    * 263500f (origin/normal-remote, origin/main, origin/HEAD) init-a
+    ");
 
     let remote_names = repo.remote_names();
     let rn = "refs/remotes/origin/feature".try_into()?;
@@ -17,14 +21,14 @@ fn journey() -> anyhow::Result<()> {
     assert_eq!(
         extract_remote_name_and_short_name(rn, &remote_names),
         None,
-        "unregisted remotes aren't handled at all due to ambiguity when there are more than one slashes"
+        "unregistered remotes aren't handled at all due to ambiguity when there are more than one slashes"
     );
 
     let rn = "refs/remotes/non-existing/feature".try_into()?;
     let (remote_name, short_name) = extract_remote_name_and_short_name(rn, &remote_names).unwrap();
     assert_eq!(
         remote_name, "non-existing",
-        "here we know for sure, there is alrays remote/branch at least"
+        "here we know for sure, there is always remote/branch at least"
     );
     assert_eq!(short_name, "feature");
 

--- a/crates/but-core/tests/core/extract_remote_name_and_short_name.rs
+++ b/crates/but-core/tests/core/extract_remote_name_and_short_name.rs
@@ -1,0 +1,42 @@
+use but_core::extract_remote_name_and_short_name;
+use but_testsupport::{read_only_in_memory_scenario, visualize_commit_graph_all};
+
+#[test]
+fn journey() -> anyhow::Result<()> {
+    let repo = read_only_in_memory_scenario("multiple-remotes-with-tracking-branches")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, 
+            @"* fafd9d0 (origin/normal-remote, origin/main, origin/HEAD, nested/remote/main, nested/remote/in-nested-remote, nested/remote/HEAD) init");
+
+    let remote_names = repo.remote_names();
+    let rn = "refs/remotes/origin/feature".try_into()?;
+    let (remote_name, short_name) = extract_remote_name_and_short_name(rn, &remote_names).unwrap();
+    assert_eq!(remote_name, "origin", "a normal remote can always be extracted");
+    assert_eq!(short_name, "feature");
+
+    let rn = "refs/remotes/nested/non-existing/feature".try_into()?;
+    assert_eq!(
+        extract_remote_name_and_short_name(rn, &remote_names),
+        None,
+        "unregisted remotes aren't handled at all due to ambiguity when there are more than one slashes"
+    );
+
+    let rn = "refs/remotes/non-existing/feature".try_into()?;
+    let (remote_name, short_name) = extract_remote_name_and_short_name(rn, &remote_names).unwrap();
+    assert_eq!(
+        remote_name, "non-existing",
+        "here we know for sure, there is alrays remote/branch at least"
+    );
+    assert_eq!(short_name, "feature");
+
+    let rn = "refs/remotes/nested/remote/feature/a".try_into()?;
+    let (remote_name, short_name) = extract_remote_name_and_short_name(rn, &remote_names).unwrap();
+    assert_eq!(remote_name, "nested/remote", "this works because we know remote names");
+    assert_eq!(short_name, "feature/a");
+
+    let rn = "refs/remotes/nested/remote-b/feature/b".try_into()?;
+    let (remote_name, short_name) = extract_remote_name_and_short_name(rn, &remote_names).unwrap();
+    assert_eq!(remote_name, "nested/remote-b");
+    assert_eq!(short_name, "feature/b");
+
+    Ok(())
+}

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -3,6 +3,7 @@ mod change_id;
 mod cmd;
 mod commit;
 mod diff;
+mod extract_remote_name_and_short_name;
 mod json_samples;
 mod ref_metadata;
 mod settings;

--- a/crates/but-core/tests/fixtures/scenario/multiple-remotes-with-tracking-branches.sh
+++ b/crates/but-core/tests/fixtures/scenario/multiple-remotes-with-tracking-branches.sh
@@ -8,19 +8,19 @@ source "${BASH_SOURCE[0]%/*}/shared.sh"
 
 git init normal-remote
 (cd normal-remote 
-    commit init
+    commit init-a
     git branch normal-remote
 )
 
 git init nested-remote
 (cd nested-remote 
-    commit init
+    commit init-b
     git branch in-nested-remote
 )
 
 git init nested-remote-b
 (cd nested-remote-b
-    commit init
+    commit init-c
     git branch in-nested-remote-b
 )
 
@@ -31,3 +31,4 @@ git remote add nested/remote-b nested-remote-b
 
 git fetch origin
 git fetch nested/remote
+git fetch nested/remote-b

--- a/crates/but-core/tests/fixtures/scenario/multiple-remotes-with-tracking-branches.sh
+++ b/crates/but-core/tests/fixtures/scenario/multiple-remotes-with-tracking-branches.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A repository that has multiple remotes with different names.
+
+git init normal-remote
+(cd normal-remote 
+    commit init
+    git branch normal-remote
+)
+
+git init nested-remote
+(cd nested-remote 
+    commit init
+    git branch in-nested-remote
+)
+
+git init nested-remote-b
+(cd nested-remote-b
+    commit init
+    git branch in-nested-remote-b
+)
+
+git init
+git remote add origin normal-remote
+git remote add nested/remote nested-remote
+git remote add nested/remote-b nested-remote-b
+
+git fetch origin
+git fetch nested/remote

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context as _, bail, ensure};
 use bstr::ByteSlice;
-use but_core::{RefMetadata, extract_remote_name, ref_metadata};
+use but_core::{RefMetadata, extract_remote_name_and_short_name, ref_metadata};
 use gix::{
     hashtable::hash_map::Entry,
     prelude::{ObjectIdExt, ReferenceExt},
@@ -318,7 +318,8 @@ impl Graph {
                     data.target_ref
                         .as_ref()
                         .and_then(|target| {
-                            extract_remote_name(target.as_ref(), &remote_names).map(|remote| (1, remote))
+                            extract_remote_name_and_short_name(target.as_ref(), &remote_names)
+                                .map(|(remote, _short_name)| (1, remote))
                         })
                         .into_iter()
                         .chain(data.push_remote.clone().map(|push_remote| (0, push_remote)))
@@ -326,7 +327,8 @@ impl Graph {
                 .chain(workspaces.iter().flat_map(|(_, _, data)| {
                     data.stacks.iter().flat_map(|s| {
                         s.branches.iter().flat_map(|b| {
-                            extract_remote_name(b.ref_name.as_ref(), &remote_names).map(|remote| (1, remote))
+                            extract_remote_name_and_short_name(b.ref_name.as_ref(), &remote_names)
+                                .map(|(remote, _short_name)| (1, remote))
                         })
                     })
                 }))

--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use anyhow::Context;
 use bstr::BStr;
-use but_core::{RefMetadata, extract_remote_name, ref_metadata::StackId};
+use but_core::{RefMetadata, extract_remote_name_and_short_name, ref_metadata::StackId};
 use petgraph::Direction;
 use tracing::instrument;
 
@@ -74,7 +74,7 @@ impl Workspace {
                 .iter()
                 .map(|name| Cow::Borrowed(name.as_str().into()))
                 .collect();
-            extract_remote_name(tr.ref_name.as_ref(), &remote_names)
+            extract_remote_name_and_short_name(tr.ref_name.as_ref(), &remote_names).map(|(remote_name, _)| remote_name)
         } else if let Some(md) = self.metadata.as_ref() {
             md.push_remote.clone()
         } else {

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1997,12 +1997,12 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   ├── ·79bbb29 (⌂|🏘|✓|1)
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   └── ✂·a381df5 (⌂|🏘|✓|1)
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:4:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:2[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4[2]:main
+                    ├── ►:4[2]:main <> origin/main →:1:
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
@@ -2036,12 +2036,12 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   ├── ·a381df5 (⌂|🏘|✓|1)
     │                   └── ✂·777b552 (⌂|🏘|✓|1)
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:5:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:4[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:5[2]:main
+                    ├── ►:5[2]:main <> origin/main →:1:
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
@@ -2059,7 +2059,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // The limit is effective for integrated workspaces branches, and it doesn't unnecessarily
     // prolong the traversal once the all tips are known to be integrated.
     let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·4077353 (⌂|🏘|1)
@@ -2071,12 +2071,12 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   ├── ·a381df5 (⌂|🏘|✓|1)
     │                   └── ✂·777b552 (⌂|🏘|✓|1)
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:5:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:4[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:5[2]:main
+                    ├── ►:5[2]:main <> origin/main →:1:
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
@@ -2114,7 +2114,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                           └── ·ce4a760 (⌂|🏘|✓|1)
     │                               ├── ►:7[5]:anon:
     │                               │   └── ·01d0e1e (⌂|🏘|✓|1)
-    │                               │       └── ►:5[6]:main
+    │                               │       └── ►:5[6]:main <> origin/main →:2:
     │                               │           ├── ·4b3e5a8 (⌂|🏘|✓|1)
     │                               │           ├── ·34d0715 (⌂|🏘|✓|1)
     │                               │           └── ·eb5f731 (⌂|🏘|✓|1)
@@ -2122,12 +2122,12 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                                   ├── ·fea59b5 (⌂|🏘|✓|1)
     │                                   └── ·4deea74 (⌂|🏘|✓|1)
     │                                       └── →:7:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:5:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── →:5: (main)
+                    ├── →:5: (main →:2:)
                     └── →:0: (A)
     ");
     // It looks like some commits are missing, but it's a first-parent traversal.
@@ -2135,16 +2135,19 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     ⌂:0:A <> ✓!
     └── ≡:0:A {1}
         ├── :0:A
-        │   ├── ·79bbb29 (🏘️|✓)
-        │   ├── ·fc98174 (🏘️|✓)
-        │   ├── ·a381df5 (🏘️|✓)
-        │   ├── ·777b552 (🏘️|✓)
-        │   ├── ·ce4a760 (🏘️|✓)
-        │   └── ·01d0e1e (🏘️|✓)
-        └── :5:main
-            ├── ·4b3e5a8 (🏘️|✓)
-            ├── ·34d0715 (🏘️|✓)
-            └── ·eb5f731 (🏘️|✓)
+        │   ├── ❄79bbb29 (🏘️|✓)
+        │   ├── ❄fc98174 (🏘️|✓)
+        │   ├── ❄a381df5 (🏘️|✓)
+        │   ├── ❄777b552 (🏘️|✓)
+        │   ├── ❄ce4a760 (🏘️|✓)
+        │   └── ❄01d0e1e (🏘️|✓)
+        └── :5:main <> origin/main →:2:⇣3
+            ├── 🟣d0df794 (✓)
+            ├── 🟣09c6e08 (✓)
+            ├── 🟣7b9f260 (✓)
+            ├── ❄️4b3e5a8 (🏘️|✓)
+            ├── ❄️34d0715 (🏘️|✓)
+            └── ❄️eb5f731 (🏘️|✓)
     ");
 
     let graph =
@@ -2163,12 +2166,12 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   ├── ·a381df5 (⌂|🏘|✓|1)
     │                   └── ✂·777b552 (⌂|🏘|✓|1)
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:5:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:5[2]:main
+                    ├── ►:5[2]:main <> origin/main →:2:
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
@@ -2212,7 +2215,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                           └── ·ce4a760 (⌂|🏘|✓|1)
     │                               ├── ►:8[6]:anon:
     │                               │   └── ·01d0e1e (⌂|🏘|✓|1)
-    │                               │       └── ►:5[7]:main
+    │                               │       └── ►:5[7]:main <> origin/main →:2:
     │                               │           ├── ·4b3e5a8 (⌂|🏘|✓|1)
     │                               │           ├── ·34d0715 (⌂|🏘|✓|1)
     │                               │           └── ·eb5f731 (⌂|🏘|✓|1)
@@ -2220,13 +2223,13 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                                   ├── ·fea59b5 (⌂|🏘|✓|1)
     │                                   └── ·4deea74 (⌂|🏘|✓|1)
     │                                       └── →:8:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:5:
         └── ►:0[1]:anon:
             ├── 👉·d0df794 (⌂|✓|1)
             └── ·09c6e08 (⌂|✓|1)
                 └── ►:3[2]:anon:
                     └── ·7b9f260 (⌂|✓|1)
-                        ├── →:5: (main)
+                        ├── →:5: (main →:2:)
                         └── →:6: (A)
     ");
 
@@ -2234,13 +2237,13 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     ⌂:0:DETACHED <> ✓! on 79bbb29
     └── ≡:0:anon: {1}
         ├── :0:anon:
-        │   ├── ·d0df794 (✓)
-        │   ├── ·09c6e08 (✓)
-        │   └── ·7b9f260 (✓)
-        └── :5:main
-            ├── ·4b3e5a8 (🏘️|✓)
-            ├── ·34d0715 (🏘️|✓)
-            └── ·eb5f731 (🏘️|✓)
+        │   ├── ❄d0df794 (✓)
+        │   ├── ❄09c6e08 (✓)
+        │   └── ❄7b9f260 (✓)
+        └── :5:main <> origin/main →:2:
+            ├── ❄️4b3e5a8 (🏘️|✓)
+            ├── ❄️34d0715 (🏘️|✓)
+            └── ❄️eb5f731 (🏘️|✓)
     ");
 
     // However, when choosing an initially unknown branch, it will get the extra target tip settings.
@@ -2266,7 +2269,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                           └── ·ce4a760 (⌂|🏘|✓|1)
     │                               ├── ►:8[6]:anon:
     │                               │   └── ·01d0e1e (⌂|🏘|✓|1)
-    │                               │       └── ►:5[7]:main
+    │                               │       └── ►:5[7]:main <> origin/main →:2:
     │                               │           ├── ·4b3e5a8 (⌂|🏘|✓|1)
     │                               │           ├── ·34d0715 (⌂|🏘|✓|1)
     │                               │           └── ·eb5f731 (⌂|🏘|✓|1)
@@ -2274,13 +2277,13 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                                   ├── ·fea59b5 (⌂|🏘|✓|1)
     │                                   └── ·4deea74 (⌂|🏘|✓|1)
     │                                       └── →:8:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:5:
         └── ►:0[1]:anon:
             ├── 👉·d0df794 (⌂|✓|1)
             └── ·09c6e08 (⌂|✓|1)
                 └── ►:4[2]:anon:
                     └── ·7b9f260 (⌂|✓|1)
-                        ├── →:5: (main)
+                        ├── →:5: (main →:2:)
                         └── →:6: (A)
     ");
 
@@ -2288,13 +2291,13 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     ⌂:0:DETACHED <> ✓! on 79bbb29
     └── ≡:0:anon: {1}
         ├── :0:anon:
-        │   ├── ·d0df794 (✓)
-        │   ├── ·09c6e08 (✓)
-        │   └── ·7b9f260 (✓)
-        └── :5:main
-            ├── ·4b3e5a8 (🏘️|✓)
-            ├── ·34d0715 (🏘️|✓)
-            └── ·eb5f731 (🏘️|✓)
+        │   ├── ❄d0df794 (✓)
+        │   ├── ❄09c6e08 (✓)
+        │   └── ❄7b9f260 (✓)
+        └── :5:main <> origin/main →:2:
+            ├── ❄️4b3e5a8 (🏘️|✓)
+            ├── ❄️34d0715 (🏘️|✓)
+            └── ❄️eb5f731 (🏘️|✓)
     ");
 
     Ok(())
@@ -2632,12 +2635,12 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     │                   ├── ·79bbb29 (⌂|🏘|✓|1)
     │                   ├── ·fc98174 (⌂|🏘|✓|1)
     │                   └── ✂·a381df5 (⌂|🏘|✓|1)
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:4:
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:2[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4[2]:main
+                    ├── ►:4[2]:main <> origin/main →:1:
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
@@ -2861,7 +2864,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // Also, without limit, we should be able to see all of 'main' without cut-off
     let graph =
         Graph::from_commit_traversal(main_id, main_ref_name.clone(), &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘)
@@ -2885,10 +2888,10 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                   ├── ·eb17e31 (⌂|🏘|✓)
     │                   ├── ·fe2046b (⌂|🏘|✓)
     │                   └── ·5532ef5 (⌂|🏘|✓)
-    │                       └── 👉►:0[4]:main
+    │                       └── 👉►:0[4]:main <> origin/main →:2:
     │                           └── ·2438292 (⌂|🏘|✓|1)
     │                               └── →:8:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:0:
         └── 🟣232ed06 (✓)
             ├── ►:4[1]:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
@@ -2908,8 +2911,19 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // Entrypoint is outside of workspace.
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {1}
-        └── :0:main
+    └── ≡:0:main <> origin/main →:2:⇣11 {1}
+        └── :0:main <> origin/main →:2:⇣11
+            ├── 🟣232ed06 (✓)
+            ├── 🟣9e2a79e (✓)
+            ├── 🟣fdeaa43 (✓)
+            ├── 🟣30565ee (✓)
+            ├── 🟣0c1c23a (✓)
+            ├── 🟣56d152c (✓)
+            ├── 🟣e6e1360 (✓)
+            ├── 🟣1a22a39 (✓)
+            ├── 🟣abcfd9a (✓)
+            ├── 🟣bc86eba (✓)
+            ├── 🟣c7ae303 (✓)
             ├── ·2438292 (🏘️|✓)
             ├── ·c056b75 (🏘️|✓)
             ├── ·f49c977 (🏘️|✓)
@@ -2928,7 +2942,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // once everything reconciled.
     let graph = Graph::from_commit_traversal(main_id, main_ref_name, &*meta, standard_options().with_limit_hint(1))?
         .validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘)
@@ -2947,10 +2961,10 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                   ├── ·eb17e31 (⌂|🏘|✓)
     │                   ├── ·fe2046b (⌂|🏘|✓)
     │                   └── ·5532ef5 (⌂|🏘|✓)
-    │                       └── 👉►:0[4]:main
+    │                       └── 👉►:0[4]:main <> origin/main →:2:
     │                           └── ·2438292 (⌂|🏘|✓|1)
     │                               └── →:8:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:0:
         └── 🟣232ed06 (✓)
             ├── ►:4[1]:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
@@ -2970,8 +2984,19 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // The limit is visible as well.
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {1}
-        └── :0:main
+    └── ≡:0:main <> origin/main →:2:⇣11 {1}
+        └── :0:main <> origin/main →:2:⇣11
+            ├── 🟣232ed06 (✓)
+            ├── 🟣9e2a79e (✓)
+            ├── 🟣fdeaa43 (✓)
+            ├── 🟣30565ee (✓)
+            ├── 🟣0c1c23a (✓)
+            ├── 🟣56d152c (✓)
+            ├── 🟣e6e1360 (✓)
+            ├── 🟣1a22a39 (✓)
+            ├── 🟣abcfd9a (✓)
+            ├── 🟣bc86eba (✓)
+            ├── 🟣c7ae303 (✓)
             ├── ·2438292 (🏘️|✓)
             ├── ·c056b75 (🏘️|✓)
             ├── ·f49c977 (🏘️|✓)
@@ -2983,7 +3008,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // From the workspace, even without limit, we don't traverse all of 'main' as it's uninteresting.
     // However, we wait for the target to be fully reconciled to get the proper workspace configuration.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·41ed0e4 (⌂|🏘|1)
@@ -3004,10 +3029,10 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                   ├── ·eb17e31 (⌂|🏘|✓|1)
     │                   ├── ·fe2046b (⌂|🏘|✓|1)
     │                   └── ·5532ef5 (⌂|🏘|✓|1)
-    │                       └── ►:7[4]:main
+    │                       └── ►:7[4]:main <> origin/main →:1:
     │                           └── ·2438292 (⌂|🏘|✓|1)
     │                               └── →:8:
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:7:
         └── 🟣232ed06 (✓)
             ├── ►:3[1]:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
@@ -3145,7 +3170,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     let (id, ref_name) = id_at(&repo, "main");
     // Here the target shouldn't be cut off from finding its workspace
     let graph = Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
     │   └── ·f514495 (⌂|🏘)
@@ -3160,10 +3185,10 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     │                   ├── ·2983a97 (⌂|🏘|✓)
     │                   ├── ·144ea85 (⌂|🏘|✓)
     │                   └── ·5aecfd2 (⌂|🏘|✓)
-    │                       └── 👉►:0[5]:main
+    │                       └── 👉►:0[5]:main <> origin/main →:2:
     │                           └── ·bce0c5e (⌂|🏘|✓|1)
     │                               └── →:6:
-    └── ►:2[0]:origin/main
+    └── ►:2[0]:origin/main →:0:
         ├── 🟣024f837 (✓) ►long-workspace-to-target
         ├── 🟣64a8284 (✓)
         ├── 🟣b72938c (✓)
@@ -3190,8 +3215,25 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     // `main` is integrated, but the entrypoint so it's shown.
     insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     ⌂:0:main <> ✓!
-    └── ≡:0:main {1}
-        └── :0:main
+    └── ≡:0:main <> origin/main →:2:⇣17 {1}
+        └── :0:main <> origin/main →:2:⇣17
+            ├── 🟣024f837 (✓) ►long-workspace-to-target
+            ├── 🟣64a8284 (✓)
+            ├── 🟣b72938c (✓)
+            ├── 🟣9ccbf6f (✓)
+            ├── 🟣5fa4905 (✓)
+            ├── 🟣43074d3 (✓)
+            ├── 🟣800d4a9 (✓)
+            ├── 🟣742c068 (✓)
+            ├── 🟣fe06afd (✓)
+            ├── 🟣3027746 (✓)
+            ├── 🟣edf041f (✓)
+            ├── 🟣d9f03f6 (✓)
+            ├── 🟣8d1d264 (✓)
+            ├── 🟣fa7ceae (✓)
+            ├── 🟣95bdbf1 (✓)
+            ├── 🟣5bac978 (✓)
+            ├── 🟣f0d2a35 (✓)
             ├── ·bce0c5e (🏘️|✓)
             └── ·3183e43 (🏘️|✓) ►A, ►B
     ");
@@ -3199,7 +3241,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     // Now the target looks for the entrypoint, which is the workspace, something it can do more easily.
     // We wait for targets to fully reconcile as well.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·f514495 (⌂|🏘|1)
@@ -3214,10 +3256,10 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     │                   ├── ·2983a97 (⌂|🏘|✓|1)
     │                   ├── ·144ea85 (⌂|🏘|✓|1)
     │                   └── ·5aecfd2 (⌂|🏘|✓|1)
-    │                       └── ►:5[5]:main
+    │                       └── ►:5[5]:main <> origin/main →:1:
     │                           └── ·bce0c5e (⌂|🏘|✓|1)
     │                               └── →:6:
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:5:
         ├── 🟣024f837 (✓) ►long-workspace-to-target
         ├── 🟣64a8284 (✓)
         ├── 🟣b72938c (✓)
@@ -3444,7 +3486,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     add_workspace(&mut meta);
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
     ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
     │   └── ·2b30d94 (⌂|🏘|1)
@@ -3458,7 +3500,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     │       │                   ├── ·d4f537e (⌂|🏘|1)
     │       │                   ├── ·b448757 (⌂|🏘|1)
     │       │                   └── ·e9a378d (⌂|🏘|1)
-    │       │                       └── ►:5[4]:main
+    │       │                       └── ►:5[4]:main <> origin/main →:1:
     │       │                           └── ·3183e43 (⌂|🏘|✓|1)
     │       ├── ►:3[1]:A
     │       │   └── ·0bad3af (⌂|🏘|1)
@@ -3467,9 +3509,9 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     │           ├── ·acdc49a (⌂|🏘|1)
     │           └── ·f0117e0 (⌂|🏘|1)
     │               └── →:7: (shared)
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:5:
         └── 🟣bce0c5e (✓)
-            └── →:5: (main)
+            └── →:5: (main →:1:)
     ");
 
     // Segments can definitely repeat
@@ -4026,46 +4068,54 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
 
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        └── ►:1[1]:A
-            ├── ·a62b0de (⌂|🏘|1)
-            └── ·120a217 (⌂|🏘|1)
-                └── ►:2[2]:main
-                    └── ·fafd9d0 (⌂|🏘|1)
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ►:1[1]:A <> origin/A →:2:
+    │       ├── ·a62b0de (⌂|🏘|11)
+    │       └── ·120a217 (⌂|🏘|11)
+    │           └── ►:3[2]:main
+    │               └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A →:1:
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:1: (A →:2:)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-    └── ≡:1:A
-        ├── :1:A
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡:1:A <> origin/A →:2:⇣1
+        ├── :1:A <> origin/A →:2:⇣1
+        │   ├── 🟣4fe5a6f
+        │   ├── ❄️a62b0de (🏘️)
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     let (id, ref_name) = id_at(&repo, "A");
     let graph = Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
-        └── 👉►:0[1]:A
-            ├── ·a62b0de (⌂|🏘|1)
-            └── ·120a217 (⌂|🏘|1)
-                └── ►:2[2]:main
-                    └── ·fafd9d0 (⌂|🏘|1)
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
+    │   └── 👉►:0[1]:A <> origin/A →:2:
+    │       ├── ·a62b0de (⌂|🏘|11)
+    │       └── ·120a217 (⌂|🏘|11)
+    │           └── ►:3[2]:main
+    │               └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A →:0:
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:0: (A →:2:)
     ");
 
     // Main can be a normal segment if there is no target ref.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-    └── ≡👉:0:A
-        ├── 👉:0:A
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡👉:0:A <> origin/A →:2:⇣1
+        ├── 👉:0:A <> origin/A →:2:⇣1
+        │   ├── 🟣4fe5a6f
+        │   ├── ❄️a62b0de (🏘️)
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
     Ok(())
 }
@@ -4083,23 +4133,27 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     // Without disambiguation, there is no segment name.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        └── ►:1[1]:anon:
-            ├── ·a62b0de (⌂|🏘|1) ►A, ►B
-            └── ·120a217 (⌂|🏘|1)
-                └── ►:2[2]:main
-                    └── ·fafd9d0 (⌂|🏘|1)
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ►:1[1]:A <> origin/A →:2:
+    │       ├── ·a62b0de (⌂|🏘|11) ►B
+    │       └── ·120a217 (⌂|🏘|11)
+    │           └── ►:3[2]:main
+    │               └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A →:1:
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:1: (A →:2:)
     ");
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-    └── ≡:1:anon:
-        ├── :1:anon:
-        │   ├── ·a62b0de (🏘️) ►A, ►B
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡:1:A <> origin/A →:2:⇣1
+        ├── :1:A <> origin/A →:2:⇣1
+        │   ├── 🟣4fe5a6f
+        │   ├── ❄️a62b0de (🏘️) ►B
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     // We can help it by adding metadata.
@@ -4108,63 +4162,71 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &[]);
     let (id, a_ref) = id_at(&repo, "A");
     let graph = Graph::from_commit_traversal(id, a_ref.clone(), &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
-        └── 👉►:3[1]:A
-            └── 📙►:0[2]:B
-                ├── ·a62b0de (⌂|🏘|1)
-                └── ·120a217 (⌂|🏘|1)
-                    └── ►:2[3]:main
-                        └── ·fafd9d0 (⌂|🏘|1)
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
+    │   └── 👉►:4[1]:A <> origin/A →:2:
+    │       └── 📙►:0[2]:B
+    │           ├── ·a62b0de (⌂|🏘|11)
+    │           └── ·120a217 (⌂|🏘|11)
+    │               └── ►:3[3]:main
+    │                   └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A →:4:
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:4: (A →:2:)
     ");
 
     // Main can be a normal segment if there is no target ref.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-    └── ≡👉:3:A {1}
-        ├── 👉:3:A
+    └── ≡👉:4:A <> origin/A →:2:⇣1 {1}
+        ├── 👉:4:A <> origin/A →:2:⇣1
+        │   └── 🟣4fe5a6f
         ├── 📙:0:B
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+        │   ├── ❄a62b0de (🏘️)
+        │   └── ❄120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     // Finally, show the normal version with just disambiguated 'B".
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        └── 📙►:1[1]:B
-            ├── ·a62b0de (⌂|🏘|1) ►A
-            └── ·120a217 (⌂|🏘|1)
-                └── ►:2[2]:main
-                    └── ·fafd9d0 (⌂|🏘|1)
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── 📙►:1[1]:B
+    │       ├── ·a62b0de (⌂|🏘|11) ►A
+    │       └── ·120a217 (⌂|🏘|11)
+    │           └── ►:3[2]:main
+    │               └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:1: (B)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:1:B {1}
         ├── 📙:1:B
         │   ├── ·a62b0de (🏘️) ►A
         │   └── ·120a217 (🏘️)
-        └── :2:main
+        └── :3:main
             └── ·fafd9d0 (🏘️)
     ");
 
     // Order is respected
     add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &["A"]);
     let graph = Graph::from_commit_traversal(id, a_ref, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-    └── ≡📙:3:B {1}
-        ├── 📙:3:B
-        ├── 👉📙:4:A
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡📙:4:B {1}
+        ├── 📙:4:B
+        ├── 👉📙:5:A <> origin/A →:2:
+        ├── 📙:0:A <> origin/A →:5:
+        │   ├── ❄️a62b0de (🏘️)
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     Ok(())
@@ -4297,48 +4359,56 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     // The commit is ambiguous, so there is just the entrypoint to split the segment.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
-        └── ·3ea2742 (⌂|🏘|1)
-            └── ►:1[1]:A
-                ├── ·a62b0de (⌂|🏘|1)
-                └── ·120a217 (⌂|🏘|1)
-                    └── ►:2[2]:main
-                        └── ·fafd9d0 (⌂|🏘|1)
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·3ea2742 (⌂|🏘|001)
+    │       └── ►:1[1]:A <> origin/A →:2:
+    │           ├── ·a62b0de (⌂|🏘|111)
+    │           └── ·120a217 (⌂|🏘|111)
+    │               └── ►:3[2]:main
+    │                   └── ·fafd9d0 (⌂|🏘|111)
+    └── ►:2[0]:origin/A →:1:
+        └── 🟣4fe5a6f (0x0|100)
+            └── →:1: (A →:2:)
     ");
     // TODO: add more stacks.
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-    └── ≡:1:A
-        ├── :1:A
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡:1:A <> origin/A →:2:⇣1
+        ├── :1:A <> origin/A →:2:⇣1
+        │   ├── 🟣4fe5a6f
+        │   ├── ❄️a62b0de (🏘️)
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     let (id, ref_name) = id_at(&repo, "A");
     let graph = Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── 📕►►►:1[0]:gitbutler/workspace[🌳]
-        └── ·3ea2742 (⌂|🏘)
-            └── 👉►:0[1]:A
-                ├── ·a62b0de (⌂|🏘|1)
-                └── ·120a217 (⌂|🏘|1)
-                    └── ►:2[2]:main
-                        └── ·fafd9d0 (⌂|🏘|1)
+    ├── 📕►►►:1[0]:gitbutler/workspace[🌳]
+    │   └── ·3ea2742 (⌂|🏘)
+    │       └── 👉►:0[1]:A <> origin/A →:2:
+    │           ├── ·a62b0de (⌂|🏘|11)
+    │           └── ·120a217 (⌂|🏘|11)
+    │               └── ►:3[2]:main
+    │                   └── ·fafd9d0 (⌂|🏘|11)
+    └── ►:2[0]:origin/A →:0:
+        └── 🟣4fe5a6f (0x0|10)
+            └── →:0: (A →:2:)
     ");
 
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
     📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
-    └── ≡👉:0:A
-        ├── 👉:0:A
-        │   ├── ·a62b0de (🏘️)
-        │   └── ·120a217 (🏘️)
-        └── :2:main
-            └── ·fafd9d0 (🏘️)
+    └── ≡👉:0:A <> origin/A →:2:⇣1
+        ├── 👉:0:A <> origin/A →:2:⇣1
+        │   ├── 🟣4fe5a6f
+        │   ├── ❄️a62b0de (🏘️)
+        │   └── ❄️120a217 (🏘️)
+        └── :3:main
+            └── ❄fafd9d0 (🏘️)
     ");
 
     Ok(())
@@ -4355,14 +4425,14 @@ fn workspace_commit_pushed_to_target() -> anyhow::Result<()> {
 
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @r"
+    insta::assert_snapshot!(graph_tree(&graph), @"
 
-    └── ►:1[0]:origin/main
+    └── ►:1[0]:origin/main →:3:
         └── 👉📕►►►:0[1]:gitbutler/workspace[🌳]
             └── ·8ee08de (⌂|🏘|✓|1)
                 └── ►:2[2]:A
                     └── ·120a217 (⌂|🏘|✓|1)
-                        └── ►:3[3]:main
+                        └── ►:3[3]:main <> origin/main →:1:
                             └── ·fafd9d0 (⌂|🏘|✓|1)
     ");
     // Everything is integrated, so nothing is shown.

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -475,7 +475,7 @@ pub fn read_only_in_memory_scenario(name: &str) -> anyhow::Result<gix::Repositor
     read_only_in_memory_scenario_named(name, "")
 }
 
-/// Obtain an isolated `repo` from the `tests/fixtures/$dirname/$script_name.sh` script, with in-memory objects.
+/// Obtain an isolated `repo` from the `tests/fixtures/$script_name.sh/…/$dirname` script, with in-memory objects.
 pub fn read_only_in_memory_scenario_named(script_name: &str, dirname: &str) -> anyhow::Result<gix::Repository> {
     let root = gix_testtools::scripted_fixture_read_only(format!("scenario/{script_name}.sh"))
         .map_err(anyhow::Error::from_boxed)?;
@@ -483,7 +483,7 @@ pub fn read_only_in_memory_scenario_named(script_name: &str, dirname: &str) -> a
     Ok(repo)
 }
 
-/// Obtain an isolated `repo` from the `tests/fixtures/$dirname/$script_name.sh` script, with in-memory objects,
+/// Obtain an isolated `repo` from the `tests/fixtures/$script_name.sh/…/$dirname` script, with in-memory objects,
 /// with `dirname` being the sub-directory to look into once the fixture was created.
 /// `dirname` can be "" to make it a no-op.
 /// Use `post_fn` to modify the fixture and produce a value of type `T`, which is also returned.

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -8,7 +8,7 @@ use gix::{
     config::tree::Key,
 };
 pub use gix_testtools;
-use gix_testtools::{Creation, tempfile};
+use gix_testtools::{Creation, FixtureState, PostResult, tempfile};
 
 mod in_memory_meta;
 pub use in_memory_meta::{InMemoryRefMetadata, InMemoryRefMetadataHandle, StackState};
@@ -375,8 +375,32 @@ pub fn write_sequence(
 
 /// Obtain a `(repo, tmp)` where `tmp` is a copy of the `tests/fixtures/scenario/$name.sh` script.
 pub fn writable_scenario(name: &str) -> (gix::Repository, tempfile::TempDir) {
-    writable_scenario_inner(name, Creation::CopyFromReadOnly, None::<String>)
-        .expect("fixtures will yield valid repositories")
+    let (a, b, _) = writable_scenario_inner(
+        name,
+        Creation::CopyFromReadOnly,
+        None::<String>,
+        None::<(_, fn(FixtureState<'_>) -> PostResult<()>)>,
+    )
+    .expect("fixtures will yield valid repositories");
+    (a, b)
+}
+
+/// Obtain a `(repo, tmp, post)` where `tmp` is a copy of the `tests/fixtures/scenario/$name.sh` script.
+/// Use `post_fn` to modify the fixture and produce a value of type `T`, which is also returned.
+/// Increment `version` each time `post_fn` is modified.
+pub fn writable_scenario_with_post<T>(
+    name: &str,
+    version: u32,
+    post_fn: impl FnMut(FixtureState<'_>) -> PostResult<T>,
+) -> (gix::Repository, tempfile::TempDir, T) {
+    let (repo, tmp, post) = writable_scenario_inner(
+        name,
+        Creation::CopyFromReadOnly,
+        None::<String>,
+        Some((version, post_fn)),
+    )
+    .expect("fixtures will yield valid repositories");
+    (repo, tmp, post.unwrap())
 }
 
 /// Obtain a `(repo, tmp)` where `tmp` is a copy of the `tests/fixtures/scenario/$name.sh` script,
@@ -385,15 +409,28 @@ pub fn writable_scenario_with_args(
     name: &str,
     args: impl IntoIterator<Item = impl Into<String>>,
 ) -> (gix::Repository, tempfile::TempDir) {
-    writable_scenario_inner(name, Creation::CopyFromReadOnly, args).expect("fixtures will yield valid repositories")
+    let (a, b, _) = writable_scenario_inner(
+        name,
+        Creation::CopyFromReadOnly,
+        args,
+        None::<(_, fn(FixtureState<'_>) -> PostResult<()>)>,
+    )
+    .expect("fixtures will yield valid repositories");
+    (a, b)
 }
 
 /// Obtain a `(repo, tmp)` where `tmp` is the result of the execution of the `tests/fixtures/scenario/$name.sh` script.
 ///
 /// It's slow because it has to re-execute the script, in case the script creates files with absolute paths in them.
 pub fn writable_scenario_slow(name: &str) -> (gix::Repository, tempfile::TempDir) {
-    writable_scenario_inner(name, Creation::ExecuteScript, None::<String>)
-        .expect("fixtures will yield valid repositories")
+    let (a, b, _) = writable_scenario_inner(
+        name,
+        Creation::ExecuteScript,
+        None::<String>,
+        None::<(_, fn(FixtureState<'_>) -> PostResult<()>)>,
+    )
+    .expect("fixtures will yield valid repositories");
+    (a, b)
 }
 
 /// Obtain a `(repo, tmp)` where `tmp` is a copy of the `tests/fixtures/scenario/$name.sh` script,
@@ -405,8 +442,13 @@ pub fn writable_scenario_slow(name: &str) -> (gix::Repository, tempfile::TempDir
 ///
 /// Git will also be configured to use the key for signing in the returned `repo`.
 pub fn writable_scenario_with_ssh_key(name: &str) -> (gix::Repository, tempfile::TempDir) {
-    let (mut repo, tmp) = writable_scenario_inner(name, Creation::CopyFromReadOnly, None::<String>)
-        .expect("fixtures will yield valid repositories");
+    let (mut repo, tmp, _) = writable_scenario_inner(
+        name,
+        Creation::CopyFromReadOnly,
+        None::<String>,
+        None::<(_, fn(FixtureState<'_>) -> PostResult<()>)>,
+    )
+    .expect("fixtures will yield valid repositories");
     let signing_key_path = repo.workdir().expect("non-bare").join("signature.key");
     assert!(
         signing_key_path.is_file(),
@@ -441,15 +483,54 @@ pub fn read_only_in_memory_scenario_named(script_name: &str, dirname: &str) -> a
     Ok(repo)
 }
 
-fn writable_scenario_inner(
+/// Obtain an isolated `repo` from the `tests/fixtures/$dirname/$script_name.sh` script, with in-memory objects,
+/// with `dirname` being the sub-directory to look into once the fixture was created.
+/// `dirname` can be "" to make it a no-op.
+/// Use `post_fn` to modify the fixture and produce a value of type `T`, which is also returned.
+/// Increment `version` each time `post_fn` is modified.
+pub fn read_only_in_memory_scenario_named_with_post<T>(
+    script_name: &str,
+    dirname: &str,
+    version: u32,
+    post_fn: impl FnMut(FixtureState<'_>) -> PostResult<T>,
+) -> anyhow::Result<(gix::Repository, T)> {
+    let (repo, value) =
+        read_only_in_memory_scenario_named_with_post_inner(script_name, dirname, Some((version, post_fn)))?;
+    Ok((repo, value.unwrap()))
+}
+
+fn read_only_in_memory_scenario_named_with_post_inner<T>(
+    script_name: &str,
+    dirname: &str,
+    post_fn: Option<(u32, impl FnMut(FixtureState<'_>) -> PostResult<T>)>,
+) -> anyhow::Result<(gix::Repository, Option<T>)> {
+    let path = format!("scenario/{script_name}.sh");
+    let (root, value) = match post_fn {
+        Some((v, f)) => {
+            gix_testtools::scripted_fixture_read_only_with_post(path, v, f).map(|(root, value)| (root, Some(value)))
+        }
+        None => gix_testtools::scripted_fixture_read_only(path).map(|root| (root, None)),
+    }
+    .map_err(anyhow::Error::from_boxed)?;
+    let repo = open_repo(&root.join(dirname))?.with_object_memory();
+    Ok((repo, value))
+}
+
+fn writable_scenario_inner<T>(
     name: &str,
     creation: Creation,
     args: impl IntoIterator<Item = impl Into<String>>,
-) -> anyhow::Result<(gix::Repository, tempfile::TempDir)> {
-    let tmp = gix_testtools::scripted_fixture_writable_with_args(format!("scenario/{name}.sh"), args, creation)
-        .map_err(anyhow::Error::from_boxed)?;
+    post_fn: Option<(u32, impl FnMut(FixtureState<'_>) -> PostResult<T>)>,
+) -> anyhow::Result<(gix::Repository, tempfile::TempDir, Option<T>)> {
+    let script_name = format!("scenario/{name}.sh");
+    let (tmp, post) = match post_fn {
+        Some((v, f)) => gix_testtools::scripted_fixture_writable_with_args_with_post(script_name, args, creation, v, f)
+            .map(|(tmp, post)| (tmp, Some(post))),
+        None => gix_testtools::scripted_fixture_writable_with_args(script_name, args, creation).map(|tmp| (tmp, None)),
+    }
+    .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(tmp.path())?;
-    Ok((repo, tmp))
+    Ok((repo, tmp, post))
 }
 
 /// Windows dummy

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -133,7 +133,7 @@ pub(crate) mod function {
 
     use anyhow::{Context as _, bail};
     use but_core::{
-        ObjectStorageExt, RefMetadata, RepositoryExt, extract_remote_name, ref_metadata,
+        ObjectStorageExt, RefMetadata, RepositoryExt, extract_remote_name_and_short_name, ref_metadata,
         ref_metadata::{
             StackId, StackKind,
             StackKind::AppliedAndUnapplied,
@@ -752,7 +752,8 @@ pub(crate) mod function {
         let mut section = config.section_mut_or_create_new("branch", Some(local_tracking_ref.shorten()))?;
         // Only edit the configuration if truly empty, let's not overwrite user data.
         if section.num_values() == 0
-            && let Some(remote_name) = extract_remote_name(remote_tracking_ref, &repo.remote_names())
+            && let Some((remote_name, _short_name)) =
+                extract_remote_name_and_short_name(remote_tracking_ref, &repo.remote_names())
         {
             section
                 .push(

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -55,7 +55,7 @@ impl RemoteTrackingReference {
     pub fn for_ui(ref_name: gix::refs::FullName, remote_names: &gix::remote::Names) -> anyhow::Result<Self> {
         let (category, _short_name) = ref_name
             .category_and_short_name()
-            .with_context(|| format!("Failed to categorize presume remote reference '{ref_name}'"))?;
+            .with_context(|| format!("Failed to categorize presumed remote reference '{ref_name}'"))?;
         if category != Category::RemoteBranch {
             bail!("Expected '{ref_name}' to be a remote tracking branch, but was {category:?}");
         }

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context as _, bail};
 use bstr::{BString, ByteSlice};
-use but_core::{ref_metadata, ref_metadata::StackId};
+use but_core::{
+    extract_remote_name_and_short_name,
+    ref_metadata::{self, StackId},
+};
 use gix::refs::Category;
 
 use crate::{
@@ -50,31 +53,19 @@ impl RemoteTrackingReference {
     /// Create a new instance from `ref_name` and `remote_names`, essentially splitting the remote
     /// name off the short name.
     pub fn for_ui(ref_name: gix::refs::FullName, remote_names: &gix::remote::Names) -> anyhow::Result<Self> {
-        let (category, short_name) = ref_name
+        let (category, _short_name) = ref_name
             .category_and_short_name()
             .with_context(|| format!("Failed to categorize presume remote reference '{ref_name}'"))?;
         if category != Category::RemoteBranch {
             bail!("Expected '{ref_name}' to be a remote tracking branch, but was {category:?}");
         }
-        let (longest_remote, short_name) = remote_names
-            .iter()
-            .rev()
-            .find_map(|remote_name| {
-                short_name.strip_prefix(remote_name.as_bytes()).and_then(|stripped| {
-                    if stripped.first() == Some(&b'/') {
-                        #[allow(clippy::indexing_slicing)]
-                        Some((remote_name, stripped[1..].as_bstr()))
-                    } else {
-                        None
-                    }
-                })
-            })
+        let (longest_remote, short_name) = extract_remote_name_and_short_name(ref_name.as_ref(), remote_names)
             .ok_or(anyhow::anyhow!("Failed to find remote branch's corresponding remote"))
             .with_context(|| format!("Remote reference '{ref_name}' couldn't be matched with any known remote"))?;
 
         Ok(RemoteTrackingReference {
             display_name: short_name.to_str_lossy().into_owned(),
-            remote_name: longest_remote.to_str_lossy().into_owned(),
+            remote_name: longest_remote,
             full_name_bytes: ref_name.into_inner(),
         })
     }

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -873,14 +873,14 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                     ref_info::ui::Segment {
                         id: NodeIndex(4),
                         ref_name: "►A",
-                        remote_tracking_ref_name: "None",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(1818c17, "A\n", integrated(0b6b861)),
                         ],
                         commits_on_remote: [],
                         commits_outside: None,
                         metadata: "None",
-                        push_status: CompletelyUnpushed,
+                        push_status: Integrated,
                         base: "281456a",
                     },
                 ],


### PR DESCRIPTION
### Tasks

* [x] test
* [x] fix
* [x] use it in but-api
* [x] test for new extraction function and `refs/remotes/nested/remote/feature` kind of RTBs.
