### PR TITLE
Fix Claude hooks failing when tools access files outside the repository

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -313,18 +313,18 @@ async fn match_subcommand(
         #[cfg(feature = "legacy")]
         Subcommands::Claude(claude::Platform { cmd }) => {
             use but_claude::hooks::OutputClaudeJson;
+            let ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             match cmd {
-                claude::Subcommands::PreTool => but_claude::hooks::handle_pre_tool_call(std::io::stdin().lock())
+                claude::Subcommands::PreTool => but_claude::hooks::handle_pre_tool_call(ctx, std::io::stdin().lock())
                     .output_claude_json()
                     .emit_metrics(metrics_ctx),
-                claude::Subcommands::PostTool => but_claude::hooks::handle_post_tool_call(std::io::stdin().lock())
+                claude::Subcommands::PostTool => but_claude::hooks::handle_post_tool_call(ctx, std::io::stdin().lock())
                     .output_claude_json()
                     .emit_metrics(metrics_ctx),
-                claude::Subcommands::Stop => but_claude::hooks::handle_stop(std::io::stdin().lock())
+                claude::Subcommands::Stop => but_claude::hooks::handle_stop(ctx, std::io::stdin().lock())
                     .output_claude_json()
                     .emit_metrics(metrics_ctx),
                 claude::Subcommands::Last { offset } => {
-                    let ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
                     let message = but_claude::db::get_user_message(&ctx, Some(offset as i64))?;
                     match message {
                         Some(msg) => {


### PR DESCRIPTION
Context::discover() walks up from the file path to find a .git
directory, which fails for files outside the repo (e.g. ~/.cargo).
Instead, pass the Context from the caller — either from init_ctx
in the CLI or from ThreadSafeContext in the SDK.

Also deduplicate the SDK/CLI hook variants into single functions,
and rename them for clarity:
- lock_file_for_tool_call (pre-tool file locking)
- assign_hunks_post_tool_call (post-tool hunk assignment)
- handle_session_stop (session end / commit creation)