### PR TITLE
For properly chaining create_commit we always want a SuccessfulRebase returned

### DIFF
--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use anyhow::bail;
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
 use but_core::{DiffSpec, sync::RepoExclusive, tree::create_tree::RejectionReason};
@@ -229,13 +228,12 @@ pub(crate) fn commit_create_only_impl(
         context_lines,
     )?;
 
-    let new_commit = match (rebase, commit_selector) {
-        (Some(rebase), Some(commit_selector)) => {
+    let new_commit = match commit_selector {
+        Some(commit_selector) => {
             let materialized = rebase.materialize()?;
             Some(materialized.lookup_pick(commit_selector)?)
         }
-        (None, None) => None,
-        (Some(_), None) | (None, Some(_)) => bail!("BUG: inconsistent commit outcome"),
+        None => None,
     };
 
     ws.refresh_from_head(&repo, &meta)?;

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -12,8 +12,10 @@ pub(crate) mod function {
     /// The result of creating and inserting a new commit in the graph rebase editor.
     #[derive(Debug)]
     pub struct CommitCreateOutcome {
-        /// The successful rebase result, if a new commit was created.
-        pub rebase: Option<SuccessfulRebase>,
+        /// A successful rebase result for continuing operations. This will be
+        /// always provided regardless of whether a commit was actually
+        /// created.
+        pub rebase: SuccessfulRebase,
         /// Selector pointing to the newly created commit, if one was created.
         ///
         /// A commit may not be created if all the diff_specs are rejected. See
@@ -70,7 +72,7 @@ pub(crate) mod function {
 
         let Some(new_commit_id) = create_out.new_commit else {
             return Ok(CommitCreateOutcome {
-                rebase: None,
+                rebase: editor.rebase()?,
                 commit_selector: None,
                 rejected_specs: create_out.rejected_specs,
             });
@@ -78,10 +80,9 @@ pub(crate) mod function {
 
         let commit_selector =
             editor.insert(relative_to_selector, Step::new_pick(new_commit_id), side)?;
-        let rebase = editor.rebase()?;
 
         Ok(CommitCreateOutcome {
-            rebase: Some(rebase),
+            rebase: editor.rebase()?,
             commit_selector: Some(commit_selector),
             rejected_specs: create_out.rejected_specs,
         })

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -38,11 +38,10 @@ fn commit_above_commit() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -85,11 +84,10 @@ fn commit_below_commit() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -126,11 +124,10 @@ fn commit_above_reference() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -178,11 +175,10 @@ fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -220,10 +216,6 @@ fn commit_all_rejected_is_noop() -> Result<()> {
         0,
     )?;
 
-    assert!(
-        outcome.rebase.is_none(),
-        "no rebase should happen if nothing was committed"
-    );
     assert!(
         outcome.commit_selector.is_none(),
         "no selector if there is no new commit"


### PR DESCRIPTION
Calling `rebase` here will have a negligable performance impact since all the 3wms are identity no-ops

