### PR TITLE
Try to avoid rust analyzer dependency issue

### DIFF
--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -78,7 +78,7 @@ tracing-forest.workspace = true
 open.workspace = true
 ## This is only used on macOS when it's the stable build to open `com.gitbutler.app` folders.
 ## Ideally, we could only use the dependency then.
-opener = { version = "0.8.3", features = ["reveal"] }
+opener = { version = "0.8.3", features = ["reveal"], optional = true }
 url = "2.5.4"
 but-path.workspace = true
 uuid.workspace = true


### PR DESCRIPTION
For some really strange reason, I was getting the error `Dependency opener is not an optional dependency` in my code editor on  line six of `gitbutler-tauri/src/lib.rs`. 

Making opener optional seems to help, but I really don’t know why.