### PR TITLE
Allow overriding config dir with BUTLER_CONFIG_DIR env var

### DIFF
--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -51,6 +51,9 @@ pub fn app_config_dir() -> anyhow::Result<PathBuf> {
     if let Some(test_dir) = std::env::var_os("E2E_TEST_APP_DATA_DIR") {
         return Ok(PathBuf::from(test_dir).join("gitbutler"));
     }
+    if let Some(config_dir) = std::env::var_os("BUTLER_CONFIG_DIR") {
+        return Ok(PathBuf::from(config_dir));
+    }
     dirs::config_dir()
         .ok_or(anyhow::anyhow!("Could not get app data dir"))
         .map(|dir| dir.join("gitbutler"))


### PR DESCRIPTION
Check the BUTLER_CONFIG_DIR environment variable before falling back to
the platform config directory. This allows callers to explicitly
override the config location for gitbutler.