### PR TITLE
feat(ui): disable ligatures in text inputs; bump design-core

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.59.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "1.7.6",
+		"@gitbutler/design-core": "1.7.7",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/svelte-comment-injector": "workspace:*",
 		"@gitbutler/ui": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.0.0",
 		"@gitbutler/core": "workspace:*",
-		"@gitbutler/design-core": "1.7.6",
+		"@gitbutler/design-core": "1.7.7",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",
 		"@playwright/test": "1.47.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
 		"@codemirror/language": "^6.12.1",
 		"@codemirror/legacy-modes": "^6.5.2",
 		"@csstools/postcss-bundler": "^2.0.8",
-		"@gitbutler/design-core": "1.7.6",
+		"@gitbutler/design-core": "1.7.7",
 		"@lezer/common": "^1.5.1",
 		"@lezer/highlight": "^1.2.1",
 		"@playwright/experimental-ct-svelte": "^1.57.0",

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -215,6 +215,7 @@
 	.textarea {
 		overflow-x: hidden;
 		overflow-y: auto; /* Enable scrolling when max height is reached */
+		font-variant-ligatures: none;
 		resize: none;
 
 		&.hide-scrollbar {

--- a/packages/ui/src/lib/components/Textbox.svelte
+++ b/packages/ui/src/lib/components/Textbox.svelte
@@ -297,6 +297,7 @@
 		position: relative;
 		flex-grow: 1;
 		width: 100%;
+		font-variant-ligatures: none;
 
 		&.size-default {
 			height: var(--size-cta);

--- a/packages/ui/src/lib/richText/RichTextEditor.svelte
+++ b/packages/ui/src/lib/richText/RichTextEditor.svelte
@@ -317,6 +317,7 @@
 		z-index: -1;
 		position: relative;
 		flex: auto;
+		font-variant-ligatures: none;
 		resize: vertical;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.7.6
-        version: 1.7.6
+        specifier: 1.7.7
+        version: 1.7.7
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -441,8 +441,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@gitbutler/design-core':
-        specifier: 1.7.6
-        version: 1.7.6
+        specifier: 1.7.7
+        version: 1.7.7
       '@gitbutler/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -560,10 +560,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
-        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)
+        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@24.10.4)(typescript@5.9.3)
 
   packages/core:
     dependencies:
@@ -847,8 +847,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(postcss@8.5.6)
       '@gitbutler/design-core':
-        specifier: 1.7.6
-        version: 1.7.6
+        specifier: 1.7.7
+        version: 1.7.7
       '@lezer/common':
         specifier: ^1.5.1
         version: 1.5.1
@@ -2008,8 +2008,8 @@ packages:
     resolution: {integrity: sha512-oC5cM6jS7aFOp0luTw5mWSRuMgdxwHRLZQ/aWkI+ETMfsprR/HyxsXfljlMY/XJ/fRxTbRJiodR5Axf66WjO3w==}
     engines: {node: '>=18.20.0'}
 
-  '@gitbutler/design-core@1.7.6':
-    resolution: {integrity: sha512-BvRA7hVhJjkQYHpPS9NtzfdzUcB7wESRDPT3xcvoySA7vRl0Wopl/TKTauOijbnIHXV3zNG0SBx6bt7JE2frvw==}
+  '@gitbutler/design-core@1.7.7':
+    resolution: {integrity: sha512-aplRKwZiOR5q7l/02kXOAUDDAauRRYeA8b1lqGvMSPpHLZzZWN75Ms0zuuhuox4auBQ7bHfgo6chFvVBvF3VGw==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -10448,7 +10448,7 @@ snapshots:
       '@gitbeaker/core': 42.5.0
       '@gitbeaker/requester-utils': 42.5.0
 
-  '@gitbutler/design-core@1.7.6': {}
+  '@gitbutler/design-core@1.7.7': {}
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -10491,14 +10491,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/checkbox@5.0.6(@types/node@22.19.11)':
+  '@inquirer/checkbox@5.0.6(@types/node@24.10.4)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/confirm@5.1.21(@types/node@24.10.4)':
     dependencies:
@@ -10507,12 +10507,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/confirm@6.0.6(@types/node@22.19.11)':
+  '@inquirer/confirm@6.0.6(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/core@10.3.2(@types/node@24.10.4)':
     dependencies:
@@ -10527,17 +10527,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/core@11.1.3(@types/node@22.19.11)':
+  '@inquirer/core@11.1.3(@types/node@24.10.4)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/editor@4.2.23(@types/node@24.10.4)':
     dependencies:
@@ -10547,13 +10547,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/editor@5.0.6(@types/node@22.19.11)':
+  '@inquirer/editor@5.0.6(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/external-editor': 2.0.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/external-editor': 2.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/expand@4.0.23(@types/node@24.10.4)':
     dependencies:
@@ -10563,12 +10563,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/expand@5.0.6(@types/node@22.19.11)':
+  '@inquirer/expand@5.0.6(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/external-editor@1.0.3(@types/node@24.10.4)':
     dependencies:
@@ -10577,12 +10577,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/external-editor@2.0.3(@types/node@22.19.11)':
+  '@inquirer/external-editor@2.0.3(@types/node@24.10.4)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/figures@1.0.15': {}
 
@@ -10595,12 +10595,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/input@5.0.6(@types/node@22.19.11)':
+  '@inquirer/input@5.0.6(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/number@3.0.23(@types/node@24.10.4)':
     dependencies:
@@ -10609,12 +10609,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/number@4.0.6(@types/node@22.19.11)':
+  '@inquirer/number@4.0.6(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/password@4.0.23(@types/node@24.10.4)':
     dependencies:
@@ -10624,13 +10624,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/password@5.0.6(@types/node@22.19.11)':
+  '@inquirer/password@5.0.6(@types/node@24.10.4)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/prompts@7.10.1(@types/node@24.10.4)':
     dependencies:
@@ -10647,20 +10647,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/prompts@8.2.1(@types/node@22.19.11)':
+  '@inquirer/prompts@8.2.1(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/checkbox': 5.0.6(@types/node@22.19.11)
-      '@inquirer/confirm': 6.0.6(@types/node@22.19.11)
-      '@inquirer/editor': 5.0.6(@types/node@22.19.11)
-      '@inquirer/expand': 5.0.6(@types/node@22.19.11)
-      '@inquirer/input': 5.0.6(@types/node@22.19.11)
-      '@inquirer/number': 4.0.6(@types/node@22.19.11)
-      '@inquirer/password': 5.0.6(@types/node@22.19.11)
-      '@inquirer/rawlist': 5.2.2(@types/node@22.19.11)
-      '@inquirer/search': 4.1.2(@types/node@22.19.11)
-      '@inquirer/select': 5.0.6(@types/node@22.19.11)
+      '@inquirer/checkbox': 5.0.6(@types/node@24.10.4)
+      '@inquirer/confirm': 6.0.6(@types/node@24.10.4)
+      '@inquirer/editor': 5.0.6(@types/node@24.10.4)
+      '@inquirer/expand': 5.0.6(@types/node@24.10.4)
+      '@inquirer/input': 5.0.6(@types/node@24.10.4)
+      '@inquirer/number': 4.0.6(@types/node@24.10.4)
+      '@inquirer/password': 5.0.6(@types/node@24.10.4)
+      '@inquirer/rawlist': 5.2.2(@types/node@24.10.4)
+      '@inquirer/search': 4.1.2(@types/node@24.10.4)
+      '@inquirer/select': 5.0.6(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/rawlist@4.1.11(@types/node@24.10.4)':
     dependencies:
@@ -10670,12 +10670,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/rawlist@5.2.2(@types/node@22.19.11)':
+  '@inquirer/rawlist@5.2.2(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/search@3.2.2(@types/node@24.10.4)':
     dependencies:
@@ -10686,13 +10686,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/search@4.1.2(@types/node@22.19.11)':
+  '@inquirer/search@4.1.2(@types/node@24.10.4)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/select@4.4.2(@types/node@24.10.4)':
     dependencies:
@@ -10704,22 +10704,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/select@5.0.6(@types/node@22.19.11)':
+  '@inquirer/select@5.0.6(@types/node@24.10.4)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/core': 11.1.3(@types/node@24.10.4)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@24.10.4)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@inquirer/type@3.0.10(@types/node@24.10.4)':
     optionalDependencies:
       '@types/node': 24.10.4
 
-  '@inquirer/type@4.0.3(@types/node@22.19.11)':
+  '@inquirer/type@4.0.3(@types/node@24.10.4)':
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.10.4
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -11021,9 +11021,9 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)':
     dependencies:
-      '@inquirer/prompts': 8.2.1(@types/node@22.19.11)
+      '@inquirer/prompts': 8.2.1(@types/node@24.10.4)
       '@napi-rs/cross-toolchain': 1.0.3
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1
@@ -18199,6 +18199,24 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.11
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.4
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
Before:
<img width="355" height="130" alt="Screenshot 2026-02-21 at 23 02 38" src="https://github.com/user-attachments/assets/bb14b938-b753-4ec5-853f-3dce5140685c" />

After:
<img width="396" height="120" alt="Screenshot 2026-02-21 at 23 01 28" src="https://github.com/user-attachments/assets/58ba2477-73f4-4829-9188-e85e74d333af" />


This pull request primarily updates the `@gitbutler/design-core` dependency across multiple packages from version 1.7.6 to 1.7.7, and makes a small UI improvement by disabling font ligatures in several text input components. It also updates some lockfile entries to reflect newer versions of `@types/node` and related dependencies.

Dependency updates:

* Upgraded `@gitbutler/design-core` from version 1.7.6 to 1.7.7 in `apps/desktop/package.json`, `apps/web/package.json`, and `packages/ui/package.json`, as well as in the corresponding sections of `pnpm-lock.yaml`. [[1]](diffhunk://#diff-f260cda9a89e97068b04d6627600f3e650fcff63642da2f62c7b9412a2da2646L28-R28) [[2]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L19-R19) [[3]](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dL50-R50) F880fb35L215R215, [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL444-R445) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL850-R851) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2011-R2012) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10451-R10451)
* Updated `@types/node` and related dependencies in `pnpm-lock.yaml` to version 24.10.4, affecting several `@inquirer` and `@napi-rs/cli` package entries. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL563-R566) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10494-R10501) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10510-R10515) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10530-R10540) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10550-R10556) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10566-R10571) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10580-R10585) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10598-R10603) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10612-R10617) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10627-R10633) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10650-R10663) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10673-R10678) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10689-R10695) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10707-R10722) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11024-R11026) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18212-R18229)

UI improvements:

* Added `font-variant-ligatures: none;` to `.textarea`, `.textbox`, and `.richTextEditor` styles in `packages/ui/src/lib/components/Textarea.svelte`, `TextBox.svelte`, and `richText/RichTextEditor.svelte` to disable font ligatures for improved text rendering. [[1]](diffhunk://#diff-52d5616db6c3e774a0ffe418b311f484f3f92c30c5cd74b3191b4e7d28924d65R218) [[2]](diffhunk://#diff-ebb68e1cbc1cb253d5548e94b92bd88878bc60f3b28b861ea658ce5fc0b96f4aR300) [[3]](diffhunk://#diff-95b41188b9291185c7cb16a2bc9ac35008b9c13df4db0b57497c4bce4a49dde0R320)