### PR TITLE
feat: add image drag-drop and paste support to codegen chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ name = "but-claude"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "but-action",
  "but-core",
  "but-ctx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 # TODO: is 'bundled' still needed?
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 backoff = "0.4.0"
+base64 = "0.22.1"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 gix = { version = "0.78.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [] }

--- a/apps/desktop/src/components/codegen/AttachmentList.svelte
+++ b/apps/desktop/src/components/codegen/AttachmentList.svelte
@@ -32,6 +32,8 @@
 				return `${attachment.commitId}`;
 			case 'directory':
 				return `${attachment.path}`;
+			case 'image':
+				return `${attachment.name}`;
 		}
 		return '';
 	}
@@ -105,6 +107,17 @@
 							{path}
 						</span>
 					{/if}
+					<!-- IMAGE -->
+					{#if attachment.type === 'image'}
+						<img
+							src="data:{attachment.mimeType};base64,{attachment.base64}"
+							alt={attachment.name}
+							class="image-thumbnail"
+						/>
+						<span class="path">
+							{attachment.name}
+						</span>
+					{/if}
 				</div>
 			</Tooltip>
 
@@ -161,6 +174,13 @@
 	.commit-badge {
 		color: var(--clr-text-3);
 		white-space: nowrap;
+	}
+
+	.image-thumbnail {
+		width: 20px;
+		height: 20px;
+		object-fit: cover;
+		border-radius: 2px;
 	}
 
 	.remove-button {

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -8,7 +8,8 @@ export type PromptAttachment =
 	| { type: 'lines'; path: string; start: number; end: number; commitId?: string }
 	| { type: 'commit'; commitId: string }
 	| { type: 'directory'; path: string }
-	| { type: 'folder'; path: string };
+	| { type: 'folder'; path: string }
+	| { type: 'image'; name: string; base64: string; mimeType: string };
 
 /**
  * Result of checking Claude Code availability

--- a/crates/but-claude/Cargo.toml
+++ b/crates/but-claude/Cargo.toml
@@ -27,6 +27,7 @@ gitbutler-project.workspace = true
 gitbutler-branch-actions.workspace = true
 
 anyhow.workspace = true
+base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true

--- a/crates/but-claude/src/legacy.rs
+++ b/crates/but-claude/src/legacy.rs
@@ -87,6 +87,7 @@ pub enum PromptAttachment {
     Lines(LinesAttachment),
     File(FileAttachment),
     Commit(CommitAttachment),
+    Image(ImageAttachment),
 }
 
 impl From<PromptAttachment> for crate::PromptAttachment {
@@ -95,6 +96,25 @@ impl From<PromptAttachment> for crate::PromptAttachment {
             PromptAttachment::Lines(lines) => crate::PromptAttachment::Lines(lines.into()),
             PromptAttachment::File(file) => crate::PromptAttachment::File(file.into()),
             PromptAttachment::Commit(commit) => crate::PromptAttachment::Commit(commit.into()),
+            PromptAttachment::Image(image) => crate::PromptAttachment::Image(image.into()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageAttachment {
+    name: String,
+    base64: String,
+    mime_type: String,
+}
+
+impl From<ImageAttachment> for crate::ImageAttachment {
+    fn from(value: ImageAttachment) -> Self {
+        crate::ImageAttachment {
+            name: value.name,
+            base64: value.base64,
+            mime_type: value.mime_type,
         }
     }
 }

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -141,6 +141,14 @@ pub struct CommitAttachment {
     commit_id: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageAttachment {
+    pub name: String,
+    pub base64: String,
+    pub mime_type: String,
+}
+
 /// Represents a file attachment with full content (used in API input).
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", tag = "type")]
@@ -148,6 +156,7 @@ pub enum PromptAttachment {
     Lines(LinesAttachment),
     File(FileAttachment),
     Commit(CommitAttachment),
+    Image(ImageAttachment),
 }
 
 /// Raw output from Claude API

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -156,6 +156,10 @@ export { default as FilePlugin } from '$lib/richText/plugins/FilePlugin.svelte';
 export { default as PlainTextPastePlugin } from '$lib/richText/plugins/PlainTextPastePlugin.svelte';
 export { default as UpDownPlugin } from '$lib/richText/plugins/UpDownPlugin.svelte';
 export {
+	default as FileUploadPlugin,
+	type DropFileResult
+} from '$lib/richText/plugins/FileUpload.svelte';
+export {
 	default as Mention,
 	type MentionSuggestion,
 	type MentionSuggestionUpdate


### PR DESCRIPTION
## Summary

- Users can now **drag-drop or paste images** (PNG, JPG, GIF, WebP, SVG, BMP) into the Claude Code chat input
- Images appear as thumbnails in the attachment list, matching how other attachments (files, commits) work
- On submit, images are decoded from base64, written to temp files, and Claude is instructed to use its Read tool to view them (since the SDK is text-only)
- Includes a **5MB size limit** per image with a toast notification for oversized files

## How it works

Since `claude_agent_sdk_rs` only exposes `client.query(&str)` (text-only), images can't be sent as native multimodal content blocks. Instead:

1. **Frontend**: Images are converted to base64 and stored in the attachment service
2. **Backend**: On submit, base64 is decoded, written to a temp file at `{tmp}/gitbutler-images/{uuid}.{ext}`, and the message tells Claude the file path so it can use its `Read` tool to view it

## Screenshot

> Example: user pastes a screenshot and asks Claude to fix a UI issue based on the image

<img width="520" height="250" alt="Gitbutler_image_upload" src="https://github.com/user-attachments/assets/45b07144-f2c1-4e73-a2d7-8901152c575b" />

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/lib/codegen/types.ts` | Add `image` variant to `PromptAttachment` |
| `packages/ui/src/lib/index.ts` | Export `FileUploadPlugin` |
| `apps/desktop/src/components/codegen/CodegenInput.svelte` | Wire `FileUpload` plugin, implement `handleFileDrop` |
| `apps/desktop/src/components/codegen/AttachmentList.svelte` | Render image thumbnails |
| `crates/but-claude/src/lib.rs` | Add `Image(ImageAttachment)` to enum |
| `crates/but-claude/src/legacy.rs` | Add `Image` variant + `From` impl |
| `crates/but-claude/src/session.rs` | Handle image in `validate_attachment` and `format_message_with_attachments` |
| `Cargo.toml` / `crates/but-claude/Cargo.toml` | Add `base64` dependency |

## Test plan

- [ ] Drag a PNG/JPG from Finder into the chat input — appears as thumbnail in attachment list
- [ ] Copy an image (e.g., Cmd+Shift+4 screenshot), paste into chat — appears as attachment
- [ ] Send a message with an image attached — Claude can view the image via Read tool
- [ ] Click X on image attachment to remove it
- [ ] Try a >5MB image — shows error toast
- [ ] Verify existing attachment types (file, commit, lines, directory) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)