### PR TITLE
Be oh-so-inclusive with the review terminology

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -531,10 +531,10 @@ pub enum Subcommands {
         id: String,
     },
 
-    /// Commands for creating and managing pull requests on a forge.
+    /// Commands for creating and managing reviews on a forge, e.g. GitHub PRs or GitLab MRs.
     ///
     /// If you are authenticated with a forge using `but config forge auth`, you can use
-    /// the `but pr` commands to create pull requests (or merge requests) on
+    /// the `but pr` or `but mr` commands to create pull requests (or merge requests) on
     /// the remote repository for your branches.
     ///
     /// Running `but pr` without a subcommand defaults to `but pr new`, which

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -805,15 +805,14 @@ async fn match_subcommand(
                 }) => {
                     // Read message content from file or inline
                     let message_content = match &file {
-                        Some(path) => Some(
-                            std::fs::read_to_string(path)
-                                .with_context(|| format!("Failed to read PR message from file: {}", path.display()))?,
-                        ),
+                        Some(path) => Some(std::fs::read_to_string(path).with_context(|| {
+                            format!("Failed to read forge review message from file: {}", path.display())
+                        })?),
                         None => message.clone(),
                     };
                     // Parse early to fail fast on invalid content
-                    let pr_message = match message_content {
-                        Some(content) => Some(command::legacy::forge::review::parse_pr_message(&content)?),
+                    let review_message = match message_content {
+                        Some(content) => Some(command::legacy::forge::review::parse_review_message(&content)?),
                         None => None,
                     };
                     // Check for non-interactive environment
@@ -821,36 +820,36 @@ async fn match_subcommand(
                         if branch.is_none() {
                             anyhow::bail!("Non-interactive environment detected. Please specify a branch.");
                         }
-                        if pr_message.is_none() && !default {
+                        if review_message.is_none() && !default {
                             anyhow::bail!(
                                 "Non-interactive environment detected. Provide one of: --message (-m), --file (-F), or --default (-t)."
                             );
                         }
                     }
-                    command::legacy::forge::review::create_pr(
+                    command::legacy::forge::review::create_review(
                         &mut ctx,
                         branch,
                         skip_force_push_protection,
                         with_force,
                         run_hooks,
                         default,
-                        pr_message,
+                        review_message,
                         out,
                     )
                     .await
-                    .context("Failed to create PR for branch.")
+                    .context("Failed to create forge review for branch.")
                     .emit_metrics(metrics_ctx)
                 }
                 Some(forge::pr::Subcommands::Template { template_path }) => {
                     command::legacy::forge::review::set_review_template(&mut ctx, template_path, out)
-                        .context("Failed to set PR template.")
+                        .context("Failed to set forge review template.")
                         .emit_metrics(metrics_ctx)
                 }
                 None => {
                     // Default to `pr new` when no subcommand is provided
-                    command::legacy::forge::review::create_pr(&mut ctx, None, false, true, true, false, None, out)
+                    command::legacy::forge::review::create_review(&mut ctx, None, false, true, true, false, None, out)
                         .await
-                        .context("Failed to create PR for branch.")
+                        .context("Failed to create forge review for branch.")
                         .emit_metrics(metrics_ctx)
                 }
             }


### PR DESCRIPTION
Since we support both PRs and MRs, use the term review instead of PRs.
GitLab butizens have the same rights as we do.