### PR TITLE
Align but-sdk debug output with ESM module mode

### DIFF
--- a/packages/but-sdk/package.json
+++ b/packages/but-sdk/package.json
@@ -10,7 +10,7 @@
 		"build:types": "cargo run -p but-schema-gen -- --output ./src/generated/index.d.ts",
 		"build:napi": "napi build --platform --release --esm --manifest-path ../../crates/but-napi/Cargo.toml --js index.js --dts index.d.ts --output-dir ./src/generated/.",
 		"build": "pnpm build:napi && pnpm build:types",
-		"build:debug": "napi build --platform --manifest-path ../../crates/but-napi/Cargo.toml --js index.js --dts index.d.ts --output-dir . --verbose",
+		"build:debug": "napi build --platform --esm --manifest-path ../../crates/but-napi/Cargo.toml --js index.js --dts index.d.ts --output-dir . --verbose",
 		"check": "tsc -p tsconfig.generated.json --noEmit",
 		"prepublishOnly": "napi prepublish -t npm",
 		"testTypes": "ts-node ./src/test.ts",


### PR DESCRIPTION
## Summary
This PR addresses an unresolved Copilot review comment from source PR #12438.

## Commits
- `788924c6b6` Make but-sdk debug builds emit ESM
  - Adds `--esm` to `packages/but-sdk/package.json` `build:debug` script so debug output matches the package ESM configuration.
  - Fixes up: https://github.com/gitbutlerapp/gitbutler/pull/12438#discussion_r2828007471
