### PR TITLE
Upgrade `gix` for faster tree-diffs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3079,7 +3079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4302,8 +4302,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.79.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.80.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4360,8 +4360,8 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.40.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4372,8 +4372,8 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.31.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4389,24 +4389,24 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.16"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.3.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
- "thiserror 2.0.18",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.7.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.7.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.8.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-path 0.11.1",
@@ -4417,8 +4417,8 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4431,8 +4431,8 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.52.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.53.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4462,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.37.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4480,8 +4480,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.15.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4493,8 +4493,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.60.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4516,8 +4516,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.22.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4535,8 +4535,8 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.48.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "dunce",
@@ -4549,8 +4549,8 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.2.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
 ]
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4577,8 +4577,8 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.27.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4645,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4657,8 +4657,8 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.48.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4695,20 +4695,20 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
+ "gix-error",
  "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-merge"
-version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.13.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4732,8 +4732,8 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4741,14 +4741,12 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.57.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4768,8 +4766,8 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.76.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.77.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4788,8 +4786,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.67.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4811,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4834,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4844,8 +4842,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4858,8 +4856,8 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.13.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.14.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4870,8 +4868,8 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.58.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4897,18 +4895,18 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.7.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
+ "gix-error",
  "gix-utils",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.60.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4928,8 +4926,8 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.38.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4943,8 +4941,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.42.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4962,8 +4960,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4978,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.1",
@@ -4989,8 +4987,8 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.9.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5002,8 +5000,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.27.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "filetime",
@@ -5024,8 +5022,8 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.27.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5039,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5052,8 +5050,8 @@ dependencies = [
 
 [[package]]
 name = "gix-testtools"
-version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.19.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "crc",
@@ -5082,15 +5080,15 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.55.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5108,8 +5106,8 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.54.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5124,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.35.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-path 0.11.1",
@@ -5137,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5157,15 +5155,15 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.49.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5182,8 +5180,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#e441fa91deb5efe372a5121c2ae23acf249ef42b"
+version = "0.27.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7277f3c9e3e5130edb714ff5bd3db06b7f589b3"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5961,7 +5959,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6036,7 +6034,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6919,7 +6917,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7453,7 +7451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8875,7 +8873,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8933,7 +8931,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10477,7 +10475,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11902,7 +11900,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,8 +208,8 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
 backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { version = "0.79.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [] }
-gix-testtools = { version = "0.18.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main" }
+gix = { version = "0.80.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [] }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main" }
 
 ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
 insta = { version = "1.45.1", features = ["json"] }


### PR DESCRIPTION
This can speed up tree-diffs by around 30%, depending on the workload even more.
