### PR TITLE
Bring back lock icons for assigned changes

### DIFF
--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -102,7 +102,7 @@
 		{listMode}
 		{stackId}
 		{onFileClick}
-		showLockedIndicator={mode === 'unassigned'}
+		showLockedIndicator
 	/>
 {/snippet}
 


### PR DESCRIPTION
They were turned off by mistake, and they're useful for knowing what commits files depend on.