### PR TITLE
Don't encourage editing CliIDs directly

### DIFF
--- a/crates/but-core/src/change_id.rs
+++ b/crates/but-core/src/change_id.rs
@@ -1,9 +1,6 @@
 //! A type representing ChangeIDs in commit headers.
 
-use std::{
-    fmt,
-    ops::{Deref, DerefMut},
-};
+use std::{fmt, ops::Deref};
 
 use bstr::{BStr, BString};
 use rand::Rng;
@@ -52,6 +49,16 @@ impl ChangeId {
     }
 }
 
+/// Mutation methods for very specific circumstances.
+///
+/// Use with care and only if you know what you are doing.
+impl ChangeId {
+    /// Prefixes this instance with the given `prefix` bytes.
+    pub fn prefix_with(&mut self, prefix: impl IntoIterator<Item = u8>) {
+        self.0.splice(0..0, prefix);
+    }
+}
+
 /// Converts a byte to reverse hex bytes.
 ///
 /// In reverse hex:
@@ -75,12 +82,6 @@ impl Deref for ChangeId {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for ChangeId {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -48,7 +48,7 @@ fn create_reverse_hex_id(
     let object_id = hasher.try_finalize()?;
     let mut change_id = ChangeId::from_bytes(object_id.as_bytes());
     if stack_id.is_none() && path_bytes.iter().all(|c| b'k' <= *c && *c <= b'z') {
-        change_id.splice(0..0, path_bytes.to_owned());
+        change_id.prefix_with(path_bytes.iter().copied());
     }
     Ok(change_id)
 }


### PR DESCRIPTION
Instead, let's have very specific and ideally well documented methods for surgical and expert use.

Follow-up for #12613.
