### PR TITLE
fix: allow file scheme in open_that

### DIFF
--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -20,6 +20,7 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
         "windsurf",
         "cursor",
         "trae",
+        "file",
     ]
     .contains(&target_url.scheme())
     {


### PR DESCRIPTION
## 🧢 Changes
Follow-up on https://github.com/gitbutlerapp/gitbutler/pull/12352 Allows the `file` scheme in `open_that` so we can actually open paths that look like `file://<path>`.

Without this patch, you get the following error when trying to open the project in a file manager (and a very similar variation if show a file in a file manager):

```bash
[ERROR] Failed to open directory '/home/slarse/projects/gitbutler' in file manager

Caused by:
    1: Invalid path scheme: file
```

## Trivia
Hilariously, with this fix applied it opens [yazi](https://github.com/sxyazi/yazi) in the terminal I use to start the GitButler GUI, which is very confusing. But that's a config issue on my side and not something that I think can be "fixed". Just thought it was funny.

## 🎫 Affected issues

Fixes: #12272