### PR TITLE
ci: clean up PAT/permissions in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,8 @@ on:
           - minor
           - major
 
+permissions: {}
+
 jobs:
   build-sveltekit:
     runs-on: ubuntu-latest
@@ -40,8 +42,6 @@ jobs:
         shell: bash
         run: curl "${{ secrets.SENTRY_CRONS }}?status=in_progress"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.PAT_JUNON }}
       - name: Consume input variables
         shell: bash
         if: ${{ !github.event.workflow_run }}
@@ -127,8 +127,6 @@ jobs:
           echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
       - name: Set Cargo build target to ${{ matrix.target }}
         shell: bash
         if: matrix.target != ''
@@ -336,7 +334,6 @@ jobs:
   sign-but:
     needs: build-tauri
     runs-on: ubuntu-latest
-    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -401,8 +398,6 @@ jobs:
             target: ''
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
       - name: Set artifact name suffix
         shell: bash
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,10 +37,6 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
-      - name: Trigger Sentry Cron - In Progress
-        if: ${{ github.event_name == 'schedule' }}
-        shell: bash
-        run: curl "${{ secrets.SENTRY_CRONS }}?status=in_progress"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Consume input variables
         shell: bash
@@ -476,7 +472,3 @@ jobs:
             delete_tag "$TAG_NAME"
           fi
           create_tag "$TAG_NAME"
-      - name: Trigger Sentry Cron - Complete
-        if: ${{ github.event_name == 'schedule' }}
-        shell: bash
-        run: curl "${{ secrets.SENTRY_CRONS }}?status=ok"


### PR DESCRIPTION
## 🧢 Changes
Remove redundant use of custom PAT and set a default of _no_ permissions for the GITHUB_TOKEN for all jobs.

Only the job that creates tags actually needs the token and it explicitly sets `contents: write`.

Although it may _seem_ like we need a bunch of permissions for e.g. the artifacts stuff, those actions are in fact not using `GITHUB_TOKEN`. Instead, they use the (seemingly completely undocumented) `ACTIONS_RUNTIME_TOKEN` that is only made available to actions, and not steps. So this should all work fine.