### PR TITLE
ci: add CLI label for PRs touching the but crate

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -4,6 +4,10 @@ rust:
   - changed-files:
       - any-glob-to-any-file: crates/**/*
 
+CLI:
+  - changed-files:
+      - any-glob-to-any-file: crates/but/**/*
+
 '@gitbutler/desktop':
   - changed-files:
       - any-glob-to-any-file: apps/desktop/**/*


### PR DESCRIPTION
Adds automatic `CLI` label to PRs that modify files under `crates/but/**/*`, matching the existing pattern used for the `rust` label.