### PR TITLE
ci: scope test-web workflow permissions

### DIFF
--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: web-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Adds explicit least-privilege permissions (`contents: read`) to `.github/workflows/test-web.yml` to address the code-scanning overly broad permissions finding.