### PR TITLE
Update but-api to use higher level commits

### DIFF
--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -124,6 +124,8 @@ mod hex_hash {
 }
 pub use hex_hash::{HexHash, HexHashString};
 
+use crate::commit::{CommitCreateResult, MoveChangesResult};
+
 mod error {
     //! Utilities to control which errors show in the frontend.
     //!
@@ -437,6 +439,18 @@ pub struct UIMoveChangesResult {
     pub replaced_commits: Vec<(HexHash, HexHash)>,
 }
 
+impl From<MoveChangesResult> for UIMoveChangesResult {
+    fn from(value: MoveChangesResult) -> Self {
+        Self {
+            replaced_commits: value
+                .replaced_commits
+                .into_iter()
+                .map(|(old, new)| (old.into(), new.into()))
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 /// UI type for creating a commit in the rebase graph.
@@ -448,4 +462,17 @@ pub struct UICommitCreateResult {
         but_core::tree::create_tree::RejectionReason,
         but_serde::BStringForFrontend,
     )>,
+}
+
+impl From<CommitCreateResult> for UICommitCreateResult {
+    fn from(value: CommitCreateResult) -> Self {
+        Self {
+            new_commit: value.new_commit.map(Into::into),
+            paths_to_rejected_changes: value
+                .rejected_specs
+                .into_iter()
+                .map(|(r, d)| (r, d.path.into()))
+                .collect(),
+        }
+    }
 }

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -18,8 +18,6 @@ pub(crate) mod function {
         pub commit_selector: Option<Selector>,
         /// Rejected diff specs from commit creation, matching legacy behavior.
         pub rejected_specs: Vec<(but_core::tree::create_tree::RejectionReason, DiffSpec)>,
-        /// The intermediate tree before cherry-picking back onto the target tree.
-        pub changed_tree_pre_cherry_pick: Option<gix::ObjectId>,
     }
 
     /// Create a commit from `changes` and insert it relative to `relative_to` on `side`.
@@ -54,7 +52,6 @@ pub(crate) mod function {
                 rebase: None,
                 commit_selector: None,
                 rejected_specs: create_out.rejected_specs,
-                changed_tree_pre_cherry_pick: create_out.changed_tree_pre_cherry_pick,
             });
         };
 
@@ -66,7 +63,6 @@ pub(crate) mod function {
             rebase: Some(rebase),
             commit_selector: Some(commit_selector),
             rejected_specs: create_out.rejected_specs,
-            changed_tree_pre_cherry_pick: create_out.changed_tree_pre_cherry_pick,
         })
     }
 

--- a/crates/but/src/command/legacy/rub/commits.rs
+++ b/crates/but/src/command/legacy/rub/commits.rs
@@ -27,12 +27,7 @@ pub fn commited_file_to_another_commit(
             .collect::<Vec<DiffSpec>>()
     };
 
-    but_api::commit::commit_move_changes_between_only(
-        ctx,
-        source_id.into(),
-        target_id.into(),
-        relevant_changes,
-    )?;
+    but_api::commit::commit_move_changes_between_only(ctx, source_id, target_id, relevant_changes)?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     update_workspace_commit(&vb_state, ctx, false)?;
@@ -73,12 +68,7 @@ pub fn uncommit_file(
             .collect::<Vec<DiffSpec>>()
     };
 
-    but_api::commit::commit_uncommit_changes_only(
-        ctx,
-        source_id.into(),
-        relevant_changes,
-        assign_to,
-    )?;
+    but_api::commit::commit_uncommit_changes_only(ctx, source_id, relevant_changes, assign_to)?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     update_workspace_commit(&vb_state, ctx, false)?;


### PR DESCRIPTION
Update the but-api to use higher level types. This means rust consumers don’t need to deal with lower-level types like a `HexHash`.

By making use of the `but_api(type)` paramater we can specify a JSON specific type.


---

This commit also ended up containing a unrelated change where I dropped the “changed_tree_pre_cherry_pick” since It’s not used at the minute.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #12570 
- <kbd>&nbsp;2&nbsp;</kbd> #12569 
- <kbd>&nbsp;1&nbsp;</kbd> #12562 👈 
<!-- GitButler Footer Boundary Bottom -->

