### PR TITLE
fix(ui): prevent 'project not found' error when removing a project

### DIFF
--- a/apps/desktop/src/components/ProblemLoadingRepo.svelte
+++ b/apps/desktop/src/components/ProblemLoadingRepo.svelte
@@ -32,10 +32,13 @@
 	async function onDeleteClicked() {
 		loading = true;
 		try {
+			// Navigate away first to unmount components that subscribe to project
+			// data. This prevents "project not found" errors from RTKQ cache
+			// invalidation triggering refetches on still-mounted components.
 			deleteConfirmationModal?.close();
+			await goto('/');
 			await projectsService.deleteProject(projectId);
 			chipToasts.success('Project deleted');
-			goto('/');
 		} catch (err: any) {
 			console.error(err);
 			showError('Failed to delete project', err);

--- a/apps/desktop/src/components/ProjectNotFound.svelte
+++ b/apps/desktop/src/components/ProjectNotFound.svelte
@@ -22,17 +22,16 @@
 
 	async function stopTracking(id: string) {
 		isDeleting = true;
-		deleteProject: {
-			try {
-				await projectsService.deleteProject(id);
-			} catch {
-				deleteSucceeded = false;
-				break deleteProject;
-			}
+		// Navigate away first to prevent "project not found" errors from
+		// RTKQ cache invalidation triggering refetches on mounted components.
+		await goto('/');
+		try {
+			await projectsService.deleteProject(id);
 			deleteSucceeded = true;
+		} catch {
+			deleteSucceeded = false;
 		}
 		isDeleting = false;
-		goto('/');
 	}
 
 	async function locate(id: string) {

--- a/apps/desktop/src/components/RemoveProjectForm.svelte
+++ b/apps/desktop/src/components/RemoveProjectForm.svelte
@@ -20,9 +20,12 @@
 	async function onDeleteClicked() {
 		isDeleting = true;
 		try {
-			await projectsService.deleteProject(projectId);
+			// Navigate away first to unmount components that subscribe to project
+			// data. This prevents "project not found" errors from RTKQ cache
+			// invalidation triggering refetches on still-mounted components.
 			closeSettings();
-			goto('/');
+			await goto('/');
+			await projectsService.deleteProject(projectId);
 			chipToasts.success('Project deleted');
 		} catch (err: any) {
 			console.error(err);


### PR DESCRIPTION
## Summary

- Removing a project triggers a 'project not found' API error because RTKQ cache invalidation causes still-mounted components to refetch the deleted project's data
- Fix: navigate to the home page (`/`) **before** calling `deleteProject()`, so all components with `getProject(projectId)` subscriptions are unmounted before cache invalidation fires
- Applied consistently to all three deletion paths: `RemoveProjectForm`, `ProblemLoadingRepo`, and `ProjectNotFound`

## Problem

When a user clicks "Remove project":

1. `deleteProject(projectId)` completes and RTKQ invalidates the `Project` tag
2. Components still mounted on the `[projectId]` route (e.g. `Chrome.svelte`, `AnalyticsMonitor.svelte`, `ForgeForm.svelte`) have active `getProject(projectId)` subscriptions
3. These subscriptions refetch because of the cache invalidation
4. The refetch returns "project not found" since the project was just deleted
5. The error is displayed to the user as a toast notification

The root cause is that `goto('/')` was not awaited (or called after the deletion), so the route change hadn't completed before the invalidation triggered refetches.

## Fix

In all three components that handle project deletion:
1. Close any open modals/settings UI
2. `await goto('/')` — navigate and wait for old components to unmount
3. Only then call `deleteProject()` — cache invalidation now has no active subscribers for the deleted project

If deletion fails after navigation, the error toast still appears and the user can navigate back.

## Test plan

- Verify manually:
  1. Open a project in GitButler
  2. Go to Settings > Remove project
  3. Confirm deletion
  4. Should navigate to home page cleanly with "Project deleted" toast
  5. No "project not found" error toast should appear
- Repeat via the "Problem loading repo" error page's delete button
- Repeat via the "Project not found" page's delete button

Fixes #12280
