### PR TITLE
fix-issue-12328: fix commit messages truncation in the CLI

### DIFF
--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -1,31 +1,14 @@
 use colored::Colorize;
 
 use crate::args::Args;
+use crate::tui::text::{terminal_width, truncate_text};
 
 pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
     use std::collections::HashSet;
 
     use clap::CommandFactory;
-    use terminal_size::{Width, terminal_size};
 
-    // Get terminal width, default to 80 if detection fails
-    let terminal_width = if let Some((Width(w), _)) = terminal_size() {
-        w as usize
-    } else {
-        80
-    };
-
-    // Helper function to truncate text to fit within available width
-    let truncate_text = |text: &str, available_width: usize| -> String {
-        const ELLIPSIS_LEN: usize = 1;
-        if text.len() <= available_width {
-            text.to_string()
-        } else if available_width > ELLIPSIS_LEN {
-            format!("{}…", &text[..available_width.saturating_sub(ELLIPSIS_LEN)])
-        } else {
-            text.chars().take(available_width).collect()
-        }
-    };
+    let terminal_width = terminal_width();
 
     let cmd = Args::command();
     let subcommands: Vec<_> = cmd.get_subcommands().collect();

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -126,7 +126,7 @@ pub(crate) fn show_oplog(
                     details.title.clone()
                 };
 
-                let display_title = truncate_text(&display_title, 80);
+                let display_title = truncate_text(display_title, 80).into_owned();
 
                 (op_type, display_title)
             } else {

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -3,10 +3,7 @@ use colored::Colorize;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
 use gix::date::time::CustomFormat;
 
-use crate::{
-    tui::text::truncate_text,
-    utils::{Confirm, ConfirmDefault, OutputChannel},
-};
+use crate::utils::{Confirm, ConfirmDefault, OutputChannel};
 
 pub const ISO8601_NO_TZ: CustomFormat = CustomFormat::new("%Y-%m-%d %H:%M:%S");
 
@@ -126,8 +123,7 @@ pub(crate) fn show_oplog(
                     details.title.clone()
                 };
 
-                let display_title = truncate_text(display_title, 80).into_owned();
-
+                let display_title = out.truncate_if_unpaged(&display_title, 80);
                 (op_type, display_title)
             } else {
                 ("UNKNOWN", "Unknown operation".to_string())

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -3,7 +3,10 @@ use colored::Colorize;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
 use gix::date::time::CustomFormat;
 
-use crate::utils::{Confirm, ConfirmDefault, OutputChannel};
+use crate::{
+    tui::text::truncate_text,
+    utils::{Confirm, ConfirmDefault, OutputChannel},
+};
 
 pub const ISO8601_NO_TZ: CustomFormat = CustomFormat::new("%Y-%m-%d %H:%M:%S");
 
@@ -123,13 +126,7 @@ pub(crate) fn show_oplog(
                     details.title.clone()
                 };
 
-                // Truncate display_title to 80 characters
-                let display_title = if display_title.chars().count() > 80 {
-                    let truncated: String = display_title.chars().take(77).collect();
-                    format!("{truncated}...")
-                } else {
-                    display_title
-                };
+                let display_title = truncate_text(&display_title, 80);
 
                 (op_type, display_title)
             } else {

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -17,7 +17,10 @@ use gitbutler_oplog::{
 };
 use gix::{revision::walk::Sorting, traverse::commit::simple::CommitTimeOrder};
 
-use crate::{CliId, IdMap, tui::text::truncate_text, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    utils::{OutputChannel, WriteWithUtils},
+};
 
 /// Handle the `but pick` command.
 ///
@@ -257,7 +260,7 @@ fn select_commits_from_branch(
         .map(|(i, (_oid, c))| {
             let short_id = &c.id().to_string()[..7];
             let message = c.summary().unwrap_or("(no message)");
-            let display = truncate_text(message, 60);
+            let display = out.truncate_if_unpaged(message, 60);
             format!("[{}] {} {}", i + 1, short_id, display)
         })
         .collect();

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -17,7 +17,7 @@ use gitbutler_oplog::{
 };
 use gix::{revision::walk::Sorting, traverse::commit::simple::CommitTimeOrder};
 
-use crate::{CliId, IdMap, utils::OutputChannel};
+use crate::{CliId, IdMap, tui::text::truncate_text, utils::OutputChannel};
 
 /// Handle the `but pick` command.
 ///
@@ -257,12 +257,7 @@ fn select_commits_from_branch(
         .map(|(i, (_oid, c))| {
             let short_id = &c.id().to_string()[..7];
             let message = c.summary().unwrap_or("(no message)");
-            let truncated: String = message.chars().take(60).collect();
-            let display = if truncated.len() < message.len() {
-                format!("{}...", truncated.trim_end())
-            } else {
-                truncated
-            };
+            let display = truncate_text(message, 60);
             format!("[{}] {} {}", i + 1, short_id, display)
         })
         .collect();

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -13,12 +13,11 @@ use gitbutler_branch_actions::upstream_integration::BranchStatus as UpstreamBran
 use gitbutler_stack::StackId;
 use gix::date::time::CustomFormat;
 use serde::Serialize;
-use unicode_width::UnicodeWidthStr;
 
 use crate::{
     CLI_DATE,
     id::{SegmentWithId, StackWithId, TreeChangeWithId},
-    tui::text::{terminal_width, truncate_text},
+    tui::text::truncate_text,
     utils::time::format_relative_time_verbose,
 };
 
@@ -130,7 +129,8 @@ pub(crate) async fn worktree(
     // Store the count of stacks for hint logic later
     let has_branches = !stacks.is_empty();
 
-    let assignments_by_file: BTreeMap<BString, FileAssignment> = FileAssignment::get_assignments_by_file(&id_map);
+    let assignments_by_file: BTreeMap<BString, FileAssignment> =
+        FileAssignment::get_assignments_by_file(&id_map);
     let mut stack_details: Vec<StackEntry> = vec![];
 
     let unassigned = assignment::filter_by_stack_id(assignments_by_file.values(), &None);
@@ -152,7 +152,10 @@ pub(crate) async fn worktree(
         let base_commit = repo.find_commit(target.sha.to_gix())?;
         let base_commit_decoded = base_commit.decode()?;
         let full_message = base_commit_decoded.message.to_string();
-        let formatted_date = base_commit_decoded.committer()?.time()?.format_or_unix(DATE_ONLY);
+        let formatted_date = base_commit_decoded
+            .committer()?
+            .time()?
+            .format_or_unix(DATE_ONLY);
         let author = base_commit_decoded.author()?;
         let common_merge_base_data = CommonMergeBase {
             target_name: target_name.clone(),
@@ -175,30 +178,39 @@ pub(crate) async fn worktree(
                     let state = if base_branch.behind > 0 {
                         // Get the latest commit on the upstream branch (current_sha is the tip of the remote branch)
                         let commit_id = base_branch.current_sha;
-                        repo.find_commit(commit_id.to_gix()).ok().and_then(|commit_obj| {
-                            let commit = commit_obj.decode().ok()?;
-                            let commit_message = {
-                                let raw = commit.message.to_string().replace('\n', " ");
-                                truncate_text(&raw, 30)
-                            };
+                        repo.find_commit(commit_id.to_gix())
+                            .ok()
+                            .and_then(|commit_obj| {
+                                let commit = commit_obj.decode().ok()?;
+                                let commit_message = truncate_text(
+                                    commit.message.to_string().replace('\n', " "),
+                                    30,
+                                );
 
-                            let formatted_date = commit.committer().ok()?.time().ok()?.format_or_unix(DATE_ONLY);
+                                let formatted_date = commit
+                                    .committer()
+                                    .ok()?
+                                    .time()
+                                    .ok()?
+                                    .format_or_unix(DATE_ONLY);
 
-                            let author = commit.author().ok()?;
+                                let author = commit.author().ok()?;
 
-                            Some(UpstreamState {
-                                target_name: base_branch.branch_name.clone(),
-                                behind_count: base_branch.behind,
-                                latest_commit: commit_id.to_string()[..7].to_string(),
-                                message: commit_message,
-                                commit_date: formatted_date,
-                                last_fetched_ms: last_fetched,
-                                commit_id: commit_id.to_gix(),
-                                created_at: commit.committer().ok()?.time().ok()?.seconds as i128 * 1000,
-                                author_name: author.name.to_string(),
-                                author_email: author.email.to_string(),
+                                Some(UpstreamState {
+                                    target_name: base_branch.branch_name.clone(),
+                                    behind_count: base_branch.behind,
+                                    latest_commit: commit_id.to_string()[..7].to_string(),
+                                    message: commit_message.into_owned(),
+                                    commit_date: formatted_date,
+                                    last_fetched_ms: last_fetched,
+                                    commit_id: commit_id.to_gix(),
+                                    created_at: commit.committer().ok()?.time().ok()?.seconds
+                                        as i128
+                                        * 1000,
+                                    author_name: author.name.to_string(),
+                                    author_email: author.email.to_string(),
+                                })
                             })
-                        })
                     } else {
                         None
                     };
@@ -207,7 +219,12 @@ pub(crate) async fn worktree(
                 .unwrap_or((None, None, None));
 
         // repo, base_commit, and base_commit_decoded are automatically dropped here at end of scope
-        (common_merge_base_data, upstream_state, last_fetched_ms, base_branch)
+        (
+            common_merge_base_data,
+            upstream_state,
+            last_fetched_ms,
+            base_branch,
+        )
     };
 
     // Compute upstream integration statuses if --upstream flag is set
@@ -324,21 +341,22 @@ pub(crate) async fn worktree(
                 let commits = base_branch.upstream_commits.iter().take(8);
                 for commit in commits {
                     // Measure prefix width using plain text (no ANSI codes)
-                    let prefix_width = format!("┊● {} ", &commit.id[..7]).width();
-                    let max_msg_width = terminal_width().saturating_sub(prefix_width);
+                    let truncated_msg =
+                        truncate_text(commit.description.to_string().replace('\n', " "), 72)
+                            .dimmed();
                     writeln!(
                         out,
-                        "┊{dot} {} {}",
-                        commit.id[..7].yellow(),
-                        {
-                            let raw = commit.description.to_string().replace('\n', " ");
-                            truncate_text(&raw, max_msg_width).dimmed()
-                        }
+                        "┊{dot} {short_id} {truncated_msg}",
+                        short_id = commit.id[..7].yellow()
                     )?;
                 }
                 let hidden_commits = base_branch.behind.saturating_sub(8);
                 if hidden_commits > 0 {
-                    writeln!(out, "┊    {}", format!("and {hidden_commits} more…").dimmed())?;
+                    writeln!(
+                        out,
+                        "┊    {}",
+                        format!("and {hidden_commits} more…").dimmed()
+                    )?;
                 }
             }
             writeln!(out, "┊┊")?;
@@ -355,21 +373,11 @@ pub(crate) async fn worktree(
     }
 
     let first_line = common_merge_base_data.message.lines().next().unwrap_or("");
-    let connector = if upstream_state.is_some() { "├╯" } else { "┴" };
-    // Build a plain-text prefix (no ANSI codes) to measure its exact display
-    // width. The output line applies styling (.dimmed(), .green(), etc.) but
-    // ANSI escape codes occupy zero display columns, so the plain-text
-    // measurement gives the correct visible width.
-    let prefix = format!(
-        "{} {} [{}] {} ",
-        connector,
-        common_merge_base_data.common_merge_base,
-        common_merge_base_data.target_name,
-        common_merge_base_data.commit_date,
-    );
-    let max_width = terminal_width().saturating_sub(prefix.width());
-    let display_message = truncate_text(first_line, max_width);
-
+    let connector = if upstream_state.is_some() {
+        "├╯"
+    } else {
+        "┴"
+    };
     writeln!(
         out,
         "{} {} [{}] {} {}",
@@ -377,10 +385,13 @@ pub(crate) async fn worktree(
         common_merge_base_data.common_merge_base.dimmed(),
         common_merge_base_data.target_name.green().bold(),
         common_merge_base_data.commit_date.dimmed(),
-        display_message,
+        truncate_text(first_line, 40)
     )?;
 
-    let not_on_workspace = matches!(mode, gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_));
+    let not_on_workspace = matches!(
+        mode,
+        gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
+    );
 
     if not_on_workspace {
         writeln!(
@@ -569,7 +580,9 @@ pub fn print_group(
 
             let review = segment
                 .branch_name()
-                .and_then(|branch_name| review::from_branch_details(review_map, branch_name, segment.pr_number()))
+                .and_then(|branch_name| {
+                    review::from_branch_details(review_map, branch_name, segment.pr_number())
+                })
                 .map(|r| format!(" {} ", r.display_cli(verbose)))
                 .unwrap_or_default();
 
@@ -634,7 +647,8 @@ pub fn print_group(
                 )?;
             }
             for commit in &segment.remote_commits {
-                let details = but_api::diff::commit_details(ctx, commit.commit_id(), ComputeLineStats::No)?;
+                let details =
+                    but_api::diff::commit_details(ctx, commit.commit_id(), ComputeLineStats::No)?;
                 print_commit(
                     commit.short_id.clone(),
                     &commit.inner,
@@ -651,8 +665,11 @@ pub fn print_group(
                 writeln!(out, "┊-")?;
             }
             for commit in segment.workspace_commits.iter() {
-                let marked = crate::command::legacy::mark::commit_marked(ctx, commit.commit_id().to_string())
-                    .unwrap_or_default();
+                let marked = crate::command::legacy::mark::commit_marked(
+                    ctx,
+                    commit.commit_id().to_string(),
+                )
+                .unwrap_or_default();
                 let classification = match commit.relation() {
                     LocalCommitRelation::LocalOnly => CommitClassification::LocalOnly,
                     LocalCommitRelation::LocalAndRemote(object_id) => {
@@ -778,27 +795,6 @@ fn print_commit(
 
     let upstream_commit = matches!(commit_changes, CommitChanges::Remote(_));
 
-    // Build the plain-text equivalent of the trailing suffix that appears
-    // after details_string: "┊{dot}   {details} {review_url} {mark}".
-    // We intentionally omit ANSI styling — escape codes are invisible and
-    // occupy zero display columns, so plain text gives the correct width.
-    //
-    // The format string always emits two separator spaces (" {} {}") between
-    // the three slots, even when review_url or mark are empty, so we include
-    // them unconditionally.
-    let mut trailing_suffix = String::new();
-    trailing_suffix.push(' '); // unconditional separator before review_url slot
-    if let Some(r) = &review_url {
-        trailing_suffix.push('◖');
-        trailing_suffix.push_str(r);
-        trailing_suffix.push('◗');
-    }
-    trailing_suffix.push(' '); // unconditional separator before mark slot
-    if marked {
-        trailing_suffix.push_str("◀ Marked ▶");
-    }
-    let trailing_width = trailing_suffix.width();
-
     let details_string = display_cli_commit_details(
         short_id,
         commit,
@@ -807,7 +803,6 @@ fn print_commit(
             CommitChanges::Remote(tree_changes) => !tree_changes.is_empty(),
         },
         verbose,
-        trailing_width,
     );
     let details_string = if upstream_commit {
         details_string.dimmed().to_string()
@@ -826,12 +821,10 @@ fn print_commit(
                 .unwrap_or_default(),
             mark.unwrap_or_default()
         )?;
-        let prefix = "┊│     ";
-        let max_width = terminal_width().saturating_sub(prefix.width());
-        let message = CommitMessage(commit.message.clone()).text(verbose);
+        let message = extract_message_text(&commit.message, verbose);
         let message = match message {
             Some(text) => {
-                let truncated = truncate_text(&text, max_width);
+                let truncated = truncate_text(&text, 50).into_owned();
                 if upstream_commit {
                     truncated.dimmed().to_string()
                 } else {
@@ -889,7 +882,6 @@ fn display_cli_commit_details(
     commit: &but_workspace::ref_info::Commit,
     has_changes: bool,
     verbose: bool,
-    extra_suffix_width: usize,
 ) -> String {
     let end_id = if short_id.len() >= 7 {
         "".to_string()
@@ -925,42 +917,27 @@ fn display_cli_commit_details(
             conflicted_str,
         )
     } else {
-        // Measure the line prefix and suffixes so we know exactly how much
-        // space is left for the commit message.
-        // Use the actual displayed ID width: short_id may be longer than 7
-        // when disambiguation requires it, but is always padded to at least 7
-        // by the dimmed `end_id` suffix.
-        let displayed_id_len = short_id.len().max(7);
-        let prefix = format!("┊●   {} ", "x".repeat(displayed_id_len));
-        let suffix_width = if has_changes { 0 } else { " (no changes)".width() }
-            + if commit.has_conflicts { " {conflicted}".width() } else { 0 }
-            + extra_suffix_width;
-        let max_width = terminal_width().saturating_sub(prefix.width() + suffix_width);
-        let message = CommitMessage(commit.message.clone()).text(verbose);
+        let message = extract_message_text(&commit.message, verbose);
         let message = match message {
-            Some(text) => truncate_text(&text, max_width),
+            Some(text) => truncate_text(text, 50).into_owned(),
             None => "(no commit message)".dimmed().italic().to_string(),
         };
         format!("{start_id}{end_id} {message}{no_changes}{conflicted_str}",)
     }
 }
 
-struct CommitMessage(pub BString);
+/// Return the plain (uncolored, unstyled) message text.
+/// First line only for inline mode, all lines joined for `verbose`.
+/// Returns `None` when the commit has no message.
+fn extract_message_text(message: &BString, verbose: bool) -> Option<String> {
+    let message = message.to_string();
+    let text = if verbose {
+        message.replace('\n', " ")
+    } else {
+        message.lines().next().unwrap_or("").to_string()
+    };
 
-impl CommitMessage {
-    /// Return the plain (uncolored, unstyled) message text.
-    /// First line only for inline mode, all lines joined for verbose.
-    /// Returns `None` when the commit has no message.
-    fn text(&self, verbose: bool) -> Option<String> {
-        let message = self.0.to_string();
-        let text = if verbose {
-            message.replace('\n', " ")
-        } else {
-            message.lines().next().unwrap_or("").to_string()
-        };
-
-        if text.is_empty() { None } else { Some(text) }
-    }
+    if text.is_empty() { None } else { Some(text) }
 }
 
 impl CliDisplay for ForgeReview {
@@ -978,12 +955,7 @@ impl CliDisplay for ForgeReview {
                 .title
                 .trim_end_matches(|c: char| !c.is_ascii() && !c.is_alphanumeric())
                 .to_string();
-            // ForgeReview appears on branch header lines whose preceding content
-            // varies (branch name, CI status, merge status, etc.), so the exact
-            // available width is unknown here. Reserve ~25 columns for the prefix
-            // (branch name, PR number, etc.) and clamp to at least 1.
-            let budget = terminal_width().saturating_sub(25).max(1);
-            let title = truncate_text(&trimmed, budget);
+            let title = truncate_text(&trimmed, 50);
             format!("#{}: {}", self.number.to_string().bold(), title)
         }
     }
@@ -1059,7 +1031,11 @@ impl CliDisplay for but_update::AvailableUpdate {
 
         if verbose {
             if let Some(url) = &self.url {
-                format!("Update available: {} {}", version_info, url.underline().blue())
+                format!(
+                    "Update available: {} {}",
+                    version_info,
+                    url.underline().blue()
+                )
             } else {
                 format!("Update available: {version_info}")
             }
@@ -1073,11 +1049,15 @@ impl CliDisplay for but_update::AvailableUpdate {
     }
 }
 
-async fn compute_branch_merge_statuses(ctx: &Context) -> anyhow::Result<BTreeMap<String, UpstreamBranchStatus>> {
+async fn compute_branch_merge_statuses(
+    ctx: &Context,
+) -> anyhow::Result<BTreeMap<String, UpstreamBranchStatus>> {
     use gitbutler_branch_actions::upstream_integration::StackStatuses;
 
     // Get upstream integration statuses using the public API
-    let statuses = but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None).await?;
+    let statuses =
+        but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
+            .await?;
 
     let mut result = BTreeMap::new();
 
@@ -1091,5 +1071,3 @@ async fn compute_branch_merge_statuses(ctx: &Context) -> anyhow::Result<BTreeMap
 
     Ok(result)
 }
-
-

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -108,6 +108,8 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     // Determine if pager should be used based on the command
     let use_pager = match args.cmd {
         #[cfg(feature = "legacy")]
+        Some(Subcommands::Status { .. }) => true,
+        #[cfg(feature = "legacy")]
         Some(Subcommands::Diff { tui, .. }) => !tui,
         #[cfg(feature = "legacy")]
         Some(Subcommands::Stage {
@@ -115,8 +117,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         }) => file_or_hunk.is_some(),
         _ => false,
     };
-    let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
-
     if args.trace > 0 {
         trace::init(args.trace)?;
     }
@@ -128,6 +128,7 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     but_secret::secret::set_application_namespace(namespace);
 
     // If no subcommand is provided, but we have source and target, default to rub
+    let mut out = OutputChannel::new_with_optional_pager(output_format, use_pager);
     match args.cmd.take() {
         None if args.source_or_path.is_some() && args.target.is_some() => {
             // Default to rub when two arguments are provided without a subcommand

--- a/crates/but/src/tui/mod.rs
+++ b/crates/but/src/tui/mod.rs
@@ -5,6 +5,8 @@
 pub mod table;
 pub use table::types::Table;
 
+pub mod text;
+
 pub mod get_text;
 
 pub(crate) mod diff_viewer;

--- a/crates/but/src/tui/table.rs
+++ b/crates/but/src/tui/table.rs
@@ -196,7 +196,7 @@ fn format_cell(content: &str, width: usize, align: Alignment) -> String {
     let content_width = stripped.width();
 
     if content_width >= width {
-        return truncate_text(content, width);
+        return truncate_text(content, width).into_owned();
     }
 
     // Calculate padding
@@ -206,5 +206,3 @@ fn format_cell(content: &str, width: usize, align: Alignment) -> String {
         Alignment::Left => format!("{}{}", content, " ".repeat(padding_needed)),
     }
 }
-
-

--- a/crates/but/src/tui/text.rs
+++ b/crates/but/src/tui/text.rs
@@ -1,0 +1,244 @@
+//! Shared utilities for terminal-width detection and text truncation.
+//!
+//! Every function here is Unicode-width-aware (CJK, emoji, combining marks)
+//! and ANSI-escape-aware so that colored strings are measured and truncated
+//! correctly.
+
+use terminal_size::Width;
+use unicode_width::UnicodeWidthChar;
+
+/// Returns the current terminal width in columns, defaulting to 80
+/// when detection fails (e.g. when stdout is not a TTY).
+pub fn terminal_width() -> usize {
+    terminal_size::terminal_size().map_or(80, |(Width(w), _)| w as usize)
+}
+
+/// Truncate `text` to fit within `max_width` display columns.
+///
+/// Uses [`unicode_width`] so that CJK / emoji characters (which occupy
+/// two terminal columns each) are measured correctly. ANSI escape
+/// sequences (e.g. color codes) are passed through without counting
+/// toward the width.
+///
+/// When truncation occurs an `…` character (1 column wide) is appended
+/// and the total result is guaranteed to be ≤ `max_width` columns.
+pub fn truncate_text(text: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    let mut width = 0;
+    let mut result = String::new();
+    let mut in_ansi = false;
+    let mut ansi_buffer = String::new();
+
+    for ch in text.chars() {
+        // Start of an ANSI escape sequence — buffer it.
+        if ch == '\x1b' {
+            in_ansi = true;
+            ansi_buffer.push(ch);
+            continue;
+        }
+
+        // Inside an escape sequence — keep buffering until the
+        // terminating 'm'.
+        if in_ansi {
+            ansi_buffer.push(ch);
+            if ch == 'm' {
+                // Flush the whole escape sequence into the result
+                // without counting toward display width.
+                result.push_str(&ansi_buffer);
+                ansi_buffer.clear();
+                in_ansi = false;
+            }
+            continue;
+        }
+
+        let ch_width = ch.width().unwrap_or(0);
+        if width + ch_width > max_width {
+            // Text will be truncated – reserve 1 column for '…'.
+            // Walk back if needed so the ellipsis still fits.
+            while width >= max_width {
+                if let Some(last) = result.pop() {
+                    // If we popped an ANSI terminator we need to
+                    // discard the whole escape sequence we just
+                    // partially undid.  In practice this is unlikely
+                    // since escapes are zero-width, but be safe.
+                    if last == 'm' {
+                        // Pop back to the ESC that started this sequence.
+                        while let Some(c) = result.pop() {
+                            if c == '\x1b' {
+                                break;
+                            }
+                        }
+                        // The escape was zero-width, keep walking.
+                        continue;
+                    }
+                    width -= last.width().unwrap_or(0);
+                } else {
+                    break;
+                }
+            }
+            result.push('…');
+            return result;
+        }
+        result.push(ch);
+        width += ch_width;
+    }
+
+    // No truncation needed.
+    result
+}
+
+/// Remove all ANSI escape sequences from `s`, returning plaintext.
+///
+/// Useful when you need to measure the *display* width of a string
+/// that may contain color / style codes.
+pub fn strip_ansi_codes(s: &str) -> String {
+    let mut result = String::new();
+    let mut in_escape = false;
+
+    for ch in s.chars() {
+        if ch == '\x1b' {
+            in_escape = true;
+            continue;
+        }
+
+        if in_escape {
+            if ch == 'm' {
+                in_escape = false;
+            }
+            continue;
+        }
+
+        result.push(ch);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use unicode_width::UnicodeWidthStr;
+
+    use super::{strip_ansi_codes, truncate_text};
+
+    // ── Plain-text truncation ────────────────────────────────────
+
+    #[test]
+    fn short_text_is_not_truncated() {
+        assert_eq!(truncate_text("hello", 10), "hello");
+    }
+
+    #[test]
+    fn text_at_exact_limit_is_not_truncated() {
+        assert_eq!(truncate_text("hello", 5), "hello");
+    }
+
+    #[test]
+    fn text_exceeding_limit_is_truncated_with_ellipsis() {
+        assert_eq!(truncate_text("hello world", 5), "hell…");
+    }
+
+    #[test]
+    fn empty_text_stays_empty() {
+        assert_eq!(truncate_text("", 10), "");
+    }
+
+    #[test]
+    fn max_width_of_zero_gives_empty_string() {
+        assert_eq!(truncate_text("hello", 0), "");
+    }
+
+    #[test]
+    fn max_width_of_one_gives_ellipsis_only() {
+        assert_eq!(truncate_text("hello", 1), "…");
+    }
+
+    #[test]
+    fn unicode_single_width_characters_are_handled() {
+        // ü is a single-width character (1 display column)
+        assert_eq!(truncate_text("über-cool", 5), "über…");
+    }
+
+    #[test]
+    fn cjk_double_width_characters_are_handled() {
+        // Each CJK character occupies 2 display columns.
+        // 你(2) + 好(2) = 4 cols, + …(1) = 5 cols total.
+        assert_eq!(truncate_text("你好世界", 5), "你好…");
+        assert_eq!(truncate_text("你好世界", 5).width(), 5);
+    }
+
+    #[test]
+    fn cjk_truncation_does_not_exceed_max_width() {
+        // With max_width 4, a second CJK char (2 cols) leaves no room
+        // for the ellipsis alongside it, so only the first char + … fits.
+        // 你(2) + …(1) = 3 cols ≤ 4
+        let result = truncate_text("你好世界", 4);
+        assert!(result.width() <= 4);
+        assert_eq!(result, "你…");
+    }
+
+    #[test]
+    fn truncation_preserves_exact_boundary() {
+        let msg = "this is a overly long commit message to demonstrate truncation";
+        let result = truncate_text(msg, 60);
+        assert!(result.ends_with('…'));
+        // For ASCII text, display width == char count
+        assert_eq!(result.width(), 60);
+    }
+
+    #[test]
+    fn emoji_characters_are_handled() {
+        // Many emoji are wide characters; ensure we respect their display width.
+        let single = "🙂";
+        let single_width = UnicodeWidthStr::width(single);
+        assert!(single_width >= 1);
+        // A single emoji that fits within max_width should not be truncated.
+        assert_eq!(truncate_text(single, single_width), single);
+        // Repeated emoji should be truncated without exceeding max_width.
+        let repeated = "🙂🙂🙂";
+        let result = truncate_text(repeated, single_width * 2);
+        assert!(result.width() <= single_width * 2);
+    }
+
+    #[test]
+    fn zero_width_combining_characters_are_handled() {
+        // "a" + COMBINING ACUTE ACCENT; display width should be 1.
+        let text = "a\u{0301}";
+        assert_eq!(UnicodeWidthStr::width(text), 1);
+        // With max_width equal to the display width, no truncation should occur.
+        assert_eq!(truncate_text(text, 1), text);
+    }
+
+    // ── ANSI-aware truncation ────────────────────────────────────
+
+    #[test]
+    fn ansi_colored_text_is_truncated_without_counting_escapes() {
+        // "\x1b[31m" = red, "\x1b[0m" = reset — both zero-width.
+        let colored = "\x1b[31mhello world\x1b[0m";
+        let result = truncate_text(colored, 5);
+        // The ANSI prefix should be preserved and the visible text
+        // truncated to 4 chars + ellipsis.
+        assert!(result.starts_with("\x1b[31m"));
+        let plain = strip_ansi_codes(&result);
+        assert_eq!(plain, "hell…");
+    }
+
+    #[test]
+    fn ansi_codes_only_produce_no_visible_output_within_width() {
+        let just_color = "\x1b[31m\x1b[0m";
+        assert_eq!(truncate_text(just_color, 5), just_color);
+    }
+
+    #[test]
+    fn plain_text_is_unchanged_by_strip_ansi() {
+        assert_eq!(strip_ansi_codes("hello world"), "hello world");
+    }
+
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        let colored = "\x1b[31mhello\x1b[0m world";
+        assert_eq!(strip_ansi_codes(colored), "hello world");
+    }
+}

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 mod output_channel;
 pub use output_channel::{
-    Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel,
+    Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel, WriteWithUtils,
 };
 
 mod pager;

--- a/crates/but/src/utils/pager.rs
+++ b/crates/but/src/utils/pager.rs
@@ -9,7 +9,12 @@ pub(crate) enum Pager {
 const DEFAULT_PAGER: &str = "less";
 
 /// This default configuration makes less behave nicely for a CLI. See the less manual for details.
-const DEFAULT_PAGER_ARGS: &str = "FXR";
+/// The options are:
+/// - `F`: Quit if content fits on screen.
+/// - `X`: Don't clear the screen on exit.
+/// - `R`: Recognize ANSI color escape sequences and use them verbatim to *keep* styling.
+/// - `S`: Don't wrap long lines. We don't want wrapping as we control the layour carefully.
+const DEFAULT_PAGER_ARGS: &str = "FXRS";
 const DEFAULT_PAGER_ENV_VAR: &str = "LESS";
 
 /// Attempt to initialize a new pager.
@@ -70,6 +75,7 @@ fn try_spawn_external_pager() -> Option<(std::process::Child, std::process::Chil
 
     match cmd.spawn() {
         Ok(mut child) => {
+            tracing::debug!(?cmd, "Launched external pager");
             let stdin = child.stdin.take()?;
             Some((child, stdin))
         }

--- a/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
@@ -7,7 +7,7 @@
       padding: 0 10px;
       line-height: 18px;
     }
-    .dimmed { opacity: 0.7; }
+    .dimmed { opacity: 0.4; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,9 +20,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green">Applied Branches</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">autho…</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green dimmed">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">autho…</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>


### PR DESCRIPTION
## 🎫 Affected issues

Fixes: [#12328](https://github.com/gitbutlerapp/gitbutler/issues/12328#issuecomment-3923486126)

## 🧢 Changes

- Replaced hard-coded 50-character commit message truncation with terminal-width-aware truncation in `but status`
- Added `truncate_text()` helper that appends `…` when text is truncated
- Added `terminal_width()` helper (reusing the existing `terminal_size` crate dependency).
- Fixed three truncation sites in `crates/but/src/command/legacy/status/mod.rs`:
  - **Commit messages** (`CommitMessage::display_cli`): was `.take(50)`, now uses `terminal_width() - 15`
  - **PR titles** (`ForgeReview::display_cli`): was `.take(50)`, now uses `terminal_width() - 25`.
  - **Common merge base message**: was `.take(40)`, now uses `terminal_width() - 40`
- All truncation sites now show `…` when text is shortened, instead of silently cutting off
- Fixed a bug in `ForgeReview::display_cli` where `trim_end_matches` would strip the `…` suffix — moved the trim to run on the raw title *before* truncation
- Added 7 unit tests for the `truncate_text` helper inline, following the project convention of keeping unit tests for private functions in-module

## ☕️ Reasoning

Commit messages longer than 50 characters were silently truncated in `but status` regardless of terminal width. For example, on a 120-column terminal:

**Before:**
```
┊●   d7959c7 this is a overly long commit message to demonstrat
```

**After:**
```
┊●   d7959c7 this is a overly long commit message to demonstrate truncation in the CLI status o…
```

The truncation limit now adapts to the actual terminal width, and whenever truncation occurs, an `…` character clearly indicates that the message continues. This follows the same patterns already used in `crates/but/src/tui/table.rs` and `crates/but/src/command/help.rs`.

## 🧪 Manual testing

1. Build the CLI: `cargo build -p but`
2. Create a test repository:
   ```bash
   mkdir ~/but-truncation-test && cd ~/but-truncation-test
   git init && git commit --allow-empty -m "initial commit"
   ```
3. Set up GitButler: `but setup`
4. Create a commit with a long message:
   ```bash
   echo "test" > test.txt
   but commit -m "this is a overly long commit message to demonstrate truncation in the CLI status output display"
   ```
5. Run `but status` on a **wide terminal** (~120 cols) → full message should be visible.
6. Run `but status` on a **narrow terminal** (~60 cols) → message should be truncated with `…`.
7. Run `but status` with a **short commit message** → no truncation, no `…`.
8. Verify the common base line (the `┴` line) also truncates with `…` on narrow terminals.
9. Cleanup: `rm -rf ~/but-truncation-test`

## 🔭 Improvements (out of scope for this PR) changes made in [this commit](https://github.com/gitbutlerapp/gitbutler/pull/12448/changes/b2bc9ea9d210529b41571a9842d7f1615bd1e2a8)

# Shared text truncation — `tui::text`

Same "detect terminal width and shorten text" logic was in five places.
Now it's in one: `crates/but/src/tui/text.rs`.

Also fixed a panic in `help.rs` (byte-slicing non-ASCII) and wrong width
measurements in `oplog.rs`/`pick.rs` (char count vs display columns).


## 🎬 Demo
**Before:**
<img width="514" height="536" alt="Screenshot 2026-02-19 at 6 06 50 PM" src="https://github.com/user-attachments/assets/bef96ec7-901b-4e9c-a575-1ea501e6c1bf" />

**After:**

<img width="682" height="502" alt="Screenshot 2026-02-19 at 5 49 21 PM" src="https://github.com/user-attachments/assets/6087b7fe-1c41-4332-af04-15aaf6ce0450" />

<img width="1081" height="638" alt="Screenshot 2026-02-19 at 5 51 46 PM" src="https://github.com/user-attachments/assets/374ccafd-d8b0-4755-9c86-a3355c69b483" />