### PR TITLE
but: Improve authentication check before PR creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "but-cursor",
  "but-db",
  "but-forge",
+ "but-forge-storage",
  "but-gerrit",
  "but-github",
  "but-gitlab",

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -8,10 +8,10 @@ mod db;
 mod review;
 pub use ci::{CiCheck, CiConclusion, CiOutput, CiStatus, ci_checks_for_ref_with_cache};
 pub use review::{
-    CacheConfig, CreateForgeReviewParams, ForgeReview, ForgeReviewDescriptionUpdate, ForgeReviewFilter,
-    ReviewTemplateFunctions, available_review_templates, create_forge_review, get_forge_review,
-    get_review_template_functions, list_forge_reviews_for_branch, list_forge_reviews_with_cache,
-    update_review_description_tables,
+    CacheConfig, CreateForgeReviewParams, ForgeAccountValidity, ForgeReview, ForgeReviewDescriptionUpdate,
+    ForgeReviewFilter, ReviewTemplateFunctions, available_review_templates, check_forge_account_is_valid,
+    create_forge_review, get_forge_review, get_review_template_functions, list_forge_reviews_for_branch,
+    list_forge_reviews_with_cache, update_review_description_tables,
 };
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -57,6 +57,7 @@ but-rebase.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
 but-forge.workspace = true
+but-forge-storage.workspace = true
 but-workspace = { workspace = true }
 but-api = { workspace = true, features = ["path-bytes"] }
 but-graph.workspace = true


### PR DESCRIPTION
Based on which forge is associated with the target branch, check whether there's a correctly authenticated account.

Before, the check logic would allow for false positives as we were checking wether there were **any** accounts authenticated.
If the user had GitLab accounts, but would try to open a PR on GitHub, the check wouldn't have caught that.