### PR TITLE
feat/simplify-forge-form-messaging

### DIFF
--- a/apps/desktop/src/components/ForgeAccountConfig.svelte
+++ b/apps/desktop/src/components/ForgeAccountConfig.svelte
@@ -1,0 +1,89 @@
+<script lang="ts" generics="TAccount">
+	import { useSettingsModal } from '$lib/settings/settingsModal.svelte';
+	import { Button, CardGroup, Link, Select, SelectItem } from '@gitbutler/ui';
+	import type { Component } from 'svelte';
+
+	type Props = {
+		projectId: string;
+		displayName: string;
+		accounts: TAccount[];
+		preferredAccount: TAccount | undefined;
+		accountToString: (account: TAccount) => string;
+		stringToAccount: (value: string) => TAccount | null;
+		getUsername: (account: TAccount) => string;
+		updatePreferredAccount: (projectId: string, account: TAccount) => void;
+		AccountBadge: Component<{ account: TAccount; class?: string }>;
+		docsUrl: string;
+		requestType: 'pull request' | 'merge request';
+	};
+
+	const {
+		projectId,
+		displayName,
+		accounts,
+		preferredAccount,
+		accountToString,
+		stringToAccount,
+		getUsername,
+		updatePreferredAccount,
+		AccountBadge,
+		docsUrl,
+		requestType
+	}: Props = $props();
+
+	const { openGeneralSettings } = useSettingsModal();
+	const hasAccounts = $derived(accounts.length > 0 && preferredAccount);
+
+	function handleAccountChange(value: string) {
+		const parsedAccount = stringToAccount(value);
+		if (!parsedAccount) return;
+		updatePreferredAccount(projectId, parsedAccount);
+	}
+</script>
+
+<CardGroup.Item>
+	{#snippet title()}
+		{#if hasAccounts}
+			Configure {displayName} integration
+		{:else}
+			Connect your {displayName} account
+		{/if}
+	{/snippet}
+
+	{#snippet caption()}
+		Enable {requestType} creation. Read more in the <Link href={docsUrl}>docs</Link>
+	{/snippet}
+
+	{#if !hasAccounts}
+		<div class="flex">
+			<Button onclick={() => openGeneralSettings('integrations')} style="pop" icon="link"
+				>Set up in General Settings</Button
+			>
+		</div>
+	{:else}
+		{@const account = preferredAccount!}
+		{@const accountStr = accountToString(account)}
+		<Select
+			label="{displayName} account for this project"
+			value={accountStr}
+			options={accounts.map((acc) => ({
+				label: getUsername(acc),
+				value: accountToString(acc)
+			}))}
+			onselect={handleAccountChange}
+			disabled={accounts.length <= 1}
+			wide
+		>
+			{#snippet itemSnippet({ item, highlighted })}
+				{@const itemAccount = item.value && stringToAccount(item.value)}
+				<SelectItem selected={item.value === accountStr} {highlighted}>
+					{item.label}
+
+					{#if itemAccount}
+						<AccountBadge account={itemAccount} class="m-l-4" />
+					{/if}
+				</SelectItem>
+			{/snippet}
+		</Select>
+	{/if}
+</CardGroup.Item>

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -161,7 +161,7 @@
 	<CardGroup.Item>
 		{#snippet title()}
 			{#if accounts.length === 0 || !preferredAccount}
-				No {displayName} accounts found
+				Connect your {displayName} account
 			{:else}
 				Configure {displayName} integration
 			{/if}

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -20,6 +20,23 @@
 
 	import type { ForgeName } from '$lib/forge/interface/forge';
 	import type { Project } from '$lib/project/project';
+	import type { ButGitHubToken, ButGitLabToken } from '@gitbutler/core/api';
+
+	type AccountIdentifier =
+		| ButGitHubToken.GithubAccountIdentifier
+		| ButGitLabToken.GitlabAccountIdentifier;
+
+	function getAccountUsername(account: AccountIdentifier): string {
+		return account.info.username;
+	}
+
+	const FORGE_OPTIONS: { label: string; value: ForgeName }[] = [
+		{ label: 'None', value: 'default' },
+		{ label: 'GitHub', value: 'github' },
+		{ label: 'GitLab', value: 'gitlab' },
+		{ label: 'Azure', value: 'azure' },
+		{ label: 'BitBucket', value: 'bitbucket' }
+	];
 
 	const { projectId }: { projectId: string } = $props();
 
@@ -37,28 +54,6 @@
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const project = $derived(projectQuery.response);
 
-	const forgeOptions: { label: string; value: ForgeName }[] = [
-		{
-			label: 'None',
-			value: 'default'
-		},
-		{
-			label: 'GitHub',
-			value: 'github'
-		},
-		{
-			label: 'GitLab',
-			value: 'gitlab'
-		},
-		{
-			label: 'Azure',
-			value: 'azure'
-		},
-		{
-			label: 'BitBucket',
-			value: 'bitbucket'
-		}
-	];
 	let selectedOption = $derived(project?.forge_override || 'default');
 
 	function handleSelectionChange(selectedOption: ForgeName) {
@@ -100,12 +95,9 @@
 		{#if forge.determinedForgeType === 'default'}
 			<Select
 				value={selectedOption}
-				options={forgeOptions}
+				options={FORGE_OPTIONS}
 				wide
-				onselect={(value) => {
-					selectedOption = value as ForgeName;
-					handleSelectionChange(selectedOption);
-				}}
+				onselect={(value) => handleSelectionChange(value as ForgeName)}
 			>
 				{#snippet itemSnippet({ item, highlighted })}
 					<SelectItem selected={item.value === selectedOption} {highlighted}>
@@ -117,117 +109,104 @@
 	</CardGroup.Item>
 
 	{#if forge.current.name === 'gitlab'}
-		<CardGroup.Item>
-			{#snippet title()}
-				{#if gitlabAccounts.current.length === 0 || !preferredGitLabAccount.current}
-					No GitLab accounts found
-				{:else}
-					Configure GitLab integration
-				{/if}
-			{/snippet}
-
-			{#snippet caption()}
-				Enable merge request creation. Read more in the <Link
-					href="https://docs.gitbutler.com/features/forge-integration/gitlab-integration">docs</Link
-				>
-			{/snippet}
-
-			{#if gitlabAccounts.current.length === 0 || !preferredGitLabAccount.current}
-				{@render openSettingsButton()}
-			{:else}
-				{@const account = preferredGitLabAccount.current}
-				<Select
-					label="GitLab account for this project"
-					value={gitlabAccountIdentifierToString(account)}
-					options={gitlabAccounts.current.map((account) => ({
-						label: account.info.username,
-						value: gitlabAccountIdentifierToString(account)
-					}))}
-					onselect={(value) => {
-						const account = stringToGitLabAccountIdentifier(value);
-						if (!account) return;
-						projectsService.updatePreferredForgeUser(projectId, {
-							provider: 'gitlab',
-							details: account
-						});
-					}}
-					disabled={gitlabAccounts.current.length <= 1}
-					wide
-				>
-					{#snippet itemSnippet({ item, highlighted })}
-						{@const itemAccount = item.value && stringToGitLabAccountIdentifier(item.value)}
-						<SelectItem
-							selected={item.value === gitlabAccountIdentifierToString(account)}
-							{highlighted}
-						>
-							{item.label}
-
-							{#if itemAccount}
-								<GitLabAccountBadge account={itemAccount} class="m-l-4" />
-							{/if}
-						</SelectItem>
-					{/snippet}
-				</Select>
-			{/if}
-		</CardGroup.Item>
+		{@render forgeAccountConfig({
+			providerName: 'gitlab',
+			displayName: 'GitLab',
+			accounts: gitlabAccounts.current,
+			preferredAccount: preferredGitLabAccount.current,
+			accountToString: gitlabAccountIdentifierToString,
+			stringToAccount: stringToGitLabAccountIdentifier,
+			AccountBadge: GitLabAccountBadge,
+			docsUrl: 'https://docs.gitbutler.com/features/forge-integration/gitlab-integration',
+			requestType: 'merge request'
+		})}
 	{/if}
 
 	{#if forge.current.name === 'github'}
-		<CardGroup.Item>
-			{#snippet title()}
-				{#if githubAccounts.current.length === 0 || !preferredGitHubAccount.current}
-					No GitHub accounts found
-				{:else}
-					Configure GitHub integration
-				{/if}
-			{/snippet}
-
-			{#snippet caption()}
-				Enable pull request creation. Read more in the <Link
-					href="https://docs.gitbutler.com/features/forge-integration/github-integration">docs</Link
-				>
-			{/snippet}
-
-			{#if githubAccounts.current.length === 0 || !preferredGitHubAccount.current}
-				{@render openSettingsButton()}
-			{:else}
-				{@const account = preferredGitHubAccount.current}
-				<Select
-					label="GitHub account for this project"
-					value={githubAccountIdentifierToString(account)}
-					options={githubAccounts.current.map((account) => ({
-						label: account.info.username,
-						value: githubAccountIdentifierToString(account)
-					}))}
-					onselect={(value) => {
-						const account = stringToGitHubAccountIdentifier(value);
-						if (!account) return;
-						projectsService.updatePreferredForgeUser(projectId, {
-							provider: 'github',
-							details: account
-						});
-					}}
-					disabled={githubAccounts.current.length <= 1}
-					wide
-				>
-					{#snippet itemSnippet({ item, highlighted })}
-						{@const itemAccount = item.value && stringToGitHubAccountIdentifier(item.value)}
-						<SelectItem
-							selected={item.value === githubAccountIdentifierToString(account)}
-							{highlighted}
-						>
-							{item.label}
-
-							{#if itemAccount}
-								<GitHubAccountBadge account={itemAccount} class="m-l-4" />
-							{/if}
-						</SelectItem>
-					{/snippet}
-				</Select>
-			{/if}
-		</CardGroup.Item>
+		{@render forgeAccountConfig({
+			providerName: 'github',
+			displayName: 'GitHub',
+			accounts: githubAccounts.current,
+			preferredAccount: preferredGitHubAccount.current,
+			accountToString: githubAccountIdentifierToString,
+			stringToAccount: stringToGitHubAccountIdentifier,
+			AccountBadge: GitHubAccountBadge,
+			docsUrl: 'https://docs.gitbutler.com/features/forge-integration/github-integration',
+			requestType: 'pull request'
+		})}
 	{/if}
 </CardGroup>
+
+{#snippet forgeAccountConfig({
+	providerName,
+	displayName,
+	accounts,
+	preferredAccount,
+	accountToString,
+	stringToAccount,
+	AccountBadge,
+	docsUrl,
+	requestType
+}: {
+	providerName: 'github' | 'gitlab';
+	displayName: string;
+	accounts: AccountIdentifier[];
+	preferredAccount: AccountIdentifier | undefined;
+	accountToString: (account: any) => string;
+	stringToAccount: (value: string) => any;
+	AccountBadge: typeof GitHubAccountBadge | typeof GitLabAccountBadge;
+	docsUrl: string;
+	requestType: string;
+})}
+	<CardGroup.Item>
+		{#snippet title()}
+			{#if accounts.length === 0 || !preferredAccount}
+				No {displayName} accounts found
+			{:else}
+				Configure {displayName} integration
+			{/if}
+		{/snippet}
+
+		{#snippet caption()}
+			Enable {requestType} creation. Read more in the <Link href={docsUrl}>docs</Link>
+		{/snippet}
+
+		{#if accounts.length === 0 || !preferredAccount}
+			{@render openSettingsButton()}
+		{:else}
+			{@const account = preferredAccount}
+			<Select
+				label="{displayName} account for this project"
+				value={accountToString(account)}
+				options={accounts.map((account) => ({
+					label: getAccountUsername(account),
+					value: accountToString(account)
+				}))}
+				onselect={(value) => {
+					const account = stringToAccount(value);
+					if (!account) return;
+					projectsService.updatePreferredForgeUser(projectId, {
+						provider: providerName,
+						details: account
+					});
+				}}
+				disabled={accounts.length <= 1}
+				wide
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					{@const itemAccount = item.value && stringToAccount(item.value)}
+					<SelectItem selected={item.value === accountToString(account)} {highlighted}>
+						{item.label}
+
+						{#if itemAccount}
+							<AccountBadge account={itemAccount} class="m-l-4" />
+						{/if}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		{/if}
+	</CardGroup.Item>
+{/snippet}
 
 {#snippet openSettingsButton()}
 	<div class="flex">

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -16,7 +16,7 @@
 	import { useSettingsModal } from '$lib/settings/settingsModal.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
-	import { Button, CardGroup, InfoMessage, Link, Select, SelectItem } from '@gitbutler/ui';
+	import { Button, CardGroup, Link, Select, SelectItem } from '@gitbutler/ui';
 
 	import type { ForgeName } from '$lib/forge/interface/forge';
 	import type { Project } from '$lib/project/project';
@@ -119,7 +119,11 @@
 	{#if forge.current.name === 'gitlab'}
 		<CardGroup.Item>
 			{#snippet title()}
-				Configure GitLab integration
+				{#if gitlabAccounts.current.length === 0 || !preferredGitLabAccount.current}
+					No GitLab accounts found
+				{:else}
+					Configure GitLab integration
+				{/if}
 			{/snippet}
 
 			{#snippet caption()}
@@ -127,15 +131,8 @@
 					href="https://docs.gitbutler.com/features/forge-integration/gitlab-integration">docs</Link
 				>
 			{/snippet}
+
 			{#if gitlabAccounts.current.length === 0 || !preferredGitLabAccount.current}
-				<InfoMessage style="warning" filled outlined={false}>
-					{#snippet title()}
-						No GitLab accounts found
-					{/snippet}
-					{#snippet content()}
-						Add a GitLab account in General Settings to enable GitLab integration
-					{/snippet}
-				</InfoMessage>
 				{@render openSettingsButton()}
 			{:else}
 				{@const account = preferredGitLabAccount.current}
@@ -178,7 +175,11 @@
 	{#if forge.current.name === 'github'}
 		<CardGroup.Item>
 			{#snippet title()}
-				Configure GitHub integration
+				{#if githubAccounts.current.length === 0 || !preferredGitHubAccount.current}
+					No GitHub accounts found
+				{:else}
+					Configure GitHub integration
+				{/if}
 			{/snippet}
 
 			{#snippet caption()}
@@ -188,14 +189,6 @@
 			{/snippet}
 
 			{#if githubAccounts.current.length === 0 || !preferredGitHubAccount.current}
-				<InfoMessage style="warning" filled outlined={false}>
-					{#snippet title()}
-						No GitHub accounts found
-					{/snippet}
-					{#snippet content()}
-						Add a GitHub account in General Settings to enable GitHub integration
-					{/snippet}
-				</InfoMessage>
 				{@render openSettingsButton()}
 			{:else}
 				{@const account = preferredGitHubAccount.current}
@@ -237,16 +230,9 @@
 </CardGroup>
 
 {#snippet openSettingsButton()}
-	<div class="forge-form__open-settings-container">
-		<Button onclick={() => openGeneralSettings('integrations')} style="pop"
-			>Go to General Settings</Button
+	<div class="flex">
+		<Button onclick={() => openGeneralSettings('integrations')} style="pop" icon="link"
+			>Set up in General Settings</Button
 		>
 	</div>
 {/snippet}
-
-<style lang="scss">
-	.forge-form__open-settings-container {
-		display: flex;
-		justify-content: center;
-	}
-</style>

--- a/apps/desktop/src/components/UnassignedViewForgePrompt.svelte
+++ b/apps/desktop/src/components/UnassignedViewForgePrompt.svelte
@@ -6,8 +6,7 @@
 		availableForgeDocsLink,
 		availableForgeLabel,
 		availableForgeReviewUnit,
-		DEFAULT_FORGE_FACTORY,
-		type AvailableForge
+		DEFAULT_FORGE_FACTORY
 	} from '$lib/forge/forgeFactory.svelte';
 	import { useSettingsModal } from '$lib/settings/settingsModal.svelte';
 	import { inject } from '@gitbutler/core/context';
@@ -19,7 +18,7 @@
 
 	const { projectId }: Props = $props();
 
-	const { openGeneralSettings, openProjectSettings } = useSettingsModal();
+	const { openGeneralSettings } = useSettingsModal();
 	const forgeFactory = inject(DEFAULT_FORGE_FACTORY);
 	const dismissedTheIntegrationPrompt = $derived(
 		persistedDismissedForgeIntegrationPrompt(projectId)
@@ -48,15 +47,8 @@
 		return () => clearTimeout(timeoutId);
 	});
 
-	function configureIntegration(forge: AvailableForge): void {
-		switch (forge) {
-			case 'github':
-				openGeneralSettings('integrations');
-				break;
-			case 'gitlab':
-				openProjectSettings(projectId);
-				break;
-		}
+	function configureIntegration(): void {
+		openGeneralSettings('integrations');
 	}
 
 	function dismissPrompt() {
@@ -82,9 +74,7 @@
 
 		<div class="forge-prompt__footer">
 			<Button kind="outline" onclick={dismissPrompt}>Dismiss</Button>
-			<Button style="pop" onclick={() => configureIntegration(forgeName)}
-				>Configure integration…</Button
-			>
+			<Button style="pop" onclick={configureIntegration}>Configure integration…</Button>
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
Before:
<img width="895" height="506" alt="Screenshot 2026-02-07 at 00 37 56" src="https://github.com/user-attachments/assets/fc951524-d85d-4c6c-be49-5c04e89c1006" />

After:
<img width="634" height="303" alt="Screenshot 2026-02-07 at 01 22 14" src="https://github.com/user-attachments/assets/497fe7ea-003c-42d6-8bc6-d703f6545b93" />

---

Figma link https://www.figma.com/design/ShIiR6hI5dzH7sT5L03Jg1/App-Design-3.5?node-id=11100-42752&t=fHeg6ha2kFbpcFI1-1

---

Summary
- Simplify ForgeForm messaging and CTA for missing accounts.
- Consolidate forge options and extract repeated account configuration into a reusable renderer.

What changed
- Replaced verbose InfoMessage blocks with inline conditional titles ("No GitLab accounts found" / "No GitHub accounts found") and a single "Set up in General Settings" button with icon.
- Removed open-settings container CSS and InfoMessage wrappers; streamlined markup and styles.
- Centralized forge options into a FORGE_OPTIONS constant (None, GitHub, GitLab, Azure, BitBucket).
- Added AccountIdentifier union type and getAccountUsername helper for consistent username access.
- Simplified Select handler to call handleSelectionChange directly.
- Extracted provider account configuration into a reusable forgeAccountConfig renderer and applied it for GitLab (pattern started for GitHub).
- Passed provider-specific utilities (account lists, conversion functions, badge component, docs URL, request type) into the reusable renderer to keep provider UI customizable and reduce duplication.

Why
- Make form copy more compact and consistent across forges.
- Reduce duplicated markup and styles.
- Emphasize a single actionable path to integrations settings.
- Improve readability and maintainability and make adding/updating providers easier.

Notes for reviewers
- Pay attention to the reusable renderer inputs for provider-specific behavior.
- Verify that account selection and CTA interactions match previous behavior.