### PR TITLE
chore(deps): pin devalue to 5.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 	},
 	"pnpm": {
 		"overrides": {
+			"devalue": "5.6.3",
 			"fast-xml-parser": "5.3.7",
 			"@isaacs/brace-expansion": "5.0.1",
 			"@lexical/clipboard": "0.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ catalogs:
       version: 4.4.0
 
 overrides:
+  devalue: 5.6.3
   fast-xml-parser: 5.3.7
   '@isaacs/brace-expansion': 5.0.1
   '@lexical/clipboard': 0.27.2
@@ -584,10 +585,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
-        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)
+        version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.10.4)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
 
   packages/core:
     dependencies:
@@ -5537,9 +5538,6 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-
-  devalue@5.6.1:
-    resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
 
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
@@ -10567,14 +10565,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/checkbox@5.0.6(@types/node@24.10.4)':
+  '@inquirer/checkbox@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/confirm@5.1.21(@types/node@22.19.11)':
     dependencies:
@@ -10583,12 +10581,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/confirm@6.0.6(@types/node@24.10.4)':
+  '@inquirer/confirm@6.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/core@10.3.2(@types/node@22.19.11)':
     dependencies:
@@ -10603,17 +10601,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/core@11.1.3(@types/node@24.10.4)':
+  '@inquirer/core@11.1.3(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/editor@4.2.23(@types/node@22.19.11)':
     dependencies:
@@ -10623,13 +10621,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/editor@5.0.6(@types/node@24.10.4)':
+  '@inquirer/editor@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/external-editor': 2.0.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/expand@4.0.23(@types/node@22.19.11)':
     dependencies:
@@ -10639,12 +10637,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/expand@5.0.6(@types/node@24.10.4)':
+  '@inquirer/expand@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.11)':
     dependencies:
@@ -10653,12 +10651,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/external-editor@2.0.3(@types/node@24.10.4)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.11)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/figures@1.0.15': {}
 
@@ -10671,12 +10669,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/input@5.0.6(@types/node@24.10.4)':
+  '@inquirer/input@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/number@3.0.23(@types/node@22.19.11)':
     dependencies:
@@ -10685,12 +10683,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/number@4.0.6(@types/node@24.10.4)':
+  '@inquirer/number@4.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/password@4.0.23(@types/node@22.19.11)':
     dependencies:
@@ -10700,13 +10698,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/password@5.0.6(@types/node@24.10.4)':
+  '@inquirer/password@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/prompts@7.10.1(@types/node@22.19.11)':
     dependencies:
@@ -10723,20 +10721,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/prompts@8.2.1(@types/node@24.10.4)':
+  '@inquirer/prompts@8.2.1(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/checkbox': 5.0.6(@types/node@24.10.4)
-      '@inquirer/confirm': 6.0.6(@types/node@24.10.4)
-      '@inquirer/editor': 5.0.6(@types/node@24.10.4)
-      '@inquirer/expand': 5.0.6(@types/node@24.10.4)
-      '@inquirer/input': 5.0.6(@types/node@24.10.4)
-      '@inquirer/number': 4.0.6(@types/node@24.10.4)
-      '@inquirer/password': 5.0.6(@types/node@24.10.4)
-      '@inquirer/rawlist': 5.2.2(@types/node@24.10.4)
-      '@inquirer/search': 4.1.2(@types/node@24.10.4)
-      '@inquirer/select': 5.0.6(@types/node@24.10.4)
+      '@inquirer/checkbox': 5.0.6(@types/node@22.19.11)
+      '@inquirer/confirm': 6.0.6(@types/node@22.19.11)
+      '@inquirer/editor': 5.0.6(@types/node@22.19.11)
+      '@inquirer/expand': 5.0.6(@types/node@22.19.11)
+      '@inquirer/input': 5.0.6(@types/node@22.19.11)
+      '@inquirer/number': 4.0.6(@types/node@22.19.11)
+      '@inquirer/password': 5.0.6(@types/node@22.19.11)
+      '@inquirer/rawlist': 5.2.2(@types/node@22.19.11)
+      '@inquirer/search': 4.1.2(@types/node@22.19.11)
+      '@inquirer/select': 5.0.6(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/rawlist@4.1.11(@types/node@22.19.11)':
     dependencies:
@@ -10746,12 +10744,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/rawlist@5.2.2(@types/node@24.10.4)':
+  '@inquirer/rawlist@5.2.2(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/search@3.2.2(@types/node@22.19.11)':
     dependencies:
@@ -10762,13 +10760,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/search@4.1.2(@types/node@24.10.4)':
+  '@inquirer/search@4.1.2(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/select@4.4.2(@types/node@22.19.11)':
     dependencies:
@@ -10780,22 +10778,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/select@5.0.6(@types/node@24.10.4)':
+  '@inquirer/select@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@24.10.4)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@24.10.4)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@inquirer/type@3.0.10(@types/node@22.19.11)':
     optionalDependencies:
       '@types/node': 22.19.11
 
-  '@inquirer/type@4.0.3(@types/node@24.10.4)':
+  '@inquirer/type@4.0.3(@types/node@22.19.11)':
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 22.19.11
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -11097,9 +11095,9 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.10.4)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@22.19.11)(node-addon-api@7.1.1)':
     dependencies:
-      '@inquirer/prompts': 8.2.1(@types/node@24.10.4)
+      '@inquirer/prompts': 8.2.1(@types/node@22.19.11)
       '@napi-rs/cross-toolchain': 1.0.3
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1
@@ -12461,7 +12459,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.6.1
+      devalue: 5.6.3
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -12480,7 +12478,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.6.1
+      devalue: 5.6.3
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -12873,6 +12871,7 @@ snapshots:
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -14569,8 +14568,6 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
-
-  devalue@5.6.1: {}
 
   devalue@5.6.3: {}
 
@@ -18418,24 +18415,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@24.10.4)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.10.4
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -18516,7 +18495,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.16.0:
+    optional: true
 
   undici@6.22.0: {}
 


### PR DESCRIPTION
Resolves Dependabot alert 183 by pinning devalue to 5.6.3 at the workspace root and refreshing the lockfile.\n\nChanges:\n- add `pnpm.overrides.devalue` in root package.json\n- regenerate pnpm-lock.yaml so all devalue entries resolve to 5.6.3