### PR TITLE
Make URL open work again

### DIFF
--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -45,7 +45,13 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
 
     let mut cmd_errors = Vec::new();
 
-    for mut cmd in open::commands(target_url.path()) {
+    let url = if target_url.scheme() == "file" {
+        target_url.path()
+    } else {
+        target_url.as_str()
+    };
+
+    for mut cmd in open::commands(url) {
         let cleaned_vars = clean_env_vars(&[
             "APPDIR",
             "GDK_PIXBUF_MODULE_FILE",

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -45,13 +45,18 @@ pub(crate) fn open_that(target_url: &Url) -> anyhow::Result<()> {
 
     let mut cmd_errors = Vec::new();
 
-    let url = if target_url.scheme() == "file" {
-        target_url.path()
+    let commands = if target_url.scheme() == "file" {
+        open::commands(
+            target_url
+                .to_file_path()
+                .ok()
+                .with_context(|| format!("Couldn't turn {target_url} into a file path"))?,
+        )
     } else {
-        target_url.as_str()
+        open::commands(target_url.as_str())
     };
 
-    for mut cmd in open::commands(url) {
+    for mut cmd in commands {
         let cleaned_vars = clean_env_vars(&[
             "APPDIR",
             "GDK_PIXBUF_MODULE_FILE",

--- a/crates/but-installer/src/download.rs
+++ b/crates/but-installer/src/download.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::http::create_client;
 
 /// Download a URL and return its contents as a string.
+#[cfg(target_os = "linux")]
 pub(crate) fn download_to_string(url: &str) -> Result<String> {
     let mut easy = create_client()?;
 


### PR DESCRIPTION
Maybe there is still some issues around file handling, the reason the change originally was introduced.

Was the idea that `file://` should just be a file path, instead of URL?`
