### PR TITLE
use gix::Id::shorten for legacy commit display IDs in `but` CLI

### DIFF
--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -105,6 +105,10 @@ impl RepositoryExt for gix::Repository {
         GitConfigSettings::try_from_snapshot(&self.config_snapshot())
     }
 
+    fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf> {
+        but_project_handle::gitbutler_storage_path(self)
+    }
+
     fn set_git_settings(&self, settings: &GitConfigSettings) -> anyhow::Result<()> {
         settings.persist_to_local_config(self)
     }
@@ -197,72 +201,6 @@ impl RepositoryExt for gix::Repository {
             merge_options,
         )
         .context("failed to merge trees for cherry pick")
-    }
-
-    fn commit_signatures(&self) -> anyhow::Result<(gix::actor::Signature, gix::actor::Signature)> {
-        let author = self
-            .author()
-            .transpose()?
-            .context("No author is configured in Git")
-            .context(Code::AuthorMissing)?;
-
-        let commit_as_gitbutler = self
-            .config_snapshot()
-            .boolean("gitbutler.gitbutlerCommitter")
-            .unwrap_or_default();
-        let committer = if commit_as_gitbutler {
-            committer_signature()
-        } else {
-            self.committer()
-                .transpose()?
-                .and_then(|s| s.to_owned().ok())
-                .unwrap_or_else(committer_signature)
-        };
-
-        Ok((author.into(), committer))
-    }
-
-    fn git_settings(&self) -> anyhow::Result<GitConfigSettings> {
-        GitConfigSettings::try_from_snapshot(&self.config_snapshot())
-    }
-
-    fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf> {
-        but_project_handle::gitbutler_storage_path(self)
-    }
-
-    fn set_git_settings(&self, settings: &GitConfigSettings) -> anyhow::Result<()> {
-        settings.persist_to_local_config(self)
-    }
-
-    fn local_common_config_for_editing(&self) -> anyhow::Result<gix::config::File<'static>> {
-        let local_config_path = self.common_dir().join("config");
-        let config = gix::config::File::from_path_no_includes(
-            local_config_path.clone(),
-            gix::config::Source::Local,
-        )?;
-        Ok(config)
-    }
-
-    fn write_local_common_config(&self, local_config: &gix::config::File) -> anyhow::Result<()> {
-        use std::io::Write;
-        // Note: we don't use a lock file here to not risk changing the mode, and it's what Git does.
-        //       But we lock the file so there is no raciness.
-        let local_config_path = self.common_dir().join("config");
-        let _lock = gix::lock::Marker::acquire_to_hold_resource(
-            &local_config_path,
-            gix::lock::acquire::Fail::Immediately,
-            None,
-        )?;
-        let mut config_file = std::io::BufWriter::new(
-            std::fs::File::options()
-                .write(true)
-                .truncate(true)
-                .create(false)
-                .open(local_config_path)?,
-        );
-        local_config.write_to(&mut config_file)?;
-        config_file.flush()?;
-        Ok(())
     }
 
     fn for_tree_diffing(mut self) -> anyhow::Result<Self> {

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -56,6 +56,10 @@ pub trait RepositoryExt: Sized {
     /// This means it needs an object cache relative to the amount of files in the repository.
     fn for_tree_diffing(self) -> anyhow::Result<Self>;
 
+    /// Return a repository configured for commit shortening,
+    /// i.e. with an object database configured to *not* check for new packs.
+    fn for_commit_shortening(self) -> Self;
+
     /// Just like the above, but with `gix` types.
     fn merges_cleanly(
         &self,
@@ -97,6 +101,68 @@ pub trait RepositoryExt: Sized {
 }
 
 impl RepositoryExt for gix::Repository {
+    fn git_settings(&self) -> anyhow::Result<GitConfigSettings> {
+        GitConfigSettings::try_from_snapshot(&self.config_snapshot())
+    }
+
+    fn set_git_settings(&self, settings: &GitConfigSettings) -> anyhow::Result<()> {
+        settings.persist_to_local_config(self)
+    }
+
+    fn commit_signatures(&self) -> anyhow::Result<(gix::actor::Signature, gix::actor::Signature)> {
+        let author = self
+            .author()
+            .transpose()?
+            .context("No author is configured in Git")
+            .context(Code::AuthorMissing)?;
+
+        let commit_as_gitbutler = self
+            .config_snapshot()
+            .boolean("gitbutler.gitbutlerCommitter")
+            .unwrap_or_default();
+        let committer = if commit_as_gitbutler {
+            committer_signature()
+        } else {
+            self.committer()
+                .transpose()?
+                .and_then(|s| s.to_owned().ok())
+                .unwrap_or_else(committer_signature)
+        };
+
+        Ok((author.into(), committer))
+    }
+
+    fn local_common_config_for_editing(&self) -> anyhow::Result<gix::config::File<'static>> {
+        let local_config_path = self.common_dir().join("config");
+        let config = gix::config::File::from_path_no_includes(
+            local_config_path.clone(),
+            gix::config::Source::Local,
+        )?;
+        Ok(config)
+    }
+
+    fn write_local_common_config(&self, local_config: &gix::config::File) -> anyhow::Result<()> {
+        use std::io::Write;
+        // Note: we don't use a lock file here to not risk changing the mode, and it's what Git does.
+        //       But we lock the file so there is no raciness.
+        let local_config_path = self.common_dir().join("config");
+        let _lock = gix::lock::Marker::acquire_to_hold_resource(
+            &local_config_path,
+            gix::lock::acquire::Fail::Immediately,
+            None,
+        )?;
+        let mut config_file = std::io::BufWriter::new(
+            std::fs::File::options()
+                .write(true)
+                .truncate(true)
+                .create(false)
+                .open(local_config_path)?,
+        );
+        local_config.write_to(&mut config_file)?;
+        config_file.flush()?;
+        Ok(())
+    }
+
     fn cherry_pick_commits_to_tree(
         &self,
         new_base_commit_id: gix::ObjectId,
@@ -203,6 +269,11 @@ impl RepositoryExt for gix::Repository {
         let bytes = self.compute_object_cache_size_for_tree_diffs(&***self.index_or_empty()?);
         self.object_cache_size_if_unset(bytes);
         Ok(self)
+    }
+
+    fn for_commit_shortening(mut self) -> Self {
+        self.objects.refresh = gix::odb::store::RefreshMode::Never;
+        self
     }
 
     fn merges_cleanly(

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use but_core::sync::RepoExclusiveGuard;
+use but_core::{RepositoryExt, sync::RepoExclusiveGuard};
 use but_ctx::Context;
 use but_hunk_assignment::{
     AbsorptionTarget, CommitAbsorption, HunkAssignment, JsonAbsorbOutput, JsonCommitAbsorption,
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use crate::{
     CliId, IdMap,
     id::{UncommittedCliId, parser::parse_sources},
-    utils::OutputChannel,
+    utils::{OutputChannel, shorten_object_id},
 };
 /// Amends changes into the appropriate commits where they belong.
 ///
@@ -79,7 +79,10 @@ pub(crate) fn handle(
     // Display the plan (in JSON mode for non-dry-run, collect without writing — we'll
     // combine it with the result in absorb_assignments to avoid a double-write that
     // would overwrite the plan in the JSON buffer).
-    let plan_json = display_absorption_plan(&absorption_plan, out, new, dry_run)?;
+    let plan_json = {
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
+        display_absorption_plan(&absorption_plan, &repo, out, new, dry_run)?
+    };
 
     if dry_run {
         // Nothing more to do
@@ -206,6 +209,7 @@ fn get_hunk_ranges(assignment: &HunkAssignment) -> Vec<String> {
 /// in a single JSON write — avoiding a double-write that would overwrite the buffer.
 fn display_absorption_plan(
     commit_absorptions: &[CommitAbsorption],
+    repo: &gix::Repository,
     out: &mut OutputChannel,
     new: bool,
     write_json: bool,
@@ -277,7 +281,7 @@ fn display_absorption_plan(
         writeln!(out)?;
 
         for absorption in commit_absorptions {
-            let short_hash = &absorption.commit_id.to_hex().to_string()[..7];
+            let short_hash = shorten_object_id(repo, absorption.commit_id);
             let verb = if new {
                 "Created on top of commit"
             } else {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use crate::{
     CliId, IdMap,
     args::branch,
-    utils::{Confirm, ConfirmDefault, OutputChannel},
+    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
 
 pub mod apply;
@@ -117,15 +117,19 @@ pub fn handle(
                 None
             };
 
-            let anchor_display = anchor.as_ref().map(|anchor_ref| match anchor_ref {
-                but_api::legacy::stack::create_reference::Anchor::AtReference {
-                    short_name,
-                    ..
-                } => short_name.clone(),
-                but_api::legacy::stack::create_reference::Anchor::AtCommit {
-                    commit_id, ..
-                } => commit_id.to_string()[..7].to_string(),
-            });
+            let anchor_display = {
+                let repo = ctx.repo.get()?;
+                anchor.as_ref().map(|anchor_ref| match anchor_ref {
+                    but_api::legacy::stack::create_reference::Anchor::AtReference {
+                        short_name,
+                        ..
+                    } => short_name.clone(),
+                    but_api::legacy::stack::create_reference::Anchor::AtCommit {
+                        commit_id,
+                        ..
+                    } => shorten_object_id(&repo, commit_id.0),
+                })
+            };
 
             but_api::legacy::stack::create_reference(
                 ctx,

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -4,7 +4,7 @@ use but_oxidize::{ObjectIdExt, OidExt};
 use colored::Colorize;
 use tracing::instrument;
 
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_object_id};
 
 #[allow(clippy::too_many_arguments)]
 pub fn show(
@@ -238,7 +238,7 @@ fn get_merge_conflict_paths(
 
 fn find_commits_modifying_file(
     git2_repo: &git2::Repository,
-    gix_repo: &gix::Repository,
+    repo: &gix::Repository,
     path: &str,
     from_commit: gix::ObjectId,
     to_commit: gix::ObjectId,
@@ -246,7 +246,7 @@ fn find_commits_modifying_file(
     use gix::prelude::ObjectIdExt as _;
 
     let traversal = to_commit
-        .attach(gix_repo)
+        .attach(repo)
         .ancestors()
         .with_hidden(Some(from_commit))
         .all()?;
@@ -289,7 +289,7 @@ fn find_commits_modifying_file(
             let author = commit.author();
             commits.push(CommitRef {
                 sha: oid.to_string(),
-                short_sha: oid.to_string()[..7].to_string(),
+                short_sha: shorten_object_id(repo, info.id),
                 message: commit
                     .message()
                     .unwrap_or("(no message)")
@@ -430,7 +430,7 @@ fn get_commits_ahead(
 
         commits.push(CommitInfo {
             sha: oid.to_string(),
-            short_sha: oid.to_string()[..7].to_string(),
+            short_sha: shorten_object_id(&gix_repo, info.id),
             message: commit
                 .message()
                 .unwrap_or("(no message)")

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -15,7 +15,7 @@ use crate::{
     CliId, IdMap,
     command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
     tui,
-    utils::{InputOutputChannel, OutputChannel},
+    utils::{InputOutputChannel, OutputChannel, shorten_object_id},
 };
 
 pub(crate) fn insert_blank_commit(
@@ -54,16 +54,16 @@ pub(crate) fn insert_blank_commit(
     // Determine target commit ID and use provided insert_side
     let success_message = match cli_id {
         CliId::Commit { commit_id: oid, .. } => {
+            let short_oid = {
+                let repo = ctx.repo.get()?;
+                shorten_object_id(&repo, *oid)
+            };
             commit_insert_blank(
                 ctx,
                 but_api::commit::ui::RelativeTo::Commit(*oid),
                 insert_side,
             )?;
-            format!(
-                "Created blank commit {} commit {}",
-                position_desc,
-                &oid.to_string()[..7]
-            )
+            format!("Created blank commit {position_desc} commit {short_oid}")
         }
         CliId::Branch { name, .. } => {
             let reference = {

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -4,7 +4,10 @@ use anyhow::bail;
 use but_ctx::Context;
 use colored::Colorize;
 
-use crate::{CliId, IdMap, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    utils::{OutputChannel, shorten_object_id},
+};
 
 pub async fn handle(
     ctx: &mut Context,
@@ -70,9 +73,9 @@ pub async fn handle(
             progress,
             "Merging {} ({}) into {} ({})",
             branch_name.bright_cyan(),
-            merge_in_branch_head_oid.to_string()[..7].bright_black(),
+            shorten_object_id(&repo, merge_in_branch_head_oid).bright_black(),
             local_branch_name.bright_cyan(),
-            local_branch_head_oid.to_string()[..7].bright_black()
+            shorten_object_id(&repo, local_branch_head_oid).bright_black()
         )?;
 
         // do the merge

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -1,9 +1,10 @@
+use but_core::RepositoryExt;
 use but_oxidize::{OidExt, TimeExt};
 use colored::Colorize;
 use gitbutler_oplog::entry::{OperationKind, Snapshot};
-use gix::date::time::CustomFormat;
+use gix::{date::time::CustomFormat, prelude::ObjectIdExt};
 
-use crate::utils::{Confirm, ConfirmDefault, OutputChannel};
+use crate::utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id};
 
 pub const ISO8601_NO_TZ: CustomFormat = CustomFormat::new("%Y-%m-%d %H:%M:%S");
 
@@ -57,17 +58,24 @@ pub(crate) fn show_oplog(
     if let Some(out) = out.for_json() {
         out.write_value(&snapshots)?;
     } else if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
         writeln!(out, "{}", "Operations History".blue().bold())?;
         writeln!(out, "{}", "─".repeat(50).dimmed())?;
+        // Find the longest short ID length to keep all lines aligned.
+        let longest_short_id_len = snapshots
+            .iter()
+            .filter_map(|s| {
+                let prefix = s.commit_id.to_gix().attach(&repo).shorten().ok()?;
+                Some(prefix.hex_len())
+            })
+            .max()
+            .unwrap_or(7);
 
         for snapshot in snapshots {
             let time_string = snapshot_time_string(&snapshot);
-
-            let commit_id = format!(
-                "{}{}",
-                &snapshot.commit_id.to_string()[..7].blue().bold(),
-                &snapshot.commit_id.to_string()[7..12].blue().dimmed()
-            );
+            let short = snapshot.commit_id.to_gix();
+            let short = short.to_hex_with_len(longest_short_id_len);
+            let commit_id = short.to_string().blue().bold();
 
             let (operation_type, title) = if let Some(details) = &snapshot.details {
                 let op_type = match details.operation {
@@ -169,8 +177,10 @@ pub(crate) fn restore_to_oplog(
 ) -> anyhow::Result<()> {
     let commit_id = ctx.repo.get()?.rev_parse_single(oplog_sha)?.detach();
     let target_snapshot = &but_api::legacy::oplog::get_snapshot(ctx, commit_id)?;
-
-    let commit_sha_string = commit_id.to_string();
+    let commit_short = {
+        let repo = ctx.repo.get()?;
+        shorten_object_id(&repo, commit_id)
+    };
 
     let target_operation = target_snapshot
         .details
@@ -189,7 +199,7 @@ pub(crate) fn restore_to_oplog(
             target_operation.green(),
             target_time.dimmed()
         )?;
-        writeln!(out, "  Snapshot: {}", commit_sha_string[..7].cyan().bold())?;
+        writeln!(out, "  Snapshot: {}", commit_short.cyan().bold())?;
 
         // Confirm the restoration (safety check)
         if !force {
@@ -266,17 +276,14 @@ pub(crate) fn undo_last_operation(
     but_api::legacy::oplog::restore_snapshot(ctx, target_snapshot.commit_id.to_gix())?;
 
     if let Some(out) = out.for_human() {
-        let restore_commit_short = format!(
-            "{}{}",
-            &target_snapshot.commit_id.to_string()[..7].blue().bold(),
-            &target_snapshot.commit_id.to_string()[7..12].blue().dimmed()
-        );
+        let repo = ctx.repo.get()?;
+        let short = shorten_object_id(&repo, target_snapshot.commit_id.to_gix());
 
         writeln!(
             out,
             "{} Undo completed successfully! Restored to snapshot: {}",
             "✓".green().bold(),
-            restore_commit_short
+            short.blue().bold()
         )?;
     }
 
@@ -297,24 +304,20 @@ pub(crate) fn create_snapshot(
             "operation": "create_snapshot"
         }))?;
     } else if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
+        let short = shorten_object_id(&repo, snapshot_id);
         writeln!(out, "{}", "Snapshot created successfully!".green().bold())?;
 
         if let Some(msg) = message {
             writeln!(out, "  Message: {}", msg.cyan())?;
         }
 
-        writeln!(
-            out,
-            "  Snapshot ID: {}{}",
-            snapshot_id.to_string()[..7].blue().bold(),
-            snapshot_id.to_string()[7..12].blue().dimmed()
-        )?;
-
+        writeln!(out, "  Snapshot ID: {}", short.blue().bold(),)?;
         writeln!(
             out,
             "\n{} Use 'but oplog restore {}' to restore to this snapshot later.",
             "💡".bright_blue(),
-            &snapshot_id.to_string()[..7]
+            short
         )?;
     }
 

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -4,7 +4,7 @@ use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_api::legacy::{cherry_apply, virtual_branches, workspace};
 use but_cherry_apply::CherryApplyStatus;
-use but_core::ref_metadata::StackId;
+use but_core::{RepositoryExt, ref_metadata::StackId};
 use but_ctx::Context;
 use but_oxidize::{ObjectIdExt, OidExt};
 use but_workspace::legacy::{StacksFilter, ui::StackEntry};
@@ -19,7 +19,7 @@ use gix::{revision::walk::Sorting, traverse::commit::simple::CommitTimeOrder};
 
 use crate::{
     CliId, IdMap,
-    utils::{OutputChannel, WriteWithUtils},
+    utils::{OutputChannel, WriteWithUtils, shorten_hex_object_id, shorten_object_id},
 };
 
 /// Handle the `but pick` command.
@@ -84,8 +84,9 @@ pub fn handle(
     }
 
     // Output results
+    let repo = ctx.repo.get()?.clone().for_commit_shortening();
     for (commit_hex, target_branch_name, _) in &picked {
-        let commit_short = &commit_hex[..7.min(commit_hex.len())];
+        let commit_short = shorten_hex_object_id(&repo, commit_hex);
         if let Some(out) = out.for_human() {
             writeln!(
                 out,
@@ -257,8 +258,8 @@ fn select_commits_from_branch(
     let options: Vec<String> = commits
         .iter()
         .enumerate()
-        .map(|(i, (_oid, c))| {
-            let short_id = &c.id().to_string()[..7];
+        .map(|(i, (oid, c))| {
+            let short_id = shorten_object_id(&gix_repo, *oid);
             let message = c.summary().unwrap_or("(no message)");
             let display = out.truncate_if_unpaged(message, 60);
             format!("[{}] {} {}", i + 1, short_id, display)
@@ -311,10 +312,11 @@ fn resolve_target_stack(
             bail!("No applied stacks in workspace. Apply a branch first with 'but branch apply'.");
         }
         CherryApplyStatus::CausesWorkspaceConflict => {
+            let repo = ctx.repo.get()?;
+            let commit_short = shorten_hex_object_id(&repo, commit_hex);
             bail!(
-                "Commit {} would cause conflicts with multiple stacks. \
-                 Resolve workspace conflicts first.",
-                &commit_hex[..7.min(commit_hex.len())]
+                "Commit {commit_short} would cause conflicts with multiple stacks. \
+                 Resolve workspace conflicts first."
             );
         }
         CherryApplyStatus::LockedToStack(locked_stack_id) => {

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -300,7 +300,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             )?;
 
             // Show upstream commits (actual new commits to integrate)
-            let repo = ctx.repo.get()?;
+            let repo = ctx.repo.get()?.clone().for_commit_shortening();
             for commit_info in &pull_result.recent_commits {
                 let msg = commit_info
                     .message
@@ -311,7 +311,6 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                     .take(65)
                     .collect::<String>();
                 let commit_short = shorten_hex_object_id(&repo, &commit_info.id);
-
                 writeln!(out, "   {} {}", commit_short.bright_black(), msg)?;
             }
 

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -2,6 +2,7 @@ mod json;
 
 use std::{collections::HashMap, fmt::Write};
 
+use but_core::RepositoryExt;
 use but_ctx::Context;
 use colored::Colorize;
 use gitbutler_branch_actions::upstream_integration::{
@@ -13,7 +14,7 @@ use gitbutler_branch_actions::upstream_integration::{
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
 use serde::{Deserialize, Serialize};
 
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_hex_object_id};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -165,13 +166,15 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
         )?;
 
         if !base_branch.upstream_commits.is_empty() {
+            let repo = ctx.repo.get()?.clone().for_commit_shortening();
             writeln!(out)?;
             let commits = base_branch.upstream_commits.iter().take(3);
             for commit in commits {
+                let commit_short = shorten_hex_object_id(&repo, &commit.id);
                 writeln!(
                     out,
                     "  {} {}",
-                    commit.id[..7].yellow(),
+                    commit_short.yellow(),
                     commit
                         .description
                         .to_string()
@@ -297,6 +300,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             )?;
 
             // Show upstream commits (actual new commits to integrate)
+            let repo = ctx.repo.get()?;
             for commit_info in &pull_result.recent_commits {
                 let msg = commit_info
                     .message
@@ -306,8 +310,9 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                     .chars()
                     .take(65)
                     .collect::<String>();
+                let commit_short = shorten_hex_object_id(&repo, &commit_info.id);
 
-                writeln!(out, "   {} {}", &commit_info.id[..7].bright_black(), msg)?;
+                writeln!(out, "   {} {}", commit_short.bright_black(), msg)?;
             }
 
             let hidden = base_branch.behind.saturating_sub(commits_to_show);

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -597,7 +597,7 @@ fn push_single_branch(
     )?;
     writeln!(progress)?;
     if !result.branch_sha_updates.is_empty() {
-        let repo = ctx.repo.get()?;
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
         for (branch, before_sha, after_sha) in &result.branch_sha_updates {
             let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                 "(new branch)".to_string()

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use crate::{
     CliId, IdMap,
     args::{push, push::Command},
-    utils::OutputChannel,
+    utils::{OutputChannel, shorten_hex_object_id, shorten_object_id},
 };
 
 /// Represents the result of branch selection when no branch is specified
@@ -194,7 +194,7 @@ fn handle_dry_run(
     let vb_state = gitbutler_stack::VirtualBranchesHandle::new(ctx.project_data_dir());
     let default_target = vb_state.get_default_target()?;
     let remote = default_target.push_remote_name();
-
+    let repo = ctx.repo.get()?.clone().for_commit_shortening();
     for (branch_name, unpushed_count, stack_name) in &branches_to_show {
         // Find the stack containing this branch
         for stack_entry in &stacks {
@@ -224,7 +224,7 @@ fn handle_dry_run(
                         .take(10) // Limit to first 10 commits for display
                         .map(|c| {
                             let sha = c.id.to_string();
-                            let sha_short: String = sha.chars().take(7).collect();
+                            let sha_short = shorten_object_id(&repo, c.id);
                             let message = c
                                 .message
                                 .to_string()
@@ -247,7 +247,7 @@ fn handle_dry_run(
                         .take(10) // Limit to first 10 commits for display
                         .map(|c| {
                             let sha = c.id.to_string();
-                            let sha_short: String = sha.chars().take(7).collect();
+                            let sha_short = shorten_object_id(&repo, c.id);
                             let message = c
                                 .message
                                 .to_string()
@@ -597,13 +597,14 @@ fn push_single_branch(
     )?;
     writeln!(progress)?;
     if !result.branch_sha_updates.is_empty() {
+        let repo = ctx.repo.get()?;
         for (branch, before_sha, after_sha) in &result.branch_sha_updates {
             let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                 "(new branch)".to_string()
             } else {
-                before_sha.chars().take(7).collect()
+                shorten_hex_object_id(&repo, before_sha)
             };
-            let after_str: String = after_sha.chars().take(7).collect();
+            let after_str = shorten_hex_object_id(&repo, after_sha);
 
             // Construct simple remote ref format: remote/branch
             let remote_ref = format!("{}/{}", result.remote, branch);
@@ -745,14 +746,15 @@ fn push_all_branches(
         writeln!(progress)?;
 
         // Print combined branch, remote, and SHA information for all pushed branches
+        let repo = ctx.repo.get()?.clone().for_commit_shortening();
         for result in &pushed_results {
             for (branch, before_sha, after_sha) in &result.branch_sha_updates {
                 let before_str = if before_sha == "0000000000000000000000000000000000000000" {
                     "(new branch)".to_string()
                 } else {
-                    before_sha.chars().take(7).collect()
+                    shorten_hex_object_id(&repo, before_sha)
                 };
-                let after_str: String = after_sha.chars().take(7).collect();
+                let after_str = shorten_hex_object_id(&repo, after_sha);
 
                 // Construct simple remote ref format: remote/branch
                 let remote_ref = format!("{}/{}", result.remote, branch);
@@ -1112,6 +1114,7 @@ fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Res
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),
     )?;
+    let repo = ctx.repo.get()?.clone().for_commit_shortening();
 
     // Find the stack containing this branch and get its details
     for stack in &stacks {
@@ -1131,7 +1134,7 @@ fn check_for_conflicted_commits(ctx: &Context, branch_name: &str) -> anyhow::Res
                         .commits
                         .iter()
                         .filter(|c| c.has_conflicts)
-                        .map(|c| c.id.to_string()[..7].to_string())
+                        .map(|c| shorten_object_id(&repo, c.id))
                         .collect();
 
                     if !conflicted_commits.is_empty() {

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -19,7 +19,7 @@ use crate::{
     IdMap,
     args::resolve::Subcommands,
     id::CliId,
-    utils::{Confirm, ConfirmDefault, OutputChannel},
+    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
 
 pub(crate) fn handle(
@@ -79,15 +79,15 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     };
 
     // Get the commit and check if it's conflicted
-    let gix_repo = ctx.repo.get()?;
-    let commit = gix_repo
+    let repo = ctx.repo.get()?;
+    let commit = repo
         .find_commit(commit_gix_oid)
         .context("Failed to find commit")?;
 
     if !commit.is_conflicted() {
+        let commit_short = shorten_object_id(&repo, commit_gix_oid);
         bail!(
-            "Commit {} is not in a conflicted state. Only conflicted commits can be resolved.",
-            &commit_gix_oid.to_string()[..7]
+            "Commit {commit_short} is not in a conflicted state. Only conflicted commits can be resolved."
         );
     }
 
@@ -102,7 +102,7 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
             // Walk the commit history to see if our commit is in this stack
             let traversal = head
                 .tip
-                .attach(&gix_repo)
+                .attach(&repo)
                 .ancestors()
                 .sorting(Sorting::BreadthFirst)
                 .all()?;
@@ -118,25 +118,24 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     }
 
     let stack_id = found_stack_id.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Could not find stack containing commit {}",
-            &commit_gix_oid.to_string()[..7]
-        )
+        let commit_short = shorten_object_id(&repo, commit_gix_oid);
+        anyhow::anyhow!("Could not find stack containing commit {commit_short}")
     })?;
 
     drop(commit);
-    drop(gix_repo);
+    drop(repo);
 
     // Enter edit mode
     enter_edit_mode(ctx, commit_gix_oid, stack_id).context("Failed to enter edit mode")?;
 
     // Show checkout message
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
         writeln!(
             out,
             "{} {}",
             "Checking out conflicted commit".bold(),
-            commit_gix_oid.to_string()[..7].cyan()
+            shorten_object_id(&repo, commit_gix_oid).cyan()
         )?;
     }
 
@@ -513,7 +512,7 @@ fn find_conflicted_commits(ctx: &mut Context) -> Result<BTreeMap<String, Vec<Con
 
                     let conflicted = ConflictedCommit {
                         commit_oid: oid,
-                        commit_short_id: oid.to_string()[..7].to_string(),
+                        commit_short_id: shorten_object_id(&gix_repo, oid),
                         commit_message: message,
                     };
 

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -7,7 +7,7 @@ use gix::ObjectId;
 use nonempty::NonEmpty;
 
 use super::assign::branch_name_to_stack_id;
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_object_id, split_short_id};
 
 pub(crate) fn uncommitted_to_commit(
     ctx: &mut Context,
@@ -24,14 +24,18 @@ pub(crate) fn uncommitted_to_commit(
         .map(|assignment| assignment.to_owned().into())
         .collect();
 
-    let mut guard = ctx.exclusive_worktree_access();
-    let outcome = amend_diff_specs(ctx, diff_specs, stack_id, *oid, guard.write_permission())?;
+    let outcome = {
+        let mut guard = ctx.exclusive_worktree_access();
+        amend_diff_specs(ctx, diff_specs, stack_id, *oid, guard.write_permission())?
+    };
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
         let new_commit = outcome
             .new_commit
             .map(|c| {
-                let s = c.to_string();
-                format!("{}{}", s[..2].blue().bold(), s[2..7].blue())
+                let short = shorten_object_id(&repo, c);
+                let (lead, rest) = split_short_id(&short, 2);
+                format!("{}{}", lead.blue().bold(), rest.blue())
             })
             .unwrap_or_default();
         writeln!(out, "Amended {description} → {new_commit}")?;
@@ -58,12 +62,15 @@ pub(crate) fn assignments_to_commit(
         .collect();
     let mut guard = ctx.exclusive_worktree_access();
     let outcome = amend_diff_specs(ctx, diff_specs, stack_id, *oid, guard.write_permission())?;
+    drop(guard);
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
         let new_commit = outcome
             .new_commit
             .map(|c| {
-                let s = c.to_string();
-                format!("{}{}", s[..2].blue().bold(), s[2..7].blue())
+                let short = shorten_object_id(&repo, c);
+                let (lead, rest) = split_short_id(&short, 2);
+                format!("{}{}", lead.blue().bold(), rest.blue())
             })
             .unwrap_or_default();
         if let Some(branch_name) = branch_name {

--- a/crates/but/src/command/legacy/rub/move.rs
+++ b/crates/but/src/command/legacy/rub/move.rs
@@ -8,7 +8,10 @@ use gitbutler_stack::VirtualBranchesHandle;
 use gix::ObjectId;
 
 use super::{assign::branch_name_to_stack_id, undo::stack_id_by_commit_id};
-use crate::{CliId, IdMap, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    utils::{OutputChannel, shorten_object_id},
+};
 
 /// Represents the operation to perform for a given source and target combination in `but move`.
 #[derive(Debug)]
@@ -216,6 +219,9 @@ fn move_to_commit(
     } else {
         // Different stacks - API limitation: can't move to specific position in another stack
         let target_stack_head_branch = get_topmost_branch_name(ctx, target_stack_id)?;
+        let repo = ctx.repo.get()?;
+        let source_short = shorten_object_id(&repo, *source_oid);
+        let target_short = shorten_object_id(&repo, *target_oid);
 
         if let Some(out) = out.for_human() {
             writeln!(
@@ -227,18 +233,17 @@ fn move_to_commit(
             writeln!(
                 out,
                 "The commit {} is in a different stack than the target commit {}.",
-                source_oid.to_string()[..7].blue(),
-                target_oid.to_string()[..7].blue()
+                source_short.blue(),
+                target_short.blue()
             )?;
             writeln!(out)?;
             writeln!(out, "{}", "You can do this in two steps:".yellow())?;
             writeln!(out)?;
-            let source_str = source_oid.to_string();
             writeln!(
                 out,
                 "  {}  {}",
                 "1.".cyan(),
-                format!("but move {} {}", &source_str[..7], target_stack_head_branch).green()
+                format!("but move {source_short} {target_stack_head_branch}").green()
             )?;
             writeln!(
                 out,
@@ -268,7 +273,7 @@ fn move_to_commit(
                 "error": "cross_stack_position",
                 "hint": format!(
                     "Move to branch first with 'but move {} {}', then reposition",
-                    &source_oid.to_string()[..7],
+                    source_short,
                     target_stack_head_branch
                 ),
             }))?;
@@ -315,10 +320,12 @@ fn move_to_branch(
         gitbutler_branch_actions::reorder_stack(ctx, source_stack_id, stack_order)?;
 
         if let Some(out) = out.for_human() {
+            let repo = ctx.repo.get()?;
+            let source_short = shorten_object_id(&repo, *source_oid);
             writeln!(
                 out,
                 "Moved {} → {}",
-                source_oid.to_string()[..7].blue(),
+                source_short.blue(),
                 format!("[{target_branch_name}]").green()
             )?;
 
@@ -337,8 +344,7 @@ fn move_to_branch(
                     "To move it to a specific position within the branch, you can run:"
                 )?;
                 writeln!(out)?;
-                let source_str = source_oid.to_string();
-                let cmd = format!("but move {} <target-commit> [--after]", &source_str[..7]);
+                let cmd = format!("but move {source_short} <target-commit> [--after]");
                 writeln!(out, "  {}", cmd.green())?;
             }
         } else if let Some(out) = out.for_json() {
@@ -384,10 +390,12 @@ fn move_to_branch(
         }
 
         if let Some(out) = out.for_human() {
+            let repo = ctx.repo.get()?;
+            let source_short = shorten_object_id(&repo, *source_oid);
             writeln!(
                 out,
                 "Moved {} → {}",
-                source_oid.to_string()[..7].blue(),
+                source_short.blue(),
                 format!("[{target_branch_name}]").green()
             )?;
 
@@ -406,8 +414,7 @@ fn move_to_branch(
                     "To move it to a specific position within the branch, you can run:"
                 )?;
                 writeln!(out)?;
-                let source_str = source_oid.to_string();
-                let cmd = format!("but move {} <target-commit> [--after]", &source_str[..7]);
+                let cmd = format!("but move {source_short} <target-commit> [--after]");
                 writeln!(out, "  {}", cmd.green())?;
             }
         } else if let Some(out) = out.for_json() {
@@ -501,12 +508,13 @@ fn move_within_stack(
 
     if let Some(out) = out.for_human() {
         let position_desc = if after { "after" } else { "before" };
+        let repo = ctx.repo.get()?;
         writeln!(
             out,
             "Moved {} {} {}",
-            source_oid.to_string()[..7].blue(),
+            shorten_object_id(&repo, *source_oid).blue(),
             position_desc,
-            target_oid.to_string()[..7].blue()
+            shorten_object_id(&repo, *target_oid).blue()
         )?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({"ok": true}))?;

--- a/crates/but/src/command/legacy/rub/move_commit.rs
+++ b/crates/but/src/command/legacy/rub/move_commit.rs
@@ -7,7 +7,7 @@ use gitbutler_stack::VirtualBranchesHandle;
 use gix::ObjectId;
 
 use super::{assign::branch_name_to_stack_id, undo::stack_id_by_commit_id};
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_object_id};
 
 pub(crate) fn to_branch(
     ctx: &mut Context,
@@ -69,10 +69,11 @@ pub(crate) fn to_branch(
         bail!("Illegal move")
     }
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
         writeln!(
             out,
             "Moved {} → {}",
-            oid.to_string()[..7].blue(),
+            shorten_object_id(&repo, *oid).blue(),
             format!("[{branch_name}]").green()
         )?;
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -7,7 +7,11 @@ use colored::Colorize;
 use gix::ObjectId;
 
 use super::undo::stack_id_by_commit_id;
-use crate::{CliId, IdMap, command::legacy::ai, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    command::legacy::ai,
+    utils::{OutputChannel, shorten_object_id},
+};
 
 pub(crate) fn commits(
     ctx: &mut Context,
@@ -277,13 +281,15 @@ fn squash_commits_internal(
 
     // Output message based on context
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
+        let final_short = shorten_object_id(&repo, final_commit_oid.to_gix());
         if source_oids.len() == 1 {
             // Single commit squash (for backwards compatibility with `but rub`)
             writeln!(
                 out,
                 "Squashed {} → {}",
-                source_oids[0].to_string()[..7].blue(),
-                final_commit_oid.to_gix().to_string()[..7].blue()
+                shorten_object_id(&repo, source_oids[0]).blue(),
+                final_short.blue()
             )?
         } else {
             // Multiple commits squash
@@ -291,7 +297,7 @@ fn squash_commits_internal(
                 out,
                 "Squashed {} commits → {}",
                 source_oids.len(),
-                final_commit_oid.to_gix().to_string()[..7].blue()
+                final_short.blue()
             )?
         }
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/legacy/rub/undo.rs
+++ b/crates/but/src/command/legacy/rub/undo.rs
@@ -4,7 +4,7 @@ use but_oxidize::ObjectIdExt;
 use colored::Colorize;
 use gix::ObjectId;
 
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_object_id};
 
 pub(crate) fn commit(
     ctx: &mut Context,
@@ -13,7 +13,8 @@ pub(crate) fn commit(
 ) -> anyhow::Result<()> {
     gitbutler_branch_actions::undo_commit(ctx, stack_id_by_commit_id(ctx, oid)?, oid.to_git2())?;
     if let Some(out) = out.for_human() {
-        writeln!(out, "Uncommitted {}", oid.to_string()[..7].blue())?;
+        let repo = ctx.repo.get()?;
+        writeln!(out, "Uncommitted {}", shorten_object_id(&repo, *oid).blue())?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({"ok": true}))?;
     }

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 
 use crate::{
     CLI_DATE, CliId, IdMap,
-    utils::{OutputChannel, time::format_relative_time},
+    utils::{OutputChannel, shorten_object_id, time::format_relative_time},
 };
 
 pub(crate) fn show_commit(
@@ -591,7 +591,7 @@ fn get_branch_commits(
 
         commits.push(BranchCommitInfo {
             sha: oid.to_string(),
-            short_sha: oid.to_string()[..7].to_string(),
+            short_sha: shorten_object_id(&gix_repo, info.id),
             message,
             full_message,
             author_name: author.name().unwrap_or("Unknown").to_string(),
@@ -619,7 +619,7 @@ fn get_branch_commits(
 
         Some(BranchCommitInfo {
             sha: merge_base_git2.to_string(),
-            short_sha: merge_base_git2.to_string()[..7].to_string(),
+            short_sha: shorten_object_id(&gix_repo, merge_base),
             message: base_message,
             full_message: None,
             author_name: base_author.name().unwrap_or("Unknown").to_string(),

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use assignment::FileAssignment;
 use bstr::{BStr, BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
-use but_core::{TreeStatus, ui};
+use but_core::{RepositoryExt, TreeStatus, ui};
 use but_ctx::Context;
 use but_forge::ForgeReview;
 use but_oxidize::OidExt;
@@ -570,7 +570,10 @@ pub fn print_group(
     out: &mut dyn WriteWithUtils,
     id_map: &IdMap,
 ) -> anyhow::Result<()> {
-    let repo = ctx.legacy_project.open_isolated_repo()?;
+    let repo = ctx
+        .legacy_project
+        .open_isolated_repo()?
+        .for_commit_shortening();
     if let Some(stack_with_id) = stack_with_id {
         let mut first = true;
         for segment in &stack_with_id.segments {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use crate::{
     CLI_DATE,
-    id::{SegmentWithId, StackWithId, TreeChangeWithId},
+    id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
     utils::{WriteWithUtils, time::format_relative_time_verbose},
 };
@@ -35,7 +35,11 @@ enum CommitClassification {
 pub(crate) mod assignment;
 pub(crate) mod json;
 
-use crate::{IdMap, command::legacy::forge::review, utils::OutputChannel};
+use crate::{
+    IdMap,
+    command::legacy::forge::review,
+    utils::{OutputChannel, shorten_hex_object_id, shorten_object_id, split_short_id},
+};
 
 type StackDetail = (Option<StackWithId>, Vec<FileAssignment>);
 type StackEntry = (Option<gitbutler_stack::StackId>, StackDetail);
@@ -159,7 +163,7 @@ pub(crate) async fn worktree(
         let author = base_commit_decoded.author()?;
         let common_merge_base_data = CommonMergeBase {
             target_name: target_name.clone(),
-            common_merge_base: target.sha.to_string()[..7].to_string(),
+            common_merge_base: shorten_object_id(&repo, target.sha.to_gix()),
             message: full_message,
             commit_date: formatted_date,
             commit_id: target.sha.to_gix(),
@@ -199,7 +203,7 @@ pub(crate) async fn worktree(
                                 Some(UpstreamState {
                                     target_name: base_branch.branch_name.clone(),
                                     behind_count: base_branch.behind,
-                                    latest_commit: commit_id.to_string()[..7].to_string(),
+                                    latest_commit: shorten_object_id(&repo, commit_id.to_gix()),
                                     message,
                                     commit_date: formatted_date,
                                     last_fetched_ms: last_fetched,
@@ -281,7 +285,9 @@ pub(crate) async fn worktree(
                 .segments
                 .first()
                 .map_or(Some(BStr::new(b"")), SegmentWithId::branch_name);
+            let repo = ctx.repo.get()?;
             print_assignments(
+                &repo,
                 stack_id,
                 &id_map,
                 branch_name,
@@ -338,17 +344,15 @@ pub(crate) async fn worktree(
             if let Some(ref base_branch) = base_branch
                 && !base_branch.upstream_commits.is_empty()
             {
+                let repo = ctx.repo.get()?;
                 let commits = base_branch.upstream_commits.iter().take(8);
                 for commit in commits {
                     // Measure prefix width using plain text (no ANSI codes)
+                    let commit_short = shorten_hex_object_id(&repo, &commit.id);
                     let truncated_msg = out
                         .truncate_if_unpaged(&commit.description.to_string().replace('\n', " "), 72)
                         .dimmed();
-                    writeln!(
-                        out,
-                        "┊{dot} {short_id} {truncated_msg}",
-                        short_id = commit.id[..7].yellow()
-                    )?;
+                    writeln!(out, "┊{dot} {} {truncated_msg}", commit_short.yellow())?;
                 }
                 let hidden_commits = base_branch.behind.saturating_sub(8);
                 if hidden_commits > 0 {
@@ -463,7 +467,9 @@ fn ci_map(
     Ok(ci_map)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn print_assignments(
+    repo: &gix::Repository,
     stack: Option<StackId>,
     id_map: &IdMap,
     branch_name: Option<&BStr>,
@@ -523,7 +529,11 @@ fn print_assignments(
             .map(|l| l.commit_id.to_string())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
-            .map(|commit_id| format!("{}{}", commit_id[..2].blue().bold(), commit_id[2..7].blue()))
+            .map(|commit_id| {
+                let short_id = shorten_hex_object_id(repo, &commit_id);
+                let (lead, rest) = split_short_id(&short_id, 2);
+                format!("{}{}", lead.blue().bold(), rest.blue())
+            })
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -650,6 +660,7 @@ pub fn print_group(
                 let details =
                     but_api::diff::commit_details(ctx, commit.commit_id(), ComputeLineStats::No)?;
                 print_commit(
+                    &repo,
                     commit.short_id.clone(),
                     &commit.inner,
                     CommitChanges::Remote(&details.diff_with_first_parent),
@@ -683,6 +694,7 @@ pub fn print_group(
                 };
 
                 print_commit(
+                    &repo,
                     commit.short_id.clone(),
                     &commit.inner.inner,
                     CommitChanges::Workspace(&commit.tree_changes_using_repo(&repo)?),
@@ -707,7 +719,7 @@ pub fn print_group(
             "unstaged changes".to_string().cyan().bold(),
             stack_mark.clone().unwrap_or_default()
         )?;
-        print_assignments(None, id_map, None, &assignments, changes, true, out)?;
+        print_assignments(&repo, None, id_map, None, &assignments, changes, true, out)?;
     }
     if !first {
         writeln!(out, "├╯")?;
@@ -769,7 +781,8 @@ enum CommitChanges<'a> {
 
 #[expect(clippy::too_many_arguments)]
 fn print_commit(
-    short_id: String,
+    repo: &gix::Repository,
+    short_id: ShortId,
     commit: &but_workspace::ref_info::Commit,
     commit_changes: CommitChanges,
     classification: CommitClassification,
@@ -796,6 +809,7 @@ fn print_commit(
     let upstream_commit = matches!(commit_changes, CommitChanges::Remote(_));
 
     let details_string = display_cli_commit_details(
+        repo,
         short_id,
         commit,
         match commit_changes {
@@ -879,17 +893,22 @@ impl CliDisplay for but_core::TreeChange {
 }
 
 fn display_cli_commit_details(
-    short_id: String,
+    repo: &gix::Repository,
+    short_id: ShortId,
     commit: &but_workspace::ref_info::Commit,
     has_changes: bool,
     verbose: bool,
     is_paged: bool,
 ) -> String {
-    let end_id = if short_id.len() >= 7 {
+    let commit_id_short = shorten_object_id(repo, commit.id);
+    let end_id = if short_id.len() >= commit_id_short.len() {
         "".to_string()
     } else {
-        let commit_id = commit.id.to_string();
-        commit_id[short_id.len()..7].dimmed().to_string()
+        commit_id_short
+            .get(short_id.len()..commit_id_short.len())
+            .unwrap_or("")
+            .dimmed()
+            .to_string()
     };
     let start_id = short_id.blue().bold();
 

--- a/crates/but/src/command/legacy/teardown.rs
+++ b/crates/but/src/command/legacy/teardown.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use gix::refs::transaction::PreviousValue;
 use serde::Serialize;
 
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, shorten_object_id};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -59,10 +59,12 @@ pub(crate) fn teardown(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Re
     let snapshot_id = snapshot.to_string();
 
     if let Some(out) = out.for_human() {
+        let repo = ctx.repo.get()?;
+        let snapshot_short = shorten_object_id(&repo, snapshot);
         writeln!(
             out,
             "  {}",
-            format!("✓ Snapshot created: {}", &snapshot_id[..7]).green()
+            format!("✓ Snapshot created: {snapshot_short}").green()
         )?;
         writeln!(out)?;
     }
@@ -261,15 +263,12 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
     } else {
         // soft reset to the first workspace commit
         let target_commit = commit.id();
+        let target_short = shorten_object_id(&repo, target_commit);
         if let Some(out) = out.for_human() {
             writeln!(
                 out,
                 "{}",
-                format!(
-                    "→ Resetting gitbutler/workspace to {}",
-                    &target_commit.to_string()[..7]
-                )
-                .dimmed()
+                format!("→ Resetting gitbutler/workspace to {target_short}").dimmed()
             )?;
         }
         repo.reference(
@@ -282,11 +281,7 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
             writeln!(
                 out,
                 "  {}",
-                format!(
-                    "✓ gitbutler/workspace reset to {}",
-                    &target_commit.to_string()[..7]
-                )
-                .green()
+                format!("✓ gitbutler/workspace reset to {target_short}").green()
             )?;
         }
 
@@ -306,7 +301,12 @@ fn try_stack_fixes(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result
             for commit in &dangling_commits {
                 let message = String::from_utf8_lossy(commit.message_raw().unwrap_or((&[]).into()));
                 let first_line = message.lines().next().unwrap_or("");
-                writeln!(out, "    {}: {}", &commit.id().to_string()[..7], first_line)?;
+                writeln!(
+                    out,
+                    "    {}: {}",
+                    shorten_object_id(&repo, commit.id()),
+                    first_line
+                )?;
             }
             writeln!(out)?;
         }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -32,7 +32,7 @@ mod uncommitted_info;
 mod tests;
 
 /// A helper to indicate that this is a short-id as a user would see.
-pub type ShortId = String;
+pub(crate) type ShortId = String;
 
 const UNASSIGNED: &str = "zz";
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -32,7 +32,7 @@ mod uncommitted_info;
 mod tests;
 
 /// A helper to indicate that this is a short-id as a user would see.
-type ShortId = String;
+pub type ShortId = String;
 
 const UNASSIGNED: &str = "zz";
 

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -5,6 +5,9 @@ pub use output_channel::{
     Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel, OutputChannel, WriteWithUtils,
 };
 
+mod object_id;
+pub use object_id::{shorten_hex_object_id, shorten_object_id, split_short_id};
+
 mod pager;
 
 pub mod metrics;

--- a/crates/but/src/utils/object_id.rs
+++ b/crates/but/src/utils/object_id.rs
@@ -1,0 +1,25 @@
+use gix::prelude::ObjectIdExt as _;
+
+/// Shorten a commit object id using repository disambiguation (`core.abbrev`), and return
+/// the result as a hex-string..
+pub fn shorten_object_id(repo: &gix::Repository, oid: impl Into<gix::ObjectId>) -> String {
+    oid.into().attach(repo).shorten_or_id().to_string()
+}
+
+/// Try to shorten a hex object id string using repository disambiguation.
+///
+/// If `hex` cannot be parsed as an object id, return it unchanged.
+pub fn shorten_hex_object_id(repo: &gix::Repository, hex: &str) -> String {
+    gix::ObjectId::from_hex(hex.as_bytes())
+        .map(|oid| shorten_object_id(repo, oid))
+        .unwrap_or_else(|_| hex.to_owned())
+}
+
+/// Split a `short_id` into a leading prefix and remaining suffix for styled output.
+pub fn split_short_id(short_id: &str, prefix_len: usize) -> (&str, &str) {
+    if short_id.len() <= prefix_len {
+        (short_id, "")
+    } else {
+        short_id.split_at(prefix_len)
+    }
+}

--- a/crates/but/src/utils/object_id.rs
+++ b/crates/but/src/utils/object_id.rs
@@ -1,7 +1,7 @@
 use gix::prelude::ObjectIdExt as _;
 
 /// Shorten a commit object id using repository disambiguation (`core.abbrev`), and return
-/// the result as a hex-string..
+/// the result as a hex-string.
 pub fn shorten_object_id(repo: &gix::Repository, oid: impl Into<gix::ObjectId>) -> String {
     oid.into().attach(repo).shorten_or_id().to_string()
 }

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -185,7 +185,7 @@ Created new independent branch 'feature-x'
         .stdout_eq(str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-[HASH] 2000-01-02 00:00:00 [CREATE] CreateCommit
+[SHORTHASH] 2000-01-02 00:00:00 [CREATE] CreateCommit
 
 "#]]);
     Ok(())


### PR DESCRIPTION
### Tasks

* [x] review
    - [x] double-check usages of lead,rest print
* [x] make it fast

### Review Notes

`but oplog` changed as I am using uniformly shortened commit-ids instead.

Compare after and before. 

<img width="474" height="637" alt="Screenshot 2026-03-01 at 15 51 51" src="https://github.com/user-attachments/assets/26fade2e-c008-4436-b996-57957aa71380" />

To my mind, there is no need for the extra coloring, particularly now where the shortening takes care of disambiguating prefixes, while respecting `core.abbrev`.
