### PR TITLE
but-gitlab: Project ID

### DIFF
--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{Error, Result};
 use but_fs::list_files;
+use but_gitlab::GitLabProjectId;
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
@@ -482,7 +483,7 @@ fn list_forge_reviews(
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.gitlab().cloned());
 
             // Clone owned data for thread
-            let project_id = "todo"; // Retrieve poject ID properly
+            let project_id = GitLabProjectId::new(owner, repo);
             let storage = storage.clone();
 
             let mrs = std::thread::spawn(move || {
@@ -538,7 +539,7 @@ pub async fn list_forge_reviews_for_branch(
         }
         ForgeName::GitLab => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.gitlab().cloned());
-            let project_id = "todo"; // Retrieve poject ID properly
+            let project_id = GitLabProjectId::new(owner, repo);
             let mrs =
                 but_gitlab::mr::list_all_for_target(preferred_account.as_ref(), project_id, branch, storage).await?;
             let mrs = filter_mrs(mrs, &filter);
@@ -645,7 +646,7 @@ pub async fn get_forge_review(
         }
         ForgeName::GitLab => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.gitlab());
-            let project_id = "todo"; // Retrieve poject ID properly
+            let project_id = GitLabProjectId::new(owner, repo);
             let mr = but_gitlab::mr::get(preferred_account, project_id, review_number, storage).await?;
             Ok(ForgeReview::from(mr))
         }
@@ -692,11 +693,11 @@ pub async fn create_forge_review(
             Ok(ForgeReview::from(pr))
         }
         ForgeName::GitLab => {
-            let project_id = "todo"; // TODO: Retrieve poject ID properly
+            let project_id = GitLabProjectId::new(owner, repo);
             // TODO: handle forks better
             // TODO: handle draft properly
             let mr_params = but_gitlab::CreateMergeRequestParams {
-                project: project_id,
+                project_id,
                 title: &params.title,
                 body: &params.body,
                 source_branch: &params.source_branch,

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -3,6 +3,8 @@ use but_secret::Sensitive;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 
+use crate::GitLabProjectId;
+
 const GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
 
 pub struct GitLabClient {
@@ -91,12 +93,8 @@ impl GitLabClient {
         })
     }
 
-    pub async fn list_open_mrs(&self, project: &str) -> Result<Vec<MergeRequest>> {
-        let url = format!(
-            "{}/projects/{}/merge_requests",
-            self.base_url,
-            urlencoding::encode(project)
-        );
+    pub async fn list_open_mrs(&self, project_id: GitLabProjectId) -> Result<Vec<MergeRequest>> {
+        let url = format!("{}/projects/{}/merge_requests", self.base_url, project_id);
 
         let response = self
             .client
@@ -113,12 +111,12 @@ impl GitLabClient {
         Ok(mrs.into_iter().map(Into::into).collect())
     }
 
-    pub async fn list_mrs_for_target(&self, project: &str, target_branch: &str) -> Result<Vec<MergeRequest>> {
-        let url = format!(
-            "{}/projects/{}/merge_requests",
-            self.base_url,
-            urlencoding::encode(project)
-        );
+    pub async fn list_mrs_for_target(
+        &self,
+        project_id: GitLabProjectId,
+        target_branch: &str,
+    ) -> Result<Vec<MergeRequest>> {
+        let url = format!("{}/projects/{}/merge_requests", self.base_url, project_id);
 
         let response = self
             .client
@@ -152,11 +150,7 @@ impl GitLabClient {
             target_project_id: Option<i64>,
         }
 
-        let url = format!(
-            "{}/projects/{}/merge_requests",
-            self.base_url,
-            urlencoding::encode(params.project)
-        );
+        let url = format!("{}/projects/{}/merge_requests", self.base_url, params.project_id);
 
         let body = CreateMergeRequestBody {
             title: params.title,
@@ -178,13 +172,8 @@ impl GitLabClient {
         Ok(mr.into())
     }
 
-    pub async fn get_merge_request(&self, project: &str, mr_iid: i64) -> Result<MergeRequest> {
-        let url = format!(
-            "{}/projects/{}/merge_requests/{}",
-            self.base_url,
-            urlencoding::encode(project),
-            mr_iid
-        );
+    pub async fn get_merge_request(&self, project_id: GitLabProjectId, mr_iid: i64) -> Result<MergeRequest> {
+        let url = format!("{}/projects/{}/merge_requests/{}", self.base_url, project_id, mr_iid);
 
         let response = self.client.get(&url).send().await?;
 
@@ -202,7 +191,7 @@ pub struct CreateMergeRequestParams<'a> {
     pub body: &'a str,
     pub source_branch: &'a str,
     pub target_branch: &'a str,
-    pub project: &'a str,
+    pub project_id: GitLabProjectId,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -3,7 +3,9 @@ use but_secret::Sensitive;
 
 mod client;
 pub mod mr;
+mod project;
 pub use client::{CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabUser, MergeRequest};
+pub use project::GitLabProjectId;
 mod token;
 use serde::Serialize;
 pub use token::GitlabAccountIdentifier;

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context as _, Result};
 
-use crate::client::GitLabClient;
+use crate::{GitLabProjectId, client::GitLabClient};
 
 pub async fn list(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
-    project: &str,
+    project_id: GitLabProjectId,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
     if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_open_mrs(project)
+        gl.list_open_mrs(project_id)
             .await
             .context("Failed to list open merge requests")
     } else {
@@ -18,12 +18,12 @@ pub async fn list(
 
 pub async fn list_all_for_target(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
-    project: &str,
+    project_id: GitLabProjectId,
     target_branch: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
     if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_mrs_for_target(project, target_branch)
+        gl.list_mrs_for_target(project_id, target_branch)
             .await
             .context("Failed to list merge requests for target branch")
     } else {
@@ -45,13 +45,13 @@ pub async fn create(
 
 pub async fn get(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
-    project: &str,
+    project_id: GitLabProjectId,
     mr_iid: usize,
     storage: &but_forge_storage::Controller,
 ) -> Result<crate::client::MergeRequest> {
     let mr_iid = mr_iid.try_into().context("MR number is too large")?;
     let mr = GitLabClient::from_storage(storage, preferred_account)?
-        .get_merge_request(project, mr_iid)
+        .get_merge_request(project_id, mr_iid)
         .await
         .context("Failed to get merge request")?;
     Ok(mr)

--- a/crates/but-gitlab/src/project.rs
+++ b/crates/but-gitlab/src/project.rs
@@ -1,0 +1,30 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitLabProjectId {
+    /// The username or group name that owns the project.
+    ///
+    /// This should be the the namespace of the project in the git remote.
+    username: String,
+    /// The name of the project
+    ///
+    /// This should be the name of the project in the git remote, without the namespace.
+    project_name: String,
+}
+
+impl GitLabProjectId {
+    pub fn new(username: &str, project_name: &str) -> Self {
+        GitLabProjectId {
+            username: username.to_string(),
+            project_name: project_name.to_string(),
+        }
+    }
+}
+
+impl Display for GitLabProjectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let project_id = format!("{}/{}", self.username, self.project_name);
+        let encoded = urlencoding::encode(&project_id);
+        write!(f, "{}", encoded)
+    }
+}


### PR DESCRIPTION
Add a project ID handler for GitLab, that creates and encodes it as
needed.