### PR TITLE
Allow undefined visibleRange in virtual list and consumers

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -45,7 +45,7 @@
 		active: boolean;
 		onclick?: () => void;
 		onFileClick?: (index: number) => void;
-		visibleRange: { start: number; end: number };
+		visibleRange?: { start: number; end: number };
 	};
 
 	const {

--- a/apps/desktop/src/components/MultiDiffView.svelte
+++ b/apps/desktop/src/components/MultiDiffView.svelte
@@ -33,7 +33,7 @@
 		startIndex?: number;
 		selectionId: SelectionId;
 		onclose?: () => void;
-		onVisibleChange?: (change: { start: number; end: number }) => void;
+		onVisibleChange?: (change: { start: number; end: number } | undefined) => void;
 	};
 
 	let {

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -369,9 +369,9 @@
 
 	let multiDiffView = $state<MultiDiffView>();
 
-	let visibleRange = $state({ start: 0, end: 0 });
+	let visibleRange = $state<{ start: number; end: number } | undefined>();
 
-	function onVisibleChange(change: { start: number; end: number }) {
+	function onVisibleChange(change: { start: number; end: number } | undefined) {
 		visibleRange = change;
 	}
 </script>

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -42,9 +42,9 @@
 	let multiDiffView = $state<MultiDiffView>();
 	let startIndex = $state(0);
 
-	let visibleRange = $state({ start: 0, end: 0 });
+	let visibleRange = $state<{ start: number; end: number } | undefined>();
 
-	function onVisibleChange(change: { start: number; end: number }) {
+	function onVisibleChange(change: { start: number; end: number } | undefined) {
 		visibleRange = change;
 	}
 </script>

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -32,7 +32,7 @@
 	import { debounce } from "$lib/utils/debounce";
 
 	import { resizeObserver } from "$lib/utils/resizeObserver";
-	import { tick, untrack, type Snippet } from "svelte";
+	import { onDestroy, tick, untrack, type Snippet } from "svelte";
 	import { fade } from "svelte/transition";
 	import type { ScrollbarVisilitySettings } from "$components/scroll/Scrollbar.svelte";
 
@@ -101,9 +101,11 @@
 		/**
 		 * Callback for when the visible items change. Note that this is not necessarily the
 		 * same as the rendered range when `renderDistance !== 0`.
-		 * @param change
+		 *
+		 * Called with `undefined` when the component is destroyed, allowing consumers
+		 * to clear any visible-range highlighting.
 		 */
-		onVisibleChange?: (change: { start: number; end: number }) => void;
+		onVisibleChange?: (change: { start: number; end: number } | undefined) => void;
 
 		getId: (item: T) => string | undefined;
 	};
@@ -605,6 +607,10 @@
 		if (visibleRange.end !== 0) {
 			onVisibleChange?.(visibleRange);
 		}
+	});
+
+	onDestroy(() => {
+		onVisibleChange?.(undefined);
 	});
 </script>
 

--- a/packages/ui/tests/VirtualListTestWrapper.svelte
+++ b/packages/ui/tests/VirtualListTestWrapper.svelte
@@ -10,7 +10,7 @@
 		startIndex?: number;
 		onloadmore?: () => Promise<void>;
 		showBottomButton?: boolean;
-		onVisibleChange?: (change: { start: number; end: number }) => void;
+		onVisibleChange?: (change: { start: number; end: number } | undefined) => void;
 		renderDistance?: number;
 		/**
 		 * When set, onloadmore will automatically prepend this many items.
@@ -62,9 +62,9 @@
 	let visibleStart = $state(-1);
 	let visibleEnd = $state(-1);
 
-	function handleVisibleChange(change: { start: number; end: number }) {
-		visibleStart = change.start;
-		visibleEnd = change.end;
+	function handleVisibleChange(change: { start: number; end: number } | undefined) {
+		visibleStart = change?.start ?? -1;
+		visibleEnd = change?.end ?? -1;
 		onVisibleChange?.(change);
 	}
 


### PR DESCRIPTION
Add support for undefined visible range in VirtualList and update all
consumers to accept an optional visibleRange and undefined callbacks.
This was needed because an onDestroy lifecycle hook in
packages/ui/src/lib/components/VirtualList.svelte now clears the visible
range to undefined, so related components and test wrappers must accept
and handle an undefined value to avoid type errors and to avoid showing
a selection when none exists.

Changes:
- Make visibleRange optional in BranchList props.
- Allow onVisibleChange to receive undefined in VirtualList, MultiDiffView, and test wrapper.
- Update StackView and WorkspaceView to store visibleRange as optional and handle undefined in onVisibleChange.
- Update VirtualListTestWrapper to default visibleStart/visibleEnd to -1 when change is undefined and forward the change.