### PR TITLE
feat: gate tokio-console instrumentation behind an environment variable

### DIFF
--- a/crates/gitbutler-tauri/src/logs.rs
+++ b/crates/gitbutler-tauri/src/logs.rs
@@ -5,7 +5,7 @@ use tracing::{Level, instrument, metadata::LevelFilter, subscriber::set_global_d
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{Layer, filter::filter_fn, fmt::format::FmtSpan, layer::SubscriberExt};
 
-pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool, tokio_console_enabled: bool) {
+pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool, enable_tokio_console_log: bool) {
     fs::create_dir_all(logs_dir).expect("failed to create logs dir");
 
     let log_prefix = "GitButler";
@@ -40,7 +40,7 @@ pub fn init(app_handle: &AppHandle, logs_dir: &Path, performance_logging: bool, 
     let log_level = log_level_filter.into_level();
 
     let use_colors_in_logs = cfg!(not(feature = "windows"));
-    let console_layer = if tokio_console_enabled {
+    let console_layer = if enable_tokio_console_log {
         Some(
             console_subscriber::ConsoleLayer::builder()
                 .server_addr(get_server_addr(app_handle))

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -78,8 +78,7 @@ fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&app_cache_dir).context("failed to create app cache dir")?;
     std::fs::create_dir_all(&app_log_dir).context("failed to create app log dir")?;
 
-    let tokio_console_enabled = std::env::var_os("GITBUTLER_TOKIO_DEBUG").is_some();
-
+    let tokio_debug = std::env::var_os("GITBUTLER_TOKIO_DEBUG").is_some();
     let app_settings_for_menu = app_settings.clone();
     runtime.block_on(async {
         tauri::async_runtime::set(tokio::runtime::Handle::current());
@@ -111,7 +110,7 @@ fn main() -> anyhow::Result<()> {
 
                 let app_handle = tauri_app.handle();
 
-                logs::init(app_handle, &app_log_dir, performance_logging, tokio_console_enabled);
+                logs::init(app_handle, &app_log_dir, performance_logging, tokio_debug);
 
                 but_action::cli::auto_fix_broken_but_cli_symlink();
                 inherit_interactive_login_shell_environment_if_not_launched_from_terminal();

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -78,6 +78,8 @@ fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&app_cache_dir).context("failed to create app cache dir")?;
     std::fs::create_dir_all(&app_log_dir).context("failed to create app log dir")?;
 
+    let tokio_console_enabled = std::env::var_os("GITBUTLER_TOKIO_DEBUG").is_some();
+
     let app_settings_for_menu = app_settings.clone();
     runtime.block_on(async {
         tauri::async_runtime::set(tokio::runtime::Handle::current());
@@ -109,7 +111,7 @@ fn main() -> anyhow::Result<()> {
 
                 let app_handle = tauri_app.handle();
 
-                logs::init(app_handle, &app_log_dir, performance_logging);
+                logs::init(app_handle, &app_log_dir, performance_logging, tokio_console_enabled);
 
                 but_action::cli::auto_fix_broken_but_cli_symlink();
                 inherit_interactive_login_shell_environment_if_not_launched_from_terminal();

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&app_cache_dir).context("failed to create app cache dir")?;
     std::fs::create_dir_all(&app_log_dir).context("failed to create app log dir")?;
 
-    let tokio_debug = std::env::var_os("GITBUTLER_TOKIO_DEBUG").is_some();
+    let tokio_debug = matches!(std::env::var("GITBUTLER_TOKIO_DEBUG").as_deref(), Ok("1"));
     let app_settings_for_menu = app_settings.clone();
     runtime.block_on(async {
         tauri::async_runtime::set(tokio::runtime::Handle::current());


### PR DESCRIPTION
Hi,

Happy GitButler user since ~day one, first time contributor. 👋

I noticed that `~/Library/Logs/com.gitbutler.app/tokio-console` was growing very large (16968 lines per 5 seconds) and a few GBs per day. It was cleared each time GB was restarted, but it's still a lot on unnecessary disk I/O. It incrementally gets worse when you have more repos added.

After digging into the code, I found that tokio-console instrumentation was unconditionally enabled in all builds. I understand having it for troubleshooting and tracing issues, but it seems excessive to have it enabled for all users by default.

So..I added a new "Tokio runtime tracing" toggle under Experimental settings to control whether the `ConsoleLayer` is registered at startup. When off, no `ConsoleLayer` is registered and no tokio-console file is written. I figured you'd want people to be able to enable it, so I also added a setting for it. 

## 🧢 Changes

Adds a "Tokio runtime tracing" toggle to the Experimental settings page that controls whether the ConsoleLayer is registered at startup. Disabled by default, eliminating unnecessary disk I/O and gRPC overhead for all users. Shows a restart-required warning toast when toggled.

## NOTE:

Changed enabling the tokio-console logging to use an environment variable, as requested. `GITBUTLER_TOKIO_DEBUG=1` makes it install the logging now. Without that, it's not installed and not generating logs.

