### PR TITLE
CI: package the but-sdk

### DIFF
--- a/packages/but-sdk/package.json
+++ b/packages/but-sdk/package.json
@@ -13,7 +13,8 @@
 		"check": "tsc -p tsconfig.generated.json --noEmit",
 		"prepublishOnly": "napi prepublish -t npm",
 		"testTypes": "ts-node ./src/test.ts",
-		"universal": "napi universal"
+		"universal": "napi universal",
+		"package": "pnpm build"
 	},
 	"napi": {
 		"binaryName": "gitbutler-sdk",


### PR DESCRIPTION
Add a package script to the but-sdk so that it’s built before lints and
tests run