### PR TITLE
feat(ui): show PR status and restyle review badge

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -253,7 +253,14 @@
 							{#if args.prNumber}
 								{@const prQuery = prService?.get(args.prNumber, { forceRefetch: true })}
 								{@const pr = prQuery?.response}
-								<ReviewBadge type={prUnit?.abbr} number={args.prNumber} status="unknown" />
+								{@const prStatus = (() => {
+									if (!pr) return 'unknown';
+									if (pr.mergedAt) return 'merged';
+									if (pr.closedAt) return 'closed';
+									if (pr.draft) return 'draft';
+									return 'open';
+								})()}
+								<ReviewBadge type={prUnit?.abbr} number={args.prNumber} status={prStatus} />
 								{#if pr && !pr.closedAt && forge.current.checks && pr.state === 'open'}
 									<ChecksPolling
 										{projectId}

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -228,6 +228,8 @@
 										gravatarUrl: sidebarEntrySubject.subject.author?.gravatarUrl
 									}}
 									modifiedAt={sidebarEntrySubject.subject.modifiedAt}
+									mergedAt={sidebarEntrySubject.subject.mergedAt}
+									closedAt={sidebarEntrySubject.subject.closedAt}
 									selected={selection.type === 'pr' &&
 										selection.prNumber === sidebarEntrySubject.subject.number}
 									onclick={(pr) => (selection = { type: 'pr', prNumber: pr.number })}

--- a/apps/desktop/src/components/BranchesViewPR.svelte
+++ b/apps/desktop/src/components/BranchesViewPR.svelte
@@ -96,6 +96,8 @@
 				title={pr.title}
 				sourceBranch={pr.sourceBranch}
 				isDraft={pr.draft ?? false}
+				mergedAt={pr.mergedAt}
+				closedAt={pr.closedAt}
 				noRemote
 			/>
 		</div>

--- a/apps/desktop/src/components/branchesPage/BranchListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchListCard.svelte
@@ -3,6 +3,7 @@
 	import { type BranchListing, BranchListingDetails } from '$lib/branches/branchListing';
 	import { BRANCH_SERVICE } from '$lib/branches/branchService.svelte';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
+	import { getPrStatus } from '$lib/forge/interface/prUtils';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
 
@@ -124,7 +125,7 @@
 			{#if pr}
 				<ReviewBadge
 					type={reviewUnit?.abbr}
-					status={pr.draft ? 'draft' : 'unknown'}
+					status={getPrStatus(pr)}
 					title={pr.title}
 					number={pr.number}
 				/>

--- a/apps/desktop/src/components/branchesPage/PRListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/PRListCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import BranchesCardTemplate from '$components/branchesPage/BranchesCardTemplate.svelte';
+	import { getPrStatus } from '$lib/forge/interface/prUtils';
 	import { Avatar, ReviewBadge, SeriesIcon, TestId, TimeAgo } from '@gitbutler/ui';
 	import type { ReviewUnitInfo } from '$lib/forge/interface/forgePrService';
 	type basePrData = {
@@ -14,6 +15,8 @@
 		};
 
 		modifiedAt?: string;
+		mergedAt?: string;
+		closedAt?: string;
 	};
 
 	interface Props extends basePrData {
@@ -33,10 +36,14 @@
 		sourceBranch,
 		author,
 		modifiedAt,
+		mergedAt,
+		closedAt,
 		onclick
 	}: Props = $props();
 
 	const unknownName = 'Unknown Author';
+
+	const prStatus = $derived(getPrStatus({ mergedAt, closedAt, draft: isDraft }));
 </script>
 
 <BranchesCardTemplate
@@ -49,7 +56,9 @@
 			title,
 			sourceBranch,
 			author,
-			modifiedAt
+			modifiedAt,
+			mergedAt,
+			closedAt
 		})}
 >
 	{#snippet content()}
@@ -61,12 +70,7 @@
 		</div>
 
 		<div class="text-12 sidebar-entry__about">
-			<ReviewBadge
-				type={reviewUnit?.abbr}
-				status={isDraft ? 'draft' : 'unknown'}
-				{title}
-				{number}
-			/>
+			<ReviewBadge type={reviewUnit?.abbr} status={prStatus} {title} {number} />
 			<span class="sidebar-entry__divider">•</span>
 
 			{#if noRemote || !sourceBranch}

--- a/apps/desktop/src/lib/forge/interface/prUtils.ts
+++ b/apps/desktop/src/lib/forge/interface/prUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * Computes the status of a pull request based on its state.
+ * Returns the status in order of priority: merged > closed > draft > open
+ */
+export function getPrStatus(pr: {
+	mergedAt?: string;
+	closedAt?: string;
+	draft: boolean;
+}): 'merged' | 'closed' | 'draft' | 'open' {
+	if (pr.mergedAt) return 'merged';
+	if (pr.closedAt) return 'closed';
+	if (pr.draft) return 'draft';
+	return 'open';
+}

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -18,43 +18,25 @@
 
 	const badgeDetails = $derived.by(() => {
 		if (title) {
-			return {
-				text: title,
-				color: undefined
-			};
+			return title;
 		}
 
 		switch (status) {
 			case 'open':
-				return {
-					text: `${reviewUnit} ${id} is open`,
-					color: 'var(--clr-theme-safe-element)'
-				};
+				return `${reviewUnit} ${id} is open`;
 			case 'closed':
-				return {
-					text: `${reviewUnit} ${id} is closed`,
-					color: 'var(--clr-theme-danger-element)'
-				};
+				return `${reviewUnit} ${id} is closed`;
 			case 'draft':
-				return {
-					text: `${reviewUnit} ${id} is a draft`,
-					color: undefined
-				};
+				return `${reviewUnit} ${id} is a draft`;
 			case 'merged':
-				return {
-					text: `${reviewUnit} ${id} is merged`,
-					color: 'var(--clr-theme-purple-element)'
-				};
+				return `${reviewUnit} ${id} is merged`;
 			default:
-				return {
-					text: `${reviewUnit} ${id}`,
-					color: undefined
-				};
+				return `${reviewUnit} ${id}`;
 		}
 	});
 </script>
 
-<Tooltip text={badgeDetails.text}>
+<Tooltip text={badgeDetails}>
 	<div class="review-badge pr-{status}">
 		<div class="review-badge__icon">
 			{#if type === 'MR'}

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -112,6 +112,7 @@
 	.pr-draft {
 		border: 1px solid var(--clr-border-1);
 		border-style: dotted;
+		background-color: var(--clr-bg-muted);
 		color: var(--clr-text-1);
 	}
 

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -55,7 +55,7 @@
 </script>
 
 <Tooltip text={badgeDetails.text}>
-	<div class="review-badge" class:pr-type={status}>
+	<div class="review-badge pr-{status}">
 		<div class="review-badge__icon">
 			{#if type === 'MR'}
 				{@html glLogo}
@@ -66,15 +66,11 @@
 
 		<span class="text-11 text-semibold review-badge-text">
 			{#if status === 'draft'}
-				Draft
+				Draft {reviewUnit}
 			{:else}
 				{reviewUnit} {id}
 			{/if}
 		</span>
-
-		{#if badgeDetails.color}
-			<div class="pr-status" style:--pr-color={badgeDetails.color}></div>
-		{/if}
 	</div>
 </Tooltip>
 
@@ -85,13 +81,10 @@
 		justify-content: center;
 		width: fit-content;
 		height: var(--size-icon);
-		padding-right: 3px;
-		padding-left: 2px;
+		padding-right: 5px;
+		padding-left: 4px;
 		gap: 3px;
-		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-ml);
-		background-color: var(--hover-bg-1);
-		color: var(--clr-text-1);
 		line-height: 1;
 	}
 
@@ -104,10 +97,26 @@
 		white-space: nowrap;
 	}
 
-	.pr-status {
-		width: 8px;
-		height: 8px;
-		border-radius: 100%;
-		background-color: var(--pr-color);
+	.pr-open,
+	.pr-unknown {
+		border: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-muted);
+		color: var(--clr-text-1);
+	}
+
+	.pr-closed {
+		background-color: var(--clr-theme-danger-soft);
+		color: var(--clr-theme-danger-on-soft);
+	}
+
+	.pr-draft {
+		border: 1px solid var(--clr-border-1);
+		border-style: dotted;
+		color: var(--clr-text-1);
+	}
+
+	.pr-merged {
+		background-color: var(--clr-theme-purple-soft);
+		color: var(--clr-theme-purple-on-soft);
 	}
 </style>


### PR DESCRIPTION
Implemented PR badge styles depending on the status.

<img width="137" height="220" alt="image" src="https://github.com/user-attachments/assets/354d5bf5-c979-4830-bdcf-0648788f5951" />

---

This pull request improves the display and logic of the `ReviewBadge` component, making pull request statuses more accurate and visually distinct. The changes include updating how status is determined, enhancing the badge appearance for different PR states, and refining the badge text.

Pull request status logic and display improvements:

* Updated the logic in `BranchCard.svelte` to determine PR status more accurately, including handling merged, closed, draft, and open states, and passing this status to `ReviewBadge`.
* Modified `ReviewBadge.svelte` to use dynamic class names based on PR status, allowing for more granular styling of badge states.
* Refined the badge text to show "Draft {reviewUnit}" for draft PRs, improving clarity.

Visual and style enhancements:

* Adjusted padding in the badge for better alignment and appearance.
* Redesigned badge styles for each PR status, replacing the old status indicator with distinct background and text colors for open, unknown, closed, draft, and merged states.