### PR TITLE
fix: reduce excessive git_get_global_config calls in BranchList

### DIFF
--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -139,16 +139,13 @@
 			}
 		});
 	}
-
-	$effect(() => {
-		setAIConfigurationValid();
-	});
 </script>
 
 <KebabButton
 	contextElement={rightClickTrigger}
 	testId={TestId.KebabMenuButton}
 	contextMenuTestId={TestId.BranchHeaderContextMenu}
+	onMenuOpen={setAIConfigurationValid}
 >
 	{#snippet contextMenu({ close })}
 		{@const { branch, prNumber, first, stackLength } = contextData}

--- a/apps/desktop/src/components/branchesPage/BranchListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchListCard.svelte
@@ -47,40 +47,42 @@
 		let canceled = false;
 
 		if (ownedByUser) {
-			gitConfigService.get('user.name').then((userName) => {
-				if (canceled) return;
-
-				if (userName) {
-					lastCommitDetails = { authorName: userName };
-				} else {
-					lastCommitDetails = undefined;
-				}
-			});
+			setOwnedUserDetails(canceled);
 		} else {
 			lastCommitDetails = {
 				authorName: branchListing.lastCommiter.name || unknownName,
 				lastCommitAt: new Date(branchListing.updatedAt)
 			};
+			setAvatars(branchListingDetails);
 		}
+
+		return () => {
+			canceled = true;
+		};
 	});
 
 	let avatars = $state<{ username: string; srcUrl: string }[]>([]);
 
-	$effect(() => {
-		setAvatars(ownedByUser, branchListingDetails);
-	});
+	async function setOwnedUserDetails(canceled: boolean) {
+		const name = (await gitConfigService.get('user.name')) || unknownName;
+		const email = (await gitConfigService.get('user.email')) || unknownEmail;
 
-	async function setAvatars(ownedByUser: boolean, branchListingDetails?: BranchListingDetails) {
-		if (ownedByUser) {
-			const name = (await gitConfigService.get('user.name')) || unknownName;
-			const email = (await gitConfigService.get('user.email')) || unknownEmail;
-			const srcUrl =
-				email.toLowerCase() === $user?.email?.toLowerCase() && $user?.picture
-					? $user?.picture
-					: await gravatarUrlFromEmail(email);
+		if (canceled) return;
 
-			avatars = [{ username: name, srcUrl: srcUrl }];
-		} else if (branchListingDetails) {
+		lastCommitDetails = name !== unknownName ? { authorName: name } : undefined;
+
+		const srcUrl =
+			email.toLowerCase() === $user?.email?.toLowerCase() && $user?.picture
+				? $user?.picture
+				: await gravatarUrlFromEmail(email);
+
+		if (canceled) return;
+
+		avatars = [{ username: name, srcUrl: srcUrl }];
+	}
+
+	async function setAvatars(branchListingDetails?: BranchListingDetails) {
+		if (branchListingDetails) {
 			avatars = branchListingDetails.authors
 				? await Promise.all(
 						branchListingDetails.authors.map(async (author) => {


### PR DESCRIPTION
## Problem

The BranchList excessively calls git_get_global_config to fetch user.name, user.email, and various AI config settings -- once per branch on every render.

## Root Cause

1. **AI config**: BranchHeaderContextMenu has an effect that calls aiService.validateConfiguration() on mount. Since one context menu is rendered per branch, this fires N x 7+ config reads on initial render.

2. **user.name / user.email**: BranchListCard had two separate effect blocks that independently fetched user.name (and the second also fetched user.email), resulting in 3 config calls per card.

## Fix

1. **BranchHeaderContextMenu**: Moved AI config validation from an eager effect to the onMenuOpen callback on KebabButton. The validation now only runs when the user actually opens the context menu.

2. **BranchListCard**: Consolidated the two separate effects into a single setOwnedUserDetails() function that fetches user.name and user.email once and sets both lastCommitDetails and avatars from the same data.

Closes #10221
