### PR TITLE
Understand Sqlite Error 517 and fix stale read issue in `changes_in_worktree`

### DIFF
--- a/crates/but-db/tests/db/transaction.rs
+++ b/crates/but-db/tests/db/transaction.rs
@@ -1,5 +1,5 @@
 use but_db::{DbHandle, HunkAssignment};
-use rusqlite::ErrorCode;
+use rusqlite::{ErrorCode, ffi};
 
 #[test]
 fn deferred() -> anyhow::Result<()> {
@@ -70,6 +70,56 @@ fn immediate() -> anyhow::Result<()> {
         db2.immediate_transaction_nonblocking()?.is_some(),
         "now we get a transaction as the other lock is dropped"
     );
+    Ok(())
+}
+
+#[test]
+fn deferred_savepoint_write_after_concurrent_commit_returns_busy_snapshot() -> anyhow::Result<()> {
+    let (mut db1, mut db2, _tmp) = two_handles_same_db()?;
+
+    // Start two deferred transactions and establish a read snapshot in t2.
+    let mut t1 = db1.transaction()?;
+    let mut t2 = db2.transaction()?;
+    assert_eq!(t2.hunk_assignments().list_all()?, vec![]);
+
+    // Write through a savepoint in t1 and commit the outer transaction.
+    let assignments = vec![HunkAssignment {
+        id: None,
+        hunk_header: None,
+        path: "from_t1".into(),
+        path_bytes: vec![],
+        stack_id: None,
+    }];
+    t1.hunk_assignments_mut()?.set_all(assignments.clone())?;
+    t1.commit()?;
+
+    // t2 tries to write through a savepoint using its stale read snapshot.
+    let err = t2
+        .hunk_assignments_mut()?
+        .set_all(assignments.clone())
+        .expect_err("stale read snapshot cannot be promoted to writer");
+    assert_eq!(err.sqlite_error_code(), Some(ErrorCode::DatabaseBusy));
+    assert_eq!(
+        err.sqlite_error().map(|err| err.extended_code),
+        Some(ffi::SQLITE_BUSY_SNAPSHOT),
+        "expected BUSY_SNAPSHOT extended code for stale snapshot write-upgrade"
+    );
+
+    assert_eq!(
+        t2.hunk_assignments().list_all()?,
+        vec![],
+        "A savepoint rollback does not refresh the outer transaction snapshot."
+    );
+
+    // Recovery requires a fresh transaction.
+    drop(t2);
+    let t2 = db2.transaction()?;
+    assert_eq!(
+        t2.hunk_assignments().list_all()?,
+        assignments,
+        "now the prior write is observable"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
I'd think that somehow this call gets interleaved with other calls that also read or write parts of the database, and *maybe* the granularity of this is global, not local.
In any case, stale reads are only a problem for writers that perform reads before their writes.