### PR TITLE
Add traits for converting types into selectors

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 use petgraph::{Direction, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
 
-use crate::graph_rebase::{Edge, Editor, Pick, Selector, Step};
+use crate::graph_rebase::{Edge, Editor, Pick, Selector, Step, ToCommitSelector, ToReferenceSelector, ToSelector};
 
 /// Describes where relative to the selector a step should be inserted
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -16,6 +16,37 @@ pub enum InsertSide {
     /// When inserting below, any nodes that the selector points to will now be
     /// pointed to by the inserted node instead.
     Below,
+}
+
+/// An enum that is helpful for describing where something should be inserted
+/// relative to.
+#[derive(Debug, Clone)]
+pub enum RelativeTo<'a> {
+    /// Relative to a commit
+    Commit(gix::ObjectId),
+    /// Relative to a reference
+    Reference(&'a gix::refs::FullNameRef),
+}
+
+impl ToSelector for RelativeTo<'_> {
+    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
+        match self {
+            Self::Commit(id) => editor.select_commit(*id),
+            Self::Reference(reference) => editor.select_reference(reference),
+        }
+    }
+}
+
+impl ToCommitSelector for gix::ObjectId {
+    fn to_commit_selector(&self, editor: &Editor) -> Result<Selector> {
+        editor.select_commit(*self)
+    }
+}
+
+impl ToReferenceSelector for &gix::refs::FullNameRef {
+    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector> {
+        editor.select_reference(self)
+    }
 }
 
 /// Operations for mutating the commit graph
@@ -71,8 +102,8 @@ impl Editor {
     /// Replaces the node that the function was pointing to.
     ///
     /// Returns the replaced step.
-    pub fn replace(&mut self, target: Selector, step: Step) -> Result<Step> {
-        let target = self.history.normalize_selector(target)?;
+    pub fn replace(&mut self, target: impl ToSelector, step: Step) -> Result<Step> {
+        let target = self.history.normalize_selector(target.to_selector(self)?)?;
         let old = self.graph[target.id].clone();
         self.graph[target.id] = step;
         Ok(old)
@@ -86,8 +117,8 @@ impl Editor {
     /// instead.
     ///
     /// Returns a selector to the inserted step
-    pub fn insert(&mut self, target: Selector, step: Step, side: InsertSide) -> Result<Selector> {
-        let target = self.history.normalize_selector(target)?;
+    pub fn insert(&mut self, target: impl ToSelector, step: Step, side: InsertSide) -> Result<Selector> {
+        let target = self.history.normalize_selector(target.to_selector(self)?)?;
         match side {
             InsertSide::Above => {
                 let edges = self

--- a/crates/but-workspace/src/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/src/commit/insert_blank_commit.rs
@@ -1,38 +1,22 @@
 //! Insertion of a blank commit
 
-/// Describes where the blank commit should be inserted relative to.
-#[derive(Debug, Clone)]
-pub enum RelativeTo<'a> {
-    /// Relative to a commit
-    Commit(gix::ObjectId),
-    /// Relative to a reference
-    Reference(&'a gix::refs::FullNameRef),
-}
-
 pub(crate) mod function {
     use anyhow::Result;
     use but_rebase::{
         commit::DateMode,
-        graph_rebase::{Editor, Selector, Step, SuccessfulRebase, mutate::InsertSide},
+        graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToSelector, mutate::InsertSide},
     };
-
-    use crate::commit::insert_blank_commit::RelativeTo;
 
     /// Inserts a blank commit relative to either a reference or a commit
     pub fn insert_blank_commit(
         mut editor: Editor,
         side: InsertSide,
-        relative_to: RelativeTo,
+        relative_to: impl ToSelector,
     ) -> Result<(SuccessfulRebase, Selector)> {
-        let target_selector = match relative_to {
-            RelativeTo::Commit(id) => editor.select_commit(id)?,
-            RelativeTo::Reference(r) => editor.select_reference(r)?,
-        };
-
         let commit = editor.empty_commit()?;
         let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorUpdate)?;
 
-        let blank_commit_selector = editor.insert(target_selector, Step::new_pick(new_id), side)?;
+        let blank_commit_selector = editor.insert(relative_to, Step::new_pick(new_id), side)?;
 
         let outcome = editor.rebase()?;
 

--- a/crates/but-workspace/src/commit/reword.rs
+++ b/crates/but-workspace/src/commit/reword.rs
@@ -5,7 +5,7 @@ pub(crate) mod function {
     use bstr::BStr;
     use but_rebase::{
         commit::DateMode,
-        graph_rebase::{Editor, Selector, Step, SuccessfulRebase},
+        graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector},
     };
 
     /// This action will rewrite a commit and any relevant history so it uses
@@ -14,12 +14,11 @@ pub(crate) mod function {
     /// Returns a selector to the rewritten commit
     pub fn reword(
         mut editor: Editor,
-        commit_id: gix::ObjectId,
+        commit: impl ToCommitSelector,
         new_message: &BStr,
     ) -> Result<(SuccessfulRebase, Selector)> {
-        let target_selector = editor.select_commit(commit_id)?;
+        let (target_selector, mut commit) = editor.find_selectable_commit(commit)?;
 
-        let mut commit = editor.find_commit(commit_id)?;
         commit.message = new_message.to_owned();
         let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
 

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use but_rebase::graph_rebase::{GraphExt as _, mutate::InsertSide};
+use but_rebase::graph_rebase::{
+    GraphExt as _,
+    mutate::{InsertSide, RelativeTo},
+};
 use but_testsupport::visualize_commit_graph_all;
-use but_workspace::commit::{insert_blank_commit, insert_blank_commit::RelativeTo};
+use but_workspace::commit::insert_blank_commit;
 
 use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
 


### PR DESCRIPTION
One of the main drivers here was to enable us to write these editor based plumbing commands in a chainable way. This allows you to take a selector from the output of one function and pass it directly to another function since.

This commit introduces a family of traits:
`ToSelector`, `ToCommitSelector`, and `ToReferenceSelector`.

Objects that implement `ToSelector`, `ToCommitSelector` or `ToReferenceSelector` directly will successfully resolve to a selector assuming it’s in the graph. It will also assert that it's the right type if it's `ToCommitSelector` or `ToReferenceSelector` variant. 

Objects implementing `ToSelector` have ToR... and ToC… implemented dynamically and will have a runtime check to ensure that they point to the right kind of step.

`ToCommitSelector` and `ToReferenceSelector` can freely downcast to `ToSelector`.

`ToSelector` has been implemented for the `RelativeTo` enum and for `Selector`s themselves.

`ToCommitSelector` has been implemented for `gix::ObjectId`
`ToReferenceSelector` has been implemented for `&gix::refs::FullNameRef`