### PR TITLE
Use gix in operating_mode and avoid panic

### DIFF
--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -22,6 +22,41 @@ fn create_edit_mode_metadata(ctx: &Context) {
 }
 
 mod operating_modes {
+    mod invalid_repo_fallback {
+        use gitbutler_testsupport::{Case, Suite};
+
+        #[test]
+        fn operating_mode_falls_back_to_outside_workspace_when_repo_cannot_be_opened() {
+            let suite = Suite::default();
+            let Case { ctx, .. } = &suite.new_case();
+
+            // Make opening the repo fail by removing the `.git` directory.
+            std::fs::remove_dir_all(&ctx.gitdir).unwrap();
+
+            assert_eq!(
+                gitbutler_operating_modes::operating_mode(ctx),
+                gitbutler_operating_modes::OperatingMode::OutsideWorkspace(
+                    gitbutler_operating_modes::OutsideWorkspaceMetadata::default()
+                )
+            );
+        }
+    }
+
+    mod edit_branch_no_metadata_fallback {
+        use gitbutler_operating_modes::{OperatingMode, operating_mode};
+        use gitbutler_testsupport::{Case, Suite};
+
+        #[test]
+        fn operating_mode_falls_back_to_outside_workspace_when_on_edit_branch_without_metadata() {
+            let suite = Suite::default();
+            let Case { ctx, .. } = &suite.new_case();
+
+            crate::create_and_checkout_branch(ctx, "gitbutler/edit");
+
+            assert!(matches!(operating_mode(ctx), OperatingMode::OutsideWorkspace(_)));
+        }
+    }
+
     mod open_workspace_mode {
         use gitbutler_operating_modes::{ensure_open_workspace_mode, in_open_workspace_mode};
         use gitbutler_testsupport::{Case, Suite};


### PR DESCRIPTION
### Motivation
- Avoid panics from unwrapping the legacy `git2` repository.
- Unify HEAD inspection to `gix` so `operating_mode` can fail gracefully.

### Description
- `gitbutler_operating_modes::operating_mode` now uses `ctx.repo.get()` (gix) instead of `ctx.git2_repo.get().unwrap()`.
- All failure paths return `OperatingMode::OutsideWorkspace` (no panics). If the repo handle can't be opened/borrowed, we return `OutsideWorkspaceMetadata::default()` directly.
- HEAD/ref inspection uses `gix` (`head().referent_name()`) and compares against `OPEN_WORKSPACE_REFS` / `EDIT_BRANCH_REF` via byte-wise comparisons.
- Minor cleanup: factor repeated OutsideWorkspace construction into a local helper and avoid redundant metadata computation when repo access already failed.

Files:
- `crates/gitbutler-operating-modes/src/lib.rs`

Regression coverage added:
- Fallback when the repo cannot be opened (`.git` removed).
- Fallback when on `gitbutler/edit` without edit-mode metadata.
