### PR TITLE
but: Fetch review information before mutation

### DIFF
--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -30,7 +30,7 @@ CREATE TABLE `forge_reviews`(
 );",
 )];
 
-/// Tests are in `but-db/tests/db/table/forge_reviews.rs`.
+/// Tests are in `but-db/tests/db/table/forge_review.rs`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ForgeReview {
     pub html_url: String,
@@ -171,6 +171,64 @@ impl ForgeReviewsHandleMut<'_> {
                 ],
             )?;
         }
+
+        self.sp.commit()?;
+        Ok(())
+    }
+
+    /// Inserts or updates a single forge review by review number.
+    pub fn upsert(self, review: ForgeReview) -> rusqlite::Result<()> {
+        self.sp.execute(
+            "INSERT INTO forge_reviews (html_url, number, title, body, author, labels, draft, \
+             source_branch, target_branch, sha, created_at, modified_at, merged_at, closed_at, \
+             repository_ssh_url, repository_https_url, repo_owner, reviewers, unit_symbol, \
+             last_sync_at, struct_version) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21) \
+             ON CONFLICT(number) DO UPDATE SET
+                html_url = excluded.html_url,
+                title = excluded.title,
+                body = excluded.body,
+                author = excluded.author,
+                labels = excluded.labels,
+                draft = excluded.draft,
+                source_branch = excluded.source_branch,
+                target_branch = excluded.target_branch,
+                sha = excluded.sha,
+                created_at = excluded.created_at,
+                modified_at = excluded.modified_at,
+                merged_at = excluded.merged_at,
+                closed_at = excluded.closed_at,
+                repository_ssh_url = excluded.repository_ssh_url,
+                repository_https_url = excluded.repository_https_url,
+                repo_owner = excluded.repo_owner,
+                reviewers = excluded.reviewers,
+                unit_symbol = excluded.unit_symbol,
+                last_sync_at = excluded.last_sync_at,
+                struct_version = excluded.struct_version",
+            rusqlite::params![
+                review.html_url,
+                review.number,
+                review.title,
+                review.body,
+                review.author,
+                review.labels,
+                review.draft,
+                review.source_branch,
+                review.target_branch,
+                review.sha,
+                review.created_at,
+                review.modified_at,
+                review.merged_at,
+                review.closed_at,
+                review.repository_ssh_url,
+                review.repository_https_url,
+                review.repo_owner,
+                review.reviewers,
+                review.unit_symbol,
+                review.last_sync_at,
+                review.struct_version,
+            ],
+        )?;
 
         self.sp.commit()?;
         Ok(())

--- a/crates/but-forge/src/db.rs
+++ b/crates/but-forge/src/db.rs
@@ -106,6 +106,13 @@ pub(crate) fn cache_reviews(
         .map_err(Into::into)
 }
 
+pub(crate) fn upsert_review(db: &mut but_db::DbHandle, review: &ForgeReview) -> anyhow::Result<()> {
+    let db_review: but_db::ForgeReview = review.clone().try_into()?;
+    db.forge_reviews_mut()?
+        .upsert(db_review)
+        .map_err(Into::into)
+}
+
 use super::CiCheck;
 
 impl TryFrom<CiCheck> for but_db::CiCheck {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -762,8 +762,7 @@ fn filter_mrs(
         .collect()
 }
 
-/// Get a specific review (e.g. pull request) for a given forge repository
-pub async fn get_forge_review(
+async fn get_forge_review_inner(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
     review_number: usize,
@@ -790,6 +789,38 @@ pub async fn get_forge_review(
             "Getting reviews for forge {forge:?} is not implemented yet.",
         ))),
     }
+}
+
+/// Get a specific review (e.g. pull request) for a given forge repository
+///
+/// The resulting review will be cached.
+pub fn get_forge_review(
+    preferred_forge_user: &Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    review_number: usize,
+    db: &mut but_db::DbHandle,
+    storage: &but_forge_storage::Controller,
+) -> Result<ForgeReview> {
+    let preferred_forge_user = preferred_forge_user.clone();
+    let forge_repo_info = forge_repo_info.clone();
+    let storage = storage.clone();
+
+    let review = std::thread::spawn(move || {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(get_forge_review_inner(
+                &preferred_forge_user,
+                &forge_repo_info,
+                review_number,
+                &storage,
+            ))
+    })
+    .join()
+    .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
+
+    // Cache the review and ignore any issues, if any.
+    crate::db::upsert_review(db, &review).ok();
+    Ok(review)
 }
 
 /// Merge a review to it's target branch

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -27,9 +27,6 @@ pub async fn enable_auto_merge(
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
 
-    let reviews =
-        but_api::legacy::forge::list_reviews(ctx, Some(but_forge::CacheConfig::CacheOnly))
-            .unwrap_or_default();
     let review_ids = resolve_review_selection(ctx, selector)?;
 
     if review_ids.is_empty() {
@@ -45,9 +42,8 @@ pub async fn enable_auto_merge(
 
     // Iterate over the reviews that need to be mutated. Skip if their in an invalid state.
     for review_id in review_ids {
-        let review_numeric_id: Option<i64> = review_id.try_into().ok();
-        let review = review_numeric_id
-            .and_then(|review_numeric_id| reviews.iter().find(|r| r.number == review_numeric_id));
+        // Fetch the latest information about the review
+        let review = but_api::legacy::forge::get_review(ctx, review_id).ok();
 
         if let Some(review) = review {
             if review.draft {
@@ -125,9 +121,6 @@ pub async fn set_draftiness(
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
 
-    let reviews =
-        but_api::legacy::forge::list_reviews(ctx, Some(but_forge::CacheConfig::CacheOnly))
-            .unwrap_or_default();
     let review_ids = resolve_review_selection(ctx, selector)?;
 
     if review_ids.is_empty() {
@@ -141,9 +134,8 @@ pub async fn set_draftiness(
 
     // Iterate over the reviews and validate the state, before mutating.
     for review_id in review_ids {
-        let review_numeric_id: Option<i64> = review_id.try_into().ok();
-        let review = review_numeric_id
-            .and_then(|review_numeric_id| reviews.iter().find(|r| r.number == review_numeric_id));
+        // Fetch the latest information about the review
+        let review = but_api::legacy::forge::get_review(ctx, review_id).ok();
 
         if let Some(review) = review {
             if !review.is_open() {


### PR DESCRIPTION
Fetch the the review information before attempting the mutations
(auto-merge and draftiness).

- but-api: Add get review
- but-db: Upsert review
- Getting a review updates the review information

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12592 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12593 
<!-- GitButler Footer Boundary Bottom -->

