### PR TITLE
cli: wire commit command to commit_create API

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,8 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::commit_insert_blank,
-    json::HexHash,
+    commit::{commit_create, commit_insert_blank},
     legacy::{diff, repo, workspace},
 };
 use but_core::{DiffSpec, ui::TreeChange};
@@ -459,18 +458,28 @@ pub(crate) fn commit(
             .ok_or_else(|| anyhow::anyhow!("No branches found in target stack"))?
     };
 
-    // Get the HEAD commit of the target branch to use as parent (preserves stacking)
-    let parent_commit_id = target_branch.tip;
-
-    // Use but-api to create the commit
-    let outcome = workspace::create_commit_from_worktree_changes(
+    // Insert relative to the branch reference itself so only that branch tip is advanced.
+    let outcome = commit_create(
         ctx,
-        target_stack_id,
-        Some(HexHash::from(parent_commit_id)),
+        but_api::commit::ui::RelativeTo::Reference(target_branch.reference.clone()),
+        InsertSide::Below,
         diff_specs,
         final_commit_message,
-        target_branch.name.to_string(),
     )?;
+
+    if !outcome.rejected_specs.is_empty() {
+        tracing::warn!(
+            ?outcome.rejected_specs,
+            "Failed to commit at least one selected change"
+        );
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "{}",
+                "Warning: Some selected changes could not be committed.".yellow()
+            )?;
+        }
+    }
 
     if let Some(out) = out.for_human() {
         let commit_short = match outcome.new_commit {

--- a/crates/but/tests/but/command/merge.rs
+++ b/crates/but/tests/but/command/merge.rs
@@ -34,7 +34,7 @@ fn merge_first_branch_into_gb_local_and_verify_rebase() -> anyhow::Result<()> {
 
     // Verify git log shows both branches before merge
     insta::assert_snapshot!(env.git_log()?, @r"
-    *   d2f5915 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    *   945f3cf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     |\  
     | * edca1cd (second-branch) second commit on branch B
     * | 549e10c (first-branch) first commit on branch A
@@ -123,7 +123,7 @@ To undo this operation:
     * e8d7818 (second-branch) second commit on branch B
     *   61888c9 (gb-local/main, gb-local/HEAD, main) Merge branch 'first-branch'
     |\  
-    | | * d2f5915 (gb-local/gitbutler/workspace) GitButler Workspace Commit
+    | | * 945f3cf (gb-local/gitbutler/workspace) GitButler Workspace Commit
     | |/| 
     |/| | 
     | | * edca1cd (gb-local/second-branch) second commit on branch B


### PR DESCRIPTION
@Caleb-T-Owens so... the semantic of the new API is every so slightly different. Take a look at the changes to the test.

The previous api (create_commit_from_worktree_changes) also carried stack_id + stack_branch_name, which scoped which branch ref gets advanced.

With commit_create, targeting a commit node can rewire incoming refs at that node, so multiple refs pointing at the same commit may move. Thats why im trying here to use RelativeTo::Reference(target_branch.reference) + InsertSide::Below: it keeps parent behavior equivalent while scoping ref movement to the selected branch reference.


Edit:

This is now based on branch-creation-2.0
