### PR TITLE
feat(ui): add configurable diff and UI font sizing

### DIFF
--- a/apps/desktop/src/components/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/AiCredentialCheck.svelte
@@ -326,7 +326,7 @@
 		border: none;
 		background: none;
 		color: var(--clr-text-2);
-		font-size: 11px;
+		font-size: calc(11px * var(--ui-font-scale, 1));
 		text-decoration: underline dotted;
 		cursor: pointer;
 	}

--- a/apps/desktop/src/components/AppUpdater.svelte
+++ b/apps/desktop/src/components/AppUpdater.svelte
@@ -343,12 +343,12 @@
 
 		& :global(h1) {
 			margin-top: 6px;
-			font-size: 15px;
+			font-size: calc(15px * var(--ui-font-scale, 1));
 		}
 
 		& :global(h2) {
 			margin-top: 6px;
-			font-size: 13px;
+			font-size: calc(13px * var(--ui-font-scale, 1));
 		}
 	}
 

--- a/apps/desktop/src/components/CommitDetails.svelte
+++ b/apps/desktop/src/components/CommitDetails.svelte
@@ -126,13 +126,13 @@
 		color: var(--clr-text-2);
 
 		& .divider {
-			font-size: 12px;
+			font-size: calc(12px * var(--ui-font-scale, 1));
 			opacity: 0.4;
 		}
 	}
 
 	.description {
-		font-size: 13px;
+		font-size: calc(13px * var(--ui-font-scale, 1));
 		line-height: var(--text-lineheight-body);
 		font-family: var(--commit-message-font);
 		white-space: pre-line;

--- a/apps/desktop/src/components/CommitFailedFileEntry.svelte
+++ b/apps/desktop/src/components/CommitFailedFileEntry.svelte
@@ -62,6 +62,7 @@
 								tabSize={$userSettings.tabSize}
 								wrapText={$userSettings.wrapText}
 								diffFont={$userSettings.diffFont}
+								diffFontSize={$userSettings.diffFontSize}
 								diffLigatures={$userSettings.diffLigatures}
 								strongContrast={$userSettings.strongContrast}
 								colorBlindFriendly={$userSettings.colorBlindFriendly}

--- a/apps/desktop/src/components/IrcMessages.svelte
+++ b/apps/desktop/src/components/IrcMessages.svelte
@@ -48,6 +48,7 @@
 							filePath={change.path}
 							hunkStr={diff.diff}
 							diffLigatures={$userSettings.diffLigatures}
+							diffFontSize={$userSettings.diffFontSize}
 							tabSize={$userSettings.tabSize}
 							wrapText={$userSettings.wrapText}
 							diffFont={$userSettings.diffFont}

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -224,6 +224,7 @@
 							stagedLines={selection.current.lines}
 							{lineLocks}
 							diffLigatures={$userSettings.diffLigatures}
+							diffFontSize={$userSettings.diffFontSize}
 							tabSize={$userSettings.tabSize}
 							wrapText={$userSettings.wrapText}
 							diffFont={$userSettings.diffFont}

--- a/apps/desktop/src/components/ZoomInOutMenuAction.svelte
+++ b/apps/desktop/src/components/ZoomInOutMenuAction.svelte
@@ -19,6 +19,10 @@
 		document.documentElement.style.fontSize = zoom + 'rem';
 	}
 
+	function setDomFontScale(scale: number) {
+		document.documentElement.style.setProperty('--ui-font-scale', String(scale));
+	}
+
 	function updateZoom(newZoom: number) {
 		zoom = Math.min(Math.max(newZoom, MIN_ZOOM), MAX_ZOOM);
 		setDomZoom(zoom);
@@ -38,6 +42,10 @@
 			})
 		)
 	);
+
+	$effect(() => {
+		setDomFontScale($userSettings.uiFontScale);
+	});
 
 	onMount(() => {
 		if (zoom !== DEFAULT_ZOOM) {

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -94,7 +94,7 @@
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-2);
 		color: var(--clr-text-2);
-		font-size: 12px;
+		font-size: calc(12px * var(--ui-font-scale, 1));
 		font-family: var(--font-mono);
 	}
 </style>

--- a/apps/desktop/src/components/profileSettings/CliSymLink.svelte
+++ b/apps/desktop/src/components/profileSettings/CliSymLink.svelte
@@ -46,7 +46,7 @@
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-muted);
 		color: var(--clr-text-1);
-		font-size: 12px;
+		font-size: calc(12px * var(--ui-font-scale, 1));
 		font-family: var(--font-mono);
 		word-break: break-all;
 	}

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -49,6 +49,38 @@
 
 <CardGroup.Item alignment="center" standalone>
 	{#snippet title()}
+		UI font size
+	{/snippet}
+	{#snippet caption()}
+		Font size scaling is global.
+		<br />
+		Layout and inter-element spacing remain consistent.
+	{/snippet}
+	{#snippet actions()}
+		<Textbox
+			type="number"
+			width={106}
+			textAlign="center"
+			value={Math.round($userSettings.uiFontScale * 100).toString()}
+			minVal={75}
+			maxVal={150}
+			showCountActions
+			onchange={(value: string) => {
+				const parsed = parseInt(value);
+				if (parsed) {
+					userSettings.update((s) => ({
+						...s,
+						uiFontScale: parsed / 100
+					}));
+				}
+			}}
+			placeholder="100"
+		/>
+	{/snippet}
+</CardGroup.Item>
+
+<CardGroup.Item alignment="center" standalone>
+	{#snippet title()}
 		Default file list mode
 	{/snippet}
 	{#snippet caption()}
@@ -131,6 +163,7 @@
 			tabSize={$userSettings.tabSize}
 			wrapText={$userSettings.wrapText}
 			diffFont={$userSettings.diffFont}
+			diffFontSize={$userSettings.diffFontSize}
 			diffLigatures={$userSettings.diffLigatures}
 			strongContrast={$userSettings.strongContrast}
 			colorBlindFriendly={$userSettings.colorBlindFriendly}
@@ -174,6 +207,34 @@
 						diffLigatures: !$userSettings.diffLigatures
 					}));
 				}}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+
+	<CardGroup.Item alignment="center">
+		{#snippet title()}
+			Font size
+		{/snippet}
+		{#snippet caption()}
+			Font size in pixels for the diff view.
+		{/snippet}
+
+		{#snippet actions()}
+			<Textbox
+				type="number"
+				width={100}
+				textAlign="center"
+				value={$userSettings.diffFontSize.toString()}
+				minVal={8}
+				maxVal={24}
+				showCountActions
+				onchange={(value: string) => {
+					userSettings.update((s) => ({
+						...s,
+						diffFontSize: parseInt(value) || $userSettings.diffFontSize
+					}));
+				}}
+				placeholder={$userSettings.diffFontSize.toString()}
 			/>
 		{/snippet}
 	</CardGroup.Item>

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -281,7 +281,7 @@
 	/* HUNK DRAG */
 	.dragchip-hunk-container {
 		display: flex;
-		font-size: 12px;
+		font-size: calc(12px * var(--ui-font-scale, 1));
 		font-family: var(--font-mono);
 	}
 

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -22,10 +22,12 @@ export interface Settings {
 	defaultFileWidth: number;
 	defaultTreeHeight: number;
 	zoom: number;
+	uiFontScale: number;
 	scrollbarVisibilityState: ScrollbarVisilitySettings;
 	tabSize: number;
 	wrapText: boolean;
 	diffFont: string;
+	diffFontSize: number;
 	diffLigatures: boolean;
 	inlineUnifiedDiffs: boolean;
 	strongContrast: boolean;
@@ -47,10 +49,12 @@ const defaults: Settings = {
 	defaultTreeHeight: 100,
 	stashedBranchesHeight: 150,
 	zoom: 1,
+	uiFontScale: 1,
 	scrollbarVisibilityState: 'scroll',
 	tabSize: 4,
 	wrapText: false,
 	diffFont: 'Geist Mono, Menlo, monospace',
+	diffFontSize: 12,
 	diffLigatures: false,
 	inlineUnifiedDiffs: false,
 	strongContrast: false,

--- a/apps/desktop/src/styles/styles.css
+++ b/apps/desktop/src/styles/styles.css
@@ -5,6 +5,48 @@
 	--dropzone-stroke: oklch(from var(--clr-theme-pop-element) l c h / 0.8);
 	--dropzone-fill-hover: oklch(from var(--clr-core-pop-50) l c h / 0.25);
 	--dropzone-stroke-hover: oklch(from var(--clr-theme-pop-element) l c h / 1);
+	--ui-font-scale: 1;
+}
+
+/* UI font scale overrides */
+.text-9 {
+	font-size: calc(0.563rem * var(--ui-font-scale));
+}
+.text-10 {
+	font-size: calc(0.625rem * var(--ui-font-scale));
+}
+.text-11 {
+	font-size: calc(0.6875rem * var(--ui-font-scale));
+}
+.text-12 {
+	font-size: calc(0.75rem * var(--ui-font-scale));
+}
+.text-13 {
+	font-size: calc(0.8125rem * var(--ui-font-scale));
+}
+.text-14 {
+	font-size: calc(0.875rem * var(--ui-font-scale));
+}
+.text-15 {
+	font-size: calc(0.938rem * var(--ui-font-scale));
+}
+.text-16 {
+	font-size: calc(1rem * var(--ui-font-scale));
+}
+.text-18 {
+	font-size: calc(1.125rem * var(--ui-font-scale));
+}
+.text-head-20 {
+	font-size: calc(1.25rem * var(--ui-font-scale));
+}
+.text-head-22 {
+	font-size: calc(1.375rem * var(--ui-font-scale));
+}
+.text-head-24 {
+	font-size: calc(1.5rem * var(--ui-font-scale));
+}
+.text-serif-42 {
+	font-size: calc(2.625rem * var(--ui-font-scale));
 }
 
 body {

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -149,7 +149,7 @@
 		class:textarea-unstyled={unstyled}
 		class:hide-scrollbar={measureElHeight < maxHeight}
 		style:height="{pxToRem(Math.max(measureElHeight, minHeight))}rem"
-		style:font-size="{pxToRem(fontSize)}rem"
+		style:font-size="calc({pxToRem(fontSize)}rem * var(--ui-font-scale, 1))"
 		style:border-top-width={borderTop && !borderless ? '1px' : '0'}
 		style:border-right-width={borderRight && !borderless ? '1px' : '0'}
 		style:border-bottom-width={borderBottom && !borderless ? '1px' : '0'}

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -24,6 +24,7 @@
 		tabSize?: number;
 		wrapText?: boolean;
 		diffFont?: string;
+		diffFontSize?: number;
 		diffLigatures?: boolean;
 		inlineUnifiedDiffs?: boolean;
 		strongContrast?: boolean;
@@ -47,6 +48,7 @@
 		tabSize = 4,
 		wrapText = true,
 		diffFont = 'var(--font-mono)',
+		diffFontSize = 12,
 		diffLigatures = true,
 		strongContrast = false,
 		colorBlindFriendly = false,
@@ -105,7 +107,7 @@
 	class="table__wrapper"
 	class:contrast-strong={strongContrast}
 	class:colorblind-friendly={colorBlindFriendly}
-	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
+	style="--tab-size: {tabSize}; --diff-font: {diffFont}; --diff-font-size: {diffFontSize}px;"
 	style:font-variant-ligatures={diffLigatures ? 'common-ligatures' : 'none'}
 >
 	{#if !draggingDisabled}
@@ -270,7 +272,7 @@
 		padding: 4px 6px;
 		border-bottom: 1px solid var(--clr-border-2);
 		color: var(--clr-diff-count-text);
-		font-size: 12px;
+		font-size: var(--diff-font-size, 12px);
 		text-wrap: nowrap;
 	}
 

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
@@ -178,7 +178,7 @@
 		padding-left: 4px;
 		border-bottom: 1px solid var(--clr-diff-count-border);
 		background-color: var(--clr-diff-count-bg);
-		font-size: 12px;
+		font-size: var(--diff-font-size, 12px);
 		line-height: 1.25;
 		text-wrap: wrap;
 		white-space: pre;
@@ -193,7 +193,7 @@
 		border-bottom: 1px solid var(--clr-diff-count-border);
 		background-color: var(--clr-diff-count-bg);
 		color: var(--clr-diff-count-text);
-		font-size: 11px;
+		font-size: calc(var(--diff-font-size, 12px) - 1px);
 		text-align: right;
 		vertical-align: middle;
 		touch-action: none;

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -223,7 +223,7 @@
 	.table__textContent {
 		width: 100%;
 		padding-left: 4px;
-		font-size: 12px;
+		font-size: var(--diff-font-size, 12px);
 		line-height: 1.25;
 		white-space: var(--pre-wrap);
 		cursor: text;
@@ -273,8 +273,8 @@
 		border-right: 1px solid var(--clr-diff-count-border);
 		background-color: var(--clr-diff-count-bg);
 		color: var(--clr-diff-count-text);
-		font-size: 11px;
-		line-height: 1.5; /* Visually centered with 12px font size that diff lines have */
+		font-size: calc(var(--diff-font-size, 12px) - 1px);
+		line-height: 1.5; /* May need adjustment at extreme font sizes */
 		text-align: right;
 		vertical-align: top;
 		touch-action: none;

--- a/packages/ui/src/lib/richText/css/standard-theme.css
+++ b/packages/ui/src/lib/richText/css/standard-theme.css
@@ -26,13 +26,13 @@
 }
 
 .StandardTheme__h1 {
-	font-size: 24px;
+	font-size: calc(24px * var(--ui-font-scale, 1));
 }
 .StandardTheme__h2 {
-	font-size: 22px;
+	font-size: calc(22px * var(--ui-font-scale, 1));
 }
 .StandardTheme__h3 {
-	font-size: 20px;
+	font-size: calc(20px * var(--ui-font-scale, 1));
 }
 
 .StandardTheme__paragraph {

--- a/packages/ui/src/styles/core/variables.css
+++ b/packages/ui/src/styles/core/variables.css
@@ -35,7 +35,7 @@
 	--lexical-input-background: var(--clr-bg-1);
 	--lexical-input-client-padding: 12px;
 	--lexical-input-client-toolbar-height: 48px;
-	--lexical-input-font-size: 13px;
+	--lexical-input-font-size: calc(13px * var(--ui-font-scale, 1));
 }
 
 :root.dark {


### PR DESCRIPTION


https://github.com/user-attachments/assets/f8c3bee6-3c34-47c0-a40e-49577769831b

https://github.com/user-attachments/assets/e68f5190-ea51-457e-81fb-5de7c8c8aa10

---


This pull request introduces customizable UI and diff font scaling across the desktop app and shared UI components. Users can now globally adjust the UI font size and set a specific font size for diff views, enhancing accessibility and personal preference. The implementation uses CSS variables and updates relevant components and settings to support these new options.

**User font scaling and settings:**

- Added `uiFontScale` and `diffFontSize` properties to the user settings, with corresponding defaults and UI controls in `AppearanceSettings.svelte` to let users adjust these values. [[1]](diffhunk://#diff-07c7e2450e47e88b7b595e01d761408dcadb5f5eafc4fb2dc9ee930326c799aaR25-R30) [[2]](diffhunk://#diff-07c7e2450e47e88b7b595e01d761408dcadb5f5eafc4fb2dc9ee930326c799aaR52-R57) [[3]](diffhunk://#diff-be97fbb14fb5833d2ecf396d6f6f2d788e9fb1c4605ee4f1da6b88f036430b32R50-R81) [[4]](diffhunk://#diff-be97fbb14fb5833d2ecf396d6f6f2d788e9fb1c4605ee4f1da6b88f036430b32R214-R241)
- Introduced a global CSS variable `--ui-font-scale` and updated the root stylesheet and utility classes to use it for consistent scaling.

**UI-wide font scaling support:**

- Refactored numerous Svelte components (e.g., `AiCredentialCheck.svelte`, `CommitDetails.svelte`, `AppUpdater.svelte`, `CodegenToolCall.svelte`, `CliSymLink.svelte`, `DragClone.svelte`, `Textarea.svelte`, `StandardTheme__h1/h2/h3` in CSS) to use `calc(... * var(--ui-font-scale, 1))` for font sizes, ensuring they respond to the global scaling. [[1]](diffhunk://#diff-f74a019a1b330e483efdb6afe554592454b97e612f1f0c071a28e1ad316422a3L329-R329) [[2]](diffhunk://#diff-39a1ec9d078ffaa662ebbe49c5efd04e52f955a9d9578ff334d2df836443ff89L346-R351) [[3]](diffhunk://#diff-c47b3e636eb996fd193f170dafe5631e033ac09bd70657a85e534ea27c8414c7L129-R135) [[4]](diffhunk://#diff-48daedd4a54886864ac6faafac6190ce0e248e4ff9dbdea2dab3c60c85df078cL97-R97) [[5]](diffhunk://#diff-b1e3da2101b19ddc52923442eab1c7b372832e0c3415342fa3dc97c30739bd7dL49-R49) [[6]](diffhunk://#diff-908130d9df4d6fb8ed3291c3371aae055d3195ea1ed04a45baa640be2c83d113L284-R284) [[7]](diffhunk://#diff-52d5616db6c3e774a0ffe418b311f484f3f92c30c5cd74b3191b4e7d28924d65L152-R152) [[8]](diffhunk://#diff-1b711dd559d0ac3040f7d6b3f1c0c83a8b71a24c9c134883f5cd83a30e397cb6L29-R35) [[9]](diffhunk://#diff-1ce373d1e311711d556de98452d2ae76f705d125e1c88f136ebab3e083bc6695L38-R38)

**Diff view font size customization:**

- Added `diffFontSize` as a prop and setting for all diff-related components, wiring it through `HunkDiff.svelte`, `HunkDiffBody.svelte`, and `HunkDiffRow.svelte` to use a CSS variable for font size, and updated all diff view usages to pass this setting. [[1]](diffhunk://#diff-2c01c71b388e0523eec14fe8e16fe63e7e391bf04b6382c7583880291f6cc9b3R27) [[2]](diffhunk://#diff-2c01c71b388e0523eec14fe8e16fe63e7e391bf04b6382c7583880291f6cc9b3R51) [[3]](diffhunk://#diff-2c01c71b388e0523eec14fe8e16fe63e7e391bf04b6382c7583880291f6cc9b3L108-R110) [[4]](diffhunk://#diff-2c01c71b388e0523eec14fe8e16fe63e7e391bf04b6382c7583880291f6cc9b3L273-R275) [[5]](diffhunk://#diff-8ef0f7d62312be7aea639a2f72f2dccb2ef8c0df73189fdf1b24c22e0d124d9bL181-R181) [[6]](diffhunk://#diff-8ef0f7d62312be7aea639a2f72f2dccb2ef8c0df73189fdf1b24c22e0d124d9bL196-R196) [[7]](diffhunk://#diff-3a387f55cb71bc80169f8971a52cbfe4e498007bb41f0c7434d92ce9f24a483bL226-R226) [[8]](diffhunk://#diff-3a387f55cb71bc80169f8971a52cbfe4e498007bb41f0c7434d92ce9f24a483bL276-R277) [[9]](diffhunk://#diff-c86d2935b7f06c0dc1f503e074eaa5ac52d10ee66bf2d1db7a8664a59b3b437aR65) [[10]](diffhunk://#diff-f2b9d00030452028b71e70e008a35d881616d885462c77871fbb8220ed61fed1R51) [[11]](diffhunk://#diff-d64ef742308dd758b6c6f4ebad3e85b0ba311b1fbe764dab035f9ad50170bd91R227) [[12]](diffhunk://#diff-be97fbb14fb5833d2ecf396d6f6f2d788e9fb1c4605ee4f1da6b88f036430b32R166)

**Font scaling logic and reactivity:**

- Implemented logic in `ZoomInOutMenuAction.svelte` to update the `--ui-font-scale` variable reactively based on user settings. [[1]](diffhunk://#diff-b3f203511ca8fc6788b17e6f813a2af3b407f02854011ff069ef9ee99f43a519R22-R25) [[2]](diffhunk://#diff-b3f203511ca8fc6788b17e6f813a2af3b407f02854011ff069ef9ee99f43a519R46-R49)

These changes collectively make the app's interface more accessible and customizable, especially for users requiring larger or smaller text.