### PR TITLE
Update "branch from" wording to be consistent with other prompts

### DIFF
--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -253,7 +253,7 @@
 						{#snippet submenu({ close: closeSubmenu })}
 							<ContextMenuSection>
 								<ContextMenuItem
-									label="Branch from this commit"
+									label="Add branch above"
 									disabled={isReadOnly || refCreation.current.isLoading}
 									onclick={async () => {
 										if (!isReadOnly) {
@@ -264,7 +264,7 @@
 									}}
 								/>
 								<ContextMenuItem
-									label="Branch after this commit"
+									label="Add branch below"
 									disabled={isReadOnly || refCreation.current.isLoading}
 									onclick={async () => {
 										if (!isReadOnly) {


### PR DESCRIPTION
In the rest of the app, we use wording like “Add empty commit below”. Perhaps I’m daft, but I found “from” and “after” more ambiguous than a spacial version of “above” and “below”.