### PR TITLE
fix(but): checkout to default target as fallback

### DIFF
--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -90,16 +90,19 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
     // Sort by order to ensure we get the leftmost (lowest order) stack first
     stacks.sort_by_key(|s| s.order.unwrap_or(usize::MAX));
 
-    let target_stack = stacks
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("No active branches found"))?;
-
-    // Get the name of the top branch in the stack
-    let target_branch_name = target_stack
-        .heads
-        .first()
-        .map(|h| h.name.to_string())
-        .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?;
+    let target_branch_name = if let Some(target_stack) = stacks.first() {
+        target_stack
+            .heads
+            .first()
+            .map(|h| h.name.to_string())
+            .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?
+    } else {
+        gitbutler_stack::VirtualBranchesHandle::new(ctx.project_data_dir())
+            .get_default_target()?
+            .branch
+            .branch()
+            .to_string()
+    };
 
     if let Some(out) = out.for_human() {
         writeln!(

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -464,3 +464,34 @@ fn json_output_with_dangling_commits() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Test: Teardown checks out target branch when there is no active branch
+#[test]
+fn teardown_checks_out_target_branch_when_there_is_no_active_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("repo-with-remote-and-head")?;
+    env.setup_metadata(&[])?;
+
+    env.but("--json teardown")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "snapshotId": "[..]",
+  "checkedOutBranch": "main"
+}
+
+"#]]);
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(env.projects_root())
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .output()?;
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "main");
+
+    Ok(())
+}


### PR DESCRIPTION
## 🧢 Changes
Makes `but teardown` check out to the default target as a fallback if there are no active branches.

Previously it would error out like so if you just setup/teardown on a fresh repository:

```bash
$ but setup && but teardown
<snip>
Exiting GitButler mode...

→ Creating snapshot...
  ✓ Snapshot created: f8bbb6f

→ Finding active branch to check out...
Error: Failed to teardown GitButler project.

Caused by:
    No active branches found
```

## TODO
This is a naive fix for this very particular issue, just wanted to see if it'd pass CI. Also want to handle broken states (e.g. top stack has no active branches).