### PR TITLE
Restore required token permissions in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,9 @@ on:
           - minor
           - major
 
-permissions: {}
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build-sveltekit:


### PR DESCRIPTION
## Summary
This PR addresses an unresolved Copilot review comment from source PR #12441.

## Commits
- `851ab7825b` Restore publish workflow token scopes
  - Replaces top-level `permissions: {}` in `.github/workflows/publish.yaml` with minimal required permissions:
    - `contents: read`
    - `actions: write`
  - This keeps least-privilege defaults while allowing checkout/artifact/cache operations used by the workflow.
  - Fixes up: https://github.com/gitbutlerapp/gitbutler/pull/12441#discussion_r2828390526
