### PR TITLE
but-forge: Draftiness and Auto-merge

### DIFF
--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -98,7 +98,7 @@
 				{#if prNumber && stackId}
 					<StackedPullRequestCard {projectId} {stackId} {branchName} {prNumber} poll />
 				{:else if prNumber}
-					<PullRequestCard {branchName} {prNumber} poll />
+					<PullRequestCard {projectId} {branchName} {prNumber} poll />
 				{/if}
 			</div>
 		{/if}

--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -26,6 +26,7 @@
 	};
 
 	interface Props {
+		projectId: string;
 		testId?: string;
 		branchName: string;
 		poll?: boolean;
@@ -47,6 +48,7 @@
 	}
 
 	const {
+		projectId,
 		testId,
 		poll,
 		prNumber,
@@ -80,7 +82,7 @@
 		if (!prService || draftToggling) return;
 		draftToggling = true;
 		try {
-			await prService.setDraft(prNumber, draft);
+			await prService.setDraft(projectId, prNumber, draft);
 			await prService.fetch(prNumber, { forceRefetch: true });
 		} catch (err: unknown) {
 			showError("Failed to update draft status", err);

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -89,6 +89,7 @@
 </script>
 
 <PullRequestCard
+	{projectId}
 	testId={TestId.StackedPullRequestCard}
 	{branchName}
 	{prNumber}

--- a/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
@@ -176,10 +176,11 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 			});
 		}
 		if (forgeType === "gitlab") {
-			const { gitLabClient, gitLabApi, posthog, dispatch } = this.params;
+			const { gitLabClient, gitLabApi, posthog, dispatch, backendApi } = this.params;
 			return new GitLab({
 				...baseParams,
 				api: gitLabApi,
+				backendApi,
 				client: gitLabClient,
 				posthog: posthog,
 				authenticated: !!gitlabAuthenticated,

--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -67,8 +67,8 @@ export class GitHub implements Forge {
 
 	get prService() {
 		if (!this.authenticated) return;
-		const { api: gitHubApi, posthog } = this.params;
-		return new GitHubPrService(gitHubApi, posthog);
+		const { api: gitHubApi, posthog, backendApi } = this.params;
+		return new GitHubPrService(gitHubApi, backendApi, posthog);
 	}
 
 	get repoService() {

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.test.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.test.ts
@@ -1,7 +1,7 @@
 import { GitLab } from "$lib/forge/gitlab/gitlab";
 import { expect, test, describe, vi } from "vitest";
 import type { GitLabClient } from "$lib/forge/gitlab/gitlabClient.svelte";
-import type { GitLabApi } from "$lib/state/clientState.svelte";
+import type { BackendApi, GitLabApi } from "$lib/state/clientState.svelte";
 
 describe("GitLab", () => {
 	// Mock GitLab API and client
@@ -17,6 +17,10 @@ describe("GitLab", () => {
 	};
 	const gitLabClient = { onReset: () => {} } as any as GitLabClient;
 
+	const MockBackendApi = vi.fn();
+	MockBackendApi.prototype.injectEndpoints = vi.fn();
+	const backendApi: BackendApi = new MockBackendApi();
+
 	const baseBranch = "main";
 	const baseRepo = {
 		domain: "gitlab.example.com",
@@ -27,6 +31,7 @@ describe("GitLab", () => {
 	test("uses https protocol by default when no protocol specified", () => {
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo: baseRepo,
 			baseBranch,
@@ -48,6 +53,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -69,6 +75,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -90,6 +97,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -111,6 +119,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -133,6 +142,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -154,6 +164,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -176,6 +187,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,
@@ -199,6 +211,7 @@ describe("GitLab", () => {
 
 		const gitlab = new GitLab({
 			api: gitLabApi,
+			backendApi,
 			client: gitLabClient,
 			repo,
 			baseBranch,

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.ts
@@ -7,7 +7,7 @@ import { toSerializable } from "@gitbutler/shared/network/types";
 import type { PostHogWrapper } from "$lib/analytics/posthog";
 import type { Forge, ForgeName } from "$lib/forge/interface/forge";
 import type { ForgeArguments, ForgeUser } from "$lib/forge/interface/types";
-import type { GitLabApi } from "$lib/state/clientState.svelte";
+import type { BackendApi, GitLabApi } from "$lib/state/clientState.svelte";
 import type { Branded } from "@gitbutler/shared/utils/branding";
 import type { ThunkDispatch, UnknownAction } from "@reduxjs/toolkit";
 import type { TagDescription } from "@reduxjs/toolkit/query";
@@ -34,6 +34,7 @@ export class GitLab implements Forge {
 		private params: ForgeArguments & {
 			posthog?: PostHogWrapper;
 			api: GitLabApi;
+			backendApi: BackendApi;
 			client: GitLabClient;
 			dispatch: ThunkDispatch<any, any, UnknownAction>;
 			isLoading: boolean;
@@ -84,8 +85,8 @@ export class GitLab implements Forge {
 
 	get prService() {
 		if (!this.authenticated) return;
-		const { api: gitLabApi, posthog } = this.params;
-		return new GitLabPrService(gitLabApi, posthog);
+		const { api: gitLabApi, posthog, backendApi } = this.params;
+		return new GitLabPrService(gitLabApi, backendApi, posthog);
 	}
 
 	get repoService() {

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -38,5 +38,5 @@ export interface ForgePrService {
 		prNumber: number,
 		details: { description?: string; state?: "open" | "closed"; targetBase?: string },
 	): Promise<void>;
-	setDraft(prNumber: number, draft: boolean): Promise<void>;
+	setDraft(projectId: string, prNumber: number, draft: boolean): Promise<void>;
 }

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -17,7 +17,7 @@ export enum ReduxTag {
 	GitHubUserList = "GitHubUserList",
 	GitLabUserList = "GitLabUserList",
 	PullRequests = "PullRequests",
-	GitLabPullRequests = "GitLabPullRequests",
+	GitlabMRs = "GitlabMRs",
 	Checks = "Checks",
 	RepoInfo = "RepoInfo",
 	BaseBranchData = "BaseBranchData",

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -252,6 +252,64 @@ pub async fn merge_review(ctx: ThreadSafeContext, review_id: usize) -> Result<()
     .await
 }
 
+/// Enable or disable a review's auto-merge.
+#[but_api]
+#[instrument(err(Debug))]
+pub async fn set_review_auto_merge(
+    ctx: ThreadSafeContext,
+    review_id: usize,
+    enable: bool,
+) -> Result<()> {
+    let (storage, base_branch, preferred_forge_user) = {
+        let ctx = ctx.into_thread_local();
+        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        (
+            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            base_branch,
+            ctx.legacy_project.preferred_forge_user.clone(),
+        )
+    };
+    but_forge::set_review_auto_merge_state(
+        &preferred_forge_user,
+        &base_branch
+            .forge_repo_info
+            .context("No forge could be determined for this repository branch")?,
+        review_id,
+        enable,
+        &storage,
+    )
+    .await
+}
+
+/// Set a review to draft or ready-for-review
+#[but_api]
+#[instrument(err(Debug))]
+pub async fn set_review_draftiness(
+    ctx: ThreadSafeContext,
+    review_id: usize,
+    draft: bool,
+) -> Result<()> {
+    let (storage, base_branch, preferred_forge_user) = {
+        let ctx = ctx.into_thread_local();
+        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        (
+            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            base_branch,
+            ctx.legacy_project.preferred_forge_user.clone(),
+        )
+    };
+    but_forge::set_review_draftiness(
+        &preferred_forge_user,
+        &base_branch
+            .forge_repo_info
+            .context("No forge could be determined for this repository branch")?,
+        review_id,
+        draft,
+        &storage,
+    )
+    .await
+}
+
 /// Update the stacked review descriptions to have the correct footers.
 #[but_api]
 #[instrument(err(Debug))]

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -12,7 +12,8 @@ pub use review::{
     ForgeReviewDescriptionUpdate, ForgeReviewFilter, ReviewTemplateFunctions,
     available_review_templates, check_forge_account_is_valid, create_forge_review,
     get_forge_review, get_review_template_functions, list_forge_reviews_for_branch,
-    list_forge_reviews_with_cache, merge_review, update_review_description_tables,
+    list_forge_reviews_with_cache, merge_review, set_review_auto_merge_state,
+    set_review_draftiness, update_review_description_tables,
 };
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -3,6 +3,11 @@ use but_secret::Sensitive;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 
+use crate::graphql::{
+    GQL_DISABLE_PR_AUTO_MERGE, GQL_ENABLE_PR_AUTO_MERGE, GQL_GET_PR_NODE_ID, GQL_SET_PR_DRAFT,
+    GQL_SET_PR_READY_FOR_REVIEW,
+};
+
 const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
 pub struct GitHubClient {
@@ -11,6 +16,7 @@ pub struct GitHubClient {
 }
 
 impl GitHubClient {
+    /// Create a new instance of the GitHub client
     pub fn new(access_token: &Sensitive<String>) -> Result<Self> {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -40,6 +46,7 @@ impl GitHubClient {
         })
     }
 
+    /// Create a new instance of a GitHub client out of the stored accounts information.
     pub fn from_storage(
         storage: &but_forge_storage::Controller,
         preferred_account: Option<&crate::GithubAccountIdentifier>,
@@ -54,6 +61,9 @@ impl GitHubClient {
         }
     }
 
+    /// Create a new instance of a GitHub client, with a custom base URL.
+    ///
+    /// This is used to create the GitHub client for Enterprise users.
     pub fn new_with_host_override(access_token: &Sensitive<String>, host: &str) -> Result<Self> {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -83,6 +93,9 @@ impl GitHubClient {
         })
     }
 
+    /// Get the authenticated user.
+    ///
+    /// This is used to verify that the client has been correctly created and it holds the right authentication.
     pub async fn get_authenticated(&self) -> Result<AuthenticatedUser> {
         #[derive(Deserialize)]
         struct User {
@@ -109,6 +122,7 @@ impl GitHubClient {
         })
     }
 
+    /// Fetch the CI checks for a given branch reference
     pub async fn list_checks_for_ref(
         &self,
         owner: &str,
@@ -140,6 +154,7 @@ impl GitHubClient {
         Ok(result.check_runs)
     }
 
+    /// Fetch the list of the open PRs on a repo.
     pub async fn list_open_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PullRequest>> {
         let url = format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo);
 
@@ -163,6 +178,7 @@ impl GitHubClient {
         Ok(pulls.into_iter().map(Into::into).collect())
     }
 
+    /// List the PRs for a given target.
     pub async fn list_pulls_for_base(
         &self,
         owner: &str,
@@ -192,6 +208,7 @@ impl GitHubClient {
         Ok(pulls.into_iter().map(Into::into).collect())
     }
 
+    /// Create a PR.
     pub async fn create_pull_request(
         &self,
         params: &CreatePullRequestParams<'_>,
@@ -228,6 +245,7 @@ impl GitHubClient {
         Ok(pr.into())
     }
 
+    /// Fetch the information of a given PR.
     pub async fn get_pull_request(
         &self,
         owner: &str,
@@ -249,6 +267,9 @@ impl GitHubClient {
         Ok(pr.into())
     }
 
+    /// Update the information of a given PR.
+    ///
+    /// This is used e.g. to update the description footers for stacked reviews.
     pub async fn update_pull_request(
         &self,
         params: &UpdatePullRequestParams<'_>,
@@ -287,6 +308,7 @@ impl GitHubClient {
         Ok(pr.into())
     }
 
+    /// Merge a PR.
     pub async fn merge_pull_request(&self, params: &MergePullRequestParams<'_>) -> Result<()> {
         #[derive(Serialize)]
         struct MergePullRequestBody<'a> {
@@ -318,6 +340,371 @@ impl GitHubClient {
         }
 
         Ok(())
+    }
+
+    /// Set the draftiness of a PR.
+    pub async fn set_pull_request_draft_state(
+        &self,
+        params: &SetPullRequestDraftStateParams<'_>,
+    ) -> Result<()> {
+        if params.pr_number <= 0 {
+            bail!("PR number must be greater than 0");
+        }
+
+        let pull_request_id = self
+            .get_pull_request_node_id(params.owner, params.repo, params.pr_number)
+            .await?;
+
+        if params.draft {
+            self.set_pull_request_to_draft(&pull_request_id).await
+        } else {
+            self.set_pull_request_to_ready_for_review(&pull_request_id)
+                .await
+        }
+    }
+
+    async fn set_pull_request_to_ready_for_review(
+        &self,
+        pull_request_id: &PullRequestNodeId,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Variables<'a> {
+            pull_request_id: &'a PullRequestNodeId,
+        }
+        #[derive(Deserialize)]
+        struct MutationData {
+            #[serde(rename = "markPullRequestReadyForReview")]
+            mark_pull_request_ready_for_review: MutationPayload,
+        }
+
+        #[derive(Deserialize)]
+        struct MutationPayload {
+            #[serde(rename = "pullRequest")]
+            pull_request: GraphQlPullRequest,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlPullRequest {
+            id: String,
+        }
+
+        let data: MutationData = self
+            .graphql_query(GQL_SET_PR_READY_FOR_REVIEW, &Variables { pull_request_id })
+            .await?;
+
+        if data
+            .mark_pull_request_ready_for_review
+            .pull_request
+            .id
+            .is_empty()
+        {
+            bail!("GitHub GraphQL markPullRequestReadyForReview returned an empty pull request id");
+        }
+
+        Ok(())
+    }
+
+    async fn set_pull_request_to_draft(&self, pull_request_id: &PullRequestNodeId) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Variables<'a> {
+            pull_request_id: &'a PullRequestNodeId,
+        }
+
+        #[derive(Deserialize)]
+        struct MutationData {
+            #[serde(rename = "convertPullRequestToDraft")]
+            convert_pull_request_to_draft: MutationPayload,
+        }
+
+        #[derive(Deserialize)]
+        struct MutationPayload {
+            #[serde(rename = "pullRequest")]
+            pull_request: GraphQlPullRequest,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlPullRequest {
+            id: String,
+        }
+
+        let data: MutationData = self
+            .graphql_query(GQL_SET_PR_DRAFT, &Variables { pull_request_id })
+            .await?;
+
+        if data
+            .convert_pull_request_to_draft
+            .pull_request
+            .id
+            .is_empty()
+        {
+            bail!("GitHub GraphQL convertPullRequestToDraft returned an empty pull request id");
+        }
+
+        Ok(())
+    }
+
+    /// Enable or disable a PR's auto-merge.
+    pub async fn set_pull_request_auto_merge(
+        &self,
+        params: &SetPullRequestAutoMergeParams<'_>,
+    ) -> Result<()> {
+        let pull_request_id = self
+            .get_pull_request_node_id(params.owner, params.repo, params.pr_number)
+            .await?;
+
+        match &params.state {
+            AutoMergeState::Disabled => {
+                self.disable_auto_merge_pull_request(&pull_request_id).await
+            }
+            AutoMergeState::Enabled(params) => {
+                self.enable_auto_merge_pull_request(&pull_request_id, params)
+                    .await
+            }
+        }
+    }
+
+    async fn enable_auto_merge_pull_request(
+        &self,
+        pull_request_id: &PullRequestNodeId,
+        params: &AutoMergeEnableParams<'_>,
+    ) -> Result<()> {
+        #[derive(Deserialize)]
+        struct MutationPayload {
+            #[serde(rename = "pullRequest")]
+            pull_request: GraphQlPullRequest,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlPullRequest {
+            id: String,
+        }
+        #[derive(Serialize)]
+        struct Variables<'a> {
+            input: EnablePullRequestAutoMergeInput<'a>,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct EnablePullRequestAutoMergeInput<'a> {
+            pull_request_id: &'a PullRequestNodeId,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            merge_method: Option<GraphQlMergeMethod>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            expected_head_oid: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            commit_headline: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            commit_body: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            author_email: Option<&'a str>,
+        }
+
+        #[derive(Deserialize)]
+        struct MutationData {
+            #[serde(rename = "enablePullRequestAutoMerge")]
+            enable_pull_request_auto_merge: MutationPayload,
+        }
+
+        let data: MutationData = self
+            .graphql_query(
+                GQL_ENABLE_PR_AUTO_MERGE,
+                &Variables {
+                    input: EnablePullRequestAutoMergeInput {
+                        pull_request_id,
+                        merge_method: params.merge_method.as_ref().map(Into::into),
+                        expected_head_oid: params.expected_head_oid,
+                        commit_headline: params.commit_headline,
+                        commit_body: params.commit_body,
+                        author_email: params.author_email,
+                    },
+                },
+            )
+            .await?;
+
+        if data
+            .enable_pull_request_auto_merge
+            .pull_request
+            .id
+            .is_empty()
+        {
+            bail!("GitHub GraphQL enablePullRequestAutoMerge returned an empty pull request id");
+        }
+
+        Ok(())
+    }
+
+    async fn disable_auto_merge_pull_request(
+        &self,
+        pull_request_id: &PullRequestNodeId,
+    ) -> Result<()> {
+        #[derive(Deserialize)]
+        struct MutationPayload {
+            #[serde(rename = "pullRequest")]
+            pull_request: GraphQlPullRequest,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlPullRequest {
+            id: String,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Variables<'a> {
+            pull_request_id: &'a PullRequestNodeId,
+        }
+
+        #[derive(Deserialize)]
+        struct MutationData {
+            #[serde(rename = "disablePullRequestAutoMerge")]
+            disable_pull_request_auto_merge: MutationPayload,
+        }
+
+        let data: MutationData = self
+            .graphql_query(GQL_DISABLE_PR_AUTO_MERGE, &Variables { pull_request_id })
+            .await?;
+
+        if data
+            .disable_pull_request_auto_merge
+            .pull_request
+            .id
+            .is_empty()
+        {
+            bail!("GitHub GraphQL disablePullRequestAutoMerge returned an empty pull request id");
+        }
+
+        Ok(())
+    }
+
+    async fn get_pull_request_node_id(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: i64,
+    ) -> Result<PullRequestNodeId> {
+        #[derive(Serialize)]
+        struct Variables<'a> {
+            owner: &'a str,
+            repo: &'a str,
+            number: i64,
+        }
+
+        #[derive(Deserialize)]
+        struct QueryData {
+            repository: Option<Repository>,
+        }
+
+        #[derive(Deserialize)]
+        struct Repository {
+            #[serde(rename = "pullRequest")]
+            pull_request: Option<GraphQlPullRequest>,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlPullRequest {
+            id: String,
+        }
+
+        let data: QueryData = self
+            .graphql_query(
+                GQL_GET_PR_NODE_ID,
+                &Variables {
+                    owner,
+                    repo,
+                    number: pr_number,
+                },
+            )
+            .await?;
+
+        let Some(repository) = data.repository else {
+            bail!("GitHub GraphQL repository not found for {owner}/{repo}");
+        };
+
+        let Some(pull_request) = repository.pull_request else {
+            bail!("GitHub GraphQL pull request #{pr_number} not found for {owner}/{repo}",);
+        };
+
+        if pull_request.id.is_empty() {
+            bail!(
+                "GitHub GraphQL pull request #{pr_number} in {owner}/{repo} returned an empty node id",
+            );
+        }
+
+        Ok(PullRequestNodeId::from_string(pull_request.id))
+    }
+
+    async fn graphql_query<T, V>(&self, query: &str, variables: &V) -> Result<T>
+    where
+        T: for<'de> Deserialize<'de>,
+        V: Serialize,
+    {
+        #[derive(Serialize)]
+        struct GraphQlRequest<'a, V> {
+            query: &'a str,
+            variables: &'a V,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlError {
+            message: String,
+        }
+
+        #[derive(Deserialize)]
+        struct GraphQlResponse<T> {
+            data: Option<T>,
+            errors: Option<Vec<GraphQlError>>,
+        }
+
+        let url = graphql_endpoint_from_base_url(&self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&GraphQlRequest { query, variables })
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!("GitHub GraphQL request failed: {}", response.status());
+        }
+
+        let payload: GraphQlResponse<T> = response.json().await?;
+
+        if let Some(errors) = payload.errors {
+            let messages = errors
+                .into_iter()
+                .map(|error| error.message)
+                .collect::<Vec<_>>()
+                .join("; ");
+            bail!("GitHub GraphQL returned errors: {messages}");
+        }
+
+        let Some(data) = payload.data else {
+            bail!("GitHub GraphQL response did not include data");
+        };
+
+        Ok(data)
+    }
+}
+
+pub struct PullRequestNodeId {
+    id: String,
+}
+
+impl PullRequestNodeId {
+    pub fn from_string(value: String) -> Self {
+        PullRequestNodeId { id: value }
+    }
+}
+
+impl Serialize for PullRequestNodeId {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.id.serialize(serializer)
     }
 }
 
@@ -368,6 +755,83 @@ pub struct MergePullRequestParams<'a> {
     pub commit_title: Option<&'a str>,
     pub commit_message: Option<&'a str>,
     pub merge_method: Option<MergeMethod>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SetPullRequestDraftStateParams<'a> {
+    pub owner: &'a str,
+    pub repo: &'a str,
+    pub pr_number: i64,
+    pub draft: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AutoMergeEnableParams<'a> {
+    merge_method: Option<MergeMethod>,
+    expected_head_oid: Option<&'a str>,
+    commit_headline: Option<&'a str>,
+    commit_body: Option<&'a str>,
+    author_email: Option<&'a str>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AutoMergeState<'a> {
+    Disabled,
+    Enabled(AutoMergeEnableParams<'a>),
+}
+
+impl From<bool> for AutoMergeState<'_> {
+    fn from(value: bool) -> Self {
+        if value {
+            AutoMergeState::Enabled(Default::default())
+        } else {
+            AutoMergeState::Disabled
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SetPullRequestAutoMergeParams<'a> {
+    pub owner: &'a str,
+    pub repo: &'a str,
+    pub pr_number: i64,
+    pub state: AutoMergeState<'a>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum GraphQlMergeMethod {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+impl From<&MergeMethod> for GraphQlMergeMethod {
+    fn from(value: &MergeMethod) -> Self {
+        match value {
+            MergeMethod::Merge => GraphQlMergeMethod::Merge,
+            MergeMethod::Squash => GraphQlMergeMethod::Squash,
+            MergeMethod::Rebase => GraphQlMergeMethod::Rebase,
+        }
+    }
+}
+
+fn graphql_endpoint_from_base_url(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+
+    if let Some(base) = base_url.strip_suffix("/api/v3") {
+        return format!("{base}/api/graphql");
+    }
+
+    if base_url == GITHUB_API_BASE_URL {
+        return format!("{base_url}/graphql");
+    }
+
+    if base_url.ends_with("/graphql") || base_url.ends_with("/api/graphql") {
+        return base_url.to_string();
+    }
+
+    format!("{base_url}/graphql")
 }
 
 #[derive(Debug, Serialize)]
@@ -570,4 +1034,38 @@ pub(crate) fn resolve_account(
     };
 
     Ok(account.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graphql_endpoint_for_github_cloud() {
+        let endpoint = graphql_endpoint_from_base_url("https://api.github.com");
+        assert_eq!(endpoint, "https://api.github.com/graphql");
+    }
+
+    #[test]
+    fn graphql_endpoint_for_ghes_api_v3() {
+        let endpoint = graphql_endpoint_from_base_url("https://ghes.example.com/api/v3");
+        assert_eq!(endpoint, "https://ghes.example.com/api/graphql");
+    }
+
+    #[test]
+    fn graphql_endpoint_preserves_existing_graphql_path() {
+        let endpoint = graphql_endpoint_from_base_url("https://ghes.example.com/api/graphql");
+        assert_eq!(endpoint, "https://ghes.example.com/api/graphql");
+    }
+
+    #[test]
+    fn graphql_merge_method_serializes_to_graphql_enum_values() {
+        let merge = serde_json::to_value(GraphQlMergeMethod::from(&MergeMethod::Merge)).unwrap();
+        let squash = serde_json::to_value(GraphQlMergeMethod::from(&MergeMethod::Squash)).unwrap();
+        let rebase = serde_json::to_value(GraphQlMergeMethod::from(&MergeMethod::Rebase)).unwrap();
+
+        assert_eq!(merge, serde_json::json!("MERGE"));
+        assert_eq!(squash, serde_json::json!("SQUASH"));
+        assert_eq!(rebase, serde_json::json!("REBASE"));
+    }
 }

--- a/crates/but-github/src/graphql.rs
+++ b/crates/but-github/src/graphql.rs
@@ -1,0 +1,49 @@
+pub const GQL_SET_PR_READY_FOR_REVIEW: &str = r#"
+    mutation MarkPullRequestReadyForReview($pullRequestId: ID!) {
+      markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+        pullRequest {
+          id
+        }
+      }
+    }
+    "#;
+
+pub const GQL_SET_PR_DRAFT: &str = r#"
+    mutation ConvertPullRequestToDraft($pullRequestId: ID!) {
+      convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+        pullRequest {
+          id
+        }
+      }
+    }
+    "#;
+
+pub const GQL_ENABLE_PR_AUTO_MERGE: &str = r#"
+    mutation EnablePullRequestAutoMerge($input: EnablePullRequestAutoMergeInput!) {
+      enablePullRequestAutoMerge(input: $input) {
+        pullRequest {
+          id
+        }
+      }
+    }
+    "#;
+
+pub const GQL_DISABLE_PR_AUTO_MERGE: &str = r#"
+    mutation DisablePullRequestAutoMerge($pullRequestId: ID!) {
+      disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+        pullRequest {
+          id
+        }
+      }
+    }
+    "#;
+
+pub const GQL_GET_PR_NODE_ID: &str = r#"
+    query PullRequestNodeId($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          id
+        }
+      }
+    }
+    "#;

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -6,10 +6,12 @@ use but_settings::AppSettings;
 use serde::{Deserialize, Serialize};
 
 mod client;
+mod graphql;
 pub mod pr;
 pub use client::{
-    CheckRun, CreatePullRequestParams, GitHubClient, GitHubPrLabel, GitHubUser, MergeMethod,
-    MergePullRequestParams, PullRequest, UpdatePullRequestParams,
+    AutoMergeEnableParams, AutoMergeState, CheckRun, CreatePullRequestParams, GitHubClient,
+    GitHubPrLabel, GitHubUser, MergeMethod, MergePullRequestParams, PullRequest,
+    SetPullRequestAutoMergeParams, SetPullRequestDraftStateParams, UpdatePullRequestParams,
 };
 mod token;
 pub use token::GithubAccountIdentifier;

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -81,3 +81,25 @@ pub async fn merge(
         .await
         .context("Failed to merge PR")
 }
+
+pub async fn set_draft_state(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    params: crate::client::SetPullRequestDraftStateParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    GitHubClient::from_storage(storage, preferred_account)?
+        .set_pull_request_draft_state(&params)
+        .await
+        .context("Failed to update PR draft state")
+}
+
+pub async fn set_auto_merge(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    params: crate::client::SetPullRequestAutoMergeParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    GitHubClient::from_storage(storage, preferred_account)?
+        .set_pull_request_auto_merge(&params)
+        .await
+        .context("Failed to update PR auto-merge state")
+}

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -6,7 +6,7 @@ pub mod mr;
 mod project;
 pub use client::{
     CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabUser, MergeMergeRequestParams,
-    MergeRequest,
+    MergeRequest, SetMergeRequestAutoMergeParams, SetMergeRequestDraftStateParams,
 };
 pub use project::GitLabProjectId;
 mod token;

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -67,3 +67,25 @@ pub async fn merge(
         .await
         .context("Faile to merge MR")
 }
+
+pub async fn set_draft_state(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    params: crate::client::SetMergeRequestDraftStateParams,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    GitLabClient::from_storage(storage, preferred_account)?
+        .set_merge_request_draft_state(&params)
+        .await
+        .context("Failed to set MR draft state")
+}
+
+pub async fn set_auto_merge(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    params: crate::client::SetMergeRequestAutoMergeParams,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    GitLabClient::from_storage(storage, preferred_account)?
+        .set_merge_request_auto_merge(&params)
+        .await
+        .context("Failed to set MR auto-merge state")
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -999,6 +999,26 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
+        "set_review_auto_merge" => {
+            let params = deserialize_json(request.params);
+            match params {
+                Ok(params) => {
+                    let result = legacy::forge::set_review_auto_merge_cmd(params).await;
+                    result.map(|_| json!({"result": "success"}))
+                }
+                Err(e) => Err(e),
+            }
+        }
+        "set_review_draftiness" => {
+            let params = deserialize_json(request.params);
+            match params {
+                Ok(params) => {
+                    let result = legacy::forge::set_review_draftiness_cmd(params).await;
+                    result.map(|_| json!({"result": "success"}))
+                }
+                Err(e) => Err(e),
+            }
+        }
         "update_review_footers" => {
             let params = deserialize_json(request.params);
             match params {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -328,6 +328,8 @@ fn main() -> anyhow::Result<()> {
                 legacy::forge::tauri_list_reviews::list_reviews,
                 legacy::forge::tauri_publish_review::publish_review,
                 legacy::forge::tauri_merge_review::merge_review,
+                legacy::forge::tauri_set_review_auto_merge::set_review_auto_merge,
+                legacy::forge::tauri_set_review_draftiness::set_review_draftiness,
                 legacy::forge::tauri_update_review_footers::update_review_footers,
                 legacy::cli::tauri_install_cli::install_cli,
                 legacy::cli::tauri_cli_path::cli_path,


### PR DESCRIPTION
- Add client endpoints and methods to toggle auto-merge for PRs/MRs.
- Add client endpoints and methods to set draft state (draft / ready for review) for PRs/MRs.
- Expose set_review_auto_merge API to tauri and the but-server.
- Update GitHub PR service to use the new backend APIs for draftiness and auto-merge.