### PR TITLE
configurable gitbutler storage path via Git config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,8 @@ cargo clippy --all-targets
 - Group imports: Std, External, Crate
 - Imports granularity: Crate level
 
+**temporary directories** - use `but-testsupport` for scenario creation. Read-only functions should use read-only fixtures. DO NOT USE the `std::env::temp_dir().join(format!(…)` pattern.
+
 ## Dependency Management
 
 ### Adding JavaScript/TypeScript Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,7 @@ dependencies = [
  "but-ctx",
  "but-fs",
  "but-oxidize",
+ "but-project-handle",
  "but-settings",
  "but-workspace",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-ctx",
+ "but-db",
  "clap",
  "crossterm",
  "gix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "but-hunk-assignment",
  "but-meta",
  "but-oxidize",
+ "but-project-handle",
  "but-rebase",
  "but-serde",
  "but-settings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,8 +1317,10 @@ name = "but-link"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "but-ctx",
  "clap",
  "crossterm",
+ "gix",
  "ratatui",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "bstr",
  "but-error",
  "but-oxidize",
+ "but-project-handle",
  "but-schemars",
  "but-serde",
  "but-testsupport",
@@ -1416,10 +1417,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "but-core",
+ "but-path",
+ "but-testsupport",
  "gix",
  "serde",
  "serde_json",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/but-api/src/legacy/projects.rs
+++ b/crates/but-api/src/legacy/projects.rs
@@ -104,6 +104,18 @@ pub fn delete_project(project_id: ProjectHandleOrLegacyProjectId) -> Result<()> 
     gitbutler_project::delete(project.id)
 }
 
+/// Prepare an already-known project for activation in the UI or server.
+///
+/// This repairs missing target metadata in freshly selected storage locations and then reconciles
+/// the legacy metadata view with the workspace currently present in Git. It is safe for activation
+/// paths because it avoids rewriting `gitbutler/workspace`.
+pub fn prepare_project_for_activation(ctx: &mut Context) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::base::bootstrap_default_target_if_missing(ctx)?;
+    super::meta::reconcile_in_workspace_state_of_vb_toml(ctx, guard.write_permission()).ok();
+    Ok(())
+}
+
 #[but_api]
 #[instrument(err(Debug))]
 pub fn is_gerrit(ctx: &but_ctx::Context) -> Result<bool> {

--- a/crates/but-cherry-apply/tests/fixtures/scenario/shared.sh
+++ b/crates/but-cherry-apply/tests/fixtures/scenario/shared.sh
@@ -43,8 +43,8 @@ function init-repo-with-files-and-remote () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler
-  cat <<EOF >>.git/gitbutler/virtual_branches.toml
+  mkdir .git/gitbutler.dev
+  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -18,6 +18,7 @@ legacy = []
 
 [dependencies]
 but-error.workspace = true
+but-project-handle.workspace = true
 but-serde.workspace = true
 
 # for safe-checkout

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -12,7 +12,7 @@ use crate::{GitConfigSettings, commit::TreeKind};
 pub trait RepositoryExt: Sized {
     /// Returns a bundle of settings by querying the git configuration itself, assuring fresh data is loaded.
     fn git_settings(&self) -> anyhow::Result<GitConfigSettings>;
-    /// Return the path to store per-project GitButler data, which is garantueed to be inside
+    /// Return the path to store per-project GitButler data, which is guaranteed to be inside
     /// of the `.git` directory, or in a unique folder outside of it.
     ///
     /// Resolution:
@@ -21,9 +21,9 @@ pub trait RepositoryExt: Sized {
     ///   `~/gitbutler-projects`.
     /// * If it is relative, it is interpreted relative to [`gix::Repository::git_dir`], so
     ///   `custom/gitbutler` resolves to `<git-dir>/custom/gitbutler`.
-    /// * If it is absolute and outside of [`gix::Repository::git_dir`], the resolved storage path
-    ///   becomes `<configured-path>/<project-handle>` so multiple projects can share one base path.
-    ///   This is common if the storagePath is set on a global level, so it's shared among all projects.
+    /// * If the resolved path is outside of [`gix::Repository::git_dir`], the storage path
+    ///   becomes `<configured-path>/<project-handle>` so multiple projects can share one base path
+    ///   without clobbering each other. This also applies to relative paths like `../../shared`.
     /// * Otherwise defaults to `<git-dir>/gitbutler` for release builds and
     ///   `<git-dir>/gitbutler.<channel>` for non-release builds.
     fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf>;

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -4,6 +4,7 @@ use gix::{
     merge::tree::{Options, TreatAsUnresolved},
     prelude::ObjectIdExt,
 };
+use std::path::PathBuf;
 
 use crate::{GitConfigSettings, commit::TreeKind};
 
@@ -11,6 +12,21 @@ use crate::{GitConfigSettings, commit::TreeKind};
 pub trait RepositoryExt: Sized {
     /// Returns a bundle of settings by querying the git configuration itself, assuring fresh data is loaded.
     fn git_settings(&self) -> anyhow::Result<GitConfigSettings>;
+    /// Return the path to store per-project GitButler data, which is garantueed to be inside
+    /// of the `.git` directory, or in a unique folder outside of it.
+    ///
+    /// Resolution:
+    /// * `gitbutler.storagePath` on release builds, or `gitbutler.<channel>.storagePath`
+    ///   on non-release builds, with values like `gitbutler-alt`, `custom/gitbutler`, or
+    ///   `~/gitbutler-projects`.
+    /// * If it is relative, it is interpreted relative to [`gix::Repository::git_dir`], so
+    ///   `custom/gitbutler` resolves to `<git-dir>/custom/gitbutler`.
+    /// * If it is absolute and outside of [`gix::Repository::git_dir`], the resolved storage path
+    ///   becomes `<configured-path>/<project-handle>` so multiple projects can share one base path.
+    ///   This is common if the storagePath is set on a global level, so it's shared among all projects.
+    /// * Otherwise defaults to `<git-dir>/gitbutler` for release builds and
+    ///   `<git-dir>/gitbutler.<channel>` for non-release builds.
+    fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf>;
     /// Set all fields in `config` that are not `None` to disk into local repository configuration, or none of them.
     fn set_git_settings(&self, config: &GitConfigSettings) -> anyhow::Result<()>;
     /// Return all signatures that would be needed to perform a commit as configured in Git: `(author, committer)`.
@@ -141,6 +157,10 @@ impl RepositoryExt for gix::Repository {
 
     fn git_settings(&self) -> anyhow::Result<GitConfigSettings> {
         GitConfigSettings::try_from_snapshot(&self.config_snapshot())
+    }
+
+    fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf> {
+        but_project_handle::gitbutler_storage_path(self)
     }
 
     fn set_git_settings(&self, settings: &GitConfigSettings) -> anyhow::Result<()> {

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -17,10 +17,11 @@ pub trait RepositoryExt: Sized {
     ///
     /// Resolution:
     /// * `gitbutler.storagePath` on release builds, or `gitbutler.<channel>.storagePath`
-    ///   on non-release builds, with values like `gitbutler-alt`, `custom/gitbutler`, or
+    ///   on non-release builds, with values like `gitbutler-alt`, `gitbutler-alt/nested`, or
     ///   `~/gitbutler-projects`.
-    /// * If it is relative, it is interpreted relative to [`gix::Repository::git_dir`], so
-    ///   `custom/gitbutler` resolves to `<git-dir>/custom/gitbutler`.
+    /// * If it is relative, it is interpreted relative to [`gix::Repository::git_dir`].
+    ///   Paths that stay inside `.git` must live under a top-level directory whose name starts
+    ///   with `gitbutler`.
     /// * If the resolved path is outside of [`gix::Repository::git_dir`], the storage path
     ///   becomes `<configured-path>/<project-handle>` so multiple projects can share one base path
     ///   without clobbering each other. This also applies to relative paths like `../../shared`.

--- a/crates/but-ctx/src/legacy.rs
+++ b/crates/but-ctx/src/legacy.rs
@@ -1,4 +1,4 @@
-use but_core::sync::RepoExclusive;
+use but_core::{RepositoryExt, sync::RepoExclusive};
 use but_settings::AppSettings;
 use tracing::instrument;
 
@@ -24,39 +24,45 @@ impl Context {
     pub fn new_from_legacy_project_and_settings(
         legacy_project: &gitbutler_project::Project,
         settings: AppSettings,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let gitdir = legacy_project.git_dir().to_owned();
+        let repo = gix::open(&gitdir)?;
+        let project_data_dir = repo.gitbutler_storage_path()?;
         let app_cache_dir = but_path::app_cache_dir().ok();
-        Context {
+        Ok(Context {
             settings,
             gitdir: gitdir.clone(),
+            project_data_dir: project_data_dir.clone(),
             legacy_project: legacy_project.clone(),
             repo: new_ondemand_repo(gitdir.clone()),
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-            db: new_ondemand_db(gitdir),
+            db: new_ondemand_db(project_data_dir),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
             app_cache_dir,
             workspace: Default::default(),
         }
+        .with_repo(repo))
     }
 
     /// Open the repository identified by `legacy_project` and `settings`.
     pub fn new_from_legacy_project(
         legacy_project: gitbutler_project::Project,
     ) -> anyhow::Result<Self> {
-        let gitdir = legacy_project.git_dir().to_owned();
-        let app_cache_dir = but_path::app_cache_dir().ok();
-        Ok(Context {
-            settings: app_settings(but_path::app_config_dir()?)?,
-            gitdir: gitdir.clone(),
-            legacy_project,
-            repo: new_ondemand_repo(gitdir.clone()),
-            git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-            db: new_ondemand_db(gitdir),
-            app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
-            app_cache_dir,
-            workspace: Default::default(),
-        })
+        Context::new_from_legacy_project_and_settings(
+            &legacy_project,
+            app_settings(but_path::app_config_dir()?)?,
+        )
+    }
+
+    /// Create a context from a legacy `project_id`,
+    /// which requires reading `projects.json` to map it to metadata.
+    pub fn new_from_legacy_project_id(project_id: LegacyProjectId) -> anyhow::Result<Self> {
+        let legacy_project =
+            gitbutler_project::get(ProjectHandleOrLegacyProjectId::LegacyProjectId(project_id))?;
+        Context::new_from_legacy_project_and_settings(
+            &legacy_project,
+            app_settings(but_path::app_config_dir()?)?,
+        )
     }
 }
 
@@ -64,9 +70,7 @@ impl TryFrom<LegacyProjectId> for Context {
     type Error = anyhow::Error;
 
     fn try_from(value: LegacyProjectId) -> Result<Self, Self::Error> {
-        let project =
-            gitbutler_project::get(ProjectHandleOrLegacyProjectId::LegacyProjectId(value))?;
-        Context::new_from_legacy_project(project)
+        Context::new_from_legacy_project_id(value)
     }
 }
 

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -91,9 +91,11 @@ pub struct Context {
     /// Derived from [`gix::Repository::config_snapshot`] using a channel-specific
     /// Git config key (`gitbutler.storagePath` for release builds and
     /// `gitbutler.<channel>.storagePath` otherwise). Relative values are resolved
-    /// against `gitdir`, and any resolved path outside `gitdir` gets a
-    /// `<configured-path>/<project-handle>` suffix. If that key is not
-    /// configured, a channel-specific default is used.
+    /// against `gitdir`; paths that stay inside `gitdir` must live under a
+    /// top-level directory whose name starts with `gitbutler`. Any resolved
+    /// path outside `gitdir` gets a `<configured-path>/<project-handle>`
+    /// suffix. If that key is not configured, a channel-specific default is
+    /// used.
     pub project_data_dir: PathBuf,
     /// The directory to store application caches in.
     pub app_cache_dir: Option<PathBuf>,

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -86,6 +86,15 @@ pub struct Context {
     /// (or repository associated with a submodule or worktree).
     /// It's also used for various derived directories to store GitButler data in.
     pub gitdir: PathBuf,
+    /// The directory where per-project GitButler data is stored.
+    ///
+    /// Derived from [`gix::Repository::config_snapshot`] using a channel-specific
+    /// Git config key (`gitbutler.storagePath` for release builds and
+    /// `gitbutler.<channel>.storagePath` otherwise). Relative values are resolved
+    /// inside `gitdir`, and absolute values outside `gitdir` are resolved as
+    /// `<configured-path>/<project-handle>`. If that key is not configured, a
+    /// channel-specific default is used.
+    pub project_data_dir: PathBuf,
     /// The directory to store application caches in.
     pub app_cache_dir: Option<PathBuf>,
     /// The most recently opened repository of the project, which also provides access to the `git_dir`.
@@ -118,6 +127,8 @@ pub struct ThreadSafeContext {
     pub settings: AppSettings,
     /// The directory at which the repository itself is located.
     pub gitdir: PathBuf,
+    /// The directory where per-project GitButler data is stored.
+    pub project_data_dir: PathBuf,
     /// The directory to store application caches in.
     pub app_cache_dir: Option<PathBuf>,
     /// The most recently opened repository of the project, which also provides access to the `git_dir`.
@@ -132,6 +143,7 @@ impl From<ThreadSafeContext> for Context {
         let ThreadSafeContext {
             settings,
             gitdir,
+            project_data_dir,
             app_cache_dir,
             repo,
             #[cfg(feature = "legacy")]
@@ -145,9 +157,10 @@ impl From<ThreadSafeContext> for Context {
             settings,
             repo: ondemand,
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-            db: new_ondemand_db(gitdir.clone()),
+            db: new_ondemand_db(project_data_dir.clone()),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
             gitdir,
+            project_data_dir,
             app_cache_dir,
             #[cfg(feature = "legacy")]
             legacy_project,
@@ -209,23 +222,26 @@ impl Context {
     ) -> anyhow::Result<Context> {
         let gitdir = gitdir.into();
         let settings = app_settings(app_config_dir)?;
+        let repo = gix::open(&gitdir)?;
+        let project_data_dir = repo.gitbutler_storage_path()?;
         #[cfg(not(feature = "legacy"))]
         {
             Ok(Context {
                 gitdir: gitdir.clone(),
+                project_data_dir: project_data_dir.clone(),
                 settings,
                 repo: new_ondemand_repo(gitdir.clone()),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-                db: new_ondemand_db(gitdir),
+                db: new_ondemand_db(project_data_dir),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
                 app_cache_dir,
                 workspace: Default::default(),
-            })
+            }
+            .with_repo(repo))
         }
         #[cfg(feature = "legacy")]
         {
             use anyhow::Context as _;
-            let repo = gix::open(&gitdir)?;
             let worktree_dir = repo
                 .workdir()
                 .context("Bare repositories aren't yet supported.")?;
@@ -234,10 +250,11 @@ impl Context {
             Ok(Context {
                 settings,
                 gitdir: gitdir.clone(),
+                project_data_dir: project_data_dir.clone(),
                 legacy_project,
                 repo: new_ondemand_repo(gitdir.clone()),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-                db: new_ondemand_db(gitdir),
+                db: new_ondemand_db(project_data_dir),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -269,6 +286,7 @@ impl Context {
 
     fn from_repo_with_legacy_support(repo: gix::Repository) -> anyhow::Result<Context> {
         let app_cache_dir = but_path::app_cache_dir().ok();
+        let project_data_dir = repo.gitbutler_storage_path()?;
         #[cfg(feature = "legacy")]
         {
             use anyhow::Context as _;
@@ -281,10 +299,11 @@ impl Context {
             Ok(Context {
                 settings: app_settings(but_path::app_config_dir()?)?,
                 gitdir: gitdir.clone(),
+                project_data_dir: project_data_dir.clone(),
                 legacy_project,
                 repo: new_ondemand_repo(gitdir.clone()),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-                db: new_ondemand_db(gitdir),
+                db: new_ondemand_db(project_data_dir),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -297,10 +316,11 @@ impl Context {
             let gitdir = repo.git_dir().to_owned();
             Ok(crate::Context {
                 gitdir: gitdir.clone(),
+                project_data_dir: project_data_dir.clone(),
                 settings: app_settings(but_path::app_config_dir()?)?,
                 repo: new_ondemand_repo(gitdir.clone()),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-                db: new_ondemand_db(gitdir),
+                db: new_ondemand_db(project_data_dir),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -315,6 +335,7 @@ impl Context {
     /// **Note that it does not have support for legacy projects to encourage single-branch compatible code.**
     pub fn from_repo(repo: gix::Repository) -> anyhow::Result<Context> {
         let gitdir = repo.git_dir().to_owned();
+        let project_data_dir = repo.gitbutler_storage_path()?;
         let settings = app_settings(but_path::app_config_dir()?)?;
         let app_cache_dir = but_path::app_cache_dir().ok();
 
@@ -322,10 +343,11 @@ impl Context {
             #[cfg(feature = "legacy")]
             legacy_project: default_legacy_project_at_repo(&repo),
             gitdir: gitdir.clone(),
+            project_data_dir: project_data_dir.clone(),
             settings,
             repo: new_ondemand_repo(gitdir.clone()),
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
-            db: new_ondemand_db(gitdir),
+            db: new_ondemand_db(project_data_dir),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone()),
             app_cache_dir,
             workspace: Default::default(),
@@ -625,6 +647,7 @@ impl Context {
         ThreadSafeContext {
             settings: self.settings.clone(),
             gitdir: self.gitdir.clone(),
+            project_data_dir: self.project_data_dir.clone(),
             app_cache_dir: self.app_cache_dir.clone(),
             repo: self.repo.get_opt().clone().map(|r| r.into_sync()),
             #[cfg(feature = "legacy")]
@@ -637,6 +660,7 @@ impl Context {
         let Context {
             settings,
             gitdir,
+            project_data_dir,
             mut repo,
             git2_repo: _,
             db: _,
@@ -649,6 +673,7 @@ impl Context {
         ThreadSafeContext {
             settings,
             gitdir,
+            project_data_dir,
             app_cache_dir,
             repo: repo.take().map(|r| r.into_sync()),
             #[cfg(feature = "legacy")]
@@ -668,7 +693,7 @@ impl ThreadSafeContext {
 impl Context {
     /// The location where project-specific data can be stored that is owned by the application.
     pub fn project_data_dir(&self) -> PathBuf {
-        project_data_dir(&self.gitdir)
+        self.project_data_dir.clone()
     }
 
     /// The path to the worktree directory or the `.git` directory if there is no worktree directory.
@@ -733,10 +758,6 @@ impl Context {
     }
 }
 
-fn project_data_dir(gitdir: &Path) -> PathBuf {
-    gitdir.join("gitbutler")
-}
-
 /// For now, always make sure we have object caches setup to make diffs fast in the common case.
 /// Optimizing this based on better heuristics can be done with [Context::clone_repo_for_merging()].
 #[instrument(level = "trace")]
@@ -760,8 +781,8 @@ fn new_ondemand_git2_repo(gitdir: PathBuf) -> OnDemand<git2::Repository> {
 }
 
 #[instrument(level = "trace")]
-fn new_ondemand_db(gitdir: PathBuf) -> OnDemand<but_db::DbHandle> {
-    OnDemand::new(move || but_db::DbHandle::new_in_directory(project_data_dir(&gitdir)))
+fn new_ondemand_db(project_data_dir: PathBuf) -> OnDemand<but_db::DbHandle> {
+    OnDemand::new(move || but_db::DbHandle::new_in_directory(project_data_dir.clone()))
 }
 
 #[instrument(level = "trace")]

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -91,9 +91,9 @@ pub struct Context {
     /// Derived from [`gix::Repository::config_snapshot`] using a channel-specific
     /// Git config key (`gitbutler.storagePath` for release builds and
     /// `gitbutler.<channel>.storagePath` otherwise). Relative values are resolved
-    /// inside `gitdir`, and absolute values outside `gitdir` are resolved as
-    /// `<configured-path>/<project-handle>`. If that key is not configured, a
-    /// channel-specific default is used.
+    /// against `gitdir`, and any resolved path outside `gitdir` gets a
+    /// `<configured-path>/<project-handle>` suffix. If that key is not
+    /// configured, a channel-specific default is used.
     pub project_data_dir: PathBuf,
     /// The directory to store application caches in.
     pub app_cache_dir: Option<PathBuf>,

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -1,4 +1,5 @@
 use but_ctx::{Context, ProjectHandle};
+use but_testsupport::{CommandExt as _, git, gix_testtools::tempfile::TempDir, open_repo};
 
 #[test]
 fn new_from_project_handle_uses_repo_gitdir() -> anyhow::Result<()> {
@@ -47,5 +48,39 @@ fn new_from_project_handle_keeps_repo_cached() -> anyhow::Result<()> {
         "the repository used during construction should be kept in context"
     );
     assert!(ctx.to_sync().repo.is_some());
+    Ok(())
+}
+
+#[test]
+fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
+    let repo_dir = TempDir::new()?;
+    let repo = gix::init(repo_dir.path())?;
+    let key = but_project_handle::storage_path_config_key().to_owned();
+    git(&repo)
+        .args(["config", "--local", key.as_str(), "gitbutler-custom"])
+        .run();
+    let repo = open_repo(repo_dir.path())?;
+
+    let ctx = Context::from_repo(repo)?;
+    assert_eq!(ctx.project_data_dir(), ctx.gitdir.join("gitbutler-custom"));
+
+    let _db = ctx.db.get()?;
+    assert!(
+        ctx.project_data_dir().join("but.sqlite").exists(),
+        "database should be created in configured project-data directory"
+    );
+    Ok(())
+}
+
+#[test]
+fn sync_context_preserves_project_data_dir() -> anyhow::Result<()> {
+    let repo_dir = TempDir::new()?;
+    gix::init(repo_dir.path())?;
+    let repo = open_repo(repo_dir.path())?;
+    let ctx = Context::from_repo(repo)?;
+
+    let sync = ctx.to_sync();
+    let restored = sync.into_thread_local();
+    assert_eq!(ctx.project_data_dir(), restored.project_data_dir());
     Ok(())
 }

--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 authors.workspace = true
 publish = false
 rust-version.workspace = true
+description = "A place for defining metadata stored in a sqlite file"
 
 [lib]
 doctest = false

--- a/crates/but-hunk-dependency/tests/fixtures/scenario/shared.sh
+++ b/crates/but-hunk-dependency/tests/fixtures/scenario/shared.sh
@@ -35,8 +35,8 @@ function setup-remote-and-vbtoml () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler
-  cat <<EOF >>.git/gitbutler/virtual_branches.toml
+  mkdir .git/gitbutler.dev
+  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"

--- a/crates/but-link/Cargo.toml
+++ b/crates/but-link/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 
 [dependencies]
 but-ctx.workspace = true
+but-db.workspace = true
 
 anyhow.workspace = true
 gix.workspace = true

--- a/crates/but-link/Cargo.toml
+++ b/crates/but-link/Cargo.toml
@@ -5,12 +5,16 @@ edition.workspace = true
 authors.workspace = true
 publish = false
 rust-version.workspace = true
+description = "multi-agent coordination via repo-scoped `SQLite`"
 
 [lib]
 doctest = false
 
 [dependencies]
+but-ctx.workspace = true
+
 anyhow.workspace = true
+gix.workspace = true
 clap.workspace = true
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/but-link/src/commands.rs
+++ b/crates/but-link/src/commands.rs
@@ -52,21 +52,19 @@ fn append_command_log(path: &Path, agent_id: &str, cmd: &str) {
 /// Entry point from the top-level `but` binary.
 pub(crate) fn run(platform: crate::cli::Platform, current_dir: &Path) -> anyhow::Result<()> {
     let (agent_id, cmd) = platform.into_runtime()?;
+    let current_dir = gix::path::realpath(current_dir)?;
+    let ctx = but_ctx::Context::discover(&current_dir)?;
 
     if matches!(cmd, Cmd::Tui) {
-        return crate::tui::run(current_dir);
+        return crate::tui::run(&ctx);
     }
 
-    let git_dir = repo::discover_git_dir(current_dir)?;
-    let repo_root = repo::discover_repo_root(current_dir)?;
-    let cwd = current_dir
-        .canonicalize()
-        .unwrap_or_else(|_| current_dir.to_path_buf());
-    let cmd = repo::normalize_command_paths(cmd, &cwd, &repo_root)?;
-    let data_dir = git_dir.join("gitbutler");
+    let data_dir = ctx.project_data_dir();
+    let worktree_dir = ctx.workdir_or_fail()?;
+    let cmd = repo::normalize_command_paths(cmd, &current_dir, &worktree_dir)?;
     std::fs::create_dir_all(&data_dir)?;
 
-    let db_path = data_dir.join("but-link.db");
+    let db_path = crate::db::db_path(&ctx.project_data_dir());
     let log_path = data_dir.join("but-link.commands.log");
 
     let mut conn = Connection::open(db_path)?;

--- a/crates/but-link/src/db/migrations.rs
+++ b/crates/but-link/src/db/migrations.rs
@@ -12,10 +12,7 @@ const MAX_MESSAGES: i64 = 10_000;
 
 /// Initialize and migrate the coordination database.
 pub(crate) fn init_db(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute_batch(
-        "PRAGMA journal_mode = WAL;\
-         PRAGMA busy_timeout = 5000;",
-    )?;
+    but_db::migration::improve_concurrency(conn)?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS claims (\
             path TEXT NOT NULL,\

--- a/crates/but-link/src/db/mod.rs
+++ b/crates/but-link/src/db/mod.rs
@@ -246,7 +246,7 @@ pub(crate) fn coord_stale_threshold_ms() -> i64 {
     seconds.saturating_mul(1000)
 }
 
-/// Produce the path at which our db-file is located, given the `project_deta_dir`.
+/// Produce the path at which our db-file is located, given the `project_data_dir`.
 pub(crate) fn db_path(project_data_dir: &Path) -> PathBuf {
     project_data_dir.join("but-link.db")
 }

--- a/crates/but-link/src/db/mod.rs
+++ b/crates/but-link/src/db/mod.rs
@@ -2,7 +2,10 @@
 //!
 //! All database access shared across command handlers and the TUI lives here.
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::Context;
 use rusqlite::{Connection, Transaction};
@@ -241,4 +244,9 @@ pub(crate) fn coord_stale_threshold_ms() -> i64 {
         .filter(|value| *value >= 0)
         .unwrap_or(default_s);
     seconds.saturating_mul(1000)
+}
+
+/// Produce the path at which our db-file is located, given the `project_deta_dir`.
+pub(crate) fn db_path(project_data_dir: &Path) -> PathBuf {
+    project_data_dir.join("but-link.db")
 }

--- a/crates/but-link/src/repo.rs
+++ b/crates/but-link/src/repo.rs
@@ -1,5 +1,4 @@
 //! Repository discovery and repo-relative path normalization helpers.
-
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 
@@ -175,61 +174,4 @@ pub(crate) fn normalize_command_paths(
         },
         other => other,
     })
-}
-
-/// Discover the shared `.git` directory for the repository or worktree.
-pub(crate) fn discover_git_dir(start: &Path) -> anyhow::Result<PathBuf> {
-    let mut current = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    loop {
-        let dot_git = current.join(".git");
-        if dot_git.is_dir() {
-            return Ok(dot_git);
-        }
-        if dot_git.is_file() {
-            let content = std::fs::read_to_string(&dot_git)?;
-            let gitdir = content
-                .strip_prefix("gitdir:")
-                .map(str::trim)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("unexpected .git file format at {}", dot_git.display())
-                })?;
-            let gitdir_path = if Path::new(gitdir).is_absolute() {
-                PathBuf::from(gitdir)
-            } else {
-                current.join(gitdir)
-            };
-            let resolved = gitdir_path.canonicalize().unwrap_or(gitdir_path);
-            if let Some(parent) = resolved.parent()
-                && parent.file_name().is_some_and(|name| name == "worktrees")
-                && let Some(git_dir) = parent.parent()
-                && git_dir.is_dir()
-            {
-                return Ok(git_dir.to_path_buf());
-            }
-            return Ok(resolved);
-        }
-        if !current.pop() {
-            anyhow::bail!(
-                "not a git repository (or any of the parent directories): {}",
-                start.display()
-            );
-        }
-    }
-}
-
-/// Discover the repository root.
-pub(crate) fn discover_repo_root(start: &Path) -> anyhow::Result<PathBuf> {
-    let mut current = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    loop {
-        let dot_git = current.join(".git");
-        if dot_git.is_dir() || dot_git.is_file() {
-            return Ok(current);
-        }
-        if !current.pop() {
-            anyhow::bail!(
-                "not a git repository (or any of the parent directories): {}",
-                start.display()
-            );
-        }
-    }
 }

--- a/crates/but-link/src/tui/mod.rs
+++ b/crates/but-link/src/tui/mod.rs
@@ -5,20 +5,18 @@ mod render;
 mod terminal;
 
 use std::io::{self, IsTerminal as _};
-use std::path::Path;
 
 /// Run the read-only `but link` terminal UI.
 ///
 /// # Errors
 ///
 /// Returns an error when a TTY is unavailable or the link database cannot be opened.
-pub(crate) fn run(current_dir: &Path) -> anyhow::Result<()> {
+pub(crate) fn run(ctx: &but_ctx::Context) -> anyhow::Result<()> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         anyhow::bail!("but link tui requires an interactive terminal (TTY)");
     }
 
-    let git_dir = crate::repo::discover_git_dir(current_dir)?;
-    let db_path = git_dir.join("gitbutler").join("but-link.db");
+    let db_path = crate::db::db_path(&ctx.project_data_dir());
     if !db_path.is_file() {
         anyhow::bail!(
             "no link database found at {} (run a `but link` command first)",

--- a/crates/but-project-handle/Cargo.toml
+++ b/crates/but-project-handle/Cargo.toml
@@ -11,17 +11,20 @@ rust-version.workspace = true
 doctest = false
 
 [features]
-legacy = ["dep:but-core"]
+legacy = []
 
 [dependencies]
-but-core = { workspace = true, optional = true }
+but-path.workspace = true
 
 anyhow.workspace = true
 gix.workspace = true
 serde.workspace = true
+uuid.workspace = true
 base64 = "0.22.1"
+tracing.workspace = true
 
 [dev-dependencies]
+but-testsupport.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/crates/but-project-handle/src/legacy_project_id.rs
+++ b/crates/but-project-handle/src/legacy_project_id.rs
@@ -1,0 +1,66 @@
+use std::{fmt, str};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
+
+/// A UUID-based legacy project identifier carried for compatibility while project storage
+/// still lives in `gitbutler-project`.
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LegacyProjectId(Uuid);
+
+impl LegacyProjectId {
+    /// Create a stable ID for tests.
+    pub fn from_number_for_testing(stable_id: u128) -> Self {
+        Self(Uuid::from_u128(stable_id))
+    }
+}
+
+impl From<Uuid> for LegacyProjectId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<LegacyProjectId> for Uuid {
+    fn from(value: LegacyProjectId) -> Self {
+        value.0
+    }
+}
+
+impl<'de> Deserialize<'de> for LegacyProjectId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Uuid::deserialize(deserializer).map(Into::into)
+    }
+}
+
+impl Serialize for LegacyProjectId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl fmt::Display for LegacyProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for LegacyProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl str::FromStr for LegacyProjectId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Into::into)
+    }
+}

--- a/crates/but-project-handle/src/lib.rs
+++ b/crates/but-project-handle/src/lib.rs
@@ -7,11 +7,15 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "legacy")]
+mod legacy_project_id;
 mod project_handle;
+mod storage_path;
 
 /// A UUID based legacy project identifier carried for compatibility while project storage
 /// still lives in `gitbutler-project`.
 #[cfg(feature = "legacy")]
-pub type LegacyProjectId = but_core::Id<'P'>;
+pub use legacy_project_id::LegacyProjectId;
 
 pub use project_handle::{ProjectHandle, ProjectHandleOrLegacyProjectId};
+pub use storage_path::{gitbutler_storage_path, storage_path_config_key};

--- a/crates/but-project-handle/src/project_handle.rs
+++ b/crates/but-project-handle/src/project_handle.rs
@@ -195,57 +195,8 @@ impl std::fmt::Display for ProjectHandleOrLegacyProjectId {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
-
     use super::path_to_string;
-    use crate::ProjectHandle;
-
-    #[test]
-    fn round_trip() -> anyhow::Result<()> {
-        let input = Path::new("/tmp/read me?/a+b/#test");
-        let handle = ProjectHandle::from_path(input)?;
-        let decoded = PathBuf::try_from(&handle)?;
-        assert_eq!(decoded, gix::path::realpath(input)?);
-        assert!(
-            handle
-                .as_raw_str()
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn from_path_and_decode_round_trip() -> anyhow::Result<()> {
-        let input = Path::new("/tmp/read me?/a+b/#test");
-        let handle = ProjectHandle::from_path(input)?;
-        let decoded = handle.to_path()?;
-        assert_eq!(decoded, gix::path::realpath(input)?);
-        Ok(())
-    }
-
-    #[test]
-    fn from_str_round_trip() -> anyhow::Result<()> {
-        let handle: ProjectHandle = "L3RtcC9yZWFkIG1l".parse()?;
-        assert_eq!(handle.to_path()?, PathBuf::from("/tmp/read me"));
-        Ok(())
-    }
-
-    #[test]
-    fn from_str_rejects_relative_payloads() {
-        assert!("cmVsYXRpdmUvcGF0aA".parse::<ProjectHandle>().is_err());
-    }
-
-    #[test]
-    fn convenience_path_methods_round_trip() -> anyhow::Result<()> {
-        let input = Path::new("/tmp/read me?/a+b/#test");
-        let handle = ProjectHandle::from_path(input)?;
-        let canonical = gix::path::realpath(input)?;
-
-        assert_eq!(handle.to_path()?, canonical);
-        assert_eq!(handle.clone().into_path()?, canonical);
-        Ok(())
-    }
+    use std::path::Path;
 
     #[test]
     fn canonical_paths() -> anyhow::Result<()> {
@@ -284,33 +235,6 @@ mod tests {
             assert_eq!(encoded, case.expected, "{}: readable mismatch", case.os);
         }
 
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn minimal_illformed_utf8_round_trip() -> anyhow::Result<()> {
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt as _;
-        let input: PathBuf = OsString::from_vec(b"/tmp/\xFF".into()).into();
-        let handle = ProjectHandle::from_path(&input)?;
-
-        let canonical = gix::path::realpath(&input)?;
-        assert_eq!(handle.to_path()?, canonical);
-        Ok(())
-    }
-
-    #[test]
-    fn display_and_debug_print() -> anyhow::Result<()> {
-        let input = Path::new("/tmp/read me?/a+b/#test");
-        let handle = ProjectHandle::from_path(input)?;
-        let display = handle.to_string();
-
-        assert_eq!(display, handle.as_raw_str());
-        assert_eq!(
-            format!("{handle:?}"),
-            format!("ProjectHandle(\"{display}\")")
-        );
         Ok(())
     }
 
@@ -387,63 +311,6 @@ mod tests {
             assert!(encoded_str_to_path("not+base64").is_err());
             assert!(encoded_str_to_path("a/b").is_err());
             assert!(encoded_str_to_path("a=").is_err());
-        }
-    }
-
-    mod project_handle_or_legacy_project_id {
-        use crate::ProjectHandleOrLegacyProjectId;
-
-        #[test]
-        fn project_handle_or_legacy_project_id_deserializes_project_handle() -> anyhow::Result<()> {
-            let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(r#""L3RtcA""#)?;
-            match value {
-                ProjectHandleOrLegacyProjectId::ProjectHandle(handle) => {
-                    assert_eq!(handle.to_string(), "L3RtcA");
-                }
-                #[cfg_attr(not(feature = "legacy"), allow(unreachable_patterns))]
-                other => unreachable!("expected project handle variant, got {other:?}"),
-            }
-            Ok(())
-        }
-
-        #[test]
-        fn project_handle_or_legacy_project_id_round_trips_project_handle() -> anyhow::Result<()> {
-            let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(r#""L3RtcA""#)?;
-            let serialized = serde_json::to_string(&value)?;
-            assert_eq!(serialized, r#""L3RtcA""#);
-            let decoded: ProjectHandleOrLegacyProjectId = serde_json::from_str(&serialized)?;
-            assert_eq!(decoded, value);
-            Ok(())
-        }
-
-        #[test]
-        #[cfg(feature = "legacy")]
-        fn project_handle_or_legacy_project_id_deserializes_legacy_project_id() -> anyhow::Result<()>
-        {
-            let expected = "00000000-0000-0000-0000-000000000000";
-            let value: ProjectHandleOrLegacyProjectId =
-                serde_json::from_str(&format!(r#""{expected}""#))?;
-            match value {
-                ProjectHandleOrLegacyProjectId::LegacyProjectId(project_id) => {
-                    assert_eq!(project_id.to_string(), expected);
-                }
-                other => panic!("expected legacy project id variant, got {other:?}"),
-            }
-            Ok(())
-        }
-
-        #[test]
-        #[cfg(feature = "legacy")]
-        fn project_handle_or_legacy_project_id_round_trips_legacy_project_id() -> anyhow::Result<()>
-        {
-            let expected = "00000000-0000-0000-0000-000000000000";
-            let expected_json = format!(r#""{expected}""#);
-            let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(&expected_json)?;
-            let serialized = serde_json::to_string(&value)?;
-            assert_eq!(serialized, expected_json);
-            let decoded: ProjectHandleOrLegacyProjectId = serde_json::from_str(&serialized)?;
-            assert_eq!(decoded, value);
-            Ok(())
         }
     }
 }

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -1,0 +1,69 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use but_path::AppChannel;
+
+use crate::ProjectHandle;
+
+/// Return the config key used to customize the GitButler storage path for the current app channel.
+pub fn storage_path_config_key() -> &'static str {
+    storage_path_config_key_for_channel(&AppChannel::new())
+}
+
+/// Return the path where per-project GitButler data should be stored for `repo`.
+pub fn gitbutler_storage_path(repo: &gix::Repository) -> anyhow::Result<PathBuf> {
+    let git_dir = repo.git_dir();
+    let channel = AppChannel::new();
+    let storage_key = storage_path_config_key_for_channel(&channel);
+
+    match repo.config_snapshot().trusted_path(storage_key) {
+        Some(Ok(path)) => resolve_configured_storage_path(git_dir, path.as_ref()),
+        Some(Err(err)) => {
+            Err(err).with_context(|| format!("{storage_key} contains an invalid path"))
+        }
+        None => Ok(git_dir.join(default_gitbutler_storage_dir_name(&channel))),
+    }
+}
+
+fn resolve_configured_storage_path(
+    git_dir: &Path,
+    configured_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    if !configured_path.is_absolute() {
+        return Ok(git_dir.join(configured_path));
+    }
+
+    let storage_path = configured_path.to_owned();
+    if storage_path.starts_with(git_dir) {
+        return Ok(storage_path);
+    }
+    let gitdir_real = gix::path::realpath(git_dir)?;
+    if storage_path.starts_with(&gitdir_real) {
+        return Ok(storage_path);
+    }
+
+    let project_handle = ProjectHandle::from_path(git_dir)?;
+    let storage_path = storage_path.join(project_handle.to_string());
+    tracing::trace!(
+        storage_path = %storage_path.display(),
+        config_key = %storage_path_config_key(),
+        "Resolved GitButler storage path; set this config key to override"
+    );
+    Ok(storage_path)
+}
+
+fn default_gitbutler_storage_dir_name(channel: &AppChannel) -> &'static str {
+    match channel {
+        AppChannel::Release => "gitbutler",
+        AppChannel::Nightly => "gitbutler.nightly",
+        AppChannel::Dev => "gitbutler.dev",
+    }
+}
+
+fn storage_path_config_key_for_channel(channel: &AppChannel) -> &'static str {
+    match channel {
+        AppChannel::Release => "gitbutler.storagePath",
+        AppChannel::Nightly => "gitbutler.nightly.storagePath",
+        AppChannel::Dev => "gitbutler.dev.storagePath",
+    }
+}

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -1,9 +1,9 @@
 use std::{
     borrow::Cow,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
-use anyhow::Context as _;
+use anyhow::{Context as _, bail};
 use but_path::AppChannel;
 
 use crate::ProjectHandle;
@@ -38,7 +38,8 @@ fn resolve_configured_storage_path(
     if storage_path.is_relative() {
         storage_path = git_dir.join(storage_path);
     }
-    if storage_path_is_inside_git_dir(git_dir, &storage_path)? {
+    if let Some(relative_to_git_dir) = storage_path_relative_to_git_dir(git_dir, &storage_path)? {
+        validate_in_git_storage_path(&relative_to_git_dir, &storage_path)?;
         return Ok(storage_path);
     }
 
@@ -52,13 +53,49 @@ fn resolve_configured_storage_path(
     Ok(storage_path)
 }
 
-fn storage_path_is_inside_git_dir(git_dir: &Path, storage_path: &Path) -> anyhow::Result<bool> {
-    if storage_path.starts_with(git_dir) {
-        return Ok(true);
+/// Return the `storage_path` as relative to `git_dir` if it is contained inside of it.
+fn storage_path_relative_to_git_dir(
+    git_dir: &Path,
+    storage_path: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if let Ok(relative) = storage_path.strip_prefix(git_dir) {
+        return Ok(Some(relative.to_owned()));
     }
 
     let gitdir_real = gix::path::realpath(git_dir)?;
-    Ok(storage_path.starts_with(&gitdir_real))
+    Ok(storage_path
+        .strip_prefix(&gitdir_real)
+        .ok()
+        .map(Path::to_owned))
+}
+
+/// Only accept `storage_path_relative_to_git_dir` if it's a top-level `gitbutler` directory.
+/// Use `storage_path` to format error messages.
+fn validate_in_git_storage_path(
+    storage_path_relative_to_git_dir: &Path,
+    storage_path: &Path,
+) -> anyhow::Result<()> {
+    let Some(Component::Normal(top_level_dir)) =
+        storage_path_relative_to_git_dir.components().next()
+    else {
+        bail!(
+            "configured storage path '{}' resolves to '.git' itself; choose a dedicated GitButler directory instead",
+            storage_path.display()
+        );
+    };
+
+    if !top_level_dir
+        .to_string_lossy()
+        .get(.."gitbutler".len())
+        .is_some_and(|name| name.eq_ignore_ascii_case("gitbutler"))
+    {
+        bail!(
+            "configured storage path '{}' resolves inside '.git' but not under a top-level 'gitbutler*' directory",
+            storage_path.display()
+        );
+    }
+
+    Ok(())
 }
 
 fn default_gitbutler_storage_dir_name(channel: &AppChannel) -> &'static str {

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context as _;
 use but_path::AppChannel;
@@ -29,16 +32,13 @@ fn resolve_configured_storage_path(
     git_dir: &Path,
     configured_path: &Path,
 ) -> anyhow::Result<PathBuf> {
-    if !configured_path.is_absolute() {
-        return Ok(git_dir.join(configured_path));
+    let mut storage_path = gix::path::normalize(configured_path.into(), git_dir)
+        .unwrap_or(Cow::Borrowed(configured_path))
+        .into_owned();
+    if storage_path.is_relative() {
+        storage_path = git_dir.join(storage_path);
     }
-
-    let storage_path = configured_path.to_owned();
-    if storage_path.starts_with(git_dir) {
-        return Ok(storage_path);
-    }
-    let gitdir_real = gix::path::realpath(git_dir)?;
-    if storage_path.starts_with(&gitdir_real) {
+    if storage_path_is_inside_git_dir(git_dir, &storage_path)? {
         return Ok(storage_path);
     }
 
@@ -50,6 +50,15 @@ fn resolve_configured_storage_path(
         "Resolved GitButler storage path; set this config key to override"
     );
     Ok(storage_path)
+}
+
+fn storage_path_is_inside_git_dir(git_dir: &Path, storage_path: &Path) -> anyhow::Result<bool> {
+    if storage_path.starts_with(git_dir) {
+        return Ok(true);
+    }
+
+    let gitdir_real = gix::path::realpath(git_dir)?;
+    Ok(storage_path.starts_with(&gitdir_real))
 }
 
 fn default_gitbutler_storage_dir_name(channel: &AppChannel) -> &'static str {

--- a/crates/but-project-handle/tests/project-handle/main.rs
+++ b/crates/but-project-handle/tests/project-handle/main.rs
@@ -1,0 +1,2 @@
+mod project_handle;
+mod storage_path;

--- a/crates/but-project-handle/tests/project-handle/project_handle.rs
+++ b/crates/but-project-handle/tests/project-handle/project_handle.rs
@@ -1,0 +1,128 @@
+use std::path::{Path, PathBuf};
+
+use but_project_handle::{ProjectHandle, ProjectHandleOrLegacyProjectId};
+
+#[test]
+fn round_trip() -> anyhow::Result<()> {
+    let input = Path::new("/tmp/read me?/a+b/#test");
+    let handle = ProjectHandle::from_path(input)?;
+    let decoded = PathBuf::try_from(&handle)?;
+    assert_eq!(decoded, gix::path::realpath(input)?);
+    assert!(
+        handle
+            .to_string()
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    );
+    Ok(())
+}
+
+#[test]
+fn from_path_and_decode_round_trip() -> anyhow::Result<()> {
+    let input = Path::new("/tmp/read me?/a+b/#test");
+    let handle = ProjectHandle::from_path(input)?;
+    let decoded = handle.to_path()?;
+    assert_eq!(decoded, gix::path::realpath(input)?);
+    Ok(())
+}
+
+#[test]
+fn from_str_round_trip() -> anyhow::Result<()> {
+    let handle: ProjectHandle = "L3RtcC9yZWFkIG1l".parse()?;
+    assert_eq!(handle.to_path()?, PathBuf::from("/tmp/read me"));
+    Ok(())
+}
+
+#[test]
+fn from_str_rejects_relative_payloads() {
+    assert!("cmVsYXRpdmUvcGF0aA".parse::<ProjectHandle>().is_err());
+}
+
+#[test]
+fn convenience_path_methods_round_trip() -> anyhow::Result<()> {
+    let input = Path::new("/tmp/read me?/a+b/#test");
+    let handle = ProjectHandle::from_path(input)?;
+    let canonical = gix::path::realpath(input)?;
+
+    assert_eq!(handle.to_path()?, canonical);
+    assert_eq!(handle.clone().into_path()?, canonical);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn minimal_illformed_utf8_round_trip() -> anyhow::Result<()> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let input: PathBuf = OsString::from_vec(b"/tmp/\xFF".into()).into();
+    let handle = ProjectHandle::from_path(&input)?;
+
+    let canonical = gix::path::realpath(&input)?;
+    assert_eq!(handle.to_path()?, canonical);
+    Ok(())
+}
+
+#[test]
+fn display_and_debug_print() -> anyhow::Result<()> {
+    let input = Path::new("/tmp/read me?/a+b/#test");
+    let handle = ProjectHandle::from_path(input)?;
+    let display = handle.to_string();
+
+    assert_eq!(format!("{handle}"), display);
+    assert_eq!(
+        format!("{handle:?}"),
+        format!("ProjectHandle(\"{display}\")")
+    );
+    Ok(())
+}
+
+#[test]
+fn project_handle_or_legacy_project_id_deserializes_project_handle() -> anyhow::Result<()> {
+    let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(r#""L3RtcA""#)?;
+    match value {
+        ProjectHandleOrLegacyProjectId::ProjectHandle(handle) => {
+            assert_eq!(handle.to_string(), "L3RtcA");
+        }
+        #[cfg_attr(not(feature = "legacy"), allow(unreachable_patterns))]
+        other => unreachable!("expected project handle variant, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn project_handle_or_legacy_project_id_round_trips_project_handle() -> anyhow::Result<()> {
+    let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(r#""L3RtcA""#)?;
+    let serialized = serde_json::to_string(&value)?;
+    assert_eq!(serialized, r#""L3RtcA""#);
+    let decoded: ProjectHandleOrLegacyProjectId = serde_json::from_str(&serialized)?;
+    assert_eq!(decoded, value);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "legacy")]
+fn project_handle_or_legacy_project_id_deserializes_legacy_project_id() -> anyhow::Result<()> {
+    let expected = "00000000-0000-0000-0000-000000000000";
+    let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(&format!(r#""{expected}""#))?;
+    match value {
+        ProjectHandleOrLegacyProjectId::LegacyProjectId(project_id) => {
+            assert_eq!(project_id.to_string(), expected);
+        }
+        other => panic!("expected legacy project id variant, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "legacy")]
+fn project_handle_or_legacy_project_id_round_trips_legacy_project_id() -> anyhow::Result<()> {
+    let expected = "00000000-0000-0000-0000-000000000000";
+    let expected_json = format!(r#""{expected}""#);
+    let value: ProjectHandleOrLegacyProjectId = serde_json::from_str(&expected_json)?;
+    let serialized = serde_json::to_string(&value)?;
+    assert_eq!(serialized, expected_json);
+    let decoded: ProjectHandleOrLegacyProjectId = serde_json::from_str(&serialized)?;
+    assert_eq!(decoded, value);
+    Ok(())
+}

--- a/crates/but-project-handle/tests/project-handle/storage_path.rs
+++ b/crates/but-project-handle/tests/project-handle/storage_path.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+use but_path::AppChannel;
+use but_project_handle::{ProjectHandle, gitbutler_storage_path, storage_path_config_key};
+use but_testsupport::{CommandExt as _, git, gix_testtools, open_repo};
+use gix_testtools::tempfile::TempDir;
+
+fn init_repo() -> anyhow::Result<(TempDir, gix::Repository)> {
+    let tmp = TempDir::new()?;
+    gix::init(tmp.path())?;
+    let repo = open_repo(tmp.path())?;
+    Ok((tmp, repo))
+}
+
+fn set_git_config(
+    repo: &gix::Repository,
+    key: &str,
+    value: impl AsRef<std::ffi::OsStr>,
+) -> anyhow::Result<gix::Repository> {
+    git(repo).args(["config", "--local", key]).arg(value).run();
+    // Have to reopen the repository for it to refresh its loaded Git configuration.
+    open_repo(repo.path())
+}
+
+fn default_storage_dir_name() -> &'static str {
+    match AppChannel::new() {
+        AppChannel::Release => "gitbutler",
+        AppChannel::Nightly => "gitbutler.nightly",
+        AppChannel::Dev => "gitbutler.dev",
+    }
+}
+
+#[test]
+fn storage_path_from_relative_config() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+
+    let repo = set_git_config(&repo, key, "gitbutler-custom")?;
+
+    assert_eq!(
+        gitbutler_storage_path(&repo)?,
+        repo.git_dir().join("gitbutler-custom")
+    );
+    Ok(())
+}
+
+#[test]
+fn storage_path_from_absolute_config_inside_git_dir() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let custom_path = repo.git_dir().join("gitbutler-custom");
+
+    let repo = set_git_config(&repo, key, &custom_path)?;
+
+    assert_eq!(gitbutler_storage_path(&repo)?, custom_path);
+    Ok(())
+}
+
+#[test]
+fn storage_path_from_absolute_config_outside_git_dir_is_project_unique() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let configured_base = if cfg!(windows) {
+        PathBuf::from(r"C:\gitbutler-storage")
+    } else {
+        PathBuf::from("/tmp/gitbutler-storage")
+    };
+
+    let repo = set_git_config(&repo, key, &configured_base)?;
+    let expected = configured_base.join(ProjectHandle::from_path(repo.git_dir())?.to_string());
+
+    assert_eq!(gitbutler_storage_path(&repo)?, expected);
+    Ok(())
+}
+
+#[test]
+fn storage_path_default_stays_in_git_dir() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let expected = repo.git_dir().join(default_storage_dir_name());
+
+    assert_eq!(gitbutler_storage_path(&repo)?, expected);
+    Ok(())
+}
+
+#[test]
+fn docs_examples_are_viable_paths() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let examples = [
+        Path::new("gitbutler-alt").to_path_buf(),
+        Path::new("custom/gitbutler").to_path_buf(),
+        if cfg!(windows) {
+            PathBuf::from(r"C:\gitbutler-projects")
+        } else {
+            PathBuf::from("/tmp/gitbutler-projects")
+        },
+    ];
+
+    for example in examples {
+        let repo = set_git_config(&repo, key, &example)?;
+        let resolved = gitbutler_storage_path(&repo)?;
+        assert!(resolved.is_absolute());
+    }
+    Ok(())
+}

--- a/crates/but-project-handle/tests/project-handle/storage_path.rs
+++ b/crates/but-project-handle/tests/project-handle/storage_path.rs
@@ -45,6 +45,25 @@ fn storage_path_from_relative_config() -> anyhow::Result<()> {
 }
 
 #[test]
+fn storage_path_from_relative_config_outside_git_dir_is_project_unique() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+
+    let repo = set_git_config(&repo, key, "../../gitbutler-shared")?;
+    let configured_base = repo
+        .git_dir()
+        .parent()
+        .expect("git dir has repo parent")
+        .parent()
+        .expect("repo parent has tempdir parent")
+        .join("gitbutler-shared");
+    let expected = configured_base.join(ProjectHandle::from_path(repo.git_dir())?.to_string());
+
+    assert_eq!(gitbutler_storage_path(&repo)?, expected);
+    Ok(())
+}
+
+#[test]
 fn storage_path_from_absolute_config_inside_git_dir() -> anyhow::Result<()> {
     let (_tmp, repo) = init_repo()?;
     let key = storage_path_config_key();
@@ -89,6 +108,7 @@ fn docs_examples_are_viable_paths() -> anyhow::Result<()> {
     let examples = [
         Path::new("gitbutler-alt").to_path_buf(),
         Path::new("custom/gitbutler").to_path_buf(),
+        Path::new("../gitbutler-projects").to_path_buf(),
         if cfg!(windows) {
             PathBuf::from(r"C:\gitbutler-projects")
         } else {

--- a/crates/but-project-handle/tests/project-handle/storage_path.rs
+++ b/crates/but-project-handle/tests/project-handle/storage_path.rs
@@ -107,7 +107,8 @@ fn docs_examples_are_viable_paths() -> anyhow::Result<()> {
     let key = storage_path_config_key();
     let examples = [
         Path::new("gitbutler-alt").to_path_buf(),
-        Path::new("custom/gitbutler").to_path_buf(),
+        Path::new("gitbutler-alt/nested").to_path_buf(),
+        Path::new("GitButler").to_path_buf(),
         Path::new("../gitbutler-projects").to_path_buf(),
         if cfg!(windows) {
             PathBuf::from(r"C:\gitbutler-projects")
@@ -121,5 +122,39 @@ fn docs_examples_are_viable_paths() -> anyhow::Result<()> {
         let resolved = gitbutler_storage_path(&repo)?;
         assert!(resolved.is_absolute());
     }
+    Ok(())
+}
+
+#[test]
+fn storage_path_from_relative_config_cannot_be_git_dir_root() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let repo = set_git_config(&repo, key, ".")?;
+
+    let err = gitbutler_storage_path(&repo).expect_err("'.' inside .git must be rejected");
+    assert!(err.to_string().contains("resolves to '.git' itself"));
+    Ok(())
+}
+
+#[test]
+fn storage_path_from_relative_config_cannot_target_git_internals() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let repo = set_git_config(&repo, key, "objects")?;
+
+    let err = gitbutler_storage_path(&repo).expect_err("'objects' inside .git must be rejected");
+    assert!(err.to_string().contains("top-level 'gitbutler*' directory"));
+    Ok(())
+}
+
+#[test]
+fn storage_path_from_relative_config_must_use_gitbutler_top_level_dir() -> anyhow::Result<()> {
+    let (_tmp, repo) = init_repo()?;
+    let key = storage_path_config_key();
+    let repo = set_git_config(&repo, key, "custom/gitbutler")?;
+
+    let err =
+        gitbutler_storage_path(&repo).expect_err("'custom/gitbutler' inside .git must be rejected");
+    assert!(err.to_string().contains("top-level 'gitbutler*' directory"));
     Ok(())
 }

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -160,6 +160,7 @@ pub async fn set_project_active(
 
     let mut active_projects = extra.active_projects.lock().await;
     let mut ctx: Context = params.id.try_into()?;
+    but_api::legacy::projects::prepare_project_for_activation(&mut ctx)?;
     active_projects.set_active(&mut ctx, claude, app_settings_sync)?;
 
     // let is_exclusive = !active_projects.projects.contains(&params.id);

--- a/crates/but-testing/src/command/project.rs
+++ b/crates/but-testing/src/command/project.rs
@@ -16,7 +16,7 @@ pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> 
     let outcome = gitbutler_project::add_at_app_data_dir(data_dir, path)?;
     let project = outcome.try_project()?;
 
-    let mut ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+    let mut ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default())?;
     if let Some(refname) = refname {
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(&ctx, &refname, guard.write_permission())?;

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -1,7 +1,7 @@
 use std::{io::Write, ops::DerefMut, path::Path};
 
 use but_core::{
-    RefMetadata,
+    RefMetadata, RepositoryExt,
     ref_metadata::{StackId, WorkspaceCommitRelation},
 };
 use but_meta::VirtualBranchesTomlMetadata;
@@ -143,7 +143,7 @@ impl Sandbox {
             && let Ok(commit_id) = repo.rev_parse_single("origin/main")
         {
             sandbox.file(
-                ".git/gitbutler/virtual_branches.toml",
+                repo.gitbutler_storage_path()?.join("virtual_branches.toml"),
                 r#"
 [default_target]
 branchName = "main"
@@ -240,8 +240,9 @@ impl Sandbox {
     /// Create a metadata instance on the project.
     pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata> {
         VirtualBranchesTomlMetadata::from_path(
-            self.projects_root()
-                .join(".git/gitbutler/virtual_branches.toml"),
+            self.open_repo()?
+                .gitbutler_storage_path()?
+                .join("virtual_branches.toml"),
         )
     }
 

--- a/crates/but-worktrees/tests/fixtures/scenario/shared.sh
+++ b/crates/but-worktrees/tests/fixtures/scenario/shared.sh
@@ -41,8 +41,8 @@ function init-repo-with-files-and-remote () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler
-  cat <<EOF >>.git/gitbutler/virtual_branches.toml
+  mkdir .git/gitbutler.dev
+  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"

--- a/crates/but/src/command/legacy/mcp/mod.rs
+++ b/crates/but/src/command/legacy/mcp/mod.rs
@@ -127,7 +127,8 @@ impl Mcp {
         let project = Project::from_path(&repo_path).expect("Failed to create project from path");
         let settings = AppSettings::load_from_default_path_creating_without_customization()
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
-        let mut ctx = Context::new_from_legacy_project_and_settings(&project, settings);
+        let mut ctx = Context::new_from_legacy_project_and_settings(&project, settings)
+            .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
         let (id, outcome) = but_action::handle_changes(
             &mut ctx,

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -17,6 +17,7 @@ but-settings.workspace = true
 but-gerrit.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-rebase.workspace = true
+but-project-handle.workspace = true
 but-core = { workspace = true, features = ["legacy"] }
 but-graph.workspace = true
 but-oxidize.workspace = true

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -93,7 +93,18 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
     };
     let remote_name = remote_name.to_string();
 
-    let target = inferred_default_target(&repo, &remote_name)?;
+    let target = match inferred_default_target(&repo, &remote_name) {
+        Ok(Some(target)) => target,
+        Ok(None) => return Ok(false),
+        Err(err) => {
+            tracing::debug!(
+                error = ?err,
+                remote_name,
+                "failed to infer default target; leaving default target uninitialized"
+            );
+            return Ok(false);
+        }
+    };
     vb_state.set_default_target(target)?;
     set_exclude_decoration(ctx)?;
     Ok(true)
@@ -431,7 +442,7 @@ fn default_target(base_path: &Path) -> Result<Target> {
 /// 1. `refs/remotes/<remote>/HEAD`
 /// 2. `refs/remotes/<remote>/main`
 /// 3. `refs/remotes/<remote>/master`
-fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<Target> {
+fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<Option<Target>> {
     let remote_url = repo
         .find_remote(remote_name)
         .ok()
@@ -444,11 +455,12 @@ fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<
         .unwrap_or_default();
 
     let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
-    if let Ok(mut head_ref) = repo.find_reference(remote_head_ref.as_str()) {
-        let branch_name = head_ref.target().try_name().map_or_else(
-            || head_ref.name().as_bstr().to_string(),
-            |name| name.as_bstr().to_string(),
-        );
+    if let Ok(mut head_ref) = repo.find_reference(remote_head_ref.as_str())
+        && let Some(branch_name) = head_ref
+            .target()
+            .try_name()
+            .map(|name| name.as_bstr().to_string())
+    {
         let branch = branch_name
             .parse()
             .with_context(|| format!("Remote HEAD resolved to invalid ref '{branch_name}'"))?;
@@ -457,12 +469,12 @@ fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<
             .context("Remote HEAD did not point to a commit")?
             .id
             .to_git2();
-        return Ok(Target {
+        return Ok(Some(Target {
             branch,
             remote_url,
             sha,
             push_remote_name: Some(remote_name.to_owned()),
-        });
+        }));
     }
 
     for branch_name in ["main", "master"] {
@@ -475,18 +487,16 @@ fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<
                 })?
                 .id
                 .to_git2();
-            return Ok(Target {
+            return Ok(Some(Target {
                 branch: full_name.parse()?,
                 remote_url,
                 sha,
                 push_remote_name: Some(remote_name.to_owned()),
-            });
+            }));
         }
     }
 
-    Err(anyhow!(
-        "Could not infer a default target branch from remote '{remote_name}'"
-    ))
+    Ok(None)
 }
 
 pub(crate) fn push(ctx: &Context, with_force: bool) -> Result<()> {

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -63,6 +63,42 @@ pub fn get_base_branch_data(ctx: &Context) -> Result<BaseBranch> {
     Ok(base)
 }
 
+/// Restore the default target metadata if it is missing in the currently configured storage
+/// location while an existing `gitbutler/workspace` ref already proves the repository was
+/// initialized before.
+///
+/// This is intentionally metadata-only recovery for activation flows. Unlike
+/// `set_base_branch()`, it must not create stacks, update the workspace commit, or move the
+/// `gitbutler/workspace` reference.
+///
+/// Returns `true` if a target was inferred and written, `false` if no recovery was needed or
+/// there wasn't enough repository state to infer a safe target.
+#[instrument(skip(ctx), err(Debug))]
+pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    if vb_state.maybe_get_default_target()?.is_some() {
+        return Ok(false);
+    }
+
+    let repo = ctx.repo.get()?;
+    if repo
+        .try_find_reference(GITBUTLER_WORKSPACE_REFERENCE.to_string().as_str())?
+        .is_none()
+    {
+        return Ok(false);
+    }
+
+    let Some(remote_name) = repo.remote_default_name(gix::remote::Direction::Push) else {
+        return Ok(false);
+    };
+    let remote_name = remote_name.to_string();
+
+    let target = inferred_default_target(&repo, &remote_name)?;
+    vb_state.set_default_target(target)?;
+    set_exclude_decoration(ctx)?;
+    Ok(true)
+}
+
 #[instrument(skip(ctx), err(Debug))]
 fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<BaseBranch> {
     let repo = ctx.repo.get()?;
@@ -387,6 +423,70 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
 
 fn default_target(base_path: &Path) -> Result<Target> {
     VirtualBranchesHandle::new(base_path).get_default_target()
+}
+
+/// Infer the default target from the Git repository without mutating workspace refs.
+///
+/// Preference order:
+/// 1. `refs/remotes/<remote>/HEAD`
+/// 2. `refs/remotes/<remote>/main`
+/// 3. `refs/remotes/<remote>/master`
+fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<Target> {
+    let remote_url = repo
+        .find_remote(remote_name)
+        .ok()
+        .and_then(|remote| {
+            remote
+                .url(gix::remote::Direction::Fetch)
+                .map(ToOwned::to_owned)
+        })
+        .map(|url| url.to_bstring().to_string())
+        .unwrap_or_default();
+
+    let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
+    if let Ok(mut head_ref) = repo.find_reference(remote_head_ref.as_str()) {
+        let branch_name = head_ref.target().try_name().map_or_else(
+            || head_ref.name().as_bstr().to_string(),
+            |name| name.as_bstr().to_string(),
+        );
+        let branch = branch_name
+            .parse()
+            .with_context(|| format!("Remote HEAD resolved to invalid ref '{branch_name}'"))?;
+        let sha = head_ref
+            .peel_to_commit()
+            .context("Remote HEAD did not point to a commit")?
+            .id
+            .to_git2();
+        return Ok(Target {
+            branch,
+            remote_url,
+            sha,
+            push_remote_name: Some(remote_name.to_owned()),
+        });
+    }
+
+    for branch_name in ["main", "master"] {
+        let full_name = format!("refs/remotes/{remote_name}/{branch_name}");
+        if let Ok(mut reference) = repo.find_reference(&full_name) {
+            let sha = reference
+                .peel_to_commit()
+                .with_context(|| {
+                    format!("Fallback target '{full_name}' did not point to a commit")
+                })?
+                .id
+                .to_git2();
+            return Ok(Target {
+                branch: full_name.parse()?,
+                remote_url,
+                sha,
+                push_remote_name: Some(remote_name.to_owned()),
+            });
+        }
+    }
+
+    Err(anyhow!(
+        "Could not infer a default target branch from remote '{remote_name}'"
+    ))
 }
 
 pub(crate) fn push(ctx: &Context, with_force: bool) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -215,3 +215,70 @@ fn submodule() {
     let stacks = stack_details(ctx);
     assert_eq!(stacks.len(), 1);
 }
+
+#[test]
+fn bootstrap_missing_target_preserves_existing_workspace_ref() -> anyhow::Result<()> {
+    let test = &mut Test::default();
+    let Test {
+        repo,
+        project_id,
+        ctx,
+        ..
+    } = test;
+
+    repo.checkout(&"refs/heads/some-feature".parse().unwrap());
+    fs::write(repo.path().join("file.txt"), "content")?;
+    repo.commit_all("commit on feature");
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )?;
+    drop(guard);
+
+    let original_workspace_ref_target = ctx
+        .git2_repo
+        .get()?
+        .find_reference("refs/heads/gitbutler/workspace")?
+        .target()
+        .expect("workspace ref should point to a commit");
+    let expected_stack_name = stack_details(ctx)[0].1.derived_name.clone();
+
+    ctx.git2_repo.get()?.config()?.set_str(
+        &but_project_handle::storage_path_config_key(),
+        "gitbutler-alt",
+    )?;
+
+    let mut reopened: Context = project_id.clone().try_into()?;
+    assert!(
+        gitbutler_stack::VirtualBranchesHandle::new(reopened.project_data_dir())
+            .maybe_get_default_target()?
+            .is_none()
+    );
+
+    let mut guard = reopened.exclusive_worktree_access();
+    assert!(gitbutler_branch_actions::base::bootstrap_default_target_if_missing(&reopened)?);
+    let meta = reopened.legacy_meta_mut(guard.write_permission())?;
+    let repo = reopened.repo.get()?;
+    meta.write_reconciled(&repo)?;
+    drop(repo);
+    drop(guard);
+
+    let workspace_ref_target_after_activation = reopened
+        .git2_repo
+        .get()?
+        .find_reference("refs/heads/gitbutler/workspace")?
+        .target()
+        .expect("workspace ref should still point to a commit");
+    assert_eq!(
+        workspace_ref_target_after_activation,
+        original_workspace_ref_target
+    );
+
+    let stacks = stack_details(&reopened);
+    assert_eq!(stacks.len(), 1);
+    assert_eq!(stacks[0].1.derived_name, expected_stack_name);
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -247,7 +247,7 @@ fn bootstrap_missing_target_preserves_existing_workspace_ref() -> anyhow::Result
     let expected_stack_name = stack_details(ctx)[0].1.derived_name.clone();
 
     ctx.git2_repo.get()?.config()?.set_str(
-        &but_project_handle::storage_path_config_key(),
+        but_project_handle::storage_path_config_key(),
         "gitbutler-alt",
     )?;
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -13,7 +13,8 @@ fn twice() {
             .expect("failed to add project")
             .unwrap_project();
         let mut ctx =
-            Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+            Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+                .expect("can create context");
 
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
@@ -33,7 +34,8 @@ fn twice() {
             .unwrap()
             .unwrap_project();
         let mut ctx =
-            Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+            Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+                .expect("can create context");
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
             &ctx,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -30,7 +30,8 @@ impl Test {
         let project = outcome.unwrap_project();
         let mut settings = AppSettings::default();
         change_settings(&mut settings);
-        let ctx = Context::new_from_legacy_project_and_settings(&project, settings);
+        let ctx = Context::new_from_legacy_project_and_settings(&project, settings)
+            .expect("can create context");
         Self {
             repo: test_project,
             project_id: project.id,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
@@ -365,7 +365,7 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
 // test operations-log.toml head is not a commit
 #[test]
 fn head_corrupt_is_recreated_automatically() {
-    let Test { repo, ctx, .. } = &mut Test::default();
+    let Test { ctx, .. } = &mut Test::default();
 
     let mut guard = ctx.exclusive_worktree_access();
     gitbutler_branch_actions::set_base_branch(
@@ -392,7 +392,7 @@ fn head_corrupt_is_recreated_automatically() {
     );
 
     // overwrite oplog head with a non-commit sha
-    let oplog_path = repo.path().join(".git/gitbutler/operations-log.toml");
+    let oplog_path = ctx.project_data_dir().join("operations-log.toml");
     fs::write(
         oplog_path,
         "head_sha = \"758d54f587227fba3da3b61fbb54a99c17903d59\"",

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -165,9 +165,16 @@ impl Controller {
             .add(&project)
             .context("failed to add project to storage")?;
 
-        // Create a .git/gitbutler directory for app data
-        if let Err(error) = std::fs::create_dir_all(project.gb_dir()) {
-            tracing::error!(project_id = %project.id, ?error, "failed to create {:?} on project add", project.gb_dir());
+        // Create the repository-local GitButler storage directory for app data.
+        match project.gb_dir() {
+            Ok(gb_dir) => {
+                if let Err(error) = std::fs::create_dir_all(&gb_dir) {
+                    tracing::error!(project_id = %project.id, ?error, "failed to create \"{}\" on project add", gb_dir.display());
+                }
+            }
+            Err(error) => {
+                tracing::error!(project_id = %project.id, ?error, "failed to resolve storage directory on project add");
+            }
         }
 
         Ok(AddProjectOutcome::Added(project))
@@ -245,10 +252,17 @@ impl Controller {
             }
         }
 
-        if !project.gb_dir().exists()
-            && let Err(error) = std::fs::create_dir_all(project.gb_dir())
-        {
-            tracing::error!(project_id = %project.id, ?error, "failed to create \"{}\" on project get", project.gb_dir().display());
+        match project.gb_dir() {
+            Ok(gb_dir) => {
+                if !gb_dir.exists()
+                    && let Err(error) = std::fs::create_dir_all(&gb_dir)
+                {
+                    tracing::error!(project_id = %project.id, ?error, "failed to create \"{}\" on project get", gb_dir.display());
+                }
+            }
+            Err(error) => {
+                tracing::error!(project_id = %project.id, ?error, "failed to resolve storage directory on project get");
+            }
         }
         // Clean up old virtual_branches.toml that was never used
         let old_virtual_branches_path = project.git_dir().join("virtual_branches.toml");
@@ -284,10 +298,17 @@ impl Controller {
             tracing::error!(project_id = %id, ?error, "failed to remove project data",);
         }
 
-        if project.gb_dir().exists()
-            && let Err(error) = std::fs::remove_dir_all(project.gb_dir())
-        {
-            tracing::error!(project_id = %project.id, ?error, "failed to remove {:?} on project delete", project.gb_dir());
+        match project.gb_dir() {
+            Ok(gb_dir) => {
+                if gb_dir.exists()
+                    && let Err(error) = std::fs::remove_dir_all(&gb_dir)
+                {
+                    tracing::error!(project_id = %project.id, ?error, "failed to remove \"{}\" on project delete", gb_dir.display());
+                }
+            }
+            Err(error) => {
+                tracing::error!(project_id = %project.id, ?error, "failed to resolve storage directory on project delete");
+            }
         }
 
         // Delete references in the gitbutler namespace

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -351,8 +351,9 @@ impl Project {
     /// By default this is `.git/gitbutler` for release builds and `.git/gitbutler.<channel>`
     /// for non-release builds. It can be overridden by setting `gitbutler.storagePath`
     /// on release, or `gitbutler.<channel>.storagePath` on non-release builds. Relative
-    /// configured values are resolved against `.git`, and any resolved path outside `.git`
-    /// gets a project-handle suffix to keep different projects isolated.
+    /// configured values are resolved against `.git`; if they stay inside `.git`, they must
+    /// live under a top-level directory whose name starts with `gitbutler`. Any resolved path
+    /// outside `.git` gets a project-handle suffix to keep different projects isolated.
     pub(crate) fn gb_dir(&self) -> anyhow::Result<PathBuf> {
         gix::open(self.git_dir())?.gitbutler_storage_path()
     }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::Context as _;
+use but_core::RepositoryExt;
 use serde::{Deserialize, Serialize};
 
 use crate::{ProjectHandle, ProjectHandleOrLegacyProjectId, default_true::DefaultTrue};
@@ -347,9 +348,13 @@ impl Project {
 
     /// Returns the path to the directory containing the `GitButler` state for this project.
     ///
-    /// Normally this is `.git/gitbutler` in the project's repository.
-    pub(crate) fn gb_dir(&self) -> PathBuf {
-        self.git_dir().join("gitbutler")
+    /// By default this is `.git/gitbutler` for release builds and `.git/gitbutler.<channel>`
+    /// for non-release builds. It can be overridden by setting `gitbutler.storagePath`
+    /// on release, or `gitbutler.<channel>.storagePath` on non-release builds. Relative
+    /// configured values stay under `.git`, while absolute values outside `.git` get a
+    /// project-handle suffix to keep different projects isolated.
+    pub(crate) fn gb_dir(&self) -> anyhow::Result<PathBuf> {
+        self.open_isolated_repo()?.gitbutler_storage_path()
     }
 }
 

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -351,10 +351,10 @@ impl Project {
     /// By default this is `.git/gitbutler` for release builds and `.git/gitbutler.<channel>`
     /// for non-release builds. It can be overridden by setting `gitbutler.storagePath`
     /// on release, or `gitbutler.<channel>.storagePath` on non-release builds. Relative
-    /// configured values stay under `.git`, while absolute values outside `.git` get a
-    /// project-handle suffix to keep different projects isolated.
+    /// configured values are resolved against `.git`, and any resolved path outside `.git`
+    /// gets a project-handle suffix to keep different projects isolated.
     pub(crate) fn gb_dir(&self) -> anyhow::Result<PathBuf> {
-        self.open_isolated_repo()?.gitbutler_storage_path()
+        gix::open(self.git_dir())?.gitbutler_storage_path()
     }
 }
 

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -1,8 +1,13 @@
+use but_core::RepositoryExt;
 use gitbutler_testsupport::{self, paths};
 use tempfile::TempDir;
 
 pub fn new() -> TempDir {
     paths::data_dir()
+}
+
+fn storage_key() -> String {
+    but_project_handle::storage_path_config_key().to_owned()
 }
 
 mod add {
@@ -20,6 +25,42 @@ mod add {
             project.title,
             path.iter().next_back().unwrap().to_str().unwrap()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn creates_configured_storage_dir() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let key = storage_key();
+        git2::Repository::open(repo.path())?
+            .config()?
+            .set_str(&key, "gitbutler-custom")?;
+
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), repo.path())?.unwrap_project();
+        let gb_dir = project.open_isolated_repo()?.gitbutler_storage_path()?;
+        assert!(gb_dir.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn get_recreates_configured_storage_dir() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let key = storage_key();
+        git2::Repository::open(repo.path())?
+            .config()?
+            .set_str(&key, "gitbutler-custom")?;
+
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), repo.path())?.unwrap_project();
+        let gb_dir = project.open_isolated_repo()?.gitbutler_storage_path()?;
+        std::fs::remove_dir_all(&gb_dir)?;
+        assert!(!gb_dir.exists(), "sanity check");
+
+        let _project = gitbutler_project::get_with_path(data_dir.path(), project.id)?;
+        assert!(gb_dir.exists(), "storage dir should be recreated on get");
         Ok(())
     }
 
@@ -161,7 +202,14 @@ mod delete {
         assert!(gitbutler_project::delete_with_path(data_dir.path(), project_id.clone()).is_ok()); // idempotent
         assert!(gitbutler_project::get_with_path(data_dir.path(), project_id).is_err());
         assert!(repo.path().exists());
-        assert!(!repo.path().join("gitbutler").exists());
+        assert!(
+            !project
+                .open_isolated_repo()
+                .unwrap()
+                .gitbutler_storage_path()
+                .unwrap()
+                .exists()
+        );
     }
 
     #[test]
@@ -251,7 +299,7 @@ mod delete {
         gitbutler_project::delete_with_path(data_dir.path(), project.id)?;
 
         assert!(repo.path().exists());
-        assert!(!repo.path().join("gitbutler").exists());
+        assert!(!repo.gitbutler_storage_path()?.exists());
 
         // Nothing changed - no reference was touched.
         insta::assert_debug_snapshot!(all_refs(&repo)?, @r#"
@@ -262,6 +310,25 @@ mod delete {
         ]
         "#);
 
+        Ok(())
+    }
+
+    #[test]
+    fn removes_configured_storage_dir() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let key = storage_key();
+        git2::Repository::open(repo.path())?
+            .config()?
+            .set_str(&key, "gitbutler-custom")?;
+        let path = repo.path();
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), path)?.unwrap_project();
+        let gb_dir = project.open_isolated_repo()?.gitbutler_storage_path()?;
+        assert!(gb_dir.exists());
+
+        gitbutler_project::delete_with_path(data_dir.path(), project.id)?;
+        assert!(!gb_dir.exists());
         Ok(())
     }
 

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -332,6 +332,32 @@ mod delete {
         Ok(())
     }
 
+    #[test]
+    fn refuses_to_delete_git_dir_when_storage_path_points_to_dot_git() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let key = storage_key();
+        let git_dir = git2::Repository::open(repo.path())?.path().to_path_buf();
+        git2::Repository::open(repo.path())?
+            .config()?
+            .set_str(&key, ".")?;
+        let path = repo.path();
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), path)?.unwrap_project();
+
+        gitbutler_project::delete_with_path(data_dir.path(), project.id)?;
+
+        assert!(
+            git_dir.exists(),
+            "the repository .git directory must remain"
+        );
+        assert!(
+            git_dir.join("objects").exists(),
+            "git internals must remain after project deletion"
+        );
+        Ok(())
+    }
+
     fn all_refs(repo: &gix::Repository) -> anyhow::Result<Vec<String>> {
         Ok(repo
             .references()?

--- a/crates/gitbutler-repo/tests/credentials.rs
+++ b/crates/gitbutler-repo/tests/credentials.rs
@@ -31,7 +31,8 @@ impl TestCase<'_> {
             repo.workdir().unwrap().to_path_buf(),
             self.preferred_key.clone(),
         );
-        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+            .expect("can create context");
 
         let git2_repo = &*ctx.git2_repo.get().unwrap();
         let flow = help(git2_repo, &ctx.legacy_project, "origin").unwrap();

--- a/crates/gitbutler-repo/tests/read_file_from_workspace_security.rs
+++ b/crates/gitbutler-repo/tests/read_file_from_workspace_security.rs
@@ -12,6 +12,7 @@ fn context_for_repo(repo: &git2::Repository) -> Context {
         projects::AuthKey::default(),
     );
     Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+        .expect("can create context")
 }
 
 #[test]

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -69,14 +69,7 @@ pub fn set_project_active(
     // --> WARNING <-- Be sure this runs BEFORE the database on `ctx` is used.
     ctx = ctx.with_git2_repo(repo);
 
-    {
-        let mut guard = ctx.exclusive_worktree_access();
-        but_api::legacy::meta::reconcile_in_workspace_state_of_vb_toml(
-            &mut ctx,
-            guard.write_permission(),
-        )
-        .ok();
-    }
+    but_api::legacy::projects::prepare_project_for_activation(&mut ctx)?;
 
     let db_error = assure_database_valid(ctx.project_data_dir())?;
     let filter_error = warn_about_filters_and_git_lfs(&*ctx.repo.get()?)?;

--- a/crates/gitbutler-testsupport/Cargo.toml
+++ b/crates/gitbutler-testsupport/Cargo.toml
@@ -17,6 +17,7 @@ but-oxidize.workspace = true
 but-workspace.workspace = true
 but-fs = {workspace = true, features = ["legacy"]}
 but-ctx.workspace = true
+but-project-handle.workspace = true
 
 gitbutler-branch-actions = { path = "../gitbutler-branch-actions" }
 gitbutler-repo = { path = "../gitbutler-repo" }

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -310,18 +310,11 @@ pub mod read_only {
 }
 
 fn set_storage_path_for_testing(git_dir: &Path) -> anyhow::Result<()> {
-    git2::Repository::open(git_dir)?
-        .config()?
-        .set_str(&storage_path_key(), "gitbutler")?;
+    git2::Repository::open(git_dir)?.config()?.set_str(
+        but_project_handle::storage_path_config_key(),
+        "gitbutler.dev",
+    )?;
     Ok(())
-}
-
-fn storage_path_key() -> String {
-    match option_env!("CHANNEL") {
-        Some("release") => "gitbutler.storagePath".to_string(),
-        Some(channel) => format!("gitbutler.{channel}.storagePath"),
-        None => "gitbutler.dev.storagePath".to_string(),
-    }
 }
 
 use std::path::{Path, PathBuf};

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -93,7 +93,7 @@ pub mod writable {
         let (project, tempdir) = fixture_project(script_name, project_directory)?;
         let mut settings = AppSettings::default();
         change_settings(&mut settings);
-        let ctx = Context::new_from_legacy_project_and_settings(&project, settings);
+        let ctx = Context::new_from_legacy_project_and_settings(&project, settings)?;
         Ok((ctx, tempdir))
     }
     pub fn fixture_project(
@@ -111,6 +111,7 @@ pub mod writable {
             project_directory.to_owned(),
             root.path().join(project_directory),
         );
+        crate::set_storage_path_for_testing(project.git_dir())?;
         Ok((project, root))
     }
 
@@ -131,7 +132,7 @@ pub mod writable {
         let (project, tempdir) = but_fixture_project(script_name, project_directory)?;
         let mut settings = AppSettings::default();
         change_settings(&mut settings);
-        let ctx = Context::new_from_legacy_project_and_settings(&project, settings);
+        let ctx = Context::new_from_legacy_project_and_settings(&project, settings)?;
         Ok((ctx, tempdir))
     }
 
@@ -151,6 +152,7 @@ pub mod writable {
             project_directory.to_owned(),
             root.path().join(project_directory),
         );
+        crate::set_storage_path_for_testing(project.git_dir())?;
         Ok((project, root))
     }
 }
@@ -256,10 +258,7 @@ pub mod read_only {
     /// Returns the project that is strictly for read-only use.
     pub fn fixture(script_name: &str, project_directory: &str) -> anyhow::Result<Context> {
         let project = fixture_project(script_name, project_directory)?;
-        Ok(Context::new_from_legacy_project_and_settings(
-            &project,
-            AppSettings::default(),
-        ))
+        Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
     }
 
     /// As [fixture()], but allows setting `features` in the app settings
@@ -269,13 +268,13 @@ pub mod read_only {
         features: FeatureFlags,
     ) -> anyhow::Result<Context> {
         let project = fixture_project(script_name, project_directory)?;
-        Ok(Context::new_from_legacy_project_and_settings(
+        Context::new_from_legacy_project_and_settings(
             &project,
             AppSettings {
                 feature_flags: features,
                 ..Default::default()
             },
-        ))
+        )
     }
 
     /// Like [`fixture()`], but will return only the `Project` at `project_directory` after executing `script_name`.
@@ -305,7 +304,23 @@ pub mod read_only {
                 project_worktree_dir,
             )
         };
+        super::set_storage_path_for_testing(project.git_dir())?;
         Ok(project)
+    }
+}
+
+fn set_storage_path_for_testing(git_dir: &Path) -> anyhow::Result<()> {
+    git2::Repository::open(git_dir)?
+        .config()?
+        .set_str(&storage_path_key(), "gitbutler")?;
+    Ok(())
+}
+
+fn storage_path_key() -> String {
+    match option_env!("CHANNEL") {
+        Some("release") => "gitbutler.storagePath".to_string(),
+        Some(channel) => format!("gitbutler.{channel}.storagePath"),
+        None => "gitbutler.dev.storagePath".to_string(),
     }
 }
 

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -104,7 +104,8 @@ impl Drop for Case {
 
 impl Case {
     fn new(project: gitbutler_project::Project, project_tmp: TempDir) -> Case {
-        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+            .expect("can create context");
         Case {
             project,
             ctx,
@@ -115,7 +116,8 @@ impl Case {
     pub fn refresh(mut self, _suite: &Suite) -> Self {
         let project =
             gitbutler_project::get(self.project.id.clone()).expect("failed to get project");
-        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default());
+        let ctx = Context::new_from_legacy_project_and_settings(&project, AppSettings::default())
+            .expect("can create context");
         Self {
             ctx,
             project,

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -395,13 +395,8 @@ pub(crate) fn setup_config(config: &git2::Config) -> anyhow::Result<()> {
             local.set_str("commit.gpgsign", "false")?;
             local.set_str("user.name", "gitbutler-test")?;
             local.set_str("user.email", "gitbutler-test@example.com")?;
-            // Keep fixtures that expect `.git/gitbutler` stable regardless of build channel.
-            let key = match option_env!("CHANNEL") {
-                Some("release") => "gitbutler.storagePath".to_string(),
-                Some(channel) => format!("gitbutler.{channel}.storagePath"),
-                None => "gitbutler.dev.storagePath".to_string(),
-            };
-            local.set_str(&key, "gitbutler")?;
+            let key = but_project_handle::storage_path_config_key();
+            local.set_str(key, "gitbutler.dev")?;
             Ok(())
         }
         Err(err) => Err(err.into()),

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -395,6 +395,13 @@ pub(crate) fn setup_config(config: &git2::Config) -> anyhow::Result<()> {
             local.set_str("commit.gpgsign", "false")?;
             local.set_str("user.name", "gitbutler-test")?;
             local.set_str("user.email", "gitbutler-test@example.com")?;
+            // Keep fixtures that expect `.git/gitbutler` stable regardless of build channel.
+            let key = match option_env!("CHANNEL") {
+                Some("release") => "gitbutler.storagePath".to_string(),
+                Some(channel) => format!("gitbutler.{channel}.storagePath"),
+                None => "gitbutler.dev.storagePath".to_string(),
+            };
+            local.set_str(&key, "gitbutler")?;
             Ok(())
         }
         Err(err) => Err(err.into()),

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -46,15 +46,17 @@ impl Handler {
     ) -> Result<()> {
         match event {
             InternalEvent::ProjectFilesChange(project_id, paths) => {
-                let mut ctx = self.open_command_context(project_id, app_settings.get()?.clone())?;
+                let mut ctx =
+                    self.open_command_context(project_id.clone(), app_settings.get()?.clone())?;
                 let mut guard = ctx.exclusive_worktree_access();
-                self.project_files_change(paths, &mut ctx, guard.write_permission())
+                self.project_files_change(project_id, paths, &mut ctx, guard.write_permission())
             }
 
             InternalEvent::GitFilesChange(project_id, paths) => {
-                let mut ctx = self.open_command_context(project_id, app_settings.get()?.clone())?;
+                let mut ctx =
+                    self.open_command_context(project_id.clone(), app_settings.get()?.clone())?;
                 let mut guard = ctx.exclusive_worktree_access();
-                self.git_files_change(paths, &mut ctx, guard.write_permission())
+                self.git_files_change(project_id, paths, &mut ctx, guard.write_permission())
                     .context("failed to handle git file change event")
             }
         }
@@ -77,15 +79,21 @@ impl Handler {
     #[instrument(skip_all, fields(paths = paths.len()))]
     fn project_files_change(
         &self,
+        project_id: ProjectHandleOrLegacyProjectId,
         paths: Vec<PathBuf>,
         ctx: &mut Context,
         perm: &mut RepoExclusive,
     ) -> Result<()> {
-        _ = self.emit_worktree_changes(ctx, perm);
+        _ = self.emit_worktree_changes(project_id, ctx, perm);
         Ok(())
     }
 
-    fn emit_worktree_changes(&self, ctx: &mut Context, perm: &mut RepoExclusive) -> Result<()> {
+    fn emit_worktree_changes(
+        &self,
+        project_id: ProjectHandleOrLegacyProjectId,
+        ctx: &mut Context,
+        perm: &mut RepoExclusive,
+    ) -> Result<()> {
         let context_lines = ctx.settings.context_lines;
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
 
@@ -146,7 +154,7 @@ impl Handler {
             };
         }
         let _ = self.emit_app_event(Change::WorktreeChanges {
-            project_id: ctx.legacy_project.id.clone(),
+            project_id,
             changes,
         });
         Ok(())
@@ -154,12 +162,12 @@ impl Handler {
 
     pub fn git_files_change(
         &self,
+        project_id: ProjectHandleOrLegacyProjectId,
         paths: Vec<PathBuf>,
         ctx: &mut Context,
         perm: &mut RepoExclusive,
     ) -> Result<()> {
         let (head_ref_name, head_sha) = head_info(ctx)?;
-        let project_id = ctx.legacy_project.id.clone();
         for path in paths {
             let Some(file_name) = path.to_str() else {
                 continue;
@@ -182,7 +190,7 @@ impl Handler {
                     })?;
                 }
                 INDEX => {
-                    let _ = self.emit_worktree_changes(ctx, perm);
+                    let _ = self.emit_worktree_changes(project_id.clone(), ctx, perm);
                 }
                 HEAD => {
                     let git2_repo = ctx.git2_repo.get()?;


### PR DESCRIPTION
Fixes #11157 and resolves the issue of Nightly builds putting the database into the future, making it unreadable with the stable build.
As this new default for `.git/gitbutler` is configurable, the user can force both build types to 

This also means that non-stable channel builds will put their metadata into:

* `.git/gitbutler.nightly`
* `.git/gitbutler.dev`

respectively.

There is a new `gitbutler.storagePath` configuration key, and `gitbutler.<channel>.storagePath` for Nightly and Dev respectively. When set to to a relative path or path within `.git/` it allows to control the storage directory, for example as a way to make Nightly put its files to `.git/gitbutler` instead of `.git/gitbutler.nightly`.
The `storagePath` can also be absolute to store project metadata side-by-side.

### Tasks

* [x] review
* [x] test in the real
    - [x] try with absolute storagePath for multi-project support
    - [x] relative override
    - [x] no override, everything works like before except for in channels
    - [x] see how one would be able to 'revert' the behaviour by configuring the storage path for the nightly channel
* [x] protection for db clashes when configuration is setup globally (must get more unique DB name then)
* [x] no-clobber for 'addproject', to ensure it will not rewrite the gitbutler/workspace ref if it already exists
    - there is a bit of a race with the GUI as it shows the 'target setup' modal, just to find it fixed a moment later. But it's clearly better than the alternative.
* [x] validate CI
* [x] conform `but-link` a bit!
* [x] address outstanding review comments
* [x] another round of GUI testing

## Notes for the Reviewer

When running a dev version, it will now recreate its data in `.git/gitbutler.dev`, causing it to want to re-initialise the workspace by picking the target branch. While it has been nerved to re-use existing gitbutler/workspace refs unconditionally, it's still something to go through.


https://github.com/user-attachments/assets/2ad34e76-988f-4f0e-a8ff-04b232ff9813

<details><summary>Codex Plan</summary>

This will also happen to Nightly users.

## Commit-Ready Plan: Configurable GitButler Storage Path with Channel Isolation

### Summary
Change GitButler project storage to be resolved from Git config (`gitbutler.storagePath`) and default non-stable builds to channel-specific storage paths (`.git/gitbutler.<channel>`).  
This addresses two motivations:
1. Prevent channel interference from incompatible DB schemas/versions.
2. Unblock repos on unsuitable drives (for example NFS/network mounts in [#11157](https://github.com/gitbutlerapp/gitbutler/issues/11157)) by letting users point storage to a safe local path.

### Scope and behavior
1. Add a repository-local config key: `gitbutler.storagePath`.
2. Resolution rules:
1. If `gitbutler.storagePath` is absolute: use it directly.
2. If `gitbutler.storagePath` is relative: resolve against `repo.git_dir()`.
3. If unset:
1. Release builds default to `<git_dir>/gitbutler`.
2. Non-release builds default to `<git_dir>/gitbutler.<channel>`.
3. If channel is unavailable, treat as `dev` and use `<git_dir>/gitbutler.dev`.
3. No automatic migration/fallback from legacy `.git/gitbutler`.
4. Do not auto-write default path into `.git/config`.

### Required implementation changes
1. Introduce a shared resolver in `but-core` (`RepositoryExt`) so all callers use one implementation.
2. Update `but-ctx::Context` to store the resolved project-data directory eagerly at creation time.
3. Ensure all `Context` constructors create/open a real repository before finalizing context so full Git config is available.
4. Route DB initialization in `Context` through the resolved project-data directory, not a hardcoded `gitdir.join("gitbutler")`.
5. Update legacy project management code (`gitbutler-project` add/get/delete storage dir operations) to use the same resolver logic.
6. Update documentation/comments that currently imply only `.git/gitbutler`.

### Public API / interface changes
1. New recognized Git config key: `gitbutler.storagePath`.
2. New `RepositoryExt` method for resolved storage path.
3. `Context::project_data_dir()` becomes config-aware instead of hardcoded.
4. `Context` and thread-safe context equivalents carry the resolved project-data directory as state.

### Testing and acceptance criteria
1. Resolver tests:
1. Unset config + release => `<git_dir>/gitbutler`.
2. Unset config + nightly => `<git_dir>/gitbutler.nightly`.
3. Unset config + unknown non-release channel => `<git_dir>/gitbutler.<channel>`.
4. Config absolute path respected exactly.
5. Config relative path resolves against `git_dir`.
2. Context tests:
1. Creating context with configured path yields matching `project_data_dir`.
2. DB path uses resolved directory.
3. Thread-safe conversion preserves resolved directory.
3. Legacy project controller tests:
1. Add/get create the resolved storage directory.
2. Delete removes the resolved storage directory.
4. Non-regression:
1. Existing stable default remains `.git/gitbutler`.
2. No implicit migration/fallback behavior.

### Rollout and compatibility notes
1. Nightly/dev users with existing `.git/gitbutler` data will start isolated storage by default.
2. Users affected by issue #11157 can set `gitbutler.storagePath` to a local filesystem path suitable for SQLite.
3. Release channel behavior remains unchanged unless override is configured.

### Proposed commit message
**Subject**
`ctx/project: make storage path git-configurable and channel-isolated`

**Body**
`Resolve GitButler project storage from gitbutler.storagePath and make non-release defaults channel-specific (.git/gitbutler.<channel>) to prevent channel interference from incompatible DB versions.`

`This also enables moving project storage off unsuitable repository drives (e.g. NFS/network mounts), addressing SQLite lock/rename failures reported in #11157.`

`Behavior notes: no automatic migration/fallback from legacy .git/gitbutler, and defaults are computed in-memory (not auto-persisted to git config).`

### Assumptions locked
1. Config key is `gitbutler.storagePath`.
2. Relative config paths are `git_dir`-relative.
3. Isolation-only strategy for existing legacy directory.
4. Legacy `gitbutler-project` storage directory operations are included in this same change.

</details>
