### PR TITLE
Add CI workflow to check for unused deps

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,6 +207,7 @@ jobs:
           rustup component add clippy
           cargo clippy --workspace --all-targets -- -D warnings
 
+  # Find unused cargo dependencies
   cargo-machete:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
@@ -218,11 +219,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Install cargo-machete
+        run: cargo install --locked cargo-machete --version 0.9.1
       - name: Run cargo-machete on workspace
-        uses: bnjbvr/cargo-machete@7959c845782fed02ee69303126d4a12d64f1db18 # v0.9.1
-        with:
-          # Point machete at the Rust workspace directory
-          args: .
+        run: cargo machete
 
   cargo-deny:
     needs: changes
@@ -534,6 +534,7 @@ jobs:
       - rust-test
       - rust-test-tauri
       - rust-lint
+      - cargo-machete
       - cargo-doc
       - build-installer
       - but-sdk-build-check

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,6 +207,23 @@ jobs:
           rustup component add clippy
           cargo clippy --workspace --all-targets -- -D warnings
 
+  cargo-machete:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run cargo-machete on workspace
+        uses: bnjbvr/cargo-machete@7959c845782fed02ee69303126d4a12d64f1db18 # v0.9.1
+        with:
+          # Point machete at the Rust workspace directory
+          args: .
+
   cargo-deny:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -11,7 +11,16 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["futures", "napi", "napi-derive", "tauri"]
+ignored = [
+    # Used by macro-generated async API glue that machete does not detect reliably.
+    "futures",
+    # Used only when the `napi` feature is enabled for Node bindings.
+    "napi",
+    # Used only when the `napi` feature is enabled for Node bindings.
+    "napi-derive",
+    # Used only when the `tauri` feature is enabled for Tauri command bindings.
+    "tauri",
+]
 
 [lib]
 doctest = false

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["futures", "napi", "napi-derive", "tauri"]
+
 [lib]
 doctest = false
 

--- a/crates/but-napi/Cargo.toml
+++ b/crates/but-napi/Cargo.toml
@@ -11,7 +11,12 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["napi", "napi-derive"]
+ignored = [
+    # Consumed via napi attribute macros and generated bindings that machete misses.
+    "napi",
+    # Consumed via napi attribute macros and generated bindings that machete misses.
+    "napi-derive",
+]
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/but-napi/Cargo.toml
+++ b/crates/but-napi/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["napi", "napi-derive"]
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["serde_regex"]
+ignored = [
+    # Referenced from serde field attributes, which machete can report as unused.
+    "serde_regex",
+]
 
 [lib]
 doctest = false

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["serde_regex"]
+
 [lib]
 doctest = false
 

--- a/crates/but-testing/Cargo.toml
+++ b/crates/but-testing/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["gitbutler-commit"]
+
 [[bin]]
 name = "but-testing"
 path = "src/main.rs"

--- a/crates/but-testing/Cargo.toml
+++ b/crates/but-testing/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["gitbutler-commit"]
+ignored = [
+    # Only used behind the optional `testing` feature for deterministic test commits.
+    "gitbutler-commit",
+]
 
 [[bin]]
 name = "but-testing"

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["gitbutler-commit"]
+ignored = [
+    # Only used behind the optional `testing` feature for deterministic test commits.
+    "gitbutler-commit",
+]
 
 [[bin]]
 name = "gitbutler-cli"

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["gitbutler-commit"]
+
 [[bin]]
 name = "gitbutler-cli"
 path = "src/main.rs"

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 rust-version.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["backtrace"]
+ignored = [
+    # Only used when the optional `error-context` feature enables backtrace capture.
+    "backtrace",
+]
 
 [lib]
 doctest = false

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["backtrace"]
+
 [lib]
 doctest = false
 crate-type = ["lib", "staticlib", "cdylib"]


### PR DESCRIPTION
## 🧢 Changes

Introduce cargo machete to block builds on unused dependencies.

088a0cfefaafdf261a65e9638b4d6b1aff73fbfc introduce machete CI workflow to prevent unused crates, and  ignore current machete false positives

## ☕️ Reasoning

Cargo.toml files had unused crates as seen in #12467 

## 📌 Todos

 - [x] Fix the inevitable false positives!
 - [x] Blocked by #12467 
