### PR TITLE
Track visible items in VirtualList and highlight corresponding file list entries

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -53,6 +53,7 @@
 		stackingReorderDropzoneManager: ReorderCommitDzFactory;
 		roundedTop?: boolean;
 		active?: boolean;
+		visibleRange?: { start: number; end: number };
 
 		handleUncommit: (commitId: string, branchName: string) => Promise<void>;
 		startEditingCommitMessage: (branchName: string, commitId: string) => void;
@@ -70,6 +71,7 @@
 		stackingReorderDropzoneManager,
 		roundedTop,
 		active,
+		visibleRange,
 		handleUncommit,
 		startEditingCommitMessage,
 		onclick,
@@ -407,6 +409,7 @@
 													title="Changed files"
 													{projectId}
 													{stackId}
+													{visibleRange}
 													draggableFiles
 													selectionId={createCommitSelection({ commitId: commitId, stackId })}
 													persistId={`commit-${commitId}`}

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -45,9 +45,19 @@
 		active: boolean;
 		onclick?: () => void;
 		onFileClick?: (index: number) => void;
+		visibleRange: { start: number; end: number };
 	};
 
-	const { projectId, branches, stackId, laneId, active, onclick, onFileClick }: Props = $props();
+	const {
+		projectId,
+		branches,
+		stackId,
+		laneId,
+		active,
+		visibleRange,
+		onclick,
+		onFileClick
+	}: Props = $props();
 	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
 	const modeService = inject(MODE_SERVICE);
@@ -407,6 +417,7 @@
 										changes={result.changes}
 										stats={result.stats}
 										allowUnselect={false}
+										{visibleRange}
 										onFileClick={(index) => {
 											// Ensure the branch is selected so the preview shows it
 											const currentSelection = laneState.selection.current;
@@ -438,6 +449,7 @@
 								codegenQuery?.response &&
 								codegenQuery.response.length > 0}
 							{active}
+							{visibleRange}
 							{handleUncommit}
 							{startEditingCommitMessage}
 							{onclick}

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -47,6 +47,7 @@
 		allowUnselect?: boolean;
 		showLockedIndicator?: boolean;
 		dataTestId?: string;
+		visibleRange?: { start: number; end: number };
 	};
 
 	const {
@@ -62,7 +63,8 @@
 		onFileClick,
 		allowUnselect = true,
 		showLockedIndicator = false,
-		dataTestId
+		dataTestId,
+		visibleRange
 	}: Props = $props();
 
 	const focusManager = inject(FOCUS_MANAGER);
@@ -275,6 +277,7 @@
 		{lockedCommitIds}
 		{lockedTargets}
 		{isLast}
+		notched={visibleRange && idx >= visibleRange.start && idx < visibleRange.end}
 		draggable={draggableFiles}
 		executable={isExecutable}
 		showCheckbox={showCheckboxes}

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -37,6 +37,7 @@
 		lockedCommitIds?: string[];
 		lockedTargets?: HunkLockTarget[];
 		isLast?: boolean;
+		notched?: boolean;
 		onclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
 		conflictEntries?: ConflictEntriesObj;
@@ -60,6 +61,7 @@
 		lockedCommitIds = [],
 		lockedTargets = [],
 		isLast = false,
+		notched,
 		onclick,
 		onkeydown
 	}: Props = $props();
@@ -183,6 +185,7 @@
 		locked={locked || false}
 		{lockText}
 		{isLast}
+		{notched}
 		onlockhover={handleLockHover}
 		onlockunhover={handleLockUnhover}
 		conflicted={!!conflict}

--- a/apps/desktop/src/components/MultiDiffView.svelte
+++ b/apps/desktop/src/components/MultiDiffView.svelte
@@ -33,6 +33,7 @@
 		startIndex?: number;
 		selectionId: SelectionId;
 		onclose?: () => void;
+		onVisibleChange?: (change: { start: number; end: number }) => void;
 	};
 
 	let {
@@ -45,7 +46,8 @@
 		showRoundedEdges = true,
 		startIndex,
 		selectionId,
-		onclose
+		onclose,
+		onVisibleChange
 	}: Props = $props();
 
 	const diffService = inject(DIFF_SERVICE);
@@ -195,6 +197,7 @@
 				defaultHeight={102}
 				visibility="scroll"
 				renderDistance={100}
+				{onVisibleChange}
 			>
 				{#snippet template(change, index)}
 					{@render changeItem(change, index, true)}

--- a/apps/desktop/src/components/NestedChangedFiles.svelte
+++ b/apps/desktop/src/components/NestedChangedFiles.svelte
@@ -25,6 +25,7 @@
 		allowUnselect?: boolean;
 		persistId?: string;
 		foldedByDefault?: boolean;
+		visibleRange?: { start: number; end: number };
 	};
 
 	const {
@@ -41,7 +42,8 @@
 		onFileClick,
 		allowUnselect = true,
 		persistId = 'default',
-		foldedByDefault = false
+		foldedByDefault = false,
+		visibleRange
 	}: Props = $props();
 
 	const idSelection = inject(FILE_SELECTION_MANAGER);
@@ -128,6 +130,7 @@
 					{draggableFiles}
 					{ancestorMostConflictedCommitId}
 					{allowUnselect}
+					{visibleRange}
 					{onFileClick}
 				/>
 			{/if}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -368,6 +368,12 @@
 	const assignedFiles = $derived(uncommittedService.getChangesByStackId(stackId || null));
 
 	let multiDiffView = $state<MultiDiffView>();
+
+	let visibleRange = $state({ start: 0, end: 0 });
+
+	function onVisibleChange(change: { start: number; end: number }) {
+		visibleRange = change;
+	}
 </script>
 
 <div
@@ -503,6 +509,7 @@
 							onFileClick={(index) => {
 								multiDiffView?.jumpToIndex(index);
 							}}
+							{visibleRange}
 						/>
 					</div>
 
@@ -638,6 +645,7 @@
 														draggable={true}
 														selectable={false}
 														startIndex={$activeLastAdded?.index}
+														{onVisibleChange}
 													/>
 												{/snippet}
 											</ReduxResult>
@@ -673,6 +681,7 @@
 											draggable={true}
 											selectable={false}
 											startIndex={$activeLastAdded?.index}
+											{onVisibleChange}
 										/>
 									{/snippet}
 								</ReduxResult>
@@ -688,6 +697,7 @@
 								selectable={isCommitting}
 								onclose={onclosePreview}
 								startIndex={$activeLastAdded.index}
+								{onVisibleChange}
 							/>
 						{/if}
 					{/if}

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -299,19 +299,6 @@
 					</div>
 				{/each}
 			{/if}
-
-			<!-- The context menu should be outside the each block. -->
-			<HunkContextMenu
-				bind:this={contextMenu}
-				trigger={viewport}
-				{projectId}
-				{change}
-				discardable={isUncommittedChange}
-				{selectable}
-				{selectAllHunkLines}
-				{unselectAllHunkLines}
-				{invertHunkSelection}
-			/>
 		{:else if diff.type === 'TooLarge'}
 			<div class="hunk-placehoder">
 				<EmptyStatePlaceholder image={tooLargeSvg} gap={12} topBottomPadding={34}>
@@ -333,6 +320,18 @@
 				</div>
 			{/if}
 		{/if}
+		<!-- The context menu should be outside the each block. -->
+		<HunkContextMenu
+			bind:this={contextMenu}
+			trigger={viewport}
+			{projectId}
+			{change}
+			discardable={isUncommittedChange}
+			{selectable}
+			{selectAllHunkLines}
+			{unselectAllHunkLines}
+			{invertHunkSelection}
+		/>
 	</div>
 {/snippet}
 

--- a/packages/ui/src/lib/components/file/FileListItem.svelte
+++ b/packages/ui/src/lib/components/file/FileListItem.svelte
@@ -9,6 +9,7 @@
 	import FileName from '$components/file/FileName.svelte';
 	import FileStatusBadge from '$components/file/FileStatusBadge.svelte';
 	import { focusable } from '$lib/focus/focusable';
+	import { slide } from 'svelte/transition';
 	import type { FileStatus } from '$components/file/types';
 	import type { FocusableOptions } from '$lib/focus/focusManager';
 
@@ -37,6 +38,7 @@
 		executable?: boolean;
 		isLast?: boolean;
 		actionOpts?: FocusableOptions;
+		notched?: boolean;
 		oncheckclick?: (e: MouseEvent) => void;
 		oncheck?: (
 			e: Event & {
@@ -77,6 +79,7 @@
 		executable,
 		isLast = false,
 		actionOpts,
+		notched,
 		oncheck,
 		oncheckclick,
 		onclick,
@@ -102,6 +105,7 @@
 	class:focused
 	class:draggable
 	class:conflicted
+	class:notched
 	class:list-mode={listMode === 'list'}
 	class:is-last={isLast}
 	aria-selected={selected}
@@ -129,6 +133,14 @@
 		<div class="file-list-item__indicators">
 			{#if showIndent}
 				<FileIndent {depth} />
+			{/if}
+
+			{#if notched}
+				<div
+					class="commit-row__select-indicator"
+					class:active
+					in:slide={{ axis: 'x', duration: 150 }}
+				></div>
 			{/if}
 
 			{#if showCheckbox}
@@ -319,5 +331,9 @@
 			display: flex;
 			color: var(--clr-change-icon-modification);
 		}
+	}
+
+	.notched {
+		margin-left: 6px;
 	}
 </style>

--- a/packages/ui/src/lib/components/file/FileListItem.svelte
+++ b/packages/ui/src/lib/components/file/FileListItem.svelte
@@ -9,7 +9,6 @@
 	import FileName from '$components/file/FileName.svelte';
 	import FileStatusBadge from '$components/file/FileStatusBadge.svelte';
 	import { focusable } from '$lib/focus/focusable';
-	import { slide } from 'svelte/transition';
 	import type { FileStatus } from '$components/file/types';
 	import type { FocusableOptions } from '$lib/focus/focusManager';
 
@@ -129,18 +128,14 @@
 		</div>
 	{/if}
 
+	{#if notched}
+		<div class="commit-row__notch"></div>
+	{/if}
+
 	{#if showIndent || showCheckbox}
 		<div class="file-list-item__indicators">
 			{#if showIndent}
 				<FileIndent {depth} />
-			{/if}
-
-			{#if notched}
-				<div
-					class="commit-row__select-indicator"
-					class:active
-					in:slide={{ axis: 'x', duration: 150 }}
-				></div>
 			{/if}
 
 			{#if showCheckbox}
@@ -289,7 +284,19 @@
 			border-bottom: none;
 		}
 
-		.draggable-handle {
+		&.active.selected .conflicted-icon {
+			color: var(--clr-theme-pop-on-element);
+		}
+
+		&.notched {
+			padding-left: 18px;
+		}
+
+		&.notched .draggable-handle {
+			left: 8px;
+		}
+
+		& .draggable-handle {
 			display: none;
 			position: absolute;
 			top: 50%;
@@ -302,14 +309,10 @@
 			opacity: 0.6;
 		}
 
-		.conflicted-icon {
+		& .conflicted-icon {
 			display: flex;
 			margin-right: -2px;
 			color: var(--clr-theme-danger-element);
-		}
-
-		&.active.selected .conflicted-icon {
-			color: var(--clr-theme-pop-on-element);
 		}
 	}
 
@@ -318,7 +321,15 @@
 		align-items: center;
 		height: 100%;
 		gap: 6px;
-		/* background-color: rgba(64, 224, 208, 0.218); */
+	}
+
+	.commit-row__notch {
+		position: absolute;
+		top: -1px;
+		left: 0;
+		width: 4px;
+		height: calc(100% + 2px);
+		background-color: var(--clr-theme-pop-element);
 	}
 
 	.file-list-item__details {
@@ -331,9 +342,5 @@
 			display: flex;
 			color: var(--clr-change-icon-modification);
 		}
-	}
-
-	.notched {
-		margin-left: 6px;
 	}
 </style>

--- a/packages/ui/src/stories/components/FileListItem.stories.svelte
+++ b/packages/ui/src/stories/components/FileListItem.stories.svelte
@@ -159,3 +159,59 @@
 		</div>
 	{/snippet}
 </Story>
+
+<Story name="Notched List">
+	{#snippet template()}
+		<div
+			style="width: 500px; display: flex; flex-direction: column; border: 1px solid var(--clr-border-3); border-radius: var(--radius-m); overflow: hidden;"
+		>
+			<FileListItem
+				filePath="src/components/Sidebar.svelte"
+				fileStatus="modification"
+				fileStatusStyle="dot"
+				clickable={true}
+				notched={true}
+				checked={true}
+				showCheckbox={true}
+			/>
+			<FileListItem
+				filePath="src/lib/api/client.ts"
+				fileStatus="addition"
+				fileStatusStyle="dot"
+				clickable={true}
+				notched={true}
+				checked={false}
+				showCheckbox={true}
+			/>
+			<FileListItem
+				filePath="src/routes/dashboard/+page.svelte"
+				fileStatus="deletion"
+				fileStatusStyle="dot"
+				clickable={true}
+				notched={true}
+				selected={true}
+				active={true}
+				checked={true}
+				showCheckbox={true}
+			/>
+			<FileListItem
+				filePath="src/styles/theme.css"
+				fileStatus="modification"
+				fileStatusStyle="dot"
+				clickable={true}
+				notched={false}
+				checked={true}
+				showCheckbox={true}
+			/>
+			<FileListItem
+				filePath="tests/integration/api.test.ts"
+				fileStatus="rename"
+				fileStatusStyle="dot"
+				clickable={true}
+				notched={false}
+				checked={false}
+				showCheckbox={true}
+			/>
+		</div>
+	{/snippet}
+</Story>


### PR DESCRIPTION
Separate the VirtualList's render range (includes buffer for smooth scrolling) from the actual visible range (what the user sees in the viewport). Expose an onVisibleChange callback that fires when the visible range updates, and thread it through the component hierarchy so the file list sidebar can highlight which files are currently in view.