### PR TITLE
ci: remove dangerous trigger from pr-labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,10 +2,11 @@
 
 name: Label Pull Requests
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   labeler:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Speaking of not using `pull_request_target` https://github.com/gitbutlerapp/gitbutler/pull/12462#discussion_r2833386231 ... @slarse 

## Summary
- switch the labeler workflow trigger from `pull_request_target` to `pull_request`
- keep least privileges and add a guard to run labeling only for same-repo PRs

## Why
This removes the `zizmor/dangerous-triggers` finding for this workflow and avoids running labeling with base-repo context on untrusted fork PRs.

## Notes
Fork PRs will skip automatic labeling in this workflow.