### PR TITLE
ci: remove use of custom PAT for tag creation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -453,10 +453,10 @@ jobs:
   create-git-tag:
     needs: [publish-tauri, build-tauri]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push tags
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
       - name: Create git tag
         shell: bash
         env:


### PR DESCRIPTION
## 🧢 Changes
We have a custom PAT for tag creation that was blocked by the new security policy, see https://github.com/gitbutlerapp/gitbutler/actions/runs/22177917761/job/64136036341

There's no need for it that I can see, we can just set write permissions on the GitHub token.