### PR TITLE
Avoid deadlock during setup

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -98,10 +98,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     // Determine if pager should be used based on the command
     let use_pager = match args.cmd {
         #[cfg(feature = "legacy")]
-        Some(Subcommands::Status { .. }) | Some(Subcommands::Oplog(..)) => false,
-        Some(Subcommands::Help) => false,
-        Some(Subcommands::Setup { .. }) => false,
-        _ => true,
+        Some(Subcommands::Diff { .. }) => true,
+        _ => false,
     };
     let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
 

--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -5,10 +5,7 @@ fn not_a_git_repository() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
 
     env.but("setup").assert().failure().stderr_eq(snapbox::str![[r#"
-Error: Failed to set up GitButler project.
-
-Caused by:
-    No git repository found - run `but setup --init` to initialize a new repository.
+Error: No git repository found - run `but setup --init` to initialize a new repository.
 
 "#]]);
 
@@ -514,10 +511,7 @@ fn json_output_not_a_git_repo() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Failed to set up GitButler project.
-
-Caused by:
-    No git repository found.
+Error: No git repository found.
 
 "#]])
         .stdout_eq(snapbox::str![]);

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -31,15 +31,10 @@ Please run 'but setup' to initialize the project.
 "#]]);
 
     // Setup doesn't work without a Git repository
-    env.but("setup").assert().failure().stderr_eq(str![
-        r#"
-Error: Failed to set up GitButler project.
+    env.but("setup").assert().failure().stderr_eq(str![[r#"
+Error: No git repository found - run `but setup --init` to initialize a new repository.
 
-Caused by:
-    No git repository found - run `but setup --init` to initialize a new repository.
-
-"#
-    ]);
+"#]]);
 
     // TODO: this should work, but we still have requirements and can't deal with any repo.
     env.but("setup --init").assert().success().stdout_eq(str![[r#"


### PR DESCRIPTION
### Tasks

* [x] fix
* [x] validate
* [x] fix logic to match tests
* [x] pager opt-in only for `but diff`

### Validation

Seems to work now, as in "it doesn't deadlock". Maybe there is more to watch out for?

```
❯ cargo run --bin but -- -C ~/dev-gb/autocrlf status
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/but -C /Users/byron/dev-gb/autocrlf status`
The current project is not configured to be managed by GitButler.

No GitButler project found at /Users/byron/dev-gb/autocrlf

In order to manage projects with GitButler, we need to do some changes:

 - Switch you to a special `gitbutler/workspace` branch to enable parallel branches
 - Install Git hooks to help manage the tooling

You can go back to normal git workflows at any time by either:

 - Running `but teardown`
 - Manually checking out a normal branch with `git checkout <branch>`

Would you like to run setup now? [Y/n]:
> Y
Setting up GitButler project...

→ Adding repository to GitButler project registry
  ✓ Repository already in project registry

GitButler project is already set up!
Target branch: origin/main



 █████      █████    ██████╗ ██╗   ██╗████████╗
   █████  █████      ██╔══██╗██║   ██║╚══██╔══╝
     ████████        ██████╔╝██║   ██║   ██║
   █████  █████      ██╔══██╗██║   ██║   ██║
 █████      █████    ██████╔╝╚██████╔╝   ██║

The command-line interface for GitButler

$ but branch new <name>                       Create a new branch
$ but status                                  View workspace status
$ but commit -m <message>                     Commit changes to current branch
$ but push                                    Push all branches
$ but teardown                                Return to normal Git mode

Learn more at https://docs.gitbutler.com/cli-overview

Initiated a background sync...
╭┄zz [unstaged changes]
┊     no changes
┊
┴ 4181411 (common base) [origin/main] 2024-11-15 init

Hint: run `but branch new` to create a new branch to work on

gitbutler ( fix3) [$] via  took 3s
❯ cargo run --bin but -- -C ~/dev-gb/autocrlf status
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/but -C /Users/byron/dev-gb/autocrlf status`
Initiated a background sync...
╭┄zz [unstaged changes]
┊     no changes
┊
┴ 4181411 (common base) [origin/main] 2024-11-15 init (checked 6 seconds ago)

Hint: run `but branch new` to create a new branch to work on
```
