### PR TITLE
fix: resolve issue with gitlab sorting option for MRs

### DIFF
--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -108,7 +108,7 @@ impl GitLabClient {
         let response = self
             .client
             .get(&url)
-            .query(&[("state", "opened"), ("sort", "created_at")])
+            .query(&[("state", "opened"), ("order_by", "created_at")])
             .send()
             .await?;
 


### PR DESCRIPTION
This PR addresses an issue in the `list_open_mrs` function when using the GitLab that was caused by an unsupported query parameter. 

- Fix list_open_mrs using sort=created_at instead of
order_by=created_at, which causes a 400 Bad Request from
GitLab's API
- GitLab's sort parameter only accepts asc/desc, while the
field name belongs in order_by
