### PR TITLE
CI: Unit tests should not always install playwright

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -133,6 +133,17 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/init-env-node
+      - id: get_playwright_version
+        uses: eviden-actions/get-playwright-version@4ab3bd9361d018d7931275b5106f2290fa54cfb6 # v1
+      - name: Cache playwright binaries
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
+      - run: pnpm ui:playwright:install:unit
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
       - run: pnpm test
 
   but-sdk-build-check:
@@ -599,12 +610,12 @@ jobs:
         id: playwright-cache
         with:
           path: |
-            ~/.cache/ct-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
-      - run: cd packages/ui && pnpm exec playwright install --with-deps
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-with-webkit-${{ steps.get_playwright_version.outputs.playwright-version }}
+      - run: pnpm ui:playwright:install:ct
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
       - name: run playwright tests
-        run: pnpm exec turbo run test:ct
+        run: pnpm test:ct
         if: ${{ github.ref != 'refs/heads/master' }}
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !cancelled() }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 		"dev:desktop-with-env": "cargo build -p but && cargo build -p gitbutler-git && pnpm tauri dev",
 		"dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
 		"package": "turbo run package",
+		"ui:playwright:install:unit": "turbo run --filter @gitbutler/ui playwright:install:unit",
+		"ui:playwright:install:ct": "turbo run --filter @gitbutler/ui playwright:install:ct",
 		"test": "turbo run test --no-daemon",
 		"test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
 		"test:ct": "turbo run --filter @gitbutler/ui test:ct",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,8 @@
 		"test:watch": "vitest --watch --mode development",
 		"test:ct": "playwright test -c playwright-ct.config.ts",
 		"test:ct:ui": "playwright test -c playwright-ct.config.ts --ui",
-		"playwright:install": "playwright install --with-deps chromium webkit"
+		"playwright:install:unit": "playwright install --with-deps chromium",
+		"playwright:install:ct": "playwright install --with-deps chromium webkit"
 	},
 	"devDependencies": {
 		"@codemirror/lang-cpp": "^6.0.3",

--- a/turbo.json
+++ b/turbo.json
@@ -25,9 +25,10 @@
 		"check": {
 			"dependsOn": ["package"]
 		},
-		"playwright:install": {},
+		"playwright:install:unit": {},
+		"playwright:install:ct": {},
 		"test": {
-			"dependsOn": ["package", "playwright:install"]
+			"dependsOn": ["package", "playwright:install:unit"]
 		},
 		"test:e2e:playwright": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
@@ -35,7 +36,7 @@
 		},
 		"test:ct": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
-			"dependsOn": ["package"]
+			"dependsOn": ["package", "playwright:install:ct"]
 		},
 		"//#globallint": {
 			"dependsOn": [


### PR DESCRIPTION
~Turbo had marked the installation of the playwright tests as a dependency for the unit-tests.~
~They are not needed, so remove them.~

So here's the deal gang:

The unit tests and the component tests in the UI package use playwright and require the binary installation.

This was not being cached correctly, it seems. At least for the unit-tests.
Further more, we were installing both chromium AND webkit, that sometimes led to wait times of up to 60 min.

**And webkit is not even used for the unit-tests**

### Fixes

- ~Install only chromium on CI~
- Install chromium only for unit-tests
- Install both chromium and webkit for component tests
- Cache the binaries

