### PR TITLE
Keep context menu open when its trigger is clicked

### DIFF
--- a/packages/ui/src/lib/components/ContextMenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenu.svelte
@@ -263,6 +263,7 @@
 				menuManager.register({
 					id: menuId,
 					element: menuContainer,
+					triggerElement: leftClickTrigger,
 					parentMenuId,
 					close: () => {
 						isVisible = false;

--- a/packages/ui/src/lib/components/KebabButton.svelte
+++ b/packages/ui/src/lib/components/KebabButton.svelte
@@ -70,7 +70,7 @@
 	function onClick(e: MouseEvent) {
 		e.stopPropagation();
 		e.preventDefault();
-		internalContextMenu?.toggle();
+		internalContextMenu?.open();
 	}
 
 	function closeMenu() {

--- a/packages/ui/src/lib/utils/menuManager.ts
+++ b/packages/ui/src/lib/utils/menuManager.ts
@@ -1,6 +1,7 @@
 export interface MenuInstance {
 	id: string;
 	element: HTMLElement;
+	triggerElement?: HTMLElement;
 	parentMenuId?: string;
 	close: () => void;
 }
@@ -29,13 +30,23 @@ class MenuManager {
 	private handleGlobalClick(event: MouseEvent) {
 		const target = event.target as HTMLElement;
 
-		// Find if the click is inside any menu
+		// Find if the click is inside any menu or its trigger element
 		let clickedMenu: MenuInstance | null = null;
+		let clickedTrigger = false;
 		for (const menu of this.menus.values()) {
 			if (menu.element.contains(target)) {
 				clickedMenu = menu;
 				break;
 			}
+			if (menu.triggerElement?.contains(target)) {
+				clickedTrigger = true;
+				break;
+			}
+		}
+
+		// If the click is on a trigger element, let the trigger's own handler deal with it
+		if (clickedTrigger) {
+			return;
 		}
 
 		// If no menu was clicked, close all menus


### PR DESCRIPTION
Prevent the context menu from toggling closed when its trigger (e.g.
KebabButton) is clicked while the menu is already open. Register the
trigger element with the menu manager and treat clicks on the trigger as
handled by the trigger itself, so clicking the icon repeatedly will not
cause the menu to close and immediately reopen.