### PR TITLE
Fix scroll position stability when items resize

### DIFF
--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -170,17 +170,26 @@
 
 				if (
 					lastScrollDirection === 'up' &&
-					calculateHeightSum(0, visibleRange.start) !== viewport.scrollTop
+					calculateHeightSum(0, visibleRange.start) !== viewport.scrollTop &&
+					visibleRange.start === index
 				) {
+					// When scrolling up, compensate for the height change of the topmost
+					// visible element to prevent content from jumping downward.
 					viewport.scrollBy({ top: heightMap[index] - oldHeight });
 				} else if (
 					(lastJumpToIndex !== undefined || startIndex) &&
 					lastScrollDirection === undefined
 				) {
-					const newScrollTop = calculateHeightSum(0, lastJumpToIndex || startIndex || 0);
-					viewport.scrollTop = newScrollTop;
+					// After jumping to an index, maintain position as off-viewport elements
+					// resize. Scroll direction is undefined during jumps.
+					viewport.scrollTop = calculateHeightSum(0, lastJumpToIndex || startIndex || 0);
 					skipNextScrollEvent = true;
-				} else if (stickToBottom && previousDistance < STICKY_DISTANCE) {
+				} else if (
+					(stickToBottom || index === items.length - 1) &&
+					previousDistance < STICKY_DISTANCE
+				) {
+					// Maintain bottom position when near bottom and either stickToBottom
+					// is enabled or the last visible item resizes.
 					skipNextScrollEvent = true;
 					scrollToBottom();
 				}

--- a/packages/ui/src/lib/components/scroll/Scrollbar.svelte
+++ b/packages/ui/src/lib/components/scroll/Scrollbar.svelte
@@ -375,8 +375,7 @@
 			transition:
 				opacity 0.2s,
 				transform 0.15s,
-				height 0.15s,
-				top 0.05s;
+				height 0.15s;
 		}
 	}
 


### PR DESCRIPTION
- Stick to bottom when the last visible item expands (e.g. expanding a
  collapsed diff), not just when stickToBottom is enabled
- Compensate scroll position only when the topmost visible element
  resizes, fixing jitter when scrolling up
- Remove scroll thumb position transition that caused lag during
  fast scrolling