### PR TITLE
Configure vscode rust analyzer to use target folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 	"rust-analyzer.check.command": "clippy",
 	"rust-analyzer.check.allTargets": true,
 	"rust-analyzer.check.features": "all",
-	"rust-analyzer.check.extraArgs": ["--target-dir", ".rust-analyzer/target"],
+	"rust-analyzer.check.extraArgs": ["--target-dir", "target/rust-analyzer"],
 	"[rust]": {
 		"editor.defaultFormatter": "rust-lang.rust-analyzer"
 	},


### PR DESCRIPTION
Using a subfolder of `target` means that rust-analyzer gets cleaned up by default when we run `cargo clean`.

I’m leaving the `scripts/clean.sh` for now so we make sure any remaining files get cleaned up.