### PR TITLE
make session_id UUID-typed across hooks and API boundaries

### DIFF
--- a/crates/but-api/src/legacy/claude.rs
+++ b/crates/but-api/src/legacy/claude.rs
@@ -56,11 +56,10 @@ pub fn claude_get_messages(claude: &Claude, params: GetMessagesParams) -> Result
 #[instrument(err(Debug))]
 pub async fn claude_get_session_details(
     ctx: ThreadSafeContext,
-    session_id: String,
+    session_id: uuid::Uuid,
 ) -> Result<but_claude::ClaudeSessionDetails> {
     let (worktree_dir, session) = {
         let ctx = ctx.into_thread_local();
-        let session_id = uuid::Uuid::parse_str(&session_id).map_err(anyhow::Error::from)?;
         let session = but_claude::db::get_session_by_id(&ctx, session_id)?.context("Could not find session")?;
         let worktree_dir = ctx.workdir_or_fail()?;
         (worktree_dir, session)

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -1521,12 +1521,12 @@ fn create_pretool_use_hook(
                 if let HookInput::PreToolUse(pre_tool_input) = input {
                     let file_path = pre_tool_input.tool_input.get("file_path").and_then(|v| v.as_str());
                     if let Some(file_path) = file_path {
-                        let raw_session_id = pre_tool_input.session_id.clone();
-                        let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                        let session_id_str = pre_tool_input.session_id;
+                        let session_id = match uuid::Uuid::parse_str(&session_id_str) {
                             Ok(id) => id,
                             Err(e) => {
                                 tracing::warn!(
-                                    session_id = %raw_session_id,
+                                    session_id = %session_id_str,
                                     error = %e,
                                     "PreToolUse hook received invalid session ID - skipping file lock"
                                 );
@@ -1630,12 +1630,12 @@ fn create_post_tool_use_hook(sync_ctx: ThreadSafeContext) -> claude_agent_sdk_rs
                         });
                     }
 
-                    let raw_session_id = post_tool_input.session_id.clone();
-                    let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                    let session_id_str = post_tool_input.session_id;
+                    let session_id = match uuid::Uuid::parse_str(&session_id_str) {
                         Ok(id) => id,
                         Err(e) => {
                             tracing::warn!(
-                                session_id = %raw_session_id,
+                                session_id = %session_id_str,
                                 error = %e,
                                 "PostToolUse hook received invalid session ID - skipping hunk assignment"
                             );
@@ -1724,12 +1724,12 @@ fn create_stop_hook(sync_ctx: ThreadSafeContext) -> claude_agent_sdk_rs::HookCal
                         stop_input.session_id,
                         stop_input.transcript_path
                     );
-                    let raw_session_id = stop_input.session_id.clone();
-                    let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                    let session_id_str = stop_input.session_id;
+                    let session_id = match uuid::Uuid::parse_str(&session_id_str) {
                         Ok(id) => id,
                         Err(e) => {
                             tracing::warn!(
-                                session_id = %raw_session_id,
+                                session_id = %session_id_str,
                                 error = %e,
                                 "Stop hook received invalid session ID - skipping stop handling"
                             );
@@ -1740,7 +1740,7 @@ fn create_stop_hook(sync_ctx: ThreadSafeContext) -> claude_agent_sdk_rs::HookCal
                         }
                     };
                     let transcript_path = stop_input.transcript_path.clone();
-                    let session_id_for_log = raw_session_id;
+                    let session_id_for_log = session_id_str;
                     let transcript_path_for_log = transcript_path.clone();
                     let result = tokio::task::spawn_blocking(move || {
                         crate::hooks::handle_session_stop(

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -1521,10 +1521,24 @@ fn create_pretool_use_hook(
                 if let HookInput::PreToolUse(pre_tool_input) = input {
                     let file_path = pre_tool_input.tool_input.get("file_path").and_then(|v| v.as_str());
                     if let Some(file_path) = file_path {
-                        let session_id = pre_tool_input.session_id.clone();
+                        let raw_session_id = pre_tool_input.session_id.clone();
+                        let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                            Ok(id) => id,
+                            Err(e) => {
+                                tracing::warn!(
+                                    session_id = %raw_session_id,
+                                    error = %e,
+                                    "PreToolUse hook received invalid session ID - skipping file lock"
+                                );
+                                return HookJsonOutput::Sync(SyncHookJsonOutput {
+                                    continue_: Some(true),
+                                    ..Default::default()
+                                });
+                            }
+                        };
                         let file_path_owned = file_path.to_string();
                         let result = tokio::task::spawn_blocking(move || {
-                            crate::hooks::lock_file_for_tool_call(sync_ctx, &session_id, &file_path_owned)
+                            crate::hooks::lock_file_for_tool_call(sync_ctx, session_id, &file_path_owned)
                         })
                         .await;
 
@@ -1616,13 +1630,27 @@ fn create_post_tool_use_hook(sync_ctx: ThreadSafeContext) -> claude_agent_sdk_rs
                         });
                     }
 
-                    let session_id = post_tool_input.session_id.clone();
+                    let raw_session_id = post_tool_input.session_id.clone();
+                    let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            tracing::warn!(
+                                session_id = %raw_session_id,
+                                error = %e,
+                                "PostToolUse hook received invalid session ID - skipping hunk assignment"
+                            );
+                            return HookJsonOutput::Sync(SyncHookJsonOutput {
+                                continue_: Some(true),
+                                ..Default::default()
+                            });
+                        }
+                    };
                     let file_path_owned = file_path.to_string();
                     let file_path_for_log = file_path_owned.clone();
                     let result = tokio::task::spawn_blocking(move || {
                         crate::hooks::assign_hunks_post_tool_call(
                             sync_ctx.into_thread_local(),
-                            &session_id,
+                            session_id,
                             &file_path_owned,
                             &structured_patch,
                             true,
@@ -1696,14 +1724,28 @@ fn create_stop_hook(sync_ctx: ThreadSafeContext) -> claude_agent_sdk_rs::HookCal
                         stop_input.session_id,
                         stop_input.transcript_path
                     );
-                    let session_id = stop_input.session_id.clone();
+                    let raw_session_id = stop_input.session_id.clone();
+                    let session_id = match uuid::Uuid::parse_str(&raw_session_id) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            tracing::warn!(
+                                session_id = %raw_session_id,
+                                error = %e,
+                                "Stop hook received invalid session ID - skipping stop handling"
+                            );
+                            return HookJsonOutput::Sync(SyncHookJsonOutput {
+                                continue_: Some(true),
+                                ..Default::default()
+                            });
+                        }
+                    };
                     let transcript_path = stop_input.transcript_path.clone();
-                    let session_id_for_log = session_id.clone();
+                    let session_id_for_log = raw_session_id;
                     let transcript_path_for_log = transcript_path.clone();
                     let result = tokio::task::spawn_blocking(move || {
                         crate::hooks::handle_session_stop(
                             sync_ctx.into_thread_local(),
-                            &session_id,
+                            session_id,
                             &transcript_path,
                             true,
                         )


### PR DESCRIPTION
This refactor makes `session_id` type-safe (`uuid::Uuid`) through `but-claude` internals and key call paths, while keeping wire formats unchanged (JSON still sends/receives UUID strings).

### Tasks

* [x] thorough review and refactor
* [x] manual claude smoke test: edit exist and create new conversation
