### PR TITLE
ci(linux): sign standalone but binary

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -190,7 +190,7 @@ jobs:
             gir1.2-javascriptcoregtk-4.1="$webkit_version" \
             gir1.2-webkit2-4.1="$webkit_version";
 
-      - uses: actions/download-artifact@v7.0.0
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         name: Download SvelteKit build output
         with:
           name: sveltekit-build
@@ -266,7 +266,7 @@ jobs:
         shell: bash
         run: rm -rf release
       - name: Download unsigned artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
           path: release
@@ -296,7 +296,7 @@ jobs:
         shell: bash
         run: rm -rf release
       - name: Download ev-signed artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
           path: release
@@ -349,7 +349,7 @@ jobs:
         shell: bash
         run: rm -rf release
       - name: Download unsigned artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
           path: release
@@ -413,7 +413,7 @@ jobs:
             echo "artifact_suffix=" >> $GITHUB_ENV
           fi
       - name: Download artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}${{ env.artifact_suffix }}-${{ github.run_number }}'
           path: release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -333,8 +333,54 @@ jobs:
           if-no-files-found: error
           overwrite: true
 
+  sign-but:
+    needs: build-tauri
+    runs-on: ubuntu-latest
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # we currently only run this for Linux builds, as we only publish a standalone but binary for those
+          - platform: ubuntu-22.04 # [linux, x64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
+    steps:
+      - name: Clean artifact directory
+        shell: bash
+        run: rm -rf release
+      - name: Download unsigned artifacts
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          path: release
+      - name: Sign but binary with minisign
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get install -y minisign
+          but_file=$(find release -name "but" -type f -printf '%P\n')
+
+          echo "sign release/$but_file"
+          timestamp=$(date +%s)
+          TRUSTED_COMMENT="timestamp:$timestamp	file:$but_file"
+          UNTRUSTED_COMMENT="signature from tauri secret key"
+          echo "${{ secrets.TAURI_PRIVATE_KEY }}" | base64 -d > minisign.key
+          echo "${{ secrets.TAURI_KEY_PASSWORD }}" | minisign -S -s minisign.key -t "$TRUSTED_COMMENT" -c "$UNTRUSTED_COMMENT" -m "release/$but_file"
+
+          # there's no particularly good reason to base64 encode this file given its current usage, we do it only to
+          # be consistent with how we treat signatures (which are always base64 encoded at present)
+          base64 -w 0 < "release/$but_file.minisig" > "release/$but_file.sig"
+          rm "release/$but_file.minisig"
+          rm minisign.key
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          path: release/
+          if-no-files-found: error
+          overwrite: true
+
   publish-tauri:
-    needs: [sign-tauri, build-tauri]
+    needs: [sign-tauri, sign-but, build-tauri]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ env.version }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -326,8 +326,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.install_script == 'true' || needs.changes.outputs.but_installer == 'true' }}
     runs-on: ubuntu-22.04
-    permissions:
-      contents: none
+    permissions: {}
     outputs:
       release_version: ${{ steps.fetch.outputs.release_version }}
       nightly_version: ${{ steps.fetch.outputs.nightly_version }}


### PR DESCRIPTION
CI job to sign the standalone Linux `but` binary with minisig and upload it as a base64 encoded file `but.sig` alongside `but`. The installer will find this file by convention.

There's no particularly compelling reason to base64 encode the signature, I'm just doing it here to follow suit with everything else. If we ever want to show it in an API, it is nice to already have it base64-encoded as well.

For macOS installer, the signature exposed in the API is precisely what we need as we're installing the entire Tauri app.

For Linux, the API shows only the AppImage signature, which does not help. As such, we need a new signature. Instead of messing with the API that's been tailored to Tauri purposes (we need to redo it at some point), I figured we'd just upload the signature as a file for the time being and figure out the API later. For security reasons it's good to have the signature in a completely separate location from the binary itself as that would require an attacker to compromise _two_ locations, so we should aim for that. But for now, this is perfectly fine.