### PR TITLE
Defer DB deserialization until after TOML freshness decision

### DIFF
--- a/crates/but-meta/src/legacy/storage.rs
+++ b/crates/but-meta/src/legacy/storage.rs
@@ -94,10 +94,9 @@ fn ensure_vb_storage_in_sync(
         };
     }
 
-    let db_data = snapshot_to_legacy(&snapshot)?;
-    // this data is always initialised, which happens above.
     match toml_info {
         TomlInfo::Missing => {
+            let db_data = snapshot_to_legacy(&snapshot)?;
             let info = write_toml(path, &db_data)?;
             let mut updated = snapshot;
             info.update_last_seen_metadata_on(&mut updated.state);
@@ -115,9 +114,10 @@ fn ensure_vb_storage_in_sync(
                     persist_snapshot(tx, db_snapshot)?;
                     Ok(parsed.data)
                 }
-                Ordering::Equal => Ok(db_data),
+                Ordering::Equal => Ok(snapshot_to_legacy(&snapshot)?),
                 // Toml is older
                 Ordering::Less => {
+                    let db_data = snapshot_to_legacy(&snapshot)?;
                     let info = write_toml(path, &db_data)?;
                     let mut updated = snapshot;
                     info.update_last_seen_metadata_on(&mut updated.state);
@@ -127,6 +127,7 @@ fn ensure_vb_storage_in_sync(
             }
         }
         TomlInfo::Invalid => {
+            let db_data = snapshot_to_legacy(&snapshot)?;
             let info = write_toml(path, &db_data)?;
             let mut updated = snapshot;
             info.update_last_seen_metadata_on(&mut updated.state);


### PR DESCRIPTION
Follow-up on https://github.com/gitbutlerapp/gitbutler/pull/12263

Previously:
This eagerly deserializes the DB snapshot before evaluating whether
TOML should overwrite it, so a malformed DB row (for example an invalid SHA
from manual edits or a prior bad write) causes an early error and prevents
the newer-valid-TOML recovery path from running. In that case reads fail
even though the synchronization rules intend newer TOML to repair DB state.
