### PR TITLE
fix(ui): correct link label to "Stacked vs. Independent"

### DIFF
--- a/apps/desktop/src/components/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/CreateBranchModal.svelte
@@ -260,7 +260,7 @@
 			<span class="text-12 text-body footer-text"
 				>See more: <Link
 					href="https://docs.gitbutler.com/features/branch-management/stacked-branches"
-					>Stacked vs. Dependent</Link
+					>Stacked vs. Independent</Link
 				></span
 			>
 


### PR DESCRIPTION
Related to https://github.com/gitbutlerapp/gitbutler/issues/12357#issuecomment-3910370126

- Update CreateBranchModal copy: change linked label from "Stacked vs. Dependent" to "Stacked vs. Independent"
- Align label with target documentation page and clarify branch relationship terminology
- Fix misleading wording in branch creation modal to prevent user confusion when navigating to docs