### PR TITLE
Improve VirtualList robustness, readability, and scroll behavior

### DIFF
--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -17,6 +17,7 @@
 		autoScroll?: boolean;
 		onthumbdrag?: (dragging: boolean) => void;
 		children: Snippet;
+		actions?: Snippet;
 		onscrollTop?: (visible: boolean) => void;
 		onscrollEnd?: (visible: boolean) => void;
 		onscroll?: (e: Event) => void;
@@ -56,6 +57,7 @@
 		childrenWrapHeight,
 		childrenWrapDisplay = "block",
 		enableDragScroll = false,
+		actions,
 	}: ScrollableProps = $props();
 
 	let scrollTopVisible = $state<boolean>(true);
@@ -170,6 +172,7 @@
 		{onscrollexists}
 		{onthumbdrag}
 	/>
+	{@render actions?.()}
 </div>
 
 <style lang="postcss">

--- a/packages/ui/tests/VirtualListTestWrapper.svelte
+++ b/packages/ui/tests/VirtualListTestWrapper.svelte
@@ -57,7 +57,7 @@
 	let items = $state(Array.from({ length: itemCount }, (_, i) => `Item ${i + 1}`));
 	let container = $state<HTMLDivElement>();
 	let loadMoreCallCount = $state(0);
-	let virtualList = $state<any>();
+	let virtualList = $state<VirtualList<any>>();
 	let showFooter = $state(false);
 	let visibleStart = $state(-1);
 	let visibleEnd = $state(-1);
@@ -168,8 +168,19 @@
 		}
 	}
 
+	function handleScrollToTop() {
+		if (virtualList) {
+			virtualList.jumpToIndex(0);
+		}
+	}
+
 	function toggleFooter() {
 		showFooter = !showFooter;
+	}
+
+	function toggleFooterAndAddItem() {
+		showFooter = !showFooter;
+		items.push(`Item ${items.length + 1}`);
 	}
 </script>
 
@@ -240,6 +251,13 @@
 		<button type="button" onclick={toggleFooter} data-testid="toggle-footer-button">
 			Toggle Footer
 		</button>
+		<button
+			type="button"
+			onclick={toggleFooterAndAddItem}
+			data-testid="toggle-footer-and-add-item-button"
+		>
+			Toggle Footer + Add
+		</button>
 		<input
 			type="number"
 			bind:value={jumpToIndexValue}
@@ -251,6 +269,9 @@
 		</button>
 		<button type="button" onclick={handleScrollToBottom} data-testid="scroll-to-bottom-button">
 			Scroll To Bottom
+		</button>
+		<button type="button" onclick={handleScrollToTop} data-testid="scroll-to-top-button">
+			Scroll To Top
 		</button>
 	</div>
 </div>


### PR DESCRIPTION
Structural cleanup:
- Extract named functions from inline blocks (compensateScrollForResize,
  handleItemsChanged, updateHeightMap, updateScrollDirection, etc.)
- Reorder for top-down readability: utilities, range calculation, core
  operations, item-change handlers, observers, effects
- Combine two range calculations into single-pass calculateVisibleRange
- Replace tuple returns with named objects, add section comments

Bug fixes:
- Prevent scroll-to-bottom cascade when user scrolls up near bottom —
  add lastScrollDirection guard to both item and children resize
  observers
- Add regression test for stickToBottom + children snippet resize race

Simplifications:
- Merge duplicate near-bottom constants into NEAR_BOTTOM_THRESHOLD
- Inline getNewIndices, eliminate visible wrapper objects
- Make isNearBottom parameter required (no call site used the fallback)
- Improve comments throughout: explain non-obvious patterns like live
  HTMLCollection, skipNextScrollEvent, untrack usage in effects