### PR TITLE
Saver UX around exiting edit mode.

### DIFF
--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -102,7 +102,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					]
 				}
 			),
-			abortEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
+			abortEditAndReturnToWorkspace: build.mutation<void, { projectId: string; force: boolean }>({
 				extraOptions: { command: 'abort_edit_and_return_to_workspace' },
 				query: (args) => args,
 				invalidatesTags: [invalidatesList(ReduxTag.HeadMetadata)]

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -60,8 +60,8 @@ pub fn enter_edit_mode(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn abort_edit_and_return_to_workspace(ctx: &mut but_ctx::Context) -> Result<()> {
-    gitbutler_edit_mode::commands::abort_and_return_to_workspace(ctx)?;
+pub fn abort_edit_and_return_to_workspace(ctx: &mut but_ctx::Context, force: bool) -> Result<()> {
+    gitbutler_edit_mode::commands::abort_and_return_to_workspace(ctx, force)?;
 
     Ok(())
 }

--- a/crates/but/src/args/resolve.rs
+++ b/crates/but/src/args/resolve.rs
@@ -13,5 +13,9 @@ pub enum Subcommands {
     ///
     /// This discards all changes made during resolution and restores
     /// the workspace to its pre-resolution state.
-    Cancel,
+    Cancel {
+        /// Forcibly remove any changes made
+        #[clap(short = 'f', long)]
+        force: bool,
+    },
 }

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -40,12 +40,12 @@ pub fn save_and_return_to_workspace(ctx: &mut Context) -> Result<()> {
     crate::save_and_return_to_workspace(ctx, guard.write_permission())
 }
 
-pub fn abort_and_return_to_workspace(ctx: &mut Context) -> Result<()> {
+pub fn abort_and_return_to_workspace(ctx: &mut Context, force: bool) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
 
     ensure_edit_mode(ctx).context("Edit mode may only be left while in edit mode")?;
 
-    crate::abort_and_return_to_workspace(ctx, guard.write_permission())
+    crate::abort_and_return_to_workspace(ctx, force, guard.write_permission())
 }
 
 pub fn starting_index_state(ctx: &mut Context) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>> {

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -193,7 +193,13 @@ pub(crate) fn enter_edit_mode(
     Ok(edit_mode_metadata)
 }
 
-pub(crate) fn abort_and_return_to_workspace(ctx: &Context, _perm: &mut RepoExclusive) -> Result<()> {
+pub(crate) fn abort_and_return_to_workspace(ctx: &Context, force: bool, perm: &mut RepoExclusive) -> Result<()> {
+    if !force && !changes_from_initial(ctx, perm.read_permission())?.is_empty() {
+        bail!(
+            "The working tree differs from the original commit. A forced abort is necessary.\nIf you are seeing this message, please report it as a bug. The UI should have prevented this line getting hit."
+        );
+    }
+
     let repo = &*ctx.git2_repo.get()?;
 
     // Checkout gitbutler workspace branch


### PR DESCRIPTION
* Resolves https://github.com/gitbutlerapp/gitbutler/issues/12310

When exiting edit mode, the intended behaviour is that any changes made are dropped.

This, however, introduced a UX issue where users were not made aware this was the case, and it unfortunately resulted in one user losing work.

This commit introduces flows that inform users of the potential risk, suggest that saving and exiting may be the preferred action, and then provide a safety override.

I have not switched over to `safe_checkout` yet because I am not sure it is doing exactly what we need here. In general, I am keen to refactor this code to use the new commit engine and move away from the older usage of stacks. This code has not seen many updates over its lifetime.

---

Desktop UX:
If it's safe, abort is immediately performed, otherwise the following modal is shown:

<img width="681" height="324" alt="Screenshot 2026-02-18 at 13 01 12" src="https://github.com/user-attachments/assets/94c95760-a8dd-4f57-b3e1-a9ac753ff2cb" />

CLI UX:
If it's safe, abort is immediately performed, otherwise this message is shown:

```bash
X why > /Users/calebowens/Sherman/projects/gitbutler-client/target/debug/but resolve cancel
Initiated a background sync...
Failed to handle conflict resolution. There are changes that differ from the original commit you were editing. Canceling will drop those changes.

If you want to go through with this, please re-run with `--force`.

If you want to keep the changes you have made, consider finishing the resolution and then moving the changes with the rub command
```