### PR TITLE
Enable `@typescript-eslint/no-unnecessary-type-assertion`

### DIFF
--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -226,7 +226,7 @@ export function formatMessages(
 			} else if (payload.data.type === 'user') {
 				const content = payload.data.message.content;
 				if (Array.isArray(content) && content[0]!.type === 'tool_result') {
-					const result = content[0]!;
+					const result = content[0];
 
 					// Check if this is a response to an AskUserQuestion
 					const askMessage = askUserQuestionToolCalls[result.tool_use_id];

--- a/apps/desktop/src/lib/irc/parser.ts
+++ b/apps/desktop/src/lib/irc/parser.ts
@@ -472,7 +472,7 @@ export function parseIRCMessage(line: string): IrcMessage {
 	}
 
 	return {
-		command: command as IrcMessage['command'],
+		command: command,
 		tags,
 		prefix,
 		params,

--- a/apps/desktop/src/lib/prompt/promptService.ts
+++ b/apps/desktop/src/lib/prompt/promptService.ts
@@ -109,7 +109,7 @@ export class PromptService {
 									abortHandle.abort('timeout');
 									return null;
 								})
-							: <Promise<string | null>>new Promise(() => null)
+							: new Promise<string | null>(() => null)
 					])
 			)
 		);

--- a/apps/desktop/src/lib/utils/codegenTools.ts
+++ b/apps/desktop/src/lib/utils/codegenTools.ts
@@ -172,7 +172,7 @@ function formatAskUserQuestion(input: Record<string, any>): string {
 		.filter(Boolean);
 	const count = questionTexts.length;
 	if (count === 1) {
-		return `Question: ${truncate(questionTexts[0]!, 160)}`;
+		return `Question: ${truncate(questionTexts[0], 160)}`;
 	}
 	const joined = questionTexts.join('; ');
 	return `Questions (${count}): ${truncate(joined, 240)}`;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,7 @@ export default ts.config(
 			'@typescript-eslint/return-await': ['error', 'always'],
 			'@typescript-eslint/promise-function-async': 'error',
 			'@typescript-eslint/await-thenable': 'error',
+			'@typescript-eslint/no-unnecessary-type-assertion': 'error',
 
 			eqeqeq: ['error', 'always'],
 			'import-x/no-cycle': 'error',

--- a/packages/no-relative-imports/src/paths.ts
+++ b/packages/no-relative-imports/src/paths.ts
@@ -117,7 +117,7 @@ export class ConfigPaths {
 			for (const target of relativePaths) {
 				if (!isHandledGlob(target)) continue;
 				const entry = new PathEntry(configDirectory, key, target);
-				this.paths[key]!.push(entry);
+				this.paths[key].push(entry);
 			}
 		}
 	}

--- a/packages/ui/src/lib/components/file/getFileIcon.ts
+++ b/packages/ui/src/lib/components/file/getFileIcon.ts
@@ -6,7 +6,7 @@ export function getFileIcon(fileName: string) {
 
 	// Check if fileName is directly an icon name
 	if (fileIcons[fileName]) {
-		return fileIcons[fileName] as string;
+		return fileIcons[fileName];
 	}
 
 	const splitName = fileName.split('.');
@@ -31,7 +31,7 @@ export function getFileIcon(fileName: string) {
 	}
 	let icon = fileIcons[iconName];
 	if (!icon) {
-		icon = fileIcons['document'] as string;
+		icon = fileIcons['document'];
 	}
 	return icon;
 }

--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -398,7 +398,7 @@ export class FocusManager {
 
 	private handleFModeInput(event: KeyboardEvent): boolean {
 		if (event.key === 'f' || event.key === 'F' || this.fModeManager.active) {
-			return this.fModeManager.handleKeypress(event, this.nodeMap, this.currentNode!);
+			return this.fModeManager.handleKeypress(event, this.nodeMap, this.currentNode);
 		}
 		return false;
 	}

--- a/packages/ui/src/lib/richText/linewrap.ts
+++ b/packages/ui/src/lib/richText/linewrap.ts
@@ -215,7 +215,7 @@ function updateParagraphsWithWrappedLines(
 
 	// Update the first paragraph with the first wrapped line
 	const children = paragraph.getChildren();
-	const firstTextNode = children.find((child) => isTextNode(child)) as TextNode | undefined;
+	const firstTextNode = children.find((child) => isTextNode(child));
 
 	if (firstTextNode) {
 		firstTextNode.setTextContent(wrappedLines[0]);
@@ -282,9 +282,9 @@ function repositionCursor(
 	}
 
 	// Navigate to the target paragraph
-	let currentPara: ParagraphNode | null = paragraph.getNextSibling() as ParagraphNode | null;
+	let currentPara: ParagraphNode | null = paragraph.getNextSibling();
 	for (let i = 1; i < targetLineIndex && currentPara; i++) {
-		currentPara = currentPara.getNextSibling() as ParagraphNode | null;
+		currentPara = currentPara.getNextSibling();
 	}
 
 	if (currentPara && $isParagraphNode(currentPara)) {

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -539,12 +539,12 @@ export type DiffLine = {
 export function encodeDiffLineRange(lineSelection: DiffLine[]): DiffLineRange | undefined {
 	if (lineSelection.length === 0) return undefined;
 	if (lineSelection.length === 1)
-		return encodeSingleDiffLine(lineSelection[0]!.oldLine, lineSelection[0]!.newLine);
+		return encodeSingleDiffLine(lineSelection[0].oldLine, lineSelection[0].newLine);
 
-	const firstLine = encodeSingleDiffLine(lineSelection[0]!.oldLine, lineSelection[0]!.newLine);
+	const firstLine = encodeSingleDiffLine(lineSelection[0].oldLine, lineSelection[0].newLine);
 	const lastLine = encodeSingleDiffLine(
-		lineSelection[lineSelection.length - 1]!.oldLine,
-		lineSelection[lineSelection.length - 1]!.newLine
+		lineSelection[lineSelection.length - 1].oldLine,
+		lineSelection[lineSelection.length - 1].newLine
 	);
 
 	if (firstLine === undefined || lastLine === undefined) {
@@ -718,8 +718,8 @@ function computeBaseWordDiff(
 	// Loop through every line in the section
 	// We're only bothered with prev/next sections with equal # of lines changes
 	for (let i = 0; i < numberOfLines; i++) {
-		const oldLine = prevSection.lines[i] as Line;
-		const newLine = nextSection.lines[i] as Line;
+		const oldLine = prevSection.lines[i];
+		const newLine = nextSection.lines[i];
 		const prevSectionRow: BaseRow = {
 			encodedLineId: encodeDiffFileLine(
 				filename,
@@ -787,8 +787,8 @@ function computeBaseInlineWordDiff(
 	// Loop through every line in the section
 	// We're only bothered with prev/next sections with equal # of lines changes
 	for (let i = 0; i < numberOfLines; i++) {
-		const oldLine = prevSection.lines[i] as Line;
-		const newLine = nextSection.lines[i] as Line;
+		const oldLine = prevSection.lines[i];
+		const newLine = nextSection.lines[i];
 
 		const sectionRow: BaseRow = {
 			encodedLineId: encodeDiffFileLine(

--- a/packages/ui/tests/test-utils.ts
+++ b/packages/ui/tests/test-utils.ts
@@ -378,7 +378,7 @@ export async function isBrowserBusy(page: Page): Promise<boolean> {
 		// Check 3: Pending transitions
 		const allElements = document.querySelectorAll('*');
 		for (const el of Array.from(allElements)) {
-			const styles = window.getComputedStyle(el as Element);
+			const styles = window.getComputedStyle(el);
 			const transitionDuration = styles.transitionDuration;
 			if (transitionDuration && transitionDuration !== '0s') {
 				// Element might be transitioning


### PR DESCRIPTION
Extra type casts make our code less safe since they can silently introduce more run-time type errors.

This eslint rule removes casts that are superfluous.

It feels like an objectivly good change to help move us towards a safer code base.