### PR TITLE
Stable IDs for unstaged files

### DIFF
--- a/crates/but-core/src/change_id.rs
+++ b/crates/but-core/src/change_id.rs
@@ -18,7 +18,7 @@ const CHANGE_ID_REVERSE_BYTE_LEN: usize = CHANGE_ID_REVERSE_HEX_LEN / 2;
 /// header, but is usually a reverse hex string or a uuid.
 ///
 /// For all intents and purposes, this type acts like a [`BString`].
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ChangeId(BString);
 
 impl ChangeId {
@@ -31,8 +31,14 @@ impl ChangeId {
     pub fn generate() -> Self {
         let mut rng = rand::rng();
         let bytes: [u8; CHANGE_ID_REVERSE_BYTE_LEN] = rng.random();
+        ChangeId::from_bytes(&bytes)
+    }
+
+    /// Creates a reverse hex ChangeId from the first 16 elements of `bytes`. If
+    /// there are fewer, the created ChangeId is right-padded with 'z'.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
         let mut out = vec![b'z'; CHANGE_ID_REVERSE_HEX_LEN];
-        for (i, byte) in bytes.iter().enumerate() {
+        for (i, byte) in bytes.iter().take(CHANGE_ID_REVERSE_BYTE_LEN).enumerate() {
             let [a, b] = byte_to_reverse_hex(*byte);
             let i = i * 2;
             out[i] = a;

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -278,7 +278,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(id_map.debug_state(), @r"
     workspace_and_remote_commits_count: 1
     branches: [ ij ]
-    uncommitted_files: [ g0, h0 ]
+    uncommitted_files: [ nx, yz ]
     uncommitted_hunks: [ i0, j0 ]
     ");
 
@@ -355,7 +355,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(id_map.debug_state(), @r"
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
-    uncommitted_files: [ g0, i0 ]
+    uncommitted_files: [ kv, ro ]
     uncommitted_hunks: [ j0, k0, l0 ]
     stacks: [ m0 ]
     ");
@@ -365,9 +365,104 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
             commit_id: Sha1(0202020202020202020202020202020202020202),
             id: "02",
         },
+        Branch {
+            name: "h0",
+            id: "h0",
+            stack_id: Some(
+                00000000-0000-0000-0000-000000000001,
+            ),
+        },
         Uncommitted(
             UncommittedCliId {
-                id: "g0",
+                id: "j0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        Uncommitted(
+            UncommittedCliId {
+                id: "k0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        Uncommitted(
+            UncommittedCliId {
+                id: "kv",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: true,
+            },
+        ),
+        Uncommitted(
+            UncommittedCliId {
+                id: "l0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-3,2", "+3,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+        Stack {
+            id: "m0",
+            stack_id: 00000000-0000-0000-0000-000000000001,
+        },
+        Uncommitted(
+            UncommittedCliId {
+                id: "ro",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
@@ -401,101 +496,6 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
                 is_entire_file: true,
             },
         ),
-        Branch {
-            name: "h0",
-            id: "h0",
-            stack_id: Some(
-                00000000-0000-0000-0000-000000000001,
-            ),
-        },
-        Uncommitted(
-            UncommittedCliId {
-                id: "i0",
-                hunk_assignments: NonEmpty {
-                    head: HunkAssignment {
-                        id: None,
-                        hunk_header: None,
-                        path: "",
-                        path_bytes: "uncommitted2.txt",
-                        stack_id: None,
-                        hunk_locks: None,
-                        line_nums_added: None,
-                        line_nums_removed: None,
-                        diff: None,
-                    },
-                    tail: [],
-                },
-                is_entire_file: true,
-            },
-        ),
-        Uncommitted(
-            UncommittedCliId {
-                id: "j0",
-                hunk_assignments: NonEmpty {
-                    head: HunkAssignment {
-                        id: None,
-                        hunk_header: Some(
-                            HunkHeader("-1,2", "+1,2"),
-                        ),
-                        path: "",
-                        path_bytes: "uncommitted1.txt",
-                        stack_id: None,
-                        hunk_locks: None,
-                        line_nums_added: None,
-                        line_nums_removed: None,
-                        diff: None,
-                    },
-                    tail: [],
-                },
-                is_entire_file: false,
-            },
-        ),
-        Uncommitted(
-            UncommittedCliId {
-                id: "k0",
-                hunk_assignments: NonEmpty {
-                    head: HunkAssignment {
-                        id: None,
-                        hunk_header: Some(
-                            HunkHeader("-3,2", "+3,2"),
-                        ),
-                        path: "",
-                        path_bytes: "uncommitted1.txt",
-                        stack_id: None,
-                        hunk_locks: None,
-                        line_nums_added: None,
-                        line_nums_removed: None,
-                        diff: None,
-                    },
-                    tail: [],
-                },
-                is_entire_file: false,
-            },
-        ),
-        Uncommitted(
-            UncommittedCliId {
-                id: "l0",
-                hunk_assignments: NonEmpty {
-                    head: HunkAssignment {
-                        id: None,
-                        hunk_header: None,
-                        path: "",
-                        path_bytes: "uncommitted2.txt",
-                        stack_id: None,
-                        hunk_locks: None,
-                        line_nums_added: None,
-                        line_nums_removed: None,
-                        diff: None,
-                    },
-                    tail: [],
-                },
-                is_entire_file: false,
-            },
-        ),
-        Stack {
-            id: "m0",
-            stack_id: 00000000-0000-0000-0000-000000000001,
-        },
     ]
     "#);
 
@@ -518,7 +518,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(id_map.debug_state(), @r"
     workspace_and_remote_commits_count: 1
     branches: [ h0 ]
-    uncommitted_files: [ g0 ]
+    uncommitted_files: [ ln ]
     uncommitted_hunks: [ i0 ]
     ");
 
@@ -551,11 +551,11 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         "the case matters for branches"
     );
 
-    insta::assert_debug_snapshot!(id_map.parse("g0", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("ln", changed_paths_fn)?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
-                id: "g0",
+                id: "ln",
                 hunk_assignments: NonEmpty {
                     head: HunkAssignment {
                         id: None,
@@ -576,7 +576,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     ]
     "#);
     assert_eq!(
-        id_map.parse("G0", changed_paths_fn)?,
+        id_map.parse("LN", changed_paths_fn)?,
         [],
         "the case matters for uncommitted files"
     );
@@ -595,6 +595,129 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         [],
         "the case matters for committed files"
     );
+
+    Ok(())
+}
+
+#[test]
+fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
+    let stacks = vec![stack([segment("foo", [id(1)], None, [])])];
+    let hunk_assignments = vec![hunk_assignment("foo23", None), hunk_assignment("foo242", None)];
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn =
+        |commit_id: gix::ObjectId, parent_id: Option<gix::ObjectId>| -> anyhow::Result<Vec<but_core::TreeChange>> {
+            Ok(if commit_id == id(1) && parent_id.is_none() {
+                vec![]
+            } else {
+                bail!("unexpected IDs {} {:?}", commit_id, parent_id);
+            })
+        };
+
+    // TODO make this return both (instead of none) so that the user can disambiguate
+    insta::assert_debug_snapshot!(id_map.parse("kp", changed_paths_fn)?, @"[]");
+
+    insta::assert_debug_snapshot!(id_map.parse("kpo", changed_paths_fn)?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "kpo",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo242",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: true,
+            },
+        ),
+    ]
+    "#);
+    insta::assert_debug_snapshot!(id_map.parse("kpr", changed_paths_fn)?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "kpr",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo23",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: true,
+            },
+        ),
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
+    let stacks = vec![stack([segment("fookpfoo", [id(1)], None, [])])];
+    let hunk_assignments = vec![hunk_assignment("foo23", None)];
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn =
+        |commit_id: gix::ObjectId, parent_id: Option<gix::ObjectId>| -> anyhow::Result<Vec<but_core::TreeChange>> {
+            Ok(if commit_id == id(1) && parent_id.is_none() {
+                vec![]
+            } else {
+                bail!("unexpected IDs {} {:?}", commit_id, parent_id);
+            })
+        };
+
+    // Only the branch is returned
+    insta::assert_debug_snapshot!(id_map.parse("kp", changed_paths_fn)?, @r#"
+    [
+        Branch {
+            name: "fookpfoo",
+            id: "ok",
+            stack_id: None,
+        },
+    ]
+    "#);
+
+    // More characters must be specified to get the file
+    insta::assert_debug_snapshot!(id_map.parse("kpr", changed_paths_fn)?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "kpr",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo23",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: true,
+            },
+        ),
+    ]
+    "#);
 
     Ok(())
 }

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -22,7 +22,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -150,7 +150,7 @@ Hint: you can run `but undo` to undo these changes
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -279,7 +279,7 @@ k0 a.txt│
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ╭┄zz [unstaged changes] 
-┊   i0 M a.txt 🔒 889385c, a7aa4ef, f4ea7f8
+┊   nk M a.txt 🔒 889385c, a7aa4ef, f4ea7f8
 ┊
 ┊╭┄g0 [A]  
 ┊●   a7aa4ef partial change to a.txt 3  
@@ -391,7 +391,7 @@ fn uncommitted_file_new() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -569,7 +569,7 @@ Hint: you can run `but undo` to undo these changes
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ╭┄zz [unstaged changes] 
-┊   i0 M a.txt 🔒 f4ea7f8
+┊   nk M a.txt 🔒 f4ea7f8
 ┊
 ┊╭┄g0 [A]  
 ┊●   5a72bff [AUTO-COMMIT] Generated commit message  
@@ -597,7 +597,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -668,7 +668,7 @@ Dry run complete. No changes were made.
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -739,7 +739,7 @@ Dry run complete. No changes were made.
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -186,7 +186,7 @@ Uncommitted changes
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "pn",
       "filePath": "b.txt",
       "changeType": "added"
     }
@@ -309,7 +309,7 @@ Unstaged a hunk in a.txt in a stack
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -388,7 +388,7 @@ Staged a hunk in a.txt in the unassigned area → [A].
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -465,12 +465,12 @@ fn uncommit_command_on_commit() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "added"
     },
     {
-      "cliId": "j0",
+      "cliId": "pn",
       "filePath": "b.txt",
       "changeType": "added"
     }
@@ -591,7 +591,7 @@ fn unstage_command() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }
@@ -629,7 +629,7 @@ fn unstage_command_with_branch() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     }

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -113,7 +113,7 @@ fn json_shows_paths_as_strings() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "qu",
       "filePath": "test-file.txt",
       "changeType": "added"
     }
@@ -236,12 +236,12 @@ fn uncommitted_and_committed_file_cli_ids() -> anyhow::Result<()> {
 {
   "unassignedChanges": [
     {
-      "cliId": "i0",
+      "cliId": "nk",
       "filePath": "a.txt",
       "changeType": "modified"
     },
     {
-      "cliId": "j0",
+      "cliId": "pn",
       "filePath": "b.txt",
       "changeType": "modified"
     }


### PR DESCRIPTION
Why I'm not automerging: I need code owner review.

As described in the "id: use filename-derived CLI IDs for unstaged files" commit message, this is limited to unstaged files. I plan to add support for the others in subsequent PRs.