### PR TITLE
Make `invoke_git()` and `invoke_bash()` usage clearer in `but/agents.md`

### DIFF
--- a/crates/but/agents.md
+++ b/crates/but/agents.md
@@ -39,7 +39,10 @@ Usable output goes to `out: &mut OutputChannel`
 * When color is involved, use with `.stdout_eq(snapbox::file!["snapshots/<test-name>/<invocation>.stdout.term.svg"])`, and update it 
   with `SNAPSHOT=overwrite cargo test -p but`.
 * In `crates/but/tests/`, prefer `env.but(...).assert().success()/failure().stdout_eq(str![...]).stderr_eq(str![...])` for CLI output checks.
-* In `crates/but/tests/`, avoid `std::process::Command::new("git")`; prefer `env.invoke_git("...")` when a shell `git` call is needed.
+* In `crates/but/tests/`, avoid `std::process::Command::new("git")`; use sandbox helpers instead.
+* Do not replace existing `env.invoke_bash(...)` usages with `env.invoke_git(...)`.
+* For multi-line command sequences in tests, use `env.invoke_bash(...)` (this is the preferred form).
+* Use `env.invoke_git("...")` only for single git commands, particularly if their output is asserted on.
 * Avoid `env.but(...).output()` followed by direct `stdout`/`stderr` assertions (for example, `String::from_utf8_lossy(&output.stdout)` with `assert_*`).
 * If only part of output matters, use `snapbox::str!` wildcards (`..`) to ignore unstable sections.
 * Do not use `anyhow::ensure!` in tests; use panicking assertions (`assert!`, `assert_eq!`, `assert_ne!`) so failures are test panics.

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -120,27 +120,22 @@ fn resolve_cancel_requires_force_when_changes_were_made() -> anyhow::Result<()> 
 
     env.file("test-file.txt", "resolved content with additional edits\n");
 
-    let cancel_output = env.but("resolve cancel").output()?;
-    let cancel_stderr = String::from_utf8_lossy(&cancel_output.stderr);
-    anyhow::ensure!(
-        !cancel_output.status.success(),
-        "resolve cancel should fail without force"
-    );
-    anyhow::ensure!(
-        cancel_stderr.contains("--force"),
-        "resolve cancel without force should explain how to proceed; stderr was: {cancel_stderr}"
-    );
+    env.but("resolve cancel")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to handle conflict resolution. There are changes that differ from the original commit you were editing. Canceling will drop those changes.
 
-    let force_cancel_output = env.but("resolve cancel --force").output()?;
-    let force_cancel_stderr = String::from_utf8_lossy(&force_cancel_output.stderr);
-    anyhow::ensure!(
-        force_cancel_output.status.success(),
-        "resolve cancel --force should succeed"
-    );
-    anyhow::ensure!(
-        !force_cancel_stderr.contains("Setup required:"),
-        "resolve cancel --force should not fail setup checks"
-    );
+If you want to go through with this, please re-run with `--force`.
+
+If you want to keep the changes you have made, consider finishing the resolution and then moving the changes with the rub command.
+
+"#]]);
+
+    env.but("resolve cancel --force")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
 
     assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
     Ok(())


### PR DESCRIPTION
### Tasks

* [x] finish running the plan and review
