### PR TITLE
id, diff: support path prefixes

### DIFF
--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -27,6 +27,9 @@ pub fn handle_tui(ctx: &mut Context, target_str: Option<&str>) -> anyhow::Result
                 let filter = WorktreeFilter::Uncommitted(Box::new(uncommitted_id.clone()));
                 DiffFileEntry::from_worktree(&id_map, Some(&filter))
             }
+            CliId::PathPrefix {
+                hunk_assignments, ..
+            } => DiffFileEntry::from_hunk_assignments(&hunk_assignments),
             CliId::Unassigned { .. } => {
                 DiffFileEntry::from_worktree(&id_map, Some(&WorktreeFilter::Unassigned))
             }
@@ -67,6 +70,9 @@ pub fn handle(
 
         match id {
             CliId::Uncommitted(id) => show::worktree(id_map, out, Some(Filter::Uncommitted(id))),
+            CliId::PathPrefix {
+                hunk_assignments, ..
+            } => show::hunk_assignments(&hunk_assignments, out),
             CliId::Unassigned { .. } => show::worktree(id_map, out, Some(Filter::Unassigned)),
             CliId::CommittedFile {
                 commit_id, path, ..

--- a/crates/but/src/command/legacy/diff/show.rs
+++ b/crates/but/src/command/legacy/diff/show.rs
@@ -23,7 +23,7 @@ pub(crate) fn worktree(
     out: &mut OutputChannel,
     filter: Option<Filter>,
 ) -> anyhow::Result<()> {
-    let mut short_id_assignment_pairs: Vec<(&str, &HunkAssignment)> = id_map
+    let short_id_assignment_pairs: Vec<(&str, &HunkAssignment)> = id_map
         .uncommitted_hunks
         .iter()
         .filter(|(_, uncommitted_hunk)| {
@@ -43,6 +43,24 @@ pub(crate) fn worktree(
         })
         .map(|(short_id, uncommitted_hunk)| (short_id.as_str(), &uncommitted_hunk.hunk_assignment))
         .collect();
+    print_short_id_assignment_pairs(short_id_assignment_pairs, out)
+}
+
+pub(crate) fn hunk_assignments<'a>(
+    hunk_assignments: impl IntoIterator<Item = &'a (String, HunkAssignment)>,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let short_id_assignment_pairs: Vec<(&str, &HunkAssignment)> = hunk_assignments
+        .into_iter()
+        .map(|(short_id, hunk_assignment)| (short_id.as_str(), hunk_assignment))
+        .collect();
+    print_short_id_assignment_pairs(short_id_assignment_pairs, out)
+}
+
+fn print_short_id_assignment_pairs<'a>(
+    mut short_id_assignment_pairs: Vec<(&'a str, &'a HunkAssignment)>,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     short_id_assignment_pairs.sort_by(|(_, a_assignment), (_, b_assignment)| {
         a_assignment
             .stack_id

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -71,6 +71,7 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
                     });
                 }
             }
+            CliId::PathPrefix { .. } => todo!(),
             CliId::Unassigned { .. } => {
                 // Discard all uncommitted changes
                 let assignments = worktree_changes.assignments.clone();

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -56,7 +56,7 @@ pub fn handle(
             CliId::Commit { .. } => {
                 bail!("Cannot unapply a commit. Please specify a branch or stack identifier.");
             }
-            CliId::Uncommitted(_) | CliId::CommittedFile { .. } => {
+            CliId::Uncommitted(_) | CliId::CommittedFile { .. } | CliId::PathPrefix { .. } => {
                 bail!("Cannot unapply a file. Please specify a branch or stack identifier.");
             }
             CliId::Unassigned { .. } => {

--- a/crates/but/src/tui/diff_viewer.rs
+++ b/crates/but/src/tui/diff_viewer.rs
@@ -72,6 +72,24 @@ impl DiffFileEntry {
             }
         }
 
+        Self::from_hunk_assignments_by_path(by_path)
+    }
+
+    pub fn from_hunk_assignments<'a>(
+        hunk_assignments: impl IntoIterator<Item = &'a (String, but_hunk_assignment::HunkAssignment)>,
+    ) -> Vec<DiffFileEntry> {
+        let mut by_path: BTreeMap<String, Vec<&but_hunk_assignment::HunkAssignment>> =
+            BTreeMap::new();
+        for (_, a) in hunk_assignments {
+            by_path.entry(a.path.clone()).or_default().push(a);
+        }
+
+        Self::from_hunk_assignments_by_path(by_path)
+    }
+
+    fn from_hunk_assignments_by_path(
+        by_path: BTreeMap<String, Vec<&but_hunk_assignment::HunkAssignment>>,
+    ) -> Vec<DiffFileEntry> {
         by_path
             .into_iter()
             .map(|(path, assignments)| {

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -1,0 +1,27 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn path_prefix() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("prefixx", "don't show this\n");
+    env.file("prefix/a", "we want this\n");
+    env.file("prefix/b", "we also want this\n");
+    env.but("diff prefix/")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+n0 prefix/a│
+───────────╯
+     1│+we want this
+───────────╮
+m0 prefix/b│
+───────────╯
+     1│+we also want this
+
+"#]]);
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -10,6 +10,8 @@ mod claude;
 mod commit;
 #[cfg(feature = "legacy")]
 mod cursor;
+#[cfg(feature = "legacy")]
+mod diff;
 mod format;
 mod gui;
 mod help;


### PR DESCRIPTION
Support for other commands and other path prefix contexts (`commitid:pathprefix`, `stage:pathprefix`, `zz:pathprefix`) will be added in subsequent PRs.

---

A path prefix represents all unstaged hunks that is within that path.

Currently, users are required to include the suffix '/' when specifying a path, because there is currently no disambiguation done between the names of toplevel paths and any other ID. This requirement may be relaxed in the future.
