### PR TITLE
hide PAT input in interactive forge auth prompts

### DIFF
--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -635,7 +635,7 @@ async fn gitlab_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_secret::Sensitive;
 
     let input = inout
-        .prompt("Please enter your GitLab Personal Access Token (PAT) and hit enter:")?
+        .prompt_secret("Please enter your GitLab Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
 
     let pat = Sensitive(input);
@@ -657,7 +657,7 @@ async fn gitlab_self_hosted(mut inout: InputOutputChannel<'_>) -> Result<()> {
         .context("No host provided. Aborting authentication.")?;
 
     let input = inout
-        .prompt("Now, please enter your GitLab Personal Access Token (PAT) and hit enter:")?
+        .prompt_secret("Now, please enter your GitLab Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
     let pat = Sensitive(input);
     let AuthStatusResponse { username, .. } =
@@ -720,7 +720,7 @@ async fn github_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_secret::Sensitive;
 
     let input = inout
-        .prompt("Please enter your GitHub Personal Access Token (PAT) and hit enter:")?
+        .prompt_secret("Please enter your GitHub Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
 
     let pat = Sensitive(input);
@@ -740,7 +740,7 @@ async fn github_enterprise(mut inout: InputOutputChannel<'_>) -> Result<()> {
     let base_url = inout.prompt("Please enter your GitHub Enterprise API base URL (e.g., https://github.mycompany.com/api/v3) and hit enter:")?.context("No host provided. Aborting authentication.")?;
 
     let input = inout
-        .prompt(
+        .prompt_secret(
             "Now, please enter your GitHub Enterprise Personal Access Token (PAT) and hit enter:",
         )?
         .context("No PAT provided. Aborting authentication.")?;

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -632,14 +632,12 @@ async fn gitlab_auth(out: &mut OutputChannel) -> Result<()> {
 /// Authenticate with GitLab using a Personal Access Token (PAT)
 async fn gitlab_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_gitlab::AuthStatusResponse;
-    use but_secret::Sensitive;
 
     let input = inout
         .prompt_secret("Please enter your GitLab Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
 
-    let pat = Sensitive(input);
-    let AuthStatusResponse { username, .. } = but_api::gitlab::store_gitlab_pat(pat)
+    let AuthStatusResponse { username, .. } = but_api::gitlab::store_gitlab_pat(input)
         .await
         .map_err(|err| err.context("Authentication failed"))?;
 
@@ -650,7 +648,6 @@ async fn gitlab_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
 /// Authenticate with self-hosted GitLab
 async fn gitlab_self_hosted(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_gitlab::AuthStatusResponse;
-    use but_secret::Sensitive;
 
     let base_url = inout
         .prompt("Please enter your GitLab instance URL (e.g., https://gitlab.mycompany.com) and hit enter:")?
@@ -659,9 +656,8 @@ async fn gitlab_self_hosted(mut inout: InputOutputChannel<'_>) -> Result<()> {
     let input = inout
         .prompt_secret("Now, please enter your GitLab Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
-    let pat = Sensitive(input);
     let AuthStatusResponse { username, .. } =
-        but_api::gitlab::store_gitlab_selfhosted_pat(pat, base_url)
+        but_api::gitlab::store_gitlab_selfhosted_pat(input, base_url)
             .await
             .map_err(|err| err.context("Authentication failed"))?;
 
@@ -717,14 +713,12 @@ async fn github_auth(out: &mut OutputChannel) -> Result<()> {
 /// Authenticate with GitHub using a Personal Access Token (PAT)
 async fn github_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_github::AuthStatusResponse;
-    use but_secret::Sensitive;
 
     let input = inout
         .prompt_secret("Please enter your GitHub Personal Access Token (PAT) and hit enter:")?
         .context("No PAT provided. Aborting authentication.")?;
 
-    let pat = Sensitive(input);
-    let AuthStatusResponse { login, .. } = but_api::github::store_github_pat(pat)
+    let AuthStatusResponse { login, .. } = but_api::github::store_github_pat(input)
         .await
         .map_err(|err| err.context("Authentication failed"))?;
 
@@ -735,7 +729,6 @@ async fn github_pat(mut inout: InputOutputChannel<'_>) -> Result<()> {
 /// Authenticate with GitHub Enterprise
 async fn github_enterprise(mut inout: InputOutputChannel<'_>) -> Result<()> {
     use but_github::AuthStatusResponse;
-    use but_secret::Sensitive;
 
     let base_url = inout.prompt("Please enter your GitHub Enterprise API base URL (e.g., https://github.mycompany.com/api/v3) and hit enter:")?.context("No host provided. Aborting authentication.")?;
 
@@ -744,9 +737,8 @@ async fn github_enterprise(mut inout: InputOutputChannel<'_>) -> Result<()> {
             "Now, please enter your GitHub Enterprise Personal Access Token (PAT) and hit enter:",
         )?
         .context("No PAT provided. Aborting authentication.")?;
-    let pat = Sensitive(input);
     let AuthStatusResponse { login, .. } =
-        but_api::github::store_github_enterprise_pat(pat, base_url)
+        but_api::github::store_github_enterprise_pat(input, base_url)
             .await
             .map_err(|err| err.context("Authentication failed"))?;
 

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -283,7 +283,8 @@ impl std::fmt::Write for InputOutputChannel<'_> {
 }
 
 impl InputOutputChannel<'_> {
-    fn readline(&mut self, prompt: &str) -> anyhow::Result<ReadlineInput> {
+    fn readline(&mut self, prompt: &str, echo: InputEcho) -> anyhow::Result<ReadlineInput> {
+        const PLACEHOLDER: &str = "•";
         self.out.stdout.write_all(prompt.as_bytes())?;
         self.out.stdout.flush()?;
 
@@ -295,8 +296,16 @@ impl InputOutputChannel<'_> {
                 Event::Key(key) => match key_to_edit_action(key, line.is_empty()) {
                     KeyEditAction::Insert(ch) => {
                         line.push(ch);
-                        write!(self.out.stdout, "{ch}")?;
-                        self.out.stdout.flush()?;
+                        match echo {
+                            InputEcho::Visible => {
+                                write!(self.out.stdout, "{ch}")?;
+                                self.out.stdout.flush()?;
+                            }
+                            InputEcho::Hidden => {
+                                self.out.stdout.write_all(PLACEHOLDER.as_bytes())?;
+                                self.out.stdout.flush()?;
+                            }
+                        }
                     }
                     KeyEditAction::Backspace => {
                         if line.pop().is_some() {
@@ -327,8 +336,17 @@ impl InputOutputChannel<'_> {
                 Event::Paste(text) => {
                     if !text.is_empty() {
                         line.push_str(&text);
-                        self.out.stdout.write_all(text.as_bytes())?;
-                        self.out.stdout.flush()?;
+                        match echo {
+                            InputEcho::Visible => {
+                                self.out.stdout.write_all(text.as_bytes())?;
+                                self.out.stdout.flush()?;
+                            }
+                            InputEcho::Hidden => {
+                                let placeholders = PLACEHOLDER.repeat(text.chars().count());
+                                self.out.stdout.write_all(placeholders.as_bytes())?;
+                                self.out.stdout.flush()?;
+                            }
+                        }
                     }
                 }
                 _ => {}
@@ -349,10 +367,25 @@ impl InputOutputChannel<'_> {
     /// // >
     /// ```
     pub fn prompt(&mut self, prompt: impl AsRef<str>) -> anyhow::Result<Option<String>> {
-        Ok(match self.readline(&format!("{}\n> ", prompt.as_ref()))? {
-            ReadlineInput::Text(line) => Some(line),
-            ReadlineInput::Empty | ReadlineInput::EndOfInput => None,
-        })
+        Ok(
+            match self.readline(&format!("{}\n> ", prompt.as_ref()), InputEcho::Visible)? {
+                ReadlineInput::Text(line) => Some(line),
+                ReadlineInput::Empty | ReadlineInput::EndOfInput => None,
+            },
+        )
+    }
+
+    /// Prompt for a non-empty secret string from the user, or `None` if the
+    /// input was empty.
+    ///
+    /// The entered text is masked in the terminal with placeholders.
+    pub fn prompt_secret(&mut self, prompt: impl AsRef<str>) -> anyhow::Result<Option<String>> {
+        Ok(
+            match self.readline(&format!("{}\n> ", prompt.as_ref()), InputEcho::Hidden)? {
+                ReadlineInput::Text(line) => Some(line),
+                ReadlineInput::Empty | ReadlineInput::EndOfInput => None,
+            },
+        )
     }
 
     /// Prompt for y/n confirmation with a default value. Automatically appends
@@ -374,7 +407,10 @@ impl InputOutputChannel<'_> {
             ConfirmDefault::Yes => "[Y/n]",
             ConfirmDefault::No => "[y/N]",
         };
-        match self.readline(&format!("{} {}: ", prompt.as_ref(), suffix))? {
+        match self.readline(
+            &format!("{} {}: ", prompt.as_ref(), suffix),
+            InputEcho::Visible,
+        )? {
             ReadlineInput::Text(input) => {
                 if input.to_lowercase().starts_with('y') {
                     Ok(Confirm::Yes)
@@ -407,7 +443,7 @@ impl InputOutputChannel<'_> {
     ) -> anyhow::Result<ConfirmOrEmpty> {
         let prompt = format!("{} [y/n]: ", prompt.as_ref());
         loop {
-            match self.readline(&prompt)? {
+            match self.readline(&prompt, InputEcho::Visible)? {
                 ReadlineInput::Text(input) => {
                     if input.to_lowercase().starts_with('y') {
                         return Ok(ConfirmOrEmpty::Yes);
@@ -431,8 +467,17 @@ enum ReadlineInput {
     EndOfInput,
 }
 
+/// How to play input back to the user during prompts.
+#[derive(Debug)]
+enum InputEcho {
+    /// Show everything that's typed and displayable.
+    Visible,
+    /// Do not show what's printed.
+    Hidden,
+}
+
 /// Editing operation derived from a terminal key event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum KeyEditAction {
     /// Insert the provided character into the current input buffer.
     Insert(char),


### PR DESCRIPTION
Add hidden-echo terminal input support to `InputOutputChannel` via `prompt_secret()`, and use it for all GitHub/GitLab PAT entry points (including enterprise/self-hosted flows) so entered tokens are no longer displayed.

Non-secret prompts (like base URLs and confirmations) remain unchanged.

Follow-up to #12623 .
