### PR TITLE
unify-and-fix-download-links

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenServiceMessageUseTool.svelte
+++ b/apps/desktop/src/components/codegen/CodegenServiceMessageUseTool.svelte
@@ -64,7 +64,7 @@
 <CodegenServiceMessage style="info" face="waiting">
 	<div class="flex flex-col gap-2">
 		<p class="text-13 text-semibold text-body clr-text-1">Claude Code wants to {wantsToDo} 👆</p>
-		<p class="text-13 text-italic text-body opacity-60">
+		<p class="text-13 text-italic text-body op-60">
 			Review the {actionName} above, then approve or reject.
 		</p>
 	</div>

--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -72,7 +72,7 @@
 				</div>
 
 				<div class="banner-nightly-text">
-					<span class="opacity-50">Experience GitButler's newest features before anyone else.</span>
+					<span class="op-50">Experience GitButler's newest features before anyone else.</span>
 					<a href="/nightly" class="nightly-link"> Get Nightly </a>
 				</div>
 			</div>

--- a/apps/web/src/lib/components/marketing/ReleaseCard.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import osIcons from '$lib/data/os-icons.json';
+	import ReleaseDownloadLinks from '$lib/components/marketing/ReleaseDownloadLinks.svelte';
 	import Markdown from 'svelte-exmarkdown';
 	import type { Release } from '$lib/types/releases';
 
@@ -13,49 +13,6 @@
 
 	// State for toggling download links visibility
 	let downloadLinksVisible = $state(false);
-
-	// Group builds by OS for easier display
-	const groupedBuilds = $derived.by(() => {
-		const builds =
-			release.builds?.reduce(
-				(acc, build) => {
-					if (!acc[build.os]) acc[build.os] = [];
-					acc[build.os].push(build);
-					return acc;
-				},
-				{} as Record<string, typeof release.builds>
-			) || {};
-
-		// Sort OS entries: macOS (darwin) first, then Windows, then Linux
-		const osOrder = ['darwin', 'windows', 'linux'];
-		return Object.fromEntries(
-			Object.entries(builds).sort(([a], [b]) => {
-				const aIndex = osOrder.indexOf(a);
-				const bIndex = osOrder.indexOf(b);
-				const aOrder = aIndex === -1 ? osOrder.length : aIndex;
-				const bOrder = bIndex === -1 ? osOrder.length : bIndex;
-				return aOrder - bOrder;
-			})
-		);
-	});
-
-	function getBuildDisplayName(build: any): string {
-		if (build.os === 'darwin') {
-			return build.arch === 'aarch64' ? 'Apple Silicon' : 'Intel';
-		}
-		if (build.os === 'windows') {
-			return 'MSI';
-		}
-		if (build.os === 'linux') {
-			const arch = build.arch === 'aarch64' ? 'ARM64' : 'Intel';
-			const file: string = build.file?.toLowerCase() ?? '';
-			if (file.includes('appimage')) return `Linux ${arch} (AppImage)`;
-			if (file.includes('.deb')) return `Linux ${arch} (Deb)`;
-			if (file.includes('.rpm')) return `Linux ${arch} (RPM)`;
-			return `Linux ${arch} (CLI)`;
-		}
-		return build.platform;
-	}
 </script>
 
 <div class="release" class:no-separator={!showSeparator}>
@@ -90,30 +47,7 @@
 			{/if}
 
 			{#if downloadLinksVisible}
-				<div class="download-links">
-					{#each Object.entries(groupedBuilds) as [os, builds]}
-						<div class="download-category">
-							<svg
-								class="download-icon"
-								viewBox="0 0 22 22"
-								fill="none"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									d={osIcons[os === 'darwin' ? 'macos' : (os as keyof typeof osIcons)]}
-									fill="currentColor"
-								/>
-							</svg>
-							<div class="download-options">
-								{#each builds as build}
-									<a href={build.url} class="download-link">
-										{getBuildDisplayName(build)}
-									</a>
-								{/each}
-							</div>
-						</div>
-					{/each}
-				</div>
+				<ReleaseDownloadLinks builds={release.builds} />
 			{/if}
 		{/if}
 	</div>
@@ -188,48 +122,6 @@
 
 		&:hover {
 			color: var(--clr-text-1);
-		}
-	}
-
-	.download-links {
-		display: flex;
-		flex-wrap: wrap;
-		padding: 32px;
-		gap: 24px;
-		background-image: radial-gradient(var(--clr-border-2) 1px, transparent 1px);
-		background-size: 6px 6px;
-	}
-
-	.download-category {
-		display: flex;
-		flex-direction: column;
-		min-width: 150px;
-		gap: 12px;
-	}
-
-	.download-icon {
-		width: 22px;
-		height: 22px;
-	}
-
-	.download-options {
-		display: flex;
-		flex-direction: column;
-		gap: 14px;
-	}
-
-	.download-link {
-		width: fit-content;
-		background-color: var(--clr-bg-2);
-		font-size: 14px;
-		font-family: var(--font-mono);
-		text-decoration: underline;
-		text-underline-offset: 2px;
-		transition: all 0.1s ease;
-
-		&:hover {
-			text-decoration: underline wavy;
-			text-decoration-color: var(--clr-theme-pop-element);
 		}
 	}
 

--- a/apps/web/src/lib/components/marketing/ReleaseCard.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseCard.svelte
@@ -218,7 +218,7 @@
 	.download-link {
 		width: fit-content;
 		background-color: var(--clr-bg-2);
-		font-size: 12px;
+		font-size: 14px;
 		font-family: var(--font-mono);
 		text-decoration: underline;
 		text-underline-offset: 2px;

--- a/apps/web/src/lib/components/marketing/ReleaseCard.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseCard.svelte
@@ -47,12 +47,12 @@
 			return 'MSI';
 		}
 		if (build.os === 'linux') {
-			const arch = build.arch === 'aarch64' ? 'ARM64' : 'x86_64';
+			const arch = build.arch === 'aarch64' ? 'ARM64' : 'Intel';
 			const file: string = build.file?.toLowerCase() ?? '';
-			if (file.includes('appimage')) return `${arch} (AppImage)`;
-			if (file.includes('.deb')) return `${arch} (Debian)`;
-			if (file.includes('.rpm')) return `${arch} (RPM)`;
-			return arch;
+			if (file.includes('appimage')) return `Linux ${arch} (AppImage)`;
+			if (file.includes('.deb')) return `Linux ${arch} (Deb)`;
+			if (file.includes('.rpm')) return `Linux ${arch} (RPM)`;
+			return `Linux ${arch} (CLI)`;
 		}
 		return build.platform;
 	}

--- a/apps/web/src/lib/components/marketing/ReleaseCard.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseCard.svelte
@@ -47,9 +47,12 @@
 			return 'MSI';
 		}
 		if (build.os === 'linux') {
-			if (build.platform.includes('appimage')) return 'AppImage';
-			if (build.platform.includes('deb')) return 'Deb';
-			if (build.platform.includes('rpm')) return 'RPM';
+			const arch = build.arch === 'aarch64' ? 'ARM64' : 'x86_64';
+			const file: string = build.file?.toLowerCase() ?? '';
+			if (file.includes('appimage')) return `${arch} (AppImage)`;
+			if (file.includes('.deb')) return `${arch} (Debian)`;
+			if (file.includes('.rpm')) return `${arch} (RPM)`;
+			return arch;
 		}
 		return build.platform;
 	}

--- a/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import osIcons from '$lib/data/os-icons.json';
+	import { RELEASE_OS_ORDER } from '$lib/utils/releaseUtils';
 	import type { Build } from '$lib/types/releases';
 
 	interface Props {
@@ -68,7 +69,7 @@
 			{} as Record<string, Build[]>
 		);
 
-		const osOrder = ['darwin', 'windows', 'linux'];
+		const osOrder: readonly string[] = RELEASE_OS_ORDER;
 		return Object.entries(grouped).sort(([a], [b]) => {
 			const aIndex = osOrder.indexOf(a);
 			const bIndex = osOrder.indexOf(b);

--- a/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	import osIcons from '$lib/data/os-icons.json';
+	import type { Build } from '$lib/types/releases';
+
+	interface Props {
+		builds: Build[];
+	}
+
+	const { builds }: Props = $props();
+
+	function getBuildDisplayName(build: Build): string {
+		if (build.os === 'darwin') {
+			const platform = build.platform.toLowerCase();
+			if (
+				build.arch === 'aarch64' ||
+				platform.includes('silicon') ||
+				platform.includes('aarch64')
+			) {
+				return 'Apple Silicon';
+			}
+			if (build.arch === 'x86_64' || platform.includes('intel') || platform.includes('x86_64')) {
+				return 'Intel Mac';
+			}
+			return build.platform.startsWith('macOS') ? build.platform : `macOS ${build.platform}`;
+		}
+
+		if (build.os === 'windows') {
+			return 'Windows (MSI)';
+		}
+
+		if (build.os === 'linux') {
+			const arch = build.arch === 'aarch64' ? 'ARM64' : 'Intel';
+			const file = build.file.toLowerCase();
+			if (file.includes('appimage')) return `Linux ${arch} (AppImage)`;
+			if (file.includes('deb')) return `Linux ${arch} (Deb)`;
+			if (file.includes('rpm')) return `Linux ${arch} (RPM)`;
+			return `Linux ${arch} (CLI)`;
+		}
+
+		return build.platform;
+	}
+
+	function getIconKey(os: string): keyof typeof osIcons {
+		if (os === 'darwin') return 'macos';
+		if (os === 'windows' || os === 'linux') return os;
+		return 'linux';
+	}
+
+	const groupedBuilds = $derived.by(() => {
+		const seenLabels = new Set<string>();
+		const uniqueBuilds = builds.filter((build) => {
+			const label = getBuildDisplayName(build);
+			if (seenLabels.has(label)) return false;
+			seenLabels.add(label);
+			return true;
+		});
+
+		const grouped = uniqueBuilds.reduce(
+			(acc, build) => {
+				if (!acc[build.os]) acc[build.os] = [];
+				acc[build.os].push(build);
+				return acc;
+			},
+			{} as Record<string, Build[]>
+		);
+
+		const osOrder = ['darwin', 'windows', 'linux'];
+		return Object.entries(grouped).sort(([a], [b]) => {
+			const aIndex = osOrder.indexOf(a);
+			const bIndex = osOrder.indexOf(b);
+			const aOrder = aIndex === -1 ? osOrder.length : aIndex;
+			const bOrder = bIndex === -1 ? osOrder.length : bIndex;
+			return aOrder - bOrder;
+		});
+	});
+</script>
+
+<div class="download-links">
+	{#each groupedBuilds as [os, osBuilds]}
+		<div class="download-category">
+			<svg class="download-icon" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path d={osIcons[getIconKey(os)]} fill="currentColor" />
+			</svg>
+			<div class="download-options">
+				{#each osBuilds as build}
+					<a href={build.url} class="download-link">
+						{getBuildDisplayName(build)}
+					</a>
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.download-links {
+		display: flex;
+		flex-wrap: wrap;
+		padding: 32px;
+		gap: 24px;
+		background-image: radial-gradient(var(--clr-border-2) 1px, transparent 1px);
+		background-size: 6px 6px;
+	}
+
+	.download-category {
+		display: flex;
+		flex-direction: column;
+		min-width: 150px;
+		gap: 12px;
+	}
+
+	.download-icon {
+		width: 22px;
+		height: 22px;
+	}
+
+	.download-options {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 14px;
+	}
+
+	.download-link {
+		width: fit-content;
+		background-color: var(--clr-bg-2);
+		font-size: 14px;
+		font-family: var(--font-mono);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+		transition: all 0.1s ease;
+
+		&:hover {
+			text-decoration: underline wavy;
+			text-decoration-color: var(--clr-theme-pop-element);
+		}
+	}
+
+	@media (--mobile-viewport) {
+		.download-links {
+			padding: 16px;
+		}
+	}
+</style>

--- a/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
@@ -91,10 +91,8 @@
 	const groupedBuilds = $derived.by(() => {
 		const seenBuilds = new Set<string>();
 		const uniqueBuilds = builds.filter((build) => {
-			const label = getBuildDisplayName(build);
-			const key = `${label}::${build.url}`;
-			if (seenBuilds.has(key)) return false;
-			seenBuilds.add(key);
+			if (seenBuilds.has(build.url)) return false;
+			seenBuilds.add(build.url);
 			return true;
 		});
 

--- a/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
+++ b/apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte
@@ -21,11 +21,14 @@
 			if (build.arch === 'x86_64' || platform.includes('intel') || platform.includes('x86_64')) {
 				return 'Intel Mac';
 			}
-			return build.platform.startsWith('macOS') ? build.platform : `macOS ${build.platform}`;
+			return platform.startsWith('macos') ? build.platform : `macOS ${build.platform}`;
 		}
 
 		if (build.os === 'windows') {
-			return 'Windows (MSI)';
+			const file = build.file.toLowerCase();
+			if (file.includes('msi')) return 'Windows (MSI)';
+			if (file.includes('exe')) return 'Windows (EXE)';
+			return 'Windows';
 		}
 
 		if (build.os === 'linux') {
@@ -47,11 +50,12 @@
 	}
 
 	const groupedBuilds = $derived.by(() => {
-		const seenLabels = new Set<string>();
+		const seenBuilds = new Set<string>();
 		const uniqueBuilds = builds.filter((build) => {
 			const label = getBuildDisplayName(build);
-			if (seenLabels.has(label)) return false;
-			seenLabels.add(label);
+			const key = `${label}::${build.url}`;
+			if (seenBuilds.has(key)) return false;
+			seenBuilds.add(key);
 			return true;
 		});
 

--- a/apps/web/src/lib/utils/releaseUtils.ts
+++ b/apps/web/src/lib/utils/releaseUtils.ts
@@ -2,6 +2,8 @@ import { getValidReleases, type Build, type Release } from '$lib/types/releases'
 
 const API_BASE_URL = 'https://app.gitbutler.com/api/downloads';
 
+export const RELEASE_OS_ORDER = ['darwin', 'linux', 'windows'] as const;
+
 /**
  * Process builds by filtering out .zip files, removing duplicates, and sorting by platform
  */

--- a/apps/web/src/routes/downloads/+page.svelte
+++ b/apps/web/src/routes/downloads/+page.svelte
@@ -74,31 +74,13 @@
 						<path d={osIcons.macos} fill="currentColor" />
 					</svg>
 					<div class="download-options">
-						{#if latestReleaseBuilds.darwin_x86_64}
-							<a href={latestReleaseBuilds.darwin_x86_64.url} class="download-link"> Intel Mac </a>
-						{/if}
 						{#if latestReleaseBuilds.darwin_aarch64}
 							<a href={latestReleaseBuilds.darwin_aarch64.url} class="download-link">
 								Apple Silicon
 							</a>
 						{/if}
-					</div>
-				</div>
-
-				<div class="download-category">
-					<svg
-						class="download-icon"
-						viewBox="0 0 22 22"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path d={osIcons.windows} fill="currentColor" />
-					</svg>
-					<div class="download-options">
-						{#if latestReleaseBuilds.windows_x86_64}
-							<a href={latestReleaseBuilds.windows_x86_64.url} class="download-link">
-								Windows (MSI)
-							</a>
+						{#if latestReleaseBuilds.darwin_x86_64}
+							<a href={latestReleaseBuilds.darwin_x86_64.url} class="download-link"> Intel Mac </a>
 						{/if}
 					</div>
 				</div>
@@ -141,6 +123,24 @@
 						{#if latestReleaseBuilds.linux_rpm_aarch64}
 							<a href={latestReleaseBuilds.linux_rpm_aarch64.url} class="download-link">
 								Linux ARM64 (RPM)
+							</a>
+						{/if}
+					</div>
+				</div>
+
+				<div class="download-category">
+					<svg
+						class="download-icon"
+						viewBox="0 0 22 22"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path d={osIcons.windows} fill="currentColor" />
+					</svg>
+					<div class="download-options">
+						{#if latestReleaseBuilds.windows_x86_64}
+							<a href={latestReleaseBuilds.windows_x86_64.url} class="download-link">
+								Windows (MSI)
 							</a>
 						{/if}
 					</div>

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -100,32 +100,14 @@
 							<path d={osIcons.macos} fill="currentColor" />
 						</svg>
 						<div class="download-options">
-							{#if latestNightlyBuilds.darwin_x86_64}
-								<a href={latestNightlyBuilds.darwin_x86_64.url} class="download-link">
-									Intel Mac
-								</a>
-							{/if}
 							{#if latestNightlyBuilds.darwin_aarch64}
 								<a href={latestNightlyBuilds.darwin_aarch64.url} class="download-link">
 									Apple Silicon
 								</a>
 							{/if}
-						</div>
-					</div>
-
-					<div class="download-category">
-						<svg
-							class="download-icon"
-							viewBox="0 0 22 22"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path d={osIcons.windows} fill="currentColor" />
-						</svg>
-						<div class="download-options">
-							{#if latestNightlyBuilds.windows_x86_64}
-								<a href={latestNightlyBuilds.windows_x86_64.url} class="download-link">
-									Windows (MSI)
+							{#if latestNightlyBuilds.darwin_x86_64}
+								<a href={latestNightlyBuilds.darwin_x86_64.url} class="download-link">
+									Intel Mac
 								</a>
 							{/if}
 						</div>
@@ -169,6 +151,24 @@
 							{#if latestNightlyBuilds.linux_rpm_aarch64}
 								<a href={latestNightlyBuilds.linux_rpm_aarch64.url} class="download-link">
 									Linux ARM64 (RPM)
+								</a>
+							{/if}
+						</div>
+					</div>
+
+					<div class="download-category">
+						<svg
+							class="download-icon"
+							viewBox="0 0 22 22"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path d={osIcons.windows} fill="currentColor" />
+						</svg>
+						<div class="download-options">
+							{#if latestNightlyBuilds.windows_x86_64}
+								<a href={latestNightlyBuilds.windows_x86_64.url} class="download-link">
+									Windows (MSI)
 								</a>
 							{/if}
 						</div>

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -101,12 +101,12 @@
 						<div class="download-options">
 							{#if latestNightlyBuilds.darwin_x86_64}
 								<a href={latestNightlyBuilds.darwin_x86_64.url} class="download-link">
-									macOS Intel
+									Intel Mac
 								</a>
 							{/if}
 							{#if latestNightlyBuilds.darwin_aarch64}
 								<a href={latestNightlyBuilds.darwin_aarch64.url} class="download-link">
-									macOS Apple Silicon
+									Apple Silicon
 								</a>
 							{/if}
 						</div>
@@ -248,9 +248,9 @@
 								<a href={build.url} class="download-link">
 									{#if build.os === 'darwin'}
 										{#if build.platform.includes('aarch64')}
-											macOS Apple Silicon
+											Apple Silicon
 										{:else if build.platform.includes('x86_64')}
-											macOS Intel
+											Intel Mac
 										{:else}
 											macOS {build.platform}
 										{/if}

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Footer from '$lib/components/marketing/Footer.svelte';
 	import Header from '$lib/components/marketing/Header.svelte';
+	import ReleaseDownloadLinks from '$lib/components/marketing/ReleaseDownloadLinks.svelte';
 	import osIcons from '$lib/data/os-icons.json';
 	import { Icon } from '@gitbutler/ui';
 	import type { Release } from '$lib/types/releases';
@@ -242,49 +243,9 @@
 				</button>
 
 				{#if expandedRelease === release.version}
-					<div class="release-row__links">
-						{#if release.builds && release.builds.length > 0}
-							{#each release.builds as build}
-								<a href={build.url} class="download-link">
-									{#if build.os === 'darwin'}
-										{#if build.platform.includes('aarch64')}
-											Apple Silicon
-										{:else if build.platform.includes('x86_64')}
-											Intel Mac
-										{:else}
-											macOS {build.platform}
-										{/if}
-									{:else if build.os === 'windows'}
-										MSI
-									{:else if build.os === 'linux'}
-										{#if build.arch === 'x86_64'}
-											{#if build.file.includes('AppImage')}
-												Linux Intel (AppImage)
-											{:else if build.file.includes('deb')}
-												Linux Intel (Deb)
-											{:else if build.file.includes('rpm')}
-												Linux Intel (RPM)
-											{:else}
-												Linux {build.platform}
-											{/if}
-										{:else if build.arch === 'aarch64'}
-											{#if build.file.includes('AppImage')}
-												Linux ARM64 (AppImage)
-											{:else if build.file.includes('deb')}
-												Linux ARM64 (Deb)
-											{:else if build.file.includes('rpm')}
-												Linux ARM64 (RPM)
-											{:else}
-												Linux {build.platform}
-											{/if}
-										{/if}
-									{:else}
-										{build.os} {build.platform}
-									{/if}
-								</a>
-							{/each}
-						{/if}
-					</div>
+					{#if release.builds && release.builds.length > 0}
+						<ReleaseDownloadLinks builds={release.builds} />
+					{/if}
 				{/if}
 			</div>
 		{/each}
@@ -551,20 +512,6 @@
 		}
 	}
 
-	.release-row__links {
-		display: flex;
-		flex-wrap: wrap;
-		padding: 24px;
-		gap: 18px 20px;
-		background-image: radial-gradient(var(--clr-border-2) 1px, transparent 1px);
-		background-size: 6px 6px;
-		font-size: 13px;
-
-		& .download-link {
-			background-color: var(--clr-bg-2);
-		}
-	}
-
 	.grainy-1 {
 		top: -40%;
 		right: -45%;
@@ -620,10 +567,6 @@
 
 		.release-row__version {
 			font-size: 16px;
-		}
-
-		.release-row__links {
-			padding: 16px;
 		}
 	}
 </style>


### PR DESCRIPTION
This pull request refactors how download links for builds are displayed on the marketing and downloads pages. The main improvement is the introduction of a new `ReleaseDownloadLinks` component, which centralizes and standardizes the logic for grouping, displaying, and styling download links across the site. This change reduces code duplication, improves maintainability, and ensures a consistent user experience. Additionally, minor style class adjustments were made for consistency.

Component refactoring and reuse:

* Introduced a new `ReleaseDownloadLinks` Svelte component that handles grouping, labeling, and displaying download links for various OSes and architectures, including improved logic for naming builds and deduplication. (`apps/web/src/lib/components/marketing/ReleaseDownloadLinks.svelte`)
* Updated `ReleaseCard.svelte` to use the new `ReleaseDownloadLinks` component, removing its own grouping and display logic and related styles. (`apps/web/src/lib/components/marketing/ReleaseCard.svelte`) [[1]](diffhunk://#diff-888cbbf1ad0f1dac9e3181e2b3dd136a4ffcb48cd73ca55de691eba8d6ad5cd9L2-R2) [[2]](diffhunk://#diff-888cbbf1ad0f1dac9e3181e2b3dd136a4ffcb48cd73ca55de691eba8d6ad5cd9L16-L55) [[3]](diffhunk://#diff-888cbbf1ad0f1dac9e3181e2b3dd136a4ffcb48cd73ca55de691eba8d6ad5cd9L90-R50) [[4]](diffhunk://#diff-888cbbf1ad0f1dac9e3181e2b3dd136a4ffcb48cd73ca55de691eba8d6ad5cd9L191-L232)
* Updated the Nightly and Downloads pages to use the new component for release build links, simplifying their markup and removing now-unnecessary custom code and styles. (`apps/web/src/routes/nightly/+page.svelte`, `apps/web/src/routes/downloads/+page.svelte`) [[1]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0R4) [[2]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0L102-R110) [[3]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0R158-R175) [[4]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0L245-L288) [[5]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0L554-L567) [[6]](diffhunk://#diff-775bf50adb0c3074e7d8bb0ce3451241ce49f04c7de0d1b3bb59adfd221305c0L624-L627) [[7]](diffhunk://#diff-52d3dad90f9076746b72529aa5cbb1ad0f7a722ab8916a0aab0724b751ad6e44L77-R83) [[8]](diffhunk://#diff-52d3dad90f9076746b72529aa5cbb1ad0f7a722ab8916a0aab0724b751ad6e44R130-R147)

Style and class consistency:

* Changed some class names from `opacity-50`/`opacity-60` to `op-50`/`op-60` for consistency with the codebase's utility class naming conventions. (`apps/web/src/lib/components/marketing/Footer.svelte`, `apps/desktop/src/components/codegen/CodegenServiceMessageUseTool.svelte`) [[1]](diffhunk://#diff-6354490b858f8152be82ab0948f137423edb4f75c5000952619236a04fdbd196L75-R75) [[2]](diffhunk://#diff-ae2103fc5d34e3ab02ee348ef0fe4a49b38e15f30d0a22c807b1b60a96c1ff39L67-R67)