### PR TITLE
Add `make fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,36 @@
-.PHONY: check fmt clippy all
+# Check all rust code - formatting, cargo check, and clippy.
+.PHONY: all
+all: fmt fmt-check check clippy
 
-all: fmt fmt-check clippy
+# Perform any automated formatting or clippy fixes that are available.
+.PHONY: fix
+fix: clippy-fix fmt
 
+# Smaller - sub-checks
+
+# Format: code to match rustfmt configuration.
+.PHONY: fmt
 fmt:
 	cargo fmt
 
+# Lint: code to ensure it matches our rustfmt configuration.
+.PHONY: fmt-check
 fmt-check:
 	cargo fmt --check --all
 
+# Lint: code to ensure there are no compiler errors or warnings.
+.PHONY: check
+check:
+	cargo check --workspace --all-targets
+
+# Lint: code to ensure rust best practices are observed.
+.PHONY: clippy
 clippy:
 	cargo clippy --workspace --all-targets -- -D warnings
+
+# Format: clippy issues --allow-dirty allows the fix to be run even with a dirty
+# working tree which can technically cause code to break, but I've never seen it
+# happen in practice.
+.PHONY: clippy-fix
+clippy-fix:
+	cargo clippy --workspace --all-targets --fix --allow-dirty


### PR DESCRIPTION
This commit adds a `make fix` which should resolve any auto-resolvable issues.

I’ve also added `cargo check` to the standard `make` configuration so compiler errors are also highlighted to users or LLMs who call it.