### PR TITLE
fix(ui): prevent duplicate revert operations when restoring a snapshot

### DIFF
--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -14,12 +14,20 @@
 	interface Props {
 		entry: Snapshot;
 		isWithinRestore?: boolean;
+		restoring?: boolean;
 		onRestoreClick: () => void;
 		onDiffClick: (filePath: string) => void;
 		projectId: string;
 	}
 
-	const { projectId, entry, isWithinRestore = true, onRestoreClick, onDiffClick }: Props = $props();
+	const {
+		projectId,
+		entry,
+		isWithinRestore = true,
+		restoring = false,
+		onRestoreClick,
+		onDiffClick,
+	}: Props = $props();
 
 	function getShortSha(sha: string | undefined) {
 		if (!sha) return "";
@@ -192,7 +200,8 @@
 				onclick={() => {
 					onRestoreClick();
 				}}
-				disabled={mode.response?.type !== "OpenWorkspace"}>Revert</Button
+				disabled={restoring || mode.response?.type !== "OpenWorkspace"}
+				loading={restoring}>Revert</Button
 			>
 		</div>
 		<span class="snapshot-time text-11">

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -38,6 +38,7 @@
 
 	let currentSelectionId: SelectionId | undefined = $state(undefined);
 	let createSnapshotModal: CreateSnapshotModal;
+	let restoring = $state(false);
 
 	// Derive selectedFile from the selection service
 	const selectedFile = $derived.by(() => {
@@ -119,11 +120,16 @@
 								{projectId}
 								{entry}
 								isWithinRestore={withinRestoreItems.includes(entry.id)}
-								onRestoreClick={() => {
-									historyService.restoreSnapshot(projectId, entry.id);
-									// In some cases, restoring the snapshot doesn't update the UI correctly
-									// Until we have that figured out, we need to reload the page.
-									location.reload();
+								{restoring}
+								onRestoreClick={async () => {
+									restoring = true;
+									try {
+										await historyService.restoreSnapshot(projectId, entry.id);
+									} finally {
+										// In some cases, restoring the snapshot doesn't update the UI correctly
+										// Until we have that figured out, we need to reload the page.
+										location.reload();
+									}
 								}}
 								onDiffClick={() => {
 									currentSelectionId = createSnapshotSelection({ snapshotId: entry.id });


### PR DESCRIPTION
## Summary

- Reverting a snapshot creates duplicate RestoreFromSnapshot entries in the history because `restoreSnapshot()` was not awaited before `location.reload()` fired
- Fix: await the restore mutation before reloading, and disable all Revert buttons during the operation to prevent double-clicks
- Added loading spinner feedback on the Revert button while restoring

## Problem

When clicking "Revert" on a snapshot:

1. `historyService.restoreSnapshot(projectId, entry.id)` is called but **not awaited**
2. `location.reload()` fires immediately, before the async IPC call completes
3. This creates a race condition where:
   - The reload may interrupt the in-flight restore
   - The button could be clicked again before the first restore finishes
   - Both scenarios can produce duplicate RestoreFromSnapshot entries

## Fix

1. **Await the mutation**: The `onRestoreClick` handler now awaits `restoreSnapshot()` before reloading
2. **Prevent double-clicks**: A `restoring` state flag disables all Revert buttons while a restore is in progress
3. **Loading feedback**: The active Revert button shows a spinner via the existing `loading` prop

## Test plan

- [ ] Open a project with snapshot history
- [ ] Click "Revert" on any snapshot entry
- [ ] Verify only ONE RestoreFromSnapshot entry appears in history after the page reloads
- [ ] Verify the Revert button shows a spinner and all Revert buttons are disabled during the operation
- [ ] Verify the page still reloads correctly after restore completes

Fixes #12282
