### PR TITLE
Gate Husky hook execution behind trusted project setting

### DIFF
--- a/apps/desktop/src/components/GitHooksForm.svelte
+++ b/apps/desktop/src/components/GitHooksForm.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-	import SettingsSection from "$components/SettingsSection.svelte";
-	import { projectRunCommitHooks } from "$lib/config/config";
-	import { CardGroup, Toggle } from "@gitbutler/ui";
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import SettingsSection from '$components/SettingsSection.svelte';
+	import { projectRunCommitHooks } from '$lib/config/config';
+	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
+	import { inject } from '@gitbutler/core/context';
+	import { CardGroup, Toggle } from '@gitbutler/ui';
+	import type { Project } from '$lib/project/project';
 
 	const { projectId }: { projectId: string } = $props();
-
 	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
+	const projectsService = inject(PROJECTS_SERVICE);
+	const projectQuery = $derived(projectsService.getProject(projectId));
+
+	async function onHuskyHooksEnabledClick(project: Project, value: boolean) {
+		await projectsService.updateProject({ ...project, husky_hooks_enabled: value });
+	}
 </script>
 
 <SettingsSection>
@@ -15,12 +24,36 @@
 				Run Git hooks
 			{/snippet}
 			{#snippet caption()}
-				Enabling this will run git pre-push, pre and post commit, and commit-msg hooks you have
-				configured in your repository.
+				Enable running git hooks (pre-push, pre/post-commit, commit-msg) during GitButler actions.
 			{/snippet}
 			{#snippet actions()}
 				<Toggle id="runHooks" bind:checked={$runCommitHooks} />
 			{/snippet}
 		</CardGroup.Item>
 	</CardGroup>
+
+	<ReduxResult {projectId} result={projectQuery.result}>
+		{#snippet children(project)}
+			<CardGroup>
+				<CardGroup.Item labelFor="huskyHooks">
+					{#snippet title()}
+						Enable Husky hooks
+					{/snippet}
+					{#snippet caption()}
+						⚠️ Only enable this for repositories you trust.
+						<br />
+						Allow GitButler to execute scripts from `.husky` (which can come from the repository). Hooks
+						in `.git/hooks` are unaffected.
+					{/snippet}
+					{#snippet actions()}
+						<Toggle
+							id="huskyHooks"
+							checked={project.husky_hooks_enabled}
+							onchange={(checked) => onHuskyHooksEnabledClick(project, checked)}
+						/>
+					{/snippet}
+				</CardGroup.Item>
+			</CardGroup>
+		{/snippet}
+	</ReduxResult>
 </SettingsSection>

--- a/apps/desktop/src/components/GitHooksForm.svelte
+++ b/apps/desktop/src/components/GitHooksForm.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import ReduxResult from '$components/ReduxResult.svelte';
-	import SettingsSection from '$components/SettingsSection.svelte';
-	import { projectRunCommitHooks } from '$lib/config/config';
-	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { inject } from '@gitbutler/core/context';
-	import { CardGroup, Toggle } from '@gitbutler/ui';
-	import type { Project } from '$lib/project/project';
+	import ReduxResult from "$components/ReduxResult.svelte";
+	import SettingsSection from "$components/SettingsSection.svelte";
+	import { projectRunCommitHooks } from "$lib/config/config";
+	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
+	import { inject } from "@gitbutler/core/context";
+	import { CardGroup, Toggle } from "@gitbutler/ui";
+	import type { Project } from "$lib/project/project";
 
 	const { projectId }: { projectId: string } = $props();
 	const runCommitHooks = $derived(projectRunCommitHooks(projectId));

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -59,6 +59,7 @@
 	// Get current project to check gerrit_mode
 	const projectResponse = $derived(projectsService.getProject(projectId));
 	const isGerritMode = $derived(projectResponse.response?.gerrit_mode ?? false);
+	const runHooks = $derived(projectRunCommitHooks(projectId));
 
 	// Component is read-only when stackId is undefined
 	const isReadOnly = $derived(!stackId);
@@ -70,8 +71,6 @@
 		stackService.upstreamCommits(projectId, stackId, branchName),
 	);
 	const upstreamCommits = $derived(upstreamCommitsQuery.response);
-	const runHooks = $derived(projectRunCommitHooks(projectId));
-
 	function handleClick(args: {
 		withForce: boolean;
 		skipForcePushProtection: boolean;

--- a/apps/desktop/src/lib/hooks/hooksService.ts
+++ b/apps/desktop/src/lib/hooks/hooksService.ts
@@ -90,7 +90,7 @@ export class HooksService {
 }
 
 function formatError(error: string): string {
-	return `${error}\n\nIf you don't want git hooks to be run, you can disable them in the project settings.`;
+	return `${error}\n\nIf you don't want git hooks to run, disable "Run Git hooks" in project settings.`;
 }
 
 function injectEndpoints(backendApi: BackendApi) {

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -26,6 +26,7 @@ export type Project = {
 	preferred_key: AuthKey;
 	ok_with_force_push: boolean;
 	force_push_protection: boolean;
+	husky_hooks_enabled: boolean;
 	omit_certificate_check: boolean | undefined;
 	use_diff_context: boolean | undefined;
 	// Produced just for the frontend to determine if the project is open in any window.

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -218,6 +218,7 @@ pub fn push_stack(
                 url,
                 push_details.head,
                 &push_details.remote_refname,
+                ctx.legacy_project.husky_hooks_enabled,
             )? {
                 hooks::HookResult::Success | hooks::HookResult::NotConfigured => {}
                 hooks::HookResult::Failure(error_data) => {

--- a/crates/gitbutler-branch-actions/tests/hooks.rs
+++ b/crates/gitbutler-branch-actions/tests/hooks.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     use gitbutler_repo::hooks::{ErrorData, HookResult, MessageData, MessageHookResult};
     use gitbutler_testsupport::{Case, Suite};
@@ -7,7 +10,9 @@ mod tests {
     #[test]
     fn post_commit_hook_rejection() -> anyhow::Result<()> {
         let suite = Suite::default();
-        let Case { ctx, .. } = &suite.new_case();
+        let mut case = suite.new_case();
+        case.ctx.legacy_project.husky_hooks_enabled = true;
+        let Case { ctx, .. } = &case;
 
         let hook = b"
 #!/bin/sh
@@ -28,7 +33,9 @@ exit 1
     #[test]
     fn message_hook_rejection() -> anyhow::Result<()> {
         let suite = Suite::default();
-        let Case { ctx, .. } = &suite.new_case();
+        let mut case = suite.new_case();
+        case.ctx.legacy_project.husky_hooks_enabled = true;
+        let Case { ctx, .. } = &case;
 
         let hook = b"
 #!/bin/sh
@@ -50,7 +57,9 @@ exit 1
     #[test]
     fn rewrite_message() -> anyhow::Result<()> {
         let suite = Suite::default();
-        let Case { ctx, .. } = &suite.new_case();
+        let mut case = suite.new_case();
+        case.ctx.legacy_project.husky_hooks_enabled = true;
+        let Case { ctx, .. } = &case;
 
         let hook = b"
 #!/bin/sh
@@ -71,7 +80,9 @@ echo 'rewritten message' > $1
     #[test]
     fn keep_message() -> anyhow::Result<()> {
         let suite = Suite::default();
-        let Case { ctx, .. } = &suite.new_case();
+        let mut case = suite.new_case();
+        case.ctx.legacy_project.husky_hooks_enabled = true;
+        let Case { ctx, .. } = &case;
 
         let hook = b"
 #!/bin/sh
@@ -83,6 +94,45 @@ echo 'commit message' > $1
         assert_eq!(
             gitbutler_repo::hooks::commit_msg(ctx, message)?,
             MessageHookResult::Success
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn husky_hooks_disabled_even_if_present() -> anyhow::Result<()> {
+        let suite = Suite::default();
+        let case = suite.new_case();
+        let Case { ctx, .. } = &case;
+
+        let repo = ctx.git2_repo.get()?;
+        let husky_dir = repo
+            .path()
+            .parent()
+            .expect("git dir in worktree")
+            .join(".husky");
+        fs::create_dir_all(&husky_dir)?;
+
+        let post_hook_path = husky_dir.join("post-commit");
+        let msg_hook_path = husky_dir.join("commit-msg");
+        fs::write(
+            &post_hook_path,
+            "#!/bin/sh\necho 'should not run'\nexit 1\n",
+        )?;
+        fs::write(&msg_hook_path, "#!/bin/sh\necho 'should not run'\nexit 1\n")?;
+
+        #[cfg(unix)]
+        {
+            fs::set_permissions(&post_hook_path, fs::Permissions::from_mode(0o755))?;
+            fs::set_permissions(&msg_hook_path, fs::Permissions::from_mode(0o755))?;
+        }
+
+        assert_eq!(
+            gitbutler_repo::hooks::post_commit(ctx)?,
+            HookResult::NotConfigured
+        );
+        assert_eq!(
+            gitbutler_repo::hooks::commit_msg(ctx, "commit message".to_owned())?,
+            MessageHookResult::NotConfigured
         );
         Ok(())
     }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -118,6 +118,10 @@ pub struct Project {
     /// Force push protection uses safer force push flags instead of doing straight force pushes
     #[serde(default)]
     pub force_push_protection: bool,
+    /// Enables running Husky hooks from `../.husky`.
+    /// Does not affect hooks in `.git/hooks`.
+    #[serde(default)]
+    pub husky_hooks_enabled: bool,
     pub api: Option<ApiProject>,
     #[serde(default)]
     pub gitbutler_data_last_fetch: Option<FetchResult>,
@@ -150,6 +154,7 @@ impl Project {
             preferred_key: Default::default(),
             ok_with_force_push: Default::default(),
             force_push_protection: false,
+            husky_hooks_enabled: false,
             api: None,
             gitbutler_data_last_fetch: None,
             gitbutler_code_push_state: None,

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -26,6 +26,7 @@ pub struct UpdateRequest {
     pub preferred_key: Option<AuthKey>,
     pub ok_with_force_push: Option<bool>,
     pub force_push_protection: Option<bool>,
+    pub husky_hooks_enabled: Option<bool>,
     pub gitbutler_code_push_state: Option<CodePushState>,
     pub project_data_last_fetched: Option<FetchResult>,
     pub omit_certificate_check: Option<bool>,
@@ -52,6 +53,7 @@ impl UpdateRequest {
             preferred_key: None,
             ok_with_force_push: None,
             force_push_protection: None,
+            husky_hooks_enabled: None,
             gitbutler_code_push_state: None,
             project_data_last_fetched: None,
             omit_certificate_check: None,
@@ -75,6 +77,7 @@ impl From<Project> for UpdateRequest {
             preferred_key,
             ok_with_force_push,
             force_push_protection,
+            husky_hooks_enabled,
             api,
             gitbutler_data_last_fetch,
             gitbutler_code_push_state,
@@ -97,6 +100,7 @@ impl From<Project> for UpdateRequest {
             preferred_key: Some(preferred_key),
             ok_with_force_push: Some(ok_with_force_push.into()),
             force_push_protection: Some(force_push_protection),
+            husky_hooks_enabled: Some(husky_hooks_enabled),
             gitbutler_code_push_state,
             project_data_last_fetched: project_data_last_fetch,
             omit_certificate_check,
@@ -168,6 +172,7 @@ impl Storage {
             preferred_key,
             ok_with_force_push,
             force_push_protection,
+            husky_hooks_enabled,
             gitbutler_code_push_state,
             project_data_last_fetched,
             omit_certificate_check,
@@ -242,6 +247,10 @@ impl Storage {
 
         if let Some(force_push_protection) = force_push_protection {
             project.force_push_protection = force_push_protection;
+        }
+
+        if let Some(husky_hooks_enabled) = husky_hooks_enabled {
+            project.husky_hooks_enabled = husky_hooks_enabled;
         }
 
         if let Some(omit_certificate_check) = omit_certificate_check {

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -17,7 +17,7 @@ but-core = { workspace = true, features = ["legacy"] }
 but-status.workspace = true
 but-gerrit.workspace = true
 but-oxidize.workspace = true
-but-ctx.workspace = true
+but-ctx = { workspace = true, features = ["legacy"] }
 
 gitbutler-project.workspace = true
 gitbutler-reference.workspace = true


### PR DESCRIPTION
### Operator Prompting Summary (Security + Implementation)

This PR was driven with a security-first prompt strategy. The key operator constraints and decisions were:

1. **Primary security concern**
   - Prevent execution of potentially malicious Husky scripts cloned from untrusted repositories.
   - Husky must be **opt-in**, not implicit.

2. **Scope and model**
   - This applies specifically to **Husky** behavior from repo-controlled paths.
   - Store per-project enablement in `gitbutler_project::Project` (`husky_hooks_enabled`).
   - Default behavior: Husky execution is disabled unless explicitly enabled.

3. **Implementation guidance enforced during review**
   - First identify where Husky hooks are executed.
   - Add backend guards so Husky paths are only considered when enabled.
   - Avoid unnecessary frontend behavior changes; keep UI minimal.
   - Add explicit trust warning text: enable Husky only for trusted repositories.

4. **Edge cases explicitly requested**
   - Ensure behavior is correct when `core.hooksPath` points into `.husky` / `.husky/_`.
   - Ensure disabled setting blocks Husky execution in those paths.
   - Ensure standard non-Husky hook behavior is not unintentionally broadened.

5. **Quality/process constraints**
   - Keep `fmt`, `clippy`, lint/prettier and generation checks green.
   - Use `but` workflow for branch/commit operations.
   - Address and resolve GitHub review comments after fixes.

6. **Outcome**
   - Husky execution is gated by trusted-project opt-in.
   - Regression coverage added for `core.hooksPath` Husky path bypass scenario.
   - Review feedback on this bypass was implemented and thread resolved.
