### PR TITLE
fix(cli): prevent panic when askpass broker is not initialized

### DIFF
--- a/crates/but-api/src/legacy/askpass.rs
+++ b/crates/but-api/src/legacy/askpass.rs
@@ -10,6 +10,10 @@ pub struct SubmitPromptResponseParams {
 }
 
 pub async fn submit_prompt_response(params: SubmitPromptResponseParams) -> anyhow::Result<()> {
-    askpass::get_broker().handle_response(params.id, params.response).await;
+    if let Some(broker) = askpass::get_broker() {
+        broker.handle_response(params.id, params.response).await;
+    } else {
+        tracing::warn!("received askpass response but broker is not initialized; ignoring");
+    }
     Ok(())
 }

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -36,9 +36,14 @@ pub async fn git_clone_repository(repository_url: String, target_dir: PathBuf) -
 
 async fn handle_git_prompt_clone(prompt: String, url: String) -> Option<String> {
     tracing::info!("received prompt for clone of {url}: {prompt:?}");
-    askpass::get_broker()
-        .submit_prompt(prompt, askpass::Context::Clone { url })
-        .await
+    if let Some(broker) = askpass::get_broker() {
+        broker
+            .submit_prompt(prompt, askpass::Context::Clone { url })
+            .await
+    } else {
+        tracing::warn!("askpass broker not initialized (running outside GUI?); returning None");
+        None
+    }
 }
 
 #[but_api]

--- a/crates/gitbutler-repo-actions/src/askpass.rs
+++ b/crates/gitbutler-repo-actions/src/askpass.rs
@@ -20,13 +20,13 @@ pub unsafe fn init(submit_prompt: impl Fn(PromptEvent<Context>) + Send + Sync + 
     }
 }
 
-/// Get the global askpass broker.
+/// Get the global askpass broker, if it has been initialized.
 ///
-/// # Panics
-/// Will panic if [`init`] was not called before this function.
+/// Returns `None` when running outside the GUI (e.g. the standalone `but` CLI)
+/// where [`init`] is never called.
 #[expect(static_mut_refs)]
-pub fn get_broker() -> &'static AskpassBroker {
-    unsafe { GLOBAL_ASKPASS_BROKER.as_ref().expect("askpass broker not initialized") }
+pub fn get_broker() -> Option<&'static AskpassBroker> {
+    unsafe { GLOBAL_ASKPASS_BROKER.as_ref() }
 }
 
 pub struct AskpassRequest {

--- a/crates/gitbutler-repo-actions/src/repository.rs
+++ b/crates/gitbutler-repo-actions/src/repository.rs
@@ -334,9 +334,14 @@ impl RepoActionsExt for Context {
 async fn handle_git_prompt_push(prompt: String, askpass: Option<Option<StackId>>) -> Option<String> {
     if let Some(branch_id) = askpass {
         tracing::info!("received prompt for branch push {branch_id:?}: {prompt:?}");
-        askpass::get_broker()
-            .submit_prompt(prompt, askpass::Context::Push { branch_id })
-            .await
+        if let Some(broker) = askpass::get_broker() {
+            broker
+                .submit_prompt(prompt, askpass::Context::Push { branch_id })
+                .await
+        } else {
+            tracing::warn!("askpass broker not initialized (running outside GUI?); returning None");
+            None
+        }
     } else {
         tracing::warn!("received askpass push prompt but no broker was supplied; returning None");
         None
@@ -346,9 +351,14 @@ async fn handle_git_prompt_push(prompt: String, askpass: Option<Option<StackId>>
 async fn handle_git_prompt_fetch(prompt: String, askpass: Option<String>) -> Option<String> {
     if let Some(action) = askpass {
         tracing::info!("received prompt for fetch with action {action:?}: {prompt:?}");
-        askpass::get_broker()
-            .submit_prompt(prompt, askpass::Context::Fetch { action })
-            .await
+        if let Some(broker) = askpass::get_broker() {
+            broker
+                .submit_prompt(prompt, askpass::Context::Fetch { action })
+                .await
+        } else {
+            tracing::warn!("askpass broker not initialized (running outside GUI?); returning None");
+            None
+        }
     } else {
         tracing::warn!("received askpass fetch prompt but no broker was supplied; returning None");
         None


### PR DESCRIPTION
## Summary

- `but pull` (and other CLI operations requiring SSH auth) panics with `askpass broker not initialized` when running outside the GUI
- Root cause: the global askpass broker is only initialized in the Tauri GUI setup path; the CLI code path skips initialization
- Fix: `get_broker()` now returns `Option` instead of panicking, and all call sites gracefully handle the uninitialized case

## Problem

The askpass broker handles SSH credential prompts (passphrase, auth tokens) by forwarding them to the GUI as Tauri events. It's stored in a global static and initialized in `crates/gitbutler-tauri/src/main.rs` during the Tauri `setup` hook.

When the same binary runs as a CLI (`but pull`, `but push`, etc.), the early-return at the CLI entry point skips the Tauri setup, leaving the broker uninitialized. Any git operation that triggers an SSH prompt then calls `get_broker()` which panics:

```
thread '' panicked at crates/gitbutler-repo-actions/src/askpass.rs:29:45:
askpass broker not initialized
```

## Fix

**`get_broker()`** now returns `Option<&'static AskpassBroker>` instead of unwrapping:

All 4 call sites updated to handle `None`:
- `handle_git_prompt_push` — returns `None` (auth fails gracefully)
- `handle_git_prompt_fetch` — returns `None` (auth fails gracefully)
- `handle_git_prompt_clone` — returns `None` (auth fails gracefully)
- `submit_prompt_response` — logs warning and no-ops

This means CLI operations that don't need credentials continue to work normally, and operations that need credentials fail with a proper authentication error instead of crashing the process.

## Test plan

- [ ] Verify `but pull` with a public repo works without panic
- [ ] Verify `but pull` with a password-protected SSH key returns an authentication error instead of panicking
- [ ] Verify the GUI askpass flow still works (broker is initialized, prompts appear as before)
- [ ] Run `cargo clippy -p but-api` — passes clean

Fixes #12279
