### PR TITLE
fix(linux): 'Show in File Manager' fails with 'Invalid path format' error

### DIFF
--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -6,8 +6,49 @@ use but_api_macros::but_api;
 use tracing::instrument;
 use url::Url;
 
-pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
-    let target_url = Url::parse(path).with_context(|| format!("Invalid path format: '{path}'"))?;
+/// Environment variable names that need cleaning when spawning subprocesses
+/// on Linux to avoid AppImage path contamination.
+const APPIMAGE_ENV_VARS: &[&str] = &[
+    "APPDIR",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GIO_EXTRA_MODULES",
+    "GIO_EXTRA_MODULES",
+    "GSETTINGS_SCHEMA_DIR",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_SYSTEM_PATH_1_0",
+    "GTK_DATA_PREFIX",
+    "GTK_EXE_PREFIX",
+    "GTK_IM_MODULE_FILE",
+    "GTK_PATH",
+    "LD_LIBRARY_PATH",
+    "PATH",
+    "PERLLIB",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "QT_PLUGIN_PATH",
+    "XDG_DATA_DIRS",
+];
+
+fn clean_env_vars<'a, 'b>(var_names: &'a [&'b str]) -> impl Iterator<Item = (&'b str, String)> + 'a {
+    var_names
+        .iter()
+        .filter_map(|name| env::var(name).map(|value| (*name, value)).ok())
+        .map(|(name, value)| {
+            (
+                name,
+                value
+                    .split(':')
+                    .filter(|path| !path.contains("appimage-run") && !path.contains("/tmp/.mount"))
+                    .collect::<Vec<_>>()
+                    .join(":"),
+            )
+        })
+}
+
+/// Open a URL with the appropriate handler, after validating the scheme.
+/// Only allows known-safe URL schemes. NOT suitable for filesystem paths.
+pub(crate) fn open_that(url: &str) -> anyhow::Result<()> {
+    let target_url = Url::parse(url).with_context(|| format!("Invalid URL format: '{url}'"))?;
     if ![
         "http",
         "https",
@@ -22,48 +63,19 @@ pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
     ]
     .contains(&target_url.scheme())
     {
-        bail!("Invalid path scheme: {}", target_url.scheme());
+        bail!("Invalid URL scheme: {}", target_url.scheme());
     }
 
-    fn clean_env_vars<'a, 'b>(var_names: &'a [&'b str]) -> impl Iterator<Item = (&'b str, String)> + 'a {
-        var_names
-            .iter()
-            .filter_map(|name| env::var(name).map(|value| (*name, value)).ok())
-            .map(|(name, value)| {
-                (
-                    name,
-                    value
-                        .split(':')
-                        .filter(|path| !path.contains("appimage-run") && !path.contains("/tmp/.mount"))
-                        .collect::<Vec<_>>()
-                        .join(":"),
-                )
-            })
-    }
+    open_with_cleaned_env(url)
+}
 
+/// Open a target (URL or filesystem path) using the system handler,
+/// with AppImage-safe environment variables on Linux.
+fn open_with_cleaned_env(target: &str) -> anyhow::Result<()> {
     let mut cmd_errors = Vec::new();
 
-    for mut cmd in open::commands(path) {
-        let cleaned_vars = clean_env_vars(&[
-            "APPDIR",
-            "GDK_PIXBUF_MODULE_FILE",
-            "GIO_EXTRA_MODULES",
-            "GIO_EXTRA_MODULES",
-            "GSETTINGS_SCHEMA_DIR",
-            "GST_PLUGIN_SYSTEM_PATH",
-            "GST_PLUGIN_SYSTEM_PATH_1_0",
-            "GTK_DATA_PREFIX",
-            "GTK_EXE_PREFIX",
-            "GTK_IM_MODULE_FILE",
-            "GTK_PATH",
-            "LD_LIBRARY_PATH",
-            "PATH",
-            "PERLLIB",
-            "PYTHONHOME",
-            "PYTHONPATH",
-            "QT_PLUGIN_PATH",
-            "XDG_DATA_DIRS",
-        ]);
+    for mut cmd in open::commands(target) {
+        let cleaned_vars = clean_env_vars(APPIMAGE_ENV_VARS);
 
         cmd.envs(cleaned_vars);
         cmd.current_dir(env::temp_dir());
@@ -115,17 +127,21 @@ pub fn show_in_finder(path: String) -> Result<()> {
 
     #[cfg(target_os = "linux")]
     {
-        // For directories, open the directory directly
+        // On Linux, open filesystem paths directly using the system handler
+        // (xdg-open / gio open). Do NOT use open_that() here — that function
+        // validates URL schemes and rejects plain filesystem paths.
         if std::path::Path::new(&path).is_dir() {
-            open_that(&path).with_context(|| format!("Failed to open directory '{path}' in file manager"))?;
+            open_with_cleaned_env(&path)
+                .with_context(|| format!("Failed to open directory '{path}' in file manager"))?;
         } else {
             // For files, try to open the parent directory
             if let Some(parent) = std::path::Path::new(&path).parent() {
                 let parent_str = parent.to_string_lossy();
-                open_that(&parent_str)
+                open_with_cleaned_env(&parent_str)
                     .with_context(|| format!("Failed to open parent directory of '{path}' in file manager",))?;
             } else {
-                open_that(&path).with_context(|| format!("Failed to open '{path}' in file manager"))?;
+                open_with_cleaned_env(&path)
+                    .with_context(|| format!("Failed to open '{path}' in file manager"))?;
             }
         }
     }


### PR DESCRIPTION
## Summary

- On Linux, right-clicking a file and selecting "Show in File Manager" fails with `Invalid path format` / `relative URL without a base` error
- Root cause: `show_in_finder` called `open_that()` with a plain filesystem path, but `open_that()` validates input as a URL via `Url::parse()` which rejects paths lacking a URL scheme
- Fix: refactored to separate URL validation from system-handler invocation, so Linux file manager opening bypasses URL validation while keeping AppImage env var cleaning

## Problem

The `open_that()` function was designed for URLs (http/https/vscode/etc.) and uses `Url::parse()` for validation. When `show_in_finder()` on Linux passed a filesystem path like `/home/user/Projects/Launcher/Launcher` to it:

1. `Url::parse("/home/user/Projects/...")` fails — plain paths aren't valid URLs
2. Error: `Invalid path format: '/home/user/Projects/Launcher/Launcher'` caused by `relative URL without a base`

macOS and Windows were unaffected because they use direct `Command::new("open")` / `Command::new("explorer")` calls that accept filesystem paths natively.

## Fix

Extracted the common AppImage-safe process spawning logic into `open_with_cleaned_env()`:

- `open_that()` — validates URL scheme, then delegates to `open_with_cleaned_env()` (for `open_url` command)
- `open_with_cleaned_env()` — opens any target (URL or path) via the `open` crate with cleaned environment variables
- Linux `show_in_finder` now calls `open_with_cleaned_env()` directly, bypassing URL validation

## Test plan

- [ ] On Linux: right-click a file in changed files list → "Show in File Manager" should open the parent directory
- [ ] On Linux: verify URLs still open correctly (e.g. clicking PR links, opening in editor)
- [ ] Verify no regressions on macOS/Windows file manager opening

Fixes #12272
