### PR TITLE
improve auto-commit oplog addition

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -92,23 +92,16 @@ pub(crate) fn handle(
     let repo = ctx.repo.get()?;
     let data_dir = ctx.project_data_dir();
     let context_lines = ctx.settings.context_lines;
-    // Create a snapshot before performing absorb operations
+    // Create a snapshot before performing absorb or auto-commit operations
     // This allows the user to undo if needed
-    if new {
-        let _snapshot = ctx
-            .create_snapshot(
-                SnapshotDetails::new(OperationKind::AutoCommit),
-                guard.write_permission(),
-            )
-            .ok(); // Ignore errors for snapshot creation
+    let operation = if new {
+        OperationKind::AutoCommit
     } else {
-        let _snapshot = ctx
-            .create_snapshot(
-                SnapshotDetails::new(OperationKind::Absorb),
-                guard.write_permission(),
-            )
-            .ok(); // Ignore errors for snapshot creation
-    }
+        OperationKind::Absorb
+    };
+    let _snapshot = ctx
+        .create_snapshot(SnapshotDetails::new(operation), guard.write_permission())
+        .ok(); // Ignore errors for snapshot creation
     absorb_assignments(
         absorption_plan,
         &mut guard,

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -68,7 +68,6 @@ pub fn auto_commit(
     let project = gitbutler_project::get(project_id)?;
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
     let absorption_plan = but_api::legacy::absorb::absorption_plan(&mut ctx, target)?;
-    let mut guard = ctx.exclusive_worktree_access();
 
     let llm = if use_ai {
         let git_config =
@@ -78,6 +77,7 @@ pub fn auto_commit(
         None
     };
 
+    let mut guard = ctx.exclusive_worktree_access();
     // Create snapshot for auto commit
     let _snapshot = ctx
         .create_snapshot(
@@ -91,7 +91,6 @@ pub fn auto_commit(
             tracing::error!("Failed to emit event '{}': {}", name, e);
         });
     };
-    let mut guard = ctx.exclusive_worktree_access();
     let repo = ctx.repo.get()?;
     let project_data_dir = ctx.project_data_dir();
     let settings = AppSettings::load_from_default_path_creating_without_customization()?;


### PR DESCRIPTION
- Don’t hold the lock longer than needed
- Deduplicate the code needed for the snapshot creation from the CLI