### PR TITLE
Implement new commit amend

### DIFF
--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use anyhow::bail;
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
 use but_core::{DiffSpec, sync::RepoExclusive, tree::create_tree::RejectionReason};
@@ -229,13 +228,12 @@ pub(crate) fn commit_create_only_impl(
         context_lines,
     )?;
 
-    let new_commit = match (rebase, commit_selector) {
-        (Some(rebase), Some(commit_selector)) => {
+    let new_commit = match commit_selector {
+        Some(commit_selector) => {
             let materialized = rebase.materialize()?;
             Some(materialized.lookup_pick(commit_selector)?)
         }
-        (None, None) => None,
-        (Some(_), None) | (None, Some(_)) => bail!("BUG: inconsistent commit outcome"),
+        None => None,
     };
 
     ws.refresh_from_head(&repo, &meta)?;

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -723,6 +723,10 @@ pub async fn run() {
             post(json_response(commit::commit_create_cmd)),
         )
         .route(
+            "/commit_amend",
+            post(json_response(commit::commit_amend_cmd)),
+        )
+        .route(
             "/commit_move_changes_between",
             post(json_response(commit::commit_move_changes_between_cmd)),
         )

--- a/crates/but-workspace/src/commit/commit_amend.rs
+++ b/crates/but-workspace/src/commit/commit_amend.rs
@@ -1,0 +1,79 @@
+//! An action to amend an existing commit with selected changes.
+
+pub(crate) mod function {
+    use anyhow::{Result, bail};
+    use but_core::DiffSpec;
+    use but_rebase::graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector};
+
+    use crate::commit_engine::{Destination, create_commit};
+
+    /// The result of amending a commit in the graph rebase editor.
+    #[derive(Debug)]
+    pub struct CommitAmendOutcome {
+        /// A successful rebase result for continuing operations. This will be
+        /// always provided regardless of whether a commit was actually
+        /// created.
+        pub rebase: SuccessfulRebase,
+        /// Selector pointing to the amended commit, if the amend was
+        /// successful.
+        ///
+        /// A commit may not be amended if all the diff_specs are rejected. See
+        /// [`create_commit`] for more details.
+        pub commit_selector: Option<Selector>,
+        /// Rejected diff specs from commit creation. See [`create_commit`] for
+        /// more details.
+        pub rejected_specs: Vec<(but_core::tree::create_tree::RejectionReason, DiffSpec)>,
+    }
+
+    /// Amend a commit specified by `commit` selector.
+    ///
+    /// Similar to other `editor` based functions, this consumes an editor and
+    /// gives it back as a [`SuccessfulRebase`] which can be used to chain more
+    /// operations or just materialize the result.
+    ///
+    /// `changes` defines which changes from the worktree should be committed.
+    /// See [`create_commit`] for more details.
+    ///
+    /// `context_lines` define how many diff context lines are being used for
+    /// this particular function call. The provided `context_lines` MUST align
+    /// with the `context_lines` value used to generate the `DiffSpec`s passed
+    /// in the `changes` parameter.
+    pub fn commit_amend(
+        mut editor: Editor,
+        commit: impl ToCommitSelector,
+        changes: Vec<DiffSpec>,
+        context_lines: u32,
+    ) -> Result<CommitAmendOutcome> {
+        let (target_selector, target) = editor.find_selectable_commit(commit)?;
+
+        if target.is_conflicted() {
+            bail!("Cannot amend a conflicted commit")
+        }
+
+        let create_out = create_commit(
+            editor.repo(),
+            Destination::AmendCommit {
+                commit_id: target.id.into(),
+                new_message: None,
+            },
+            changes,
+            context_lines,
+        )?;
+
+        let Some(new_commit_id) = create_out.new_commit else {
+            return Ok(CommitAmendOutcome {
+                rebase: editor.rebase()?,
+                commit_selector: None,
+                rejected_specs: create_out.rejected_specs,
+            });
+        };
+
+        editor.replace(target_selector, Step::new_pick(new_commit_id))?;
+
+        Ok(CommitAmendOutcome {
+            rebase: editor.rebase()?,
+            commit_selector: Some(target_selector),
+            rejected_specs: create_out.rejected_specs,
+        })
+    }
+}

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -12,8 +12,10 @@ pub(crate) mod function {
     /// The result of creating and inserting a new commit in the graph rebase editor.
     #[derive(Debug)]
     pub struct CommitCreateOutcome {
-        /// The successful rebase result, if a new commit was created.
-        pub rebase: Option<SuccessfulRebase>,
+        /// A successful rebase result for continuing operations. This will be
+        /// always provided regardless of whether a commit was actually
+        /// created.
+        pub rebase: SuccessfulRebase,
         /// Selector pointing to the newly created commit, if one was created.
         ///
         /// A commit may not be created if all the diff_specs are rejected. See
@@ -70,7 +72,7 @@ pub(crate) mod function {
 
         let Some(new_commit_id) = create_out.new_commit else {
             return Ok(CommitCreateOutcome {
-                rebase: None,
+                rebase: editor.rebase()?,
                 commit_selector: None,
                 rejected_specs: create_out.rejected_specs,
             });
@@ -78,10 +80,9 @@ pub(crate) mod function {
 
         let commit_selector =
             editor.insert(relative_to_selector, Step::new_pick(new_commit_id), side)?;
-        let rebase = editor.rebase()?;
 
         Ok(CommitCreateOutcome {
-            rebase: Some(rebase),
+            rebase: editor.rebase()?,
             commit_selector: Some(commit_selector),
             rejected_specs: create_out.rejected_specs,
         })

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -8,6 +8,8 @@ pub mod reword;
 pub use reword::function::reword;
 pub mod commit_create;
 pub use commit_create::function::{CommitCreateOutcome, commit_create};
+pub mod commit_amend;
+pub use commit_amend::function::{CommitAmendOutcome, commit_amend};
 pub mod insert_blank_commit;
 pub use insert_blank_commit::function::insert_blank_commit;
 pub mod move_changes;

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+use but_core::DiffSpec;
+use but_rebase::graph_rebase::{GraphExt as _, LookupStep as _};
+use but_workspace::commit::commit_amend;
+
+use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
+
+fn worktree_changes_as_specs(repo: &gix::Repository) -> Result<Vec<DiffSpec>> {
+    Ok(but_core::diff::worktree_changes(repo)?
+        .changes
+        .into_iter()
+        .map(DiffSpec::from)
+        .collect())
+}
+
+#[test]
+fn amend_commit_smoke_test() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+    let two_id = repo.rev_parse_single("two")?.detach();
+    std::fs::write(
+        repo.workdir_path("amended.txt").expect("non-bare"),
+        "amended\n",
+    )?;
+
+    let editor = graph.to_editor(&repo)?;
+    let outcome = commit_amend(editor, two_id, worktree_changes_as_specs(&repo)?, 0)?;
+
+    assert!(outcome.rejected_specs.is_empty());
+    let selector = outcome.commit_selector.expect("selector exists");
+    let materialized = outcome.rebase.materialize()?;
+    let rewritten_id = materialized.lookup_pick(selector)?;
+
+    let rewritten_commit = repo.find_commit(rewritten_id)?;
+    assert_eq!(rewritten_commit.message_raw()?, "commit two\n");
+    let spec = format!("{rewritten_id}:amended.txt");
+    let object_with_path = repo.rev_parse_single(spec.as_str())?;
+    assert_eq!(object_with_path.object()?.kind, gix::objs::Kind::Blob);
+
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -38,11 +38,10 @@ fn commit_above_commit() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -85,11 +84,10 @@ fn commit_below_commit() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -126,11 +124,10 @@ fn commit_above_reference() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -178,11 +175,10 @@ fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
     )?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let rebase = outcome.rebase.expect("a new commit was created");
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = rebase.materialize()?;
+    let materialized = outcome.rebase.materialize()?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -220,10 +216,6 @@ fn commit_all_rejected_is_noop() -> Result<()> {
         0,
     )?;
 
-    assert!(
-        outcome.rebase.is_none(),
-        "no rebase should happen if nothing was committed"
-    );
     assert!(
         outcome.commit_selector.is_none(),
         "no selector if there is no new commit"

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -1,3 +1,4 @@
+mod commit_amend;
 mod commit_create;
 mod insert_blank_commit;
 mod move_changes;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -405,6 +405,7 @@ fn main() -> anyhow::Result<()> {
                 commit::tauri_commit_reword::commit_reword,
                 commit::tauri_commit_insert_blank::commit_insert_blank,
                 commit::tauri_commit_create::commit_create,
+                commit::tauri_commit_amend::commit_amend,
                 commit::tauri_commit_move_changes_between::commit_move_changes_between,
                 commit::tauri_commit_uncommit_changes::commit_uncommit_changes,
                 platform::tauri_build_type::build_type,


### PR DESCRIPTION
This makes a new version of our amend function call. The API omits omits replacing the commit message since the frontend doesn’t make use of it, and the CLI should really chain an amend & reword if it want’s  that capability.

This commit doesn’t try to port all of the codebases usage of ammend to the new function, though we should now have complelty obseleted the `legacy/commit_engine` code.