### PR TITLE
dont truncate branch

### DIFF
--- a/crates/but/src/command/legacy/branch/apply.rs
+++ b/crates/but/src/command/legacy/branch/apply.rs
@@ -11,6 +11,8 @@ use crate::utils::OutputChannel;
 /// Apply a branch to the workspace, and return the full ref name to it.
 ///
 /// Look first in through the local references, then the remote references.
+/// If no exact match is found, look for branches whose names contain the given string
+/// and offer an interactive selection.
 pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> anyhow::Result<()> {
     let repo = ctx.repo.get()?;
     let reference = if let Some(r) = repo.try_find_reference(branch_name)? {
@@ -49,9 +51,69 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
         )?;
         r
     } else {
-        // NOTE: this is aligned with the 'modern' version for now which doesn't handle this specifically.
-        //       Once there is only one impl, this can be adjusted more easily.
-        bail!("The reference '{branch_name}' did not exist");
+        // No exact match - look for branches whose names contain the given string
+        let git2_repo = ctx.git2_repo.get()?;
+        let mut partial = find_partial_matches(&git2_repo, branch_name)?;
+        drop(repo);
+        drop(git2_repo);
+
+        if partial.is_empty() {
+            // NOTE: this is aligned with the 'modern' version for now which doesn't handle this specifically.
+            //       Once there is only one impl, this can be adjusted more easily.
+            bail!("The reference '{branch_name}' did not exist");
+        }
+
+        // Sort by last commit date, most recent first
+        partial.sort_by_key(|b| std::cmp::Reverse(b.timestamp()));
+
+        let chosen = select_partial_match(partial, branch_name, out)?;
+
+        // Apply the chosen match using the same logic as the exact-match paths above
+        let repo = ctx.repo.get()?;
+        match chosen {
+            PartialMatch::Local { branch, .. } => {
+                let r = repo
+                    .try_find_reference(&branch)?
+                    .ok_or_else(|| anyhow::anyhow!("Branch '{branch}' not found"))?;
+                let ref_name = gitbutler_reference::Refname::from_str(&r.name().to_string())?;
+                let remote_ref_name = r
+                    .remote_ref_name(gix::remote::Direction::Push)
+                    .transpose()?
+                    .as_deref()
+                    .and_then(|rn| {
+                        gitbutler_reference::RemoteRefname::from_str(&rn.to_string()).ok()
+                    });
+                let r = r.detach();
+                drop(repo);
+                but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
+                    ctx,
+                    ref_name,
+                    remote_ref_name,
+                    None,
+                )?;
+                r
+            }
+            PartialMatch::Remote { remote, branch, .. } => {
+                let remote_ref = RemoteRefname::new(&remote, &branch);
+                let ref_name = gitbutler_reference::Refname::from_str(&format!(
+                    "refs/remotes/{remote}/{branch}"
+                ))?;
+                let r = repo
+                    .try_find_reference(&remote_ref.fullname())?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Branch 'refs/remotes/{remote}/{branch}' not found")
+                    })?;
+                let r = r.detach();
+                drop(repo);
+                but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
+                    ctx,
+                    ref_name,
+                    Some(remote_ref),
+                    None,
+                )?;
+                r
+            }
+        }
     };
 
     if let Some(out) = out.for_human() {
@@ -73,6 +135,131 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
         out.write_value(but_api::json::Reference::from(reference))?;
     }
     Ok(())
+}
+
+enum PartialMatch {
+    Local {
+        display: String,
+        branch: String,
+        timestamp: i64,
+    },
+    Remote {
+        display: String,
+        remote: String,
+        branch: String,
+        timestamp: i64,
+    },
+}
+
+impl PartialMatch {
+    fn display(&self) -> &str {
+        match self {
+            Self::Local { display, .. } | Self::Remote { display, .. } => display,
+        }
+    }
+
+    fn timestamp(&self) -> i64 {
+        match self {
+            Self::Local { timestamp, .. } | Self::Remote { timestamp, .. } => *timestamp,
+        }
+    }
+}
+
+/// Find all local and remote branches whose names contain `pattern` (case-insensitive).
+fn find_partial_matches(
+    repo: &git2::Repository,
+    pattern: &str,
+) -> anyhow::Result<Vec<PartialMatch>> {
+    let pattern_lower = pattern.to_lowercase();
+    let mut matches = Vec::new();
+
+    for reference in repo.references()? {
+        let reference = reference?;
+        let full_name = match reference.name() {
+            Some(n) => n,
+            None => continue,
+        };
+
+        if let Some(branch) = full_name.strip_prefix("refs/heads/") {
+            if !branch.to_lowercase().contains(&pattern_lower) {
+                continue;
+            }
+            let timestamp = reference
+                .peel(git2::ObjectType::Commit)
+                .ok()
+                .and_then(|o| o.into_commit().ok())
+                .map(|c| c.time().seconds())
+                .unwrap_or(0);
+            matches.push(PartialMatch::Local {
+                display: branch.to_string(),
+                branch: branch.to_string(),
+                timestamp,
+            });
+        } else if let Some(remote_branch) = full_name.strip_prefix("refs/remotes/") {
+            // Skip symbolic HEAD refs like "origin/HEAD"
+            if remote_branch.ends_with("/HEAD") {
+                continue;
+            }
+            if !remote_branch.to_lowercase().contains(&pattern_lower) {
+                continue;
+            }
+            let slash = match remote_branch.find('/') {
+                Some(p) => p,
+                None => continue,
+            };
+            let remote = remote_branch[..slash].to_string();
+            let branch = remote_branch[slash + 1..].to_string();
+            let timestamp = reference
+                .peel(git2::ObjectType::Commit)
+                .ok()
+                .and_then(|o| o.into_commit().ok())
+                .map(|c| c.time().seconds())
+                .unwrap_or(0);
+            matches.push(PartialMatch::Remote {
+                display: remote_branch.to_string(),
+                remote,
+                branch,
+                timestamp,
+            });
+        }
+    }
+
+    Ok(matches)
+}
+
+/// Present an interactive selection prompt (or a non-interactive error) for partial branch matches.
+fn select_partial_match(
+    mut matches: Vec<PartialMatch>,
+    pattern: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<PartialMatch> {
+    if !out.can_prompt() {
+        if matches.len() == 1 {
+            return Ok(matches.remove(0));
+        }
+        let options = matches
+            .iter()
+            .map(|m| format!("  {}", m.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!("'{pattern}' didn't match exactly. Possible matches:\n{options}");
+    }
+
+    use cli_prompts::DisplayPrompt;
+
+    let displays: Vec<String> = matches.iter().map(|m| m.display().to_string()).collect();
+    let prompt = cli_prompts::prompts::Selection::new(
+        &format!("'{pattern}' didn't match exactly. Which branch did you mean?"),
+        displays.iter().cloned(),
+    );
+    let selected = prompt
+        .display()
+        .map_err(|e| anyhow::anyhow!("Selection aborted: {e:?}"))?;
+    let idx = matches
+        .iter()
+        .position(|m| m.display() == selected)
+        .ok_or_else(|| anyhow::anyhow!("Selected branch not found"))?;
+    Ok(matches.remove(idx))
 }
 
 fn find_remote_reference<'repo>(

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -4,7 +4,6 @@ use but_oxidize::{ObjectIdExt, OidExt};
 use colored::Colorize;
 use tracing::instrument;
 
-use super::list::load_id_map;
 use crate::utils::OutputChannel;
 
 #[allow(clippy::too_many_arguments)]
@@ -17,24 +16,7 @@ pub fn show(
     generate_ai_summary: bool,
     check_merge: bool,
 ) -> anyhow::Result<()> {
-    let id_map = load_id_map(&ctx.project_data_dir())?;
-
-    // Find the branch name from the ID
-    let branch_name = if branch_id.len() == 2 {
-        // Lookup by CLI ID
-        id_map
-            .iter()
-            .find(|(_, id)| id.as_str() == branch_id)
-            .map(|(name, _)| name.clone())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Branch ID '{branch_id}' not found. Run 'but branch' to see available IDs."
-                )
-            })?
-    } else {
-        // Assume it's a branch name
-        branch_id.to_string()
-    };
+    let branch_name = branch_id.to_string();
 
     // Get the list of commits ahead of base for this branch
     let commits = get_commits_ahead(ctx, &branch_name, show_files)?;

--- a/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
@@ -20,9 +20,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green">Applied Branches</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="dimmed">00</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">autho…</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="dimmed">01</tspan><tspan>   </tspan><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan><tspan>            </tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green dimmed">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">autho…</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>


### PR DESCRIPTION
In the `but branch` output, we show shortcodes and they are not usable by `but branch apply`, only the branch name. But if the screen is small, we truncate the branch name, which makes applying very difficult.

This does a few things - gets rid of the shortcodes entirely, as they’re not used. It also tries not to truncate the branch names. It also takes partial branch names and prompts for which one you mean.