### PR TITLE
fix(resolve): Prevent submodule deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,6 +4300,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-stack",
  "gix",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -21,7 +21,12 @@ use gitbutler_repo::{RepositoryExt as _, SignaturePurpose, signature};
 use gitbutler_stack::VirtualBranchesHandle;
 use gitbutler_workspace::{
     branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree},
-    submodules::has_submodules_configured,
+    submodules::{
+        configured_submodule_paths,
+        has_submodules_configured,
+        is_submodule_related_path,
+        remove_untracked_excluding_submodule_paths,
+    },
 };
 use serde::Serialize;
 
@@ -152,62 +157,6 @@ fn get_uncommited_changes(ctx: &Context) -> Result<git2::Oid> {
     Ok(uncommited_changes)
 }
 
-fn sync_configured_submodules(repo: &git2::Repository) {
-    let Ok(mut submodules) = repo.submodules() else {
-        return;
-    };
-
-    for submodule in &mut submodules {
-        let _ = submodule.update(true, None);
-    }
-}
-
-fn configured_submodule_paths(repo: &git2::Repository) -> Vec<String> {
-    let mut paths = HashSet::new();
-
-    if let Ok(submodules) = repo.submodules() {
-        for submodule in submodules {
-            paths.insert(submodule.path().to_string_lossy().to_string());
-        }
-    }
-
-    // When only .git/modules entries exist, derive logical submodule paths from that layout.
-    let modules_root = repo.path().join("modules");
-    if modules_root.exists() {
-        let mut stack = vec![modules_root.clone()];
-        while let Some(dir) = stack.pop() {
-            let Ok(entries) = std::fs::read_dir(&dir) else {
-                continue;
-            };
-
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_dir() {
-                    continue;
-                }
-
-                if path.join("HEAD").is_file()
-                    && let Ok(relative) = path.strip_prefix(&modules_root)
-                {
-                    paths.insert(relative.to_string_lossy().to_string());
-                }
-
-                stack.push(path);
-            }
-        }
-    }
-
-    let mut output = paths.into_iter().collect::<Vec<_>>();
-    output.sort();
-    output
-}
-
-fn is_submodule_related_path(path: &str, submodule_paths: &[String]) -> bool {
-    submodule_paths
-        .iter()
-    .any(|sm| path == sm || path.strip_prefix(sm).is_some_and(|rest| rest.starts_with('/')))
-}
-
 fn collect_checkout_paths(
     repo: &git2::Repository,
     baseline: &git2::Tree,
@@ -262,15 +211,14 @@ fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
         repo.set_head(EDIT_BRANCH_REF)?;
         let mut checkout_head = CheckoutBuilder::new();
         checkout_head.force();
-        if !has_submodules {
-            checkout_head.remove_untracked(true);
-        } else {
+        if has_submodules {
             for path in &checkout_head_paths {
                 checkout_head.path(path);
             }
         }
         if !has_submodules || !checkout_head_paths.is_empty() {
             repo.checkout_head(Some(&mut checkout_head))?;
+            remove_untracked_excluding_submodule_paths(repo)?;
         }
 
         // Checkout the commit as unstaged changes
@@ -284,9 +232,7 @@ fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
         )?;
         let mut checkout_index = CheckoutBuilder::new();
         checkout_index.force().conflict_style_diff3(true);
-        if !has_submodules {
-            checkout_index.remove_untracked(true);
-        } else {
+        if has_submodules {
             for path in &checkout_index_paths {
                 checkout_index.path(path);
             }
@@ -294,11 +240,7 @@ fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
 
         if !has_submodules || !checkout_index_paths.is_empty() {
             repo.checkout_index(Some(&mut index), Some(&mut checkout_index))?;
-        }
-
-        // Keep configured submodule worktrees populated after moving into edit mode.
-        if has_submodules {
-            sync_configured_submodules(repo);
+            remove_untracked_excluding_submodule_paths(repo)?;
         }
 
         Ok(())
@@ -333,14 +275,24 @@ pub(crate) fn abort_and_return_to_workspace(
     force: bool,
     perm: &mut RepoExclusive,
 ) -> Result<()> {
-    if !force && !changes_from_initial(ctx, perm.read_permission())?.is_empty() {
+    let repo = &*ctx.git2_repo.get()?;
+    let changes = changes_from_initial(ctx, perm.read_permission())?;
+    if !force && !changes.is_empty() {
+        let submodule_paths = configured_submodule_paths(repo);
+        let has_submodule_or_gitlink_changes = changes.iter().any(|change| {
+            is_submodule_related_path(&change.path.to_str_lossy(), &submodule_paths)
+        });
+
+        if has_submodule_or_gitlink_changes {
+            bail!(
+                "The working tree differs from the original commit, including submodule or gitlink changes. A forced abort is necessary and will revert changes made during edit mode.\nIf you are seeing this message, please report it as a bug. The UI should have prevented this line getting hit."
+            );
+        }
+
         bail!(
             "The working tree differs from the original commit. A forced abort is necessary.\nIf you are seeing this message, please report it as a bug. The UI should have prevented this line getting hit."
         );
     }
-
-    let repo = &*ctx.git2_repo.get()?;
-    let has_submodules = has_submodules_configured(repo);
 
     // Checkout gitbutler workspace branch
     repo.set_head(WORKSPACE_BRANCH_REF)
@@ -351,10 +303,13 @@ pub(crate) fn abort_and_return_to_workspace(
 
     let mut checkout_tree = CheckoutBuilder::new();
     checkout_tree.force();
-    if !has_submodules {
-        checkout_tree.remove_untracked(true);
-    }
     repo.checkout_tree(uncommited_changes.as_object(), Some(&mut checkout_tree))?;
+    remove_untracked_excluding_submodule_paths(repo)?;
+
+    // Keep index in sync with HEAD after forceful checkout + cleanup.
+    let mut index = repo.index()?;
+    index.read_tree(&repo.head()?.peel_to_tree()?)?;
+    index.write()?;
 
     Ok(())
 }

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -22,9 +22,7 @@ use gitbutler_stack::VirtualBranchesHandle;
 use gitbutler_workspace::{
     branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree},
     submodules::{
-        configured_submodule_paths,
-        has_submodules_configured,
-        is_submodule_related_path,
+        configured_submodule_paths, is_submodule_related_path,
         remove_untracked_excluding_submodule_paths,
     },
 };
@@ -188,12 +186,8 @@ fn collect_checkout_paths(
 
 fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
-    let has_submodules = has_submodules_configured(repo);
-    let submodule_paths = if has_submodules {
-        configured_submodule_paths(repo)
-    } else {
-        Vec::new()
-    };
+    let submodule_paths = configured_submodule_paths(repo);
+    let preserve_submodule_worktrees = !submodule_paths.is_empty();
     let result = (|| -> Result<()> {
         let current_head_tree = repo.head()?.peel_to_tree()?;
 
@@ -211,36 +205,40 @@ fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
         repo.set_head(EDIT_BRANCH_REF)?;
         let mut checkout_head = CheckoutBuilder::new();
         checkout_head.force();
-        if has_submodules {
+        if preserve_submodule_worktrees {
             for path in &checkout_head_paths {
                 checkout_head.path(path);
             }
+        } else {
+            checkout_head.remove_untracked(true);
         }
-        if !has_submodules || !checkout_head_paths.is_empty() {
+        if !preserve_submodule_worktrees || !checkout_head_paths.is_empty() {
             repo.checkout_head(Some(&mut checkout_head))?;
-            remove_untracked_excluding_submodule_paths(repo)?;
+            if preserve_submodule_worktrees {
+                remove_untracked_excluding_submodule_paths(repo)?;
+            }
         }
 
         // Checkout the commit as unstaged changes
         let mut index = get_commit_index(ctx, &commit)?;
         let commit_tree = commit.tree()?;
-        let checkout_index_paths = collect_checkout_paths(
-            repo,
-            &commit_parent_tree,
-            &commit_tree,
-            &submodule_paths,
-        )?;
+        let checkout_index_paths =
+            collect_checkout_paths(repo, &commit_parent_tree, &commit_tree, &submodule_paths)?;
         let mut checkout_index = CheckoutBuilder::new();
         checkout_index.force().conflict_style_diff3(true);
-        if has_submodules {
+        if preserve_submodule_worktrees {
             for path in &checkout_index_paths {
                 checkout_index.path(path);
             }
+        } else {
+            checkout_index.remove_untracked(true);
         }
 
-        if !has_submodules || !checkout_index_paths.is_empty() {
+        if !preserve_submodule_worktrees || !checkout_index_paths.is_empty() {
             repo.checkout_index(Some(&mut index), Some(&mut checkout_index))?;
-            remove_untracked_excluding_submodule_paths(repo)?;
+            if preserve_submodule_worktrees {
+                remove_untracked_excluding_submodule_paths(repo)?;
+            }
         }
 
         Ok(())
@@ -276,12 +274,13 @@ pub(crate) fn abort_and_return_to_workspace(
     perm: &mut RepoExclusive,
 ) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
+    let submodule_paths = configured_submodule_paths(repo);
+    let preserve_submodule_worktrees = !submodule_paths.is_empty();
     let changes = changes_from_initial(ctx, perm.read_permission())?;
     if !force && !changes.is_empty() {
-        let submodule_paths = configured_submodule_paths(repo);
-        let has_submodule_or_gitlink_changes = changes.iter().any(|change| {
-            is_submodule_related_path(&change.path.to_str_lossy(), &submodule_paths)
-        });
+        let has_submodule_or_gitlink_changes = changes
+            .iter()
+            .any(|change| is_submodule_related_path(&change.path.to_str_lossy(), &submodule_paths));
 
         if has_submodule_or_gitlink_changes {
             bail!(
@@ -303,10 +302,15 @@ pub(crate) fn abort_and_return_to_workspace(
 
     let mut checkout_tree = CheckoutBuilder::new();
     checkout_tree.force();
+    if !preserve_submodule_worktrees {
+        checkout_tree.remove_untracked(true);
+    }
     repo.checkout_tree(uncommited_changes.as_object(), Some(&mut checkout_tree))?;
-    remove_untracked_excluding_submodule_paths(repo)?;
+    if preserve_submodule_worktrees {
+        remove_untracked_excluding_submodule_paths(repo)?;
+    }
 
-    // Keep index in sync with HEAD after forceful checkout + cleanup.
+    // Keep index in sync with HEAD after the forceful checkout.
     let mut index = repo.index()?;
     index.read_tree(&repo.head()?.peel_to_tree()?)?;
     index.write()?;

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context as _, Result, bail};
 use bstr::{BString, ByteSlice};
@@ -19,7 +19,10 @@ use gitbutler_operating_modes::{
 };
 use gitbutler_repo::{RepositoryExt as _, SignaturePurpose, signature};
 use gitbutler_stack::VirtualBranchesHandle;
-use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree};
+use gitbutler_workspace::{
+    branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree},
+    submodules::has_submodules_configured,
+};
 use serde::Serialize;
 
 pub mod commands;
@@ -149,29 +152,158 @@ fn get_uncommited_changes(ctx: &Context) -> Result<git2::Oid> {
     Ok(uncommited_changes)
 }
 
+fn sync_configured_submodules(repo: &git2::Repository) {
+    let Ok(mut submodules) = repo.submodules() else {
+        return;
+    };
+
+    for submodule in &mut submodules {
+        let _ = submodule.update(true, None);
+    }
+}
+
+fn configured_submodule_paths(repo: &git2::Repository) -> Vec<String> {
+    let mut paths = HashSet::new();
+
+    if let Ok(submodules) = repo.submodules() {
+        for submodule in submodules {
+            paths.insert(submodule.path().to_string_lossy().to_string());
+        }
+    }
+
+    // When only .git/modules entries exist, derive logical submodule paths from that layout.
+    let modules_root = repo.path().join("modules");
+    if modules_root.exists() {
+        let mut stack = vec![modules_root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+
+                if path.join("HEAD").is_file()
+                    && let Ok(relative) = path.strip_prefix(&modules_root)
+                {
+                    paths.insert(relative.to_string_lossy().to_string());
+                }
+
+                stack.push(path);
+            }
+        }
+    }
+
+    let mut output = paths.into_iter().collect::<Vec<_>>();
+    output.sort();
+    output
+}
+
+fn is_submodule_related_path(path: &str, submodule_paths: &[String]) -> bool {
+    submodule_paths
+        .iter()
+    .any(|sm| path == sm || path.strip_prefix(sm).is_some_and(|rest| rest.starts_with('/')))
+}
+
+fn collect_checkout_paths(
+    repo: &git2::Repository,
+    baseline: &git2::Tree,
+    target: &git2::Tree,
+    submodule_paths: &[String],
+) -> Result<Vec<String>> {
+    let mut paths = HashSet::new();
+    let diff = repo.diff_tree_to_tree(Some(baseline), Some(target), None)?;
+
+    for delta in diff.deltas() {
+        if let Some(path) = delta.old_file().path() {
+            let path = path.to_string_lossy().to_string();
+            if !is_submodule_related_path(&path, submodule_paths) {
+                paths.insert(path);
+            }
+        }
+        if let Some(path) = delta.new_file().path() {
+            let path = path.to_string_lossy().to_string();
+            if !is_submodule_related_path(&path, submodule_paths) {
+                paths.insert(path);
+            }
+        }
+    }
+
+    let mut output = paths.into_iter().collect::<Vec<_>>();
+    output.sort();
+    Ok(output)
+}
+
 fn checkout_edit_branch(ctx: &Context, commit: git2::Commit) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
+    let has_submodules = has_submodules_configured(repo);
+    let submodule_paths = if has_submodules {
+        configured_submodule_paths(repo)
+    } else {
+        Vec::new()
+    };
+    let result = (|| -> Result<()> {
+        let current_head_tree = repo.head()?.peel_to_tree()?;
 
-    // Checkout commits's parent
-    let commit_parent = find_or_create_base_commit(repo, &commit)?;
-    repo.reference(EDIT_BRANCH_REF, commit_parent.id(), true, "")?;
-    repo.set_head(EDIT_BRANCH_REF)?;
-    repo.checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))?;
+        // Checkout commits's parent
+        let commit_parent = find_or_create_base_commit(repo, &commit)?;
+        let commit_parent_tree = commit_parent.tree()?;
+        let checkout_head_paths = collect_checkout_paths(
+            repo,
+            &current_head_tree,
+            &commit_parent_tree,
+            &submodule_paths,
+        )?;
 
-    // Checkout the commit as unstaged changes
-    let mut index = get_commit_index(ctx, &commit)?;
+        repo.reference(EDIT_BRANCH_REF, commit_parent.id(), true, "")?;
+        repo.set_head(EDIT_BRANCH_REF)?;
+        let mut checkout_head = CheckoutBuilder::new();
+        checkout_head.force();
+        if !has_submodules {
+            checkout_head.remove_untracked(true);
+        } else {
+            for path in &checkout_head_paths {
+                checkout_head.path(path);
+            }
+        }
+        if !has_submodules || !checkout_head_paths.is_empty() {
+            repo.checkout_head(Some(&mut checkout_head))?;
+        }
 
-    repo.checkout_index(
-        Some(&mut index),
-        Some(
-            CheckoutBuilder::new()
-                .force()
-                .remove_untracked(true)
-                .conflict_style_diff3(true),
-        ),
-    )?;
+        // Checkout the commit as unstaged changes
+        let mut index = get_commit_index(ctx, &commit)?;
+        let commit_tree = commit.tree()?;
+        let checkout_index_paths = collect_checkout_paths(
+            repo,
+            &commit_parent_tree,
+            &commit_tree,
+            &submodule_paths,
+        )?;
+        let mut checkout_index = CheckoutBuilder::new();
+        checkout_index.force().conflict_style_diff3(true);
+        if !has_submodules {
+            checkout_index.remove_untracked(true);
+        } else {
+            for path in &checkout_index_paths {
+                checkout_index.path(path);
+            }
+        }
 
-    Ok(())
+        if !has_submodules || !checkout_index_paths.is_empty() {
+            repo.checkout_index(Some(&mut index), Some(&mut checkout_index))?;
+        }
+
+        // Keep configured submodule worktrees populated after moving into edit mode.
+        if has_submodules {
+            sync_configured_submodules(repo);
+        }
+
+        Ok(())
+    })();
+    result
 }
 
 pub(crate) fn enter_edit_mode(
@@ -208,6 +340,7 @@ pub(crate) fn abort_and_return_to_workspace(
     }
 
     let repo = &*ctx.git2_repo.get()?;
+    let has_submodules = has_submodules_configured(repo);
 
     // Checkout gitbutler workspace branch
     repo.set_head(WORKSPACE_BRANCH_REF)
@@ -216,10 +349,12 @@ pub(crate) fn abort_and_return_to_workspace(
     let uncommited_changes = get_uncommited_changes(ctx)?;
     let uncommited_changes = repo.find_tree(uncommited_changes)?;
 
-    repo.checkout_tree(
-        uncommited_changes.as_object(),
-        Some(CheckoutBuilder::new().force().remove_untracked(true)),
-    )?;
+    let mut checkout_tree = CheckoutBuilder::new();
+    checkout_tree.force();
+    if !has_submodules {
+        checkout_tree.remove_untracked(true);
+    }
+    repo.checkout_tree(uncommited_changes.as_object(), Some(&mut checkout_tree))?;
 
     Ok(())
 }

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -6,10 +6,25 @@ use gitbutler_edit_mode::commands::{
 };
 use gitbutler_operating_modes::{EDIT_BRANCH_REF, WORKSPACE_BRANCH_REF};
 use gitbutler_stack::VirtualBranchesHandle;
+use std::process::Command;
 use tempfile::TempDir;
 
 fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
     gitbutler_testsupport::writable::fixture("edit_mode.sh", folder)
+}
+
+fn run_git(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git").args(args).current_dir(cwd).output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git command failed in {}: git {}\nstderr: {}",
+            cwd.display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 // Fixture:
@@ -86,6 +101,8 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     drop(repo);
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
+    let untracked_path = worktree_dir.join("new-untracked-during-edit-mode.txt");
+    std::fs::write(&untracked_path, "temporary file\n")?;
 
     let result = abort_and_return_to_workspace(&mut ctx, false);
     assert!(result.is_err());
@@ -100,6 +117,10 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     assert_eq!(
         ctx.git2_repo.get()?.head()?.name(),
         Some(WORKSPACE_BRANCH_REF)
+    );
+    assert!(
+        !untracked_path.exists(),
+        "forced abort should clean untracked files in non-submodule repos"
     );
 
     Ok(())
@@ -136,3 +157,110 @@ fn save_and_return_to_workspace_preserves_submodule_worktree() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn abort_preserves_preexisting_dirty_and_diverged_submodule_state() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (foobar, worktree_dir) = {
+        let repo = ctx.git2_repo.get()?;
+        let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
+        (foobar, repo.path().parent().unwrap().to_path_buf())
+    };
+    let submodule_dir = worktree_dir.join("submodules/test-module");
+
+    run_git(
+        &submodule_dir,
+        &["config", "user.name", "Submodule Author"],
+    )?;
+    run_git(
+        &submodule_dir,
+        &["config", "user.email", "submodule@example.com"],
+    )?;
+    std::fs::write(submodule_dir.join("diverged.txt"), "diverged commit\n")?;
+    run_git(&submodule_dir, &["add", "diverged.txt"])?;
+    run_git(&submodule_dir, &["commit", "-m", "local diverged commit"])?;
+
+    std::fs::write(submodule_dir.join("dirty.txt"), "dirty worktree change\n")?;
+
+    let baseline_submodule_head = run_git(&submodule_dir, &["rev-parse", "HEAD"])?;
+    let baseline_submodule_status = run_git(&submodule_dir, &["status", "--porcelain"])?;
+    let baseline_superproject_submodule_status =
+        run_git(&worktree_dir, &["status", "--porcelain", "submodules/test-module"])?;
+
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks = vb_state.list_stacks_in_workspace()?;
+    let stack = stacks.first().unwrap();
+
+    enter_edit_mode(&mut ctx, foobar, stack.id)?;
+    abort_and_return_to_workspace(&mut ctx, true)?;
+
+    let final_submodule_head = run_git(&submodule_dir, &["rev-parse", "HEAD"])?;
+    let final_submodule_status = run_git(&submodule_dir, &["status", "--porcelain"])?;
+    let final_superproject_submodule_status =
+        run_git(&worktree_dir, &["status", "--porcelain", "submodules/test-module"])?;
+
+    assert_eq!(
+        final_submodule_head, baseline_submodule_head,
+        "abort should preserve pre-existing submodule commit divergence"
+    );
+    assert_eq!(
+        final_submodule_status, baseline_submodule_status,
+        "abort should preserve pre-existing dirty submodule working tree state"
+    );
+    assert_eq!(
+        final_superproject_submodule_status, baseline_superproject_submodule_status,
+        "abort should restore the same superproject-visible submodule state"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn abort_requires_force_warns_about_submodule_and_gitlink_reversion() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (foobar, worktree_dir) = {
+        let repo = ctx.git2_repo.get()?;
+        let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
+        (foobar, repo.path().parent().unwrap().to_path_buf())
+    };
+    let submodule_dir = worktree_dir.join("submodules/test-module");
+
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks = vb_state.list_stacks_in_workspace()?;
+    let stack = stacks.first().unwrap();
+
+    enter_edit_mode(&mut ctx, foobar, stack.id)?;
+
+    run_git(
+        &submodule_dir,
+        &["config", "user.name", "Submodule Author"],
+    )?;
+    run_git(
+        &submodule_dir,
+        &["config", "user.email", "submodule@example.com"],
+    )?;
+    std::fs::write(
+        submodule_dir.join("during-edit-mode-gitlink-change.txt"),
+        "changed during edit mode\n",
+    )?;
+    run_git(&submodule_dir, &["add", "during-edit-mode-gitlink-change.txt"])?;
+    run_git(&submodule_dir, &["commit", "-m", "gitlink change during edit mode"])?;
+
+    // Stage the submodule entry so superproject tree diff includes the gitlink change.
+    run_git(&worktree_dir, &["add", "submodules/test-module"])?;
+
+    let result = abort_and_return_to_workspace(&mut ctx, false);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("including submodule or gitlink changes"),
+        "expected submodule/gitlink warning in abort error, got: {err}"
+    );
+    assert!(
+        err.contains("will revert changes made during edit mode"),
+        "expected explicit reversion warning in abort error, got: {err}"
+    );
+
+    Ok(())
+}
+

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -25,7 +25,6 @@ fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
 fn conficted_entries_get_written_when_leaving_edit_mode() -> Result<()> {
     let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;
     let repo = ctx.git2_repo.get()?;
-
     let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
@@ -101,6 +100,38 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     assert_eq!(
         ctx.git2_repo.get()?.head()?.name(),
         Some(WORKSPACE_BRANCH_REF)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn save_and_return_to_workspace_preserves_submodule_worktree() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (foobar, worktree_dir) = {
+        let repo = ctx.git2_repo.get()?;
+        let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
+        (foobar, repo.path().parent().unwrap().to_path_buf())
+    };
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks = vb_state.list_stacks_in_workspace()?;
+    let stack = stacks.first().unwrap();
+    let submodule_probe = worktree_dir.join("submodules/test-module/probe.txt");
+    assert!(
+        submodule_probe.exists(),
+        "fixture should start with populated submodule worktree"
+    );
+
+    enter_edit_mode(&mut ctx, foobar, stack.id)?;
+    assert!(
+        submodule_probe.exists(),
+        "submodule file should remain after entering edit mode"
+    );
+    save_and_return_to_workspace(&mut ctx)?;
+
+    assert!(
+        submodule_probe.exists(),
+        "submodule file should remain after leaving edit mode"
     );
 
     Ok(())

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -6,25 +6,11 @@ use gitbutler_edit_mode::commands::{
 };
 use gitbutler_operating_modes::{EDIT_BRANCH_REF, WORKSPACE_BRANCH_REF};
 use gitbutler_stack::VirtualBranchesHandle;
-use std::process::Command;
+use gitbutler_testsupport::run_git_at_dir;
 use tempfile::TempDir;
 
 fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
     gitbutler_testsupport::writable::fixture("edit_mode.sh", folder)
-}
-
-fn run_git(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git").args(args).current_dir(cwd).output()?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "git command failed in {}: git {}\nstderr: {}",
-            cwd.display(),
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 // Fixture:
@@ -128,7 +114,8 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
 
 #[test]
 fn save_and_return_to_workspace_preserves_submodule_worktree() -> Result<()> {
-    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (mut ctx, _tempdir) =
+        command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
     let (foobar, worktree_dir) = {
         let repo = ctx.git2_repo.get()?;
         let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
@@ -160,7 +147,8 @@ fn save_and_return_to_workspace_preserves_submodule_worktree() -> Result<()> {
 
 #[test]
 fn abort_preserves_preexisting_dirty_and_diverged_submodule_state() -> Result<()> {
-    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (mut ctx, _tempdir) =
+        command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
     let (foobar, worktree_dir) = {
         let repo = ctx.git2_repo.get()?;
         let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
@@ -168,24 +156,23 @@ fn abort_preserves_preexisting_dirty_and_diverged_submodule_state() -> Result<()
     };
     let submodule_dir = worktree_dir.join("submodules/test-module");
 
-    run_git(
-        &submodule_dir,
-        &["config", "user.name", "Submodule Author"],
-    )?;
-    run_git(
+    run_git_at_dir(&submodule_dir, &["config", "user.name", "Submodule Author"])?;
+    run_git_at_dir(
         &submodule_dir,
         &["config", "user.email", "submodule@example.com"],
     )?;
     std::fs::write(submodule_dir.join("diverged.txt"), "diverged commit\n")?;
-    run_git(&submodule_dir, &["add", "diverged.txt"])?;
-    run_git(&submodule_dir, &["commit", "-m", "local diverged commit"])?;
+    run_git_at_dir(&submodule_dir, &["add", "diverged.txt"])?;
+    run_git_at_dir(&submodule_dir, &["commit", "-m", "local diverged commit"])?;
 
     std::fs::write(submodule_dir.join("dirty.txt"), "dirty worktree change\n")?;
 
-    let baseline_submodule_head = run_git(&submodule_dir, &["rev-parse", "HEAD"])?;
-    let baseline_submodule_status = run_git(&submodule_dir, &["status", "--porcelain"])?;
-    let baseline_superproject_submodule_status =
-        run_git(&worktree_dir, &["status", "--porcelain", "submodules/test-module"])?;
+    let baseline_submodule_head = run_git_at_dir(&submodule_dir, &["rev-parse", "HEAD"])?;
+    let baseline_submodule_status = run_git_at_dir(&submodule_dir, &["status", "--porcelain"])?;
+    let baseline_superproject_submodule_status = run_git_at_dir(
+        &worktree_dir,
+        &["status", "--porcelain", "submodules/test-module"],
+    )?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     let stacks = vb_state.list_stacks_in_workspace()?;
@@ -194,10 +181,12 @@ fn abort_preserves_preexisting_dirty_and_diverged_submodule_state() -> Result<()
     enter_edit_mode(&mut ctx, foobar, stack.id)?;
     abort_and_return_to_workspace(&mut ctx, true)?;
 
-    let final_submodule_head = run_git(&submodule_dir, &["rev-parse", "HEAD"])?;
-    let final_submodule_status = run_git(&submodule_dir, &["status", "--porcelain"])?;
-    let final_superproject_submodule_status =
-        run_git(&worktree_dir, &["status", "--porcelain", "submodules/test-module"])?;
+    let final_submodule_head = run_git_at_dir(&submodule_dir, &["rev-parse", "HEAD"])?;
+    let final_submodule_status = run_git_at_dir(&submodule_dir, &["status", "--porcelain"])?;
+    let final_superproject_submodule_status = run_git_at_dir(
+        &worktree_dir,
+        &["status", "--porcelain", "submodules/test-module"],
+    )?;
 
     assert_eq!(
         final_submodule_head, baseline_submodule_head,
@@ -217,7 +206,8 @@ fn abort_preserves_preexisting_dirty_and_diverged_submodule_state() -> Result<()
 
 #[test]
 fn abort_requires_force_warns_about_submodule_and_gitlink_reversion() -> Result<()> {
-    let (mut ctx, _tempdir) = command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
+    let (mut ctx, _tempdir) =
+        command_ctx("save_and_return_to_workspace_preserves_submodule_worktree")?;
     let (foobar, worktree_dir) = {
         let repo = ctx.git2_repo.get()?;
         let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
@@ -231,11 +221,8 @@ fn abort_requires_force_warns_about_submodule_and_gitlink_reversion() -> Result<
 
     enter_edit_mode(&mut ctx, foobar, stack.id)?;
 
-    run_git(
-        &submodule_dir,
-        &["config", "user.name", "Submodule Author"],
-    )?;
-    run_git(
+    run_git_at_dir(&submodule_dir, &["config", "user.name", "Submodule Author"])?;
+    run_git_at_dir(
         &submodule_dir,
         &["config", "user.email", "submodule@example.com"],
     )?;
@@ -243,11 +230,17 @@ fn abort_requires_force_warns_about_submodule_and_gitlink_reversion() -> Result<
         submodule_dir.join("during-edit-mode-gitlink-change.txt"),
         "changed during edit mode\n",
     )?;
-    run_git(&submodule_dir, &["add", "during-edit-mode-gitlink-change.txt"])?;
-    run_git(&submodule_dir, &["commit", "-m", "gitlink change during edit mode"])?;
+    run_git_at_dir(
+        &submodule_dir,
+        &["add", "during-edit-mode-gitlink-change.txt"],
+    )?;
+    run_git_at_dir(
+        &submodule_dir,
+        &["commit", "-m", "gitlink change during edit mode"],
+    )?;
 
     // Stage the submodule entry so superproject tree diff includes the gitlink change.
-    run_git(&worktree_dir, &["add", "submodules/test-module"])?;
+    run_git_at_dir(&worktree_dir, &["add", "submodules/test-module"])?;
 
     let result = abort_and_return_to_workspace(&mut ctx, false);
     assert!(result.is_err());
@@ -263,4 +256,3 @@ fn abort_requires_force_warns_about_submodule_and_gitlink_reversion() -> Result<
 
     Ok(())
 }
-

--- a/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
+++ b/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
@@ -38,3 +38,22 @@ git clone repo conficted_entries_get_written_when_leaving_edit_mode
   $CLI branches create --set-default branchy
   $CLI branches commit  branchy --message foobar
 )
+
+git init submodule-source
+(cd submodule-source
+  git config user.name "Author"
+  git config user.email "author@example.com"
+  echo "probe" > probe.txt
+  git add . && git commit -m "init submodule"
+)
+
+git clone repo save_and_return_to_workspace_preserves_submodule_worktree
+(cd save_and_return_to_workspace_preserves_submodule_worktree
+  git config user.name "Author"
+  git config user.email "author@example.com"
+  git -c protocol.file.allow=always submodule add ../submodule-source submodules/test-module
+  git add . && git commit -m "add submodule"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name origin/main)"
+  $CLI branches create --set-default branchy
+  $CLI branches commit branchy --message foobar
+)

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -71,6 +71,24 @@ pub fn init_opts_bare() -> git2::RepositoryInitOptions {
     opts
 }
 
+/// Run `git` in `dir`, returning trimmed stdout on success.
+pub fn run_git_at_dir(dir: impl AsRef<std::path::Path>, args: &[&str]) -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir.as_ref())
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git command failed in {}: git {}\nstderr: {}",
+            dir.as_ref().display(),
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 pub mod writable {
     use but_ctx::Context;
     use but_settings::AppSettings;

--- a/crates/gitbutler-workspace/Cargo.toml
+++ b/crates/gitbutler-workspace/Cargo.toml
@@ -23,5 +23,8 @@ anyhow.workspace = true
 gix.workspace = true
 git2.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -8,7 +8,11 @@ use gitbutler_cherry_pick::RepositoryExt;
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_stack::VirtualBranchesHandle;
 
-use crate::{submodules::has_submodules_configured, workspace_base, workspace_base_from_heads};
+use crate::{
+    submodules::remove_untracked_excluding_submodule_paths,
+    workspace_base,
+    workspace_base_from_heads,
+};
 
 /// A snapshot of the workspace at a point in time.
 #[derive(Debug)]
@@ -97,7 +101,6 @@ pub fn update_uncommitted_changes_with_tree(
     _perm: &mut RepoExclusive,
 ) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
-    let has_submodules = has_submodules_configured(repo);
 
     if let Some(worktree_id) = old_uncommitted_changes {
         let mut new_uncommitted_changes =
@@ -113,13 +116,9 @@ pub fn update_uncommitted_changes_with_tree(
 
         let mut checkout = git2::build::CheckoutBuilder::new();
         checkout.force().conflict_style_diff3(true);
-        // Submodule worktrees can be deleted by aggressive untracked cleanup.
-        // Keep that cleanup only for repos without configured submodules.
-        if !has_submodules {
-            checkout.remove_untracked(true);
-        }
 
         repo.checkout_index(Some(&mut new_uncommitted_changes), Some(&mut checkout))?;
+        remove_untracked_excluding_submodule_paths(repo)?;
     } else {
         let old_tree_id = merge_workspace(repo, old)?.to_gix();
         let new_tree_id = merge_workspace(repo, new)?.to_gix();

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -8,7 +8,7 @@ use gitbutler_cherry_pick::RepositoryExt;
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_stack::VirtualBranchesHandle;
 
-use crate::{workspace_base, workspace_base_from_heads};
+use crate::{submodules::has_submodules_configured, workspace_base, workspace_base_from_heads};
 
 /// A snapshot of the workspace at a point in time.
 #[derive(Debug)]
@@ -97,6 +97,8 @@ pub fn update_uncommitted_changes_with_tree(
     _perm: &mut RepoExclusive,
 ) -> Result<()> {
     let repo = &*ctx.git2_repo.get()?;
+    let has_submodules = has_submodules_configured(repo);
+
     if let Some(worktree_id) = old_uncommitted_changes {
         let mut new_uncommitted_changes =
             move_tree_between_workspaces(repo, worktree_id, old, new)?;
@@ -109,15 +111,15 @@ pub fn update_uncommitted_changes_with_tree(
             }
         }
 
-        repo.checkout_index(
-            Some(&mut new_uncommitted_changes),
-            Some(
-                git2::build::CheckoutBuilder::new()
-                    .force()
-                    .remove_untracked(true)
-                    .conflict_style_diff3(true),
-            ),
-        )?;
+        let mut checkout = git2::build::CheckoutBuilder::new();
+        checkout.force().conflict_style_diff3(true);
+        // Submodule worktrees can be deleted by aggressive untracked cleanup.
+        // Keep that cleanup only for repos without configured submodules.
+        if !has_submodules {
+            checkout.remove_untracked(true);
+        }
+
+        repo.checkout_index(Some(&mut new_uncommitted_changes), Some(&mut checkout))?;
     } else {
         let old_tree_id = merge_workspace(repo, old)?.to_gix();
         let new_tree_id = merge_workspace(repo, new)?.to_gix();

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -9,9 +9,8 @@ use gitbutler_repo::RepositoryExt as _;
 use gitbutler_stack::VirtualBranchesHandle;
 
 use crate::{
-    submodules::remove_untracked_excluding_submodule_paths,
-    workspace_base,
-    workspace_base_from_heads,
+    submodules::{configured_submodule_paths, remove_untracked_excluding_submodule_paths},
+    workspace_base, workspace_base_from_heads,
 };
 
 /// A snapshot of the workspace at a point in time.
@@ -105,6 +104,7 @@ pub fn update_uncommitted_changes_with_tree(
     if let Some(worktree_id) = old_uncommitted_changes {
         let mut new_uncommitted_changes =
             move_tree_between_workspaces(repo, worktree_id, old, new)?;
+        let submodule_paths = configured_submodule_paths(repo);
 
         // If the new tree and old tree are the same, then we don't need to do anything
         if !new_uncommitted_changes.has_conflicts() && !always_checkout.unwrap_or(false) {
@@ -116,9 +116,14 @@ pub fn update_uncommitted_changes_with_tree(
 
         let mut checkout = git2::build::CheckoutBuilder::new();
         checkout.force().conflict_style_diff3(true);
+        if submodule_paths.is_empty() {
+            checkout.remove_untracked(true);
+        }
 
         repo.checkout_index(Some(&mut new_uncommitted_changes), Some(&mut checkout))?;
-        remove_untracked_excluding_submodule_paths(repo)?;
+        if !submodule_paths.is_empty() {
+            remove_untracked_excluding_submodule_paths(repo)?;
+        }
     } else {
         let old_tree_id = merge_workspace(repo, old)?.to_gix();
         let new_tree_id = merge_workspace(repo, new)?.to_gix();

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod branch_trees;
+pub mod submodules;
 
 use anyhow::Result;
 use but_ctx::{Context, access::RepoShared};

--- a/crates/gitbutler-workspace/src/submodules.rs
+++ b/crates/gitbutler-workspace/src/submodules.rs
@@ -1,3 +1,7 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+
 pub fn has_submodules_configured(repo: &git2::Repository) -> bool {
     if repo
         .workdir()
@@ -10,6 +14,8 @@ pub fn has_submodules_configured(repo: &git2::Repository) -> bool {
         return false;
     };
 
+    // `repo.path()` points to the repository git-dir (for non-bare repos: `.git`),
+    // so this checks `.git/modules` rather than a `modules` folder in the worktree root.
     let modules_dir_has_entries = repo
         .path()
         .join("modules")
@@ -22,4 +28,189 @@ pub fn has_submodules_configured(repo: &git2::Repository) -> bool {
     };
 
     entries.next().transpose().ok().flatten().is_some() || modules_dir_has_entries
+}
+
+pub fn configured_submodule_paths(repo: &git2::Repository) -> Vec<String> {
+    let mut paths = HashSet::new();
+
+    if let Ok(submodules) = repo.submodules() {
+        for submodule in submodules {
+            paths.insert(submodule.path().to_string_lossy().to_string());
+        }
+    }
+
+    let modules_root = repo.path().join("modules");
+    if modules_root.exists() {
+        let mut stack = vec![modules_root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+
+                if path.join("HEAD").is_file()
+                    && let Ok(relative) = path.strip_prefix(&modules_root)
+                {
+                    paths.insert(relative.to_string_lossy().to_string());
+                }
+
+                stack.push(path);
+            }
+        }
+    }
+
+    let mut output = paths.into_iter().collect::<Vec<_>>();
+    output.sort();
+    output
+}
+
+pub fn is_submodule_related_path(path: &str, submodule_paths: &[String]) -> bool {
+    submodule_paths
+        .iter()
+        .any(|sm| path == sm || path.strip_prefix(sm).is_some_and(|rest| rest.starts_with('/')))
+}
+
+pub fn remove_untracked_excluding_submodule_paths(repo: &git2::Repository) -> Result<()> {
+    let Some(workdir) = repo.workdir() else {
+        return Ok(());
+    };
+
+    let submodule_paths = configured_submodule_paths(repo);
+    let mut status_opts = git2::StatusOptions::new();
+    status_opts
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false)
+        .include_unmodified(false)
+        .exclude_submodules(true);
+
+    let statuses = repo.statuses(Some(&mut status_opts))?;
+    for status_entry in statuses.iter() {
+        if !status_entry.status().contains(git2::Status::WT_NEW) {
+            continue;
+        }
+        let Some(path) = status_entry.path() else {
+            continue;
+        };
+        if is_submodule_related_path(path, &submodule_paths) {
+            continue;
+        }
+
+        let absolute = workdir.join(path);
+        if absolute.is_dir() {
+            let _ = std::fs::remove_dir_all(&absolute);
+        } else {
+            let _ = std::fs::remove_file(&absolute);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::{
+        has_submodules_configured, remove_untracked_excluding_submodule_paths,
+    };
+
+    fn init_repo() -> (TempDir, git2::Repository) {
+        let tempdir = TempDir::new().expect("tempdir should be created");
+        let repo = git2::Repository::init(tempdir.path()).expect("repo should be initialized");
+        (tempdir, repo)
+    }
+
+    #[test]
+    fn detects_submodules_from_gitmodules_file() {
+        let (_tempdir, repo) = init_repo();
+        let workdir = repo.workdir().expect("non-bare repository");
+        fs::write(workdir.join(".gitmodules"), "[submodule \"example\"]\n")
+            .expect(".gitmodules should be created");
+
+        assert!(has_submodules_configured(&repo));
+    }
+
+    #[test]
+    fn detects_submodules_from_config_entries() {
+        let (_tempdir, repo) = init_repo();
+        {
+            let mut config = repo.config().expect("repo config should open");
+            config
+                .set_str("submodule.example.url", "https://example.com/example.git")
+                .expect("submodule config should be written");
+        }
+
+        assert!(has_submodules_configured(&repo));
+    }
+
+    #[test]
+    fn detects_submodules_from_git_modules_directory_entries() {
+        let (_tempdir, repo) = init_repo();
+        fs::create_dir_all(repo.path().join("modules").join("example"))
+            .expect("modules dir should be created");
+
+        assert!(has_submodules_configured(&repo));
+    }
+
+    #[test]
+    fn uses_modules_directory_fallback_when_config_entries_cannot_be_read() {
+        let (_tempdir, repo) = init_repo();
+        fs::create_dir_all(repo.path().join("modules").join("example"))
+            .expect("modules dir should be created");
+        fs::write(repo.path().join("config"), "[core\n")
+            .expect("config file should be made invalid");
+
+        assert!(has_submodules_configured(&repo));
+    }
+
+    #[test]
+    fn returns_false_when_no_submodule_signals_exist() {
+        let (_tempdir, repo) = init_repo();
+
+        assert!(!has_submodules_configured(&repo));
+    }
+
+    #[test]
+    fn cleanup_removes_non_submodule_untracked_files() {
+        let (_tempdir, repo) = init_repo();
+        let workdir = repo.workdir().expect("non-bare repository");
+        let untracked = workdir.join("tmp-untracked.txt");
+        fs::write(&untracked, "tmp").expect("untracked file should be created");
+
+        remove_untracked_excluding_submodule_paths(&repo)
+            .expect("cleanup should succeed");
+
+        assert!(!untracked.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_submodule_untracked_files() {
+        let (_tempdir, repo) = init_repo();
+        let workdir = repo.workdir().expect("non-bare repository");
+        let modules_repo_path = repo.path().join("modules").join("submodules").join("test-module");
+        fs::create_dir_all(&modules_repo_path).expect("modules path should be created");
+        fs::write(modules_repo_path.join("HEAD"), "ref: refs/heads/main\n")
+            .expect("head marker should be created");
+
+        let submodule_file = workdir
+            .join("submodules")
+            .join("test-module")
+            .join("probe.txt");
+        fs::create_dir_all(submodule_file.parent().expect("submodule parent"))
+            .expect("submodule worktree path should be created");
+        fs::write(&submodule_file, "probe").expect("submodule probe should be created");
+
+        remove_untracked_excluding_submodule_paths(&repo)
+            .expect("cleanup should succeed");
+
+        assert!(submodule_file.exists());
+    }
 }

--- a/crates/gitbutler-workspace/src/submodules.rs
+++ b/crates/gitbutler-workspace/src/submodules.rs
@@ -2,79 +2,102 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
-pub fn has_submodules_configured(repo: &git2::Repository) -> bool {
-    if repo
-        .workdir()
-        .is_some_and(|workdir| workdir.join(".gitmodules").exists())
-    {
-        return true;
-    }
-
-    let Ok(config) = repo.config() else {
-        return false;
-    };
-
-    // `repo.path()` points to the repository git-dir (for non-bare repos: `.git`),
-    // so this checks `.git/modules` rather than a `modules` folder in the worktree root.
-    let modules_dir_has_entries = repo
-        .path()
-        .join("modules")
-        .read_dir()
-        .map(|mut it| it.next().is_some())
-        .unwrap_or(false);
-
-    let Ok(mut entries) = config.entries(Some("submodule\\..*\\.url")) else {
-        return modules_dir_has_entries;
-    };
-
-    entries.next().transpose().ok().flatten().is_some() || modules_dir_has_entries
-}
-
 pub fn configured_submodule_paths(repo: &git2::Repository) -> Vec<String> {
     let mut paths = HashSet::new();
 
-    if let Ok(submodules) = repo.submodules() {
-        for submodule in submodules {
-            paths.insert(submodule.path().to_string_lossy().to_string());
-        }
-    }
-
-    let modules_root = repo.path().join("modules");
-    if modules_root.exists() {
-        let mut stack = vec![modules_root.clone()];
-        while let Some(dir) = stack.pop() {
-            let Ok(entries) = std::fs::read_dir(&dir) else {
-                continue;
-            };
-
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_dir() {
-                    continue;
-                }
-
-                if path.join("HEAD").is_file()
-                    && let Ok(relative) = path.strip_prefix(&modules_root)
-                {
-                    paths.insert(relative.to_string_lossy().to_string());
-                }
-
-                stack.push(path);
-            }
-        }
-    }
+    collect_submodule_paths_from_repository(repo, &mut paths);
+    collect_submodule_paths_from_gitmodules(repo, &mut paths);
+    collect_submodule_paths_from_modules_dir(repo, &mut paths);
 
     let mut output = paths.into_iter().collect::<Vec<_>>();
     output.sort();
     output
 }
 
-pub fn is_submodule_related_path(path: &str, submodule_paths: &[String]) -> bool {
-    submodule_paths
-        .iter()
-        .any(|sm| path == sm || path.strip_prefix(sm).is_some_and(|rest| rest.starts_with('/')))
+fn collect_submodule_paths_from_repository(repo: &git2::Repository, paths: &mut HashSet<String>) {
+    if let Ok(submodules) = repo.submodules() {
+        for submodule in submodules {
+            paths.insert(submodule.path().to_string_lossy().to_string());
+        }
+    }
 }
 
+fn collect_submodule_paths_from_gitmodules(repo: &git2::Repository, paths: &mut HashSet<String>) {
+    let Some(workdir) = repo.workdir() else {
+        return;
+    };
+
+    let gitmodules = workdir.join(".gitmodules");
+    if !gitmodules.is_file() {
+        return;
+    }
+
+    let Ok(config) = git2::Config::open(&gitmodules) else {
+        return;
+    };
+    let Ok(mut entries) = config.entries(Some("submodule\\..*\\.path")) else {
+        return;
+    };
+
+    while let Some(entry) = entries.next() {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Some(path) = entry.value() else {
+            continue;
+        };
+        if !path.is_empty() {
+            paths.insert(path.to_owned());
+        }
+    }
+}
+
+fn collect_submodule_paths_from_modules_dir(repo: &git2::Repository, paths: &mut HashSet<String>) {
+    let modules_root = repo.path().join("modules");
+    if !modules_root.exists() {
+        return;
+    }
+
+    let mut stack = vec![modules_root.clone()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            if path.join("HEAD").is_file()
+                && let Ok(relative) = path.strip_prefix(&modules_root)
+            {
+                paths.insert(relative.to_string_lossy().to_string());
+            }
+
+            stack.push(path);
+        }
+    }
+}
+
+pub fn is_submodule_related_path(path: &str, submodule_paths: &[String]) -> bool {
+    submodule_paths.iter().any(|sm| {
+        path == sm
+            || path
+                .strip_prefix(sm)
+                .is_some_and(|rest| rest.starts_with('/'))
+    })
+}
+
+/// libgit2's checkout cleanup can't express "remove unrelated untracked files while preserving
+/// populated submodule worktrees":
+/// - an unrestricted `remove_untracked(true)` deletes the populated submodule worktree
+/// - a path-limited `remove_untracked(true)` preserves the submodule, but also leaves unrelated
+///   untracked files behind
+///
+/// When concrete submodule paths exist we therefore perform the checkout without libgit2 cleanup
+/// and prune only the non-submodule untracked paths afterwards.
 pub fn remove_untracked_excluding_submodule_paths(repo: &git2::Repository) -> Result<()> {
     let Some(workdir) = repo.workdir() else {
         return Ok(());
@@ -115,12 +138,12 @@ pub fn remove_untracked_excluding_submodule_paths(repo: &git2::Repository) -> Re
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
+    use git2::build::CheckoutBuilder;
     use tempfile::TempDir;
 
-    use super::{
-        has_submodules_configured, remove_untracked_excluding_submodule_paths,
-    };
+    use super::{configured_submodule_paths, remove_untracked_excluding_submodule_paths};
 
     fn init_repo() -> (TempDir, git2::Repository) {
         let tempdir = TempDir::new().expect("tempdir should be created");
@@ -129,53 +152,94 @@ mod tests {
     }
 
     #[test]
-    fn detects_submodules_from_gitmodules_file() {
+    fn configured_paths_include_gitmodules_entries() {
         let (_tempdir, repo) = init_repo();
         let workdir = repo.workdir().expect("non-bare repository");
-        fs::write(workdir.join(".gitmodules"), "[submodule \"example\"]\n")
-            .expect(".gitmodules should be created");
+        fs::write(
+            workdir.join(".gitmodules"),
+            "[submodule \"example\"]\n\tpath = example\n\turl = https://example.com/example.git\n",
+        )
+        .expect(".gitmodules should be created");
 
-        assert!(has_submodules_configured(&repo));
+        assert_eq!(configured_submodule_paths(&repo), vec!["example"]);
     }
 
     #[test]
-    fn detects_submodules_from_config_entries() {
+    fn configured_paths_include_modules_directory_entries() {
         let (_tempdir, repo) = init_repo();
-        {
-            let mut config = repo.config().expect("repo config should open");
-            config
-                .set_str("submodule.example.url", "https://example.com/example.git")
-                .expect("submodule config should be written");
-        }
+        fs::create_dir_all(
+            repo.path()
+                .join("modules")
+                .join("submodules")
+                .join("test-module"),
+        )
+        .expect("modules dir should be created");
+        fs::write(
+            repo.path()
+                .join("modules")
+                .join("submodules")
+                .join("test-module")
+                .join("HEAD"),
+            "ref: refs/heads/main\n",
+        )
+        .expect("head marker should be created");
 
-        assert!(has_submodules_configured(&repo));
+        assert_eq!(
+            configured_submodule_paths(&repo),
+            vec!["submodules/test-module"]
+        );
     }
 
     #[test]
-    fn detects_submodules_from_git_modules_directory_entries() {
+    fn configured_paths_use_modules_directory_when_gitmodules_is_invalid() {
         let (_tempdir, repo) = init_repo();
-        fs::create_dir_all(repo.path().join("modules").join("example"))
-            .expect("modules dir should be created");
+        let workdir = repo.workdir().expect("non-bare repository");
+        fs::write(workdir.join(".gitmodules"), "[submodule\n")
+            .expect("gitmodules file should be made invalid");
+        fs::create_dir_all(
+            repo.path()
+                .join("modules")
+                .join("submodules")
+                .join("test-module"),
+        )
+        .expect("modules dir should be created");
+        fs::write(
+            repo.path()
+                .join("modules")
+                .join("submodules")
+                .join("test-module")
+                .join("HEAD"),
+            "ref: refs/heads/main\n",
+        )
+        .expect("head marker should be created");
 
-        assert!(has_submodules_configured(&repo));
+        assert_eq!(
+            configured_submodule_paths(&repo),
+            vec!["submodules/test-module"]
+        );
     }
 
     #[test]
-    fn uses_modules_directory_fallback_when_config_entries_cannot_be_read() {
+    fn configured_paths_return_empty_when_no_submodule_signals_exist() {
         let (_tempdir, repo) = init_repo();
-        fs::create_dir_all(repo.path().join("modules").join("example"))
-            .expect("modules dir should be created");
-        fs::write(repo.path().join("config"), "[core\n")
-            .expect("config file should be made invalid");
 
-        assert!(has_submodules_configured(&repo));
+        assert!(configured_submodule_paths(&repo).is_empty());
     }
 
-    #[test]
-    fn returns_false_when_no_submodule_signals_exist() {
-        let (_tempdir, repo) = init_repo();
-
-        assert!(!has_submodules_configured(&repo));
+    fn commit_tracked_file(repo: &git2::Repository) {
+        let workdir = repo.workdir().expect("non-bare repository");
+        fs::write(workdir.join("tracked.txt"), "tracked\n")
+            .expect("tracked file should be created");
+        let mut index = repo.index().expect("index should open");
+        index
+            .add_path(Path::new("tracked.txt"))
+            .expect("tracked file should be added");
+        let tree_id = index.write_tree().expect("tree should be written");
+        let tree = repo.find_tree(tree_id).expect("tree should exist");
+        let signature =
+            git2::Signature::now("test", "test@example.com").expect("signature should be created");
+        repo.commit(Some("HEAD"), &signature, &signature, "init", &tree, &[])
+            .expect("commit should succeed");
     }
 
     #[test]
@@ -185,8 +249,7 @@ mod tests {
         let untracked = workdir.join("tmp-untracked.txt");
         fs::write(&untracked, "tmp").expect("untracked file should be created");
 
-        remove_untracked_excluding_submodule_paths(&repo)
-            .expect("cleanup should succeed");
+        remove_untracked_excluding_submodule_paths(&repo).expect("cleanup should succeed");
 
         assert!(!untracked.exists());
     }
@@ -195,7 +258,11 @@ mod tests {
     fn cleanup_preserves_submodule_untracked_files() {
         let (_tempdir, repo) = init_repo();
         let workdir = repo.workdir().expect("non-bare repository");
-        let modules_repo_path = repo.path().join("modules").join("submodules").join("test-module");
+        let modules_repo_path = repo
+            .path()
+            .join("modules")
+            .join("submodules")
+            .join("test-module");
         fs::create_dir_all(&modules_repo_path).expect("modules path should be created");
         fs::write(modules_repo_path.join("HEAD"), "ref: refs/heads/main\n")
             .expect("head marker should be created");
@@ -208,9 +275,78 @@ mod tests {
             .expect("submodule worktree path should be created");
         fs::write(&submodule_file, "probe").expect("submodule probe should be created");
 
-        remove_untracked_excluding_submodule_paths(&repo)
-            .expect("cleanup should succeed");
+        remove_untracked_excluding_submodule_paths(&repo).expect("cleanup should succeed");
 
         assert!(submodule_file.exists());
+    }
+
+    #[test]
+    fn libgit2_remove_untracked_deletes_populated_submodule_worktrees() {
+        let (_tempdir, repo) = init_repo();
+        commit_tracked_file(&repo);
+        let workdir = repo.workdir().expect("non-bare repository");
+        let modules_repo_path = repo
+            .path()
+            .join("modules")
+            .join("submodules")
+            .join("test-module");
+        fs::create_dir_all(&modules_repo_path).expect("modules path should be created");
+        fs::write(modules_repo_path.join("HEAD"), "ref: refs/heads/main\n")
+            .expect("head marker should be created");
+        let submodule_file = workdir
+            .join("submodules")
+            .join("test-module")
+            .join("probe.txt");
+        fs::create_dir_all(submodule_file.parent().expect("submodule parent"))
+            .expect("submodule worktree path should be created");
+        fs::write(&submodule_file, "probe").expect("submodule probe should be created");
+
+        let mut checkout = CheckoutBuilder::new();
+        checkout.force().remove_untracked(true);
+        repo.checkout_head(Some(&mut checkout))
+            .expect("checkout should succeed");
+
+        assert!(
+            !submodule_file.exists(),
+            "libgit2 remove_untracked(true) removes the populated submodule worktree"
+        );
+    }
+
+    #[test]
+    fn libgit2_path_limited_remove_untracked_leaves_unrelated_untracked_files_behind() {
+        let (_tempdir, repo) = init_repo();
+        commit_tracked_file(&repo);
+        let workdir = repo.workdir().expect("non-bare repository");
+        let ordinary = workdir.join("ordinary.txt");
+        fs::write(&ordinary, "ordinary").expect("ordinary file should be created");
+        let modules_repo_path = repo
+            .path()
+            .join("modules")
+            .join("submodules")
+            .join("test-module");
+        fs::create_dir_all(&modules_repo_path).expect("modules path should be created");
+        fs::write(modules_repo_path.join("HEAD"), "ref: refs/heads/main\n")
+            .expect("head marker should be created");
+        let submodule_file = workdir
+            .join("submodules")
+            .join("test-module")
+            .join("probe.txt");
+        fs::create_dir_all(submodule_file.parent().expect("submodule parent"))
+            .expect("submodule worktree path should be created");
+        fs::write(&submodule_file, "probe").expect("submodule probe should be created");
+
+        let mut checkout = CheckoutBuilder::new();
+        checkout.force().remove_untracked(true).path("tracked.txt");
+        repo.checkout_head(Some(&mut checkout))
+            .expect("checkout should succeed");
+
+        assert!(
+            ordinary.exists(),
+            "path-limited remove_untracked(true) leaves unrelated untracked files behind"
+        );
+        assert!(
+            submodule_file.exists(),
+            "path-limited remove_untracked(true) preserves the submodule worktree"
+        );
     }
 }

--- a/crates/gitbutler-workspace/src/submodules.rs
+++ b/crates/gitbutler-workspace/src/submodules.rs
@@ -1,0 +1,25 @@
+pub fn has_submodules_configured(repo: &git2::Repository) -> bool {
+    if repo
+        .workdir()
+        .is_some_and(|workdir| workdir.join(".gitmodules").exists())
+    {
+        return true;
+    }
+
+    let Ok(config) = repo.config() else {
+        return false;
+    };
+
+    let modules_dir_has_entries = repo
+        .path()
+        .join("modules")
+        .read_dir()
+        .map(|mut it| it.next().is_some())
+        .unwrap_or(false);
+
+    let Ok(mut entries) = config.entries(Some("submodule\\..*\\.url")) else {
+        return modules_dir_has_entries;
+    };
+
+    entries.next().transpose().ok().flatten().is_some() || modules_dir_has_entries
+}


### PR DESCRIPTION
## Summary
This PR is now scoped to the submodule-preservation fix in resolve/edit mode. The recovery guidance/UI changes and overwrite diagnostics that were previously on this branch have been split out.

## What changed
- Added shared helpers in `gitbutler-workspace::submodules` to detect configured submodules, identify submodule-related paths, and remove untracked files without deleting populated submodule worktrees.
- Updated `update_uncommitted_changes_with_tree(...)` to stop using broad `remove_untracked(true)` cleanup and instead perform targeted cleanup via `remove_untracked_excluding_submodule_paths(...)`.
- Updated edit-mode enter/abort flows to preserve submodule worktrees during checkout/cleanup, keep the index in sync after forced cleanup, and surface a clearer forced-abort error when submodule/gitlink changes would be reverted.
- Added regression coverage for submodule detection, targeted cleanup, and edit-mode save/abort behavior with populated, dirty, and diverged submodule worktrees.

## Key files touched
- `crates/gitbutler-workspace/src/submodules.rs`
- `crates/gitbutler-workspace/src/branch_trees.rs`
- `crates/gitbutler-workspace/src/lib.rs`
- `crates/gitbutler-edit-mode/src/lib.rs`
- `crates/gitbutler-edit-mode/tests/edit_mode.rs`
- `crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh`
- `crates/gitbutler-workspace/Cargo.toml`
- `Cargo.lock`

## Validation run
- `cargo test -p gitbutler-edit-mode -p gitbutler-workspace`
