### PR TITLE
Thread visibleRange from diff preview to worktree file lists

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -446,6 +446,7 @@
 									projectId={stableProjectId}
 									stackId={stableStackId}
 									mode="assigned"
+									{visibleRange}
 									onDropzoneActivated={(activated) => {
 										dropzoneActivated = activated;
 									}}

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -17,9 +17,10 @@
 	interface Props {
 		projectId: string;
 		onFileClick?: (index: number) => void;
+		visibleRange?: { start: number; end: number };
 	}
 
-	const { projectId, onFileClick }: Props = $props();
+	const { projectId, onFileClick, visibleRange }: Props = $props();
 
 	const selectionId = createWorktreeSelection({ stackId: undefined });
 
@@ -110,6 +111,7 @@
 					mode="unassigned"
 					{foldButton}
 					{onFileClick}
+					{visibleRange}
 				>
 					{#snippet emptyPlaceholder()}
 						<div class="unassigned-empty">

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -41,6 +41,12 @@
 
 	let multiDiffView = $state<MultiDiffView>();
 	let startIndex = $state(0);
+
+	let visibleRange = $state({ start: 0, end: 0 });
+
+	function onVisibleChange(change: { start: number; end: number }) {
+		visibleRange = change;
+	}
 </script>
 
 {#snippet leftPreview()}
@@ -55,6 +61,7 @@
 		selectable={isCommitting}
 		showBorder={false}
 		showRoundedEdges={false}
+		{onVisibleChange}
 		onclose={() => {
 			idSelection.clear(selectionId);
 		}}
@@ -72,6 +79,7 @@
 	{#snippet left()}
 		<UnassignedView
 			{projectId}
+			{visibleRange}
 			onFileClick={(index) => {
 				startIndex = index;
 				multiDiffView?.jumpToIndex(index);

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -32,6 +32,7 @@
 		foldButton?: Snippet;
 		onFileClick?: (index: number) => void;
 		onscrollexists?: (exists: boolean) => void;
+		visibleRange?: { start: number; end: number };
 	};
 
 	let {
@@ -44,7 +45,8 @@
 		emptyPlaceholder,
 		foldButton,
 		onFileClick,
-		onscrollexists
+		onscrollexists,
+		visibleRange
 	}: Props = $props();
 
 	// Create a unique persist ID based on stackId and mode (both are static props)
@@ -102,6 +104,7 @@
 		{listMode}
 		{stackId}
 		{onFileClick}
+		{visibleRange}
 		showLockedIndicator
 	/>
 {/snippet}


### PR DESCRIPTION
The notch indicator showing which file is visible in the diff preview
was not working for worktree changes. Pass visibleRange through
WorktreeChanges, UnassignedView, and WorkspaceView so that
staged/unstaged file lists show the same notch as committed file lists.