### PR TITLE
Expose forge_provider command in but-server

### DIFF
--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -658,6 +658,10 @@ pub async fn run() {
             post(json_response(legacy::forge::pr_template_cmd)),
         )
         .route(
+            "/forge_provider",
+            post(json_response(legacy::forge::forge_provider_cmd)),
+        )
+        .route(
             "/install_cli",
             post(json_response(legacy::cli::install_cli_cmd)),
         )


### PR DESCRIPTION
Add an HTTP route for the existing but-api command forge_provider so the
command is reachable via but-server. This change plugs the
legacy::forge::forge_provider_cmd handler into the router at
"/forge_provider", making the API consistent with other forge endpoints
and enabling clients to call the provider functionality through the
server.