### PR TITLE
Pin ci-base-image by digest in E2E workflows

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -166,7 +166,7 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -265,7 +265,7 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     env:
       CARGO_TERM_COLOR: always
     defaults:
@@ -549,7 +549,7 @@ jobs:
     if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -19,7 +19,7 @@ jobs:
     name: e2e-blackbox
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -17,7 +17,7 @@ jobs:
     name: e2e-playwright
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
     timeout-minutes: 60
     env:
       DESKTOP_PORT: 3000


### PR DESCRIPTION
Pin the GHCR ci-base-image in e2e-blackbox and e2e-playwright workflows to an immutable sha256 digest instead of using latest.