### PR TITLE
feat(but): make less default pager and add pager override

### DIFF
--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -5,6 +5,8 @@ pub use output_channel::{
     Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel,
 };
 
+mod pager;
+
 pub mod metrics;
 #[cfg(feature = "legacy")]
 pub use metrics::types::BackgroundMetrics;

--- a/crates/but/src/utils/pager.rs
+++ b/crates/but/src/utils/pager.rs
@@ -1,0 +1,92 @@
+pub(crate) enum Pager {
+    /// An external pager process (e.g. `less`)
+    External(std::process::Child, std::process::ChildStdin),
+    /// The built-in fallback pager.
+    Builtin(minus::Pager),
+}
+
+/// We use less as the default pager as it's an excellent pager that is ubiquitous in UNIX-likes.
+const DEFAULT_PAGER: &str = "less";
+
+/// This default configuration makes less behave nicely for a CLI. See the less manual for details.
+const DEFAULT_PAGER_ARGS: &str = "FXR";
+const DEFAULT_PAGER_ENV_VAR: &str = "LESS";
+
+/// Attempt to initialize a new pager.
+///
+/// We first try to spawn an external pager, and if that fails, we fall back on the builtin
+/// one. If that _also_ fails we simply move on with our lives without a pager, as the app does
+/// function without it. It's just less great.
+///
+/// # Safety
+/// This function should never be called when a pager is running, especially not an external
+/// one. That can lead to some _very_ funky things in the terminal. There is currently no use
+/// case for initializing a pager more than once per CLI invocation, but if that need arises
+/// this implementation needs to be extended to account for the fact that there may already be
+/// a pager running that needs to be dropped before a new one is initialized.
+pub(crate) fn try_init_pager() -> Option<Pager> {
+    if let Some((child, stdin)) = try_spawn_external_pager() {
+        Some(Pager::External(child, stdin))
+    } else {
+        match try_spawn_builtin_pager() {
+            Ok(pager) => Some(Pager::Builtin(pager)),
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    "Failed to initialize builtin pager"
+                );
+                None
+            }
+        }
+    }
+}
+
+fn try_spawn_external_pager() -> Option<(std::process::Child, std::process::ChildStdin)> {
+    use std::process::{Command, Stdio};
+
+    let pager_override = std::env::var("BUT_PAGER")
+        .or_else(|_| std::env::var("PAGER"))
+        .ok();
+    let program = if let Some(cmd) = &pager_override {
+        cmd
+    } else if Command::new(DEFAULT_PAGER)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+    {
+        DEFAULT_PAGER
+    } else {
+        return None;
+    };
+
+    let mut cmd = Command::new(program);
+    cmd.stdin(Stdio::piped());
+
+    if program == DEFAULT_PAGER && std::env::var_os(DEFAULT_PAGER_ENV_VAR).is_none() {
+        cmd.env(DEFAULT_PAGER_ENV_VAR, DEFAULT_PAGER_ARGS);
+    }
+
+    match cmd.spawn() {
+        Ok(mut child) => {
+            let stdin = child.stdin.take()?;
+            Some((child, stdin))
+        }
+        Err(err) => {
+            tracing::warn!(
+                pager = program,
+                error = %err,
+                "Failed to start pager"
+            );
+            None
+        }
+    }
+}
+
+fn try_spawn_builtin_pager() -> Result<minus::Pager, minus::MinusError> {
+    let pager = minus::Pager::new();
+    pager.set_exit_strategy(minus::ExitStrategy::PagerQuit)?;
+    pager.set_prompt("GitButler")?;
+    Ok(pager)
+}


### PR DESCRIPTION
This changes the default pager from the built-in minus pager to using `less` instead. `less` is ubiquitous on UNIX-like systems and a really good pager.

We also now respect the PAGER environment variable (which is good practice) along with the more specific BUT_PAGER variable.

The built-in pager is still used as a fallback in case `less` is not available or the user-specified pager is not working for some reason.