### PR TITLE
Fix unmounting cursor

### DIFF
--- a/apps/desktop/src/components/FocusCursor.svelte
+++ b/apps/desktop/src/components/FocusCursor.svelte
@@ -48,24 +48,26 @@
 	}
 
 	$effect(() => {
-		if (!$target || !$outline || metadata?.dim) {
+		const currentTarget = $target;
+
+		if (!currentTarget || !$outline || metadata?.dim) {
 			return;
 		}
 
-		$target.classList.add("focused");
-		const element = createCursor($target);
-		copyPosition($target, element);
+		currentTarget.classList.add("focused");
+		const element = createCursor(currentTarget);
+		copyPosition(currentTarget, element);
 
 		const observer = new ResizeObserver(() => {
-			if ($target && element.isConnected) {
-				copyPosition($target, element);
+			if (currentTarget && element.isConnected) {
+				copyPosition(currentTarget, element);
 			}
 		});
 
-		observer.observe($target);
+		observer.observe(currentTarget);
 
 		return () => {
-			$target.classList.remove("focused");
+			currentTarget.classList.remove("focused");
 			element.remove();
 			observer.disconnect();
 		};


### PR DESCRIPTION
I had an issue when switching projects where it seems like `$target` was undefiend in the unsubscribe call, which could totally happen in the time between the effect being registered and the unsubscribe being called, so this adds an extra guard to hopfully prevent this form happening again.