### PR TITLE
Add --status-after flag to mutation subcommands

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -16,8 +16,8 @@ Help users work with GitButler CLI (`but` command) in workspace mode.
 1. **Check state** → `but status --json` (always use `--json` for structured output)
 2. **Start work** → `but branch new <task-name>` (create stack for this work theme)
 3. **Make changes** → Edit files as needed
-4. **Commit work** → `but commit <branch> -m "message" --changes <id>,<id>` (commit specific files by CLI ID)
-5. **Refine** → Use `but absorb` or `but squash` to clean up history
+4. **Commit work** → `but commit <branch> -m "message" --changes <id>,<id> --json --status-after` (commit specific files by CLI ID, get updated status in one call)
+5. **Refine** → Use `but absorb --json --status-after` or `but squash --json --status-after` to clean up history
 
 **Commit early, commit often.** Don't hesitate to create commits - GitButler makes editing history trivial. You can always `squash`, `reword`, or `absorb` changes into existing commits later. Small atomic commits are better than large uncommitted changes.
 
@@ -26,7 +26,7 @@ Help users work with GitButler CLI (`but` command) in workspace mode.
 When ready to commit:
 
 1. Run `but status --json` to see uncommitted changes and get their CLI IDs
-2. Commit the relevant files directly: `but commit <branch> -m "message" --changes <id>,<id>`
+2. Commit the relevant files directly: `but commit <branch> -m "message" --changes <id>,<id> --json --status-after`
 
 You can batch multiple file edits before committing - no need to commit after every single change.
 
@@ -63,7 +63,7 @@ but skill install --path <path>    # Install/update skill (agents use --path wit
 but status --json       # Always start here - shows workspace state (JSON for agents)
 but branch new feature  # Create new stack for work
 # Make changes...
-but commit <branch> -m "…" --changes <id>,<id>  # Commit specific files by CLI ID
+but commit <branch> -m "…" --changes <id>,<id> --json --status-after  # Commit + get updated status
 but push <branch>       # Push to remote
 ```
 
@@ -83,6 +83,7 @@ For detailed command syntax and all available options, see [references/reference
 **Flags explanation:**
 - `--json` - Output structured JSON instead of human-readable text (always use for agents)
 - `-f` - Include detailed file lists in status output (combines with --json: `but status --json -f`)
+- `--status-after` - After a mutation command (`commit`, `absorb`, `rub`, `stage`, `amend`, `squash`, `move`, `uncommit`), also output workspace status. With `--json`, wraps both in `{"result": ..., "status": ...}`. Saves a separate `but status` call.
 
 **Organizing work:**
 
@@ -150,24 +151,23 @@ but branch new api-endpoint
 but branch new ui-update
 # Make changes, then commit specific files to appropriate branches
 but status --json  # Get file CLI IDs
-but commit api-endpoint -m "Add endpoint" --changes <api-file-id>
-but commit ui-update -m "Update UI" --changes <ui-file-id>
+but commit api-endpoint -m "Add endpoint" --changes <api-file-id> --json --status-after
+but commit ui-update -m "Update UI" --changes <ui-file-id> --json --status-after
 ```
 
 **Committing specific hunks (fine-grained control):**
 
 ```bash
 but diff --json             # See hunk IDs when a file has multiple changes
-but commit <branch> -m "Fix first issue" --changes <hunk-id-1>
-but commit <branch> -m "Fix second issue" --changes <hunk-id-2>
+but commit <branch> -m "Fix first issue" --changes <hunk-id-1> --json --status-after
+but commit <branch> -m "Fix second issue" --changes <hunk-id-2> --json --status-after
 ```
 
 **Cleaning up commits:**
 
 ```bash
-but absorb              # Auto-amend changes
-but status --json       # Verify absorb result
-but squash <branch>     # Squash all commits in branch
+but absorb --json --status-after    # Auto-amend changes + get updated status in one call
+but squash <branch> --json --status-after  # Squash all commits in branch + get updated status
 ```
 
 **Resolving conflicts:**
@@ -185,6 +185,7 @@ but resolve finish      # Complete resolution
 3. Use `--changes` to commit specific files directly - no need to stage first
 4. **Commit early and often** - don't wait for perfection. Unlike traditional git, GitButler makes editing history trivial with `absorb`, `squash`, and `reword`. It's better to have small, atomic commits that you refine later than to accumulate large uncommitted changes.
 5. **Use `--json` flag for ALL commands** when running as an agent - this provides structured, parseable output instead of human-readable text
-6. Use `--dry-run` flags (push, absorb) when unsure
-7. Run `but pull` regularly to stay updated with upstream
-8. When updating this skill, use `but skill install --path <known-path>` to avoid prompts
+6. **Use `--status-after`** on mutation commands (`commit`, `absorb`, `rub`, `stage`, `amend`, `squash`, `move`, `uncommit`) to get workspace status in the same call — avoids a separate `but status` round-trip
+7. Use `--dry-run` flags (push, absorb) when unsure
+8. Run `but pull` regularly to stay updated with upstream
+9. When updating this skill, use `but skill install --path <known-path>` to avoid prompts

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -25,8 +25,8 @@ but stage a1 bu    # api/users.js → api-endpoint branch
 but stage a2 bv    # Button.svelte → ui-styling branch
 
 # 6. Commit each branch (--only to commit only staged files)
-but commit bu --only -m "Add user details endpoint"
-but commit bv --only -m "Update button hover styles"
+but commit bu --only -m "Add user details endpoint" --json --status-after
+but commit bv --only -m "Update button hover styles" --json --status-after
 
 # 7. Push branches independently (optional, can skip if using pr new)
 but push bu
@@ -54,8 +54,8 @@ but branch new add-authentication
 # 3. Implement auth and commit
 # (edit auth/login.js, auth/middleware.js)
 but status --json
-but stage <file-ids> bu  # Stage changes to auth branch
-but commit bu --only -m "Add JWT authentication"
+but stage <file-ids> bu --json --status-after  # Stage changes to auth branch
+but commit bu --only -m "Add JWT authentication" --json --status-after
 
 # 4. Create stacked branch anchored on authentication
 but branch new user-profile -a bu
@@ -63,8 +63,8 @@ but branch new user-profile -a bu
 # 5. Implement profile page (depends on auth)
 # (edit pages/profile.js)
 but status --json
-but stage <file-ids> bv  # Stage changes to profile branch
-but commit bv --only -m "Add user profile page"
+but stage <file-ids> bv --json --status-after  # Stage changes to profile branch
+but commit bv --only -m "Add user profile page" --json --status-after
 
 # 6. Push both branches (maintains stack relationship)
 but push
@@ -92,7 +92,7 @@ but status --json
 but absorb a1 --dry-run    # Shows where a1 would be absorbed
 
 # 3. Absorb the specific file into appropriate commit
-but absorb a1              # Absorb just this file
+but absorb a1 --json --status-after    # Absorb just this file + get updated status
 
 # GitButler analyzes the change and amends it into c3
 # (because the typo is in code from c3)
@@ -101,9 +101,9 @@ but absorb a1              # Absorb just this file
 **Targeted vs blanket absorb:**
 
 ```bash
-but absorb a1              # Absorb specific file (recommended)
-but absorb bu              # Absorb all changes staged to branch bu
-but absorb                 # Absorb ALL uncommitted changes (use with caution)
+but absorb a1 --json --status-after    # Absorb specific file (recommended)
+but absorb bu --json --status-after    # Absorb all changes staged to branch bu
+but absorb --json --status-after       # Absorb ALL uncommitted changes (use with caution)
 ```
 
 **Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
@@ -123,13 +123,13 @@ but absorb                 # Absorb ALL uncommitted changes (use with caution)
 # c1: Initial implementation
 
 # Squash all commits in branch
-but squash bu
+but squash bu --json --status-after
 
 # Or squash specific range
-but squash c2..c5    # Squashes c2, c3, c4, c5 into one
+but squash c2..c5 --json --status-after    # Squashes c2, c3, c4, c5 into one
 
 # Or squash specific commits
-but squash c2 c3 c4    # Squashes these three
+but squash c2 c3 c4 --json --status-after    # Squashes these three
 ```
 
 ### Scenario B: Moving Files Between Commits
@@ -145,7 +145,7 @@ but status --json -f
 # c2: config.js
 
 # 2. Move utils.js from c3 to c2
-but rub a2 c2    # File a2 (utils.js) → commit c2
+but rub a2 c2 --json --status-after    # File a2 (utils.js) → commit c2 + get updated status
 ```
 
 ### Scenario C: Moving Commit to Different Branch
@@ -165,7 +165,7 @@ but status --json
 but branch new feature-b    # Creates branch bv
 
 # 3. Move the commit
-but move c3 bv    # Move c3 to top of branch bv
+but move c3 bv --json --status-after    # Move c3 to top of branch bv
 ```
 
 ## Example 5: Using Marks for Focused Work
@@ -186,7 +186,7 @@ but mark bu    # Branch bu (refactor) is now marked
 but status --json  # Shows all changes staged to bu
 
 # 5. Commit the staged changes
-but commit bu --only -m "Refactor error handling across app"
+but commit bu --only -m "Refactor error handling across app" --json --status-after
 
 # 6. Remove mark
 but unmark
@@ -271,28 +271,24 @@ but branch new user-dashboard
 
 # 4. Check and stage
 but status --json
-but stage <file-ids> bu  # Stage changes to dashboard branch
+but stage <file-ids> bu --json --status-after  # Stage changes to dashboard branch
 
 # 5. First commit
-but commit bu --only -m "Add dashboard route and basic layout"
+but commit bu --only -m "Add dashboard route and basic layout" --json --status-after
 
 # 6. Continue iterating
 # (add widgets, styling)
-but stage <file-ids> bu
-but commit bu --only -m "Add dashboard widgets"
-but stage <file-ids> bu
-but commit bu --only -m "Style dashboard components"
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Add dashboard widgets" --json --status-after
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Style dashboard components" --json --status-after
 
 # 7. Make small fix
 # (fix typo in widget)
-but status --json          # Check file ID of the fix (e.g., a1)
-but absorb a1              # Absorb specific file into appropriate commit
-
-# 8. Review history
-but status --json
+but absorb a1 --json --status-after    # Absorb specific file into appropriate commit
 
 # 9. Clean up if needed
-but squash bu    # Combine all commits (optional)
+but squash bu --json --status-after    # Combine all commits (optional)
 
 # 10. Push to remote (can also skip - pr new auto-pushes)
 but push bu
@@ -328,8 +324,8 @@ but unapply bw
 
 # 3. Focus on feature-a
 # (make changes, stage, commit)
-but stage <file-ids> bu
-but commit bu --only -m "Complete feature-a"
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Complete feature-a" --json --status-after
 
 # 4. Create PR for feature-a (auto-pushes)
 but pr new bu
@@ -364,13 +360,10 @@ but reword c3 -m "Fix edge case in parser"
 but reword c2 -m "Update error messages"
 
 # 3. Move c5 to be earlier
-but move c5 c3    # Move c5 before c3
+but move c5 c3 --json --status-after    # Move c5 before c3
 
 # 4. Squash similar commits
-but squash c2 c3    # Combine error handling commits
-
-# 5. Review final state
-but status --json
+but squash c2 c3 --json --status-after    # Combine error handling commits
 
 # Output:
 # Branch: feature-x (bu)
@@ -397,37 +390,35 @@ but branch new fix-auth-bug       # Create branch for today's work
 # Work and commit iteratively
 # (make changes)
 but status --json                 # Check changes
-but stage <file-ids> bu           # Stage to branch
-but commit bu --only -m "Identify auth bug source"
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Identify auth bug source" --json --status-after
 # (make more changes)
-but stage <file-ids> bu           # Stage to branch
-but commit bu --only -m "Fix token expiration handling"
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Fix token expiration handling" --json --status-after
 # (small fix to existing code)
-but status --json                 # Get file ID (e.g., a1)
-but absorb a1                     # Absorb specific fix into appropriate commit
+but absorb a1 --json --status-after              # Absorb specific fix into appropriate commit
 
 # Mid-day: Start urgent fix on different branch
 but branch new hotfix-login       # Parallel branch for urgent work
 # (make fix)
-but stage <file-ids> bv           # Stage to hotfix branch
-but commit bv --only -m "Fix login redirect loop"
+but stage <file-ids> bv --json --status-after    # Stage to hotfix branch
+but commit bv --only -m "Fix login redirect loop" --json --status-after
 but pr new bv                     # Push and create PR immediately
 
 # Back to original work
 # (continue working on bu, auth bug fix)
-but stage <file-ids> bu           # Stage to auth branch
-but commit bu --only -m "Add tests for token handling"
+but stage <file-ids> bu --json --status-after    # Stage to auth branch
+but commit bu --only -m "Add tests for token handling" --json --status-after
 
 # End of day: Clean up and create PR
-but squash bu                     # Combine into clean history
+but squash bu --json --status-after    # Combine into clean history
 but pr new bu                     # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)
-but status --json                 # Check file IDs of changes
-but absorb <file-id>              # Absorb specific changes into commits
+but absorb <file-id> --json --status-after    # Absorb specific changes into commits
 # Or absorb all changes for this branch:
-but absorb bu                     # Absorb all changes staged to bu
+but absorb bu --json --status-after          # Absorb all changes staged to bu
 but push bu --with-force          # Force push updated history
 ```
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -146,6 +146,7 @@ Stage file to a specific branch.
 
 ```bash
 but stage <file-id> <branch-id>
+but stage <file-id> <branch-id> --status-after  # Stage then show workspace status
 ```
 
 Alias for `but rub <file> <branch>`. You can't stage changes that depend on branch A to branch B.
@@ -169,6 +170,7 @@ but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommend
 but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
 but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
 but commit <branch> -i                   # AI-generated commit message
+but commit <branch> -m "message" --status-after  # Commit then show workspace status
 but commit empty --before <target>       # Insert empty commit before target
 but commit empty --after <target>        # Insert empty commit after target
 ```
@@ -197,6 +199,7 @@ but absorb <branch-id>        # Absorb all changes staged to this branch
 but absorb                    # Absorb ALL uncommitted changes (use with caution)
 but absorb --dry-run          # Preview without making changes
 but absorb <file-id> --dry-run  # Preview specific file absorption
+but absorb --status-after     # Absorb then show workspace status
 ```
 
 **Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
@@ -218,6 +221,7 @@ but rub <file> <branch>      # Stage file to branch
 but rub <file> <commit>      # Amend file into commit
 but rub <commit> <commit>    # Squash commits together
 but rub <commit> <branch>    # Move commit to branch
+but rub <file> <commit> --status-after  # Amend then show workspace status
 ```
 
 The core "rub two things together" operation.
@@ -230,6 +234,7 @@ Squash commits together.
 but squash <c1> <c2> <c3>    # Squash multiple commits (into last)
 but squash <c1>..<c4>        # Squash a range
 but squash <branch>          # Squash all commits in branch into bottom-most
+but squash <branch> --status-after  # Squash then show workspace status
 ```
 
 ### `but amend <file> <commit>`
@@ -237,7 +242,8 @@ but squash <branch>          # Squash all commits in branch into bottom-most
 Amend file into a specific commit. Use when you know exactly which commit the change belongs to.
 
 ```bash
-but amend <file-id> <commit-id>    # Amend file into specific commit
+but amend <file-id> <commit-id>                  # Amend file into specific commit
+but amend <file-id> <commit-id> --status-after   # Amend then show workspace status
 ```
 
 **When to use `amend` vs `absorb`:**
@@ -254,6 +260,7 @@ Move a commit to a different location.
 but move <source> <target>           # Move before target
 but move <source> <target> --after   # Move after target
 but move <commit> <branch>           # Move to top of branch
+but move <commit> <branch> --status-after  # Move then show workspace status
 ```
 
 ### `but uncommit <source>`
@@ -263,6 +270,7 @@ Uncommit changes back to unstaged area.
 ```bash
 but uncommit <commit-id>      # Uncommit entire commit
 but uncommit <file-id>        # Uncommit specific file from its commit
+but uncommit <commit-id> --status-after  # Uncommit then show workspace status
 ```
 
 ### `but reword <id>`
@@ -491,6 +499,7 @@ but alias
 Available on most commands:
 
 - `-j, --json` - Output in JSON format for parsing
+- `--status-after` - After a mutation command, also output workspace status. In human mode, prints status after the command output. In JSON mode, wraps both in `{"result": ..., "status": ...}`. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
 - `-C, --current-dir <PATH>` - Run as if started in different directory
 - `-h, --help` - Show help for command
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -38,6 +38,13 @@ pub struct Args {
     /// Whether to use JSON output format.
     #[clap(long, short = 'j', global = true)]
     pub json: bool,
+    /// After a mutation command completes, also output workspace status.
+    ///
+    /// In human mode, prints status after the command output.
+    /// In JSON mode, wraps both in {"result": ..., "status": ...} on success, or
+    /// {"result": ..., "status_error": ...} if the status query fails (in which case "status" is absent).
+    #[clap(long = "status-after", global = true)]
+    pub status_after: bool,
     /// Source entity for rub operation (when no subcommand is specified).
     /// If no target is specified, this is treated as a path to open on the GUI.
     #[clap(value_name = "SOURCE")]

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -22,6 +22,8 @@ pub(crate) fn assign_uncommitted_to_branch(
     do_assignments(ctx, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Staged {} → {}.", description, format!("[{branch_name}]").green())?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }
@@ -53,6 +55,8 @@ pub(crate) fn assign_uncommitted_to_stack(
             description,
             format!("[{}]", stack_id).green()
         )?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }
@@ -72,6 +76,8 @@ pub(crate) fn unassign_uncommitted(
     do_assignments(ctx, reqs, out)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Unstaged {description}")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }
@@ -163,6 +169,8 @@ fn assign_all_inner(
                     .unwrap_or_else(|| "unstaged".to_string().bold())
             )?;
         }
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/rub/commits.rs
+++ b/crates/but/src/command/legacy/rub/commits.rs
@@ -34,6 +34,8 @@ pub fn commited_file_to_another_commit(
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Moved files between commits!")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
 
     Ok(())
@@ -73,6 +75,8 @@ pub fn uncommit_file(
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Uncommitted changes")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -18,6 +18,29 @@ use gitbutler_oplog::{
 
 use crate::{CliId, IdMap, utils::OutputChannel};
 
+/// Serialize a [`gitbutler_branch_actions::MoveCommitIllegalAction`] to a structured JSON value.
+///
+/// Shared between `move.rs` and `move_commit.rs` to avoid duplicated match arms.
+pub(crate) fn illegal_move_to_json(action: &gitbutler_branch_actions::MoveCommitIllegalAction) -> serde_json::Value {
+    let (reason, deps) = match action {
+        gitbutler_branch_actions::MoveCommitIllegalAction::DependsOnCommits(deps) => {
+            ("depends_on_commits", Some(deps.clone()))
+        }
+        gitbutler_branch_actions::MoveCommitIllegalAction::HasDependentChanges(deps) => {
+            ("has_dependent_changes", Some(deps.clone()))
+        }
+        gitbutler_branch_actions::MoveCommitIllegalAction::HasDependentUncommittedChanges => {
+            ("has_dependent_uncommitted_changes", None)
+        }
+    };
+    serde_json::json!({
+        "ok": false,
+        "error": "illegal_move",
+        "reason": reason,
+        "dependencies": deps,
+    })
+}
+
 /// Represents the operation to perform for a given source and target combination.
 /// This enum serves as the single source of truth for valid rub operations.
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/rub/move_commit.rs
+++ b/crates/but/src/command/legacy/rub/move_commit.rs
@@ -34,7 +34,7 @@ pub(crate) fn to_branch(
         gitbutler_branch_actions::move_commit(ctx, target_stack_id, oid.to_git2(), source_stack_id)?
     {
         if let Some(out) = out.for_human() {
-            match illegal_move {
+            match &illegal_move {
                 gitbutler_branch_actions::MoveCommitIllegalAction::DependsOnCommits(deps) => {
                     writeln!(
                         out,
@@ -58,6 +58,8 @@ pub(crate) fn to_branch(
                     )
                 }
             }?;
+        } else if let Some(out) = out.for_json() {
+            out.write_value(super::illegal_move_to_json(&illegal_move))?;
         }
         bail!("Illegal move")
     }
@@ -68,6 +70,8 @@ pub(crate) fn to_branch(
             oid.to_string()[..7].blue(),
             format!("[{branch_name}]").green()
         )?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -256,6 +256,12 @@ fn squash_commits_internal(
                 final_commit_oid.to_gix().to_string()[..7].blue()
             )?
         }
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "ok": true,
+            "new_commit_id": final_commit_oid.to_gix().to_string(),
+            "squashed_count": source_oids.len(),
+        }))?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/rub/undo.rs
+++ b/crates/but/src/command/legacy/rub/undo.rs
@@ -10,6 +10,8 @@ pub(crate) fn commit(ctx: &mut Context, oid: &ObjectId, out: &mut OutputChannel)
     gitbutler_branch_actions::undo_commit(ctx, stack_id_by_commit_id(ctx, oid)?, oid.to_git2())?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Uncommitted {}", oid.to_string()[..7].blue())?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({"ok": true}))?;
     }
     Ok(())
 }

--- a/crates/but/tests/but/command/snapshots/help/rub-long-help.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/rub-long-help.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="776px" height="1208px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="1334px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -144,11 +144,25 @@
 </tspan>
     <tspan x="10px" y="1144px">
 </tspan>
-    <tspan x="10px" y="1162px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="1162px"><tspan>      </tspan><tspan class="bold">--status-after</tspan>
 </tspan>
-    <tspan x="10px" y="1180px"><tspan>          Print help (see a summary with '-h')</tspan>
+    <tspan x="10px" y="1180px"><tspan>          After a mutation command completes, also output workspace status.</tspan>
 </tspan>
-    <tspan x="10px" y="1198px">
+    <tspan x="10px" y="1198px"><tspan>          </tspan>
+</tspan>
+    <tspan x="10px" y="1216px"><tspan>          In human mode, prints status after the command output. In JSON mode, wraps both in</tspan>
+</tspan>
+    <tspan x="10px" y="1234px"><tspan>          {"result": ..., "status": ...} on success, or {"result": ..., "status_error": ...} if the</tspan>
+</tspan>
+    <tspan x="10px" y="1252px"><tspan>          status query fails (in which case "status" is absent).</tspan>
+</tspan>
+    <tspan x="10px" y="1270px">
+</tspan>
+    <tspan x="10px" y="1288px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="1306px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="1324px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/help/rub-short-help.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/help/rub-short-help.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="776px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="776px" height="254px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -36,11 +36,13 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="underline bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="bold">-j</tspan><tspan>, </tspan><tspan class="bold">--json</tspan><tspan>  Whether to use JSON output format</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="bold">-j</tspan><tspan>, </tspan><tspan class="bold">--json</tspan><tspan>          Whether to use JSON output format</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan><tspan>  Print help (see more with '--help')</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="bold">--status-after</tspan><tspan>  After a mutation command completes, also output workspace status</tspan>
 </tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan><tspan>          Print help (see more with '--help')</tspan>
+</tspan>
+    <tspan x="10px" y="244px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary
- Adds a global `--status-after` flag to the `but` CLI that appends workspace status output after mutation commands (`rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`) complete
- In human mode, prints a blank line then full workspace status (with hints, matching standalone `but status`)
- In JSON mode, wraps both mutation result and status in a combined `{"result": ..., "status": ...}` object — agents save a round-trip by not needing a separate `but status` call
- Graceful error handling: if status query fails, mutation JSON is never lost (emits `"status_error"` field instead); on mutation failure, `OutputChannel::drop` flushes any buffered structured error JSON (e.g. illegal move details)
- Fixes absorb double-write bug: `display_absorption_plan` returns plan data instead of writing directly when in non-dry-run mode, allowing `absorb_assignments` to combine plan + result into a single `write_value` call
- All JSON keys use consistent snake_case (`new_commit_id`, `squashed_count`)
- Updates skill files (SKILL.md, reference.md, examples.md) with `--json --status-after` in all agent-facing examples

## Implementation
- `OutputChannel` gains JSON buffering (`start_json_buffering`, `begin_status_after`, `take_json_buffer`) to capture mutation JSON before combining with status JSON
- `maybe_run_status_after` / `run_status_after` helpers handle the two-phase protocol across all mutation match arms, including the implicit rub path (no subcommand, two positional args)
- On mutation error, the buffer is NOT drained — `OutputChannel::drop` safety net flushes any non-null buffered JSON to stdout
- `display_absorption_plan` takes a `write_json` parameter: `true` (dry-run) writes JSON directly, `false` (non-dry-run) returns `Option<JsonAbsorbOutput>` for the caller to merge with operation results

## Test plan
- [x] `cargo fmt -p but --check` passes
- [x] `cargo clippy -p but --lib --bins` clean
- [x] `cargo test -p but` — all 160 tests pass (2 new)
- [x] Snapshot tests updated for new `--status-after` in help output
- [x] New: `status_after_json_wraps_mutation_and_status` — verifies `{"result": {"ok": true}, "status": {"stacks": ..., "unassignedChanges": ...}}` shape
- [x] New: `status_after_json_with_status_error_has_status_error_field` — verifies `status_error` absent on success

