### PR TITLE
refactor/rename-useExtraConciseStyle

### DIFF
--- a/apps/desktop/src/components/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/AiCredentialCheck.svelte
@@ -127,7 +127,7 @@
 			const aiResult = await aiService.summarizeCommit({
 				diffInput: testDiff,
 				useEmojiStyle: false,
-				useBriefStyle: false,
+				useExtraConciseStyle: false,
 				onToken: (token) => {
 					// Append each token as it comes in
 					streamingResult += token;

--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -2,7 +2,7 @@
 	export type AiButtonClickParams = {
 		useHaiku?: boolean;
 		useEmojiStyle?: boolean;
-		useBriefStyle?: boolean;
+		useExtraConciseStyle?: boolean;
 	};
 </script>
 
@@ -223,7 +223,7 @@
 		onAiButtonClick({
 			useHaiku: $commitGenerationHaiku,
 			useEmojiStyle: $commitGenerationUseEmojis,
-			useBriefStyle: $commitGenerationExtraConcise
+			useExtraConciseStyle: $commitGenerationExtraConcise
 		});
 	}
 

--- a/apps/desktop/src/lib/ai/macros.svelte.ts
+++ b/apps/desktop/src/lib/ai/macros.svelte.ts
@@ -9,7 +9,7 @@ type GenerateCommitMessageParams = {
 	onToken?: (token: string) => void;
 	useHaiku?: boolean;
 	useEmojiStyle?: boolean;
-	useBriefStyle?: boolean;
+	useExtraConciseStyle?: boolean;
 };
 
 export default class AIMacros {
@@ -51,7 +51,7 @@ export default class AIMacros {
 			diffInput,
 			useHaiku: params.useHaiku ?? false,
 			useEmojiStyle: params.useEmojiStyle ?? false,
-			useBriefStyle: params.useBriefStyle ?? false,
+			useExtraConciseStyle: params.useExtraConciseStyle ?? false,
 			commitTemplate: prompt,
 			branchName: params.branchName,
 			onToken: params.onToken

--- a/apps/desktop/src/lib/ai/prompts.ts
+++ b/apps/desktop/src/lib/ai/prompts.ts
@@ -12,7 +12,7 @@ Use a semantic commit prefix.
 Hard wrap lines at 72 characters.
 Ensure the title is only 50 characters.
 Do not start any lines with the hash symbol.
-%{brief_style}
+%{extra_concise_style}
 %{emoji_style}
 
 Here is my git diff:

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -287,7 +287,7 @@ describe('AIService', () => {
 			);
 		});
 
-		test('When the commit is in brief mode, When the AI returns a title and body, it takes just the title', async () => {
+		test('When the commit is in extra concise mode, When the AI returns a title and body, it takes just the title', async () => {
 			const { aiService } = buildDefaultServices();
 
 			const clientResponse = 'one\nnew line';
@@ -297,7 +297,7 @@ describe('AIService', () => {
 			);
 
 			expect(
-				await aiService.summarizeCommit({ diffInput: exampleDiffs, useBriefStyle: true })
+				await aiService.summarizeCommit({ diffInput: exampleDiffs, useExtraConciseStyle: true })
 			).toStrictEqual('one');
 		});
 	});

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -366,7 +366,7 @@ export class AIService {
 			const extraConcisePart = useHaiku
 				? 'Compose the commit message in the form of a haiku. A haiku is a three-line poem with a 5-7-5 syllable structure.'
 				: useExtraConciseStyle
-					? 'The commit message must be only one sentence and as short as possible.'
+					? 'Keep the commit message extra concise: output only the title line, no body or description. Keep it as short as possible.'
 					: '';
 			content = content.replaceAll('%{extra_concise_style}', extraConcisePart);
 

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -72,7 +72,7 @@ interface SummarizeCommitOpts extends BaseAIServiceOpts {
 	diffInput: DiffInput[];
 	useHaiku?: boolean;
 	useEmojiStyle?: boolean;
-	useBriefStyle?: boolean;
+	useExtraConciseStyle?: boolean;
 	commitTemplate?: Prompt;
 	branchName?: string;
 }
@@ -341,7 +341,7 @@ export class AIService {
 		diffInput,
 		useHaiku = false,
 		useEmojiStyle = false,
-		useBriefStyle = false,
+		useExtraConciseStyle = false,
 		commitTemplate,
 		onToken,
 		branchName
@@ -363,12 +363,12 @@ export class AIService {
 				buildDiff(diffInput, diffLengthLimit)
 			);
 
-			const briefPart = useHaiku
+			const extraConcisePart = useHaiku
 				? 'Compose the commit message in the form of a haiku. A haiku is a three-line poem with a 5-7-5 syllable structure.'
-				: useBriefStyle
+				: useExtraConciseStyle
 					? 'The commit message must be only one sentence and as short as possible.'
 					: '';
-			content = content.replaceAll('%{brief_style}', briefPart);
+			content = content.replaceAll('%{extra_concise_style}', extraConcisePart);
 
 			const emojiPart = useEmojiStyle
 				? 'Make use of GitMoji in the title prefix.'
@@ -387,7 +387,7 @@ export class AIService {
 
 		let message = (await aiClient.evaluate(prompt, { onToken })).trim();
 
-		if (useBriefStyle) {
+		if (useExtraConciseStyle) {
 			message = message.split('\n')[0] ?? message;
 		}
 


### PR DESCRIPTION
This pull request refactors the "brief" commit message generation option throughout the codebase, renaming it to "extra concise" for clarity and consistency. All related variable names, parameter names, prompt template placeholders, and test descriptions have been updated to reflect this change. Additionally, the prompt logic and instructions for the AI model have been updated to better describe the "extra concise" behavior to **prevent text flickering** when we call the trim function.

**Refactor: Rename "brief" style to "extra concise" style**

* Renamed all instances of `useBriefStyle` to `useExtraConciseStyle` in type definitions, function parameters, and method calls in `MessageEditor.svelte`, `AiCredentialCheck.svelte`, `macros.svelte.ts`, and `service.ts`. [[1]](diffhunk://#diff-5158493bd76d5fd6a21710b1fc0c504453a41fa5eaf1813b913534eba50ceaf5L5-R5) [[2]](diffhunk://#diff-5158493bd76d5fd6a21710b1fc0c504453a41fa5eaf1813b913534eba50ceaf5L226-R226) [[3]](diffhunk://#diff-f74a019a1b330e483efdb6afe554592454b97e612f1f0c071a28e1ad316422a3L130-R130) [[4]](diffhunk://#diff-1bbba8b31f9c3c80148b1035b7b45cc6b65aea87fee02756481feb4e29056981L12-R12) [[5]](diffhunk://#diff-1bbba8b31f9c3c80148b1035b7b45cc6b65aea87fee02756481feb4e29056981L54-R54) [[6]](diffhunk://#diff-37f52369f5ed334db3842506377d8de5b7dc8d0c3d92839f1cab80e2c4733dbbL75-R75) [[7]](diffhunk://#diff-37f52369f5ed334db3842506377d8de5b7dc8d0c3d92839f1cab80e2c4733dbbL344-R344) [[8]](diffhunk://#diff-37f52369f5ed334db3842506377d8de5b7dc8d0c3d92839f1cab80e2c4733dbbL390-R390)
* Updated the prompt template placeholder from `%{brief_style}` to `%{extra_concise_style}` in `prompts.ts`, and adjusted the logic for replacing this placeholder in `service.ts`. [[1]](diffhunk://#diff-91d46f6289cb9552816e30c81ed6a5460d3376302f5a910938fa3e974fe4f3c6L15-R15) [[2]](diffhunk://#diff-37f52369f5ed334db3842506377d8de5b7dc8d0c3d92839f1cab80e2c4733dbbL366-R371)
* Modified the instruction for "extra concise" mode to clarify that only the title line should be output, with no body or description, making it as short as possible.
* Updated test descriptions and usage to reflect the renaming from "brief" to "extra concise" mode in `service.test.ts`. [[1]](diffhunk://#diff-3fc9c77e6f64cea24e1f52b4eacc90616b051fd834f3cee5672a4f6c418749abL290-R290) [[2]](diffhunk://#diff-3fc9c77e6f64cea24e1f52b4eacc90616b051fd834f3cee5672a4f6c418749abL300-R300)