### PR TITLE
docs(skill): clarify --changes usage after parser update

### DIFF
--- a/crates/but/skill/RESEARCH.md
+++ b/crates/but/skill/RESEARCH.md
@@ -115,7 +115,7 @@ Based on industry standards and our specific skill file, here are the metrics to
 | **Tool routing accuracy** | Uses `but` instead of `git` for write ops | 100% | Binary per command |
 | **`--json` compliance** | All `but` commands include `--json` | 100% | Count across all commands in response |
 | **`--status-after` compliance** | Mutation commands include `--status-after` | 100% | Check commit/absorb/rub/stage/squash/move/uncommit |
-| **`--changes` specificity** | `but commit` uses `--changes <ids>` not bare commit | >90% | Binary per commit command |
+| **`--changes` specificity** | `but commit` uses `--changes` with explicit IDs (`a1,b2` or repeated flag), not bare commit | >90% | Binary per commit command |
 | **Workflow ordering** | Runs `but status --json` before mutations | 100% | Check command sequence |
 | **Unnecessary round-trips** | No `but status` after commands with `--status-after` | 0 | Count redundant status calls |
 | **Task completion** | End-to-end task succeeds | >80% | Binary per scenario |
@@ -207,7 +207,7 @@ Test complete workflows with mock tool execution. This is the highest-signal tie
 User: "I just finished implementing auth. Commit it."
 Expected sequence:
   1. but status --json           (check state)
-  2. but commit <branch> -m "..." --changes <ids> --json --status-after  (commit)
+  2. but commit <branch> -m "..." --changes <id>,<id> --json --status-after  (commit)
 Assertions:
   - Step 1 happens before step 2
   - Commit includes --changes (not bare commit)

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -104,6 +104,7 @@ Do not run `git push`, even if `but push` reports nothing to push.
 
 - Prefer explicit IDs over file paths for mutations.
 - `--changes` is the safe default for precise commits.
+- `--changes` accepts one argument per flag. For multiple IDs, use comma-separated values (`--changes a1,b2`) or repeat the flag (`--changes a1 --changes b2`), not `--changes a1 b2`.
 - Read-only git inspection is allowed (`git log`, `git blame`) when needed.
 - Keep skill version checks low-noise:
   - Do not run `but skill check` as a routine preflight on every task.

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -24,6 +24,7 @@ but status --json
 
 # 5. Commit specific files directly using --changes (recommended for agents)
 # Use cliId values from but status --json output (e.g., branch IDs and file IDs)
+# For multiple IDs, use one comma-separated argument or repeat --changes.
 but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --json --status-after
 but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --json --status-after
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -182,6 +182,7 @@ Commit changes to a branch.
 but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
 but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
 but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
+but commit <branch> -m "message" --changes <id> --changes <id>  # Alternative: repeat flag
 but commit <branch> --message-file msg.txt  # Read commit message from file
 but commit <branch> -i                   # AI-generated commit message
 but commit <branch> -i="fix the auth bug"  # AI-generated with instructions (equals sign required)
@@ -197,6 +198,7 @@ but commit empty --after <target>        # Insert empty commit after target
 **Committing specific files or hunks:** Use `--changes` (or `-p`) with comma-separated CLI IDs to commit only those files or hunks:
 - **File IDs** from `but status --json`: commits entire files
 - **Hunk IDs** from `but diff --json`: commits individual hunks
+- `--changes` takes one argument per flag. Use `--changes a1,b2` or `--changes a1 --changes b2`, not `--changes a1 b2`.
 
 **Note:** `--changes` and `--only` are mutually exclusive.
 


### PR DESCRIPTION
Follow-up to #12223.

This updates the but skill docs to match the merged --changes parsing semantics:
- one argument per --changes flag
- use comma-separated IDs or repeated --changes for multiple IDs
- avoid space-separated IDs after a single --changes flag