### PR TITLE
fix: enable askpass feature for tauri app again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "console-subscriber",
  "document-features",
  "git2",
+ "gitbutler-git",
  "gitbutler-oplog",
  "gitbutler-project",
  "gitbutler-repo-actions",

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -10,6 +10,8 @@ rust-version.workspace = true
 ignored = [
     # Only used when the optional `error-context` feature enables backtrace capture.
     "backtrace",
+    # We include this only to set the askpass feature flag when compiling. This little hack will be removed in future update.
+    "gitbutler-git"
 ]
 
 [lib]
@@ -44,6 +46,7 @@ but-hunk-assignment.workspace = true
 gitbutler-repo-actions.workspace = true
 gitbutler-watcher.workspace = true
 gitbutler-project.workspace = true
+gitbutler-git = { workspace = true, features = ["askpass"] }
 gitbutler-oplog.workspace = true
 tauri = { version = "^2.9.5", features = ["unstable"] }
 tauri-plugin-single-instance = { version = "2.3.6", features = ["deep-link"] }


### PR DESCRIPTION
## 🧢 Changes
It was accidentally disabled in pruning deps.

This feature flag will go away soon-ish so this workaround can then go away as well.