### PR TITLE
Improve tauri tracing filter due to release build log verbosity

### DIFF
--- a/crates/gitbutler-tauri/src/logs.rs
+++ b/crates/gitbutler-tauri/src/logs.rs
@@ -1,9 +1,9 @@
 use std::{fs, net::Ipv4Addr, path::Path, time::Duration};
 
 use tauri::{AppHandle, Manager};
-use tracing::{instrument, metadata::LevelFilter, subscriber::set_global_default};
+use tracing::{Level, instrument, metadata::LevelFilter, subscriber::set_global_default};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::{Layer, fmt::format::FmtSpan, layer::SubscriberExt};
+use tracing_subscriber::{Layer, filter::filter_fn, fmt::format::FmtSpan, layer::SubscriberExt};
 
 pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool) {
     fs::create_dir_all(logs_dir).expect("failed to create logs dir");
@@ -37,6 +37,7 @@ pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool) 
         .to_lowercase()
         .parse()
         .unwrap_or(LevelFilter::INFO);
+    let log_level = log_level_filter.into_level();
 
     let use_colors_in_logs = cfg!(not(feature = "windows"));
     let subscriber = tracing_subscriber::registry()
@@ -56,7 +57,7 @@ pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool) 
                 .with_ansi(false)
                 .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .with_writer(file_writer)
-                .with_filter(log_level_filter),
+                .with_filter(filter_fn(move |meta| should_log(log_level, meta))),
         );
     if performance_logging {
         set_global_default(
@@ -64,7 +65,7 @@ pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool) 
                 tracing_forest::ForestLayer::from(
                     tracing_forest::printer::PrettyPrinter::new().writer(std::io::stdout),
                 )
-                .with_filter(log_level_filter),
+                .with_filter(filter_fn(move |meta| should_log(log_level, meta))),
             ),
         )
     } else {
@@ -75,11 +76,28 @@ pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool) 
                     .event_format(format_for_humans)
                     .with_ansi(use_colors_in_logs)
                     .with_span_events(FmtSpan::CLOSE)
-                    .with_filter(log_level_filter),
+                    .with_filter(filter_fn(move |meta| should_log(log_level, meta))),
             ),
         )
     }
     .expect("failed to set subscriber");
+}
+
+/// This function is much like `LevelFilter`, but it also filters based on the module path.
+/// This is necessary, strangely enough, in release builds only, but is the same in the `but` CLI builds as well.
+/// It is pretty much the same as `LevelFilter` in debug builds.
+fn should_log(level: Option<Level>, meta: &tracing::Metadata<'_>) -> bool {
+    let Some(level) = level else {
+        return false;
+    };
+    if *meta.level() > level {
+        return false;
+    }
+    if level > Level::DEBUG {
+        return true;
+    }
+    meta.module_path()
+        .is_none_or(|p| p.starts_with("gitbutler_") || p.starts_with("but::") || p.starts_with("but_"))
 }
 
 fn get_server_addr(app_handle: &AppHandle) -> (Ipv4Addr, u16) {


### PR DESCRIPTION
Nightly logs look like this now:

```
	fatal: unable to access 'https://gitlab.com/Byron1/small-gb/': Failed to connect to gitlab.com port 443 after 22 ms: Couldn't connect to server
INFO     stacks [ 6.00ms | 80.63% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | filter: None
INFO     ┝━ ThreadSafeRepository::open() [ 714µs | 3.76% / 11.92% ]
INFO     │  ┕━ open_from_paths() [ 489µs | 6.10% / 8.15% ]
INFO     │     ┕━ gix_odb::Store::at() [ 123µs | 2.05% ]
INFO     ┝━ gix_index::File::at() [ 81.2µs | 1.36% ]
INFO     ┕━ open_from_paths() [ 365µs | 4.89% / 6.10% ]
INFO        ┕━ gix_odb::Store::at() [ 72.5µs | 1.21% ]
INFO     stack_details [ 6.41ms | 86.30% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | stack_id: Some(dd81ac21-8999-44ef-9098-94342972cfb0)
INFO     ┝━ ThreadSafeRepository::open() [ 388µs | 1.47% / 6.05% ]
INFO     │  ┕━ open_from_paths() [ 294µs | 3.33% / 4.58% ]
INFO     │     ┕━ gix_odb::Store::at() [ 80.2µs | 1.25% ]
INFO     ┝━ gix_index::File::at() [ 42.3µs | 0.66% ]
INFO     ┕━ open_from_paths() [ 448µs | 5.66% / 6.99% ]
INFO        ┕━ gix_odb::Store::at() [ 85.4µs | 1.33% ]
```

And with this filter, they are expected not contain the gitoxide traces anymore
unless one goes all the way up to trace level.

The same issue applies to the stable version.

With this PR, it *should* look like this, even in DEBUG level.

````
STDERR:
fatal: unable to access 'https://gitlab.com/Byron1/small-gb/': Failed to connect to gitlab.com port 443 after 3 ms: Couldn't connect to server
INFO     stacks [ 8.07ms | 99.85% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | filter: None
DEBUG    ┝━ 🐛 [debug]: Deleting seemingly isolated and now completely unused segment | sidx: NodeIndex(5)
DEBUG    ┕━ Graph::into_workspace [ 12.4µs | 0.15% ]
INFO     git_get_global_config [ 175µs | 100.00% ] key: "gitbutler.aiModelProvider"
INFO     list_workspace_rules [ 6.52ms | 94.28% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" }
DEBUG    ┝━ 🐛 [debug]: Deleting seemingly isolated and now completely unused segment | sidx: NodeIndex(5)
DEBUG    ┝━ Graph::into_workspace [ 12.3µs | 0.19% ]
DEBUG    ┕━ DbHandle::new_at_path [ 361µs | 5.53% ]
INFO     claude_get_mcp_config [ 1.19ms | 100.00% ] ctx: ThreadSafeContext { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" }
INFO     stack_details [ 7.80ms | 15.99% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | stack_id: Some(c6584598-a3ea-48fb-9430-9996e5d1bf9b)
DEBUG    ┝━ stack_details_v3 [ 6.25ms | 2.70% / 80.04% ] stack_id: Some(c6584598-a3ea-48fb-9430-9996e5d1bf9b) | repo: Repository { kind: Common, git_dir: "/Users/byron/dev/github.com/Byron/small/.git", workdir: Some("/Users/byron/dev/github.com/Byron/small") }
DEBUG    │  ┕━ ref_info [ 6.03ms | 77.19% / 77.34% ] existing_ref: Reference { name: FullName("refs/heads/hello-world"), target: Object(Sha1(fd34ece15a21a101b0258791e826574decaa70b6)), peeled: None } | opts: Options { traversal: Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false }, expensive_commit_info: true }
DEBUG    │     ┝━ 🐛 [debug]: Deleting seemingly isolated and now completely unused segment | sidx: NodeIndex(5)
DEBUG    │     ┕━ Graph::into_workspace [ 11.2µs | 0.14% ]
DEBUG    ┕━ DbHandle::new_at_path [ 310µs | 3.97% ]
````


### Tasks

* [x] try nightly based on [this publish](https://github.com/gitbutlerapp/gitbutler/actions/runs/22098007368).

Works:

```
STDERR:
fatal: unable to access 'https://gitlab.com/Byron1/small-gb/': Failed to connect to gitlab.com port 443 after 4 ms: Couldn't connect to server
INFO     stacks [ 6.12ms | 99.85% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | filter: None
DEBUG    ┝━ 🐛 [debug]: Deleting seemingly isolated and now completely unused segment | sidx: NodeIndex(5)
DEBUG    ┕━ Graph::into_workspace [ 9.00µs | 0.15% ]
INFO     stack_details [ 6.42ms | 10.81% / 100.00% ] ctx: Context { git_dir: "/Users/byron/dev/github.com/Byron/small/.git" } | stack_id: Some(dd81ac21-8999-44ef-9098-94342972cfb0)
DEBUG    ┝━ stack_details_v3 [ 5.46ms | 1.46% / 85.03% ] stack_id: Some(dd81ac21-8999-44ef-9098-94342972cfb0) | repo: Repository { kind: Common, git_dir: "/Users/byron/dev/github.com/Byron/small/.git", workdir: Some("/Users/byron/dev/github.com/Byron/small") }
DEBUG    │  ┕━ ref_info [ 5.36ms | 83.42% / 83.57% ] existing_ref: Reference { name: FullName("refs/heads/#hl"), target: Object(Sha1(ccf9b9709bd45e89babd99e6e4b2193279c2ebc8)), peeled: None } | opts: Options { traversal: Options { collect_tags: false, commits_limit_hint: Some(300), commits_limit_recharge_location: [], hard_limit: None, extra_target_commit_id: None, dangerously_skip_postprocessing_for_debugging: false }, expensive_commit_info: true }
DEBUG    │     ┝━ 🐛 [debug]: Deleting seemingly isolated and now completely unused segment | sidx: NodeIndex(0)
```