### PR TITLE
Trace resolved command as part of the top-level CLI span

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -120,7 +120,9 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     if args.trace > 0 {
         trace::init(args.trace)?;
     }
-    let _span = tracing::info_span!("CLI").entered();
+    let _span =
+        tracing::info_span!("CLI", cmd = ?args.cmd.as_ref().map(|cmd| cmd.to_metrics_command()))
+            .entered();
 
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -53,7 +53,8 @@ impl Subcommands {
         OneshotMetricsContext::new_if_enabled(settings, cmd)
     }
 
-    fn to_metrics_command(&self) -> CommandName {
+    /// Turn `self` into a `CommandName` that serves as metric identifier.
+    pub(crate) fn to_metrics_command(&self) -> CommandName {
         use CommandName::*;
 
         use crate::args::{alias as alias_args, branch, claude, cursor, forge, skill, worktree};


### PR DESCRIPTION
That way it's easier to gather intelligence for how the CLI is invoked.

`cmd` is new.
```
INFO     CLI [ 3.57s | 99.56% / 100.00% ] cmd: Some(ForgeAuth)
INFO     ┕━ setup [ 15.7ms | 0.44% ]
```