### PR TITLE
fix: preserve `#` in branch names during frontend slugification

### DIFF
--- a/apps/desktop/src/components/BranchNameTextbox.svelte
+++ b/apps/desktop/src/components/BranchNameTextbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Textbox } from '@gitbutler/ui';
-	import { slugify } from '@gitbutler/ui/utils/string';
+	import { slugifyBranchName } from '@gitbutler/ui/utils/string';
 
 	type Props = {
 		value?: string;
@@ -19,7 +19,7 @@
 
 	let textbox = $state<ReturnType<typeof Textbox>>();
 
-	const slugifiedName = $derived(value && slugify(value));
+	const slugifiedName = $derived(value && slugifyBranchName(value));
 	const namesDiverge = $derived(!!value && slugifiedName !== value);
 	const computedHelperText = $derived(
 		namesDiverge ? `Will be created as '${slugifiedName}'` : helperText

--- a/packages/ui/src/lib/utils/string.test.ts
+++ b/packages/ui/src/lib/utils/string.test.ts
@@ -1,4 +1,4 @@
-import { slugify, camelCaseToTitleCase } from '$lib/utils/string';
+import { slugify, slugifyBranchName, camelCaseToTitleCase } from '$lib/utils/string';
 import { describe, expect, test } from 'vitest';
 
 describe.concurrent('camelCaseToTitleCase with valid inputs', () => {
@@ -56,5 +56,35 @@ describe.concurrent('branch slugify with replaced characters', () => {
 
 	test('most special characters are nuked', () => {
 		expect(slugify('a!b@c$d;e%f^g&h*i(j)k+l=m~n`')).toEqual('abcdefghijklmn');
+	});
+});
+
+describe.concurrent('slugifyBranchName preserves git-valid characters', () => {
+	test('hash/number sign is preserved', () => {
+		expect(slugifyBranchName('feat/#1234-ticket-name')).toEqual('feat/#1234-ticket-name');
+	});
+
+	test('at sign is preserved', () => {
+		expect(slugifyBranchName('user@feature')).toEqual('user@feature');
+	});
+
+	test('forward slashes are preserved', () => {
+		expect(slugifyBranchName('my/branch')).toEqual('my/branch');
+	});
+
+	test('periods are preserved', () => {
+		expect(slugifyBranchName('v1.2.3')).toEqual('v1.2.3');
+	});
+
+	test('whitespace becomes hyphens', () => {
+		expect(slugifyBranchName('my branch name')).toEqual('my-branch-name');
+	});
+
+	test('git-invalid characters are removed', () => {
+		expect(slugifyBranchName('a~b^c:d?e*f')).toEqual('abcdef');
+	});
+
+	test('behaves like slugify for simple names', () => {
+		expect(slugifyBranchName('feature/my-branch')).toEqual('feature/my-branch');
 	});
 });

--- a/packages/ui/src/lib/utils/string.ts
+++ b/packages/ui/src/lib/utils/string.ts
@@ -45,3 +45,18 @@ export function slugify(input: string) {
 		.replace(/\s+/g, '-')
 		.replace(/-+/g, '-');
 }
+
+/**
+ * Branch-name-aware slugify that preserves characters valid in git ref names
+ * (like `#`) which the generic `slugify` strips. Git allows `#` in branch
+ * names (e.g. `feat/#1234-ticket-name`), so this variant keeps them.
+ */
+export function slugifyBranchName(input: string) {
+	return String(input)
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.trim()
+		.replace(/[^A-Za-z0-9._/#@ -]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-');
+}


### PR DESCRIPTION
## Summary

Fixes #9076

Branch names containing `#` (e.g. `feat/#1234-ticket-name`) have the `#` silently stripped when creating or renaming branches. This is because the frontend's `slugify` function uses a character allowlist that doesn't include `#`, even though `#` is a valid character in git ref names.

The backend's `normalize_short_name` correctly preserves `#` (confirmed by existing Rust tests: `foo#branch` → `foo#branch`). The issue is purely in the frontend `BranchNameTextbox` component.

## Root Cause

`packages/ui/src/lib/utils/string.ts`:
```typescript
// This regex strips # because it's not in the allowed set
.replace(/[^A-Za-z0-9._/ -]/g, '')
```

This `slugify` is also used for non-branch contexts (org slugs, markdown headings) where `#` should be stripped, so modifying it directly would break those contexts.

## Fix

1. **New function `slugifyBranchName`** in `packages/ui/src/lib/utils/string.ts` — a branch-name-aware variant that additionally allows `#` and `@` (both valid in git refs)
2. **`BranchNameTextbox.svelte`** now imports `slugifyBranchName` instead of the generic `slugify`
3. The generic `slugify` remains unchanged for non-branch contexts (`OrganizationEditModal`, `Heading.svelte`)

## Changes

- `packages/ui/src/lib/utils/string.ts` — Add `slugifyBranchName` function
- `packages/ui/src/lib/utils/string.test.ts` — Add 7 tests for the new function
- `apps/desktop/src/components/BranchNameTextbox.svelte` — Use `slugifyBranchName`

## Test Plan

- [x] New vitest tests cover `#`, `@`, slashes, periods, whitespace, git-invalid chars
- [x] Existing `slugify` tests unmodified and still pass
- [x] Backend already preserves `#` (Rust test: `normalize_short_name("foo#branch") == "foo#branch"`)
- [ ] Manual: type `feat/#1234-ticket` in branch name input → should show the `#` preserved