### PR TITLE
increase installer + curl download timeout from 30s to 300s

### DIFF
--- a/crates/but-installer/src/http.rs
+++ b/crates/but-installer/src/http.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use curl::easy::Easy;
 
-const REQUEST_TIMEOUT_SECS: u64 = 30;
+const REQUEST_TIMEOUT_SECS: u64 = 300;
 const CONNECT_TIMEOUT_SECS: u64 = 10;
 const MAX_REDIRECTS: u32 = 5;
 const USER_AGENT: &str = concat!("GitButler-Installer/", env!("CARGO_PKG_VERSION"), " (Rust installer)");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ trap 'rm -f "$INSTALLER_JSON" "$INSTALLER_BIN"' EXIT INT TERM
 INSTALLER_API_URL="https://app.gitbutler.com/installers/info/$INSTALLER_OS/$INSTALLER_ARCH"
 echo "Fetching installer information..."
 
-EFFECTIVE_URL=$(curl --fail --silent --show-error --location --max-redirs 5 --max-time 120 \
+EFFECTIVE_URL=$(curl --fail --silent --show-error --location --max-redirs 5 --max-time 300 \
     -o "$INSTALLER_JSON" -w '%{url_effective}' "$INSTALLER_API_URL") || {
     echo "Error: Failed to fetch installer information from $INSTALLER_API_URL" >&2
     exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,7 +46,7 @@ trap 'rm -f "$INSTALLER_JSON" "$INSTALLER_BIN"' EXIT INT TERM
 INSTALLER_API_URL="https://app.gitbutler.com/installers/info/$INSTALLER_OS/$INSTALLER_ARCH"
 echo "Fetching installer information..."
 
-EFFECTIVE_URL=$(curl --fail --silent --show-error --location --max-redirs 5 --max-time 30 \
+EFFECTIVE_URL=$(curl --fail --silent --show-error --location --max-redirs 5 --max-time 120 \
     -o "$INSTALLER_JSON" -w '%{url_effective}' "$INSTALLER_API_URL") || {
     echo "Error: Failed to fetch installer information from $INSTALLER_API_URL" >&2
     exit 1


### PR DESCRIPTION
## 🧢 Changes

 - [30db885032895af1d8b14c6addd72d6b3d30e917] Increase curl timeout from 30s to 300s in install sh script
 - [9965bccc5dd727ab2b46ad72621ccbd648797143] Modified rust installer to wait 300 seconds

## ☕️ Reasoning

Slow conference wifi prevented me installing `but`!

## 🎫 Affected issues

n/a
