### PR TITLE
fix(sync-button): prevent time-ago casing flicker

### DIFF
--- a/apps/desktop/src/components/SyncButton.svelte
+++ b/apps/desktop/src/components/SyncButton.svelte
@@ -49,11 +49,11 @@
 		}
 	}}
 >
-	<span class="capitalize">
+	<span>
 		{#if loading}
 			Fetching...
 		{:else if lastFetched}
-			<TimeAgo date={lastFetched} addSuffix={true} />
+			<TimeAgo date={lastFetched} addSuffix={true} capitalize={true} />
 		{:else}
 			Refetch
 		{/if}

--- a/packages/ui/src/lib/components/TimeAgo.svelte
+++ b/packages/ui/src/lib/components/TimeAgo.svelte
@@ -6,19 +6,26 @@
 		date?: Date;
 		addSuffix?: boolean;
 		showTooltip?: boolean;
+		capitalize?: boolean;
 	}
 
-	const { date, addSuffix, showTooltip = true }: Props = $props();
+	const { date, addSuffix, showTooltip = true, capitalize = false }: Props = $props();
 	const store = $derived(createTimeAgoStore(date, addSuffix));
 	const absoluteTime = $derived(date ? getAbsoluteTimestamp(date) : '');
+
+	function formatText(value: string | undefined): string {
+		if (!value) return '';
+		if (!capitalize) return value;
+		return `${value[0].toUpperCase()}${value.slice(1)}`;
+	}
 </script>
 
 {#if store}
 	{#if showTooltip && date}
 		<Tooltip text={absoluteTime}>
-			<span>{$store}</span>
+			<span>{formatText($store)}</span>
 		</Tooltip>
 	{:else}
-		{$store}
+		{formatText($store)}
 	{/if}
 {/if}


### PR DESCRIPTION
<img width="561" height="342" alt="image" src="https://github.com/user-attachments/assets/97425e89-6718-4897-8e33-9776dbb3ddd1" />
<img width="534" height="308" alt="image" src="https://github.com/user-attachments/assets/73812407-90f3-434f-b66e-946407612c22" />

---

**Summary**
This PR fixes a UI flicker where the sync timestamp briefly rendered in lowercase and then appeared capitalized.

**Root Cause**
The text from TimeAgo is lowercase by design, while SyncButton was applying capitalization via CSS (first-letter transform). During render/hydration updates, lowercase content could paint before the style transform became visible.