### PR TITLE
Prevent Claude SDK from running before project registration

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -319,7 +319,7 @@
 
 	let mcpConfigModal = $state<CodegenMcpConfigModal>();
 
-	const mcpConfigQuery = $derived(claudeCodeService.mcpConfig({ projectId }));
+	const claudeConfigQuery = $derived(claudeCodeService.claudeConfig({ projectId }));
 	const isStackActiveQuery = $derived(claudeCodeService.isStackActive(projectId, stackId));
 	const isStackActive = $derived(isStackActiveQuery?.response || false);
 	const events = $derived(claudeCodeService.messages({ projectId, stackId }));
@@ -566,6 +566,10 @@
 							sessionId={sessionId.response}
 							{isStackActive}
 							{hasRulesToClear}
+							projectRegistered={claudeConfigQuery.response?.projectRegistered ?? true}
+							onRetryConfig={async () => {
+								await claudeCodeService.fetchClaudeConfig({ projectId }, { forceRefetch: true });
+							}}
 							onAnswerQuestion={handleAnswerQuestion}
 						/>
 					{:else}
@@ -722,13 +726,13 @@
 	</ReduxResult>
 </div>
 
-<ReduxResult result={mcpConfigQuery.result} {projectId} {stackId} hideError>
-	{#snippet children(mcpConfig, { stackId })}
+<ReduxResult result={claudeConfigQuery.result} {projectId} {stackId} hideError>
+	{#snippet children(claudeConfig, { stackId })}
 		{@const laneState = stackId ? uiState.lane(stackId) : undefined}
 		<CodegenMcpConfigModal
 			disabledServers={laneState?.disabledMcpServers.current || []}
 			bind:this={mcpConfigModal}
-			{mcpConfig}
+			{claudeConfig}
 			toggleServer={(server) => {
 				const disabledServers = laneState?.disabledMcpServers.current;
 				if (disabledServers) {

--- a/apps/desktop/src/components/codegen/CodegenChatClaudeNotRegistered.svelte
+++ b/apps/desktop/src/components/codegen/CodegenChatClaudeNotRegistered.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { sleep } from '$lib/utils/sleep';
+	import { Icon, AsyncButton } from '@gitbutler/ui';
+
+	interface Props {
+		onRetryConfig?: () => Promise<void>;
+	}
+
+	const { onRetryConfig }: Props = $props();
+</script>
+
+<div class="not-available-banner__wrapper">
+	<div class="not-available-banner">
+		<div class="not-available-banner__content">
+			<h3 class="text-16 text-semibold">
+				<span class="not-available-banner__icon">
+					<Icon name="warning" />
+				</span> Project not setup
+			</h3>
+			<p class="text-13 text-body clr-text-2">
+				Please run claude in the project directory to finish setup.
+			</p>
+			<AsyncButton
+				style="gray"
+				icon="mixer"
+				type="button"
+				reversedDirection
+				action={async () => {
+					await onRetryConfig?.();
+					await sleep(500); // for the sake of ux
+				}}
+			>
+				Retry…
+			</AsyncButton>
+		</div>
+	</div>
+</div>
+
+<style lang="postcss">
+	.not-available-banner__wrapper {
+		display: flex;
+		z-index: var(--z-ground);
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		justify-content: center;
+		width: 100%;
+		padding: 14px;
+	}
+	.not-available-banner {
+		display: flex;
+		bottom: 16px;
+		flex-direction: column;
+		width: fit-content;
+		padding: 16px;
+		overflow: hidden;
+		gap: 16px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-1);
+		box-shadow: var(--fx-shadow-l);
+	}
+
+	.not-available-banner__content {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 10px;
+	}
+
+	.not-available-banner__icon {
+		display: inline-flex;
+		margin-right: 2px;
+		transform: translateY(2px);
+		color: var(--clr-theme-warn-element);
+	}
+</style>

--- a/apps/desktop/src/components/codegen/CodegenMcpConfigModal.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMcpConfigModal.svelte
@@ -9,15 +9,15 @@
 		ScrollableContainer,
 		Toggle
 	} from '@gitbutler/ui';
-	import type { McpConfig, McpServer } from '$lib/codegen/types';
+	import type { ClaudeConfig, McpServer } from '$lib/codegen/types';
 
 	type Props = {
-		mcpConfig: McpConfig;
+		claudeConfig: ClaudeConfig;
 		disabledServers: string[];
 		toggleServer: (server: string) => void;
 	};
 
-	const { mcpConfig, disabledServers, toggleServer }: Props = $props();
+	const { claudeConfig, disabledServers, toggleServer }: Props = $props();
 
 	let modal = $state<Modal>();
 
@@ -29,11 +29,13 @@
 <Modal
 	bind:this={modal}
 	width={480}
-	title={Object.entries(mcpConfig.mcpServers).length > 0 ? 'MCP server configuration' : undefined}
+	title={Object.entries(claudeConfig.mcpServers).length > 0
+		? 'MCP server configuration'
+		: undefined}
 >
 	<ScrollableContainer>
 		<div class="flex flex-col gap-8">
-			{#if Object.entries(mcpConfig.mcpServers).length === 0}
+			{#if Object.entries(claudeConfig.mcpServers).length === 0}
 				<EmptyStatePlaceholder image={emptyFolderSvg} width={300} topBottomPadding={38}>
 					{#snippet title()}
 						No MCP servers available
@@ -53,7 +55,7 @@
 					>
 				</p>
 				<CardGroup>
-					{#each Object.entries(mcpConfig.mcpServers) as [name, server]}
+					{#each Object.entries(claudeConfig.mcpServers) as [name, server]}
 						{@render mcpServer(name, server)}
 					{/each}
 				</CardGroup>

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -6,6 +6,7 @@
 	import ClaudeCheck from '$components/codegen/ClaudeCheck.svelte';
 	import CodegenAskUserQuestion from '$components/codegen/CodegenAskUserQuestion.svelte';
 	import CodegenChatClaudeNotAvaliableBanner from '$components/codegen/CodegenChatClaudeNotAvaliableBanner.svelte';
+	import CodegenChatClaudeNotRegistered from '$components/codegen/CodegenChatClaudeNotRegistered.svelte';
 	import CodegenClaudeMessage from '$components/codegen/CodegenClaudeMessage.svelte';
 	import CodegenInput from '$components/codegen/CodegenInput.svelte';
 	import CodegenPromptConfigModal from '$components/codegen/CodegenPromptConfigModal.svelte';
@@ -64,6 +65,7 @@
 		laneId: string;
 		initialPrompt?: string;
 		isStackActive?: boolean;
+		projectRegistered?: boolean;
 		events: ClaudeMessage[];
 		permissionRequests: ClaudePermissionRequest[];
 		sessionId?: string;
@@ -74,6 +76,7 @@
 		onAbort?: () => Promise<void>;
 		onSubmit?: (prompt: string) => Promise<void>;
 		onAnswerQuestion?: (answers: Record<string, string>) => Promise<void>;
+		onRetryConfig?: () => Promise<void>;
 	};
 	const {
 		projectId,
@@ -81,7 +84,8 @@
 		laneId,
 		branchName,
 		initialPrompt,
-		isStackActive = false,
+		isStackActive,
+		projectRegistered,
 		events,
 		permissionRequests,
 		sessionId,
@@ -91,7 +95,8 @@
 		onAbort,
 		onSubmit,
 		onMcpSettings,
-		onAnswerQuestion
+		onAnswerQuestion,
+		onRetryConfig
 	}: Props = $props();
 
 	const stableBranchName = $derived(branchName);
@@ -478,6 +483,18 @@
 							</p>
 						</div>
 					</ConfigurableScrollableContainer>
+				{:else if !projectRegistered && formattedMessages.length === 0}
+					<ConfigurableScrollableContainer childrenWrapDisplay="contents">
+						<div class="no-agent-placeholder">
+							<div class="no-agent-placeholder__content">
+								{@html noClaudeCodeSvg}
+								<h2 class="text-serif-42">Set up Claude Code</h2>
+								<p class="text-13 text-body clr-text-2">
+									Run <code>claude</code> in this project's directory to finish setting up the integration.
+								</p>
+							</div>
+						</div>
+					</ConfigurableScrollableContainer>
 				{:else if !isStackActive && formattedMessages.length === 0}
 					<div class="chat-view__placeholder">
 						<EmptyStatePlaceholder
@@ -546,6 +563,10 @@
 							});
 						}}
 					/>
+				{/if}
+			{:else if !projectRegistered}
+				{#if formattedMessages.length > 0}
+					<CodegenChatClaudeNotRegistered {onRetryConfig} />
 				{/if}
 			{:else}
 				{@const status = currentStatus(events, isStackActive)}

--- a/apps/desktop/src/lib/codegen/claude.ts
+++ b/apps/desktop/src/lib/codegen/claude.ts
@@ -9,7 +9,7 @@ import {
 	type PermissionDecision,
 	type PromptTemplate,
 	type PromptDir,
-	type McpConfig,
+	type ClaudeConfig,
 	type SubAgent,
 	type PromptAttachment
 } from '$lib/codegen/types';
@@ -115,8 +115,12 @@ export class ClaudeCodeService {
 		return this.api.endpoints.createPromptDir.mutate;
 	}
 
-	get mcpConfig() {
-		return this.api.endpoints.getMcpConfig.useQuery;
+	get claudeConfig() {
+		return this.api.endpoints.getConfig.useQuery;
+	}
+
+	get fetchClaudeConfig() {
+		return this.api.endpoints.getConfig.fetch;
 	}
 
 	get subAgents() {
@@ -321,8 +325,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				},
 				query: (args) => args
 			}),
-			getMcpConfig: build.query<McpConfig, { projectId: string }>({
-				extraOptions: { command: 'claude_get_mcp_config' },
+			getConfig: build.query<ClaudeConfig, { projectId: string }>({
+				extraOptions: { command: 'claude_get_config' },
 				query: (args) => args
 			}),
 			getSubAgents: build.query<SubAgent[], { projectId: string }>({

--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -103,7 +103,7 @@ export function reverseMessages(messages: Message[]): Message[] {
 export function formatMessages(
 	events: ClaudeMessage[],
 	permissionRequests: ClaudePermissionRequest[],
-	isActive: boolean
+	isActive?: boolean
 ): Message[] {
 	const permReqsById: Record<string, ClaudePermissionRequest> = {};
 	for (const request of permissionRequests) {
@@ -551,7 +551,7 @@ function findModelPricing(name: string) {
 /**
  * Based on the current event log, determine the current status
  */
-export function currentStatus(events: ClaudeMessage[], isActive: boolean): ClaudeStatus {
+export function currentStatus(events: ClaudeMessage[], isActive?: boolean): ClaudeStatus {
 	if (events.length === 0) return 'disabled';
 	const lastEvent = events.at(-1)!;
 	if (lastEvent.payload.source === 'claude' && lastEvent.payload.data.type === 'result') {

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -259,8 +259,10 @@ export type PromptDir = {
 	filters: string[];
 };
 
-export type McpConfig = {
+export type ClaudeConfig = {
 	mcpServers: Record<string, McpServer>;
+	/** Whether this project appears in ~/.claude.json's projects map. False means the user needs to run `claude` in the project directory first. */
+	projectRegistered: boolean;
 };
 
 export type McpServer = {

--- a/crates/but-api/src/legacy/claude.rs
+++ b/crates/but-api/src/legacy/claude.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use but_api_macros::but_api;
 use but_claude::{
     Claude, ClaudeCheckResult, ClaudeMessage, ClaudeUserParams, Transcript,
-    claude_mcp::{ClaudeMcpConfig, McpConfig},
+    claude_mcp::{ClaudeConfig, ClaudeProjectConfig},
     claude_settings::ClaudeSettings,
     prompt_templates,
 };
@@ -191,11 +191,11 @@ pub fn claude_maybe_create_prompt_dir(ctx: &but_ctx::Context, path: String) -> R
 
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn claude_get_mcp_config(ctx: ThreadSafeContext) -> Result<McpConfig> {
+pub async fn claude_get_config(ctx: ThreadSafeContext) -> Result<ClaudeConfig> {
     let worktree_dir = ctx.into_thread_local().workdir_or_fail()?;
     let settings = ClaudeSettings::open(&worktree_dir).await;
-    let mcp_config = ClaudeMcpConfig::open(&settings, &worktree_dir).await;
-    Ok(mcp_config.mcp_servers())
+    let project_config = ClaudeProjectConfig::open(&settings, &worktree_dir).await;
+    Ok(project_config.config())
 }
 
 #[but_api]

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -987,7 +987,7 @@ async fn handle_command(
             let result = legacy::claude::claude_send_message(&app, params).await;
             result.map(|r| json!(r))
         }
-        "claude_get_mcp_config" => {
+        "claude_get_config" => {
             #[derive(Deserialize)]
             #[serde(rename_all = "camelCase")]
             struct Params {
@@ -995,7 +995,7 @@ async fn handle_command(
             }
             let params = serde_json::from_value::<Params>(request.params)?;
             let ctx = Context::new_from_legacy_project_id(params.project_id)?;
-            let result = legacy::claude::claude_get_mcp_config(ctx.into_sync()).await;
+            let result = legacy::claude::claude_get_config(ctx.into_sync()).await;
             result.map(|r| json!(r))
         }
         "claude_get_messages" => {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -352,7 +352,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::claude::tauri_claude_list_prompt_templates::claude_list_prompt_templates,
                 legacy::claude::tauri_claude_get_prompt_dirs::claude_get_prompt_dirs,
                 legacy::claude::tauri_claude_maybe_create_prompt_dir::claude_maybe_create_prompt_dir,
-                legacy::claude::tauri_claude_get_mcp_config::claude_get_mcp_config,
+                legacy::claude::tauri_claude_get_config::claude_get_config,
                 legacy::claude::tauri_claude_get_sub_agents::claude_get_sub_agents,
                 legacy::claude::tauri_claude_verify_path::claude_verify_path,
                 legacy::claude::tauri_claude_get_user_message::claude_get_user_message,


### PR DESCRIPTION
Gate the Claude integration on whether the project has been registered
in ~/.claude.json. When a user first runs `claude` in a project
directory, Claude Code prompts them to review and approve/deny MCP
servers configured in .mcp.json — this is a critical security step that
prevents unauthorized execution of potentially malicious MCP server
commands.

Changes:
- Add `project_registered` field to ClaudeConfig by checking if the
  project path exists in ~/.claude.json's projects map
- Block SDK session startup in send_message() when project isn't
  registered, returning a clear error
- Show a setup banner in the UI when projectRegistered is false
- Rename McpConfig → ClaudeConfig, ClaudeMcpConfig →
  ClaudeProjectConfig and claude_get_mcp_config → claude_get_config
  to better reflect that the config carries more than MCP data