### PR TITLE
feat(but): enable sig verification and `but update install` under Linux

### DIFF
--- a/crates/but-installer/src/install.rs
+++ b/crates/but-installer/src/install.rs
@@ -1,9 +1,15 @@
 //! Platform-agnostic installation logic
 
 use std::{
+    fs::{self, File},
+    io::Read,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::ui::success;
 
 /// Returns the path to the `but` CLI binary for the given home directory.
 pub(crate) fn but_binary_path(home_dir: &Path) -> PathBuf {
@@ -19,4 +25,88 @@ pub(crate) fn validate_installed_binary(path: &Path) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+/// Verify the signature for a CLI installable
+pub(crate) fn verify_signature(installable: &Path, signature_b64: &str, temp_dir: &Path) -> Result<()> {
+    crate::ui::info("Verifying download signature...");
+
+    // Validate signature is not empty - this is a security requirement
+    if signature_b64.trim().is_empty() {
+        bail!("Signature is empty - refusing to verify without a valid signature");
+    }
+
+    // GitButler's minisign public key
+    let pubkey_str = "RWTrOEI+im1XYA9RBwyxnzFN/evFzJhU1lbQ70LVayWH3WRo7xQnRLD2";
+
+    // Parse the public key
+    let public_key = minisign_verify::PublicKey::from_base64(pubkey_str).context("Failed to parse public key")?;
+
+    // Decode signature from base64 and write to file
+    // The signature format from the API is base64-encoded minisign signature file content
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    let signature_bytes = STANDARD
+        .decode(signature_b64)
+        .context("Failed to decode signature from base64")?;
+
+    // Write signature to temp file for minisign to parse
+    let signature_file = temp_dir.join("signature.minisig");
+    fs::write(&signature_file, &signature_bytes)?;
+
+    // Read it back as a string (minisign signatures are text files)
+    let signature_str = fs::read_to_string(&signature_file).context("Failed to read signature file as string")?;
+
+    // Parse the signature
+    let signature = minisign_verify::Signature::decode(&signature_str).context("Failed to parse signature")?;
+
+    // Use streaming verification to avoid loading entire file into memory
+    let mut file = File::open(installable).context("Failed to open installable for verification")?;
+    let mut verifier = public_key
+        .verify_stream(&signature)
+        .map_err(|e| anyhow!("Failed to initialize signature verifier: {e}"))?;
+
+    // Read and verify file in 64KB chunks
+    let mut buffer = [0u8; 65536];
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        verifier.update(&buffer[..bytes_read]);
+    }
+
+    // Finalize verification
+    verifier
+        .finalize()
+        .map_err(|e| anyhow!("Signature verification failed - the download may have been tampered with: {e}"))?;
+
+    success("Signature verification passed");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn test_verify_signature_empty() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let test_file = temp_dir.path().join("test.tar.gz");
+
+        // Create a dummy file
+        let mut file = File::create(&test_file).unwrap();
+        file.write_all(&[0x1f, 0x8b, 0x08, 0x00]).unwrap();
+
+        // Empty signature should fail with clear error
+        let result = verify_signature(&test_file, "", temp_dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+
+        // Whitespace-only signature should also fail
+        let result = verify_signature(&test_file, "   ", temp_dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
 }

--- a/crates/but-installer/src/install_macos.rs
+++ b/crates/but-installer/src/install_macos.rs
@@ -20,7 +20,7 @@ use crate::{
     ui::{info, success, warn},
 };
 
-use crate::install::validate_installed_binary;
+use crate::install::{validate_installed_binary, verify_signature};
 
 pub fn download_and_install_app(
     config: &InstallerConfig,
@@ -381,62 +381,6 @@ fn remove_quarantine_recursive(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn verify_signature(tarball: &Path, signature_b64: &str, temp_dir: &Path) -> Result<()> {
-    crate::ui::info("Verifying download signature...");
-
-    // Validate signature is not empty - this is a security requirement
-    if signature_b64.trim().is_empty() {
-        bail!("Signature is empty - refusing to verify without a valid signature");
-    }
-
-    // GitButler's minisign public key
-    let pubkey_str = "RWTrOEI+im1XYA9RBwyxnzFN/evFzJhU1lbQ70LVayWH3WRo7xQnRLD2";
-
-    // Parse the public key
-    let public_key = minisign_verify::PublicKey::from_base64(pubkey_str).context("Failed to parse public key")?;
-
-    // Decode signature from base64 and write to file
-    // The signature format from the API is base64-encoded minisign signature file content
-    use base64::{Engine, engine::general_purpose::STANDARD};
-    let signature_bytes = STANDARD
-        .decode(signature_b64)
-        .context("Failed to decode signature from base64")?;
-
-    // Write signature to temp file for minisign to parse
-    let signature_file = temp_dir.join("signature.minisig");
-    fs::write(&signature_file, &signature_bytes)?;
-
-    // Read it back as a string (minisign signatures are text files)
-    let signature_str = fs::read_to_string(&signature_file).context("Failed to read signature file as string")?;
-
-    // Parse the signature
-    let signature = minisign_verify::Signature::decode(&signature_str).context("Failed to parse signature")?;
-
-    // Use streaming verification to avoid loading entire file into memory
-    let mut file = File::open(tarball).context("Failed to open tarball for verification")?;
-    let mut verifier = public_key
-        .verify_stream(&signature)
-        .map_err(|e| anyhow!("Failed to initialize signature verifier: {e}"))?;
-
-    // Read and verify file in 64KB chunks
-    let mut buffer = [0u8; 65536];
-    loop {
-        let bytes_read = file.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        verifier.update(&buffer[..bytes_read]);
-    }
-
-    // Finalize verification
-    verifier
-        .finalize()
-        .map_err(|e| anyhow!("Signature verification failed - the download may have been tampered with: {e}"))?;
-
-    success("Signature verification passed");
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -515,25 +459,5 @@ mod tests {
 
         // Should fail because it's not gzip
         assert!(validate_tarball(&test_file).is_err());
-    }
-
-    #[test]
-    fn test_verify_signature_empty() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let test_file = temp_dir.path().join("test.tar.gz");
-
-        // Create a dummy file
-        let mut file = File::create(&test_file).unwrap();
-        file.write_all(&[0x1f, 0x8b, 0x08, 0x00]).unwrap();
-
-        // Empty signature should fail with clear error
-        let result = verify_signature(&test_file, "", temp_dir.path());
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("empty"));
-
-        // Whitespace-only signature should also fail
-        let result = verify_signature(&test_file, "   ", temp_dir.path());
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("empty"));
     }
 }

--- a/crates/but/src/args/update.rs
+++ b/crates/but/src/args/update.rs
@@ -19,17 +19,18 @@ pub enum Subcommands {
         days: u32,
     },
 
-    /// Install or update the GitButler desktop application (macOS only)
+    /// Install or update the GitButler desktop application.
     ///
-    /// Downloads and installs the GitButler desktop app. The CLI (but) is included
-    /// with the app and will also be updated.
+    /// By default, auto-detects your current channel (release/nightly) and installs the latest
+    /// version for that channel.
     ///
-    /// By default, auto-detects your current channel (release/nightly) and installs
-    /// the latest version for that channel.
+    /// macOS: Installs the full GitButler desktop application. The CLI (but) is included with the
+    /// app and will also be updated.
     ///
-    /// Note: Currently only supported on macOS. For other platforms, download from
-    /// <https://gitbutler.com/downloads>
-    #[cfg(target_os = "macos")]
+    /// Linux: Installs and updates only the CLI itself.
+    ///
+    /// Note: For other platforms and install forms, see <https://gitbutler.com/downloads>
+    #[cfg(unix)]
     Install {
         /// What to install: "nightly", "release", or a version like "0.18.7"
         ///

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 use but_installer::VersionRequest;
 use but_settings::AppSettings;
 use but_update::{AppName, CheckUpdateStatus, check_status};
@@ -11,7 +11,7 @@ pub fn handle(cmd: update::Subcommands, out: &mut OutputChannel, app_settings: &
     match cmd {
         update::Subcommands::Check => check_for_updates(out, app_settings),
         update::Subcommands::Suppress { days } => suppress_updates(out, days),
-        #[cfg(target_os = "macos")]
+        #[cfg(unix)]
         update::Subcommands::Install { target } => install(out, target),
     }
 }
@@ -105,7 +105,7 @@ fn suppress_updates(out: &mut OutputChannel, days: u32) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
     // Installation requires interactive output and cannot be used with JSON mode
     // because the installer writes directly to stdout/stderr


### PR DESCRIPTION
## 🧢 Changes
Adds in `but update install` for Linux, along with signature verification of the `but` binary. It's a bit awkward compared to the macOS variant of the installer as we don't yet have an API that exposes the signature for the Linux `but` binary. We'll get there in due time.

As we don't have any releases with the `but.sig` file available yet, I haven't _fully_ tested this, but I've gone as far as possible with `but` binary and accompanying `but.sig` in a different location and hard-coded the URLs. That works, so there's no reason to believe it won't work when this is released.