### PR TITLE
Conflicted commits are based on auto-resolution tree

### DIFF
--- a/crates/but-rebase/src/cherry_pick.rs
+++ b/crates/but-rebase/src/cherry_pick.rs
@@ -195,7 +195,7 @@ pub(crate) mod function {
         let conflicted_files_string = toml::to_string(&conflicted_files)?;
         let conflicted_files_blob = repo.write_blob(conflicted_files_string.as_bytes())?;
 
-        let mut tree = repo.empty_tree().edit()?;
+        let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
 
         // save the state of the conflict, so we can recreate it later
         let (base_tree_id, ours_tree_id, theirs_tree_id) = find_cherry_pick_trees(&head, &to_rebase)?;
@@ -208,7 +208,7 @@ pub(crate) mod function {
             resolved_tree_id,
         )?;
         tree.upsert(".conflict-files", EntryKind::Blob, conflicted_files_blob)?;
-        tree.upsert("README.txt", EntryKind::Blob, readme_blob)?;
+        tree.upsert("CONFLICT-README.txt", EntryKind::Blob, readme_blob)?;
 
         let mut headers = to_rebase
             .headers()

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -306,7 +306,7 @@ fn commit_from_conflicted_tree<'repo>(
     let conflicted_files_string = toml::to_string(&conflicted_files)?;
     let conflicted_files_blob = repo.write_blob(conflicted_files_string.as_bytes())?;
 
-    let mut tree = repo.empty_tree().edit()?;
+    let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
 
     tree.upsert(TreeKind::Ours.as_tree_entry_name(), EntryKind::Tree, ours_tree_id)?;
     tree.upsert(TreeKind::Theirs.as_tree_entry_name(), EntryKind::Tree, theirs_tree_id)?;
@@ -317,7 +317,7 @@ fn commit_from_conflicted_tree<'repo>(
         resolved_tree_id,
     )?;
     tree.upsert(".conflict-files", EntryKind::Blob, conflicted_files_blob)?;
-    tree.upsert("README.txt", EntryKind::Blob, readme_blob)?;
+    tree.upsert("CONFLICT-README.txt", EntryKind::Blob, readme_blob)?;
 
     let mut headers = to_rebase
         .headers()

--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -56,7 +56,7 @@ fn basic_cherry_pick_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(92a5de18951fc289787883411346bf5151f9c854),
+        Sha1(e9ee7b59aff786fc970c30f6965d1de1913c7ec4),
     )
     ");
 
@@ -67,7 +67,7 @@ fn basic_cherry_pick_cp_conflicts() -> Result<()> {
     assert_eq!(&get_parents(&id.attach(&repo))?, &[onto]);
 
     insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
-    3417b4c
+    0367fb7
     ├── .auto-resolution:aa3d213 
     │   ├── base-f:100644:7898192 "a\n"
     │   └── target-f:100644:eb5a316 "target\n"
@@ -82,7 +82,9 @@ fn basic_cherry_pick_cp_conflicts() -> Result<()> {
     │   ├── base-f:100644:7898192 "a\n"
     │   ├── clean-f:100644:8312630 "clean\n"
     │   └── target-f:100644:9b1719f "conflict\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── base-f:100644:7898192 "a\n"
+    └── target-f:100644:eb5a316 "target\n"
     "#);
 
     Ok(())
@@ -151,7 +153,7 @@ fn single_parent_to_multiple_parents_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(e0da7f3ff8f416b3f93c84a5e737b265021897f1),
+        Sha1(0fcbe01202743fa55f1a1e07342ad26f2e7a0abe),
     )
     ");
 
@@ -162,7 +164,7 @@ fn single_parent_to_multiple_parents_cp_conflicts() -> Result<()> {
     assert_eq!(&get_parents(&id.attach(&repo))?, &[onto, onto2]);
 
     insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
-    75fdd2c
+    1804f3d
     ├── .auto-resolution:744efa9 
     │   ├── base-f:100644:7898192 "a\n"
     │   ├── target-2-f:100644:caac8f9 "target 2\n"
@@ -179,7 +181,10 @@ fn single_parent_to_multiple_parents_cp_conflicts() -> Result<()> {
     │   ├── base-f:100644:7898192 "a\n"
     │   ├── clean-f:100644:8312630 "clean\n"
     │   └── target-f:100644:9b1719f "conflict\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── base-f:100644:7898192 "a\n"
+    ├── target-2-f:100644:caac8f9 "target 2\n"
+    └── target-f:100644:eb5a316 "target\n"
     "#);
 
     Ok(())
@@ -257,7 +262,7 @@ fn multiple_parents_to_single_parent_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(b31d986b2deb4337c487ae0f431fe37688fa2197),
+        Sha1(28fa7c91af8652f4e69c1e3184f92569a3468a34),
     )
     ");
 
@@ -268,7 +273,7 @@ fn multiple_parents_to_single_parent_cp_conflicts() -> Result<()> {
     assert_eq!(&get_parents(&id.attach(&repo))?, &[onto]);
 
     insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
-    fde5970
+    91fe014
     ├── .auto-resolution:aa3d213 
     │   ├── base-f:100644:7898192 "a\n"
     │   └── target-f:100644:eb5a316 "target\n"
@@ -285,7 +290,9 @@ fn multiple_parents_to_single_parent_cp_conflicts() -> Result<()> {
     │   ├── clean-2-f:100644:13e9394 "clean 2\n"
     │   ├── clean-f:100644:8312630 "clean\n"
     │   └── target-f:100644:9b1719f "conflict\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── base-f:100644:7898192 "a\n"
+    └── target-f:100644:eb5a316 "target\n"
     "#);
 
     Ok(())
@@ -367,7 +374,7 @@ fn multiple_parents_to_multiple_parents_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(ef56061bb8c852be7983011e1a59fe80eefcf31d),
+        Sha1(2e6cb06fe98780bb8c7a301a522edd98805d1499),
     )
     ");
 
@@ -378,7 +385,7 @@ fn multiple_parents_to_multiple_parents_cp_conflicts() -> Result<()> {
     assert_eq!(&get_parents(&id.attach(&repo))?, &[onto, onto2]);
 
     insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
-    acdd833
+    0aeaf79
     ├── .auto-resolution:744efa9 
     │   ├── base-f:100644:7898192 "a\n"
     │   ├── target-2-f:100644:caac8f9 "target 2\n"
@@ -397,7 +404,10 @@ fn multiple_parents_to_multiple_parents_cp_conflicts() -> Result<()> {
     │   ├── clean-2-f:100644:13e9394 "clean 2\n"
     │   ├── clean-f:100644:8312630 "clean\n"
     │   └── target-f:100644:9b1719f "conflict\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── base-f:100644:7898192 "a\n"
+    ├── target-2-f:100644:caac8f9 "target 2\n"
+    └── target-f:100644:eb5a316 "target\n"
     "#);
 
     Ok(())
@@ -569,7 +579,7 @@ fn no_parents_to_single_parent_cp_conflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(fc01136874918a3912b3a5ff76e625d46dda7cb6),
+        Sha1(28f862257bff139659b763a2c873b8d3f0f780b0),
     )
     ");
 
@@ -580,7 +590,7 @@ fn no_parents_to_single_parent_cp_conflicts() -> Result<()> {
     assert_eq!(&get_parents(&id.attach(&repo))?, &[onto]);
 
     insta::assert_snapshot!(visualize_tree(id.attach(&repo)), @r#"
-    d92cbc8
+    1267a55
     ├── .auto-resolution:aa3d213 
     │   ├── base-f:100644:7898192 "a\n"
     │   └── target-f:100644:eb5a316 "target\n"
@@ -592,7 +602,9 @@ fn no_parents_to_single_parent_cp_conflicts() -> Result<()> {
     ├── .conflict-side-1:144e5f5 
     │   ├── base-f:100644:7898192 "a\n"
     │   └── target-f:100644:9b1719f "conflict\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── base-f:100644:7898192 "a\n"
+    └── target-f:100644:eb5a316 "target\n"
     "#);
 
     Ok(())
@@ -611,7 +623,7 @@ fn cherry_pick_back_to_original_parents_unconflicts() -> Result<()> {
 
     insta::assert_debug_snapshot!(result, @"
     ConflictedCommit(
-        Sha1(ef56061bb8c852be7983011e1a59fe80eefcf31d),
+        Sha1(2e6cb06fe98780bb8c7a301a522edd98805d1499),
     )
     ");
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -35,7 +35,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
 
     // We expect to see conflicted headers
     insta::assert_snapshot!(cat_commit(&repo, "c")?, @"
-    tree 7c4363d235e51107d74c858038cfab0d192db092
+    tree c199bde16a034b8588f7c896ec3640c40ad017dd
     parent 5e0ba4636be91de6216903697b269915d3db6c53
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -325,7 +325,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
         .rebase()?;
     insta::assert_debug_snapshot!(out, @"
     RebaseOutput {
-        top_commit: Sha1(3ccc6a6db258bc7deed5a08efc892de13ba21746),
+        top_commit: Sha1(b811bdb2d96bfc96bf54030ce094edea09fc8db0),
         references: [],
         commit_mapping: [
             (
@@ -347,22 +347,22 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
-                Sha1(c4a99d5da6b9e2c434563ae56ab51b85f03587d5),
+                Sha1(a5e5bdbc985301d4f814944f11f1cace8eac13a1),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(134887021e06909021776c023a608f8ef179e859),
-                Sha1(3ccc6a6db258bc7deed5a08efc892de13ba21746),
+                Sha1(b811bdb2d96bfc96bf54030ce094edea09fc8db0),
             ),
         ],
     }
     ");
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    *-.   3ccc6a6 Re-merge branches 'A', 'B' and 'C'
+    *-.   b811bdb Re-merge branches 'A', 'B' and 'C'
     |\ \  
-    | | * c4a99d5 C~1
+    | | * a5e5bdb C~1
     | | * eebaa8b C
     | | * a037d4a C~2
     | * | a748762 (B) B: another 10 lines at the bottom
@@ -387,7 +387,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
 
     let conflict_commit_id = repo.rev_parse_single(format!("{}^3", out.top_commit).as_str())?;
     insta::assert_snapshot!(but_testsupport::visualize_tree(conflict_commit_id), @r#"
-    db4a5b8
+    9a27e64
     ├── .auto-resolution:5b3a532 
     │   ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
     │   └── new-file:100644:213ec44 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n"
@@ -401,12 +401,14 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     ├── .conflict-side-1:71364f9 
     │   ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
     │   └── new-file:100644:0ff3bbb "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
+    └── new-file:100644:213ec44 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n"
     "#);
 
     // gitbutler headers were added here to indicate conflict (change-id is frozen for testing)
     insta::assert_snapshot!(conflict_commit_id.object()?.data.as_bstr(), @"
-    tree db4a5b82b209e5165cdf8d04ff4328ec1fc2526d
+    tree 9a27e6447201f9ae394c1e0aaef1536633943fe0
     parent eebaa8b32984736d7a835f805724c66a3988f01b
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
@@ -422,7 +424,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     tree 6abc3da6f1642bfd5543ef97f98b924f4f232a96
     parent add59d26b2ffd7468fcb44c2db48111dd8f481e5
     parent a7487625f079bedf4d20e48f052312c010117b38
-    parent c4a99d5da6b9e2c434563ae56ab51b85f03587d5
+    parent a5e5bdbc985301d4f814944f11f1cace8eac13a1
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771200 +0000
     gitbutler-headers-version 2
@@ -465,7 +467,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     // The base doesn't have new file, and we pick that up from the base of `base` of
     // the previous conflict. `our` side then is the original our.
     insta::assert_snapshot!(visualize_tree(&repo, &out ), @r#"
-    cb71c19
+    72b9cf3
     ├── .auto-resolution:5b3a532 
     │   ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
     │   └── new-file:100644:213ec44 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n"
@@ -478,7 +480,9 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     ├── .conflict-side-1:fa799da 
     │   ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
     │   └── new-file:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
-    └── README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── CONFLICT-README.txt:100644:2af04b7 "You have checked out a GitButler Conflicted commit. You probably didn\'t mean to do this."
+    ├── file:100644:5ecf5f4 "50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n"
+    └── new-file:100644:213ec44 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n"
     "#);
 
     Ok(())
@@ -570,9 +574,9 @@ fn reversible_conflicts() -> anyhow::Result<()> {
 
     let conflict_tip = repo.rev_parse_single(format!("{}^3", out.top_commit).as_str())?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    *-.   3ccc6a6 Re-merge branches 'A', 'B' and 'C'
+    *-.   b811bdb Re-merge branches 'A', 'B' and 'C'
     |\ \  
-    | | * c4a99d5 C~1
+    | | * a5e5bdb C~1
     | | * eebaa8b C
     | | * a037d4a C~2
     | * | a748762 (B) B: another 10 lines at the bottom

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -204,7 +204,7 @@ Uncommitted changes
 ...
               "changes": [
                 {
-                  "cliId": "1e:nk",
+                  "cliId": "76:nk",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }


### PR DESCRIPTION
This change means that if a conflicted commit is checked out, it will just introduce some extra folders, rather than seemingly deleting the entire repository which can be much more disruptive to resolve.