### PR TITLE
but: Fetch review information before mutation

### DIFF
--- a/crates/but-forge/src/db.rs
+++ b/crates/but-forge/src/db.rs
@@ -106,6 +106,13 @@ pub(crate) fn cache_reviews(
         .map_err(Into::into)
 }
 
+pub(crate) fn upsert_review(db: &mut but_db::DbHandle, review: &ForgeReview) -> anyhow::Result<()> {
+    let db_review: but_db::ForgeReview = review.clone().try_into()?;
+    db.forge_reviews_mut()?
+        .upsert(db_review)
+        .map_err(Into::into)
+}
+
 use super::CiCheck;
 
 impl TryFrom<CiCheck> for but_db::CiCheck {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -762,8 +762,7 @@ fn filter_mrs(
         .collect()
 }
 
-/// Get a specific review (e.g. pull request) for a given forge repository
-pub async fn get_forge_review(
+async fn get_forge_review_inner(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
     review_number: usize,
@@ -790,6 +789,44 @@ pub async fn get_forge_review(
             "Getting reviews for forge {forge:?} is not implemented yet.",
         ))),
     }
+}
+
+/// Get a specific review (e.g. pull request) for a given forge repository
+///
+/// The resulting review will be cached.
+pub fn get_forge_review(
+    preferred_forge_user: &Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    review_number: usize,
+    db: &mut but_db::DbHandle,
+    storage: &but_forge_storage::Controller,
+) -> Result<ForgeReview> {
+    let preferred_forge_user = preferred_forge_user.clone();
+    let forge_repo_info = forge_repo_info.clone();
+    let storage = storage.clone();
+
+    let review = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().map_err(|e| {
+            anyhow::anyhow!(
+                "Failed fetch review {review_number}: failed to create Tokio runtime: {e}"
+            )
+        })?;
+
+        runtime.block_on(get_forge_review_inner(
+            &preferred_forge_user,
+            &forge_repo_info,
+            review_number,
+            &storage,
+        ))
+    })
+    .join()
+    .map_err(|e| {
+        anyhow::anyhow!("Failed to fetch review {review_number}: thread panicked: {e:?}")
+    })??;
+
+    // Cache the review and ignore any issues, if any.
+    crate::db::upsert_review(db, &review).ok();
+    Ok(review)
 }
 
 /// Merge a review to it's target branch

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -27,9 +27,6 @@ pub async fn enable_auto_merge(
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
 
-    let reviews =
-        but_api::legacy::forge::list_reviews(ctx, Some(but_forge::CacheConfig::CacheOnly))
-            .unwrap_or_default();
     let review_ids = resolve_review_selection(ctx, selector)?;
 
     if review_ids.is_empty() {
@@ -45,9 +42,8 @@ pub async fn enable_auto_merge(
 
     // Iterate over the reviews that need to be mutated. Skip if their in an invalid state.
     for review_id in review_ids {
-        let review_numeric_id: Option<i64> = review_id.try_into().ok();
-        let review = review_numeric_id
-            .and_then(|review_numeric_id| reviews.iter().find(|r| r.number == review_numeric_id));
+        // Fetch the latest information about the review
+        let review = but_api::legacy::forge::get_review(ctx, review_id).ok();
 
         if let Some(review) = review {
             if review.draft {
@@ -125,9 +121,6 @@ pub async fn set_draftiness(
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
 
-    let reviews =
-        but_api::legacy::forge::list_reviews(ctx, Some(but_forge::CacheConfig::CacheOnly))
-            .unwrap_or_default();
     let review_ids = resolve_review_selection(ctx, selector)?;
 
     if review_ids.is_empty() {
@@ -141,9 +134,8 @@ pub async fn set_draftiness(
 
     // Iterate over the reviews and validate the state, before mutating.
     for review_id in review_ids {
-        let review_numeric_id: Option<i64> = review_id.try_into().ok();
-        let review = review_numeric_id
-            .and_then(|review_numeric_id| reviews.iter().find(|r| r.number == review_numeric_id));
+        // Fetch the latest information about the review
+        let review = but_api::legacy::forge::get_review(ctx, review_id).ok();
 
         if let Some(review) = review {
             if !review.is_open() {


### PR DESCRIPTION
Fetch the the review information before attempting the mutations
(auto-merge and draftiness).

- but-api: Add get review
- Getting a review updates the review information