### PR TITLE
Backport the reverse of 0170552d55c53ac6c944c5e3aa1fa913534b42d6 for "auto" filewatcher and 'recursive' by default

### DIFF
--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -90,6 +90,7 @@ impl ActiveProjects {
 
         let watch_mode = gitbutler_watcher::WatchMode::from_env_or_settings(
             &app_settings_sync.get()?.feature_flags.watch_mode,
+            |key| std::env::var(key).ok(),
         );
         let file_watcher = gitbutler_watcher::watch_in_background(
             handler,

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -34,8 +34,8 @@
 		/// Enable single branch mode.
 		"singleBranch": false,
 		/// Control how the filesystem watch should be established.
-		/// Possible values: "legacy", "modern".
-		"watchMode": "modern"
+		/// Possible values: "auto", "legacy", "modern".
+		"watchMode": "auto"
 	},
 	// Allows for additional "connect-src" hosts to be included. Requires app restart.
 	"extraCsp": {

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -73,9 +73,10 @@ pub struct FeatureFlags {
     /// Enable single branch mode.
     pub single_branch: bool,
     /// Control how the filesystem watch should be established.
-    /// Possible values: "legacy", "modern".
-    /// "modern" uses ignore-aware non-recursive watching (default).
+    /// Possible values: "auto", "legacy", "modern".
+    /// "auto" automatically picks based on platform heuristics (default).
     /// "legacy" uses recursive watching.
+    /// "modern" uses ignore-aware non-recursive watching.
     pub watch_mode: String,
 }
 

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -132,7 +132,7 @@ pub enum Subcommands {
     },
     Watch {
         /// How to watch the current working directory.
-        #[clap(long, short = 'm', value_parser = ["legacy", "modern"], env = "GITBUTLER_WATCH_MODE")]
+        #[clap(long, short = 'm', value_parser = ["legacy", "modern", "auto"], env = "GITBUTLER_WATCH_MODE")]
         mode: Option<String>,
     },
     WatchDb,

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -448,7 +448,7 @@ impl Sandbox {
                 undo: true,
                 rules: true,
                 single_branch: true,
-                watch_mode: "modern".into(),
+                watch_mode: "auto".into(),
             },
             extra_csp: ExtraCsp {
                 hosts: vec![],

--- a/crates/gitbutler-filemonitor/src/file_monitor.rs
+++ b/crates/gitbutler-filemonitor/src/file_monitor.rs
@@ -68,12 +68,16 @@ const ENV_WATCH_MODE: &str = "GITBUTLER_WATCH_MODE";
 pub enum WatchMode {
     /// Recursively watch the worktree (and an extra git-dir if the repo uses
     /// a linked worktree with a git-dir outside the worktree), using [`notify::RecursiveMode::Recursive`].
+    #[default]
     Legacy,
     /// Ignore-aware watch plan: non-recursive watches of non-ignored worktree directories,
     /// plus explicit git-dir watches and dynamic watch additions for newly created directories.
     /// Each directory is watched with [`notify::RecursiveMode::NonRecursive`].
-    #[default]
     Modern,
+    /// Automatically pick a mode based on platform heuristics.
+    ///
+    /// Currently, this enables `Modern` on WSL (Windows Subsystem for Linux.) and `Legacy` elsewhere.
+    Auto,
 }
 
 impl std::str::FromStr for WatchMode {
@@ -83,6 +87,7 @@ impl std::str::FromStr for WatchMode {
         Ok(match s.trim().to_ascii_lowercase().as_str() {
             "legacy" => Self::Legacy,
             "modern" => Self::Modern,
+            "auto" => Self::Auto,
             _ => {
                 return Err(());
             }
@@ -94,16 +99,16 @@ impl WatchMode {
     /// Initialise the mode from the environment.
     pub fn from_env() -> Self {
         let Ok(mode) = std::env::var(ENV_WATCH_MODE) else {
-            return Self::Modern;
+            return Self::Auto;
         };
 
         mode.parse().ok().unwrap_or_else(|| {
             tracing::warn!(
                 env = ENV_WATCH_MODE,
                 value = mode,
-                "unknown watch mode; falling back to modern"
+                "unknown watch mode; falling back to auto"
             );
-            WatchMode::Modern
+            WatchMode::Auto
         })
     }
 
@@ -119,11 +124,34 @@ impl WatchMode {
                 tracing::warn!(
                     feature_flag = watch_mode_from_settings,
                     env_var = ?std::env::var(ENV_WATCH_MODE),
-                    "unknown watch mode from feature flag or environment variable; falling back to modern"
+                    "unknown watch mode from feature flag or environment variable; falling back to auto"
                 );
-                WatchMode::Modern
+                WatchMode::Auto
             })
     }
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl() -> bool {
+    if std::env::var_os("WSL_DISTRO_NAME").is_some() || std::env::var_os("WSL_INTEROP").is_some() {
+        return true;
+    }
+
+    for path in ["/proc/sys/kernel/osrelease", "/proc/version"] {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let lower = contents.to_ascii_lowercase();
+        if lower.contains("microsoft") || lower.contains("wsl") {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_wsl() -> bool {
+    false
 }
 
 fn watch_backoff_policy() -> backoff::ExponentialBackoff {
@@ -234,7 +262,7 @@ pub fn spawn(
     project_id: ProjectId,
     worktree_path: &std::path::Path,
     out: tokio::sync::mpsc::UnboundedSender<InternalEvent>,
-    mut watch_mode: WatchMode,
+    watch_mode: WatchMode,
 ) -> Result<FileMonitorHandle> {
     let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
     let (notify_tx, notify_rx) = std::sync::mpsc::channel();
@@ -253,6 +281,8 @@ pub fn spawn(
     ))?;
     let git_dir = repo.path().to_owned();
 
+    let mut effective_watch_mode = watch_mode;
+
     match watch_mode {
         WatchMode::Legacy => {
             setup_legacy_watch(&mut debouncer, &worktree_path, &git_dir)?;
@@ -266,18 +296,41 @@ pub fn spawn(
                     ?err,
                     "watch-plan setup failed; falling back to legacy watch mode"
                 );
-                watch_mode = WatchMode::Legacy;
+                effective_watch_mode = WatchMode::Legacy;
+                setup_legacy_watch(&mut debouncer, &worktree_path, &git_dir)?;
+            }
+        }
+        WatchMode::Auto => {
+            if is_wsl() {
+                match setup_watch_plan(&mut debouncer, project_id, &repo, &worktree_path, &git_dir)
+                {
+                    Ok(()) => {
+                        effective_watch_mode = WatchMode::Modern;
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            %project_id,
+                            ?err,
+                            "watch-plan setup failed; falling back to legacy watch mode"
+                        );
+                        effective_watch_mode = WatchMode::Legacy;
+                        setup_legacy_watch(&mut debouncer, &worktree_path, &git_dir)?;
+                    }
+                }
+            } else {
+                effective_watch_mode = WatchMode::Legacy;
                 setup_legacy_watch(&mut debouncer, &worktree_path, &git_dir)?;
             }
         }
     }
     tracing::debug!(
         %project_id,
-        ?watch_mode,
+        requested = ?watch_mode,
+        effective = ?effective_watch_mode,
         "file watcher started"
     );
 
-    let dynamic_watch_enabled = matches!(watch_mode, WatchMode::Modern);
+    let dynamic_watch_enabled = matches!(effective_watch_mode, WatchMode::Modern);
     let worktree_path = worktree_path.to_owned();
     task::spawn_blocking(move || {
         let _runtime = tracing::span!(Level::INFO, "file monitor", %project_id ).entered();

--- a/crates/gitbutler-filemonitor/tests/filemonitor/main.rs
+++ b/crates/gitbutler-filemonitor/tests/filemonitor/main.rs
@@ -120,14 +120,31 @@ mod watch_mode {
 
     #[test]
     fn from_env_or_settings() {
-        assert_eq!(WatchMode::from_env_or_settings("auto"), WatchMode::Auto);
-        assert_eq!(WatchMode::from_env_or_settings("legacy"), WatchMode::Legacy);
-        assert_eq!(WatchMode::from_env_or_settings("modern"), WatchMode::Modern);
+        assert_eq!(
+            WatchMode::from_env_or_settings("auto", |_| None),
+            WatchMode::Auto
+        );
+        assert_eq!(
+            WatchMode::from_env_or_settings("legacy", |_| None),
+            WatchMode::Legacy
+        );
+        assert_eq!(
+            WatchMode::from_env_or_settings("modern", |_| None),
+            WatchMode::Modern
+        );
 
         assert_eq!(
-            WatchMode::from_env_or_settings("invalid"),
+            WatchMode::from_env_or_settings("invalid", |_| None),
             WatchMode::Auto,
             "Invalid value should fall back to auto"
+        );
+    }
+
+    #[test]
+    fn from_env_or_settings_prefers_env() {
+        assert_eq!(
+            WatchMode::from_env_or_settings("legacy", |_| Some("modern".to_string())),
+            WatchMode::Modern
         );
     }
 

--- a/crates/gitbutler-filemonitor/tests/filemonitor/main.rs
+++ b/crates/gitbutler-filemonitor/tests/filemonitor/main.rs
@@ -120,26 +120,25 @@ mod watch_mode {
 
     #[test]
     fn from_env_or_settings() {
+        assert_eq!(WatchMode::from_env_or_settings("auto"), WatchMode::Auto);
         assert_eq!(WatchMode::from_env_or_settings("legacy"), WatchMode::Legacy);
         assert_eq!(WatchMode::from_env_or_settings("modern"), WatchMode::Modern);
 
         assert_eq!(
             WatchMode::from_env_or_settings("invalid"),
-            WatchMode::Modern,
-            "Invalid value should fall back to modern"
+            WatchMode::Auto,
+            "Invalid value should fall back to auto"
         );
     }
 
     #[test]
     fn from_str() {
+        assert_eq!("auto".parse::<WatchMode>().ok(), Some(WatchMode::Auto));
         assert_eq!("legacy".parse::<WatchMode>().ok(), Some(WatchMode::Legacy));
         assert_eq!("modern".parse::<WatchMode>().ok(), Some(WatchMode::Modern));
+        assert_eq!("AUTO".parse::<WatchMode>().ok(), Some(WatchMode::Auto));
         assert_eq!("Legacy".parse::<WatchMode>().ok(), Some(WatchMode::Legacy));
         assert_eq!("MODERN".parse::<WatchMode>().ok(), Some(WatchMode::Modern));
-        assert!(
-            "auto".parse::<WatchMode>().is_err(),
-            "'auto' is now unsupported, and was used previously to enable plan-mode only under WSL"
-        );
         assert!("invalid".parse::<WatchMode>().is_err());
     }
 }

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -184,6 +184,7 @@ pub(crate) mod state {
             let worktree_dir = ctx.workdir_or_fail()?;
             let watch_mode = gitbutler_watcher::WatchMode::from_env_or_settings(
                 &app_settings.get()?.feature_flags.watch_mode,
+                |key| std::env::var(key).ok(),
             );
             let watcher = gitbutler_watcher::watch_in_background(
                 handler,

--- a/packages/core/src/generated/settings/appSettings.ts
+++ b/packages/core/src/generated/settings/appSettings.ts
@@ -74,9 +74,10 @@ export type FeatureFlags = {
 	singleBranch: boolean;
 	/**
 	 * Control how the filesystem watch should be established.
-	 * Possible values: "legacy", "modern".
-	 * "modern" uses ignore-aware non-recursive watching (default).
+	 * Possible values: "auto", "legacy", "modern".
+	 * "auto" automatically picks based on platform heuristics (default).
 	 * "legacy" uses recursive watching.
+	 * "modern" uses ignore-aware non-recursive watching.
 	 */
 	watchMode: string;
 };


### PR DESCRIPTION
This fixes issues with the plan/gitignore based implementation which was completely illusive, i.e. it just didn't work.
