### PR TITLE
chore(publish): Build and publish standalone but CLI for Linux

### DIFF
--- a/.github/workflows/publish.include.txt
+++ b/.github/workflows/publish.include.txt
@@ -9,3 +9,4 @@
 *.app
 *.nsis
 *.zip
+but

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -11,9 +11,9 @@ fi
 
 set -x
 cargo build --release -p gitbutler-git
-if [ "${OS:-}" == "windows" ]; then
-  # WARNING: should only run if the `builtin-but` feature is *not* selected in `release.sh`.
-  #          Right now we just keep these scripts in sync to do the right thing, assuming it won't change.
+if [ "${OS:-}" == "windows" ] || [ "${OS:-}" == "linux" ]; then
+  # NOTE: Should run either if the builtin-but feature is *not* selected in `release.sh` (case for Windows), OR if we
+  # need the standalone CLI for separate publishing (case for Linux)
   cargo build --release -p but
 fi
 bash ./crates/gitbutler-tauri/inject-git-binaries.sh


### PR DESCRIPTION
## 🧢 Changes
Builds the `but` CLI as part of the Linux build and adds it the the publish include list s.t. it should get uploaded with the rest of the artifacts.

Note that this does not include said binary into the Tauri bundles, nor does it alter the information published to the backend. We might want to do that too at some point but one thing at a time.

Omitting the signature for now, will add that in later.