### PR TITLE
Narrow permissions in push-e2e image workflow

### DIFF
--- a/.github/workflows/push-e2e-img.yml
+++ b/.github/workflows/push-e2e-img.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   docker_publish:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Replace write-all with least-privilege workflow permissions: contents:read and packages:write for GHCR publish.