### PR TITLE
Use nucleo-matcher for VSCode-style file search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,15 +3457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,7 +3996,6 @@ dependencies = [
  "but-rebase",
  "but-settings",
  "but-status",
- "fuzzy-matcher",
  "git2",
  "git2-hooks",
  "gitbutler-cherry-pick",
@@ -4019,6 +4009,7 @@ dependencies = [
  "infer",
  "insta",
  "itertools 0.14.0",
+ "nucleo-matcher",
  "resolve-path",
  "scopeguard",
  "serde",
@@ -6922,6 +6913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -39,7 +39,7 @@ toml.workspace = true
 base64 = "0.22.1"
 infer = "0.19.0"
 scopeguard = "1.2.0"
-fuzzy-matcher = "0.3.7"
+nucleo-matcher = "0.3"
 ignore = "0.4.25"
 
 [[test]]


### PR DESCRIPTION
Replace the previous skim-based fuzzy matcher with nucleo-matcher to
provide path-aware matching similar to VSCode's Cmd+P. The new
implementation:

- swaps fuzzy-matcher for nucleo-matcher in Cargo.toml
- bonuses for matches after '/', word boundaries and camelCase
  transitions
- updates compute_match_score to combine nucleo's path score with a
  filename bonus and a mild depth penalty