### PR TITLE
Remove .gitattirbute for Cargo.lock merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.sh eol=lf
-/Cargo.lock merge=binary


### PR DESCRIPTION
Byron confirmed it doesn't work the way it was intended.