### PR TITLE
Commit creation

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -515,11 +515,19 @@ export class StackService {
 	}
 
 	createCommit() {
-		return this.api.endpoints.createCommit.useMutation();
+		if (get(useNewRebaseEngine)) {
+			return this.api.endpoints.commitCreate.useMutation();
+		} else {
+			return this.api.endpoints.legacyCreateCommit.useMutation();
+		}
 	}
 
 	get createCommitMutation() {
-		return this.api.endpoints.createCommit.mutate;
+		if (get(useNewRebaseEngine)) {
+			return this.api.endpoints.commitCreate.mutate;
+		} else {
+			return this.api.endpoints.legacyCreateCommit.mutate;
+		}
 	}
 
 	filePathsChangedInCommits(projectId: string, commitIds: string[]) {
@@ -956,6 +964,31 @@ function transformStacksResponse(response: Stack[]) {
 	return stackAdapter.addMany(stackAdapter.getInitialState(), response);
 }
 
+function toCommitCreatePlacement(args: CreateCommitRequest): {
+	relativeTo: RelativeTo;
+	side: "above" | "below";
+} {
+	if (args.parentId) {
+		return {
+			relativeTo: {
+				type: "commit",
+				subject: args.parentId,
+			},
+			side: "above",
+		};
+	}
+
+	return {
+		relativeTo: {
+			type: "reference",
+			subject: args.stackBranchName.startsWith("refs/")
+				? args.stackBranchName
+				: `refs/heads/${args.stackBranchName}`,
+		},
+		side: "below",
+	};
+}
+
 function injectEndpoints(api: ClientState["backendApi"], uiState: UiState) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
@@ -1143,7 +1176,7 @@ function injectEndpoints(api: ClientState["backendApi"], uiState: UiState) {
 					return invalidations;
 				},
 			}),
-			createCommit: build.mutation<
+			legacyCreateCommit: build.mutation<
 				CreateCommitOutcome,
 				{ projectId: string } & CreateCommitRequest
 			>({
@@ -1152,6 +1185,30 @@ function injectEndpoints(api: ClientState["backendApi"], uiState: UiState) {
 					actionName: "Commit",
 				},
 				query: (args) => args,
+				invalidatesTags: [
+					invalidatesList(ReduxTag.WorktreeChanges),
+					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+					invalidatesList(ReduxTag.HeadSha),
+				],
+			}),
+			commitCreate: build.mutation<
+				CreateCommitOutcome,
+				{ projectId: string } & CreateCommitRequest
+			>({
+				extraOptions: {
+					command: "commit_create",
+					actionName: "Commit",
+				},
+				query: (args) => {
+					const { relativeTo, side } = toCommitCreatePlacement(args);
+					return {
+						projectId: args.projectId,
+						relativeTo,
+						side,
+						changes: args.worktreeChanges,
+						message: args.message,
+					};
+				},
 				invalidatesTags: [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
+use anyhow::bail;
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
-use but_core::sync::RepoExclusive;
+use but_core::{DiffSpec, sync::RepoExclusive};
 use but_hunk_assignment::HunkAssignmentRequest;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{
@@ -156,6 +157,111 @@ pub fn commit_insert_blank(
 
     let mut guard = ctx.exclusive_worktree_access();
     let res = commit_insert_blank_only_impl(ctx, relative_to, side, guard.write_permission());
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx, guard.write_permission()).ok();
+    };
+    res
+}
+
+/// Creates and inserts a commit relative to either a commit or a reference.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn commit_create_only(
+    ctx: &mut but_ctx::Context,
+    relative_to: ui::RelativeTo,
+    side: InsertSide,
+    changes: Vec<DiffSpec>,
+    message: String,
+) -> anyhow::Result<json::UICommitCreateResult> {
+    let context_lines = ctx.settings.context_lines;
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_create_only_impl(
+        ctx,
+        relative_to,
+        side,
+        changes,
+        message,
+        context_lines,
+        guard.write_permission(),
+    )
+}
+
+/// Creates and inserts a commit relative to either a commit or a reference.
+pub(crate) fn commit_create_only_impl(
+    ctx: &mut but_ctx::Context,
+    relative_to: ui::RelativeTo,
+    side: InsertSide,
+    changes: Vec<DiffSpec>,
+    message: String,
+    context_lines: u32,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<json::UICommitCreateResult> {
+    let meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let editor = ws.graph.to_editor(&repo)?;
+    let relative_to: RelativeTo = (&relative_to).into();
+
+    let but_workspace::commit::CommitCreateOutcome {
+        rebase,
+        commit_selector,
+        rejected_specs,
+        changed_tree_pre_cherry_pick: _,
+    } = but_workspace::commit::commit_create(
+        editor,
+        changes,
+        relative_to,
+        side,
+        &message,
+        context_lines,
+    )?;
+
+    let new_commit = match (rebase, commit_selector) {
+        (Some(rebase), Some(commit_selector)) => {
+            let materialized = rebase.materialize()?;
+            Some(materialized.lookup_pick(commit_selector)?)
+        }
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => bail!("BUG: inconsistent commit outcome"),
+    };
+
+    ws.refresh_from_head(&repo, &meta)?;
+
+    Ok(json::UICommitCreateResult {
+        new_commit: new_commit.map(Into::into),
+        paths_to_rejected_changes: rejected_specs
+            .into_iter()
+            .map(|(reason, spec)| (reason, spec.path.into()))
+            .collect(),
+    })
+}
+
+/// Creates and inserts a commit relative to either a commit or a reference, with oplog support.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn commit_create(
+    ctx: &mut but_ctx::Context,
+    relative_to: ui::RelativeTo,
+    side: InsertSide,
+    changes: Vec<DiffSpec>,
+    message: String,
+) -> anyhow::Result<json::UICommitCreateResult> {
+    let context_lines = ctx.settings.context_lines;
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+        ctx,
+        SnapshotDetails::new(OperationKind::CreateCommit),
+    )
+    .ok();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let res = commit_create_only_impl(
+        ctx,
+        relative_to,
+        side,
+        changes,
+        message,
+        context_lines,
+        guard.write_permission(),
+    );
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
         snapshot.commit(ctx, guard.write_permission()).ok();
     };

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -436,3 +436,16 @@ pub struct UIMoveChangesResult {
     /// Commits that have been mapped from one thing to another
     pub replaced_commits: Vec<(HexHash, HexHash)>,
 }
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// UI type for creating a commit in the rebase graph.
+pub struct UICommitCreateResult {
+    /// The new commit if one was created.
+    pub new_commit: Option<HexHash>,
+    /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
+    pub paths_to_rejected_changes: Vec<(
+        but_core::tree::create_tree::RejectionReason,
+        but_serde::BStringForFrontend,
+    )>,
+}

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -51,6 +51,12 @@ impl ToReferenceSelector for &gix::refs::FullNameRef {
     }
 }
 
+impl ToReferenceSelector for gix::refs::FullName {
+    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector> {
+        editor.select_reference(self.as_ref())
+    }
+}
+
 /// Operations for mutating the commit graph
 impl Editor {
     /// Get a selector to a particular commit in the graph

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -711,6 +711,10 @@ pub async fn run() {
             post(json_response(commit::commit_reword_cmd)),
         )
         .route(
+            "/commit_create",
+            post(json_response(commit::commit_create_cmd)),
+        )
+        .route(
             "/commit_move_changes_between",
             post(json_response(commit::commit_move_changes_between_cmd)),
         )

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -1,0 +1,90 @@
+//! An action to create a new commit relative to a commit or reference.
+
+pub(crate) mod function {
+    use anyhow::Result;
+    use but_core::DiffSpec;
+    use but_rebase::graph_rebase::{
+        Editor, LookupStep, Pick, Selector, Step, SuccessfulRebase, ToSelector, mutate::InsertSide,
+    };
+
+    use crate::commit_engine::{Destination, create_commit};
+
+    /// The result of creating and inserting a new commit in the graph rebase editor.
+    #[derive(Debug)]
+    pub struct CommitCreateOutcome {
+        /// The successful rebase result, if a new commit was created.
+        pub rebase: Option<SuccessfulRebase>,
+        /// Selector pointing to the newly created commit, if one was created.
+        pub commit_selector: Option<Selector>,
+        /// Rejected diff specs from commit creation, matching legacy behavior.
+        pub rejected_specs: Vec<(but_core::tree::create_tree::RejectionReason, DiffSpec)>,
+        /// The intermediate tree before cherry-picking back onto the target tree.
+        pub changed_tree_pre_cherry_pick: Option<gix::ObjectId>,
+    }
+
+    /// Create a commit from `changes` and insert it relative to `relative_to` on `side`.
+    pub fn commit_create(
+        mut editor: Editor,
+        changes: Vec<DiffSpec>,
+        relative_to: impl ToSelector,
+        side: InsertSide,
+        message: &str,
+        context_lines: u32,
+    ) -> Result<CommitCreateOutcome> {
+        let relative_to_selector = relative_to.to_selector(&editor)?;
+        let parent_commit_id = parent_commit_id_for_new_commit(
+            &editor,
+            editor.lookup_step(relative_to_selector)?,
+            side,
+        )?;
+
+        let create_out = create_commit(
+            editor.repo(),
+            Destination::NewCommit {
+                parent_commit_id,
+                stack_segment: None,
+                message: message.to_owned(),
+            },
+            changes,
+            context_lines,
+        )?;
+
+        let Some(new_commit_id) = create_out.new_commit else {
+            return Ok(CommitCreateOutcome {
+                rebase: None,
+                commit_selector: None,
+                rejected_specs: create_out.rejected_specs,
+                changed_tree_pre_cherry_pick: create_out.changed_tree_pre_cherry_pick,
+            });
+        };
+
+        let commit_selector =
+            editor.insert(relative_to_selector, Step::new_pick(new_commit_id), side)?;
+        let rebase = editor.rebase()?;
+
+        Ok(CommitCreateOutcome {
+            rebase: Some(rebase),
+            commit_selector: Some(commit_selector),
+            rejected_specs: create_out.rejected_specs,
+            changed_tree_pre_cherry_pick: create_out.changed_tree_pre_cherry_pick,
+        })
+    }
+
+    fn parent_commit_id_for_new_commit(
+        editor: &Editor,
+        target_step: Step,
+        side: InsertSide,
+    ) -> Result<Option<gix::ObjectId>> {
+        Ok(match (target_step, side) {
+            (Step::Pick(Pick { id, .. }), InsertSide::Above) => Some(id),
+            (Step::Pick(Pick { id, .. }), InsertSide::Below) => {
+                let commit = editor.find_commit(id)?;
+                commit.parents.first().copied()
+            }
+            (Step::Reference { refname }, _) => {
+                Some(editor.find_reference_target(refname)?.1.id.detach())
+            }
+            (Step::None, _) => None,
+        })
+    }
+}

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -6,6 +6,8 @@ use crate::WorkspaceCommit;
 
 pub mod reword;
 pub use reword::function::reword;
+pub mod commit_create;
+pub use commit_create::function::{CommitCreateOutcome, commit_create};
 pub mod insert_blank_commit;
 pub use insert_blank_commit::function::insert_blank_commit;
 pub mod move_changes;

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -1,0 +1,239 @@
+use anyhow::Result;
+use but_core::DiffSpec;
+use but_rebase::graph_rebase::{
+    GraphExt as _, LookupStep as _,
+    mutate::{InsertSide, RelativeTo},
+};
+use but_workspace::commit::commit_create;
+
+use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
+
+fn worktree_changes_as_specs(repo: &gix::Repository) -> Result<Vec<DiffSpec>> {
+    Ok(but_core::diff::worktree_changes(repo)?
+        .changes
+        .into_iter()
+        .map(DiffSpec::from)
+        .collect())
+}
+
+#[test]
+fn commit_above_commit() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    let two_id = repo.rev_parse_single("two")?.detach();
+    std::fs::write(
+        repo.workdir_path("inserted-above-commit.txt")
+            .expect("non-bare"),
+        "inserted\n",
+    )?;
+
+    let editor = graph.to_editor(&repo)?;
+    let outcome = commit_create(
+        editor,
+        worktree_changes_as_specs(&repo)?,
+        RelativeTo::Commit(two_id),
+        InsertSide::Above,
+        "insert above commit",
+        0,
+    )?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let rebase = outcome.rebase.expect("a new commit was created");
+    let selector = outcome
+        .commit_selector
+        .expect("a selector for the new commit");
+    let materialized = rebase.materialize()?;
+    let new_commit_id = materialized.lookup_pick(selector)?;
+
+    let new_commit = repo.find_commit(new_commit_id)?;
+    assert_eq!(new_commit.message_raw()?, "insert above commit");
+    assert_eq!(
+        new_commit.parent_ids().next().expect("one parent").detach(),
+        two_id,
+        "new commit should be based on the target commit when inserted above"
+    );
+    let mut two_ref = repo.find_reference("two")?;
+    assert_eq!(
+        two_ref.peel_to_id()?.detach(),
+        new_commit_id,
+        "the two reference should now point to the inserted commit"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_below_commit() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    let one_id = repo.rev_parse_single("one")?.detach();
+    let two_id = repo.rev_parse_single("two")?.detach();
+    std::fs::write(
+        repo.workdir_path("inserted-below-commit.txt")
+            .expect("non-bare"),
+        "inserted\n",
+    )?;
+
+    let editor = graph.to_editor(&repo)?;
+    let outcome = commit_create(
+        editor,
+        worktree_changes_as_specs(&repo)?,
+        RelativeTo::Commit(two_id),
+        InsertSide::Below,
+        "insert below commit",
+        0,
+    )?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let rebase = outcome.rebase.expect("a new commit was created");
+    let selector = outcome
+        .commit_selector
+        .expect("a selector for the new commit");
+    let materialized = rebase.materialize()?;
+    let new_commit_id = materialized.lookup_pick(selector)?;
+
+    let new_commit = repo.find_commit(new_commit_id)?;
+    assert_eq!(new_commit.message_raw()?, "insert below commit");
+    assert_eq!(
+        new_commit.parent_ids().next().expect("one parent").detach(),
+        one_id,
+        "new commit should be based on the target's first parent when inserted below"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_above_reference() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    let two_id = repo.rev_parse_single("two")?.detach();
+    let reference = repo.find_reference("two")?;
+    std::fs::write(
+        repo.workdir_path("inserted-above-reference.txt")
+            .expect("non-bare"),
+        "inserted\n",
+    )?;
+
+    let editor = graph.to_editor(&repo)?;
+    let outcome = commit_create(
+        editor,
+        worktree_changes_as_specs(&repo)?,
+        RelativeTo::Reference(reference.name()),
+        InsertSide::Above,
+        "insert above reference",
+        0,
+    )?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let rebase = outcome.rebase.expect("a new commit was created");
+    let selector = outcome
+        .commit_selector
+        .expect("a selector for the new commit");
+    let materialized = rebase.materialize()?;
+    let new_commit_id = materialized.lookup_pick(selector)?;
+
+    let new_commit = repo.find_commit(new_commit_id)?;
+    assert_eq!(new_commit.message_raw()?, "insert above reference");
+    assert_eq!(
+        new_commit.parent_ids().next().expect("one parent").detach(),
+        two_id,
+        "new commit should be based on the referenced commit"
+    );
+    let mut two_ref = repo.find_reference("two")?;
+    assert_eq!(
+        two_ref.peel_to_id()?.detach(),
+        two_id,
+        "when inserting above a reference, the reference keeps pointing to the original commit"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("merge-with-two-branches-line-offset", |_| {})?;
+    let merge_id = repo.rev_parse_single("HEAD")?.detach();
+    let merge_commit = repo.find_commit(merge_id)?;
+    let first_parent_id = merge_commit
+        .parent_ids()
+        .next()
+        .expect("merge commit has parent")
+        .detach();
+    std::fs::write(
+        repo.workdir_path("inserted-below-merge.txt")
+            .expect("non-bare"),
+        "inserted\n",
+    )?;
+
+    let editor = graph.to_editor(&repo)?;
+    let outcome = commit_create(
+        editor,
+        worktree_changes_as_specs(&repo)?,
+        RelativeTo::Commit(merge_id),
+        InsertSide::Below,
+        "insert below merge",
+        0,
+    )?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let rebase = outcome.rebase.expect("a new commit was created");
+    let selector = outcome
+        .commit_selector
+        .expect("a selector for the new commit");
+    let materialized = rebase.materialize()?;
+    let new_commit_id = materialized.lookup_pick(selector)?;
+
+    let new_commit = repo.find_commit(new_commit_id)?;
+    assert_eq!(new_commit.message_raw()?, "insert below merge");
+    assert_eq!(
+        new_commit
+            .parent_ids()
+            .next()
+            .expect("has a parent")
+            .detach(),
+        first_parent_id,
+        "for below merge commits, we base creation on first parent"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn commit_all_rejected_is_noop() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    let two_id = repo.rev_parse_single("two")?.detach();
+    let editor = graph.to_editor(&repo)?;
+
+    let outcome = commit_create(
+        editor,
+        vec![DiffSpec {
+            previous_path: None,
+            path: "does-not-exist".into(),
+            hunk_headers: vec![],
+        }],
+        RelativeTo::Commit(two_id),
+        InsertSide::Above,
+        "no-op commit",
+        0,
+    )?;
+
+    assert!(
+        outcome.rebase.is_none(),
+        "no rebase should happen if nothing was committed"
+    );
+    assert!(
+        outcome.commit_selector.is_none(),
+        "no selector if there is no new commit"
+    );
+    assert_eq!(
+        outcome.rejected_specs.len(),
+        1,
+        "the invalid spec should be rejected"
+    );
+    assert_eq!(outcome.rejected_specs[0].1.path, "does-not-exist");
+
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -1,3 +1,4 @@
+mod commit_create;
 mod insert_blank_commit;
 mod move_changes;
 mod reword;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -402,6 +402,7 @@ fn main() -> anyhow::Result<()> {
                 claude::claude_compact_history,
                 commit::tauri_commit_reword::commit_reword,
                 commit::tauri_commit_insert_blank::commit_insert_blank,
+                commit::tauri_commit_create::commit_create,
                 commit::tauri_commit_move_changes_between::commit_move_changes_between,
                 commit::tauri_commit_uncommit_changes::commit_uncommit_changes,
                 platform::tauri_build_type::build_type,


### PR DESCRIPTION
Introduce a non-legacy version of `commit_and_update_refs`. Instead of the old reference frame and other complicated setup, this now takes the standard relative_to selector and an insert side.