### PR TITLE
fix(ui,git): clarify integrated label and handle integrated-only pushes

### DIFF
--- a/apps/desktop/src/components/lib.ts
+++ b/apps/desktop/src/components/lib.ts
@@ -67,7 +67,7 @@ export function getBranchStatusLabelAndColor(pushStatus: PushStatus): {
 		case 'unpushedCommitsRequiringForce':
 			return { label: 'Some unpushed', color: colorMap.LocalAndRemote };
 		case 'integrated':
-			return { label: 'Integrated', color: colorMap.Integrated };
+			return { label: 'Integrated branch', color: colorMap.Integrated };
 		default:
 			return { label: 'Unknown', color: colorMap.Error };
 	}


### PR DESCRIPTION
Looks like there was an issue with the labels. The branch appears to be “integrated,” but it is labeled as “Unpushed branch.”

<img width="734" height="540" alt="image" src="https://github.com/user-attachments/assets/f02e6f92-3bad-499c-a7a3-a8a16de16e40" />

---

This pull request makes minor improvements to branch status labeling and refines the logic for determining the `PushStatus` in the backend. The main changes are:

Branch status labeling:

* Updated the label for the `'integrated'` branch status from `'Integrated'` to `'Integrated branch'` in the `getBranchStatusLabelAndColor` function in `lib.ts` to provide a clearer description to users.

Backend logic improvements:

* Refactored the `derive_from_commits` method in `PushStatus` (`changeset.rs`) to clarify the logic for determining when a branch is considered integrated, improving readability and maintainability. The logic is unchanged, but variable assignments were moved to the top and the return for `PushStatus::Integrated` is now explicit and early.