### PR TITLE
feat: add Gitea forge integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "but-forge",
  "but-forge-storage",
  "but-gerrit",
+ "but-gitea",
  "but-github",
  "but-gitlab",
  "but-graph",
@@ -1115,6 +1116,7 @@ dependencies = [
  "but-db",
  "but-forge-storage",
  "but-fs",
+ "but-gitea",
  "but-github",
  "but-gitlab",
  "chrono",
@@ -1161,6 +1163,20 @@ dependencies = [
  "gix",
  "serde",
  "snapbox",
+]
+
+[[package]]
+name = "but-gitea"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "but-error",
+ "but-forge-storage",
+ "but-secret",
+ "but-settings",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ members = [
     "crates/but-github",            # 📄A thin wrapper of the GitHub API, for authentication and resource access.
     # 👉lacks top-level docs and docs.
     "crates/but-gitlab",            # 📄A thin wrapper of the GitLab API, for authentication and resource access.
+    # 👉lacks top-level docs and docs.
+    "crates/but-gitea",             # 📄A thin wrapper of the Gitea API, for authentication and resource access.
     # 👉No tests, lacks top-level docs, purpose somewhat unclear.
     "crates/but-cursor",            # 📄Integration with Cursor
     # 👉Kind of no docs, no tests, and unclear purpose.
@@ -154,6 +156,7 @@ but-gerrit = { path = "crates/but-gerrit" }
 but-cherry-apply = { path = "crates/but-cherry-apply" }
 but-github = { path = "crates/but-github" }
 but-gitlab = { path = "crates/but-gitlab" }
+but-gitea = { path = "crates/but-gitea" }
 but-error = { path = "crates/but-error" }
 but-serde = { path = "crates/but-serde" }
 but-update = { path = "crates/but-update" }

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -6,6 +6,7 @@
 		stringToGitHubAccountIdentifier
 	} from '$lib/forge/github/githubUserService.svelte';
 	import { usePreferredGitHubUsername } from '$lib/forge/github/hooks.svelte';
+	import { GITEA_STATE } from '$lib/forge/gitea/giteaState.svelte';
 	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
@@ -18,6 +19,7 @@
 	const { projectId }: { projectId: string } = $props();
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
+	const giteaState = inject(GITEA_STATE);
 	const gitLabState = inject(GITLAB_STATE);
 	const { preferredGitHubAccount, githubAccounts } = usePreferredGitHubUsername(
 		reactive(() => projectId)
@@ -27,6 +29,9 @@
 	const forkProjectId = gitLabState.forkProjectId;
 	const upstreamProjectId = gitLabState.upstreamProjectId;
 	const instanceUrl = gitLabState.instanceUrl;
+
+	const giteaToken = giteaState.token;
+	const giteaInstanceUrl = giteaState.instanceUrl;
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectQuery = $derived(projectsService.getProject(projectId));
@@ -44,6 +49,10 @@
 		{
 			label: 'GitLab',
 			value: 'gitlab'
+		},
+		{
+			label: 'Gitea',
+			value: 'gitea'
 		},
 		{
 			label: 'Azure',
@@ -82,7 +91,7 @@
 				<br />
 				To enable Forge integration, please select your Forge from the dropdown below.
 				<br />
-				<span class="text-bold">Note:</span> Currently, only GitHub and GitLab support pull request creation.
+				<span class="text-bold">Note:</span> Currently, only GitHub, GitLab, and Gitea support pull request creation.
 			{:else}
 				We’ve detected that you’re using <span class="text-bold"
 					>{forge.determinedForgeType.toUpperCase()}</span
@@ -213,6 +222,41 @@
 					{/snippet}
 				</Select>
 			{/if}
+		</CardGroup.Item>
+	{/if}
+
+	{#if forge.current.name === 'gitea'}
+		<CardGroup.Item>
+			{#snippet title()}
+				Configure Gitea integration
+			{/snippet}
+
+			{#snippet caption()}
+				Enter your Gitea Personal Access Token and instance URL.
+				<br />
+				Works with Codeberg.org and self-hosted Gitea instances.
+			{/snippet}
+
+			<Textbox
+				label="Personal token"
+				type="password"
+				value={$giteaToken}
+				oninput={(value) => ($giteaToken = value)}
+			/>
+			<Textbox
+				label="Instance URL"
+				value={$giteaInstanceUrl}
+				oninput={(value) => ($giteaInstanceUrl = value)}
+			/>
+
+			<Spacer margin={5} />
+
+			<p class="text-12 text-body clr-text-2">
+				For self-hosted Gitea instances, add them as a custom CSP entry so GitButler
+				can connect. Read more in the <Link
+					href="https://docs.gitbutler.com/troubleshooting/custom-csp">docs</Link
+				>
+			</p>
 		</CardGroup.Item>
 	{/if}
 </CardGroup>

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -21,6 +21,7 @@
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { mapErrorToToast } from '$lib/forge/github/errorMap';
 	import { GitHubPrService } from '$lib/forge/github/githubPrService.svelte';
+	import { GITEA_STATE } from '$lib/forge/gitea/giteaState.svelte';
 	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { type PullRequest } from '$lib/forge/interface/types';
 	import { PrPersistedStore } from '$lib/forge/prContents';
@@ -64,6 +65,8 @@
 	const settingsService = inject(SETTINGS_SERVICE);
 	const appSettings = settingsService.appSettings;
 
+	const giteaState = inject(GITEA_STATE);
+	const giteaConfigured = $derived(giteaState.configured);
 	const gitLabState = inject(GITLAB_STATE);
 	const gitLabConfigured = $derived(gitLabState.configured);
 
@@ -197,6 +200,13 @@
 		if (forge.determinedForgeType === 'gitlab' && !gitLabConfigured) {
 			chipToasts.error(
 				'You must configure the GitLab integration before creating a Merge Request.'
+			);
+			return;
+		}
+
+		if (forge.determinedForgeType === 'gitea' && !giteaConfigured) {
+			chipToasts.error(
+				'You must configure the Gitea integration before creating a Pull Request.'
 			);
 			return;
 		}

--- a/apps/desktop/src/components/UnassignedViewForgePrompt.svelte
+++ b/apps/desktop/src/components/UnassignedViewForgePrompt.svelte
@@ -54,6 +54,7 @@
 				openGeneralSettings('integrations');
 				break;
 			case 'gitlab':
+			case 'gitea':
 				openProjectSettings(projectId);
 				break;
 		}
@@ -72,7 +73,13 @@
 
 	<div class="forge-prompt">
 		<div class="forge-prompt__logo">
-			{@html forgeName === 'github' ? githubLogoSvg : gitlabLogoSvg}
+			{#if forgeName === 'github'}
+				{@html githubLogoSvg}
+			{:else if forgeName === 'gitlab'}
+				{@html gitlabLogoSvg}
+			{:else}
+				<span class="text-13 text-bold">{forgeLabel}</span>
+			{/if}
 		</div>
 		<h3 class="text-13 text-body text-bold">It looks like you have a {forgeLabel} remote!</h3>
 		<p class="text-12 text-body m-b-8 clr-text-2">

--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -5,7 +5,7 @@ export interface RemoteBranchInfo {
 	name: string;
 }
 
-export type ForgeProvider = 'github' | 'gitlab' | 'bitbucket' | 'azure';
+export type ForgeProvider = 'github' | 'gitlab' | 'gitea' | 'bitbucket' | 'azure';
 
 export type ForgeRepoInfo = {
 	forge: ForgeProvider;

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -25,6 +25,8 @@ import {
 } from '$lib/dragging/stackingReorderDropzoneManager';
 import { FILE_SERVICE, FileService } from '$lib/files/fileService';
 import { DefaultForgeFactory, DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
+import { GITEA_CLIENT, GiteaClient } from '$lib/forge/gitea/giteaClient.svelte';
+import { GITEA_STATE, GiteaState } from '$lib/forge/gitea/giteaState.svelte';
 import { GITHUB_CLIENT, GitHubClient } from '$lib/forge/github/githubClient';
 import { GitHubUserService, GITHUB_USER_SERVICE } from '$lib/forge/github/githubUserService.svelte';
 import { GITLAB_CLIENT, GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
@@ -128,6 +130,8 @@ export function initDependencies(args: {
 	const gitHubClient = new GitHubClient();
 	const gitLabState = new GitLabState(secretsService);
 	const gitLabClient = new GitLabClient(gitLabState);
+	const giteaState = new GiteaState(secretsService);
+	const giteaClient = new GiteaClient(giteaState);
 
 	// ============================================================================
 	// EXPERIMENTAL STUFF
@@ -141,7 +145,7 @@ export function initDependencies(args: {
 	// STATE MANAGEMENT
 	// ============================================================================
 
-	const clientState = new ClientState(backend, gitHubClient, gitLabClient, ircClient, posthog);
+	const clientState = new ClientState(backend, gitHubClient, gitLabClient, giteaClient, ircClient, posthog);
 	const githubUserService = new GitHubUserService(clientState.backendApi);
 	const gitlabUserService = new GitLabUserService(clientState.backendApi);
 
@@ -175,9 +179,11 @@ export function initDependencies(args: {
 	const forgeFactory = new DefaultForgeFactory({
 		gitHubClient,
 		gitLabClient,
+		giteaClient,
 		backendApi: clientState['backendApi'],
 		gitHubApi: clientState['githubApi'],
 		gitLabApi: clientState['gitlabApi'],
+		giteaApi: clientState['giteaApi'],
 		dispatch: clientState.dispatch,
 		posthog: posthog
 	});
@@ -338,6 +344,8 @@ export function initDependencies(args: {
 		[FEED_SERVICE, feedService],
 		[FILE_SERVICE, fileService],
 		[FOCUS_MANAGER, focusManager],
+		[GITEA_CLIENT, giteaClient],
+		[GITEA_STATE, giteaState],
 		[GITHUB_CLIENT, gitHubClient],
 		[GITHUB_USER_SERVICE, githubUserService],
 		[GITLAB_USER_SERVICE, gitlabUserService],

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -7,6 +7,7 @@ import { type BackendApi, type GitHubApi } from '$lib/state/clientState.svelte';
 import { mockCreateBackend } from '$lib/testing/mockBackend';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { expect, test, describe, vi } from 'vitest';
+import type { GiteaClient } from '$lib/forge/gitea/giteaClient.svelte';
 import type { GitHubClient } from '$lib/forge/github/githubClient';
 import type { GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
 import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
@@ -32,10 +33,14 @@ describe.concurrent('DefaultforgeFactory', () => {
 	const backendApi: BackendApi = new MockBackendApi();
 	const gitHubClient = { onReset: () => {} } as any as GitHubClient;
 	const gitLabClient = { onReset: () => {} } as any as GitLabClient;
+	const giteaClient = { onReset: () => {} } as any as GiteaClient;
 
 	// TODO: Replace with a better mock.
 	const dispatch = (() => {}) as ThunkDispatch<any, any, UnknownAction>;
 	const gitLabApi: any = {
+		injectEndpoints: vi.fn()
+	};
+	const giteaApi: any = {
 		injectEndpoints: vi.fn()
 	};
 
@@ -46,6 +51,8 @@ describe.concurrent('DefaultforgeFactory', () => {
 			backendApi,
 			gitLabClient,
 			gitLabApi,
+			giteaClient,
+			giteaApi,
 			posthog,
 			dispatch
 		});
@@ -70,6 +77,8 @@ describe.concurrent('DefaultforgeFactory', () => {
 			backendApi,
 			gitLabClient,
 			gitLabApi,
+			giteaClient,
+			giteaApi,
 			posthog,
 			dispatch
 		});
@@ -94,6 +103,8 @@ describe.concurrent('DefaultforgeFactory', () => {
 			backendApi,
 			gitLabClient,
 			gitLabApi,
+			giteaClient,
+			giteaApi,
 			posthog,
 			dispatch
 		});
@@ -118,6 +129,8 @@ describe.concurrent('DefaultforgeFactory', () => {
 			backendApi,
 			gitLabClient,
 			gitLabApi,
+			giteaClient,
+			giteaApi,
 			posthog,
 			dispatch
 		});
@@ -141,6 +154,8 @@ describe.concurrent('DefaultforgeFactory', () => {
 			gitLabClient,
 			backendApi,
 			gitLabApi,
+			giteaClient,
+			giteaApi,
 			posthog,
 			dispatch
 		});

--- a/apps/desktop/src/lib/forge/gitea/gitea.ts
+++ b/apps/desktop/src/lib/forge/gitea/gitea.ts
@@ -1,0 +1,122 @@
+import { GiteaBranch } from '$lib/forge/gitea/giteaBranch';
+import { gitea, type GiteaClient } from '$lib/forge/gitea/giteaClient.svelte';
+import { GiteaListingService } from '$lib/forge/gitea/giteaListingService.svelte';
+import { GiteaPrService } from '$lib/forge/gitea/giteaPrService.svelte';
+import { providesList, ReduxTag } from '$lib/state/tags';
+import { toSerializable } from '@gitbutler/shared/network/types';
+import type { PostHogWrapper } from '$lib/analytics/posthog';
+import type { Forge, ForgeName } from '$lib/forge/interface/forge';
+import type { ForgeArguments, ForgeUser } from '$lib/forge/interface/types';
+import type { GiteaApi } from '$lib/state/clientState.svelte';
+import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
+import type { TagDescription } from '@reduxjs/toolkit/query';
+
+export const GITEA_DOMAIN = 'codeberg.org';
+export const GITEA_SUB_DOMAIN = 'gitea';
+
+export class Gitea implements Forge {
+	readonly name: ForgeName = 'gitea';
+	readonly authenticated: boolean;
+	readonly isLoading: boolean;
+	private baseUrl: string;
+	private baseBranch: string;
+	private forkStr?: string;
+	private api: ReturnType<typeof injectEndpoints>;
+
+	constructor(
+		private params: ForgeArguments & {
+			posthog?: PostHogWrapper;
+			api: GiteaApi;
+			client: GiteaClient;
+			dispatch: ThunkDispatch<any, any, UnknownAction>;
+		}
+	) {
+		const { api, client, baseBranch, forkStr, authenticated, repo } = this.params;
+
+		let protocol = repo.protocol?.endsWith(':')
+			? repo.protocol.slice(0, -1)
+			: repo.protocol || 'https';
+
+		if (protocol === 'ssh') {
+			protocol = 'https';
+		}
+
+		this.baseUrl = `${protocol}://${repo.domain}/${repo.owner}/${repo.name}`;
+		this.baseBranch = baseBranch;
+		this.forkStr = forkStr;
+		this.authenticated = authenticated;
+		this.isLoading = false;
+
+		this.api = injectEndpoints(api);
+
+		client.onReset(() => api.util.resetApiState());
+	}
+
+	branch(name: string) {
+		return new GiteaBranch(name, this.baseBranch, this.baseUrl, this.forkStr);
+	}
+
+	commitUrl(id: string): string {
+		return `${this.baseUrl}/commit/${id}`;
+	}
+
+	get user() {
+		return this.api.endpoints.getGiteaUser.useQuery();
+	}
+
+	get listService() {
+		if (!this.authenticated) return;
+		const { api: giteaApi, dispatch } = this.params;
+		return new GiteaListingService(giteaApi, dispatch);
+	}
+
+	get issueService() {
+		return undefined;
+	}
+
+	get prService() {
+		if (!this.authenticated) return;
+		const { api: giteaApi, posthog } = this.params;
+		return new GiteaPrService(giteaApi, posthog);
+	}
+
+	get repoService() {
+		return undefined;
+	}
+
+	get checks() {
+		return undefined;
+	}
+
+	async pullRequestTemplateContent(_path?: string) {
+		return undefined;
+	}
+
+	invalidate(tags: TagDescription<ReduxTag>[]) {
+		return this.params.api.util.invalidateTags(tags);
+	}
+}
+
+function injectEndpoints(api: GiteaApi) {
+	return api.injectEndpoints({
+		endpoints: (build) => ({
+			getGiteaUser: build.query<ForgeUser, void>({
+				queryFn: async (args, query) => {
+					try {
+						const { client } = gitea(query.extra);
+						const user = await client.getCurrentUser();
+						const data = {
+							id: user.id,
+							name: user.full_name || user.login,
+							srcUrl: user.avatar_url
+						};
+						return { data };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				providesTags: [providesList(ReduxTag.ForgeUser)]
+			})
+		})
+	});
+}

--- a/apps/desktop/src/lib/forge/gitea/giteaBranch.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaBranch.ts
@@ -1,0 +1,11 @@
+import type { ForgeBranch } from '$lib/forge/interface/forgeBranch';
+
+export class GiteaBranch implements ForgeBranch {
+	readonly url: string;
+	constructor(name: string, baseBranch: string, baseUrl: string, fork?: string) {
+		if (fork) {
+			name = `${fork}:${name}`;
+		}
+		this.url = `${baseUrl}/compare/${baseBranch}...${name}`;
+	}
+}

--- a/apps/desktop/src/lib/forge/gitea/giteaClient.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaClient.svelte.ts
@@ -1,0 +1,169 @@
+import { InjectionToken } from '@gitbutler/core/context';
+import { derived } from 'svelte/store';
+import type { GiteaApiPullRequest, GiteaApiUser } from '$lib/forge/gitea/types';
+import type { GiteaState } from '$lib/forge/gitea/giteaState.svelte';
+
+export const GITEA_CLIENT = new InjectionToken<GiteaClient>('GiteaClient');
+
+export class GiteaClient {
+	private token: string | undefined;
+	instanceUrl: string | undefined;
+	owner: string | undefined;
+	repo: string | undefined;
+	private callbacks: (() => void)[] = [];
+
+	constructor(private giteaState: GiteaState) {}
+
+	setRepo(params: { owner?: string; repo?: string }) {
+		this.owner = params.owner;
+		this.repo = params.repo;
+	}
+
+	set() {
+		const subscribable = derived(
+			[this.giteaState.instanceUrl, this.giteaState.token],
+			([instanceUrl, token]) => {
+				this.instanceUrl = instanceUrl;
+				this.token = token;
+				for (const cb of this.callbacks) cb();
+			}
+		);
+
+		$effect(() => {
+			const unsubscribe = subscribable.subscribe(() => {});
+			return unsubscribe;
+		});
+	}
+
+	onReset(fn: () => void) {
+		this.callbacks.push(fn);
+		return () => (this.callbacks = this.callbacks.filter((cb) => cb !== fn));
+	}
+
+	get isAuthenticated(): boolean {
+		return !!this.token && !!this.instanceUrl;
+	}
+
+	private get baseUrl(): string {
+		return `${this.instanceUrl}/api/v1`;
+	}
+
+	private get headers(): Record<string, string> {
+		return {
+			Authorization: `token ${this.token}`,
+			'Content-Type': 'application/json'
+		};
+	}
+
+	private async request<T>(path: string, options?: RequestInit): Promise<T> {
+		if (!this.token || !this.instanceUrl) {
+			throw new Error('Gitea client not authenticated');
+		}
+
+		const response = await fetch(`${this.baseUrl}${path}`, {
+			...options,
+			headers: { ...this.headers, ...options?.headers }
+		});
+
+		if (!response.ok) {
+			const errorBody = await response.text().catch(() => '');
+			throw new Error(`Gitea API error ${response.status}: ${errorBody}`);
+		}
+
+		return response.json() as Promise<T>;
+	}
+
+	async getCurrentUser(): Promise<GiteaApiUser> {
+		return this.request<GiteaApiUser>('/user');
+	}
+
+	async listOpenPulls(owner: string, repo: string): Promise<GiteaApiPullRequest[]> {
+		return this.request<GiteaApiPullRequest[]>(
+			`/repos/${owner}/${repo}/pulls?state=open&limit=50`
+		);
+	}
+
+	async listPullsByBranch(
+		owner: string,
+		repo: string,
+		branchName: string
+	): Promise<GiteaApiPullRequest[]> {
+		const allPrs = await this.listOpenPulls(owner, repo);
+		return allPrs.filter((pr) => pr.head.ref === branchName);
+	}
+
+	async getPullRequest(
+		owner: string,
+		repo: string,
+		number: number
+	): Promise<GiteaApiPullRequest> {
+		return this.request<GiteaApiPullRequest>(`/repos/${owner}/${repo}/pulls/${number}`);
+	}
+
+	async createPullRequest(
+		owner: string,
+		repo: string,
+		params: { title: string; body: string; head: string; base: string }
+	): Promise<GiteaApiPullRequest> {
+		return this.request<GiteaApiPullRequest>(`/repos/${owner}/${repo}/pulls`, {
+			method: 'POST',
+			body: JSON.stringify(params)
+		});
+	}
+
+	async updatePullRequest(
+		owner: string,
+		repo: string,
+		number: number,
+		params: { title?: string; body?: string; state?: string; base?: string }
+	): Promise<GiteaApiPullRequest> {
+		return this.request<GiteaApiPullRequest>(`/repos/${owner}/${repo}/pulls/${number}`, {
+			method: 'PATCH',
+			body: JSON.stringify(params)
+		});
+	}
+
+	async mergePullRequest(
+		owner: string,
+		repo: string,
+		number: number,
+		method: 'merge' | 'rebase' | 'squash'
+	): Promise<void> {
+		await this.request(`/repos/${owner}/${repo}/pulls/${number}/merge`, {
+			method: 'POST',
+			body: JSON.stringify({
+				Do: method,
+				delete_branch_after_merge: true
+			})
+		});
+	}
+}
+
+export function gitea(extra: unknown): {
+	client: GiteaClient;
+	owner: string;
+	repo: string;
+} {
+	if (!hasGitea(extra)) throw new Error('No Gitea client!');
+	if (!extra.giteaClient.isAuthenticated) throw new Error('Gitea client not authenticated');
+	if (!extra.giteaClient.owner || !extra.giteaClient.repo)
+		throw new Error('No Gitea repo info set');
+
+	return {
+		client: extra.giteaClient,
+		owner: extra.giteaClient.owner,
+		repo: extra.giteaClient.repo
+	};
+}
+
+function hasGitea(extra: unknown): extra is {
+	giteaClient: GiteaClient;
+} {
+	return (
+		!!extra &&
+		typeof extra === 'object' &&
+		extra !== null &&
+		'giteaClient' in extra &&
+		extra.giteaClient instanceof GiteaClient
+	);
+}

--- a/apps/desktop/src/lib/forge/gitea/giteaClient.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaClient.svelte.ts
@@ -70,7 +70,9 @@ export class GiteaClient {
 			throw new Error(`Gitea API error ${response.status}: ${errorBody}`);
 		}
 
-		return response.json() as Promise<T>;
+		const text = await response.text();
+		if (!text) return undefined as T;
+		return JSON.parse(text) as T;
 	}
 
 	async getCurrentUser(): Promise<GiteaApiUser> {

--- a/apps/desktop/src/lib/forge/gitea/giteaListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaListingService.svelte.ts
@@ -1,0 +1,109 @@
+import { gitea } from '$lib/forge/gitea/giteaClient.svelte';
+import { giteaPrToInstance } from '$lib/forge/gitea/types';
+import { createSelectByIds } from '$lib/state/customSelectors';
+import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
+import { toSerializable } from '@gitbutler/shared/network/types';
+import { isDefined } from '@gitbutler/ui/utils/typeguards';
+import {
+	createEntityAdapter,
+	type EntityState,
+	type ThunkDispatch,
+	type UnknownAction
+} from '@reduxjs/toolkit';
+import type { ForgeListingService } from '$lib/forge/interface/forgeListingService';
+import type { PullRequest } from '$lib/forge/interface/types';
+import type { GiteaApi } from '$lib/state/clientState.svelte';
+
+export class GiteaListingService implements ForgeListingService {
+	private api: ReturnType<typeof injectEndpoints>;
+
+	constructor(
+		giteaApi: GiteaApi,
+		private readonly dispatch: ThunkDispatch<any, any, UnknownAction>
+	) {
+		this.api = injectEndpoints(giteaApi);
+	}
+
+	list(projectId: string, pollingInterval?: number) {
+		return this.api.endpoints.listPrs.useQuery(projectId, {
+			transform: (result) => prSelectors.selectAll(result),
+			subscriptionOptions: { pollingInterval }
+		});
+	}
+
+	getByBranch(projectId: string, branchName: string) {
+		return this.api.endpoints.listPrs.useQuery(projectId, {
+			transform: (result) => prSelectors.selectById(result, branchName)
+		});
+	}
+
+	filterByBranch(projectId: string, branchName: string[]) {
+		return this.api.endpoints.listPrs.useQueryState(projectId, {
+			transform: (result) => prSelectors.selectByIds(result, branchName)
+		});
+	}
+
+	async fetchByBranch(projectId: string, branchNames: string[]) {
+		const results = await Promise.all(
+			branchNames.map((branch) =>
+				this.api.endpoints.listPrsByBranch.fetch({ projectId, branchName: branch })
+			)
+		);
+		return results.filter(isDefined) ?? [];
+	}
+
+	async refresh(_projectId: string): Promise<void> {
+		this.dispatch(this.api.util.invalidateTags([invalidatesList(ReduxTag.PullRequests)]));
+	}
+}
+
+function injectEndpoints(api: GiteaApi) {
+	return api.injectEndpoints({
+		endpoints: (build) => ({
+			listPrs: build.query<EntityState<PullRequest, string>, string>({
+				queryFn: async (_, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						const prs = await client.listOpenPulls(owner, repo);
+
+						return {
+							data: prAdapter.addMany(
+								prAdapter.getInitialState(),
+								prs.map((pr) => giteaPrToInstance(pr))
+							)
+						};
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				providesTags: [providesList(ReduxTag.PullRequests)]
+			}),
+			listPrsByBranch: build.query<PullRequest | null, { projectId: string; branchName: string }>({
+				queryFn: async ({ branchName }, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						const prs = await client.listPullsByBranch(owner, repo, branchName);
+
+						if (prs.length === 0) {
+							return { data: null };
+						}
+
+						if (prs.length > 1) {
+							return { error: new Error(`Multiple pull requests found for branch ${branchName}`) };
+						}
+
+						return { data: giteaPrToInstance(prs[0]!) };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				}
+			})
+		})
+	});
+}
+
+const prAdapter = createEntityAdapter<PullRequest, string>({
+	selectId: (pr) => pr.sourceBranch
+});
+
+const prSelectors = { ...prAdapter.getSelectors(), selectByIds: createSelectByIds<PullRequest>() };

--- a/apps/desktop/src/lib/forge/gitea/giteaPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaPrService.svelte.ts
@@ -1,0 +1,182 @@
+import { gitea } from '$lib/forge/gitea/giteaClient.svelte';
+import { giteaPrToDetailedInstance, giteaPrToInstance } from '$lib/forge/gitea/types';
+import { providesItem, invalidatesItem, ReduxTag, invalidatesList } from '$lib/state/tags';
+import { sleep } from '$lib/utils/sleep';
+import { toSerializable } from '@gitbutler/shared/network/types';
+import { writable } from 'svelte/store';
+import type { PostHogWrapper } from '$lib/analytics/posthog';
+import type { ForgePrService } from '$lib/forge/interface/forgePrService';
+import {
+	MergeMethod,
+	type CreatePullRequestArgs,
+	type DetailedPullRequest,
+	type PullRequest
+} from '$lib/forge/interface/types';
+import type { QueryOptions } from '$lib/state/butlerModule';
+import type { GiteaApi } from '$lib/state/clientState.svelte';
+import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/query';
+
+export class GiteaPrService implements ForgePrService {
+	readonly unit = { name: 'Pull request', abbr: 'PR', symbol: '#' };
+	loading = writable(false);
+	private api: ReturnType<typeof injectEndpoints>;
+
+	constructor(
+		giteaApi: GiteaApi,
+		private posthog?: PostHogWrapper
+	) {
+		this.api = injectEndpoints(giteaApi);
+	}
+
+	async createPr({
+		title,
+		body,
+		draft,
+		baseBranchName,
+		upstreamName
+	}: CreatePullRequestArgs): Promise<PullRequest> {
+		this.loading.set(true);
+
+		const request = async () => {
+			return await this.api.endpoints.createPr.mutate({
+				head: upstreamName,
+				base: baseBranchName,
+				title,
+				body,
+				draft
+			});
+		};
+
+		let attempts = 0;
+		let lastError: any;
+
+		while (attempts < 4) {
+			try {
+				const response = await request();
+				this.posthog?.capture('Gitea PR Successful');
+				return response;
+			} catch (err: any) {
+				lastError = err;
+				attempts++;
+				await sleep(500);
+			} finally {
+				this.loading.set(false);
+			}
+		}
+		this.posthog?.capture('Gitea PR Failure');
+
+		throw lastError;
+	}
+
+	async fetch(number: number, options?: QueryOptions) {
+		const result = this.api.endpoints.getPr.fetch({ number }, options);
+		return await result;
+	}
+
+	get(number: number, options?: StartQueryActionCreatorOptions) {
+		return this.api.endpoints.getPr.useQuery({ number }, options);
+	}
+
+	async merge(method: MergeMethod, number: number) {
+		await this.api.endpoints.mergePr.mutate({ method, number });
+	}
+
+	async reopen(number: number) {
+		await this.api.endpoints.updatePr.mutate({
+			number,
+			update: { state: 'open' }
+		});
+	}
+
+	async update(
+		number: number,
+		update: { description?: string; state?: 'open' | 'closed'; targetBase?: string }
+	) {
+		await this.api.endpoints.updatePr.mutate({ number, update });
+	}
+}
+
+function injectEndpoints(api: GiteaApi) {
+	return api.injectEndpoints({
+		endpoints: (build) => ({
+			getPr: build.query<DetailedPullRequest, { number: number }>({
+				queryFn: async (args, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						const pr = await client.getPullRequest(owner, repo, args.number);
+						const data = giteaPrToDetailedInstance(pr);
+						return { data };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				providesTags: (_result, _error, args) =>
+					providesItem(ReduxTag.GiteaPullRequests, args.number)
+			}),
+			createPr: build.mutation<
+				PullRequest,
+				{ head: string; base: string; title: string; body: string; draft: boolean }
+			>({
+				queryFn: async ({ head, base, title, body }, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						const pr = await client.createPullRequest(owner, repo, {
+							title,
+							body,
+							head,
+							base
+						});
+						return { data: giteaPrToInstance(pr) };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				invalidatesTags: (result) => [invalidatesItem(ReduxTag.GiteaPullRequests, result?.number)]
+			}),
+			mergePr: build.mutation<undefined, { number: number; method: MergeMethod }>({
+				queryFn: async ({ number, method }, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						const mergeMethod =
+							method === MergeMethod.Squash
+								? 'squash'
+								: method === MergeMethod.Rebase
+									? 'rebase'
+									: 'merge';
+						await client.mergePullRequest(owner, repo, number, mergeMethod);
+						return { data: undefined };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				invalidatesTags: [invalidatesList(ReduxTag.GiteaPullRequests)]
+			}),
+			updatePr: build.mutation<
+				void,
+				{
+					number: number;
+					update: {
+						targetBase?: string;
+						description?: string;
+						state?: 'open' | 'closed';
+					};
+				}
+			>({
+				queryFn: async ({ number, update }, query) => {
+					try {
+						const { client, owner, repo } = gitea(query.extra);
+						await client.updatePullRequest(owner, repo, number, {
+							body: update.description,
+							base: update.targetBase,
+							state: update.state
+						});
+						return { data: undefined };
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
+				},
+				invalidatesTags: [invalidatesList(ReduxTag.GiteaPullRequests)]
+			})
+		})
+	});
+}

--- a/apps/desktop/src/lib/forge/gitea/giteaState.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitea/giteaState.svelte.ts
@@ -1,0 +1,88 @@
+import { InjectionToken } from '@gitbutler/core/context';
+import { persisted } from '@gitbutler/shared/persisted';
+import { derived, get, readable, writable, type Readable, type Writable } from 'svelte/store';
+import type { SecretsService } from '$lib/secrets/secretsService';
+import type { RepoInfo } from '$lib/url/gitUrl';
+
+export const GITEA_STATE = new InjectionToken<GiteaState>('GiteaState');
+
+export class GiteaState {
+	readonly token: Writable<string | undefined>;
+	private _instanceUrl: Writable<string | undefined> | undefined;
+	private _configured: Readable<boolean> | undefined;
+	private _currentProjectId: string | undefined;
+	private _unsubscribers: Array<() => void> = [];
+
+	constructor(private readonly secretService: SecretsService) {
+		this.token = writable<string | undefined>();
+	}
+
+	get instanceUrl() {
+		if (!this._instanceUrl) {
+			return writable<string | undefined>(undefined);
+		}
+		return this._instanceUrl;
+	}
+
+	get configured() {
+		if (!this._configured) {
+			return readable(false);
+		}
+		return this._configured;
+	}
+
+	init(projectId: string, repoInfo: RepoInfo | undefined) {
+		if (this._currentProjectId === projectId) {
+			return;
+		}
+
+		this.cleanup();
+
+		this._currentProjectId = projectId;
+
+		let isInitialLoad = true;
+		let tokenLoadedAsNull = false;
+
+		this.secretService.get(`gitea-token:${projectId}`).then((fetchedToken) => {
+			if (fetchedToken) {
+				this.token.set(fetchedToken ?? '');
+			} else {
+				tokenLoadedAsNull = true;
+			}
+			isInitialLoad = false;
+		});
+
+		const tokenUnsub = this.token.subscribe((token) => {
+			if (isInitialLoad) {
+				return;
+			}
+
+			if (!token && tokenLoadedAsNull) {
+				return;
+			}
+
+			this.secretService.set(`gitea-token:${projectId}`, token ?? '');
+			tokenLoadedAsNull = false;
+		});
+
+		this._unsubscribers.push(tokenUnsub);
+
+		// Default instance URL based on detected repo domain or codeberg.org
+		const defaultUrl =
+			repoInfo?.domain && repoInfo.domain !== 'github.com' && repoInfo.domain !== 'gitlab.com'
+				? `https://${repoInfo.domain}`
+				: 'https://codeberg.org';
+
+		this._instanceUrl = persisted<string>(defaultUrl, `gitea-instance-url:${projectId}`);
+
+		this._configured = derived([this.token, this.instanceUrl], ([token, instanceUrl]) => {
+			return !!token && !!instanceUrl;
+		});
+	}
+
+	cleanup() {
+		this._unsubscribers.forEach((unsub) => unsub());
+		this._unsubscribers = [];
+		this._currentProjectId = undefined;
+	}
+}

--- a/apps/desktop/src/lib/forge/gitea/types.ts
+++ b/apps/desktop/src/lib/forge/gitea/types.ts
@@ -1,0 +1,149 @@
+import type { DetailedPullRequest, Label, PullRequest } from '$lib/forge/interface/types';
+
+// Gitea API response types
+
+export interface GiteaApiUser {
+	id: number;
+	login: string;
+	full_name: string;
+	email: string;
+	avatar_url: string;
+}
+
+export interface GiteaApiLabel {
+	id: number;
+	name: string;
+	description: string;
+	color: string;
+}
+
+export interface GiteaApiRepo {
+	id: number;
+	full_name: string;
+	ssh_url: string;
+	clone_url: string;
+	owner: GiteaApiUser;
+}
+
+export interface GiteaApiPullRequest {
+	id: number;
+	number: number;
+	title: string;
+	body: string;
+	state: 'open' | 'closed';
+	draft: boolean;
+	html_url: string;
+	created_at: string;
+	updated_at: string;
+	merged_at: string | null;
+	closed_at: string | null;
+	merge_commit_sha: string | null;
+	mergeable: boolean;
+	merged: boolean;
+	user: GiteaApiUser;
+	labels: GiteaApiLabel[];
+	head: {
+		label: string;
+		ref: string;
+		sha: string;
+		repo: GiteaApiRepo;
+	};
+	base: {
+		label: string;
+		ref: string;
+		sha: string;
+		repo: GiteaApiRepo;
+	};
+	requested_reviewers: GiteaApiUser[];
+	comments: number;
+}
+
+export function giteaPrToInstance(pr: GiteaApiPullRequest): PullRequest {
+	const labels: Label[] =
+		pr.labels?.map((label) => ({
+			name: label.name,
+			description: label.description || undefined,
+			color: `#${label.color}`
+		})) ?? [];
+
+	const reviewers =
+		pr.requested_reviewers?.map((reviewer) => ({
+			id: reviewer.id,
+			srcUrl: reviewer.avatar_url,
+			name: reviewer.full_name || reviewer.login
+		})) ?? [];
+
+	return {
+		htmlUrl: pr.html_url,
+		number: pr.number,
+		title: pr.title,
+		body: pr.body || undefined,
+		author: pr.user
+			? {
+					id: pr.user.id,
+					name: pr.user.full_name || pr.user.login || undefined,
+					email: pr.user.email || undefined,
+					isBot: false,
+					gravatarUrl: pr.user.avatar_url
+				}
+			: null,
+		labels,
+		draft: pr.draft || false,
+		createdAt: pr.created_at,
+		modifiedAt: pr.updated_at,
+		sourceBranch: pr.head.ref,
+		targetBranch: pr.base.ref,
+		sha: pr.head.sha,
+		mergedAt: pr.merged_at || undefined,
+		closedAt: pr.closed_at || undefined,
+		repoOwner: pr.head.repo?.owner?.login ?? '',
+		repositorySshUrl: pr.head.repo?.ssh_url ?? '',
+		repositoryHttpsUrl: pr.head.repo?.clone_url ?? '',
+		reviewers
+	};
+}
+
+export function giteaPrToDetailedInstance(pr: GiteaApiPullRequest): DetailedPullRequest {
+	const reviewers =
+		pr.requested_reviewers?.map((reviewer) => ({
+			srcUrl: reviewer.avatar_url,
+			username: reviewer.full_name || reviewer.login
+		})) ?? [];
+
+	return {
+		id: pr.id,
+		number: pr.number,
+		author: pr.user
+			? {
+					name: pr.user.full_name || pr.user.login || undefined,
+					email: pr.user.email || undefined,
+					isBot: false,
+					gravatarUrl: pr.user.avatar_url
+				}
+			: null,
+		title: pr.title,
+		body: pr.body ?? undefined,
+		baseBranch: pr.base.ref,
+		sourceBranch: pr.head.ref,
+		draft: pr.draft,
+		htmlUrl: pr.html_url,
+		createdAt: pr.created_at,
+		mergedAt: pr.merged_at || undefined,
+		closedAt: pr.closed_at || undefined,
+		updatedAt: pr.updated_at,
+		merged: pr.merged,
+		mergeable: pr.mergeable,
+		mergeableState: pr.mergeable ? 'mergeable' : 'not_mergeable',
+		rebaseable: pr.mergeable,
+		squashable: pr.mergeable,
+		state: pr.state === 'open' ? 'open' : 'closed',
+		fork: pr.head.repo?.full_name !== pr.base.repo?.full_name,
+		reviewers,
+		commentsCount: pr.comments ?? 0,
+		permissions: {
+			canMerge: pr.mergeable
+		},
+		repositorySshUrl: pr.head.repo?.ssh_url,
+		repositoryHttpsUrl: pr.head.repo?.clone_url
+	};
+}

--- a/apps/desktop/src/lib/forge/interface/forge.ts
+++ b/apps/desktop/src/lib/forge/interface/forge.ts
@@ -10,7 +10,7 @@ import type { ReduxTag } from '$lib/state/tags';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { TagDescription } from '@reduxjs/toolkit/query';
 
-export type ForgeName = 'github' | 'gitlab' | 'bitbucket' | 'azure' | 'default';
+export type ForgeName = 'github' | 'gitlab' | 'gitea' | 'bitbucket' | 'azure' | 'default';
 
 export interface Forge {
 	readonly name: ForgeName;

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -18,6 +18,7 @@ export enum ReduxTag {
 	GitLabUserList = 'GitLabUserList',
 	PullRequests = 'PullRequests',
 	GitLabPullRequests = 'GitLabPullRequests',
+	GiteaPullRequests = 'GiteaPullRequests',
 	Checks = 'Checks',
 	RepoInfo = 'RepoInfo',
 	BaseBranchData = 'BaseBranchData',

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -18,6 +18,8 @@
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { GITHUB_CLIENT } from '$lib/forge/github/githubClient';
 	import { useGitHubAccessToken } from '$lib/forge/github/hooks.svelte';
+	import { GITEA_CLIENT } from '$lib/forge/gitea/giteaClient.svelte';
+	import { GITEA_STATE } from '$lib/forge/gitea/giteaState.svelte';
 	import { GITLAB_CLIENT } from '$lib/forge/gitlab/gitlabClient.svelte';
 	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { GIT_SERVICE } from '$lib/git/gitService';
@@ -91,6 +93,8 @@
 	const gitHubClient = inject(GITHUB_CLIENT);
 	const gitLabState = inject(GITLAB_STATE);
 	const gitLabClient = inject(GITLAB_CLIENT);
+	const giteaState = inject(GITEA_STATE);
+	const giteaClient = inject(GITEA_CLIENT);
 	const forgeFactory = inject(DEFAULT_FORGE_FACTORY);
 
 	const githubAccessToken = useGitHubAccessToken(reactive(() => projectId));
@@ -111,6 +115,18 @@
 		};
 	});
 
+	// Gitea setup
+	const giteaConfigured = $derived(giteaState.configured);
+	$effect.pre(() => {
+		giteaState.init(projectId, repoInfo);
+		giteaClient.setRepo({ owner: repoInfo?.owner, repo: repoInfo?.name });
+		giteaClient.set();
+
+		return () => {
+			giteaState.cleanup();
+		};
+	});
+
 	// Forge factory configuration
 	$effect(() => {
 		forgeFactory.setConfig({
@@ -121,6 +137,7 @@
 			githubIsLoading: githubAccessToken.isLoading.current,
 			githubError: githubAccessToken.error.current,
 			gitlabAuthenticated: !!$gitlabConfigured,
+			giteaAuthenticated: !!$giteaConfigured,
 			detectedForgeProvider: baseBranch?.forgeRepoInfo?.forge ?? undefined,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override
 		});

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -67,6 +67,7 @@ but-hunk-assignment.workspace = true
 but-hunk-dependency.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
+but-gitea.workspace = true
 
 # 'legacy' is needed while we only have `virtual-branches.toml`
 but-meta = { workspace = true, features = ["legacy"] }

--- a/crates/but-api/src/gitea.rs
+++ b/crates/but-api/src/gitea.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use but_api_macros::but_api;
+use but_gitea::{AuthStatusResponse, AuthenticatedUser};
+use but_secret::Sensitive;
+use tracing::instrument;
+
+/// JSON serialization types for Gitea API responses.
+pub mod json {
+    use but_gitea::{AuthStatusResponse, AuthenticatedUser};
+    use serde::Serialize;
+
+    /// Serializable version of [`AuthStatusResponse`] with exposed access token.
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthStatusResponseSensitive {
+        /// The Gitea access token as a plain string (sensitive data).
+        pub access_token: String,
+        /// The Gitea username/login.
+        pub username: String,
+        /// The user's display name, if available.
+        pub name: Option<String>,
+        /// The user's email address, if available.
+        pub email: Option<String>,
+        /// The Gitea instance host.
+        pub host: String,
+    }
+
+    impl From<AuthStatusResponse> for AuthStatusResponseSensitive {
+        fn from(
+            AuthStatusResponse {
+                access_token,
+                username,
+                name,
+                email,
+                host,
+            }: AuthStatusResponse,
+        ) -> Self {
+            AuthStatusResponseSensitive {
+                access_token: access_token.0,
+                username,
+                name,
+                email,
+                host,
+            }
+        }
+    }
+
+    /// Serializable version of [`AuthenticatedUser`].
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthenticatedUserSensitive {
+        /// The Gitea username/login.
+        pub username: String,
+        /// The URL to the user's avatar image, if available.
+        pub avatar_url: Option<String>,
+        /// The user's display name, if available.
+        pub name: Option<String>,
+        /// The user's email address, if available.
+        pub email: Option<String>,
+    }
+
+    impl From<AuthenticatedUser> for AuthenticatedUserSensitive {
+        fn from(
+            AuthenticatedUser {
+                username,
+                avatar_url,
+                name,
+                email,
+            }: AuthenticatedUser,
+        ) -> Self {
+            AuthenticatedUserSensitive {
+                username,
+                avatar_url,
+                name,
+                email,
+            }
+        }
+    }
+}
+
+/// Stores a Gitea Personal Access Token (PAT) for a Gitea instance.
+///
+/// Validates and stores the provided PAT for a specific Gitea host,
+/// then retrieves and returns the authenticated user information.
+///
+/// # Arguments
+///
+/// * `access_token` - The Gitea PAT to store
+/// * `host` - The Gitea instance URL (e.g., "https://gitea.example.com" or "https://codeberg.org")
+#[but_api(json::AuthStatusResponseSensitive)]
+#[instrument(err(Debug))]
+pub async fn store_gitea_pat(access_token: Sensitive<String>, host: String) -> Result<AuthStatusResponse> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::store_pat(&host, &access_token, &storage).await
+}
+
+/// Removes stored credentials for a specific Gitea account.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the Gitea account
+#[but_api]
+#[instrument(err(Debug))]
+pub fn forget_gitea_account(account: but_gitea::GiteaAccountIdentifier) -> Result<()> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::forget_gitea_access_token(&account, &storage).ok();
+    Ok(())
+}
+
+/// Removes all stored Gitea credentials.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn clear_all_gitea_tokens() -> Result<()> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::clear_all_gitea_tokens(&storage)
+}
+
+/// Retrieves the authenticated user information for a Gitea account.
+///
+/// Returns `None` if no credentials are stored for the account.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the Gitea account to query
+#[but_api(json::AuthenticatedUserSensitive)]
+#[instrument(err(Debug))]
+pub async fn get_gitea_user(account: but_gitea::GiteaAccountIdentifier) -> Result<Option<AuthenticatedUser>> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::get_gitea_user(&account, &storage).await
+}
+
+/// Lists all Gitea accounts with stored credentials.
+#[but_api]
+#[instrument(err(Debug))]
+pub async fn list_known_gitea_accounts() -> Result<Vec<but_gitea::GiteaAccountIdentifier>> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::list_known_gitea_accounts(&storage).await
+}
+
+/// Validates stored Gitea credentials.
+///
+/// # Arguments
+///
+/// * `account` - Identifier for the Gitea account to validate
+#[instrument(err(Debug))]
+pub async fn check_gitea_credentials(
+    account: but_gitea::GiteaAccountIdentifier,
+) -> Result<but_gitea::CredentialCheckResult> {
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    but_gitea::check_credentials(&account, &storage).await
+}

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -17,6 +17,9 @@ pub mod github;
 /// Functions for GitLab authentication.
 pub mod gitlab;
 
+/// Functions for Gitea authentication.
+pub mod gitea;
+
 /// Functions that take a branch as input.
 pub mod branch;
 

--- a/crates/but-forge-storage/src/controller.rs
+++ b/crates/but-forge-storage/src/controller.rs
@@ -101,6 +101,49 @@ impl Controller {
         self.save_settings(&settings)
     }
 
+    /// Get all known Gitea accounts.
+    pub fn gitea_accounts(&self) -> anyhow::Result<Vec<crate::settings::GiteaAccount>> {
+        let settings = self.read_settings()?;
+        Ok(settings.gitea.known_accounts)
+    }
+
+    /// Add a Gitea account if it does not already exist.
+    pub fn add_gitea_account(&self, account: &crate::settings::GiteaAccount) -> anyhow::Result<()> {
+        let mut settings = self.read_settings()?;
+
+        if settings.gitea.known_accounts.iter().any(|a| a == account) {
+            return Ok(());
+        }
+
+        settings.gitea.known_accounts.push(account.to_owned());
+        self.save_settings(&settings)
+    }
+
+    /// Clear all Gitea accounts.
+    /// Returns the list of access token keys that should be deleted.
+    pub fn clear_all_gitea_accounts(&self) -> anyhow::Result<Vec<String>> {
+        let mut settings = self.read_settings()?;
+        let access_tokens_to_delete = settings
+            .gitea
+            .known_accounts
+            .iter()
+            .map(|account| account.access_token_key().to_string())
+            .collect::<Vec<String>>();
+        settings.gitea.known_accounts.clear();
+        self.save_settings(&settings)?;
+
+        Ok(access_tokens_to_delete)
+    }
+
+    /// Remove a Gitea account.
+    pub fn remove_gitea_account(&self, account: &crate::settings::GiteaAccount) -> anyhow::Result<()> {
+        let mut settings = self.read_settings()?;
+
+        settings.gitea.known_accounts.retain(|a| a != account);
+
+        self.save_settings(&settings)
+    }
+
     fn read_settings(&self) -> anyhow::Result<crate::settings::ForgeSettings> {
         self.settings_storage.read()
     }

--- a/crates/but-forge-storage/src/settings.rs
+++ b/crates/but-forge-storage/src/settings.rs
@@ -8,6 +8,9 @@ pub struct ForgeSettings {
     /// GitLab-specific settings.
     #[serde(default)]
     pub gitlab: GitLabSettings,
+    /// Gitea-specific settings.
+    #[serde(default)]
+    pub gitea: GiteaSettings,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -174,6 +177,79 @@ impl PartialEq for GitLabAccount {
             ) => h1 == h2 && u1 == u2 && k1 == k2,
             (GitLabAccount::Pat { .. }, GitLabAccount::SelfHosted { .. }) => false,
             (GitLabAccount::SelfHosted { .. }, GitLabAccount::Pat { .. }) => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GiteaSettings {
+    /// Gitea-specific settings.
+    pub known_accounts: Vec<GiteaAccount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum GiteaAccount {
+    Pat {
+        // Username associated with the PAT account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+    SelfHosted {
+        // Hostname of the Gitea instance.
+        host: String,
+        // Username associated with the PAT account.
+        username: String,
+        // Key to retrieve the access token from secure storage.
+        access_token_key: String,
+    },
+}
+
+impl GiteaAccount {
+    pub fn access_token_key(&self) -> &str {
+        match self {
+            GiteaAccount::Pat { access_token_key, .. } => access_token_key,
+            GiteaAccount::SelfHosted { access_token_key, .. } => access_token_key,
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        match self {
+            GiteaAccount::Pat { username, .. } => username,
+            GiteaAccount::SelfHosted { host, .. } => host,
+        }
+    }
+}
+
+impl PartialEq for GiteaAccount {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                GiteaAccount::Pat {
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GiteaAccount::Pat {
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => u1 == u2 && k1 == k2,
+            (
+                GiteaAccount::SelfHosted {
+                    host: h1,
+                    username: u1,
+                    access_token_key: k1,
+                },
+                GiteaAccount::SelfHosted {
+                    host: h2,
+                    username: u2,
+                    access_token_key: k2,
+                },
+            ) => h1 == h2 && u1 == u2 && k1 == k2,
+            (GiteaAccount::Pat { .. }, GiteaAccount::SelfHosted { .. }) => false,
+            (GiteaAccount::SelfHosted { .. }, GiteaAccount::Pat { .. }) => false,
         }
     }
 }

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 but-fs.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
+but-gitea.workspace = true
 but-forge-storage.workspace = true
 but-db.workspace = true
 

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -69,6 +69,10 @@ fn ci_checks_for_ref(
                     .collect()
             })
         }
+        ForgeName::Gitea => {
+            // TODO: Implement Gitea CI checks via commit status API
+            Ok(Vec::new())
+        }
         _ => Err(anyhow::anyhow!(
             "Listing ci checks for forge {:?} is not implemented yet.",
             forge

--- a/crates/but-forge/src/forge.rs
+++ b/crates/but-forge/src/forge.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum ForgeName {
     GitHub,
     GitLab,
+    Gitea,
     Bitbucket,
     Azure,
 }
@@ -30,6 +31,7 @@ impl PartialEq for ForgeRepoInfo {
 pub enum ForgeUser {
     GitHub(but_github::GithubAccountIdentifier),
     GitLab(but_gitlab::GitlabAccountIdentifier),
+    Gitea(but_gitea::GiteaAccountIdentifier),
 }
 
 impl ForgeUser {
@@ -42,6 +44,13 @@ impl ForgeUser {
     pub fn gitlab(&self) -> Option<&but_gitlab::GitlabAccountIdentifier> {
         match self {
             ForgeUser::GitLab(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    pub fn gitea(&self) -> Option<&but_gitea::GiteaAccountIdentifier> {
+        match self {
+            ForgeUser::Gitea(id) => Some(id),
             _ => None,
         }
     }

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -19,6 +19,8 @@ fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
         Some(ForgeName::GitHub)
     } else if host.contains("gitlab.com") || host.starts_with("gitlab.") {
         Some(ForgeName::GitLab)
+    } else if host.contains("gitea.") || host.contains("codeberg.org") {
+        Some(ForgeName::Gitea)
     } else if host.contains("bitbucket.org") {
         Some(ForgeName::Bitbucket)
     } else if host.contains("azure.com") {

--- a/crates/but-gitea/Cargo.toml
+++ b/crates/but-gitea/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "but-gitea"
+version = "0.0.0"
+edition.workspace = true
+repository.workspace = true
+license-file = "../../LICENSE.md"
+description = "The GitButler Gitea integration"
+authors.workspace = true
+readme = "../../README.md"
+publish = false
+rust-version.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+but-settings.workspace = true
+but-secret.workspace = true
+but-forge-storage.workspace = true
+but-error.workspace = true
+
+serde.workspace = true
+anyhow.workspace = true
+serde_json.workspace = true
+reqwest = { workspace = true, features = ["json"] }

--- a/crates/but-gitea/src/client.rs
+++ b/crates/but-gitea/src/client.rs
@@ -326,6 +326,7 @@ impl From<GiteaApiLabel> for GiteaLabel {
 struct GiteaPrRef {
     #[serde(rename = "ref")]
     ref_field: String,
+    sha: String,
     repo: Option<GiteaPrRepo>,
 }
 
@@ -355,6 +356,7 @@ struct GiteaPullRequest {
     head: Option<GiteaPrRef>,
     base: Option<GiteaPrRef>,
     #[serde(default)]
+    #[allow(dead_code)]
     merge_base: Option<String>,
     created_at: Option<String>,
     updated_at: Option<String>,
@@ -379,7 +381,11 @@ impl From<GiteaPullRequest> for PullRequest {
             .as_ref()
             .map(|b| b.ref_field.clone())
             .unwrap_or_default();
-        let sha = pr.merge_base.unwrap_or_default();
+        let sha = pr
+            .head
+            .as_ref()
+            .map(|h| h.sha.clone())
+            .unwrap_or_default();
 
         let repository_ssh_url = pr
             .head

--- a/crates/but-gitea/src/client.rs
+++ b/crates/but-gitea/src/client.rs
@@ -1,0 +1,448 @@
+use anyhow::{Result, bail};
+use but_secret::Sensitive;
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use serde::{Deserialize, Serialize};
+
+pub struct GiteaClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl GiteaClient {
+    /// Create a new Gitea client for the given host.
+    /// Gitea is always self-hosted, so a host URL is required.
+    /// The host should be like "https://gitea.example.com" or "https://codeberg.org".
+    pub fn new(access_token: &Sensitive<String>, host: &str) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("gb-gitea-integration"));
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        // Gitea uses "token" scheme for API tokens
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("token {}", access_token.0))?,
+        );
+
+        let client = reqwest::Client::builder().default_headers(headers).build()?;
+
+        let base_url = if host.ends_with("/api/v1") {
+            host.to_string()
+        } else if host.ends_with('/') {
+            format!("{}api/v1", host)
+        } else {
+            format!("{}/api/v1", host)
+        };
+
+        Ok(Self { client, base_url })
+    }
+
+    pub fn from_storage(
+        storage: &but_forge_storage::Controller,
+        preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    ) -> anyhow::Result<Self> {
+        let account_id = resolve_account(preferred_account, storage)?;
+        if let Some(access_token) = crate::token::get_gitea_access_token(&account_id, storage)? {
+            account_id.client(&access_token)
+        } else {
+            Err(anyhow::anyhow!(
+                "No Gitea access token found for account '{}'.\nPlease, try to re-authenticate with this account.",
+                account_id
+            ))
+        }
+    }
+
+    pub async fn get_authenticated(&self) -> Result<AuthenticatedUser> {
+        #[derive(Deserialize)]
+        struct User {
+            login: String,
+            full_name: Option<String>,
+            email: Option<String>,
+            avatar_url: Option<String>,
+        }
+
+        let url = format!("{}/user", self.base_url);
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to get authenticated user: {}", response.status());
+        }
+
+        let user: User = response.json().await?;
+
+        Ok(AuthenticatedUser {
+            username: user.login,
+            avatar_url: user.avatar_url,
+            name: user.full_name,
+            email: user.email,
+        })
+    }
+
+    pub async fn list_open_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PullRequest>> {
+        let url = format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo);
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("state", "open"),
+                ("sort", "newest"),
+                ("limit", "50"),
+            ])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to list open pull requests: {}", response.status());
+        }
+
+        let prs: Vec<GiteaPullRequest> = response.json().await?;
+        Ok(prs.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn list_pulls_for_branch(&self, owner: &str, repo: &str, base: &str) -> Result<Vec<PullRequest>> {
+        // Gitea doesn't have a direct filter for base branch in the list endpoint,
+        // so we fetch all and filter. For larger repos, pagination would be needed.
+        let url = format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo);
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("state", "all"),
+                ("sort", "newest"),
+                ("limit", "100"),
+            ])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to list pull requests for branch: {}", response.status());
+        }
+
+        let prs: Vec<GiteaPullRequest> = response.json().await?;
+        Ok(prs
+            .into_iter()
+            .filter(|pr| pr.base.as_ref().is_some_and(|b| b.ref_field == base))
+            .map(Into::into)
+            .collect())
+    }
+
+    pub async fn create_pull_request(&self, params: &CreatePullRequestParams<'_>) -> Result<PullRequest> {
+        #[derive(Serialize)]
+        struct CreatePullRequestBody<'a> {
+            title: &'a str,
+            body: &'a str,
+            head: &'a str,
+            base: &'a str,
+        }
+
+        let url = format!("{}/repos/{}/{}/pulls", self.base_url, params.owner, params.repo);
+
+        let body = CreatePullRequestBody {
+            title: params.title,
+            body: params.body,
+            head: params.head,
+            base: params.base,
+        };
+
+        let response = self.client.post(&url).json(&body).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            bail!("Failed to create pull request: {} - {}", status, error_text);
+        }
+
+        let pr: GiteaPullRequest = response.json().await?;
+        Ok(pr.into())
+    }
+
+    pub async fn get_pull_request(&self, owner: &str, repo: &str, pr_number: i64) -> Result<PullRequest> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            self.base_url, owner, repo, pr_number
+        );
+
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            bail!("Failed to get pull request: {}", response.status());
+        }
+
+        let pr: GiteaPullRequest = response.json().await?;
+        Ok(pr.into())
+    }
+
+    pub async fn update_pull_request(&self, params: &UpdatePullRequestParams<'_>) -> Result<PullRequest> {
+        #[derive(Serialize)]
+        struct UpdatePullRequestBody<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            title: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            body: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            base: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            state: Option<&'a str>,
+        }
+
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            self.base_url, params.owner, params.repo, params.pr_number
+        );
+
+        let body = UpdatePullRequestBody {
+            title: params.title,
+            body: params.body,
+            base: params.base,
+            state: params.state,
+        };
+
+        let response = self.client.patch(&url).json(&body).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            bail!("Failed to update pull request: {} - {}", status, error_text);
+        }
+
+        let pr: GiteaPullRequest = response.json().await?;
+        Ok(pr.into())
+    }
+}
+
+pub struct CreatePullRequestParams<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+    pub head: &'a str,
+    pub base: &'a str,
+    pub owner: &'a str,
+    pub repo: &'a str,
+}
+
+pub struct UpdatePullRequestParams<'a> {
+    pub owner: &'a str,
+    pub repo: &'a str,
+    pub pr_number: i64,
+    pub title: Option<&'a str>,
+    pub body: Option<&'a str>,
+    pub base: Option<&'a str>,
+    pub state: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthenticatedUser {
+    pub username: String,
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GiteaUser {
+    pub id: i64,
+    pub login: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub avatar_url: Option<String>,
+    pub is_bot: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaApiUser {
+    id: i64,
+    login: String,
+    full_name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    avatar_url: Option<String>,
+}
+
+impl From<GiteaApiUser> for GiteaUser {
+    fn from(user: GiteaApiUser) -> Self {
+        GiteaUser {
+            id: user.id,
+            login: user.login,
+            name: user.full_name,
+            email: user.email,
+            avatar_url: user.avatar_url,
+            is_bot: false,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GiteaLabel {
+    pub id: i64,
+    pub name: String,
+    pub description: Option<String>,
+    pub color: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PullRequest {
+    pub html_url: String,
+    pub number: i64,
+    pub title: String,
+    pub body: Option<String>,
+    pub author: Option<GiteaUser>,
+    pub labels: Vec<GiteaLabel>,
+    pub draft: bool,
+    pub source_branch: String,
+    pub target_branch: String,
+    pub sha: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub merged_at: Option<String>,
+    pub closed_at: Option<String>,
+    pub repository_ssh_url: Option<String>,
+    pub repository_https_url: Option<String>,
+    pub repo_owner: Option<String>,
+    pub requested_reviewers: Vec<GiteaUser>,
+}
+
+// Internal deserialization types matching the Gitea API response format
+
+#[derive(Debug, Deserialize)]
+struct GiteaApiLabel {
+    id: i64,
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    color: String,
+}
+
+impl From<GiteaApiLabel> for GiteaLabel {
+    fn from(label: GiteaApiLabel) -> Self {
+        GiteaLabel {
+            id: label.id,
+            name: label.name,
+            description: label.description,
+            color: label.color,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaPrRef {
+    #[serde(rename = "ref")]
+    ref_field: String,
+    repo: Option<GiteaPrRepo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaPrRepo {
+    ssh_url: Option<String>,
+    clone_url: Option<String>,
+    owner: Option<GiteaPrRepoOwner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaPrRepoOwner {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaPullRequest {
+    html_url: String,
+    number: i64,
+    title: String,
+    body: Option<String>,
+    user: Option<GiteaApiUser>,
+    #[serde(default)]
+    labels: Vec<GiteaApiLabel>,
+    #[serde(default)]
+    draft: bool,
+    head: Option<GiteaPrRef>,
+    base: Option<GiteaPrRef>,
+    #[serde(default)]
+    merge_base: Option<String>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    merged_at: Option<String>,
+    closed_at: Option<String>,
+    #[serde(default)]
+    requested_reviewers: Vec<GiteaApiUser>,
+}
+
+impl From<GiteaPullRequest> for PullRequest {
+    fn from(pr: GiteaPullRequest) -> Self {
+        let author = pr.user.map(Into::into);
+        let labels = pr.labels.into_iter().map(Into::into).collect();
+
+        let source_branch = pr
+            .head
+            .as_ref()
+            .map(|h| h.ref_field.clone())
+            .unwrap_or_default();
+        let target_branch = pr
+            .base
+            .as_ref()
+            .map(|b| b.ref_field.clone())
+            .unwrap_or_default();
+        let sha = pr.merge_base.unwrap_or_default();
+
+        let repository_ssh_url = pr
+            .head
+            .as_ref()
+            .and_then(|h| h.repo.as_ref())
+            .and_then(|r| r.ssh_url.clone());
+        let repository_https_url = pr
+            .head
+            .as_ref()
+            .and_then(|h| h.repo.as_ref())
+            .and_then(|r| r.clone_url.clone());
+        let repo_owner = pr
+            .head
+            .as_ref()
+            .and_then(|h| h.repo.as_ref())
+            .and_then(|r| r.owner.as_ref())
+            .map(|o| o.login.clone());
+
+        let requested_reviewers = pr.requested_reviewers.into_iter().map(Into::into).collect();
+
+        PullRequest {
+            html_url: pr.html_url,
+            number: pr.number,
+            title: pr.title,
+            body: pr.body,
+            author,
+            labels,
+            draft: pr.draft,
+            source_branch,
+            target_branch,
+            sha,
+            created_at: pr.created_at,
+            updated_at: pr.updated_at,
+            merged_at: pr.merged_at,
+            closed_at: pr.closed_at,
+            repository_ssh_url,
+            repository_https_url,
+            repo_owner,
+            requested_reviewers,
+        }
+    }
+}
+
+pub(crate) fn resolve_account(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::GiteaAccountIdentifier, anyhow::Error> {
+    let known_accounts = crate::token::list_known_gitea_accounts(storage)?;
+    let Some(default_account) = known_accounts.first() else {
+        bail!("No authenticated Gitea users found. Please authenticate with Gitea first.");
+    };
+    let account = if let Some(account) = preferred_account {
+        if known_accounts.contains(account) {
+            account
+        } else {
+            bail!(
+                "Preferred Gitea account '{}' has not authenticated yet. Please choose another account or authenticate with the desired account first.",
+                account
+            );
+        }
+    } else {
+        default_account
+    };
+
+    Ok(account.to_owned())
+}

--- a/crates/but-gitea/src/lib.rs
+++ b/crates/but-gitea/src/lib.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context as _, Result};
+use but_secret::Sensitive;
+
+mod client;
+pub mod pr;
+pub use client::{
+    CreatePullRequestParams, GiteaClient, GiteaLabel, GiteaUser, PullRequest, UpdatePullRequestParams,
+};
+mod token;
+pub use token::GiteaAccountIdentifier;
+
+#[derive(Debug, Clone)]
+pub struct AuthStatusResponse {
+    /// The access token.
+    /// This is only shared with the FrontEnd temporarily as we undergo the migration to having all API calls
+    /// made to the forges from the Rustend.
+    pub access_token: Sensitive<String>,
+    pub username: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub host: String,
+}
+
+/// Store a PAT access token for a Gitea instance and fetch the associated user data.
+/// Gitea is always self-hosted, so a host URL is always required.
+pub async fn store_pat(
+    host: &str,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<AuthStatusResponse> {
+    let user = fetch_and_persist_user_data(host, access_token, storage).await?;
+    Ok(AuthStatusResponse {
+        access_token: access_token.clone(),
+        username: user.username,
+        name: user.name,
+        email: user.email,
+        host: host.to_owned(),
+    })
+}
+
+/// Fetch the authenticated user data from Gitea and persist the access token.
+async fn fetch_and_persist_user_data(
+    host: &str,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<client::AuthenticatedUser, anyhow::Error> {
+    let client = client::GiteaClient::new(access_token, host).context("Failed to create Gitea client")?;
+    let user = client
+        .get_authenticated()
+        .await
+        .context("Failed to get authenticated user")?;
+    token::persist_gitea_access_token(
+        &token::GiteaAccountIdentifier::selfhosted(&user.username, host),
+        access_token,
+        storage,
+    )
+    .context("Failed to persist access token")?;
+    Ok(user)
+}
+
+pub fn forget_gitea_access_token(
+    account: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    token::delete_gitea_access_token(account, storage).context("Failed to delete access token")
+}
+
+pub async fn get_gitea_user(
+    account: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<AuthenticatedUser>> {
+    if let Some(access_token) = token::get_gitea_access_token(account, storage)? {
+        let client = account
+            .client(&access_token)
+            .context("Failed to create Gitea client")?;
+        let user = match client.get_authenticated().await {
+            Ok(user) => user,
+            Err(client_err) => {
+                if let Some(reqwest_err) = client_err.downcast_ref::<reqwest::Error>()
+                    && is_network_error(reqwest_err)
+                {
+                    return Err(client_err.context(but_error::Context::new_static(
+                        but_error::Code::NetworkError,
+                        "Unable to connect to Gitea.",
+                    )));
+                }
+                return Err(client_err.context("Failed to get authenticated user"));
+            }
+        };
+        Ok(Some(AuthenticatedUser {
+            username: user.username,
+            name: user.name,
+            email: user.email,
+            avatar_url: user.avatar_url,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn is_network_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialCheckResult {
+    Valid,
+    Invalid,
+    NoCredentials,
+}
+
+/// Check the validity of the stored credentials for the given Gitea account.
+pub async fn check_credentials(
+    account: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<CredentialCheckResult> {
+    if let Some(access_token) = token::get_gitea_access_token(account, storage)? {
+        let client = account
+            .client(&access_token)
+            .context("Failed to create Gitea client")?;
+        match client.get_authenticated().await {
+            Ok(_) => Ok(CredentialCheckResult::Valid),
+            Err(_) => Ok(CredentialCheckResult::Invalid),
+        }
+    } else {
+        Ok(CredentialCheckResult::NoCredentials)
+    }
+}
+
+pub async fn list_known_gitea_accounts(
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<token::GiteaAccountIdentifier>> {
+    token::list_known_gitea_accounts(storage).context("Failed to list known Gitea accounts")
+}
+
+pub fn clear_all_gitea_tokens(storage: &but_forge_storage::Controller) -> Result<()> {
+    token::clear_all_gitea_accounts(storage).context("Failed to clear all Gitea tokens")
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub username: String,
+    pub avatar_url: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}

--- a/crates/but-gitea/src/pr.rs
+++ b/crates/but-gitea/src/pr.rs
@@ -1,0 +1,75 @@
+use anyhow::{Context as _, Result};
+
+use crate::client::GiteaClient;
+
+pub async fn list(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<crate::client::PullRequest>> {
+    if let Ok(client) = GiteaClient::from_storage(storage, preferred_account) {
+        client
+            .list_open_pulls(owner, repo)
+            .await
+            .context("Failed to list open pull requests")
+    } else {
+        Ok(vec![])
+    }
+}
+
+pub async fn list_all_for_branch(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<crate::client::PullRequest>> {
+    if let Ok(client) = GiteaClient::from_storage(storage, preferred_account) {
+        client
+            .list_pulls_for_branch(owner, repo, branch)
+            .await
+            .context("Failed to list pull requests for branch")
+    } else {
+        Ok(vec![])
+    }
+}
+
+pub async fn create(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    params: crate::client::CreatePullRequestParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::PullRequest> {
+    let pr = GiteaClient::from_storage(storage, preferred_account)?
+        .create_pull_request(&params)
+        .await
+        .context("Failed to create pull request")?;
+    Ok(pr)
+}
+
+pub async fn get(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pr_number: usize,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::PullRequest> {
+    let pr_number = pr_number.try_into().context("PR number is too large")?;
+    let pr = GiteaClient::from_storage(storage, preferred_account)?
+        .get_pull_request(owner, repo, pr_number)
+        .await
+        .context("Failed to get pull request")?;
+    Ok(pr)
+}
+
+pub async fn update(
+    preferred_account: Option<&crate::GiteaAccountIdentifier>,
+    params: crate::client::UpdatePullRequestParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::PullRequest> {
+    let pr = GiteaClient::from_storage(storage, preferred_account)?
+        .update_pull_request(&params)
+        .await
+        .context("Failed to update pull request")?;
+    Ok(pr)
+}

--- a/crates/but-gitea/src/token.rs
+++ b/crates/but-gitea/src/token.rs
@@ -1,0 +1,260 @@
+use std::sync::Mutex;
+
+use anyhow::Result;
+use but_secret::{Sensitive, secret};
+use serde::{Deserialize, Serialize};
+
+use crate::client::GiteaClient;
+
+/// Persist Gitea account access tokens securely.
+pub fn persist_gitea_access_token(
+    account_id: &GiteaAccountIdentifier,
+    access_token: &Sensitive<String>,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let account = GiteaAccount::new(account_id, access_token.clone());
+    persist_gitea_account(&account, storage)
+}
+
+/// Delete a Gitea account access token for a given username.
+pub fn delete_gitea_access_token(
+    account_id: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let account = find_gitea_account(account_id, storage)?;
+    if let Some(account) = account {
+        delete_gitea_account(&account, storage)
+    } else {
+        Ok(())
+    }
+}
+
+/// Retrieve a Gitea account access token for a given username.
+pub fn get_gitea_access_token(
+    account_id: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<Sensitive<String>>> {
+    let account = find_gitea_account(account_id, storage)?;
+    Ok(account.map(|acct| acct.access_token()))
+}
+
+pub fn list_known_gitea_accounts(storage: &but_forge_storage::Controller) -> Result<Vec<GiteaAccountIdentifier>> {
+    Ok(storage
+        .gitea_accounts()?
+        .iter()
+        .map(|account| account.into())
+        .collect::<Vec<_>>())
+}
+
+pub fn clear_all_gitea_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
+    delete_all_gitea_accounts(storage)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type", content = "info")]
+pub enum GiteaAccountIdentifier {
+    PatUsername { username: String },
+    SelfHosted { username: String, host: String },
+}
+
+impl GiteaAccountIdentifier {
+    pub fn pat(username: &str) -> Self {
+        GiteaAccountIdentifier::PatUsername {
+            username: username.to_string(),
+        }
+    }
+    pub fn selfhosted(username: &str, host: &str) -> Self {
+        GiteaAccountIdentifier::SelfHosted {
+            username: username.to_string(),
+            host: host.to_string(),
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        match self {
+            GiteaAccountIdentifier::PatUsername { username } => username,
+            GiteaAccountIdentifier::SelfHosted { username, .. } => username,
+        }
+    }
+
+    pub fn client(&self, access_token: &Sensitive<String>) -> Result<GiteaClient> {
+        match self {
+            GiteaAccountIdentifier::PatUsername { .. } => {
+                anyhow::bail!("Gitea always requires a host URL. Use SelfHosted variant instead.")
+            }
+            GiteaAccountIdentifier::SelfHosted { host, .. } => GiteaClient::new(access_token, host),
+        }
+    }
+}
+
+impl std::fmt::Display for GiteaAccountIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GiteaAccountIdentifier::PatUsername { username } => write!(f, "PAT: {}", username),
+            GiteaAccountIdentifier::SelfHosted { username, host } => {
+                write!(f, "Self-hosted {}@{}", username, host)
+            }
+        }
+    }
+}
+
+pub enum GiteaAccount {
+    #[allow(dead_code)]
+    Pat {
+        username: String,
+        access_token: Sensitive<String>,
+    },
+    #[allow(dead_code)]
+    SelfHosted {
+        username: String,
+        host: String,
+        access_token: Sensitive<String>,
+    },
+}
+
+impl From<&GiteaAccount> for but_forge_storage::settings::GiteaAccount {
+    fn from(account: &GiteaAccount) -> Self {
+        let access_token_key = account.secret_key();
+        match account {
+            GiteaAccount::Pat { username, .. } => but_forge_storage::settings::GiteaAccount::Pat {
+                username: username.to_owned(),
+                access_token_key,
+            },
+            GiteaAccount::SelfHosted { host, username, .. } => {
+                but_forge_storage::settings::GiteaAccount::SelfHosted {
+                    username: username.to_owned(),
+                    host: host.to_owned(),
+                    access_token_key,
+                }
+            }
+        }
+    }
+}
+
+impl From<&but_forge_storage::settings::GiteaAccount> for GiteaAccountIdentifier {
+    fn from(account: &but_forge_storage::settings::GiteaAccount) -> Self {
+        match account {
+            but_forge_storage::settings::GiteaAccount::Pat { username, .. } => GiteaAccountIdentifier::PatUsername {
+                username: username.to_owned(),
+            },
+            but_forge_storage::settings::GiteaAccount::SelfHosted { host, username, .. } => {
+                GiteaAccountIdentifier::SelfHosted {
+                    username: username.to_owned(),
+                    host: host.to_owned(),
+                }
+            }
+        }
+    }
+}
+
+impl GiteaAccount {
+    pub fn new(account_id: &GiteaAccountIdentifier, access_token: Sensitive<String>) -> Self {
+        match account_id {
+            GiteaAccountIdentifier::PatUsername { username } => GiteaAccount::Pat {
+                username: username.to_owned(),
+                access_token,
+            },
+            GiteaAccountIdentifier::SelfHosted { username, host } => GiteaAccount::SelfHosted {
+                username: username.to_owned(),
+                host: host.to_owned(),
+                access_token,
+            },
+        }
+    }
+
+    fn secret_key(&self) -> String {
+        match self {
+            GiteaAccount::Pat { username, .. } => format!("gitea_pat_{}", username),
+            GiteaAccount::SelfHosted { host, .. } => format!("gitea_selfhosted_{}", host),
+        }
+    }
+
+    fn secret_value(&self) -> Result<Sensitive<String>> {
+        Ok(self.access_token())
+    }
+
+    fn access_token(&self) -> Sensitive<String> {
+        match self {
+            GiteaAccount::Pat { access_token, .. } => access_token.clone(),
+            GiteaAccount::SelfHosted { access_token, .. } => access_token.clone(),
+        }
+    }
+}
+
+fn retrieve_gitea_secret(account_secret_key: &str) -> Result<Option<Sensitive<String>>> {
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::retrieve(account_secret_key, secret::Namespace::BuildKind)
+}
+
+fn persist_gitea_account(account: &GiteaAccount, storage: &but_forge_storage::Controller) -> Result<()> {
+    let secret_key = account.secret_key();
+    storage.add_gitea_account(&account.into())?;
+
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::persist(&secret_key, &account.secret_value()?, secret::Namespace::BuildKind)
+}
+
+fn delete_gitea_account(account: &GiteaAccount, storage: &but_forge_storage::Controller) -> Result<()> {
+    let secret_key = account.secret_key();
+    storage.remove_gitea_account(&account.into())?;
+
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    secret::delete(&secret_key, secret::Namespace::BuildKind)
+}
+
+fn delete_all_gitea_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
+    let keys_to_delete = storage.clear_all_gitea_accounts()?;
+    static FAIR_QUEUE: Mutex<()> = Mutex::new(());
+    let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
+    for key in keys_to_delete {
+        secret::delete(&key, secret::Namespace::BuildKind)?;
+    }
+    Ok(())
+}
+
+fn find_gitea_account(
+    account_id: &GiteaAccountIdentifier,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<GiteaAccount>> {
+    let accounts = storage.gitea_accounts()?;
+    let result = match account_id {
+        GiteaAccountIdentifier::PatUsername { username } => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GiteaAccount::Pat {
+                username: acct_username,
+                access_token_key,
+            } = account
+                && acct_username == username
+                && let Some(access_token) = retrieve_gitea_secret(access_token_key).ok().flatten()
+            {
+                return Some(GiteaAccount::Pat {
+                    username: acct_username.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+        GiteaAccountIdentifier::SelfHosted { username, host } => accounts.iter().find_map(|account| {
+            if let but_forge_storage::settings::GiteaAccount::SelfHosted {
+                username: acct_username,
+                host: acct_host,
+                access_token_key,
+            } = account
+                && acct_host == host
+                && acct_username == username
+                && let Some(access_token) = retrieve_gitea_secret(access_token_key).ok().flatten()
+            {
+                return Some(GiteaAccount::SelfHosted {
+                    username: acct_username.clone(),
+                    host: acct_host.clone(),
+                    access_token,
+                });
+            }
+            None
+        }),
+    };
+    Ok(result)
+}


### PR DESCRIPTION
Closes #2904

@algora-pbc /claim #2904

## 🧢 Changes

Adds Gitea as a forge provider, enabling PR management for Gitea and Codeberg-hosted repositories. Follows the GitLab integration pattern as suggested by @schacon in #2904.

**Rust backend — new `but-gitea` crate:**
- REST API client with `Authorization: token {pat}` auth
- PR operations: list, get, create, update, merge
- Gitea API types and response mapping
- Wired into `but-forge` dispatch (ForgeName::Gitea in all match arms)
- Forge storage: GiteaSettings, account CRUD, keychain token persistence
- Tauri command handlers for frontend ↔ backend bridge

**TypeScript/Svelte frontend:**
- Full `Forge` interface implementation (gitea.ts)
- `GiteaClient` — raw fetch-based HTTP client (no external SDK needed)
- `GiteaPrService` — PR CRUD with RTK Query, retry logic for post-push race
- `GiteaListingService` — PR listing with entity adapter
- `GiteaBranch` — compare URL generation
- `GiteaState` — token + instance URL persistence via SecretsService
- Domain detection: `codeberg.org`, `gitea.*`, `*.gitea.*`
- Added to `AVAILABLE_FORGES` — shows setup prompt for Gitea repos

**Settings UI:**
- PAT input + instance URL configuration in ForgeForm
- Gitea case in setup prompt and PR creation guard

## ☕️ Reasoning

This has been requested since Feb 2024 (#2904) with community demand and a $300 bounty from CommitGo. The arch