### PR TITLE
chore(deps): pin fast-xml-parser to 5.3.7

### DIFF
--- a/crates/but/skill/eval/package.json
+++ b/crates/but/skill/eval/package.json
@@ -18,10 +18,13 @@
     "promptfoo": "^0.120.25"
   },
   "devDependencies": {
-    "@types/node": "^24.10.1",
+    "@types/node": "^22.19.11",
     "typescript": "^5.9.3"
   },
   "pnpm": {
+    "overrides": {
+      "fast-xml-parser": "5.3.7"
+    },
     "onlyBuiltDependencies": [
       "@playwright/browser-chromium",
       "@swc/core",

--- a/crates/but/skill/eval/pnpm-lock.yaml
+++ b/crates/but/skill/eval/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-xml-parser: 5.3.7
+
 importers:
 
   .:
@@ -13,11 +16,11 @@ importers:
         version: 0.1.77(zod@4.3.6)
       promptfoo:
         specifier: ^0.120.25
-        version: 0.120.25(@types/json-schema@7.0.15)(@types/node@24.10.11)(pg@8.18.0)(playwright-core@1.58.2)(socks@2.8.7)
+        version: 0.120.25(@types/json-schema@7.0.15)(@types/node@22.19.11)(pg@8.18.0)(playwright-core@1.58.2)(socks@2.8.7)
     devDependencies:
       '@types/node':
-        specifier: ^24.10.1
-        version: 24.10.11
+        specifier: ^22.19.11
+        version: 22.19.11
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1606,8 +1609,8 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@24.10.11':
-    resolution: {integrity: sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==}
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
   '@types/pegjs@0.10.6':
     resolution: {integrity: sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==}
@@ -2402,10 +2405,6 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-xml-parser@5.3.6:
-    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
-    hasBin: true
 
   fast-xml-parser@5.3.7:
     resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
@@ -4011,8 +4010,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@7.21.0:
     resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
@@ -5080,7 +5079,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.5':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.3.6
+      fast-xml-parser: 5.3.7
       tslib: 2.8.1
     optional: true
 
@@ -5683,70 +5682,70 @@ snapshots:
 
   '@inquirer/ansi@2.0.3': {}
 
-  '@inquirer/checkbox@5.0.4(@types/node@24.10.11)':
+  '@inquirer/checkbox@5.0.4(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/confirm@6.0.4(@types/node@24.10.11)':
+  '@inquirer/confirm@6.0.4(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/core@11.1.1(@types/node@24.10.11)':
+  '@inquirer/core@11.1.1(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
       cli-width: 4.1.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
       wrap-ansi: 9.0.2
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/editor@5.0.4(@types/node@24.10.11)':
+  '@inquirer/editor@5.0.4(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
-      '@inquirer/external-editor': 2.0.3(@types/node@24.10.11)
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/external-editor@2.0.3(@types/node@24.10.11)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.11)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
   '@inquirer/figures@2.0.3': {}
 
-  '@inquirer/input@5.0.4(@types/node@24.10.11)':
+  '@inquirer/input@5.0.4(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/select@5.0.4(@types/node@24.10.11)':
+  '@inquirer/select@5.0.4(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
-  '@inquirer/type@4.0.3(@types/node@24.10.11)':
+  '@inquirer/type@4.0.3(@types/node@22.19.11)':
     optionalDependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6084,7 +6083,7 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
     optional: true
 
   '@slack/types@2.20.0':
@@ -6094,7 +6093,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.20.0
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
       '@types/retry': 0.12.0
       axios: 1.13.5
       eventemitter3: 5.0.4
@@ -6571,7 +6570,7 @@ snapshots:
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
   '@types/debug@4.1.12':
     dependencies:
@@ -6588,9 +6587,9 @@ snapshots:
       undici-types: 5.26.5
     optional: true
 
-  '@types/node@24.10.11':
+  '@types/node@22.19.11':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 6.21.0
 
   '@types/pegjs@0.10.6':
     optional: true
@@ -6613,7 +6612,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
 
   '@typespec/ts-http-runtime@0.3.3':
     dependencies:
@@ -7165,7 +7164,7 @@ snapshots:
   engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -7344,11 +7343,6 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
-
-  fast-xml-parser@5.3.6:
-    dependencies:
-      strnum: 2.1.2
-    optional: true
 
   fast-xml-parser@5.3.7:
     dependencies:
@@ -8573,17 +8567,17 @@ snapshots:
   process@0.11.10:
     optional: true
 
-  promptfoo@0.120.25(@types/json-schema@7.0.15)(@types/node@24.10.11)(pg@8.18.0)(playwright-core@1.58.2)(socks@2.8.7):
+  promptfoo@0.120.25(@types/json-schema@7.0.15)(@types/node@22.19.11)(pg@8.18.0)(playwright-core@1.58.2)(socks@2.8.7):
     dependencies:
       '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
       '@apidevtools/json-schema-ref-parser': 15.2.2(@types/json-schema@7.0.15)
       '@googleapis/sheets': 13.0.1
-      '@inquirer/checkbox': 5.0.4(@types/node@24.10.11)
-      '@inquirer/confirm': 6.0.4(@types/node@24.10.11)
-      '@inquirer/core': 11.1.1(@types/node@24.10.11)
-      '@inquirer/editor': 5.0.4(@types/node@24.10.11)
-      '@inquirer/input': 5.0.4(@types/node@24.10.11)
-      '@inquirer/select': 5.0.4(@types/node@24.10.11)
+      '@inquirer/checkbox': 5.0.4(@types/node@22.19.11)
+      '@inquirer/confirm': 6.0.4(@types/node@22.19.11)
+      '@inquirer/core': 11.1.1(@types/node@22.19.11)
+      '@inquirer/editor': 5.0.4(@types/node@22.19.11)
+      '@inquirer/input': 5.0.4(@types/node@22.19.11)
+      '@inquirer/select': 5.0.4(@types/node@22.19.11)
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       '@openai/agents': 0.4.15(ws@8.19.0)(zod@4.3.6)
       '@opencode-ai/sdk': 1.2.10
@@ -8763,7 +8757,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
       long: 5.3.2
     optional: true
 
@@ -8779,7 +8773,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.11
+      '@types/node': 22.19.11
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -9439,7 +9433,7 @@ snapshots:
   undici-types@5.26.5:
     optional: true
 
-  undici-types@7.16.0: {}
+  undici-types@6.21.0: {}
 
   undici@7.21.0: {}
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"devDependencies": {
 		"@playwright/test": "1.58.2",
-		"@types/node": "^24.3.0",
+		"@types/node": "^22.19.11",
 		"@wdio/cli": "^9.24.0",
 		"@wdio/globals": "^9.23.0",
 		"@wdio/local-runner": "^9.24.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 	},
 	"pnpm": {
 		"overrides": {
+			"fast-xml-parser": "5.3.7",
 			"@lexical/clipboard": "0.27.2",
 			"@lexical/code": "0.27.2",
 			"@lexical/file": "0.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ catalogs:
       version: 4.4.0
 
 overrides:
+  fast-xml-parser: 5.3.7
   '@lexical/clipboard': 0.27.2
   '@lexical/code': 0.27.2
   '@lexical/file': 0.27.2
@@ -554,11 +555,11 @@ importers:
         specifier: 1.58.2
         version: 1.58.2
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.10.4
+        specifier: ^22.19.11
+        version: 22.19.11
       '@wdio/cli':
         specifier: ^9.24.0
-        version: 9.24.0(@types/node@24.10.4)(expect-webdriverio@5.5.0)
+        version: 9.24.0(@types/node@22.19.11)(expect-webdriverio@5.5.0)
       '@wdio/globals':
         specifier: ^9.23.0
         version: 9.23.0(expect-webdriverio@5.5.0)(webdriverio@9.24.0)
@@ -582,10 +583,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
-        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)
+        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.10.4)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
 
   packages/core:
     dependencies:
@@ -6013,8 +6014,8 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-parser@5.3.3:
-    resolution: {integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==}
+  fast-xml-parser@5.3.7:
+    resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
     hasBin: true
 
   fastq@1.19.1:
@@ -10552,245 +10553,245 @@ snapshots:
 
   '@inquirer/ansi@2.0.3': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.10.4)':
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/checkbox@5.0.6(@types/node@24.10.4)':
+  '@inquirer/checkbox@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/confirm@5.1.21(@types/node@24.10.4)':
+  '@inquirer/confirm@5.1.21(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/confirm@6.0.6(@types/node@24.10.4)':
+  '@inquirer/confirm@6.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/core@10.3.2(@types/node@24.10.4)':
+  '@inquirer/core@10.3.2(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/core@11.1.3(@types/node@24.10.4)':
+  '@inquirer/core@11.1.3(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/editor@4.2.23(@types/node@24.10.4)':
+  '@inquirer/editor@4.2.23(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/editor@5.0.6(@types/node@24.10.4)':
+  '@inquirer/editor@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/external-editor': 2.0.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/expand@4.0.23(@types/node@24.10.4)':
+  '@inquirer/expand@4.0.23(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/expand@5.0.6(@types/node@24.10.4)':
+  '@inquirer/expand@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.10.4)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/external-editor@2.0.3(@types/node@24.10.4)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.11)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
+
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.11)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.3': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.10.4)':
+  '@inquirer/input@4.3.1(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/input@5.0.6(@types/node@24.10.4)':
+  '@inquirer/input@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/number@3.0.23(@types/node@24.10.4)':
+  '@inquirer/number@3.0.23(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/number@4.0.6(@types/node@24.10.4)':
+  '@inquirer/number@4.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/password@4.0.23(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/password@5.0.6(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/prompts@7.10.1(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.10.4)
-      '@inquirer/confirm': 5.1.21(@types/node@24.10.4)
-      '@inquirer/editor': 4.2.23(@types/node@24.10.4)
-      '@inquirer/expand': 4.0.23(@types/node@24.10.4)
-      '@inquirer/input': 4.3.1(@types/node@24.10.4)
-      '@inquirer/number': 3.0.23(@types/node@24.10.4)
-      '@inquirer/password': 4.0.23(@types/node@24.10.4)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.10.4)
-      '@inquirer/search': 3.2.2(@types/node@24.10.4)
-      '@inquirer/select': 4.4.2(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/prompts@8.2.1(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/checkbox': 5.0.6(@types/node@24.10.4)
-      '@inquirer/confirm': 6.0.6(@types/node@24.10.4)
-      '@inquirer/editor': 5.0.6(@types/node@24.10.4)
-      '@inquirer/expand': 5.0.6(@types/node@24.10.4)
-      '@inquirer/input': 5.0.6(@types/node@24.10.4)
-      '@inquirer/number': 4.0.6(@types/node@24.10.4)
-      '@inquirer/password': 5.0.6(@types/node@24.10.4)
-      '@inquirer/rawlist': 5.2.2(@types/node@24.10.4)
-      '@inquirer/search': 4.1.2(@types/node@24.10.4)
-      '@inquirer/select': 5.0.6(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/rawlist@4.1.11(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/rawlist@5.2.2(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/search@3.2.2(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/search@4.1.2(@types/node@24.10.4)':
-    dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
-    optionalDependencies:
-      '@types/node': 24.10.4
-
-  '@inquirer/select@4.4.2(@types/node@24.10.4)':
+  '@inquirer/password@4.0.23(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/select@5.0.6(@types/node@24.10.4)':
+  '@inquirer/password@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.11)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.11)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.11)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.11)
+      '@inquirer/input': 4.3.1(@types/node@22.19.11)
+      '@inquirer/number': 3.0.23(@types/node@22.19.11)
+      '@inquirer/password': 4.0.23(@types/node@22.19.11)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.11)
+      '@inquirer/search': 3.2.2(@types/node@22.19.11)
+      '@inquirer/select': 4.4.2(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/prompts@8.2.1(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/checkbox': 5.0.6(@types/node@22.19.11)
+      '@inquirer/confirm': 6.0.6(@types/node@22.19.11)
+      '@inquirer/editor': 5.0.6(@types/node@22.19.11)
+      '@inquirer/expand': 5.0.6(@types/node@22.19.11)
+      '@inquirer/input': 5.0.6(@types/node@22.19.11)
+      '@inquirer/number': 4.0.6(@types/node@22.19.11)
+      '@inquirer/password': 5.0.6(@types/node@22.19.11)
+      '@inquirer/rawlist': 5.2.2(@types/node@22.19.11)
+      '@inquirer/search': 4.1.2(@types/node@22.19.11)
+      '@inquirer/select': 5.0.6(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/rawlist@5.2.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/search@3.2.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/search@4.1.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/type@3.0.10(@types/node@24.10.4)':
+  '@inquirer/select@4.4.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
-  '@inquirer/type@4.0.3(@types/node@24.10.4)':
+  '@inquirer/select@5.0.6(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
+
+  '@inquirer/type@3.0.10(@types/node@22.19.11)':
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/type@4.0.3(@types/node@22.19.11)':
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -10821,7 +10822,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       jest-regex-util: 30.0.1
 
   '@jest/schemas@30.0.5':
@@ -10834,7 +10835,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -11092,9 +11093,9 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)':
     dependencies:
-      '@inquirer/prompts': 8.2.1(@types/node@24.10.4)
+      '@inquirer/prompts': 8.2.1(@types/node@22.19.11)
       '@napi-rs/cross-toolchain': 1.0.3
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1
@@ -12771,7 +12772,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -12781,7 +12782,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/cookie@0.6.0': {}
 
@@ -12802,7 +12803,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/git-url-parse@9.0.3': {}
 
@@ -12826,7 +12827,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/lscache@1.3.4': {}
 
@@ -12842,7 +12843,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -12864,6 +12865,7 @@ snapshots:
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -12875,13 +12877,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       xmlbuilder: 15.1.1
     optional: true
 
@@ -12901,7 +12903,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/sinonjs__fake-timers@8.1.1': {}
 
@@ -12913,7 +12915,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -12929,7 +12931,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -12939,7 +12941,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
@@ -13261,7 +13263,7 @@ snapshots:
     transitivePeerDependencies:
       - allure-playwright
 
-  '@wdio/cli@9.24.0(@types/node@24.10.4)(expect-webdriverio@5.5.0)':
+  '@wdio/cli@9.24.0(@types/node@22.19.11)(expect-webdriverio@5.5.0)':
     dependencies:
       '@vitest/snapshot': 2.1.9
       '@wdio/config': 9.24.0
@@ -13273,7 +13275,7 @@ snapshots:
       async-exit-hook: 2.0.1
       chalk: 5.6.2
       chokidar: 4.0.3
-      create-wdio: 9.21.0(@types/node@24.10.4)
+      create-wdio: 9.21.0(@types/node@22.19.11)
       dotenv: 17.2.3
       import-meta-resolve: 4.2.0
       lodash.flattendeep: 4.4.0
@@ -14270,7 +14272,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  create-wdio@9.21.0(@types/node@24.10.4):
+  create-wdio@9.21.0(@types/node@22.19.11):
     dependencies:
       chalk: 5.6.2
       commander: 14.0.2
@@ -14278,7 +14280,7 @@ snapshots:
       ejs: 3.1.10
       execa: 9.6.1
       import-meta-resolve: 4.2.0
-      inquirer: 12.11.1(@types/node@24.10.4)
+      inquirer: 12.11.1(@types/node@22.19.11)
       normalize-package-data: 7.0.1
       read-pkg-up: 10.1.0
       recursive-readdir: 2.2.3
@@ -14678,7 +14680,7 @@ snapshots:
       '@zip.js/zip.js': 2.8.11
       decamelize: 6.0.1
       edge-paths: 3.0.5
-      fast-xml-parser: 5.3.3
+      fast-xml-parser: 5.3.7
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       which: 6.0.0
@@ -15237,7 +15239,7 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-parser@5.3.3:
+  fast-xml-parser@5.3.7:
     dependencies:
       strnum: 2.1.2
 
@@ -15723,17 +15725,17 @@ snapshots:
 
   ini@2.0.0: {}
 
-  inquirer@12.11.1(@types/node@24.10.4):
+  inquirer@12.11.1(@types/node@22.19.11):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.10.4)
-      '@inquirer/prompts': 7.10.1(@types/node@24.10.4)
-      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   install@0.13.0: {}
 
@@ -15878,7 +15880,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       jest-util: 30.2.0
 
   jest-regex-util@30.0.1: {}
@@ -15886,7 +15888,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -17404,7 +17406,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
       long: 5.3.2
 
   protocols@2.0.2: {}
@@ -18410,24 +18412,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.10.4
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -18508,7 +18492,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.16.0:
+    optional: true
 
   undici@6.22.0: {}
 


### PR DESCRIPTION
## Summary
- Add a root pnpm override to pin `fast-xml-parser` to `5.3.7`.
- Standardize direct `@types/node` declarations to `^22.19.11` in:
  - `e2e/package.json`
  - `crates/but/skill/eval/package.json`
- Update `pnpm-lock.yaml` accordingly.

## Note on lockfile resolution
- The lockfile includes broader metadata updates tied to the `@types/node` standardization (including e2e/webdriver inquirer/jest-related resolution entries), in addition to the `fast-xml-parser` pin.
