### PR TITLE
Eslint: Ignore but-sdk generated code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -155,7 +155,9 @@ export default ts.config(
 			'crates/',
 			'packages/ui/storybook-static',
 			// Storybook Meta type wrapper
-			'packages/ui/src/stories/**/*.stories.ts'
+			'packages/ui/src/stories/**/*.stories.ts',
+			// but-sdk generated code
+			'packages/but-sdk/src/generated'
 		]
 	}
 );


### PR DESCRIPTION
Ignore the generated type definitions and other generated code.

We’ll valideate the generated code separately