### PR TITLE
Ensure but cli projects are migrated

### DIFF
--- a/crates/but/tests/but/command/setup.rs
+++ b/crates/but/tests/but/command/setup.rs
@@ -1,3 +1,5 @@
+use serde_json::json;
+
 use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
@@ -682,6 +684,112 @@ To undo these changes and return to normal Git mode, either:
     - Run `but teardown`
 
 More info: https://docs.gitbutler.com/workspace-branch
+
+
+
+ █████      █████    ██████╗ ██╗   ██╗████████╗
+   █████  █████      ██╔══██╗██║   ██║╚══██╔══╝
+     ████████        ██████╔╝██║   ██║   ██║
+   █████  █████      ██╔══██╗██║   ██║   ██║
+ █████      █████    ██████╔╝╚██████╔╝   ██║
+
+The command-line interface for GitButler
+
+$ but branch new <name>                       Create a new branch
+$ but status                                  View workspace status
+$ but commit -m <message>                     Commit changes to current branch
+$ but push                                    Push all branches
+$ but teardown                                Return to normal Git mode
+
+Learn more at https://docs.gitbutler.com/cli-overview
+
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn setup_called_on_unmigrated_projects_json() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("repo-no-remote")?;
+
+    // Run first to create the metadata in `projects.json` which we then mutate
+    // to create the "legacy" metadata scenario.
+    env.but("setup")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Setting up GitButler project...
+
+→ Adding repository to GitButler project registry
+  ✓ Repository already in project registry
+
+→ Configuring default target branch
+  No push remote found, creating gb-local remote...
+  ✓ Created gb-local remote tracking main
+  ✓ Set default target to: gb-local/main
+
+GitButler project setup complete!
+Target branch: gb-local/main
+Remote: gb-local
+
+
+Setting up your project for GitButler tooling. Some things to note:
+
+- Switching you to a special `gitbutler/workspace` branch to enable parallel branches
+- Installing Git hooks to help manage commits on the workspace branch
+
+To undo these changes and return to normal Git mode, either:
+
+    - Directly checkout a branch (`git checkout main`)
+    - Run `but teardown`
+
+More info: https://docs.gitbutler.com/workspace-branch
+
+
+
+ █████      █████    ██████╗ ██╗   ██╗████████╗
+   █████  █████      ██╔══██╗██║   ██║╚══██╔══╝
+     ████████        ██████╔╝██║   ██║   ██║
+   █████  █████      ██╔══██╗██║   ██║   ██║
+ █████      █████    ██████╔╝╚██████╔╝   ██║
+
+The command-line interface for GitButler
+
+$ but branch new <name>                       Create a new branch
+$ but status                                  View workspace status
+$ but commit -m <message>                     Commit changes to current branch
+$ but push                                    Push all branches
+$ but teardown                                Return to normal Git mode
+
+Learn more at https://docs.gitbutler.com/cli-overview
+
+
+"#]]);
+
+    let projects_file = env.app_data_dir().join("com.gitbutler.app/projects.json");
+    let mut file: serde_json::Value = std::fs::read_to_string(&projects_file)?.parse()?;
+
+    file.as_array_mut().unwrap()[0]
+        .as_object_mut()
+        .unwrap()
+        .insert("git_dir".into(), json!(""));
+
+    std::fs::write(projects_file, serde_json::to_string_pretty(&file)?)?;
+
+    env.but("setup")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Setting up GitButler project...
+
+→ Adding repository to GitButler project registry
+  ✓ Repository already in project registry
+
+GitButler project is already set up!
+Target branch: gb-local/main
 
 
 

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -71,7 +71,7 @@ impl Controller {
             .iter()
             .find(|project| resolved_path.starts_with(project.worktree_dir_but_should_use_git_dir()))
         {
-            return Ok(AddProjectOutcome::AlreadyExists(existing_project.to_owned()));
+            return Ok(AddProjectOutcome::AlreadyExists(existing_project.clone().migrated()?));
         }
 
         self.add(worktree_dir)
@@ -88,7 +88,7 @@ impl Controller {
             .iter()
             .find(|project| project.worktree_dir_but_should_use_git_dir() == resolved_path)
         {
-            return Ok(AddProjectOutcome::AlreadyExists(existing_project.to_owned()));
+            return Ok(AddProjectOutcome::AlreadyExists(existing_project.clone().migrated()?));
         }
         if !resolved_path.exists() {
             return Ok(AddProjectOutcome::PathNotFound);


### PR DESCRIPTION
We’ve seen newly reactivated users having issues with very old metadata in their projects.json.

This PR makes sure that we call migrate on projects that are already found in the projects list & tests this old flow by manually modify the problematic entry in the `projects.json` file.