### PR TITLE
feat(but): make ids bold instead of underlined

### DIFF
--- a/crates/but/src/command/legacy/diff/display.rs
+++ b/crates/but/src/command/legacy/diff/display.rs
@@ -180,7 +180,7 @@ impl DiffDisplay for HunkAssignment {
         // ────────╯
         output.push_str(&format!("{}╮\n", "─".repeat(content_width).dimmed()));
         if let Some(id) = &short_id {
-            output.push_str(&format!("{} {}│\n", id.blue().underline(), self.path.bold()));
+            output.push_str(&format!("{} {}│\n", id.blue().bold(), self.path.bold()));
         } else {
             output.push_str(&format!("{}│\n", self.path.bold()));
         }

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -65,7 +65,7 @@ pub(crate) fn show_oplog(
 
             let commit_id = format!(
                 "{}{}",
-                &snapshot.commit_id.to_string()[..7].blue().underline(),
+                &snapshot.commit_id.to_string()[..7].blue().bold(),
                 &snapshot.commit_id.to_string()[7..12].blue().dimmed()
             );
 
@@ -189,7 +189,7 @@ pub(crate) fn restore_to_oplog(
         use std::fmt::Write;
         writeln!(out, "{}", "Restoring to oplog snapshot...".blue().bold())?;
         writeln!(out, "  Target: {} ({})", target_operation.green(), target_time.dimmed())?;
-        writeln!(out, "  Snapshot: {}", commit_sha_string[..7].cyan().underline())?;
+        writeln!(out, "  Snapshot: {}", commit_sha_string[..7].cyan().bold())?;
 
         // Confirm the restoration (safety check)
         if !force {
@@ -259,7 +259,7 @@ pub(crate) fn undo_last_operation(ctx: &mut but_ctx::Context, out: &mut OutputCh
     if let Some(out) = out.for_human() {
         let restore_commit_short = format!(
             "{}{}",
-            &target_snapshot.commit_id.to_string()[..7].blue().underline(),
+            &target_snapshot.commit_id.to_string()[..7].blue().bold(),
             &target_snapshot.commit_id.to_string()[7..12].blue().dimmed()
         );
 
@@ -297,7 +297,7 @@ pub(crate) fn create_snapshot(
         writeln!(
             out,
             "  Snapshot ID: {}{}",
-            snapshot_id.to_string()[..7].blue().underline(),
+            snapshot_id.to_string()[..7].blue().bold(),
             snapshot_id.to_string()[7..12].blue().dimmed()
         )?;
 

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -32,7 +32,7 @@ pub(crate) fn uncommitted_to_commit(
             .new_commit
             .map(|c| {
                 let s = c.to_string();
-                format!("{}{}", s[..2].blue().underline(), s[2..7].blue())
+                format!("{}{}", s[..2].blue().bold(), s[2..7].blue())
             })
             .unwrap_or_default();
         writeln!(out, "Amended {description} → {new_commit}")?;
@@ -64,7 +64,7 @@ pub(crate) fn assignments_to_commit(
             .new_commit
             .map(|c| {
                 let s = c.to_string();
-                format!("{}{}", s[..2].blue().underline(), s[2..7].blue())
+                format!("{}{}", s[..2].blue().bold(), s[2..7].blue())
             })
             .unwrap_or_default();
         if let Some(branch_name) = branch_name {

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -279,9 +279,9 @@ pub(crate) fn handle(
 fn makes_no_sense_error(source: &CliId, target: &CliId) -> String {
     format!(
         "Operation doesn't make sense. Source {} is {} and target {} is {}.",
-        source.to_short_string().blue().underline(),
+        source.to_short_string().blue().bold(),
         source.kind_for_humans().yellow(),
-        target.to_short_string().blue().underline(),
+        target.to_short_string().blue().bold(),
         target.kind_for_humans().yellow()
     )
 }
@@ -730,7 +730,7 @@ pub(crate) fn handle_uncommit(ctx: &mut Context, out: &mut OutputChannel, source
             _ => {
                 bail!(
                     "Cannot uncommit {} - it is {}. Only commits and files-in-commits can be uncommitted.",
-                    source_str.blue().underline(),
+                    source_str.blue().bold(),
                     source.kind_for_humans().yellow()
                 );
             }
@@ -762,7 +762,7 @@ pub(crate) fn handle_amend(
             _ => {
                 bail!(
                     "Cannot amend {} - it is {}. Only uncommitted files and hunks can be amended.",
-                    file.to_short_string().blue().underline(),
+                    file.to_short_string().blue().bold(),
                     file.kind_for_humans().yellow()
                 );
             }
@@ -777,7 +777,7 @@ pub(crate) fn handle_amend(
         other => {
             bail!(
                 "Cannot amend into {} - it is {}. Target must be a commit.",
-                other.to_short_string().blue().underline(),
+                other.to_short_string().blue().bold(),
                 other.kind_for_humans().yellow()
             );
         }
@@ -808,7 +808,7 @@ pub(crate) fn handle_stage(
             _ => {
                 bail!(
                     "Cannot stage {} - it is {}. Only uncommitted files and hunks can be staged.",
-                    file.to_short_string().blue().underline(),
+                    file.to_short_string().blue().bold(),
                     file.kind_for_humans().yellow()
                 );
             }
@@ -823,7 +823,7 @@ pub(crate) fn handle_stage(
         other => {
             bail!(
                 "Cannot stage to {} - it is {}. Target must be a branch.",
-                other.to_short_string().blue().underline(),
+                other.to_short_string().blue().bold(),
                 other.kind_for_humans().yellow()
             );
         }
@@ -852,7 +852,7 @@ pub(crate) fn handle_stage_tui(
             other => {
                 bail!(
                     "Cannot stage to {} - it is {}. Target must be a branch.",
-                    other.to_short_string().blue().underline(),
+                    other.to_short_string().blue().bold(),
                     other.kind_for_humans().yellow()
                 );
             }
@@ -950,7 +950,7 @@ pub(crate) fn handle_unstage(
             _ => {
                 bail!(
                     "Cannot unstage {} - it is {}. Only uncommitted files and hunks can be unstaged.",
-                    file.to_short_string().blue().underline(),
+                    file.to_short_string().blue().bold(),
                     file.kind_for_humans().yellow()
                 );
             }
@@ -967,7 +967,7 @@ pub(crate) fn handle_unstage(
             other => {
                 bail!(
                     "Cannot unstage from {} - it is {}. Target must be a branch.",
-                    other.to_short_string().blue().underline(),
+                    other.to_short_string().blue().bold(),
                     other.kind_for_humans().yellow()
                 );
             }

--- a/crates/but/src/command/legacy/rub/move.rs
+++ b/crates/but/src/command/legacy/rub/move.rs
@@ -167,9 +167,9 @@ pub(crate) fn handle(
         bail!(
             "Cannot move {} ({}) to {} ({}).\n\
             Valid moves: commit→commit, commit→branch, or committed-file→commit",
-            source_id.to_short_string().blue().underline(),
+            source_id.to_short_string().blue().bold(),
             source_id.kind_for_humans().yellow(),
-            target_id.to_short_string().blue().underline(),
+            target_id.to_short_string().blue().bold(),
             target_id.kind_for_humans().yellow()
         );
     };

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -130,7 +130,7 @@ fn handle_multi_commit_squash(
             other => {
                 bail!(
                     "Cannot squash {} - it is {}. All arguments must be commits.",
-                    other.to_short_string().blue().underline(),
+                    other.to_short_string().blue().bold(),
                     other.kind_for_humans().yellow()
                 );
             }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -464,7 +464,7 @@ fn print_assignments(
 
     let id = stack
         .and_then(|s| id_map.resolve_stack(s))
-        .map(|s| s.to_short_string().underline().blue())
+        .map(|s| s.to_short_string().bold().blue())
         .unwrap_or_default();
 
     if !unstaged && !assignments.is_empty() {
@@ -497,7 +497,7 @@ fn print_assignments(
 
         let cli_id = &fa.assignments[0].cli_id;
         let pad = max_id_width.saturating_sub(cli_id.len());
-        let id = format!("{:pad$}{}", "", cli_id.underline().blue());
+        let id = format!("{:pad$}{}", "", cli_id.bold().blue());
 
         let mut locks = fa
             .assignments
@@ -507,7 +507,7 @@ fn print_assignments(
             .map(|l| l.commit_id.to_string())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
-            .map(|commit_id| format!("{}{}", commit_id[..2].blue().underline(), commit_id[2..7].blue()))
+            .map(|commit_id| format!("{}{}", commit_id[..2].blue().bold(), commit_id[2..7].blue()))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -548,7 +548,7 @@ pub fn print_group(
     if let Some(stack_with_id) = stack_with_id {
         let mut first = true;
         for segment in &stack_with_id.segments {
-            let id = segment.short_id.underline().blue();
+            let id = segment.short_id.bold().blue();
             let notch = if first { "╭" } else { "├" };
             if !first {
                 writeln!(out, "┊│")?;
@@ -677,7 +677,7 @@ pub fn print_group(
             }
         }
     } else {
-        let id = id_map.unassigned().to_short_string().underline().blue();
+        let id = id_map.unassigned().to_short_string().bold().blue();
         writeln!(
             out,
             "╭┄{} [{}] {}",
@@ -823,7 +823,7 @@ fn print_commit(
         match commit_changes {
             CommitChanges::Workspace(tree_changes) => {
                 for TreeChangeWithId { short_id, inner } in tree_changes {
-                    let cid = short_id.blue().underline();
+                    let cid = short_id.blue().bold();
                     writeln!(out, "┊│     {cid} {}", inner.display_cli(false))?;
                 }
             }
@@ -861,7 +861,7 @@ fn display_cli_commit_details(
         let commit_id = commit.id.to_string();
         commit_id[short_id.len()..7].dimmed().to_string()
     };
-    let start_id = short_id.blue().underline();
+    let start_id = short_id.blue().bold();
 
     let conflicted_str = if commit.has_conflicts {
         " {conflicted}".red()

--- a/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
@@ -10,7 +11,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -22,39 +22,39 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="underline">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="underline">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="underline">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="underline">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="underline">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="underline">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
@@ -9,7 +10,6 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -21,43 +21,43 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊    </tspan><tspan class="underline">yr</tspan><tspan> A </tspan><tspan class="fg-green">foo1</tspan><tspan> </tspan>
+    <tspan x="10px" y="46px"><tspan>┊    </tspan><tspan class="fg-blue bold">yr</tspan><tspan> A </tspan><tspan class="fg-green">foo1</tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="underline">kpr</tspan><tspan> A </tspan><tspan class="fg-green">foo23</tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpr</tspan><tspan> A </tspan><tspan class="fg-green">foo23</tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="underline">kpo</tspan><tspan> A </tspan><tspan class="fg-green">foo242</tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpo</tspan><tspan> A </tspan><tspan class="fg-green">foo242</tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="118px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="underline">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="underline">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="underline">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="underline">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="underline">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="underline">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="underline">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="underline">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="underline">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊●   </tspan><tspan class="underline">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+    <tspan x="10px" y="334px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>┊●   </tspan><tspan class="underline">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+    <tspan x="10px" y="352px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
@@ -11,7 +12,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -23,33 +23,33 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">28</tspan><tspan class="dimmed">baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">28</tspan><tspan class="dimmed">baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     A </tspan><tspan class="fg-green">only-on-remote</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="underline">64:tp</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
+    <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="fg-blue bold">64:tp</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
@@ -11,7 +12,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -23,25 +23,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊│     </tspan><tspan class="dimmed">A-remote </tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     A </tspan>
 </tspan>
@@ -49,9 +49,9 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>┊│     B </tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
@@ -11,7 +12,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -23,31 +23,31 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="underline dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="226px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="underline">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
@@ -10,7 +11,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊│     add A </tspan>
 </tspan>
@@ -38,9 +38,9 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     add B </tspan>
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-blue { fill: #0000AA }
     .fg-cyan { fill: #00AAAA }
     .fg-green { fill: #00AA00 }
     .container {
@@ -10,7 +11,6 @@
     }
     .bold { font-weight: bold; }
     .italic { font-style: italic; }
-    .underline { text-decoration-line: underline; }
     .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
@@ -22,23 +22,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="underline">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="underline">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="underline">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="underline">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="underline">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B  </tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>


### PR DESCRIPTION
## 🧢 Changes

Makes IDs in the CLI bold instead of underlined to increase readability. There are some before/after SVG comparisons in https://github.com/gitbutlerapp/gitbutler/pull/12397/commits/82c1fc39439f266357905e4d7a1c2e0f0f81c9a5, but I don't really think they do the changes justice. Here are some samples from my terminal with before followed by after (`but` is the before, `but-debug` is the after):

### Status

This is the one I had the most trouble reading, with e.g. `p`, `q` and `y` cutting through the underline. I was quite literally squinting at the text, and among other things mistook a `y` for a `v` at some point (see the branch `yv-demo` at the bottom, `y` and `v` look _very_ similar to my eyes when underlined).

<img width="1269" height="1324" alt="status" src="https://github.com/user-attachments/assets/2dd5383c-edcd-4cff-a3fe-9d2dabc7e0cc" />


### Oplog
<img width="1018" height="1198" alt="oplog" src="https://github.com/user-attachments/assets/65c2d5a9-d1fe-4cfb-b0cf-9fce8cc5af1b" />

### Diff
<img width="939" height="440" alt="diff" src="https://github.com/user-attachments/assets/9bb67a1d-4c90-467a-b9a1-43cb9a15fdf1" />

### URLs
And URL's are left unchanged, still underlined:

<img width="938" height="290" alt="url" src="https://github.com/user-attachments/assets/9cda246d-a291-4836-adcb-51306d5a3415" />

