### PR TITLE
fix(but): invalidate update cache on install

### DIFF
--- a/crates/but-db/src/cache/table/update.rs
+++ b/crates/but-db/src/cache/table/update.rs
@@ -17,6 +17,9 @@ pub(crate) const M: &[M<'static>] = &[M::up(
 );",
 )];
 
+// This table currently only has a single row representing the latest update check.
+const SINGLETON_RECORD_ID: u8 = 1;
+
 /// A utility for accessing the update checks.
 pub struct UpdateCheckHandle<'conn> {
     conn: &'conn rusqlite::Connection,
@@ -179,7 +182,7 @@ impl UpdateCheckHandleMut<'_> {
               suppressed_at, suppress_duration_hours)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
-                1, // Singleton record
+                SINGLETON_RECORD_ID,
                 result.checked_at.naive_utc(),
                 result.status.up_to_date,
                 result.status.latest_version,
@@ -192,6 +195,22 @@ impl UpdateCheckHandleMut<'_> {
         )?;
 
         sp.commit()?;
+        Ok(())
+    }
+
+    /// Deletes the update check, which is equivalent to cache invalidation.
+    ///
+    /// This operation is idempotent and is safe to perform regardless of if an update check record
+    /// exists or not.
+    pub fn delete(self) -> rusqlite::Result<()> {
+        let sp = self.sp;
+
+        sp.execute(
+            "DELETE FROM `update-check` WHERE id = ?1;",
+            rusqlite::params![SINGLETON_RECORD_ID],
+        )?;
+        sp.commit()?;
+
         Ok(())
     }
 
@@ -222,8 +241,8 @@ impl UpdateCheckHandleMut<'_> {
         sp.execute(
             "UPDATE `update-check`
              SET suppressed_at = ?1, suppress_duration_hours = ?2
-             WHERE id = 1",
-            rusqlite::params![Utc::now().naive_utc(), hours],
+             WHERE id = ?3",
+            rusqlite::params![Utc::now().naive_utc(), hours, SINGLETON_RECORD_ID],
         )?;
 
         sp.commit()?;
@@ -237,8 +256,8 @@ impl UpdateCheckHandleMut<'_> {
         sp.execute(
             "UPDATE `update-check`
              SET suppressed_at = NULL, suppress_duration_hours = NULL
-             WHERE id = 1",
-            [],
+             WHERE id = ?1",
+            [SINGLETON_RECORD_ID],
         )?;
 
         sp.commit()?;

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -161,5 +161,16 @@ fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
         writeln!(writer)?;
     }
 
+    let mut cache = but_ctx::Context::app_cache();
+    if let Err(err) = cache.update_check_mut().and_then(|handle| handle.delete()) {
+        tracing::warn!(?err, "Failed to invalidate update check cache");
+        if let Some(writer) = out.for_human() {
+            writeln!(
+                writer,
+                "Failed to invalidate update check cache - skipping invalidation: {err:?}",
+            )?;
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
As the cache includes not only the latest version at the time, but also whether the client is up-to-date with that version, installing a new version invalidates the result of the check. This could cause a confusing "Update available: <newer version> -> <older version>" to show when a new version was installed, and the cache was populated before the version now installed was even released. It goes away only when the cache is refreshed.

This happens to me pretty much daily with the nightly builds.

This PR invalidates (deletes) the cache when a new version is installed s.t. we don't have that outdated cache.