### PR TITLE
Remove the `inventory` crate in favor of a simple inline list.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,6 @@ dependencies = [
  "gitbutler-user",
  "gix",
  "insta",
- "inventory",
  "itertools 0.14.0",
  "napi",
  "napi-derive",
@@ -5921,15 +5920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "inventory"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,6 @@ tempfile = "3.24"
 rand = "0.9.2"
 notify-rust = "4.11.7"
 git2-hooks = { version = "0.5.0" }
-inventory = "0.3"
 itertools = "0.14.0"
 dirs = "6.0.0"
 rmcp = { version = "0.9.1", default-features = false, features = [

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -132,7 +132,6 @@ open.workspace = true
 url = { version = "2.5", optional = true }
 uuid.workspace = true
 which = "8.0.0"
-inventory.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/but-api/src/schema.rs
+++ b/crates/but-api/src/schema.rs
@@ -27,8 +27,6 @@ pub fn collect_all_schemas() -> Vec<(&'static str, schemars::Schema)> {
         };
         use schemars::schema_for;
 
-        use crate::legacy::projects::ProjectForFrontend;
-
         // Register types that have JsonSchema derives. Add more entries here as derives
         // are added across the codebase.
         let mut schemas: Vec<_> = [
@@ -52,9 +50,10 @@ pub fn collect_all_schemas() -> Vec<(&'static str, schemars::Schema)> {
                 name: "ProjectId",
                 schema_fn: || schema_for!(String),
             },
+            #[cfg(feature = "legacy")]
             TypeSchemaEntry {
                 name: "ProjectForFrontend",
-                schema_fn: || schema_for!(ProjectForFrontend),
+                schema_fn: || schema_for!(crate::legacy::projects::ProjectForFrontend),
             },
         ]
         .into_iter()

--- a/crates/but-schema-gen/README.md
+++ b/crates/but-schema-gen/README.md
@@ -27,7 +27,7 @@ This crate is intended to be the single solution for TypeScript type generation.
 
 ## How it works
 
-1. `but-api` registers schema entries in `but_api::schema` using `inventory::submit!`.
+1. `but-api` registers schema entries in `but_api::schema`.
 2. `but-schema-gen` collects the registry (`collect_all_schemas`).
 3. It converts schema definitions into TypeScript declarations.
 4. It writes/appends output to the target file (`--output`).

--- a/crates/but-schema-gen/src/main.rs
+++ b/crates/but-schema-gen/src/main.rs
@@ -1,7 +1,7 @@
 //! Generate TypeScript type definitions from JSON schemas registered by `#[but_api]` functions.
 //!
-//! This binary collects all type schemas registered via the `inventory` crate
-//! in the `but-api` crate, converts them to TypeScript type definitions, and
+//! This binary collects all type schemas registered in the `but-api` crate,
+//! converts them to TypeScript type definitions, and
 //! writes them to a `.d.ts` file.
 //!
 //! Usage:
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 fn main() -> anyhow::Result<()> {
     let output_path = parse_args()?;
 
-    // Collect schemas from the but-api inventory registry
+    // Collect schemas from the but-api schema registry
     let schemas = but_api::schema::collect_all_schemas();
 
     eprintln!("Collected {} unique type schemas", schemas.len());

--- a/packages/but-sdk/README.md
+++ b/packages/but-sdk/README.md
@@ -57,7 +57,7 @@ You should see a new `*Napi` export in `src/generated/index.d.ts`.
 ### Add a new generated TypeScript type
 
 1. Make sure the Rust type derives `schemars::JsonSchema`.
-2. Register the type in `crates/but-api/src/schema.rs` using `TypeSchemaEntry` (`inventory::submit!`).
+2. Register the type in `crates/but-api/src/schema.rs` using `TypeSchemaEntry`.
 3. Re-run:
 
 ```bash


### PR DESCRIPTION
It's meant to be used as plugin-registry which is confusing, so if all we need is a list of schemas to export, then let's use a list of schemas.

**What changed**  
- Replaced `inventory::{collect, iter, submit}` usage with a direct `TypeSchemaEntry` list in `collect_all_schemas()`.
- Kept deterministic output + dedup behavior unchanged.
- Removed `inventory` from:
  - `crates/but-api/Cargo.toml`
  - workspace dependencies in `Cargo.toml`
  - `Cargo.lock`
- Updated docs/comments that referenced `inventory`.

**Why**  
All schema registrations were already centralized in one file, so `inventory` added complexity without real benefit.

**Validation**  
- `cargo check -p but-api --features "legacy,export-schema"`
- `cargo check -p but-schema-gen
- `pnpm --filter @gitbutler/but-sdk build`
