### PR TITLE
ci: turn on optimizations for nightlies as well

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -189,13 +189,6 @@ jobs:
         with:
           name: sveltekit-build
           path: ./apps/desktop/build/
-      - name: Set release build optimization env vars
-        shell: bash
-        if: github.event.inputs.channel == 'release'
-        run: |
-          echo "CARGO_PROFILE_RELEASE_LTO=fat" >> $GITHUB_ENV
-          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1" >> $GITHUB_ENV
-          echo "CARGO_PROFILE_RELEASE_OPT_LEVEL=s" >> $GITHUB_ENV
       - name: Build binary
         shell: bash
         run: |
@@ -205,6 +198,9 @@ jobs:
             --dist                       "./release" \
             --version                    "${{ env.version }}"
         env:
+          CARGO_PROFILE_RELEASE_LTO: fat
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: s
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
## 🧢 Changes
Turns on all optimizations for all builds (which in this case means nightlies also get optimizations).

## ☕️ Reasoning
I've observed that there isn't much of a difference in total CI time between release and nightly, so I want to try optimizing all builds. I don't think we'll notice much of a difference.

The spark of this was that I observed the nightly CLI binary for Linux to be 67 MB large, compared to the 34 MB of the release binary.