### PR TITLE
fix(graph): solve commit graph sort transitivity issue 

### DIFF
--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 but-core.workspace = true

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -1088,3 +1088,103 @@ impl crate::RefInfo {
         Self { ref_name, worktree }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gtt(generation: Option<u32>, committer_time: u64) -> GenThenTime {
+        GenThenTime {
+            generation,
+            committer_time,
+        }
+    }
+
+    #[test]
+    fn gen_then_time_total_ordering_is_transitive_with_mixed_generations() {
+        // This is the exact scenario that previously caused a panic:
+        //   "user-provided comparison function does not correctly implement a total order"
+        //
+        // With the old implementation (fall back to time-only when generations are mixed):
+        //   A < B (by time: 200 > 150)
+        //   B < C (by time: 150 > 100)
+        //   A > C (by generation: 5 > 3)  — transitivity violation!
+        let a = gtt(Some(3), 200);
+        let b = gtt(None, 150);
+        let c = gtt(Some(5), 100);
+
+        let ab = a.cmp(&b);
+        let bc = b.cmp(&c);
+        let ac = a.cmp(&c);
+
+        // With the fix, None is treated as u32::MAX (youngest), so B sorts first.
+        // B(gen=MAX) > A(gen=3) → B < A (reversed)
+        // B(gen=MAX) > C(gen=5) → B < C (reversed)
+        // C(gen=5) > A(gen=3)  → C < A (reversed)
+        // Order: B < C < A — fully transitive.
+        assert_eq!(ab, Ordering::Greater, "A should sort after B (B has None → u32::MAX)");
+        assert_eq!(bc, Ordering::Less, "B should sort before C (B has None → u32::MAX)");
+        assert_eq!(ac, Ordering::Greater, "A should sort after C (gen 5 > gen 3)");
+    }
+
+    #[test]
+    fn gen_then_time_none_generation_treated_as_youngest() {
+        // None generation maps to u32::MAX, which reversed sorts first (youngest).
+        let with_gen = gtt(Some(100), 500);
+        let without_gen = gtt(None, 500);
+        assert_eq!(
+            without_gen.cmp(&with_gen),
+            Ordering::Less,
+            "None generation (u32::MAX) should sort before any known generation"
+        );
+    }
+
+    #[test]
+    fn gen_then_time_both_some_sorts_by_generation_then_time() {
+        let young_gen = gtt(Some(10), 100);
+        let old_gen = gtt(Some(2), 200);
+        // Higher generation sorts first (reversed), regardless of time.
+        assert_eq!(young_gen.cmp(&old_gen), Ordering::Less);
+
+        // Equal generation falls back to time (higher time sorts first).
+        let recent = gtt(Some(5), 300);
+        let old = gtt(Some(5), 100);
+        assert_eq!(recent.cmp(&old), Ordering::Less);
+    }
+
+    #[test]
+    fn gen_then_time_both_none_sorts_by_time() {
+        let recent = gtt(None, 300);
+        let old = gtt(None, 100);
+        // Higher time sorts first (reversed).
+        assert_eq!(recent.cmp(&old), Ordering::Less);
+
+        // Equal time → equal.
+        assert_eq!(gtt(None, 100).cmp(&gtt(None, 100)), Ordering::Equal);
+    }
+
+    #[test]
+    fn gen_then_time_sort_is_deterministic_and_total() {
+        // Throw a mix of items at sort and ensure it doesn't panic.
+        // This directly exercises the code path from the stack trace.
+        let mut items = [
+            gtt(Some(3), 200),
+            gtt(None, 150),
+            gtt(Some(5), 100),
+            gtt(None, 300),
+            gtt(Some(1), 300),
+            gtt(Some(5), 200),
+            gtt(None, 100),
+            gtt(Some(3), 100),
+        ];
+        items.sort();
+
+        // Verify the result is actually sorted (each element ≤ the next).
+        for window in items.windows(2) {
+            assert!(
+                window[0].cmp(&window[1]) != Ordering::Greater,
+                "Sort result is not ordered: {window:?}"
+            );
+        }
+    }
+}

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -550,15 +550,20 @@ impl PartialOrd<Self> for GenThenTime {
     }
 }
 
-/// Sort it so younger generations sort first, and lacking two generations, so that more recent times (i.e. higher)
-/// sort first.
+/// Sort it so younger generations sort first, with more recent times (i.e. higher) as tiebreaker.
+/// When the generation is unknown (`None`), treat it as `u32::MAX` (youngest possible) to match
+/// git's `GENERATION_NUMBER_INFINITY` convention, ensuring unknown-generation commits are processed
+/// first during traversal. Using a fixed sentinel for `None` is necessary to maintain a total order
+/// — the previous approach of falling back to time-only comparison when generations were mixed
+/// violated transitivity.
 impl Ord for GenThenTime {
     fn cmp(&self, other: &Self) -> Ordering {
-        let time_cmp = self.committer_time.cmp(&other.committer_time).reverse();
-        match (self.generation, other.generation) {
-            (Some(a), Some(b)) => a.cmp(&b).reverse().then(time_cmp),
-            _ => time_cmp,
-        }
+        let gen_a = self.generation.unwrap_or(u32::MAX);
+        let gen_b = other.generation.unwrap_or(u32::MAX);
+        gen_a
+            .cmp(&gen_b)
+            .reverse()
+            .then_with(|| self.committer_time.cmp(&other.committer_time).reverse())
     }
 }
 

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -553,11 +553,12 @@ impl PartialOrd<Self> for GenThenTime {
 /// Sort it so younger generations sort first, with more recent times (i.e. higher) as tiebreaker.
 /// When the generation is unknown (`None`), treat it as `u32::MAX` (youngest possible) to match
 /// git's `GENERATION_NUMBER_INFINITY` convention, ensuring unknown-generation commits are processed
-/// first during traversal. Using a fixed sentinel for `None` is necessary to maintain a total order
-/// — the previous approach of falling back to time-only comparison when generations were mixed
-/// violated transitivity.
+/// first during traversal.
 impl Ord for GenThenTime {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Using a fixed sentinel for `None` is necessary to maintain a total order
+        // — the previous approach of falling back to time-only comparison when generations were mixed
+        // violated transitivity.
         let gen_a = self.generation.unwrap_or(u32::MAX);
         let gen_b = other.generation.unwrap_or(u32::MAX);
         gen_a
@@ -1095,101 +1096,4 @@ impl crate::RefInfo {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn gtt(generation: Option<u32>, committer_time: u64) -> GenThenTime {
-        GenThenTime {
-            generation,
-            committer_time,
-        }
-    }
-
-    #[test]
-    fn gen_then_time_total_ordering_is_transitive_with_mixed_generations() {
-        // This is the exact scenario that previously caused a panic:
-        //   "user-provided comparison function does not correctly implement a total order"
-        //
-        // With the old implementation (fall back to time-only when generations are mixed):
-        //   A < B (by time: 200 > 150)
-        //   B < C (by time: 150 > 100)
-        //   A > C (by generation: 5 > 3)  — transitivity violation!
-        let a = gtt(Some(3), 200);
-        let b = gtt(None, 150);
-        let c = gtt(Some(5), 100);
-
-        let ab = a.cmp(&b);
-        let bc = b.cmp(&c);
-        let ac = a.cmp(&c);
-
-        // With the fix, None is treated as u32::MAX (youngest), so B sorts first.
-        // B(gen=MAX) > A(gen=3) → B < A (reversed)
-        // B(gen=MAX) > C(gen=5) → B < C (reversed)
-        // C(gen=5) > A(gen=3)  → C < A (reversed)
-        // Order: B < C < A — fully transitive.
-        assert_eq!(ab, Ordering::Greater, "A should sort after B (B has None → u32::MAX)");
-        assert_eq!(bc, Ordering::Less, "B should sort before C (B has None → u32::MAX)");
-        assert_eq!(ac, Ordering::Greater, "A should sort after C (gen 5 > gen 3)");
-    }
-
-    #[test]
-    fn gen_then_time_none_generation_treated_as_youngest() {
-        // None generation maps to u32::MAX, which reversed sorts first (youngest).
-        let with_gen = gtt(Some(100), 500);
-        let without_gen = gtt(None, 500);
-        assert_eq!(
-            without_gen.cmp(&with_gen),
-            Ordering::Less,
-            "None generation (u32::MAX) should sort before any known generation"
-        );
-    }
-
-    #[test]
-    fn gen_then_time_both_some_sorts_by_generation_then_time() {
-        let young_gen = gtt(Some(10), 100);
-        let old_gen = gtt(Some(2), 200);
-        // Higher generation sorts first (reversed), regardless of time.
-        assert_eq!(young_gen.cmp(&old_gen), Ordering::Less);
-
-        // Equal generation falls back to time (higher time sorts first).
-        let recent = gtt(Some(5), 300);
-        let old = gtt(Some(5), 100);
-        assert_eq!(recent.cmp(&old), Ordering::Less);
-    }
-
-    #[test]
-    fn gen_then_time_both_none_sorts_by_time() {
-        let recent = gtt(None, 300);
-        let old = gtt(None, 100);
-        // Higher time sorts first (reversed).
-        assert_eq!(recent.cmp(&old), Ordering::Less);
-
-        // Equal time → equal.
-        assert_eq!(gtt(None, 100).cmp(&gtt(None, 100)), Ordering::Equal);
-    }
-
-    #[test]
-    fn gen_then_time_sort_is_deterministic_and_total() {
-        // Throw a mix of items at sort and ensure it doesn't panic.
-        // This directly exercises the code path from the stack trace.
-        let mut items = [
-            gtt(Some(3), 200),
-            gtt(None, 150),
-            gtt(Some(5), 100),
-            gtt(None, 300),
-            gtt(Some(1), 300),
-            gtt(Some(5), 200),
-            gtt(None, 100),
-            gtt(Some(3), 100),
-        ];
-        items.sort();
-
-        // Verify the result is actually sorted (each element ≤ the next).
-        for window in items.windows(2) {
-            assert!(
-                window[0].cmp(&window[1]) != Ordering::Greater,
-                "Sort result is not ordered: {window:?}"
-            );
-        }
-    }
-}
+mod tests;

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+fn gtt(generation: Option<u32>, committer_time: u64) -> GenThenTime {
+    GenThenTime {
+        generation,
+        committer_time,
+    }
+}
+
+#[test]
+fn gen_then_time_total_ordering_is_transitive_with_mixed_generations() {
+    // This is the exact scenario that previously caused a panic:
+    //   "user-provided comparison function does not correctly implement a total order"
+    //
+    // With the old implementation (fall back to time-only when generations are mixed):
+    //   A < B (by time: 200 > 150)
+    //   B < C (by time: 150 > 100)
+    //   A > C (by generation: 5 > 3)  — transitivity violation!
+    let a = gtt(Some(3), 200);
+    let b = gtt(None, 150);
+    let c = gtt(Some(5), 100);
+
+    let ab = a.cmp(&b);
+    let bc = b.cmp(&c);
+    let ac = a.cmp(&c);
+
+    // With the fix, None is treated as u32::MAX (youngest), so B sorts first.
+    // B(gen=MAX) > A(gen=3) → B < A (reversed)
+    // B(gen=MAX) > C(gen=5) → B < C (reversed)
+    // C(gen=5) > A(gen=3)  → C < A (reversed)
+    // Order: B < C < A — fully transitive.
+    assert_eq!(ab, Ordering::Greater, "A should sort after B (B has None → u32::MAX)");
+    assert_eq!(bc, Ordering::Less, "B should sort before C (B has None → u32::MAX)");
+    assert_eq!(ac, Ordering::Greater, "A should sort after C (gen 5 > gen 3)");
+}
+
+#[test]
+fn gen_then_time_none_generation_treated_as_youngest() {
+    // None generation maps to u32::MAX, which reversed sorts first (youngest).
+    let with_gen = gtt(Some(100), 500);
+    let without_gen = gtt(None, 500);
+    assert_eq!(
+        without_gen.cmp(&with_gen),
+        Ordering::Less,
+        "None generation (u32::MAX) should sort before any known generation"
+    );
+}
+
+#[test]
+fn gen_then_time_both_some_sorts_by_generation_then_time() {
+    let young_gen = gtt(Some(10), 100);
+    let old_gen = gtt(Some(2), 200);
+    assert_eq!(
+        young_gen.cmp(&old_gen),
+        Ordering::Less,
+        "Higher generation sorts first (reversed), regardless of time."
+    );
+
+    let recent = gtt(Some(5), 300);
+    let old = gtt(Some(5), 100);
+    assert_eq!(
+        recent.cmp(&old),
+        Ordering::Less,
+        "Equal generation falls back to time (higher time sorts first)."
+    );
+}
+
+#[test]
+fn gen_then_time_both_none_sorts_by_time() {
+    let recent = gtt(None, 300);
+    let old = gtt(None, 100);
+    assert_eq!(recent.cmp(&old), Ordering::Less, "Higher time sorts first (reversed).");
+    assert_eq!(
+        gtt(None, 100).cmp(&gtt(None, 100)),
+        Ordering::Equal,
+        "Equal time → equal."
+    );
+}
+
+#[test]
+fn gen_then_time_sort_is_deterministic_and_total_issue_12343() {
+    // Throw a mix of items at sort and ensure it doesn't panic.
+    // This directly exercises the code path from the stack trace.
+    let mut items = [
+        gtt(Some(3), 200),
+        gtt(None, 150),
+        gtt(Some(5), 100),
+        gtt(None, 300),
+        gtt(Some(1), 300),
+        gtt(Some(5), 200),
+        gtt(None, 100),
+        gtt(Some(3), 100),
+    ];
+    items.sort();
+
+    // Verify the result is actually sorted (each element ≤ the next).
+    for window in items.windows(2) {
+        assert!(
+            window[0].cmp(&window[1]) != Ordering::Greater,
+            "Sort result is not ordered: {window:?}"
+        );
+    }
+}


### PR DESCRIPTION
**DISCLAIMER:** this fix was written by Claude Code. it looks *reasonable* to me but i am severely lacking in the context of how the commit graph works to know if this solution is right. just sharing this to maybe save you some time, take with a grain of salt

## 🧢 Changes

this PR solves a sort transitivity issue when constructing the commit graph. it also adds some unit tests to avoid this issue cropping up in the future

## ☕️ Reasoning

see https://github.com/gitbutlerapp/gitbutler/issues/12343 for more context, but tl;dr after a force push my commit graph ended up in a state where Git Butler panicked trying to parse. this boils down to a violation of the rules of transitivity when it comes to sorting. i will share the explanation that Claude Code gave me as it does a better job explaining than me lol:

```
  Root Cause: GenThenTime::cmp() violates transitivity

  The Ord impl at crates/but-graph/src/init/walk.rs:555-563:

  fn cmp(&self, other: &Self) -> Ordering {
      let time_cmp = self.committer_time.cmp(&other.committer_time).reverse();
      match (self.generation, other.generation) {
          (Some(a), Some(b)) => a.cmp(&b).reverse().then(time_cmp),
          _ => time_cmp,  // BUG: ignores generation when only one side has it
      }
  }

  Concrete transitivity violation:
  - A: gen=Some(3), time=200
  - B: gen=None, time=150
  - C: gen=Some(5), time=100
  ┌────────────┬───────────────────────┬──────────────────────────────────┐
  │ Comparison │         Path          │              Result              │
  ├────────────┼───────────────────────┼──────────────────────────────────┤
  │ A vs B     │ mixed gen → time only │ A < B (200 > 150, younger first) │
  ├────────────┼───────────────────────┼──────────────────────────────────┤
  │ B vs C     │ mixed gen → time only │ B < C (150 > 100, younger first) │
  ├────────────┼───────────────────────┼──────────────────────────────────┤
  │ A vs C     │ both Some → gen first │ A > C (gen 5 > 3, younger first) │
  └────────────┴───────────────────────┴──────────────────────────────────┘
  A < B < C but A > C — transitivity broken. Newer Rust sort implementations
  detect this and panic.

  The issue is that when both have generations, generation is primary. But when
  one is None, it falls back to time-only ordering, and these two orderings can
  disagree.

  Fix

  The fix is to give None a consistent sentinel value so generation ordering is
  always total. Using u32::MAX (matching git's GENERATION_NUMBER_INFINITY
  convention) treats unknown-generation commits as "assume youngest, process
  first" — conservative and safe since the sort is an optimization, not a
  correctness requirement.
```

## 🎫 Affected issues

Fixes: https://github.com/gitbutlerapp/gitbutler/issues/12343

