### PR TITLE
id: switch to node-based parsing

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -569,7 +569,7 @@ fn find_stack_by_hint(
     }
 
     // Try CLI ID parsing
-    let cli_ids = id_map.parse(hint, |_, _| Ok(Vec::new())).ok()?;
+    let cli_ids = id_map.parse(hint, Box::new(move |_, _| Ok(Vec::new()))).ok()?;
     for cli_id in cli_ids {
         if let CliId::Branch { name, .. } = cli_id {
             for (stack_id, stack_details) in stacks {

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -597,7 +597,7 @@ fn get_all_files_in_display_order(ctx: &mut Context, id_map: &IdMap) -> anyhow::
                 Some(stack_id) => stack_ids.iter().position(|e| *e == stack_id)?,
                 None => usize::MAX,
             };
-            Some((position, uncommitted_file.path(), uncommitted_file.to_cli_id()))
+            Some((position, uncommitted_file.path(), uncommitted_file.to_id()))
         })
         .collect();
     positioned_files

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -40,6 +40,7 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
                 inner: segment,
                 workspace_commits,
                 remote_commits,
+                stack_id: stack.id,
             });
         }
         stacks_info.stacks.push(stack_with_id);

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -55,21 +55,17 @@ fn commit_id_works_with_two_or_more_characters() -> anyhow::Result<()> {
         id: "01".to_string(),
     }];
     assert_eq!(
-        id_map.parse("01", changed_paths_fn)?,
+        id_map.parse("01", Box::new(changed_paths_fn))?,
         expected,
         "two characters are sufficient to parse a commit ID"
     );
-    let expected = [CliId::Commit {
-        commit_id: id1,
-        id: "010".to_string(),
-    }];
     assert_eq!(
-        id_map.parse("010", changed_paths_fn)?,
+        id_map.parse("010", Box::new(changed_paths_fn))?,
         expected,
         "three characters work too"
     );
     assert_eq!(
-        id_map.parse("1", changed_paths_fn).unwrap_err().to_string(),
+        id_map.parse("1", Box::new(changed_paths_fn)).unwrap_err().to_string(),
         "Id needs to be at least 2 characters long: '1'",
         "one character isn't enough"
     );
@@ -143,11 +139,15 @@ fn branches_work_with_single_character() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("f", changed_paths_fn)?,
+        id_map.parse("f", Box::new(changed_paths_fn))?,
         expected,
         "it's OK to have a CliID that is longer, but it would be up to the UI to not show them"
     );
-    assert_eq!(id_map.parse("g0", changed_paths_fn)?, expected, "the ID also works");
+    assert_eq!(
+        id_map.parse("g0", Box::new(changed_paths_fn))?,
+        expected,
+        "the ID also works"
+    );
     Ok(())
 }
 
@@ -172,18 +172,18 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
 
     let expected = [
         CliId::Branch {
-            name: "foo".into(),
-            id: "i0".into(),
-            stack_id: None,
-        },
-        CliId::Branch {
             name: "foo-bar".into(),
             id: "g0".into(),
             stack_id: None,
         },
+        CliId::Branch {
+            name: "foo".into(),
+            id: "i0".into(),
+            stack_id: None,
+        },
     ];
     assert_eq!(
-        id_map.parse("fo", changed_paths_fn)?,
+        id_map.parse("fo", Box::new(changed_paths_fn))?,
         expected,
         "substring searches can yield multiple items"
     );
@@ -194,7 +194,7 @@ fn branches_match_by_substring() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("az", changed_paths_fn)?,
+        id_map.parse("az", Box::new(changed_paths_fn))?,
         expected,
         "We see the ID was generated from a substring directly"
     );
@@ -220,7 +220,7 @@ fn branches_avoid_unassigned_area_id() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("za", changed_paths_fn)?,
+        id_map.parse("za", Box::new(changed_paths_fn))?,
         expected,
         "avoids unassigned area ID (zz)"
     );
@@ -249,7 +249,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("x-yz", changed_paths_fn)?,
+        id_map.parse("x-yz", Box::new(changed_paths_fn))?,
         expected,
         "avoids non-alphanumeric, taking first alphanumeric pair"
     );
@@ -259,7 +259,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("0ax", changed_paths_fn)?,
+        id_map.parse("0ax", Box::new(changed_paths_fn))?,
         expected,
         "avoids hexdigit pair which can be confused with a commit ID"
     );
@@ -288,7 +288,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("ghij", changed_paths_fn)?,
+        id_map.parse("ghij", Box::new(changed_paths_fn))?,
         expected,
         "avoids 'gh' and 'hi', which conflict with filenames"
     );
@@ -317,7 +317,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("substring", changed_paths_fn)?,
+        id_map.parse("substring", Box::new(changed_paths_fn))?,
         expected,
         "no unique ID, so take from pool of IDs (this one matched precisely)",
     );
@@ -327,7 +327,7 @@ fn branch_cannot_generate_id() -> anyhow::Result<()> {
         stack_id: None,
     }];
     assert_eq!(
-        id_map.parse("supersubstring", changed_paths_fn)?,
+        id_map.parse("supersubstring", Box::new(changed_paths_fn))?,
         expected,
         "'su' would collide with substring, so 'up' is chosen (this one matched precisely)"
     );
@@ -522,7 +522,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     uncommitted_hunks: [ i0 ]
     ");
 
-    insta::assert_debug_snapshot!(id_map.parse("0a", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("0a", Box::new(changed_paths_fn))?, @r#"
     [
         Commit {
             commit_id: Sha1(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a),
@@ -531,12 +531,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     ]
     "#);
     assert_eq!(
-        id_map.parse("0A", changed_paths_fn)?,
+        id_map.parse("0A", Box::new(changed_paths_fn))?,
         [],
         "the case matters for commits"
     );
 
-    insta::assert_debug_snapshot!(id_map.parse("h0", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("h0", Box::new(changed_paths_fn))?, @r#"
     [
         Branch {
             name: "h0",
@@ -546,12 +546,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     ]
     "#);
     assert_eq!(
-        id_map.parse("H0", changed_paths_fn)?,
+        id_map.parse("H0", Box::new(changed_paths_fn))?,
         [],
         "the case matters for branches"
     );
 
-    insta::assert_debug_snapshot!(id_map.parse("ln", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("ln", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -576,12 +576,12 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     ]
     "#);
     assert_eq!(
-        id_map.parse("LN", changed_paths_fn)?,
+        id_map.parse("LN", Box::new(changed_paths_fn))?,
         [],
         "the case matters for uncommitted files"
     );
 
-    insta::assert_debug_snapshot!(id_map.parse("0a:zt", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("0a:zt", Box::new(changed_paths_fn))?, @r#"
     [
         CommittedFile {
             commit_id: Sha1(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a),
@@ -591,7 +591,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
     ]
     "#);
     assert_eq!(
-        id_map.parse("0a:ZT", changed_paths_fn)?,
+        id_map.parse("0a:ZT", Box::new(changed_paths_fn))?,
         [],
         "the case matters for committed files"
     );
@@ -614,7 +614,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         };
 
     // Ambiguous ID returns every possible match
-    insta::assert_debug_snapshot!(id_map.parse("kp", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kp", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -659,7 +659,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
     ]
     "#);
 
-    insta::assert_debug_snapshot!(id_map.parse("kpo", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kpo", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -683,7 +683,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         ),
     ]
     "#);
-    insta::assert_debug_snapshot!(id_map.parse("kpr", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kpr", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -726,7 +726,7 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
         };
 
     // Only the branch is returned
-    insta::assert_debug_snapshot!(id_map.parse("kp", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kp", Box::new(changed_paths_fn))?, @r#"
     [
         Branch {
             name: "fookpfoo",
@@ -737,7 +737,7 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
     "#);
 
     // More characters must be specified to get the file
-    insta::assert_debug_snapshot!(id_map.parse("kpr", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kpr", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -780,7 +780,7 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
         };
 
     // "kp" would be sufficient (see the "id" field in the output), but "kpr" works too
-    insta::assert_debug_snapshot!(id_map.parse("kpr", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kpr", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -823,7 +823,7 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
         };
 
     // "klmxyz" does not have an autogenerated ID
-    insta::assert_debug_snapshot!(id_map.parse("kl", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("kl", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -868,7 +868,7 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
     // Both branches and uncommitted, unassigned files match by name, and none
     // have priority over the other (i.e. if there is both a branch and a file
     // that matches, the result is ambiguous).
-    insta::assert_debug_snapshot!(id_map.parse("foo", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("foo", Box::new(changed_paths_fn))?, @r#"
     [
         Branch {
             name: "foo",
@@ -918,7 +918,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         };
 
     // Short branch works
-    insta::assert_debug_snapshot!(id_map.parse("gg@{stack}:assigned", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("gg@{stack}:assigned", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -946,7 +946,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
     "#);
 
     // Long branch works
-    insta::assert_debug_snapshot!(id_map.parse("gggg@{stack}:assigned", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("gggg@{stack}:assigned", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -974,7 +974,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
     "#);
 
     // Unassigned works
-    insta::assert_debug_snapshot!(id_map.parse("zz:unassigned", changed_paths_fn)?, @r#"
+    insta::assert_debug_snapshot!(id_map.parse("zz:unassigned", Box::new(changed_paths_fn))?, @r#"
     [
         Uncommitted(
             UncommittedCliId {
@@ -1023,10 +1023,10 @@ fn committed_files_are_deduplicated_by_commit_oid_path() -> anyhow::Result<()> {
         };
 
     // Verify we can look up both files both by ID and filename
-    assert!(id_map.parse("02:uv", changed_paths_fn)?.len() == 1);
-    assert!(id_map.parse("02:xw", changed_paths_fn)?.len() == 1);
-    assert!(id_map.parse("02:file.txt", changed_paths_fn)?.len() == 1);
-    assert!(id_map.parse("02:other.txt", changed_paths_fn)?.len() == 1);
+    assert!(id_map.parse("02:uv", Box::new(changed_paths_fn))?.len() == 1);
+    assert!(id_map.parse("02:xw", Box::new(changed_paths_fn))?.len() == 1);
+    assert!(id_map.parse("02:file.txt", Box::new(changed_paths_fn))?.len() == 1);
+    assert!(id_map.parse("02:other.txt", Box::new(changed_paths_fn))?.len() == 1);
 
     Ok(())
 }
@@ -1144,15 +1144,37 @@ mod util {
             DebugState { inner: self }
         }
 
+        /// Return a list of all branch CliIds.
+        pub fn branch_ids(&self) -> Vec<String> {
+            let mut short_ids = Vec::new();
+            for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
+                for segment_with_id in stack_with_id.segments.iter() {
+                    short_ids.push(segment_with_id.short_id.clone());
+                }
+            }
+            short_ids
+        }
+
+        /// Return a list of all commit CliIds.
+        pub fn commit_ids(&self) -> Vec<String> {
+            let mut short_ids = Vec::new();
+            for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
+                for segment_with_id in stack_with_id.segments.iter() {
+                    for workspace_commit_with_id in segment_with_id.workspace_commits.iter() {
+                        short_ids.push(workspace_commit_with_id.short_id.clone());
+                    }
+                    for remote_commit_with_id in segment_with_id.remote_commits.iter() {
+                        short_ids.push(remote_commit_with_id.short_id.clone());
+                    }
+                }
+            }
+            short_ids
+        }
+
         /// Return a sorted list of all CliIds we can provide, excluding unassigned.
         pub fn all_ids(&self) -> Vec<CliId> {
             let IdMap {
-                indexed_stacks,
-                branch_name_to_cli_id,
-                // All branch IDs are already obtained from
-                // `branch_name_to_cli_id`, so we don't need the keys in
-                // `branch_auto_id_to_cli_id`.
-                branch_auto_id_to_cli_id: _,
+                indexed_stacks: _,
                 stack_ids,
                 unassigned: _,
                 uncommitted_files,
@@ -1164,31 +1186,20 @@ mod util {
                 bail!("unexpected IDs {} {:?}", commit_id, parent_id);
             };
 
-            branch_name_to_cli_id
-                .values()
-                .chain(stack_ids.values())
-                .map(|id| id.to_short_string())
-                .chain(
-                    indexed_stacks
-                        .borrow_dependent()
-                        .workspace_commits
-                        .values()
-                        .map(|workspace_commit| workspace_commit.short_id.clone()),
-                )
-                .chain(
-                    indexed_stacks
-                        .borrow_dependent()
-                        .remote_commits
-                        .values()
-                        .map(|remote_commit| remote_commit.short_id.clone()),
-                )
+            self.branch_ids()
+                .into_iter()
+                .chain(stack_ids.values().map(|id| id.to_short_string()))
+                .chain(self.commit_ids())
                 .chain(
                     uncommitted_files
                         .values()
                         .map(|uncommitted_file| uncommitted_file.short_id.clone()),
                 )
                 .chain(uncommitted_hunks.keys().cloned())
-                .flat_map(|id| self.parse(&id, changed_paths_fn).expect("BUG: valid ID means no error"))
+                .flat_map(|id| {
+                    self.parse(&id, Box::new(changed_paths_fn))
+                        .expect("BUG: valid ID means no error")
+                })
                 .sorted_by(id_cmp)
                 .collect()
         }
@@ -1203,23 +1214,14 @@ mod util {
             use itertools::Itertools;
             let IdMap {
                 indexed_stacks: _,
-                branch_name_to_cli_id,
-                // All branch IDs are already obtained from
-                // `branch_name_to_cli_id`, so we don't need to print the keys
-                // in `branch_auto_id_to_cli_id`.
-                branch_auto_id_to_cli_id: _,
                 stack_ids,
                 unassigned: _,
                 uncommitted_files,
                 uncommitted_hunks,
             } = self.inner;
-            let commits_count = self.inner.workspace_and_remote_commit_ids().count();
+            let commits_count = self.inner.commit_ids().len();
             writeln!(f, "workspace_and_remote_commits_count: {}", &commits_count)?;
-            id_list_if_not_empty(
-                f,
-                "branches",
-                branch_name_to_cli_id.values().map(|id| id.to_short_string()).sorted(),
-            )?;
+            id_list_if_not_empty(f, "branches", self.inner.branch_ids().into_iter().sorted())?;
             id_list_if_not_empty(
                 f,
                 "uncommitted_files",


### PR DESCRIPTION
Why I'm not automerging: in case someone thinks this is a bad refactor, or has ideas on how to better write some parts (I basically put lifetimes wherever the compiler told me to).

I think this is a much better way to architect the parsing of CLI IDs, but I had to fight the lifetime checker a lot (hopefully I won). I'll leave it here for one day to see if people have comments.