### PR TITLE
Re-add `HexHash` to Request struct for `create_reference` call (#12354)

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -13,6 +13,8 @@ use tracing::instrument;
 pub mod create_reference {
     use serde::{Deserialize, Serialize};
 
+    use crate::json::HexHash;
+
     #[derive(Deserialize, Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct Request {
@@ -26,7 +28,7 @@ pub mod create_reference {
     #[serde(tag = "type", content = "subject", rename_all = "camelCase")]
     pub enum Anchor {
         AtCommit {
-            commit_id: gix::ObjectId,
+            commit_id: HexHash,
             position: but_workspace::branch::create_reference::Position,
         },
         AtReference {
@@ -51,7 +53,10 @@ pub fn create_reference(
         .map(|anchor| -> Result<_> {
             Ok(match anchor {
                 create_reference::Anchor::AtCommit { commit_id, position } => {
-                    but_workspace::branch::create_reference::Anchor::AtCommit { commit_id, position }
+                    but_workspace::branch::create_reference::Anchor::AtCommit {
+                        commit_id: commit_id.into(),
+                        position,
+                    }
                 }
                 create_reference::Anchor::AtReference { short_name, position } => {
                     but_workspace::branch::create_reference::Anchor::AtSegment {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use branch::Subcommands;
+use but_api::json::HexHash;
 use but_core::ref_metadata::StackId;
 use colored::Colorize;
 
@@ -83,7 +84,7 @@ pub fn handle(cmd: Option<Subcommands>, ctx: &mut but_ctx::Context, out: &mut Ou
                 match anchor_id {
                     CliId::Commit { commit_id: oid, .. } => {
                         Some(but_api::legacy::stack::create_reference::Anchor::AtCommit {
-                            commit_id: (*oid),
+                            commit_id: HexHash(*oid),
                             position: but_workspace::branch::create_reference::Position::Above,
                         })
                     }


### PR DESCRIPTION
This was changed by accident, and a way to prevent such mistakes in future would be to not add serde support to `gix` types.

Fixes #12354.
