### PR TITLE
Use `sapling-streampager` instead of `minus` for paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "anstyle-lossy",
  "anstyle-parse",
  "html-escape",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -802,12 +802,12 @@ dependencies = [
  "insta",
  "itertools",
  "machine-uid",
- "minus",
  "nonempty",
  "posthog-rs",
  "ratatui",
  "regex",
  "rmcp",
+ "sapling-streampager",
  "schemars 1.2.1",
  "self_cell",
  "serde",
@@ -822,7 +822,7 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3017,6 +3017,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -6605,19 +6617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minus"
-version = "5.6.1"
-source = "git+https://github.com/arijit79/minus?rev=57f1848f831d153a10d65060562ce1fdde938a01#57f1848f831d153a10d65060562ce1fdde938a01"
-dependencies = [
- "crossbeam-channel",
- "crossterm",
- "parking_lot",
- "regex",
- "textwrap",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8379,7 +8378,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -8430,7 +8429,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -8973,6 +8972,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sapling-streampager"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17810e56620c313aa7ee8b1ffcd6b148e84061a9f80fbc609df0495c4b4a6172"
+dependencies = [
+ "dirs 6.0.0",
+ "enum_dispatch",
+ "lru",
+ "memmap2",
+ "regex",
+ "scopeguard",
+ "serde",
+ "smallvec",
+ "terminfo",
+ "termwiz",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "vec_map",
 ]
 
 [[package]]
@@ -10580,15 +10601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11287,8 +11299,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -11393,6 +11411,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -121,10 +121,7 @@ tracing-subscriber = { workspace = true, features = [
 tracing-forest.workspace = true
 cli-prompts.path = "vendor/cli-prompts"
 dirs.workspace = true
-minus = { git = "https://github.com/arijit79/minus", rev = "57f1848f831d153a10d65060562ce1fdde938a01", default-features = false, features = [
-    "static_output",
-    "search",
-] }
+sapling-streampager = "0.12.0"
 unicode-width = "0.2"
 cfg-if = "1.0.4"
 ratatui.workspace = true

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -108,6 +108,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     // Determine if pager should be used based on the command
     let use_pager = match args.cmd {
         #[cfg(feature = "legacy")]
+        Some(Subcommands::Status { .. }) => true,
+        #[cfg(feature = "legacy")]
         Some(Subcommands::Diff { tui, .. }) => !tui,
         #[cfg(feature = "legacy")]
         Some(Subcommands::Stage {

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -1,7 +1,7 @@
 use std::io::{IsTerminal, Write};
+use std::thread::JoinHandle;
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use minus::ExitStrategy;
 
 use crate::{args::OutputFormat, utils::json_pretty_to_stdout};
 
@@ -33,11 +33,50 @@ pub struct OutputChannel {
     format: OutputFormat,
     /// The output to use if there is no pager.
     stdout: std::io::Stdout,
-    /// Possibly a pager we are using. If `Some`, the pager itself is used for output instead of `stdout`.
-    pager: Option<minus::Pager>,
+    /// Optional streaming pager output.
+    pager: Option<PagerOutput>,
     /// When `Some`, JSON values written via `write_value` are captured here instead of going to stdout.
     /// Used by `--status-after` to buffer mutation JSON before combining with status JSON.
     json_buffer: Option<serde_json::Value>,
+}
+
+/// Streaming pager session.
+struct PagerOutput {
+    out_wr: std::io::PipeWriter,
+    pager_thread: JoinHandle<streampager::Result<()>>,
+}
+
+impl PagerOutput {
+    fn new() -> streampager::Result<Self> {
+        let config = streampager::config::Config {
+            interface_mode: streampager::config::InterfaceMode::Hybrid,
+            wrapping_mode: streampager::config::WrappingMode::GraphemeBoundary,
+            show_ruler: false,
+            scroll_past_eof: false,
+            ..Default::default()
+        };
+        let mut pager = streampager::Pager::new_using_system_terminal_with_config(config)?;
+        let (out_rd, out_wr) = std::io::pipe()?;
+        pager.add_stream(out_rd, "")?;
+        let pager_thread = std::thread::spawn(|| pager.run());
+        Ok(Self {
+            out_wr,
+            pager_thread,
+        })
+    }
+
+    fn write_all_ignoring_broken_pipe(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        self.out_wr.write_all(bytes).or_else(ignore_broken_pipe)
+    }
+
+    fn finalize(self) -> Result<(), String> {
+        drop(self.out_wr);
+        match self.pager_thread.join() {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(err)) => Err(format!("failed to run pager: {err}")),
+            Err(_) => Err("pager thread panicked".to_owned()),
+        }
+    }
 }
 
 /// A channel that implements [`std::io::Write`], to make unbuffered writes to [`std::io::stderr`]
@@ -105,6 +144,18 @@ impl OutputChannel {
     /// Get the output format setting.
     pub fn format(&self) -> OutputFormat {
         self.format
+    }
+
+    fn write_stdout_ignoring_broken_pipe(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        self.stdout.write_all(bytes).or_else(ignore_broken_pipe)
+    }
+
+    fn write_output_ignoring_broken_pipe(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        if let Some(pager) = self.pager.as_mut() {
+            pager.write_all_ignoring_broken_pipe(bytes)
+        } else {
+            self.write_stdout_ignoring_broken_pipe(bytes)
+        }
     }
 }
 
@@ -221,24 +272,10 @@ impl OutputChannel {
 
 impl std::fmt::Write for OutputChannel {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        use std::io::Write;
         match self.format {
-            OutputFormat::Human | OutputFormat::Shell => {
-                if let Some(out) = self.pager.as_mut() {
-                    out.write_str(s)
-                } else {
-                    self.stdout.write_all(s.as_bytes()).or_else(|err| {
-                        if err.kind() == std::io::ErrorKind::BrokenPipe {
-                            // Ignore broken pipes and keep writing.
-                            // This allows the caller to use `?` without having to think
-                            // about ignoring errors selectively.
-                            Ok(())
-                        } else {
-                            Err(std::fmt::Error)
-                        }
-                    })
-                }
-            }
+            OutputFormat::Human | OutputFormat::Shell => self
+                .write_output_ignoring_broken_pipe(s.as_bytes())
+                .map_err(|_| std::fmt::Error),
             OutputFormat::Json | OutputFormat::None => {
                 // It's not an error to try to write in JSON mode, it's a feature.
                 // However, the only way to write JSON is to use [Self::write_value()].
@@ -490,21 +527,25 @@ impl OutputChannel {
     /// It's configured to print to stdout unless [`OutputFormat::Json`] is used, then it prints everything
     /// to a `/dev/null` equivalent, so callers never have to worry if they interleave JSON with other output.
     pub fn new_with_optional_pager(format: OutputFormat, use_pager: bool) -> Self {
+        let stdout = std::io::stdout();
+        let use_streaming_pager = matches!(format, OutputFormat::Human)
+            && std::env::var_os("NOPAGER").is_none()
+            && use_pager
+            && stdout.is_terminal();
         OutputChannel {
             format,
-            stdout: std::io::stdout(),
-            pager: if !matches!(format, OutputFormat::Human)
-                || std::env::var_os("NOPAGER").is_some()
-                || !use_pager
-            {
-                None
+            pager: if use_streaming_pager {
+                match PagerOutput::new() {
+                    Ok(pager) => Some(pager),
+                    Err(err) => {
+                        eprintln!("warning: failed to set up pager: {err}");
+                        None
+                    }
+                }
             } else {
-                let pager = minus::Pager::new();
-                let msg = "can talk to newly created pager";
-                pager.set_exit_strategy(ExitStrategy::PagerQuit).expect(msg);
-                pager.set_prompt("GitButler").expect(msg);
-                Some(pager)
+                None
             },
+            stdout,
             json_buffer: None,
         }
     }
@@ -535,8 +576,10 @@ impl Drop for OutputChannel {
         {
             eprintln!("warning: failed to flush buffered JSON on drop: {err}");
         }
-        if let Some(pager) = self.pager.take() {
-            minus::page_all(pager).ok();
+        if let Some(pager) = self.pager.take()
+            && let Err(err) = pager.finalize()
+        {
+            eprintln!("warning: {err}");
         }
     }
 }


### PR DESCRIPTION
This makes it possible to keep the visible content on screen, probably because it doesn't use an alaternate screen.

However, this still won't reprint the lines that are 'above' the screen.

https://github.com/user-attachments/assets/abce6b30-289d-485f-8f63-d353488df1f7

### *Benefits* of `streampager` over `minus`

- It seems to be better with large content as it doesn't buffer everything, somehow.

### *Shortcomings* of `streampager` over `minus`

- It has more dependencies, and bundles `fancy-regex`


### Tasks

* [ ] repeat lines above the screen without duplicating content. This might need a patch in the streampager.
    - if we'd have to patch it, we might as well patch and vendor `minus`, which was unresponsive to my previous PR
    - maybe `streampager`, the original, would be more responsive to PRs
* [ ] thorough testing - how does it work on Windows?
* [ ] use the pager more, but validate how it interacts with input. Probably it's an opt-in affair anyway.
* [ ] Thorough review and refactor (the PR is fully vibed
