### PR TITLE
fix(stack-service): normalize commit stats shape

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1175,10 +1175,11 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 				],
 				transformResponse(rsp: CommitDetails) {
 					const changes = changesAdapter.addMany(changesAdapter.getInitialState(), rsp.changes);
+					const stats = rsp.stats;
 					return {
 						changes: changes,
 						details: rsp.commit,
-						stats: rsp.stats,
+						stats,
 						conflictEntries: rsp.conflictEntries
 							? new ConflictEntries(
 									rsp.conflictEntries.ancestorEntries,

--- a/crates/but-core/src/diff/commit_details.rs
+++ b/crates/but-core/src/diff/commit_details.rs
@@ -13,6 +13,7 @@ pub struct CommitDetails {
 
 /// Line statistics obtained from diffing the blobs of one or more [TreeChange](crate::TreeChange).
 #[derive(Default, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LineStats {
     /// The total amount of lines added in the between blobs of the two trees.
     pub lines_added: u64,


### PR DESCRIPTION
<img width="446" height="288" alt="Screenshot 2026-02-16 at 15 24 47" src="https://github.com/user-attachments/assets/fb40175b-63b2-4c60-85f5-9af02ad0d231" />

The statistics for commits were not visible because the backend keys were in snake_case format, while the UI expected camelCase.