### PR TITLE
but-sdk: Validate the generated code

### DIFF
--- a/packages/but-sdk/package.json
+++ b/packages/but-sdk/package.json
@@ -10,6 +10,7 @@
 		"build:napi": "napi build --platform --release --manifest-path ../../crates/but-napi/Cargo.toml --js index.js --dts index.d.ts --output-dir ./src/generated/.",
 		"build": "pnpm build:napi && pnpm build:types",
 		"build:debug": "napi build --platform --manifest-path ../../crates/but-napi/Cargo.toml --js index.js --dts index.d.ts --output-dir . --verbose",
+		"check": "tsc -p tsconfig.generated.json --noEmit",
 		"prepublishOnly": "napi prepublish -t npm",
 		"testTypes": "ts-node ./src/test.ts",
 		"universal": "napi universal"

--- a/packages/but-sdk/tsconfig.generated.json
+++ b/packages/but-sdk/tsconfig.generated.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": false,
+    "composite": true
+  },
+  "include": ["src/generated/**/*.ts"]
+}

--- a/packages/but-sdk/tsconfig.json
+++ b/packages/but-sdk/tsconfig.json
@@ -20,5 +20,8 @@
 		"rootDir": "src"
 	},
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts", "src/generated"],
+	"references": [ {
+		"path": "tsconfig.generated.json"
+	}]
 }


### PR DESCRIPTION
Have TS checks for the generated code, so that if there are any missing
types, the checker complains about it.

Add some validation of the but-sdk