### PR TITLE
Fix undefined reference errors in VirtualList and BranchList

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -379,7 +379,13 @@
 					{/snippet}
 
 					{#snippet changedFiles()}
-						{#if selected}
+						<!--
+							Based on anecdotal evidence the type for `items` seems incorrect. It's
+							likely that during some kind of unmount event items can become `undefined`
+							due to some subtle reactivity condition, causing `branchChanges` to be
+							called without a branch name.
+						-->
+						{#if selected && branchName}
 							{@const changesQuery = stackService.branchChanges({
 								projectId,
 								stackId,

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -103,7 +103,7 @@
 	const STICKY_DISTANCE = 40;
 	const LOAD_MORE_THRESHOLD = 300;
 	const DEBOUNCE_DELAY = 50;
-	const HEIGHT_LOCK_DURATION = 1000;
+	const HEIGHT_LOCK_DURATION = 250;
 
 	const {
 		items,
@@ -184,12 +184,17 @@
 					// resize. Scroll direction is undefined during jumps.
 					viewport.scrollTop = calculateHeightSum(0, lastJumpToIndex || startIndex || 0);
 					skipNextScrollEvent = true;
+				} else if (stickToBottom && previousDistance < STICKY_DISTANCE) {
+					// Maintain bottom position when near bottom and `stickToBottom` is true
+					skipNextScrollEvent = true;
+					scrollToBottom();
 				} else if (
-					(stickToBottom || index === items.length - 1) &&
-					previousDistance < STICKY_DISTANCE
+					previousDistance < STICKY_DISTANCE &&
+					index === items.length - 1 &&
+					viewport.scrollTop !== 0
 				) {
-					// Maintain bottom position when near bottom and either stickToBottom
-					// is enabled or the last visible item resizes.
+					// When we are not at the scrollTop, but near the bottom, if the last
+					// element resizes we scroll to bottom
 					skipNextScrollEvent = true;
 					scrollToBottom();
 				}

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -361,7 +361,11 @@
 
 		updateOffsets();
 		await tick();
-		viewport.scrollTop = calculateHeightSum(0, startingAt);
+
+		// Based on anecdotal evidence the type for `viewport` seems incorrect. It's likely
+		// that during some kind of unmount event it can become `undefined` due to a subtle
+		// reactivity condition.
+		if (viewport) viewport.scrollTop = calculateHeightSum(0, startingAt);
 	}
 
 	async function recalculateVisibleRange(): Promise<void> {
@@ -413,7 +417,10 @@
 	}
 
 	export async function jumpToIndex(index: number) {
-		if (index < 0 || index > items.length - 1) {
+		// Based on anecdotal evidence the type for `items` seems incorrect. It's likely
+		// that during some kind of unmount event it can become `undefined` due to
+		// some subtle reactivity condition.
+		if (!items || index < 0 || index > items.length - 1) {
 			return;
 		}
 		lastScrollDirection = undefined;
@@ -566,7 +573,7 @@
 					icon="arrow-down"
 					tooltip="Scroll to bottom"
 					onclick={() => {
-						if (items.length > 0) {
+						if (items && items.length > 0) {
 							initializeAt(items.length - 1);
 						}
 					}}


### PR DESCRIPTION
Changing the selection from branch changes to an assigned file would
throw an error, yet have no side-effect.

Guard against undefined `viewport`, `items`, and `branchName` which can
occur during component unmount due to Svelte reactivity timing. Without
these checks, scrollToIndex, jumpToIndex, and the scroll-to-bottom
button could throw when accessed after teardown.