### PR TITLE
docs(skill): sync CLI skill files with current command flags

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -97,6 +97,8 @@ For detailed command syntax and all available options, see [references/reference
 - `but commit <branch> -m "msg" -p <id>,<id>` - Same as above, using short flag
 - `but commit <branch> -m "msg"` - Commit ALL uncommitted changes to branch
 - `but commit <branch> --only -m "msg"` - Commit only pre-staged changes (cannot combine with --changes)
+- `but commit <branch> --message-file msg.txt` - Read commit message from file
+- `but commit <branch> -c -m "msg"` - Create new branch (or use existing) and commit
 - `but amend <file-id> <commit-id>` - Amend file into specific commit (explicit control)
 - `but absorb <file-id>` - Absorb file into auto-detected commit (smart matching)
 - `but absorb <branch-id>` - Absorb all changes staged to a branch
@@ -138,6 +140,9 @@ For deeper understanding of the workspace model, dependency tracking, and philos
 - File + Commit → Amend
 - Commit + Commit → Squash
 - Commit + Branch → Move
+- File/Commit + `zz` → Unstage/Undo (back to unassigned)
+- `zz` + Branch/Commit → Stage/Amend all unassigned changes
+- File-in-Commit + `zz` → Uncommit specific file
 
 ## Workflow Examples
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -131,12 +131,30 @@ but commit ui-branch -m "..."    # Commit from ui-branch's staging area
 
 The operation performed depends on what you combine:
 
+```
+SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+Commit               │ Undo            │ Squash     │ Move        │ -
+Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+File-in-Commit       │ Uncommit        │ Move       │ Uncommit & assign │ -
+```
+
+`zz` is a special target meaning "unassigned" (no branch).
+
+**Common examples:**
+
 | Source | Target | Operation | Example |
 |--------|--------|-----------|---------|
 | File | Branch | Stage file to branch | `but rub a1 bu` |
 | File | Commit | Amend file into commit | `but rub a1 c3` |
 | Commit | Commit | Squash commits | `but rub c2 c3` |
 | Commit | Branch | Move commit to branch | `but rub c2 bu` |
+| File | `zz` | Unstage file | `but rub a1 zz` |
+| Commit | `zz` | Undo commit | `but rub c2 zz` |
+| `zz` | Branch | Stage all unassigned | `but rub zz bu` |
 
 ### Higher-Level Conveniences
 


### PR DESCRIPTION
Audit all `but` and `but-engineering` CLI --help output against skill
docs and add missing agent-relevant flags:

- commit: --message-file, --create, --no-hooks, --ai=<instructions>
- absorb: --new (create new commits instead of amending)
- squash: --ai, -d (drop messages), -m (custom message)
- push: --skip-force-push-protection, --run-hooks
- pr new: --default/-t (skip prompts), note --with-force/--run-hooks defaults
- branch show: --files, --ai, --check, --review
- branch list: --no-ahead, --no-check, [FILTER], -r, -l, -a, --review
- setup: --init
- but-engineering claims: --active-within

Add full `but rub` operations matrix (6 source types × 4 targets)
to reference.md, concepts.md, and SKILL.md — previously only 4 of
~20 combinations were documented.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>