### PR TITLE
Reuse minimal Debian deps script in but-sdk CI job

### DIFF
--- a/.github/ci/but-sdk-apt-packages.txt
+++ b/.github/ci/but-sdk-apt-packages.txt
@@ -1,2 +1,0 @@
-libdbus-1-dev
-pkg-config

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -145,12 +145,10 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: .apt-cache
-          key: ${{ runner.os }}-apt-but-sdk-${{ hashFiles('.github/ci/but-sdk-apt-packages.txt') }}
+          key: ${{ runner.os }}-apt-but-sdk-${{ hashFiles('scripts/install-minimal-debian-dependencies.sh') }}
       - name: Install dependencies for but-sdk
         run: |
-          sudo mkdir -p "$PWD/.apt-cache/partial"
-          sudo apt-get update
-          sudo xargs -a .github/ci/but-sdk-apt-packages.txt apt-get -o dir::cache::archives="$PWD/.apt-cache" install -y --no-install-recommends
+          sudo ./scripts/install-minimal-debian-dependencies.sh "$PWD/.apt-cache"
           sudo chown -R "$(id -u)":"$(id -g)" "$PWD/.apt-cache"
       - uses: ./.github/actions/init-env-node
       - name: Rust Cache

--- a/scripts/install-minimal-debian-dependencies.sh
+++ b/scripts/install-minimal-debian-dependencies.sh
@@ -2,6 +2,13 @@
 
 set -eu -o pipefail
 
+apt_cache_archives_dir="${1:-}"
+apt_options=()
+if [[ -n "${apt_cache_archives_dir}" ]]; then
+    mkdir -p "${apt_cache_archives_dir}/partial"
+    apt_options=(-o "dir::cache::archives=${apt_cache_archives_dir}")
+fi
+
 # Install the dependencies needed to build the but-server and the CLI.
-apt update
-apt install -y libdbus-1-dev pkg-config
+apt-get update
+apt-get install -y --no-install-recommends "${apt_options[@]}" libdbus-1-dev pkg-config


### PR DESCRIPTION
The but-sdk workflow duplicated apt install intent that already exists in scripts/install-minimal-debian-dependencies.sh. Keeping the same dependency intent in two places increases drift risk and makes updates easy to miss.

Refactor the but-sdk build-check job to call the shared script instead of installing from a separate package list file. Add an optional cache-archives directory argument to the script so CI can still use actions/cache with dir::cache::archives.

Also switch the apt cache key hash to the script and remove the now-redundant .github/ci/but-sdk-apt-packages.txt file.

Motivation: make dependency installation a single source of truth while preserving CI apt caching behavior.
