### PR TITLE
but-forge: Support for creating review from forks

### DIFF
--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -938,10 +938,36 @@ pub struct CreateForgeReviewParams {
     pub draft: bool,
 }
 
+fn github_head_owner_and_repo<'a>(
+    forge_repo_info: &'a crate::forge::ForgeRepoInfo,
+    forge_push_repo_info: &'a Option<crate::forge::ForgeRepoInfo>,
+) -> (&'a str, Option<&'a str>) {
+    if let Some(forge_push_repo_info) = forge_push_repo_info
+        && forge_push_repo_info != forge_repo_info
+    {
+        // If there's a push repo defined, it means we're handling a fork.
+        // The head owner is the repository were we push the branches to (the fork) and
+        // the target repo (the one holding the base branch) is the original repository.
+        (
+            forge_push_repo_info.owner.as_str(),
+            Some(forge_push_repo_info.repo.as_str()),
+        )
+    } else {
+        // If there's no push repo, we assume the owner is the same as the owner of the target repo.
+        // We don't need a `head_repo`` in that case.
+        (forge_repo_info.owner.as_str(), None)
+    }
+}
+
 /// Create a new review (e.g. pull request) for a given forge repository
+///
+/// Some info on the push repo:
+/// If there's a push repository specified and it's different from the main repository,
+/// we assume we're opening a review from a fork.
 pub async fn create_forge_review(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
+    forge_push_repo_info: &Option<crate::forge::ForgeRepoInfo>,
     params: &CreateForgeReviewParams,
     storage: &but_forge_storage::Controller,
 ) -> Result<ForgeReview> {
@@ -950,14 +976,17 @@ pub async fn create_forge_review(
     } = forge_repo_info;
     match forge {
         ForgeName::GitHub => {
-            // TODO: handle forks better
-            let head = format!("{}:{}", owner, params.source_branch);
+            let (head_owner, head_repo) =
+                github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
+
+            let head = format!("{}:{}", head_owner, params.source_branch);
             let pr_params = but_github::CreatePullRequestParams {
                 owner,
                 repo,
                 title: &params.title,
                 body: &params.body,
                 head: &head,
+                head_repo,
                 base: &params.target_branch,
                 draft: params.draft,
             };
@@ -967,14 +996,19 @@ pub async fn create_forge_review(
         }
         ForgeName::GitLab => {
             let project_id = GitLabProjectId::new(owner, repo);
-            // TODO: handle forks better
-            // TODO: handle draft properly
+            // If there's a push repo defined, we consider that the source repository.
+            let source_project_id = forge_push_repo_info
+                .as_ref()
+                .map(|repo_info| GitLabProjectId::new(&repo_info.owner, &repo_info.repo));
+
             let mr_params = but_gitlab::CreateMergeRequestParams {
                 project_id,
                 title: &params.title,
                 body: &params.body,
                 source_branch: &params.source_branch,
                 target_branch: &params.target_branch,
+                source_project_id,
+                draft: params.draft,
             };
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.gitlab());
             let mr = but_gitlab::mr::create(preferred_account, mr_params, storage).await?;
@@ -1144,6 +1178,49 @@ mod tests {
 
     fn p(path: &str) -> &Path {
         Path::new(path)
+    }
+
+    fn repo_info(owner: &str, repo: &str) -> crate::forge::ForgeRepoInfo {
+        crate::forge::ForgeRepoInfo {
+            forge: crate::forge::ForgeName::GitHub,
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            protocol: "https".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_github_head_owner_and_repo_without_push_repo() {
+        let forge_repo_info = repo_info("target-owner", "target-repo");
+
+        let (head_owner, head_repo) = github_head_owner_and_repo(&forge_repo_info, &None);
+
+        assert_eq!(head_owner, "target-owner");
+        assert_eq!(head_repo, None);
+    }
+
+    #[test]
+    fn test_github_head_owner_and_repo_with_fork_push_repo() {
+        let forge_repo_info = repo_info("target-owner", "target-repo");
+        let forge_push_repo_info = Some(repo_info("fork-owner", "fork-repo"));
+
+        let (head_owner, head_repo) =
+            github_head_owner_and_repo(&forge_repo_info, &forge_push_repo_info);
+
+        assert_eq!(head_owner, "fork-owner");
+        assert_eq!(head_repo, Some("fork-repo"));
+    }
+
+    #[test]
+    fn test_github_head_owner_and_repo_with_equal_push_repo() {
+        let forge_repo_info = repo_info("target-owner", "target-repo");
+        let forge_push_repo_info = Some(repo_info("target-owner", "target-repo"));
+
+        let (head_owner, head_repo) =
+            github_head_owner_and_repo(&forge_repo_info, &forge_push_repo_info);
+
+        assert_eq!(head_owner, "target-owner");
+        assert_eq!(head_repo, None);
     }
 
     #[test]

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -218,6 +218,8 @@ impl GitHubClient {
             title: &'a str,
             body: &'a str,
             head: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            head_repo: Option<&'a str>,
             base: &'a str,
             draft: bool,
         }
@@ -231,6 +233,7 @@ impl GitHubClient {
             title: params.title,
             body: params.body,
             head: params.head,
+            head_repo: params.head_repo,
             base: params.base,
             draft: params.draft,
         };
@@ -712,6 +715,7 @@ pub struct CreatePullRequestParams<'a> {
     pub title: &'a str,
     pub body: &'a str,
     pub head: &'a str,
+    pub head_repo: Option<&'a str>,
     pub base: &'a str,
     pub draft: bool,
     pub owner: &'a str,

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use but_secret::Sensitive;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
@@ -165,17 +165,45 @@ impl GitLabClient {
             target_project_id: Option<i64>,
         }
 
+        // The host project id is the one where we create the merge request in.
+        // If there's a source project defined, it means we're dealing with a fork,
+        // and hence should create the review on it.
+        let host_project_id = if let Some(source_project_id) = &params.source_project_id {
+            source_project_id
+        } else {
+            &params.project_id
+        };
+
         let url = format!(
             "{}/projects/{}/merge_requests",
-            self.base_url, params.project_id
+            self.base_url, host_project_id
         );
 
+        // If there's a source project defined, and it's different than the
+        // 'main' project id, it means we're handling the creation of a merge request
+        // from a fork.
+        // Fetch the target project numeric ID and pass it to the params.
+        let target_project_id = if let Some(source_project_id) = &params.source_project_id
+            && &params.project_id != source_project_id
+        {
+            let target_project_id = self
+                .fetch_project(params.project_id.clone())
+                .await
+                .map(|project| project.id)
+                .context("Failed to fetch target project information.")?;
+            Some(target_project_id)
+        } else {
+            None
+        };
+
+        let title = update_draft_state_in_title(params.title, params.draft);
+
         let body = CreateMergeRequestBody {
-            title: params.title,
+            title: &title,
             description: params.body,
             source_branch: params.source_branch,
             target_branch: params.target_branch,
-            target_project_id: None,
+            target_project_id,
         };
 
         let response = self.client.post(&url).json(&body).send().await?;
@@ -322,6 +350,40 @@ impl GitLabClient {
 
         Ok(())
     }
+
+    pub async fn fetch_project(&self, project_id: GitLabProjectId) -> Result<GitLabProject> {
+        #[derive(Deserialize)]
+        struct GitLabApiProject {
+            id: i64,
+            path_with_namespace: String,
+            default_branch: Option<String>,
+            #[serde(default)]
+            forked_from_project: Option<GitLabApiProjectRef>,
+        }
+
+        #[derive(Deserialize)]
+        struct GitLabApiProjectRef {
+            id: i64,
+        }
+
+        let url = format!("{}/projects/{}", self.base_url, project_id);
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            bail!("Failed to fetch project: {status} - {error_text}");
+        }
+
+        let project: GitLabApiProject = response.json().await?;
+
+        Ok(GitLabProject {
+            id: project.id,
+            path_with_namespace: project.path_with_namespace,
+            default_branch: project.default_branch,
+            forked_from_project_id: project.forked_from_project.map(|fork| fork.id),
+        })
+    }
 }
 
 pub struct CreateMergeRequestParams<'a> {
@@ -330,6 +392,8 @@ pub struct CreateMergeRequestParams<'a> {
     pub source_branch: &'a str,
     pub target_branch: &'a str,
     pub project_id: GitLabProjectId,
+    pub source_project_id: Option<GitLabProjectId>,
+    pub draft: bool,
 }
 pub struct MergeMergeRequestParams {
     pub project_id: GitLabProjectId,
@@ -435,6 +499,14 @@ impl From<String> for GitLabLabel {
     fn from(name: String) -> Self {
         GitLabLabel { name }
     }
+}
+
+#[derive(Debug, Serialize)]
+pub struct GitLabProject {
+    pub id: i64,
+    pub path_with_namespace: String,
+    pub default_branch: Option<String>,
+    pub forked_from_project_id: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -7,7 +7,7 @@ mod project;
 pub use client::{
     CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabProject, GitLabUser,
     MergeMergeRequestParams, MergeRequest, SetMergeRequestAutoMergeParams,
-    SetMergeRequestDraftStateParams,
+    SetMergeRequestDraftStateParams, UpdateMergeRequestParams,
 };
 pub use project::{GitLabProjectId, fetch_project};
 mod token;

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -5,10 +5,11 @@ mod client;
 pub mod mr;
 mod project;
 pub use client::{
-    CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabUser, MergeMergeRequestParams,
-    MergeRequest, SetMergeRequestAutoMergeParams, SetMergeRequestDraftStateParams,
+    CreateMergeRequestParams, GitLabClient, GitLabLabel, GitLabProject, GitLabUser,
+    MergeMergeRequestParams, MergeRequest, SetMergeRequestAutoMergeParams,
+    SetMergeRequestDraftStateParams,
 };
-pub use project::GitLabProjectId;
+pub use project::{GitLabProjectId, fetch_project};
 mod token;
 use serde::Serialize;
 pub use token::GitlabAccountIdentifier;

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -57,6 +57,18 @@ pub async fn get(
     Ok(mr)
 }
 
+pub async fn update(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    params: crate::client::UpdateMergeRequestParams<'_>,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::MergeRequest> {
+    let mr = GitLabClient::from_storage(storage, preferred_account)?
+        .update_merge_request(&params)
+        .await
+        .context("Failed to update merge request")?;
+    Ok(mr)
+}
+
 pub async fn merge(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
     params: crate::client::MergeMergeRequestParams,

--- a/crates/but-gitlab/src/project.rs
+++ b/crates/but-gitlab/src/project.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use anyhow::Context;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitLabProjectId {
     /// The username or group name that owns the project.
@@ -27,4 +29,18 @@ impl Display for GitLabProjectId {
         let encoded = urlencoding::encode(&project_id);
         write!(f, "{encoded}")
     }
+}
+
+/// Fetch the GitLab project information by its ID.
+///
+/// Can be used to resolve a numeric ID from an encoded one.
+pub async fn fetch_project(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project_id: GitLabProjectId,
+    storage: &but_forge_storage::Controller,
+) -> anyhow::Result<crate::client::GitLabProject> {
+    crate::GitLabClient::from_storage(storage, preferred_account)?
+        .fetch_project(project_id)
+        .await
+        .context("Failed to set MR auto-merge state")
 }


### PR DESCRIPTION
## CLI changes
- but now can support the creation of PRs and MRs from forks correctly
- but now fully supports stacks MRs (it was missing the ability to update description footers)

### What this adds
- Resolution of numeric IDs from encoded IDs for GitLab projects
- Title-based support for draft MRs for GitLab
- GitLab MR description footers

### What this changes
Now, if there’s a different push-repository defined, we pass the correct information to the API request so that the fork review can be opened.