### PR TITLE
Improve the way we determine the forge repository info

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -32,7 +32,6 @@ export class BaseBranch {
 	diverged!: boolean;
 	divergedAhead!: string[];
 	divergedBehind!: string[];
-	forgeRepoInfo!: ForgeRepoInfo | null;
 
 	actualPushRemoteName(): string {
 		return this.pushRemoteName || this.remoteName;

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -21,6 +21,7 @@ export enum ReduxTag {
 	Checks = "Checks",
 	RepoInfo = "RepoInfo",
 	BaseBranchData = "BaseBranchData",
+	ForgeProvider = "ForgeProvider",
 	UpstreamIntegrationStatus = "UpstreamIntegrationStatus",
 	BranchListing = "BranchListing",
 	BranchDetails = "BranchDetails",

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -75,6 +75,9 @@
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
 	const baseBranch = $derived(baseBranchQuery.response);
 	const baseBranchName = $derived(baseBranch?.shortName);
+	const forgeProviderQuery = $derived(baseBranchService.forgeProvider(projectId));
+	const detectedForgeProvider = $derived(forgeProviderQuery.response);
+	const detectedForgeProviderIsLoading = $derived(detectedForgeProvider === undefined);
 
 	// =============================================================================
 	// WORKSPACE & MODE MANAGEMENT
@@ -152,10 +155,11 @@
 			pushRepo: forkInfo,
 			baseBranch: baseBranchName,
 			githubAuthenticated: !!githubAccessToken.accessToken.current,
-			forgeIsLoading: githubAccessToken.isLoading.current || gitlabIsLoading,
+			forgeIsLoading:
+				githubAccessToken.isLoading.current || gitlabIsLoading || detectedForgeProviderIsLoading,
 			githubError: githubAccessToken.error.current,
 			gitlabAuthenticated: !!gitlabAccessToken.accessToken.current,
-			detectedForgeProvider: baseBranch?.forgeRepoInfo?.forge ?? undefined,
+			detectedForgeProvider: detectedForgeProvider ?? undefined,
 			forgeOverride: projects?.find((project) => project.id === projectId)?.forge_override,
 		});
 	});

--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -154,9 +154,9 @@ pub async fn get_gh_user(
 /// * `Err(_)` - If storage access fails
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdentifier>> {
+pub fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdentifier>> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
-    but_github::list_known_github_accounts(&storage).await
+    but_github::list_known_github_accounts(&storage)
 }
 
 /// Validates stored GitHub credentials.

--- a/crates/but-api/src/gitlab.rs
+++ b/crates/but-api/src/gitlab.rs
@@ -118,9 +118,9 @@ pub async fn get_gl_user(
 /// * `Err(_)` - If storage access fails
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn list_known_gitlab_accounts() -> Result<Vec<but_gitlab::GitlabAccountIdentifier>> {
+pub fn list_known_gitlab_accounts() -> Result<Vec<but_gitlab::GitlabAccountIdentifier>> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
-    but_gitlab::list_known_gitlab_accounts(&storage).await
+    but_gitlab::list_known_gitlab_accounts(&storage)
 }
 
 /// Validates stored GitLab credentials.

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -17,6 +17,17 @@ pub fn pr_templates(ctx: &but_ctx::Context, forge: ForgeName) -> Result<Vec<Stri
     Ok(available_review_templates(&ctx.workdir_or_fail()?, &forge))
 }
 
+/// Get the forge provider name.
+///
+/// This is determined by the forge the base branch is pointing to.
+#[but_api]
+#[instrument(err(Debug))]
+pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
+    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    Ok(forge_repo_info.map(|info| info.forge))
+}
+
 /// Get the list of review template paths for the given project.
 #[but_api]
 #[instrument(err(Debug))]

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -22,8 +22,8 @@ pub fn pr_templates(ctx: &but_ctx::Context, forge: ForgeName) -> Result<Vec<Stri
 #[instrument(err(Debug))]
 pub fn list_available_review_templates(ctx: &Context) -> Result<Vec<String>> {
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge = &base_branch
-        .forge_repo_info
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
         .forge;
@@ -79,8 +79,8 @@ pub fn review_template(ctx: &Context) -> Result<Option<json::ReviewTemplateInfo>
     let project = gitbutler_project::get_validated(ctx.legacy_project.id)?;
     let ctx = Context::new_from_legacy_project(project.clone())?;
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
-    let forge = &base_branch
-        .forge_repo_info
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
         .forge;
@@ -124,8 +124,8 @@ pub fn set_review_template(ctx: &but_ctx::Context, template_path: Option<String>
     let mut git_config = repo.git_settings()?;
 
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-    let forge = &base_branch
-        .forge_repo_info
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let forge = &forge_repo_info
         .as_ref()
         .context("No forge could be determined for this repository branch")?
         .forge;
@@ -153,11 +153,13 @@ pub fn list_reviews(
     ctx: &mut Context,
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::ForgeReview>> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
@@ -166,9 +168,7 @@ pub fn list_reviews(
 
     but_forge::list_forge_reviews_with_cache(
         preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         &storage,
         db,
         cache_config,
@@ -182,19 +182,21 @@ pub fn list_ci_checks_and_update_cache(
     reference: String,
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::CiCheck>> {
-    let (storage, base_branch) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
+            ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
     let db = &mut *ctx.db.get_mut()?;
+
     but_forge::ci_checks_for_ref_with_cache(
-        ctx.legacy_project.preferred_forge_user.clone(),
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        preferred_forge_user,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         &storage,
         &reference,
         db,
@@ -208,20 +210,21 @@ pub async fn publish_review(
     ctx: ThreadSafeContext,
     params: but_forge::CreateForgeReviewParams,
 ) -> Result<but_forge::ForgeReview> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
+
     but_forge::create_forge_review(
         &preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         &params,
         &storage,
     )
@@ -232,20 +235,21 @@ pub async fn publish_review(
 #[but_api]
 #[instrument(err(Debug))]
 pub async fn merge_review(ctx: ThreadSafeContext, review_id: usize) -> Result<()> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
+
     but_forge::merge_review(
         &preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         review_id,
         &storage,
     )
@@ -260,20 +264,21 @@ pub async fn set_review_auto_merge(
     review_id: usize,
     enable: bool,
 ) -> Result<()> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
+
     but_forge::set_review_auto_merge_state(
         &preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         review_id,
         enable,
         &storage,
@@ -289,20 +294,21 @@ pub async fn set_review_draftiness(
     review_id: usize,
     draft: bool,
 ) -> Result<()> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
+
     but_forge::set_review_draftiness(
         &preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         review_id,
         draft,
         &storage,
@@ -317,20 +323,21 @@ pub async fn update_review_footers(
     ctx: ThreadSafeContext,
     reviews: Vec<but_forge::ForgeReviewDescriptionUpdate>,
 ) -> Result<()> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
+
     but_forge::update_review_description_tables(
         &preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         &reviews,
         &storage,
     )
@@ -344,20 +351,20 @@ pub async fn list_reviews_for_branch(
     branch: String,
     filter: Option<but_forge::ForgeReviewFilter>,
 ) -> Result<Vec<but_forge::ForgeReview>> {
-    let (storage, base_branch, project) = {
+    let (storage, forge_repo_info, project) = {
         let ctx = ctx.into_thread_local();
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.clone(),
         )
     };
+
     but_forge::list_forge_reviews_for_branch(
         project.preferred_forge_user,
-        &base_branch
-            .forge_repo_info
-            .context("No forge could be determined for this repository branch")?,
+        &forge_repo_info.context("No forge could be determined for this repository branch")?,
         &branch,
         &storage,
         filter,

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -518,8 +518,8 @@ async fn resolve_review_map(
     ctx: ThreadSafeContext,
     base_branch: &BaseBranch,
 ) -> Result<HashMap<String, but_forge::ForgeReview>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
-    let Some(forge_repo_info) = base_branch.forge_repo_info.as_ref() else {
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+    let Some(forge_repo_info) = forge_repo_info.as_ref() else {
         // No forge? No problem!
         // If there's no forge associated with the base branch, there can't be any reviews.
         // Return an empty map.
@@ -542,6 +542,7 @@ async fn resolve_review_map(
         acc
     });
     let mut resolved_reviews = HashMap::new();
+    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
     for (key, pr_number) in reviews.drain() {
         if let Ok(resolved) =
             but_forge::get_forge_review(&preferred_forge_user, forge_repo_info, pr_number, &storage)

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -129,21 +129,9 @@ fn normalize_host_for_comparison(value: &str) -> String {
 
 /// Get all known forge accounts
 pub fn get_all_forge_accounts() -> anyhow::Result<Vec<ForgeUser>> {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        tokio::task::block_in_place(|| handle.block_on(get_all_forge_accounts_async()))
-    } else {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        runtime.block_on(get_all_forge_accounts_async())
-    }
-}
-
-/// Get all known forge accounts, the way of the async people.
-pub async fn get_all_forge_accounts_async() -> anyhow::Result<Vec<ForgeUser>> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
-    let gh_accounts = but_github::list_known_github_accounts(&storage).await?;
-    let gl_accounts = but_gitlab::list_known_gitlab_accounts(&storage).await?;
+    let gh_accounts = but_github::list_known_github_accounts(&storage)?;
+    let gl_accounts = but_gitlab::list_known_gitlab_accounts(&storage)?;
 
     let mut forge_users = vec![];
     for gh_account in gh_accounts {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -503,7 +503,7 @@ pub async fn check_forge_account_is_valid(
             {
                 Some(account) => account,
                 None => {
-                    let known_accounts = but_github::list_known_github_accounts(storage).await?;
+                    let known_accounts = but_github::list_known_github_accounts(storage)?;
                     match known_accounts.first() {
                         Some(account) => account.clone(),
                         None => {
@@ -524,7 +524,7 @@ pub async fn check_forge_account_is_valid(
             {
                 Some(account) => account,
                 None => {
-                    let known_accounts = but_gitlab::list_known_gitlab_accounts(storage).await?;
+                    let known_accounts = but_gitlab::list_known_gitlab_accounts(storage)?;
                     match known_accounts.first() {
                         Some(account) => account.clone(),
                         None => {

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -284,7 +284,7 @@ pub async fn check_credentials(
     }
 }
 
-pub async fn list_known_github_accounts(
+pub fn list_known_github_accounts(
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<token::GithubAccountIdentifier>> {
     token::list_known_github_accounts(storage).context("Failed to list known GitHub usernames")

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -171,7 +171,7 @@ pub async fn check_credentials(
     }
 }
 
-pub async fn list_known_gitlab_accounts(
+pub fn list_known_gitlab_accounts(
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<token::GitlabAccountIdentifier>> {
     token::list_known_gitlab_accounts(storage).context("Failed to list known GitLab usernames")

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -629,12 +629,20 @@ pub async fn run() {
             post(json_response(github::forget_github_account_cmd)),
         )
         .route(
+            "/list_known_github_accounts",
+            post(json_response(github::list_known_github_accounts_cmd)),
+        )
+        .route(
             "/clear_all_github_tokens",
             post(json_response(github::clear_all_github_tokens_cmd)),
         )
         .route(
             "/forget_gitlab_account",
             post(json_response(gitlab::forget_gitlab_account_cmd)),
+        )
+        .route(
+            "/list_known_gitlab_accounts",
+            post(json_response(gitlab::list_known_gitlab_accounts_cmd)),
         )
         .route(
             "/clear_all_gitlab_tokens",
@@ -925,9 +933,6 @@ async fn handle_command(
                 Err(e) => Err(e),
             }
         }
-        "list_known_github_accounts" => {
-            github::list_known_github_accounts().await.map(|r| json!(r))
-        }
         "get_gh_user" => {
             let params = deserialize_json(request.params);
             match params {
@@ -958,9 +963,6 @@ async fn handle_command(
                 }
                 Err(e) => Err(e),
             }
-        }
-        "list_known_gitlab_accounts" => {
-            gitlab::list_known_gitlab_accounts().await.map(|r| json!(r))
         }
         "get_gl_user" => {
             let params = deserialize_json(request.params);

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -69,7 +69,7 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
     };
 
     // Get forge accounts
-    let known_accounts = but_api::github::list_known_github_accounts().await?;
+    let known_accounts = but_api::github::list_known_github_accounts()?;
     let forge_accounts: Vec<ForgeAccountInfo> = known_accounts
         .iter()
         .map(|account| ForgeAccountInfo {
@@ -434,8 +434,8 @@ pub(crate) async fn forge_config(
 
 /// Show overview of forge configuration (same as list-users)
 async fn forge_show_overview(out: &mut OutputChannel) -> Result<()> {
-    let known_gh_accounts = but_api::github::list_known_github_accounts().await?;
-    let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts().await?;
+    let known_gh_accounts = but_api::github::list_known_github_accounts()?;
+    let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts()?;
 
     if let Some(out) = out.for_human() {
         if known_gh_accounts.is_empty() && known_gl_accounts.is_empty() {
@@ -886,8 +886,8 @@ fn forget_account(account: &AccountToForget) -> Result<()> {
 async fn forge_forget(username: Option<String>, out: &mut OutputChannel) -> Result<()> {
     use cli_prompts::DisplayPrompt;
 
-    let known_gh_accounts = but_api::github::list_known_github_accounts().await?;
-    let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts().await?;
+    let known_gh_accounts = but_api::github::list_known_github_accounts()?;
+    let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts()?;
 
     // Gather all potential accounts to delete based on the provided username (or all if no username provided)
     let mut accounts_to_delete: Vec<AccountToForget> = Vec::new();

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -359,16 +359,17 @@ pub async fn create_review(
 
 /// Make sure that the account that is about to be used in this repository's forge is correctly authenticated.
 async fn ensure_forge_authentication(ctx: &mut Context) -> Result<(), anyhow::Error> {
-    let (storage, base_branch, preferred_forge_user) = {
+    let (storage, forge_repo_info, preferred_forge_user) = {
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
-            base_branch,
+            forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
 
-    let forge_repo_info = base_branch.forge_repo_info.ok_or_else(|| {
+    let forge_repo_info = forge_repo_info.ok_or_else(|| {
         anyhow::anyhow!(
             "Unable to determine the forge for this project. Is target branch associated with a supported forge?"
         )

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -4,7 +4,6 @@ use anyhow::{Context as _, Result, anyhow};
 use but_core::worktree::checkout::UncommitedWorktreeChanges;
 use but_ctx::Context;
 use but_error::Marker;
-use but_forge::ForgeRepoInfo;
 use but_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_branch::GITBUTLER_WORKSPACE_REFERENCE;
 use gitbutler_project::FetchResult;
@@ -46,7 +45,6 @@ pub struct BaseBranch {
     pub diverged_ahead: Vec<git2::Oid>,
     #[serde(with = "but_serde::oid_vec")]
     pub diverged_behind: Vec<git2::Oid>,
-    pub forge_repo_info: Option<ForgeRepoInfo>,
 }
 
 impl BaseBranch {
@@ -362,9 +360,6 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         target.remote_url.clone()
     };
 
-    let forge_accounts = but_forge::get_all_forge_accounts()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url, &forge_accounts);
-
     let base = BaseBranch {
         branch_name: target.branch.fullname(),
         remote_name: target.branch.remote().to_string(),
@@ -386,7 +381,6 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         diverged,
         diverged_ahead,
         diverged_behind,
-        forge_repo_info,
     };
     Ok(base)
 }


### PR DESCRIPTION
Detach the forge repository information from the base branch data, since this might be expensive in the worst case scenario.

We now only get that information when needed.

Also:
- Listing of github and gitlab persisted account information is synchronous now.