### PR TITLE
Fix dismissing focus manager outline

### DIFF
--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -91,11 +91,12 @@ export class FocusManager {
 			return;
 		}
 
+		this.setOutline(false);
+
 		if (e.target instanceof HTMLElement) {
 			const focusableNode = this.findNearestFocusableElement(e.target);
 			if (focusableNode && focusableNode.element.contains(e.target)) {
 				this.setActiveNode(focusableNode, true);
-				this.setOutline(false);
 			}
 		}
 


### PR DESCRIPTION
Should always go away when you click something with the mouse.