### PR TITLE
In Tauri and Cmd API functions, turn panics into errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,7 @@ dependencies = [
  "but-settings",
  "but-workspace",
  "but-worktrees",
+ "futures",
  "git2",
  "gitbutler-branch",
  "gitbutler-branch-actions",

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -165,7 +165,6 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let call_fn_args = if asyncness.is_some() {
         quote! {{
-            crate::panic_capture::prepare_for_call();
             let __call_result =
                 ::futures::FutureExt::catch_unwind(::std::panic::AssertUnwindSafe(async {
                     #fn_name(#(#call_arg_idents),*).await
@@ -178,7 +177,6 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         }}
     } else {
         quote! {{
-            crate::panic_capture::prepare_for_call();
             let __call_result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
                 #fn_name(#(#call_arg_idents),*)
             }))

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -164,9 +164,29 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let call_fn_args = if asyncness.is_some() {
-        quote! { #fn_name(#(#call_arg_idents),*).await }
+        quote! {{
+            crate::panic_capture::prepare_for_call();
+            let __call_result =
+                ::futures::FutureExt::catch_unwind(::std::panic::AssertUnwindSafe(async {
+                    #fn_name(#(#call_arg_idents),*).await
+                }))
+                .await
+                .map_err(|__panic_payload| {
+                    crate::panic_capture::panic_payload_to_anyhow(stringify!(#fn_name), __panic_payload)
+                })?;
+            __call_result
+        }}
     } else {
-        quote! { #fn_name(#(#call_arg_idents),*) }
+        quote! {{
+            crate::panic_capture::prepare_for_call();
+            let __call_result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                #fn_name(#(#call_arg_idents),*)
+            }))
+            .map_err(|__panic_payload| {
+                crate::panic_capture::panic_payload_to_anyhow(stringify!(#fn_name), __panic_payload)
+            })?;
+            __call_result
+        }}
     };
 
     // Build napi-specific parameter list and conversions.

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -121,6 +121,7 @@ bstr = { workspace = true }
 schemars.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -36,3 +36,5 @@ pub mod platform;
 
 /// Functions related to the generation of TS types out of schemas
 pub mod schema;
+
+mod panic_capture;

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -37,4 +37,4 @@ pub mod platform;
 /// Functions related to the generation of TS types out of schemas
 pub mod schema;
 
-mod panic_capture;
+pub mod panic_capture;

--- a/crates/but-api/src/panic_capture.rs
+++ b/crates/but-api/src/panic_capture.rs
@@ -1,0 +1,96 @@
+use std::any::Any;
+use std::cell::RefCell;
+use std::panic::{self, PanicHookInfo};
+use std::sync::Once;
+
+#[derive(Debug)]
+struct PanicInfoSnapshot {
+    payload_message: Option<String>,
+    location: Option<String>,
+    thread_name: String,
+    thread_id: String,
+    backtrace: String,
+}
+
+thread_local! {
+    static LAST_PANIC_INFO: RefCell<Option<PanicInfoSnapshot>> = const { RefCell::new(None) };
+}
+
+static INSTALL_PANIC_HOOK: Once = Once::new();
+
+pub(crate) fn prepare_for_call() {
+    install_panic_hook();
+    LAST_PANIC_INFO.with(|slot| {
+        slot.borrow_mut().take();
+    });
+}
+
+pub(crate) fn panic_payload_to_anyhow(
+    function_name: &'static str,
+    panic_payload: Box<dyn Any + Send + 'static>,
+) -> anyhow::Error {
+    let payload_message = panic_payload_message(panic_payload.as_ref());
+    let snapshot = LAST_PANIC_INFO.with(|slot| slot.borrow_mut().take());
+
+    if let Some(snapshot) = snapshot {
+        let panic_message = snapshot
+            .payload_message
+            .as_deref()
+            .or(payload_message.as_deref())
+            .unwrap_or("panic payload was not a string");
+        let panic_location = snapshot.location.as_deref().unwrap_or("<unknown location>");
+        anyhow::anyhow!(
+            "panic while executing `{}` on thread '{}' ({}) at {}: {}\n\npanic backtrace:\n{}",
+            function_name,
+            snapshot.thread_name,
+            snapshot.thread_id,
+            panic_location,
+            panic_message,
+            snapshot.backtrace
+        )
+    } else {
+        let panic_message = payload_message.as_deref().unwrap_or("panic payload was not a string");
+        anyhow::anyhow!(
+            "panic while executing `{}`: {}\n\npanic backtrace unavailable from hook; conversion backtrace:\n{}",
+            function_name,
+            panic_message,
+            std::backtrace::Backtrace::force_capture()
+        )
+    }
+}
+
+fn install_panic_hook() {
+    INSTALL_PANIC_HOOK.call_once(|| {
+        let previous_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic_info| {
+            capture_panic_info(panic_info);
+            previous_hook(panic_info);
+        }));
+    });
+}
+
+fn capture_panic_info(panic_info: &PanicHookInfo<'_>) {
+    let thread = std::thread::current();
+    let snapshot = PanicInfoSnapshot {
+        payload_message: panic_payload_message(panic_info.payload()),
+        location: panic_info
+            .location()
+            .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column())),
+        thread_name: thread.name().unwrap_or("<unnamed>").to_owned(),
+        thread_id: format!("{:?}", thread.id()),
+        backtrace: std::backtrace::Backtrace::force_capture().to_string(),
+    };
+    LAST_PANIC_INFO.with(|slot| {
+        *slot.borrow_mut() = Some(snapshot);
+    });
+}
+
+fn panic_payload_message(payload: &(dyn Any + Send)) -> Option<String> {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        return Some((*message).to_owned());
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return Some(message.clone());
+    }
+    None
+}

--- a/crates/but-api/src/panic_capture.rs
+++ b/crates/but-api/src/panic_capture.rs
@@ -1,30 +1,49 @@
+//! Panic capture helpers used when converting unwind payloads into `anyhow::Error`.
+//!
+//! The application should call [`install_panic_hook()`] once at startup.
+//!
+//! Then, if an unwind happens, the hook stores panic metadata in `LAST_PANIC_INFO`, and
+//! `panic_payload_to_anyhow()` combines that snapshot with the unwind payload to
+//! produce a detailed error.
+
 use std::any::Any;
 use std::cell::RefCell;
 use std::panic::{self, PanicHookInfo};
 use std::sync::Once;
 
+/// Snapshot of panic metadata captured by the installed hook.
 #[derive(Debug)]
 struct PanicInfoSnapshot {
+    /// Message extracted from the panic payload, when the payload is a string type.
     payload_message: Option<String>,
+    /// Source location in `file:line:column` format, when provided by the runtime.
     location: Option<String>,
+    /// Name of the thread that panicked, or `"<unnamed>"` if no name exists.
     thread_name: String,
+    /// Debug-formatted thread identifier for disambiguating worker threads.
     thread_id: String,
+    /// The backtrace captured at panic-hook time on the panicking thread.
     backtrace: String,
 }
 
 thread_local! {
+    /// Most recent panic snapshot for the current thread.
+    ///
+    /// This is cleared when the information is consumed via [`panic_payload_to_anyhow()`].
     static LAST_PANIC_INFO: RefCell<Option<PanicInfoSnapshot>> = const { RefCell::new(None) };
 }
 
+/// Ensures panic-hook installation happens exactly once per process.
 static INSTALL_PANIC_HOOK: Once = Once::new();
 
-pub(crate) fn prepare_for_call() {
-    install_panic_hook();
-    LAST_PANIC_INFO.with(|slot| {
-        slot.borrow_mut().take();
-    });
-}
-
+/// Converts a caught panic payload into an `anyhow::Error`.
+///
+/// The error prefers metadata captured by the panic hook (panic message, location,
+/// thread info, and panic-time backtrace). If no snapshot is available, it falls
+/// back to payload-derived message plus a backtrace captured during conversion.
+///
+/// Assumes that the panic hook has been installed via [`install_panic_hook()`], or
+/// else the panic message will not have a backtrace.
 pub(crate) fn panic_payload_to_anyhow(
     function_name: &'static str,
     panic_payload: Box<dyn Any + Send + 'static>,
@@ -59,7 +78,9 @@ pub(crate) fn panic_payload_to_anyhow(
     }
 }
 
-fn install_panic_hook() {
+/// Installs a hook that captures panic context and then delegates to the previous hook.
+/// Can be called multiple times, but only the first call will install the hook.
+pub fn install_panic_hook() {
     INSTALL_PANIC_HOOK.call_once(|| {
         let previous_hook = panic::take_hook();
         panic::set_hook(Box::new(move |panic_info| {
@@ -69,6 +90,7 @@ fn install_panic_hook() {
     });
 }
 
+/// Captures panic metadata from `panic_info` into thread-local storage.
 fn capture_panic_info(panic_info: &PanicHookInfo<'_>) {
     let thread = std::thread::current();
     let snapshot = PanicInfoSnapshot {
@@ -85,6 +107,9 @@ fn capture_panic_info(panic_info: &PanicHookInfo<'_>) {
     });
 }
 
+/// Extracts a human-readable panic payload message when the payload is string-like.
+///
+/// Returns `Some(String)` for `&'static str` and `String` payloads, otherwise `None`.
 fn panic_payload_message(payload: &(dyn Any + Send)) -> Option<String> {
     if let Some(message) = payload.downcast_ref::<&'static str>() {
         return Some((*message).to_owned());

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -110,6 +110,7 @@ async fn localhost_only_middleware(
 }
 
 pub async fn run() {
+    but_api::panic_capture::install_panic_hook();
     let cors = CorsLayer::new()
         .allow_methods(cors::Any)
         .allow_origin(cors::AllowOrigin::predicate(|origin, _parts| {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -23,6 +23,7 @@ use tauri_plugin_log::{Target, TargetKind};
 use tokio::sync::Mutex;
 
 fn main() -> anyhow::Result<()> {
+    but_api::panic_capture::install_panic_hook();
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
     #[cfg(feature = "builtin-but")]
     {


### PR DESCRIPTION
This way we will always see them, and surface them in the UI as well. Previously, they would always end up being caught by `tokio` and surface in its console logs, which isn't very intuitive.

Related to #12414.

https://github.com/user-attachments/assets/749f8d52-6ca3-4015-883d-ad2ee62fdec7

### Tasks

* [x] validate locally
* [x] does it provide the correct stacktrace?
* [x] cleanup

### Review Notes

* Not all panics will be captured as panics in functions that *do not* go through frontend calls still bubble up to `tokio`, but this is a clear step up.
