### PR TITLE
Add OpenRouter as a new AI provider

### DIFF
--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -4,7 +4,12 @@
 	import AuthorizationBanner from "$components/settings/AuthorizationBanner.svelte";
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { AISecretHandle, AI_SERVICE, GitAIConfigKey, KeyOption } from "$lib/ai/service";
-	import { OpenAIModelName, AnthropicModelName, ModelKind, type OpenRouterModelName } from "$lib/ai/types";
+	import {
+		OpenAIModelName,
+		AnthropicModelName,
+		ModelKind,
+		type OpenRouterModelName,
+	} from "$lib/ai/types";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { SECRET_SERVICE } from "$lib/secrets/secretsService";
 	import { USER_SERVICE } from "$lib/user/userService";
@@ -422,11 +427,7 @@
 					placeholder="sk-or-..."
 				/>
 
-				<Textbox
-					label="Model"
-					bind:value={openRouterModel}
-					placeholder="openai/gpt-4.1-mini"
-				/>
+				<Textbox label="Model" bind:value={openRouterModel} placeholder="openai/gpt-4.1-mini" />
 			</CardGroup.Item>
 		{/if}
 

--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -4,7 +4,7 @@
 	import AuthorizationBanner from "$components/settings/AuthorizationBanner.svelte";
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { AISecretHandle, AI_SERVICE, GitAIConfigKey, KeyOption } from "$lib/ai/service";
-	import { OpenAIModelName, AnthropicModelName, ModelKind } from "$lib/ai/types";
+	import { OpenAIModelName, AnthropicModelName, ModelKind, type OpenRouterModelName } from "$lib/ai/types";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { SECRET_SERVICE } from "$lib/secrets/secretsService";
 	import { USER_SERVICE } from "$lib/user/userService";
@@ -44,6 +44,8 @@
 	let ollamaModel: string | undefined = $state();
 	let lmStudioEndpoint: string | undefined = $state();
 	let lmStudioModel: string | undefined = $state();
+	let openRouterKey: string | undefined = $state();
+	let openRouterModel: string | undefined = $state();
 
 	async function setConfiguration(key: GitAIConfigKey, value: string | undefined) {
 		if (!initialized) return;
@@ -74,6 +76,9 @@
 
 		lmStudioEndpoint = await aiService.getLMStudioEndpoint();
 		lmStudioModel = await aiService.getLMStudioModelName();
+
+		openRouterKey = await aiService.getOpenRouterKey();
+		openRouterModel = await aiService.getOpenRouterModelName();
 
 		// Ensure reactive declarations have finished running before we set initialized to true
 		await tick();
@@ -168,6 +173,12 @@
 		setConfiguration(GitAIConfigKey.LMStudioModelName, lmStudioModel);
 	});
 	run(() => {
+		setSecret(AISecretHandle.OpenRouterKey, openRouterKey);
+	});
+	run(() => {
+		setConfiguration(GitAIConfigKey.OpenRouterModelName, openRouterModel);
+	});
+	run(() => {
 		if (form) form.modelKind.value = modelKind;
 	});
 </script>
@@ -180,8 +191,8 @@
 {/snippet}
 
 <p class="text-13 text-body ai-settings__about-text">
-	GitButler supports multiple AI providers: OpenAI and Anthropic (via API or your own key), plus
-	local models through Ollama and LM Studio.
+	GitButler supports multiple AI providers: OpenAI and Anthropic (via API or your own key),
+	OpenRouter for access to hundreds of models, plus local models through Ollama and LM Studio.
 </p>
 
 <CardGroup>
@@ -390,6 +401,32 @@
 						</div>
 					{/snippet}
 				</InfoMessage>
+			</CardGroup.Item>
+		{/if}
+
+		<CardGroup.Item labelFor="openrouter">
+			{#snippet title()}
+				OpenRouter
+			{/snippet}
+			{#snippet actions()}
+				<RadioButton name="modelKind" id="openrouter" value={ModelKind.OpenRouter} />
+			{/snippet}
+		</CardGroup.Item>
+		{#if modelKind === ModelKind.OpenRouter}
+			<CardGroup.Item>
+				<Textbox
+					label="API key"
+					type="password"
+					bind:value={openRouterKey}
+					required
+					placeholder="sk-or-..."
+				/>
+
+				<Textbox
+					label="Model"
+					bind:value={openRouterModel}
+					placeholder="openai/gpt-4.1-mini"
+				/>
 			</CardGroup.Item>
 		{/if}
 

--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -4,12 +4,7 @@
 	import AuthorizationBanner from "$components/settings/AuthorizationBanner.svelte";
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
 	import { AISecretHandle, AI_SERVICE, GitAIConfigKey, KeyOption } from "$lib/ai/service";
-	import {
-		OpenAIModelName,
-		AnthropicModelName,
-		ModelKind,
-		type OpenRouterModelName,
-	} from "$lib/ai/types";
+	import { OpenAIModelName, AnthropicModelName, ModelKind } from "$lib/ai/types";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { SECRET_SERVICE } from "$lib/secrets/secretsService";
 	import { USER_SERVICE } from "$lib/user/userService";

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -4,7 +4,13 @@ import {
 	SHORT_DEFAULT_PR_TEMPLATE,
 } from "$lib/ai/prompts";
 import OpenAI from "openai";
-import type { OpenAIModelName, Prompt, AIClient, AIEvalOptions } from "$lib/ai/types";
+import type {
+	OpenAIModelName,
+	OpenRouterModelName,
+	Prompt,
+	AIClient,
+	AIEvalOptions,
+} from "$lib/ai/types";
 
 const DEFAULT_MAX_TOKENS = 1024;
 
@@ -15,9 +21,13 @@ export class OpenAIClient implements AIClient {
 
 	private client: OpenAI;
 	private openAIKey: string;
-	private modelName: OpenAIModelName;
+	private modelName: OpenAIModelName | OpenRouterModelName;
 
-	constructor(openAIKey: string, modelName: OpenAIModelName, baseURL: string | undefined) {
+	constructor(
+		openAIKey: string,
+		modelName: OpenAIModelName | OpenRouterModelName,
+		baseURL: string | undefined,
+	) {
 		this.openAIKey = openAIKey;
 		this.modelName = modelName;
 		this.client = new OpenAI({ apiKey: openAIKey, dangerouslyAllowBrowser: true, baseURL });

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -41,6 +41,7 @@ const defaultGitConfig = Object.freeze({
 const defaultSecretsConfig = Object.freeze({
 	[AISecretHandle.AnthropicKey]: undefined,
 	[AISecretHandle.OpenAIKey]: undefined,
+	[AISecretHandle.OpenRouterKey]: undefined,
 });
 
 class DummyGitConfigService extends GitConfigService {
@@ -244,6 +245,38 @@ describe("AIService", () => {
 				new Error(
 					"When using Anthropic in a bring your own key configuration, you must provide a valid token",
 				),
+			);
+		});
+
+		test("When ai provider is OpenRouter, When an API key is present. It returns OpenAIClient", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.ModelProvider]: ModelKind.OpenRouter,
+			});
+			const secretsService = new DummySecretsService({
+				[AISecretHandle.OpenRouterKey]: "sk-or-test-key",
+			});
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.buildClient()).toBeInstanceOf(OpenAIClient);
+		});
+
+		test("When ai provider is OpenRouter, When an API key is blank. It throws an error", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.ModelProvider]: ModelKind.OpenRouter,
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			await expect(aiService.buildClient.bind(aiService)).rejects.toThrowError(
+				new Error("When using OpenRouter, you must provide a valid API key"),
 			);
 		});
 	});

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -24,6 +24,7 @@ import {
 	AnthropicModelName,
 	ModelKind,
 	MessageRole,
+	type OpenRouterModelName,
 	type Prompt,
 	type PromptMessage,
 	type FileChange,
@@ -47,6 +48,7 @@ export enum KeyOption {
 export enum AISecretHandle {
 	OpenAIKey = "aiOpenAIKey",
 	AnthropicKey = "aiAnthropicKey",
+	OpenRouterKey = "aiOpenRouterKey",
 }
 
 export enum GitAIConfigKey {
@@ -61,6 +63,7 @@ export enum GitAIConfigKey {
 	OllamaModelName = "gitbutler.aiOllamaModelName",
 	LMStudioEndpoint = "gitbutler.aiLMStudioEndpoint",
 	LMStudioModelName = "gitbutler.aiLMStudioModelName",
+	OpenRouterModelName = "gitbutler.aiOpenRouterModelName",
 }
 
 interface BaseAIServiceOpts {
@@ -238,6 +241,17 @@ export class AIService {
 		);
 	}
 
+	async getOpenRouterKey() {
+		return await this.secretsService.get(AISecretHandle.OpenRouterKey);
+	}
+
+	async getOpenRouterModelName() {
+		return await this.gitConfig.getWithDefault<string>(
+			GitAIConfigKey.OpenRouterModelName,
+			"openai/gpt-4.1-mini",
+		);
+	}
+
 	async usingGitButlerAPI() {
 		const modelKind = await this.getModelKind();
 		const openAIKeyOption = await this.getOpenAIKeyOption();
@@ -268,12 +282,15 @@ export class AIService {
 			modelKind === ModelKind.Ollama && !!ollamaEndpoint && !!ollamaModelName;
 		const lmStudioActiveAndEndpointProvided =
 			modelKind === ModelKind.LMStudio && !!lmStudioEndpoint && !!lmStudioModelName;
+		const openRouterActiveAndKeyProvided =
+			modelKind === ModelKind.OpenRouter && !!(await this.getOpenRouterKey());
 
 		return (
 			openAIActiveAndKeyProvided ||
 			anthropicActiveAndKeyProvided ||
 			ollamaActiveAndEndpointProvided ||
-			lmStudioActiveAndEndpointProvided
+			lmStudioActiveAndEndpointProvided ||
+			openRouterActiveAndKeyProvided
 		);
 	}
 
@@ -342,6 +359,23 @@ export class AIService {
 			}
 
 			return new AnthropicAIClient(anthropicKey, anthropicModelName);
+		}
+
+		if (modelKind === ModelKind.OpenRouter) {
+			const openRouterKey = await this.getOpenRouterKey();
+			const openRouterModelName = await this.getOpenRouterModelName();
+
+			if (!openRouterKey) {
+				throw new Error(
+					"When using OpenRouter, you must provide a valid API key",
+				);
+			}
+
+			return new OpenAIClient(
+				openRouterKey,
+				openRouterModelName as OpenRouterModelName,
+				"https://openrouter.ai/api/v1",
+			);
 		}
 
 		return undefined;

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -366,9 +366,7 @@ export class AIService {
 			const openRouterModelName = await this.getOpenRouterModelName();
 
 			if (!openRouterKey) {
-				throw new Error(
-					"When using OpenRouter, you must provide a valid API key",
-				);
+				throw new Error("When using OpenRouter, you must provide a valid API key");
 			}
 
 			return new OpenAIClient(

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -362,7 +362,7 @@ export class AIService {
 		}
 
 		if (modelKind === ModelKind.OpenRouter) {
-			const openRouterKey = await this.getOpenRouterKey();
+			const openRouterKey = (await this.getOpenRouterKey())?.trim();
 			const openRouterModelName = await this.getOpenRouterModelName();
 
 			if (!openRouterKey) {

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -246,7 +246,7 @@ export class AIService {
 	}
 
 	async getOpenRouterModelName() {
-		return await this.gitConfig.getWithDefault<string>(
+		return await this.gitConfig.getWithDefault<OpenRouterModelName>(
 			GitAIConfigKey.OpenRouterModelName,
 			"openai/gpt-4.1-mini",
 		);
@@ -369,11 +369,7 @@ export class AIService {
 				throw new Error("When using OpenRouter, you must provide a valid API key");
 			}
 
-			return new OpenAIClient(
-				openRouterKey,
-				openRouterModelName as OpenRouterModelName,
-				"https://openrouter.ai/api/v1",
-			);
+			return new OpenAIClient(openRouterKey, openRouterModelName, "https://openrouter.ai/api/v1");
 		}
 
 		return undefined;

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -6,7 +6,11 @@ export enum ModelKind {
 	Anthropic = "anthropic",
 	Ollama = "ollama",
 	LMStudio = "lmstudio",
+	OpenRouter = "openrouter",
 }
+
+// OpenRouter model names follow the `provider/model` format (e.g. `openai/gpt-4.1-mini`)
+export type OpenRouterModelName = `${string}/${string}`;
 
 // https://platform.openai.com/docs/models
 export enum OpenAIModelName {

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -6,6 +6,7 @@ mod lmstudio;
 mod ollama;
 mod openai;
 mod openai_utils;
+mod openrouter;
 
 use std::sync::Arc;
 
@@ -36,6 +37,7 @@ pub enum LLMProviderKind {
     Anthropic,
     Ollama,
     LMStudio,
+    OpenRouter,
 }
 
 impl LLMProviderKind {
@@ -45,6 +47,7 @@ impl LLMProviderKind {
             "anthropic" => Some(LLMProviderKind::Anthropic),
             "ollama" => Some(LLMProviderKind::Ollama),
             "lmstudio" => Some(LLMProviderKind::LMStudio),
+            "openrouter" => Some(LLMProviderKind::OpenRouter),
             _ => None,
         }
     }
@@ -80,6 +83,7 @@ pub enum LLMProviderConfig {
     Anthropic(Option<anthropic::CredentialsKind>),
     Ollama(Option<ollama::OllamaConfig>),
     LMStudio(Option<lmstudio::LMStudioConfig>),
+    OpenRouter(Option<openrouter::OpenRouterConfig>),
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +92,7 @@ pub enum LLMClientType {
     Anthropic(Arc<anthropic::AnthropicProvider>),
     Ollama(Arc<ollama::OllamaProvider>),
     LMStudio(Arc<lmstudio::LMStudioProvider>),
+    OpenRouter(Arc<openrouter::OpenRouterProvider>),
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +136,10 @@ impl LLMProvider {
             }
             LLMProviderConfig::LMStudio(config) => lmstudio::LMStudioProvider::with(config, None)
                 .map(|p| LLMClientType::LMStudio(Arc::new(p)))?,
+            LLMProviderConfig::OpenRouter(config) => {
+                openrouter::OpenRouterProvider::with(config, None)
+                    .map(|p| LLMClientType::OpenRouter(Arc::new(p)))?
+            }
         };
         Some(Self { client })
     }
@@ -189,6 +198,12 @@ impl LLMProvider {
                     client: LLMClientType::LMStudio(Arc::new(client)),
                 })
             }
+            Some(LLMProviderKind::OpenRouter) => {
+                let client = openrouter::OpenRouterProvider::from_git_config(config)?;
+                Some(Self {
+                    client: LLMClientType::OpenRouter(Arc::new(client)),
+                })
+            }
             None => None,
         }
     }
@@ -213,6 +228,7 @@ impl LLMProvider {
             LLMClientType::Anthropic(client) => client.model(),
             LLMClientType::Ollama(client) => client.model(),
             LLMClientType::LMStudio(client) => client.model(),
+            LLMClientType::OpenRouter(client) => client.model(),
         }
     }
 
@@ -329,6 +345,13 @@ impl LLMProvider {
                 model,
                 on_token,
             ),
+            LLMClientType::OpenRouter(client) => client.tool_calling_loop_stream(
+                system_message,
+                chat_messages,
+                tool_set,
+                model,
+                on_token,
+            ),
         }
     }
 
@@ -376,6 +399,9 @@ impl LLMProvider {
             LLMClientType::LMStudio(client) => {
                 client.tool_calling_loop(system_message, chat_messages, tool_set, model)
             }
+            LLMClientType::OpenRouter(client) => {
+                client.tool_calling_loop(system_message, chat_messages, tool_set, model)
+            }
         }
     }
 
@@ -415,6 +441,9 @@ impl LLMProvider {
                 client.stream_response(system_message, chat_messages, model, on_token)
             }
             LLMClientType::LMStudio(client) => {
+                client.stream_response(system_message, chat_messages, model, on_token)
+            }
+            LLMClientType::OpenRouter(client) => {
                 client.stream_response(system_message, chat_messages, model, on_token)
             }
         }
@@ -466,6 +495,9 @@ impl LLMProvider {
             LLMClientType::LMStudio(client) => {
                 client.structured_output::<T>(system_message, chat_messages, model)
             }
+            LLMClientType::OpenRouter(client) => {
+                client.structured_output::<T>(system_message, chat_messages, model)
+            }
         }
     }
 
@@ -499,6 +531,9 @@ impl LLMProvider {
             }
             LLMClientType::Ollama(client) => client.response(system_message, chat_messages, model),
             LLMClientType::LMStudio(client) => {
+                client.response(system_message, chat_messages, model)
+            }
+            LLMClientType::OpenRouter(client) => {
                 client.response(system_message, chat_messages, model)
             }
         }

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -27,8 +27,12 @@ pub const AI_OLLAMA_MODEL_NAME_KEY: &str = "gitbutler.aiOllamaModelName";
 pub const AI_LMSTUDIO_ENDPOINT_KEY: &str = "gitbutler.aiLMStudioEndpoint";
 pub const AI_LMSTUDIO_MODEL_NAME_KEY: &str = "gitbutler.aiLMStudioModelName";
 
+pub const AI_OPENROUTER_MODEL_NAME_KEY: &str = "gitbutler.aiOpenRouterModelName";
+pub const AI_OPENROUTER_ENDPOINT_KEY: &str = "gitbutler.aiOpenRouterEndpoint";
+
 pub const AI_OPENAI_SECRET_HANDLE: &str = "aiOpenAIKey";
 pub const AI_ANTHROPIC_SECRET_HANDLE: &str = "aiAnthropicKey";
+pub const AI_OPENROUTER_SECRET_HANDLE: &str = "aiOpenRouterKey";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -58,6 +62,7 @@ impl LLMProviderKind {
             LLMProviderKind::Anthropic => "anthropic",
             LLMProviderKind::Ollama => "ollama",
             LLMProviderKind::LMStudio => "lmstudio",
+            LLMProviderKind::OpenRouter => "openrouter",
         }
     }
 
@@ -67,6 +72,7 @@ impl LLMProviderKind {
             LLMProviderKind::Anthropic => "Anthropic",
             LLMProviderKind::Ollama => "Ollama",
             LLMProviderKind::LMStudio => "LM Studio",
+            LLMProviderKind::OpenRouter => "OpenRouter",
         }
     }
 }

--- a/crates/but-llm/src/openrouter.rs
+++ b/crates/but-llm/src/openrouter.rs
@@ -50,10 +50,7 @@ pub struct OpenRouterProvider {
 }
 
 impl OpenRouterProvider {
-    pub fn with(
-        config: Option<OpenRouterConfig>,
-        model: Option<String>,
-    ) -> Option<Self> {
+    pub fn with(config: Option<OpenRouterConfig>, model: Option<String>) -> Option<Self> {
         let config = config.unwrap_or_default();
         let api_key = Self::retrieve_api_key()?;
         Some(Self {
@@ -95,9 +92,7 @@ impl LLMClient for OpenRouterProvider {
         Self: Sized,
     {
         let openrouter_config = OpenRouterConfig::from_git_config(config);
-        let model = config
-            .string(OPENROUTER_MODEL_NAME)
-            .map(|v| v.to_string());
+        let model = config.string(OPENROUTER_MODEL_NAME).map(|v| v.to_string());
         let api_key = Self::retrieve_api_key()?;
         Some(Self {
             config: openrouter_config,

--- a/crates/but-llm/src/openrouter.rs
+++ b/crates/but-llm/src/openrouter.rs
@@ -66,10 +66,14 @@ impl OpenRouterProvider {
     fn retrieve_api_key() -> Option<Sensitive<String>> {
         // Try secret storage first, then fall back to env var
         if let Ok(Some(key)) = secret::retrieve("aiOpenRouterKey", secret::Namespace::Global) {
-            return Some(key);
+            if !key.0.trim().is_empty() {
+                return Some(key);
+            }
         }
         if let Ok(val) = std::env::var("OPENROUTER_API_KEY") {
-            return Some(Sensitive(val));
+            if !val.trim().is_empty() {
+                return Some(Sensitive(val));
+            }
         }
         None
     }

--- a/crates/but-llm/src/openrouter.rs
+++ b/crates/but-llm/src/openrouter.rs
@@ -1,0 +1,167 @@
+use anyhow::Result;
+use async_openai::{Client, config::OpenAIConfig};
+use but_secret::{Sensitive, secret};
+use but_tools::tool::Toolset;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    chat::ChatMessage,
+    client::LLMClient,
+    openai_utils::{
+        OpenAIClientProvider, response_blocking, stream_response_blocking,
+        structured_output_blocking, tool_calling_loop, tool_calling_loop_stream,
+    },
+};
+
+const OPENROUTER_API_BASE_DEFAULT: &str = "https://openrouter.ai/api/v1";
+const OPENROUTER_API_BASE_OPTION: &str = "gitbutler.aiOpenRouterEndpoint";
+const OPENROUTER_MODEL_NAME: &str = "gitbutler.aiOpenRouterModelName";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OpenRouterConfig {
+    pub api_base: String,
+}
+
+impl Default for OpenRouterConfig {
+    fn default() -> Self {
+        Self {
+            api_base: OPENROUTER_API_BASE_DEFAULT.to_string(),
+        }
+    }
+}
+
+impl OpenRouterConfig {
+    fn from_git_config(config: &gix::config::File<'static>) -> Self {
+        let api_base = config
+            .string(OPENROUTER_API_BASE_OPTION)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| OPENROUTER_API_BASE_DEFAULT.to_string());
+
+        Self { api_base }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenRouterProvider {
+    model: Option<String>,
+    config: OpenRouterConfig,
+    api_key: Sensitive<String>,
+}
+
+impl OpenRouterProvider {
+    pub fn with(
+        config: Option<OpenRouterConfig>,
+        model: Option<String>,
+    ) -> Option<Self> {
+        let config = config.unwrap_or_default();
+        let api_key = Self::retrieve_api_key()?;
+        Some(Self {
+            config,
+            model,
+            api_key,
+        })
+    }
+
+    fn retrieve_api_key() -> Option<Sensitive<String>> {
+        // Try secret storage first, then fall back to env var
+        if let Ok(Some(key)) = secret::retrieve("aiOpenRouterKey", secret::Namespace::Global) {
+            return Some(key);
+        }
+        if let Ok(val) = std::env::var("OPENROUTER_API_KEY") {
+            return Some(Sensitive(val));
+        }
+        None
+    }
+}
+
+impl OpenAIClientProvider for OpenRouterProvider {
+    fn client(&self) -> Result<Client<OpenAIConfig>> {
+        let open_ai_config = OpenAIConfig::new()
+            .with_api_base(self.config.api_base.clone())
+            .with_api_key(self.api_key.0.clone());
+
+        Ok(Client::with_config(open_ai_config))
+    }
+}
+
+impl LLMClient for OpenRouterProvider {
+    fn from_git_config(config: &gix::config::File<'static>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let openrouter_config = OpenRouterConfig::from_git_config(config);
+        let model = config
+            .string(OPENROUTER_MODEL_NAME)
+            .map(|v| v.to_string());
+        let api_key = Self::retrieve_api_key()?;
+        Some(Self {
+            config: openrouter_config,
+            model,
+            api_key,
+        })
+    }
+
+    fn model(&self) -> Option<String> {
+        self.model.clone()
+    }
+
+    fn tool_calling_loop_stream(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        tool_set: &mut impl Toolset,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
+    ) -> Result<(String, Vec<ChatMessage>)> {
+        let result = tool_calling_loop_stream(
+            self,
+            system_message,
+            chat_messages,
+            tool_set,
+            model,
+            on_token,
+        )?;
+        Ok((result.final_response, result.message_history))
+    }
+
+    fn tool_calling_loop(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        tool_set: &mut impl Toolset,
+        model: &str,
+    ) -> Result<String> {
+        tool_calling_loop(self, system_message, chat_messages, tool_set, model)
+    }
+
+    fn stream_response(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        model: &str,
+        on_token: impl Fn(&str) + Send + Sync + 'static,
+    ) -> Result<Option<String>> {
+        stream_response_blocking(self, system_message, chat_messages, model, on_token)
+    }
+
+    fn structured_output<
+        T: serde::Serialize + DeserializeOwned + JsonSchema + std::marker::Send + 'static,
+    >(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        model: &str,
+    ) -> Result<Option<T>> {
+        structured_output_blocking::<T>(self, system_message, chat_messages, model)
+    }
+
+    fn response(
+        &self,
+        system_message: &str,
+        chat_messages: Vec<ChatMessage>,
+        model: &str,
+    ) -> Result<Option<String>> {
+        response_blocking(self, system_message, chat_messages, model)
+    }
+}

--- a/crates/but-llm/src/openrouter.rs
+++ b/crates/but-llm/src/openrouter.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
+    AI_OPENROUTER_ENDPOINT_KEY, AI_OPENROUTER_MODEL_NAME_KEY,
     chat::ChatMessage,
     client::LLMClient,
     openai_utils::{
@@ -15,8 +16,6 @@ use crate::{
 };
 
 const OPENROUTER_API_BASE_DEFAULT: &str = "https://openrouter.ai/api/v1";
-const OPENROUTER_API_BASE_OPTION: &str = "gitbutler.aiOpenRouterEndpoint";
-const OPENROUTER_MODEL_NAME: &str = "gitbutler.aiOpenRouterModelName";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OpenRouterConfig {
@@ -34,7 +33,7 @@ impl Default for OpenRouterConfig {
 impl OpenRouterConfig {
     fn from_git_config(config: &gix::config::File<'static>) -> Self {
         let api_base = config
-            .string(OPENROUTER_API_BASE_OPTION)
+            .string(AI_OPENROUTER_ENDPOINT_KEY)
             .map(|v| v.to_string())
             .unwrap_or_else(|| OPENROUTER_API_BASE_DEFAULT.to_string());
 
@@ -92,7 +91,9 @@ impl LLMClient for OpenRouterProvider {
         Self: Sized,
     {
         let openrouter_config = OpenRouterConfig::from_git_config(config);
-        let model = config.string(OPENROUTER_MODEL_NAME).map(|v| v.to_string());
+        let model = config
+            .string(AI_OPENROUTER_MODEL_NAME_KEY)
+            .map(|v| v.to_string());
         let api_key = Self::retrieve_api_key()?;
         Some(Self {
             config: openrouter_config,

--- a/crates/but-llm/src/openrouter.rs
+++ b/crates/but-llm/src/openrouter.rs
@@ -62,15 +62,15 @@ impl OpenRouterProvider {
 
     fn retrieve_api_key() -> Option<Sensitive<String>> {
         // Try secret storage first, then fall back to env var
-        if let Ok(Some(key)) = secret::retrieve("aiOpenRouterKey", secret::Namespace::Global) {
-            if !key.0.trim().is_empty() {
-                return Some(key);
-            }
+        if let Ok(Some(key)) = secret::retrieve("aiOpenRouterKey", secret::Namespace::Global)
+            && !key.0.trim().is_empty()
+        {
+            return Some(key);
         }
-        if let Ok(val) = std::env::var("OPENROUTER_API_KEY") {
-            if !val.trim().is_empty() {
-                return Some(Sensitive(val));
-            }
+        if let Ok(val) = std::env::var("OPENROUTER_API_KEY")
+            && !val.trim().is_empty()
+        {
+            return Some(Sensitive(val));
         }
         None
     }

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -264,6 +264,19 @@ pub enum AiSubcommand {
         #[clap(long)]
         model: Option<String>,
     },
+
+    /// Configure OpenRouter as the active AI provider.
+    Openrouter {
+        /// Preferred model name (for example, openai/gpt-4.1-mini).
+        #[clap(long)]
+        model: Option<String>,
+        /// OpenRouter API key. Prefer --api-key-env to avoid shell history exposure.
+        #[clap(long, hide_env_values = true)]
+        api_key: Option<String>,
+        /// Name of an environment variable holding the OpenRouter API key.
+        #[clap(long)]
+        api_key_env: Option<String>,
+    },
 }
 
 /// Credential source options for OpenAI/Anthropic.

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -12,7 +12,8 @@ use but_llm::{
     AI_ANTHROPIC_KEY_OPTION_KEY, AI_ANTHROPIC_MODEL_NAME_KEY, AI_ANTHROPIC_SECRET_HANDLE,
     AI_LMSTUDIO_ENDPOINT_KEY, AI_LMSTUDIO_MODEL_NAME_KEY, AI_MODEL_PROVIDER_KEY,
     AI_OLLAMA_ENDPOINT_KEY, AI_OLLAMA_MODEL_NAME_KEY, AI_OPENAI_CUSTOM_ENDPOINT_KEY,
-    AI_OPENAI_KEY_OPTION_KEY, AI_OPENAI_MODEL_NAME_KEY, AI_OPENAI_SECRET_HANDLE, LLMProviderKind,
+    AI_OPENAI_KEY_OPTION_KEY, AI_OPENAI_MODEL_NAME_KEY, AI_OPENAI_SECRET_HANDLE,
+    AI_OPENROUTER_MODEL_NAME_KEY, AI_OPENROUTER_SECRET_HANDLE, LLMProviderKind,
 };
 use but_secret::{Sensitive, secret};
 use but_settings::{AppSettingsWithDiskSync, api::TelemetryUpdate};
@@ -1201,6 +1202,15 @@ fn ai_config_non_interactive(
             apply_lmstudio_config(repo, scope, endpoint, model)?;
             write_ai_config_success(out, scope, LLMProviderKind::LMStudio)?;
         }
+        AiSubcommand::Openrouter {
+            model,
+            api_key,
+            api_key_env,
+        } => {
+            let secret = resolve_secret_input(api_key, api_key_env)?;
+            apply_openrouter_config(repo, scope, model, secret)?;
+            write_ai_config_success(out, scope, LLMProviderKind::OpenRouter)?;
+        }
     }
 
     Ok(())
@@ -1219,7 +1229,7 @@ fn ai_config_interactive(
 
     let provider_prompt = cli_prompts::prompts::Selection::new(
         "Select an AI provider",
-        vec!["OpenAI", "Anthropic", "Ollama", "LM Studio"].into_iter(),
+        vec!["OpenAI", "Anthropic", "Ollama", "LM Studio", "OpenRouter"].into_iter(),
     );
 
     let provider_label = provider_prompt
@@ -1230,6 +1240,7 @@ fn ai_config_interactive(
         "Anthropic" => LLMProviderKind::Anthropic,
         "Ollama" => LLMProviderKind::Ollama,
         "LM Studio" => LLMProviderKind::LMStudio,
+        "OpenRouter" => LLMProviderKind::OpenRouter,
         _ => anyhow::bail!("Unsupported AI provider selection: {provider_label}"),
     };
 
@@ -1289,6 +1300,15 @@ fn ai_config_interactive(
             let endpoint = inout.prompt("LM Studio endpoint URL (optional):")?;
             let model = inout.prompt("Preferred LM Studio model (optional):")?;
             apply_lmstudio_config(repo, scope, endpoint, model)?;
+        }
+        LLMProviderKind::OpenRouter => {
+            let model = inout.prompt("Preferred OpenRouter model (e.g. openai/gpt-4.1-mini):")?;
+            let secret = Some(
+                inout
+                    .prompt_secret("Enter OpenRouter API key:")?
+                    .context("No API key provided. Aborting configuration.")?,
+            );
+            apply_openrouter_config(repo, scope, model, secret)?;
         }
     }
 
@@ -1484,6 +1504,27 @@ fn apply_lmstudio_config(
         set_optional_config_value(config, AI_LMSTUDIO_MODEL_NAME_KEY, model)?;
         Ok(())
     })
+}
+
+fn apply_openrouter_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    model: Option<String>,
+    secret: Option<Sensitive<String>>,
+) -> Result<()> {
+    edit_ai_git_config(repo, scope, |config| {
+        set_config_value(
+            config,
+            AI_MODEL_PROVIDER_KEY,
+            LLMProviderKind::OpenRouter.as_git_config_value(),
+        )?;
+        set_optional_config_value(config, AI_OPENROUTER_MODEL_NAME_KEY, model)?;
+        Ok(())
+    })?;
+    if let Some(key) = secret {
+        secret::persist(AI_OPENROUTER_SECRET_HANDLE, &key, secret::Namespace::Global)?;
+    }
+    Ok(())
 }
 
 fn get_ai_config_info(repo: Option<&gix::Repository>, scope: AiScope) -> Result<AiConfigInfo> {

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -61,7 +61,7 @@
 			"csp": {
 				"default-src": "'self'",
 				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com https://*.giphy.com/ blob:",
-				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data:",
+				"connect-src": "'self' ipc: http://ipc.localhost https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com https://api.anthropic.com https://openrouter.ai https://app.staging.gitbutler.com https://*.gitlab.com https://gitlab.com wss://irc.gitbutler.com:8097 data:",
 				"script-src": "'self' 'wasm-unsafe-eval' https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"
 			}


### PR DESCRIPTION
## 🧢 Changes

Add OpenRouter as a new AI provider. OpenRouter exposes an OpenAI-compatible API, so the frontend reuses OpenAIClient with the OpenRouter base URL. The model name is a free-form text input since OpenRouter supports hundreds of models in `provider/model` format (e.g. `openai/gpt-4.1-mini`).

Frontend: new `OpenRouter` variant in `ModelKind`, config keys, secret handle, service methods, settings panel with API key and model inputs, and two new tests.

Backend: new `OpenRouterProvider` following the LM Studio pattern which implements `OpenAIClientProvider + LLMClient`, reads API key from secret storage with `OPENROUTER_API_KEY` env var fallback.

CSP: added `https://openrouter.ai` to `connect-src`.

## 🎫 Affected issues

Fixes: #12070

## Preview

<img width="1674" height="2046" alt="CleanShot 2026-02-27 at 16 26 46@2x" src="https://github.com/user-attachments/assets/1a234279-c14f-4303-98ec-501473df44c2" />
