### PR TITLE
chore: Fix ts definitions check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typed-builder",

--- a/scripts/generate-ts-definitions-from-rust.sh
+++ b/scripts/generate-ts-definitions-from-rust.sh
@@ -16,6 +16,6 @@ pnpm format
 
 if ! git diff --quiet; then
   git status
-  echo "There are changed TS bindings. This error will go away with `git add .`, and on CI when the changes are committed."
+  echo "There are changed TS bindings. This error will go away with 'git add .', and on CI when the changes are committed."
   exit 2
 fi


### PR DESCRIPTION
## 🧢 Changes
scripts/generate-ts-definitions-from-rust.sh script is failing on master because it updates Cargo.lock (a bit of a false positive but IMO not really worth investing time into fixing atm).

Hilariously, the script also has `git add .` in backticks in the echo at the end of the script, which actually executes `git add .`, staging the changes and makes the error message `<snip> This error will go away with ,<snip>` instead of `<snip>This error will go away with 'git add .'<snip>`.