### PR TITLE
Remove all usage of VirtualBranchesHandle in favor of using the workspace projection (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,6 @@ dependencies = [
  "futures",
  "gitbutler-branch",
  "gitbutler-branch-actions",
- "gitbutler-stack",
  "gix",
  "notify-rust",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4060,7 +4060,6 @@ dependencies = [
  "but-serde",
  "but-workspace",
  "git2",
- "gitbutler-stack",
  "gitbutler-testsupport",
  "serde",
  "toml 0.9.12+spec-1.1.0",

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -82,7 +82,7 @@ fn handle_changes_simple_inner(
     perm: &mut RepoExclusive,
     exclusive_stack: Option<StackId>,
 ) -> anyhow::Result<Outcome> {
-    match gitbutler_operating_modes::operating_mode(ctx) {
+    match gitbutler_operating_modes::operating_mode(ctx, perm.read_permission())? {
         OperatingMode::OpenWorkspace => {
             // No action needed, we're already in the workspace
         }

--- a/crates/but-api/src/legacy/modes.rs
+++ b/crates/but-api/src/legacy/modes.rs
@@ -14,12 +14,13 @@ use crate::json::Error;
 #[serde(rename_all = "camelCase")]
 pub struct HeadAndMode {
     pub head: Option<String>,
-    pub operating_mode: Option<OperatingMode>,
+    pub operating_mode: OperatingMode,
 }
 
 #[but_api]
 #[instrument(err(Debug))]
 pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
+    let guard = ctx.shared_worktree_access();
     let repo = ctx.repo.get()?;
     let head = repo.head();
     let head_ref_short = match head.as_ref().map(|head| head.referent_name()) {
@@ -29,7 +30,7 @@ pub fn operating_mode(ctx: &Context) -> Result<HeadAndMode, Error> {
 
     Ok(HeadAndMode {
         head: head_ref_short,
-        operating_mode: Some(gitbutler_operating_modes::operating_mode(ctx)),
+        operating_mode: gitbutler_operating_modes::operating_mode(ctx, guard.read_permission())?,
     })
 }
 

--- a/crates/but-claude/Cargo.toml
+++ b/crates/but-claude/Cargo.toml
@@ -20,9 +20,10 @@ but-workspace = { workspace = true, features = ["legacy"] }
 but-path.workspace = true
 but-ctx = { workspace = true, features = ["legacy"] }
 but-llm.workspace = true
+
 gitbutler-branch.workspace = true
-gitbutler-stack.workspace = true
 gitbutler-branch-actions.workspace = true
+
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/but-claude/src/db.rs
+++ b/crates/but-claude/src/db.rs
@@ -231,7 +231,7 @@ pub fn answer_ask_user_question(
 /// Returns true if an update was made, false if no pending request was found for the stack.
 pub fn set_ask_user_question_answers_by_stack(
     _ctx: &mut Context,
-    stack_id: gitbutler_stack::StackId,
+    stack_id: but_core::ref_metadata::StackId,
     answers: std::collections::HashMap<String, String>,
 ) -> anyhow::Result<bool> {
     let pending = crate::pending_requests::pending_requests();

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -460,7 +460,7 @@ pub struct ClaudeAskUserQuestionRequest {
     /// None if not yet answered
     pub answers: Option<std::collections::HashMap<String, String>>,
     /// The stack ID this question is associated with
-    pub stack_id: Option<gitbutler_stack::StackId>,
+    pub stack_id: Option<but_core::ref_metadata::StackId>,
 }
 
 /// Represents the thinking level for Claude Code.

--- a/crates/but-claude/src/pending_requests.rs
+++ b/crates/but-claude/src/pending_requests.rs
@@ -159,7 +159,7 @@ impl PendingRequests {
     /// Gets a pending question request by stack ID.
     pub fn get_question_by_stack(
         &self,
-        stack_id: &gitbutler_stack::StackId,
+        stack_id: &but_core::ref_metadata::StackId,
     ) -> Option<ClaudeAskUserQuestionRequest> {
         let questions = self.questions.lock().unwrap();
         questions

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -19,7 +19,6 @@ use but_core::{
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::{Context, ThreadSafeContext};
-use gitbutler_stack::VirtualBranchesHandle;
 use gix::bstr::ByteSlice;
 use serde::Serialize;
 use tokio::{
@@ -922,7 +921,7 @@ fn format_branch_info(ctx: &mut Context, stack_id: StackId, perm: &RepoShared) -
         consider both committed and uncommitted changes.\n\n",
     );
 
-    append_target_branch_info(&mut output, ctx);
+    append_target_branch_info(&mut output, ctx, perm);
     append_stack_branches_info(&mut output, stack_id, ctx);
     append_assigned_files_info(&mut output, stack_id, ctx, perm).ok();
 
@@ -931,15 +930,19 @@ fn format_branch_info(ctx: &mut Context, stack_id: StackId, perm: &RepoShared) -
 }
 
 /// Appends target branch (upstream) information to the output
-fn append_target_branch_info(output: &mut String, ctx: &Context) {
-    let state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    match state.get_default_target() {
-        Ok(target) => {
-            output.push_str(&format!(
-                "Target branch (upstream): {}/{}\n\n",
-                target.branch.remote(),
-                target.branch.branch()
-            ));
+fn append_target_branch_info(output: &mut String, ctx: &Context, perm: &RepoShared) {
+    match ctx.workspace_and_db_with_perm(perm) {
+        Ok((_repo, ws, _db)) => {
+            if let Some(target_ref) = ws.target_ref.as_ref() {
+                output.push_str(&format!(
+                    "Target branch (upstream): {}\n\n",
+                    target_ref.ref_name.shorten()
+                ));
+            } else {
+                tracing::warn!(
+                    "Failed to fetch target branch information: no target ref in workspace"
+                );
+            }
         }
         Err(e) => {
             tracing::warn!("Failed to fetch target branch information: {}", e);
@@ -1260,7 +1263,7 @@ or commits, is unspecified.
 fn create_can_use_tool_callback(
     sync_ctx: ThreadSafeContext,
     broadcaster: Arc<Mutex<Broadcaster>>,
-    stack_id: gitbutler_stack::StackId,
+    stack_id: but_core::ref_metadata::StackId,
     auto_approve_tools: bool,
     session_id: uuid::Uuid,
 ) -> claude_agent_sdk_rs::CanUseToolCallback {
@@ -1494,7 +1497,7 @@ fn create_can_use_tool_callback(
 /// Handle AskUserQuestion tool - waits for user answers via in-memory channel
 async fn handle_ask_user_question(
     sync_ctx: ThreadSafeContext,
-    stack_id: gitbutler_stack::StackId,
+    stack_id: but_core::ref_metadata::StackId,
     session_id: uuid::Uuid,
     tool_input: serde_json::Value,
 ) -> claude_agent_sdk_rs::PermissionResult {
@@ -1590,7 +1593,7 @@ async fn handle_ask_user_question(
 #[allow(unused_variables)]
 fn create_pretool_use_hook(
     sync_ctx: ThreadSafeContext,
-    stack_id: gitbutler_stack::StackId,
+    stack_id: but_core::ref_metadata::StackId,
 ) -> claude_agent_sdk_rs::HookCallback {
     use std::sync::Arc;
 

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -389,7 +389,11 @@ pub fn watch_db(args: &super::Args) -> anyhow::Result<()> {
 
 pub fn operating_mode(args: &super::Args) -> anyhow::Result<()> {
     let ctx = Context::discover(&args.current_dir)?;
-    debug_print(gitbutler_operating_modes::operating_mode(&ctx))
+    let guard = ctx.shared_worktree_access();
+    debug_print(gitbutler_operating_modes::operating_mode(
+        &ctx,
+        guard.read_permission(),
+    )?)
 }
 
 pub fn ref_info(args: &super::Args, ref_name: Option<&str>, expensive: bool) -> anyhow::Result<()> {

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_api::legacy::modes::{
-    abort_edit_and_return_to_workspace, edit_initial_index_state, enter_edit_mode,
+    abort_edit_and_return_to_workspace, edit_initial_index_state, enter_edit_mode, operating_mode,
     save_edit_and_return_to_workspace_with_output,
 };
 use but_ctx::Context;
@@ -38,7 +38,7 @@ pub(crate) fn handle(
                 enter_resolution(ctx, out, &commit_id_str)
             } else {
                 // Check if we're already in edit mode
-                let mode = gitbutler_operating_modes::operating_mode(ctx);
+                let mode = operating_mode(ctx)?.operating_mode;
                 if matches!(mode, OperatingMode::Edit(_)) {
                     // If in edit mode, show status instead of help
                     show_status(ctx, out)
@@ -158,7 +158,7 @@ fn show_status_impl(
     prompt_to_finalize: bool,
 ) -> Result<()> {
     // Check if we're in edit mode
-    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
         // Not in edit mode, show the workflow help instead
         return show_workflow_help(out);
@@ -319,7 +319,7 @@ fn has_conflict_markers(content: &str) -> bool {
 
 fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
     // Check if we're in edit mode
-    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
         // Not in edit mode, show the workflow help instead
         return show_workflow_help(out);
@@ -354,7 +354,7 @@ fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
 
 fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) -> Result<()> {
     // Check if we're in edit mode
-    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    let mode = operating_mode(ctx)?.operating_mode;
     if !matches!(mode, OperatingMode::Edit(_)) {
         // Not in edit mode, show the workflow help instead
         return show_workflow_help(out);

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -85,7 +85,7 @@ pub(crate) async fn worktree(
     hint: bool,
 ) -> anyhow::Result<()> {
     // Check if we're in edit mode first, before doing any expensive operations
-    let mode = gitbutler_operating_modes::operating_mode(ctx);
+    let mode = but_api::legacy::modes::operating_mode(ctx)?.operating_mode;
     if let gitbutler_operating_modes::OperatingMode::Edit(_metadata) = mode {
         // In edit mode, show the conflict resolution status
         return show_edit_mode_status(ctx, out);

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context as _, Result};
 use but_core::DiffSpec;
-use but_ctx::{Context, access::RepoExclusive};
+use but_ctx::{
+    Context,
+    access::{RepoExclusive, RepoShared},
+};
 use but_oxidize::{ObjectIdExt, OidExt};
 use but_workspace::legacy::{commit_engine, stack_heads_info, ui};
 use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
@@ -38,7 +41,8 @@ pub fn create_virtual_branch(
     perm: &mut RepoExclusive,
 ) -> Result<ui::StackEntryNoOpt> {
     ctx.verify(perm)?;
-    ensure_open_workspace_mode(ctx).context("Creating a branch requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, perm.read_permission())
+        .context("Creating a branch requires open workspace mode")?;
     let branch_manager = ctx.branch_manager();
     let stack = branch_manager.create_virtual_branch(create, perm)?;
     let repo = ctx.repo.get()?;
@@ -114,7 +118,7 @@ pub fn integrate_upstream_commits(
 ) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Integrating upstream commits requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::MergeUpstream),
@@ -133,8 +137,9 @@ pub fn get_initial_integration_steps_for_branch(
     ctx: &Context,
     stack_id: Option<StackId>,
     branch_name: String,
+    perm: &RepoShared,
 ) -> Result<Vec<branch_upstream_integration::InteractiveIntegrationStep>> {
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, perm)
         .context("Getting initial integration steps requires open workspace mode")?;
     branch_upstream_integration::get_initial_integration_steps_for_branch(
         ctx,
@@ -151,7 +156,7 @@ pub fn integrate_branch_with_steps(
 ) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Integrating a branch with steps requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::MergeUpstream),
@@ -169,7 +174,7 @@ pub fn integrate_branch_with_steps(
 pub fn update_stack_order(ctx: &mut Context, updates: Vec<BranchUpdateRequest>) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Updating branch order requires open workspace mode")?;
     for stack_update in updates {
         let stack = ctx
@@ -190,7 +195,7 @@ pub fn unapply_stack(
     assigned_diffspec: Vec<DiffSpec>,
 ) -> Result<String> {
     ctx.verify(perm)?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, perm.read_permission())
         .context("Deleting a branch order requires open workspace mode")?;
     let branch_manager = ctx.branch_manager();
     // NB: unapply_without_saving is also called from save_and_unapply
@@ -215,7 +220,8 @@ pub fn amend(
 ) -> Result<git2::Oid> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Amending a commit requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Amending a commit requires open workspace mode")?;
     {
         // commit_engine::create_commit_and_update_refs_with_project is also doing a write lock,
         // so we want to allow this guard to be dropped first
@@ -259,7 +265,8 @@ fn amend_with_commit_engine(
 pub fn undo_commit(ctx: &mut Context, stack_id: StackId, commit_oid: git2::Oid) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Undoing a commit requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Undoing a commit requires open workspace mode")?;
     let snapshot_tree = ctx.prepare_snapshot(guard.read_permission());
     let result: Result<()> =
         crate::undo_commit::undo_commit(ctx, stack_id, commit_oid, guard.write_permission())
@@ -278,7 +285,8 @@ pub fn undo_commit(ctx: &mut Context, stack_id: StackId, commit_oid: git2::Oid) 
 pub fn reorder_stack(ctx: &mut Context, stack_id: StackId, stack_order: StackOrder) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Reordering a commit requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Reordering a commit requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::ReorderCommit),
         guard.write_permission(),
@@ -295,7 +303,8 @@ pub fn squash_commits(
 ) -> Result<git2::Oid> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Squashing a commit requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Squashing a commit requires open workspace mode")?;
     crate::squash::squash_commits(
         ctx,
         stack_id,
@@ -313,7 +322,7 @@ pub fn update_commit_message(
 ) -> Result<git2::Oid> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Updating a commit message requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::UpdateCommitMessage),
@@ -357,7 +366,8 @@ pub fn move_commit(
 ) -> Result<Option<MoveCommitIllegalAction>> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Moving a commit requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Moving a commit requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::MoveCommit),
         guard.write_permission(),
@@ -380,7 +390,8 @@ pub fn move_branch(
 ) -> Result<MoveBranchResult> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Moving a branch requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Moving a branch requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::MoveBranch),
         guard.write_permission(),
@@ -402,7 +413,8 @@ pub fn tear_off_branch(
 ) -> Result<MoveBranchResult> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Moving a branch requires open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Moving a branch requires open workspace mode")?;
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::TearOffBranch),
         guard.write_permission(),
@@ -424,7 +436,7 @@ pub fn create_virtual_branch_from_branch(
 ) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Creating a virtual branch from a branch open workspace mode")?;
     let branch_manager = ctx.branch_manager();
     branch_manager.create_virtual_branch_from_branch(

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -35,7 +35,8 @@ pub fn create_branch(ctx: &mut Context, stack_id: StackId, req: CreateSeriesRequ
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     let _ = ctx.snapshot_create_dependent_branch(&req.name, guard.write_permission());
-    ensure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     let normalized_head_name = normalize_branch_name(&req.name)?;
     let repo = ctx.repo.get()?;
@@ -72,7 +73,8 @@ pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: &str) ->
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     let _ = ctx.snapshot_remove_dependent_branch(branch_name, guard.write_permission());
-    ensure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     stack.remove_branch(ctx, branch_name)
 }
@@ -88,7 +90,8 @@ pub fn update_branch_name(
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     let _ = ctx.snapshot_update_dependent_branch_name(&branch_name, guard.write_permission());
-    ensure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     let normalized_head_name = normalize_branch_name(&new_name)?;
     stack.update_branch(
@@ -121,7 +124,8 @@ pub fn update_branch_pr_number(
         SnapshotDetails::new(OperationKind::UpdateDependentBranchPrNumber),
         guard.write_permission(),
     );
-    ensure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     stack.set_pr_number(ctx, &branch_name, pr_number)
 }
@@ -139,7 +143,8 @@ pub fn push_stack(
 ) -> Result<PushResult> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
+    ensure_open_workspace_mode(ctx, guard.read_permission())
+        .context("Requires an open workspace mode")?;
     let state = ctx.virtual_branches();
     let stack = state.get_stack(stack_id)?;
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
@@ -21,7 +21,8 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
     );
 
     // Should not throw verification error until migration is complete.
-    let result = ensure_open_workspace_mode(&ctx);
+    let guard = ctx.shared_worktree_access();
+    let result = ensure_open_workspace_mode(&ctx, guard.read_permission());
     assert!(result.is_ok());
 
     // Updating workspace commit should put us on the workspace branch.

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -16,7 +16,7 @@ pub fn enter_edit_mode(
 ) -> Result<EditModeMetadata> {
     let mut guard = ctx.exclusive_worktree_access();
 
-    ensure_open_workspace_mode(ctx)
+    ensure_open_workspace_mode(ctx, guard.read_permission())
         .context("Entering edit mode may only be done when the workspace is open")?;
 
     let git2_repo = ctx.git2_repo.get()?;
@@ -43,7 +43,8 @@ pub fn enter_edit_mode(
 pub fn save_and_return_to_workspace(ctx: &mut Context) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
 
-    ensure_edit_mode(ctx).context("Edit mode may only be left while in edit mode")?;
+    ensure_edit_mode(ctx, guard.read_permission())
+        .context("Edit mode may only be left while in edit mode")?;
 
     crate::save_and_return_to_workspace(ctx, guard.write_permission())
 }
@@ -51,7 +52,8 @@ pub fn save_and_return_to_workspace(ctx: &mut Context) -> Result<()> {
 pub fn abort_and_return_to_workspace(ctx: &mut Context, force: bool) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
 
-    ensure_edit_mode(ctx).context("Edit mode may only be left while in edit mode")?;
+    ensure_edit_mode(ctx, guard.read_permission())
+        .context("Edit mode may only be left while in edit mode")?;
 
     crate::abort_and_return_to_workspace(ctx, force, guard.write_permission())
 }
@@ -61,7 +63,7 @@ pub fn starting_index_state(
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>> {
     let guard = ctx.exclusive_worktree_access();
 
-    ensure_edit_mode(ctx)?;
+    ensure_edit_mode(ctx, guard.read_permission())?;
 
     let state = crate::starting_index_state(ctx, guard.read_permission())?;
     Ok(state.into_iter().map(|(a, b)| (a.into(), b)).collect())
@@ -70,7 +72,7 @@ pub fn starting_index_state(
 pub fn changes_from_initial(ctx: &mut Context) -> Result<Vec<TreeChange>> {
     let guard = ctx.exclusive_worktree_access();
 
-    ensure_edit_mode(ctx)?;
+    ensure_edit_mode(ctx, guard.read_permission())?;
 
     let state = crate::changes_from_initial(ctx, guard.read_permission())?;
     Ok(state.into_iter().map(|a| a.into()).collect())

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -342,9 +342,9 @@ pub struct ConflictEntryPresence {
 
 pub(crate) fn starting_index_state(
     ctx: &Context,
-    _perm: &RepoShared,
+    perm: &RepoShared,
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>> {
-    let OperatingMode::Edit(metadata) = operating_mode(ctx) else {
+    let OperatingMode::Edit(metadata) = operating_mode(ctx, perm)? else {
         bail!("Starting index state can only be fetched while in edit mode")
     };
 
@@ -404,8 +404,8 @@ pub(crate) fn starting_index_state(
     Ok(outcome)
 }
 
-pub(crate) fn changes_from_initial(ctx: &Context, _perm: &RepoShared) -> Result<Vec<TreeChange>> {
-    let OperatingMode::Edit(metadata) = operating_mode(ctx) else {
+pub(crate) fn changes_from_initial(ctx: &Context, perm: &RepoShared) -> Result<Vec<TreeChange>> {
+    let OperatingMode::Edit(metadata) = operating_mode(ctx, perm)? else {
         bail!("Starting index state can only be fetched while in edit mode")
     };
 

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -16,8 +16,6 @@ but-core.workspace = true
 but-fs.workspace = true
 but-ctx.workspace = true
 
-gitbutler-stack.workspace = true
-
 serde.workspace = true
 tracing.workspace = true
 git2.workspace = true

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -2,10 +2,9 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{Context as _, Result, bail};
 use bstr::BString;
-use but_core::ref_metadata::StackId;
+use but_core::{ref_metadata::StackId, sync::RepoShared};
 use but_ctx::Context;
 use but_serde::BStringForFrontend;
-use gitbutler_stack::VirtualBranchesHandle;
 use serde::{Deserialize, Serialize};
 
 /// The reference the app will checkout when the workspace is open
@@ -84,41 +83,48 @@ pub enum OperatingMode {
     Edit(EditModeMetadata),
 }
 
-pub fn operating_mode(ctx: &Context) -> OperatingMode {
-    let repo = ctx.git2_repo.get().unwrap();
+pub fn operating_mode(ctx: &Context, perm: &RepoShared) -> Result<OperatingMode> {
+    let repo = ctx.git2_repo.get()?;
     let Ok(head_ref) = repo.head() else {
-        return OperatingMode::OutsideWorkspace(
-            outside_workspace_metadata(ctx).unwrap_or_default(),
-        );
+        return Ok(OperatingMode::OutsideWorkspace(
+            outside_workspace_metadata(ctx, perm).unwrap_or_default(),
+        ));
     };
 
     let Some(head_ref_name) = head_ref.name() else {
-        return OperatingMode::OutsideWorkspace(
-            outside_workspace_metadata(ctx).unwrap_or_default(),
-        );
+        return Ok(OperatingMode::OutsideWorkspace(
+            outside_workspace_metadata(ctx, perm).unwrap_or_default(),
+        ));
     };
 
     if OPEN_WORKSPACE_REFS.contains(&head_ref_name) {
-        OperatingMode::OpenWorkspace
+        Ok(OperatingMode::OpenWorkspace)
     } else if head_ref_name == EDIT_BRANCH_REF {
         let edit_mode_metadata = read_edit_mode_metadata(ctx);
 
         match edit_mode_metadata {
-            Ok(edit_mode_metadata) => OperatingMode::Edit(edit_mode_metadata),
+            Ok(edit_mode_metadata) => Ok(OperatingMode::Edit(edit_mode_metadata)),
             Err(error) => {
                 tracing::warn!(
                     "Failed to open in edit mode, falling back to outside workspace {}",
                     error
                 );
-                OperatingMode::OutsideWorkspace(outside_workspace_metadata(ctx).unwrap_or_default())
+                Ok(OperatingMode::OutsideWorkspace(
+                    outside_workspace_metadata(ctx, perm).unwrap_or_default(),
+                ))
             }
         }
     } else {
-        OperatingMode::OutsideWorkspace(outside_workspace_metadata(ctx).unwrap_or_default())
+        Ok(OperatingMode::OutsideWorkspace(
+            outside_workspace_metadata(ctx, perm).unwrap_or_default(),
+        ))
     }
 }
 
-fn outside_workspace_metadata(ctx: &Context) -> Result<OutsideWorkspaceMetadata> {
+fn outside_workspace_metadata(
+    ctx: &Context,
+    perm: &RepoShared,
+) -> Result<OutsideWorkspaceMetadata> {
     // We do a virtual-merge, extracting conflicts.
     let gix_repo = ctx.clone_repo_for_merging_non_persisting()?;
 
@@ -127,10 +133,8 @@ fn outside_workspace_metadata(ctx: &Context) -> Result<OutsideWorkspaceMetadata>
         .referent_name()
         .map(|r| r.as_partial_name().as_bstr().to_owned());
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let applied_stacks = vb_state.list_stacks_in_workspace()?;
-
-    if vb_state.maybe_get_default_target()?.is_none() || applied_stacks.is_empty() {
+    let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
+    if ws.target_ref.is_none() || ws.stacks.is_empty() {
         // Nothing to conflict
         return Ok(OutsideWorkspaceMetadata {
             branch_name,
@@ -153,35 +157,38 @@ fn outside_workspace_metadata(ctx: &Context) -> Result<OutsideWorkspaceMetadata>
     })
 }
 
-pub fn in_open_workspace_mode(ctx: &Context) -> bool {
-    operating_mode(ctx) == OperatingMode::OpenWorkspace
+pub fn in_open_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<bool> {
+    Ok(operating_mode(ctx, perm)? == OperatingMode::OpenWorkspace)
 }
 
-pub fn ensure_open_workspace_mode(ctx: &Context) -> Result<()> {
-    if in_open_workspace_mode(ctx) {
+pub fn ensure_open_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<()> {
+    if in_open_workspace_mode(ctx, perm)? {
         Ok(())
     } else {
         bail!("Expected to be in open workspace mode")
     }
 }
 
-pub fn in_edit_mode(ctx: &Context) -> bool {
-    matches!(operating_mode(ctx), OperatingMode::Edit(_))
+pub fn in_edit_mode(ctx: &Context, perm: &RepoShared) -> Result<bool> {
+    Ok(matches!(operating_mode(ctx, perm)?, OperatingMode::Edit(_)))
 }
 
-pub fn ensure_edit_mode(ctx: &Context) -> Result<EditModeMetadata> {
-    match operating_mode(ctx) {
+pub fn ensure_edit_mode(ctx: &Context, perm: &RepoShared) -> Result<EditModeMetadata> {
+    match operating_mode(ctx, perm)? {
         OperatingMode::Edit(edit_mode_metadata) => Ok(edit_mode_metadata),
         _ => bail!("Expected to be in edit mode"),
     }
 }
 
-pub fn in_outside_workspace_mode(ctx: &Context) -> bool {
-    matches!(operating_mode(ctx), OperatingMode::OutsideWorkspace(_))
+pub fn in_outside_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<bool> {
+    Ok(matches!(
+        operating_mode(ctx, perm)?,
+        OperatingMode::OutsideWorkspace(_)
+    ))
 }
 
-pub fn ensure_outside_workspace_mode(ctx: &Context) -> Result<()> {
-    if in_outside_workspace_mode(ctx) {
+pub fn ensure_outside_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<()> {
+    if in_outside_workspace_mode(ctx, perm)? {
         Ok(())
     } else {
         bail!("Expected to be in outside workspace mode")

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -40,7 +40,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/workspace");
 
-            let in_open_workspace = in_open_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_open_workspace = in_open_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(in_open_workspace);
         }
 
@@ -51,7 +52,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/edit");
 
-            let in_open_workspace = in_open_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_open_workspace = in_open_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_open_workspace);
         }
 
@@ -62,7 +64,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "testeroni");
 
-            let in_open_workspace = in_open_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_open_workspace = in_open_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_open_workspace);
         }
 
@@ -73,7 +76,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/workspace");
 
-            assert!(ensure_open_workspace_mode(ctx).is_ok());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_open_workspace_mode(ctx, guard.read_permission()).is_ok());
         }
 
         #[test]
@@ -83,7 +87,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/edit");
 
-            assert!(ensure_open_workspace_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_open_workspace_mode(ctx, guard.read_permission()).is_err());
         }
 
         #[test]
@@ -93,7 +98,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "testeroni");
 
-            assert!(ensure_open_workspace_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_open_workspace_mode(ctx, guard.read_permission()).is_err());
         }
     }
 
@@ -110,7 +116,9 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "testeroni");
 
-            let in_outside_workspace = in_outside_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_outside_workspace =
+                in_outside_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(in_outside_workspace);
         }
 
@@ -122,7 +130,9 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "gitbutler/edit");
             create_edit_mode_metadata(ctx);
 
-            let in_outside_worskpace = in_outside_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_outside_worskpace =
+                in_outside_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_outside_worskpace);
         }
 
@@ -133,7 +143,9 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/workspace");
 
-            let in_outside_worskpace = in_outside_workspace_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_outside_worskpace =
+                in_outside_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_outside_worskpace);
         }
 
@@ -144,7 +156,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "testeroni");
 
-            assert!(ensure_outside_workspace_mode(ctx).is_ok());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_ok());
         }
 
         #[test]
@@ -155,7 +168,8 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "gitbutler/edit");
             create_edit_mode_metadata(ctx);
 
-            assert!(ensure_outside_workspace_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_err());
         }
 
         #[test]
@@ -165,7 +179,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/workspace");
 
-            assert!(ensure_outside_workspace_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_err());
         }
     }
 
@@ -183,7 +198,8 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "gitbutler/edit");
             create_edit_mode_metadata(ctx);
 
-            let in_edit_mode = in_edit_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_edit_mode = in_edit_mode(ctx, guard.read_permission()).unwrap();
             assert!(in_edit_mode);
         }
 
@@ -194,7 +210,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/edit");
 
-            let in_edit_mode = in_edit_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_edit_mode = in_edit_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_edit_mode);
         }
 
@@ -206,7 +223,8 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "testeroni");
             create_edit_mode_metadata(ctx);
 
-            let in_edit_mode = in_edit_mode(ctx);
+            let guard = ctx.shared_worktree_access();
+            let in_edit_mode = in_edit_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_edit_mode);
         }
 
@@ -218,7 +236,8 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "gitbutler/edit");
             create_edit_mode_metadata(ctx);
 
-            assert!(ensure_edit_mode(ctx).is_ok());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_edit_mode(ctx, guard.read_permission()).is_ok());
         }
 
         #[test]
@@ -228,7 +247,8 @@ mod operating_modes {
 
             create_and_checkout_branch(ctx, "gitbutler/edit");
 
-            assert!(ensure_edit_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_edit_mode(ctx, guard.read_permission()).is_err());
         }
 
         #[test]
@@ -239,7 +259,8 @@ mod operating_modes {
             create_and_checkout_branch(ctx, "testeroni");
             create_edit_mode_metadata(ctx);
 
-            assert!(ensure_edit_mode(ctx).is_err());
+            let guard = ctx.shared_worktree_access();
+            assert!(ensure_edit_mode(ctx, guard.read_permission()).is_err());
         }
     }
 }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -199,7 +199,7 @@ impl Handler {
                         self.emit_app_event(Change::GitHead {
                             project_id: project_id.clone(),
                             head: head.to_string(),
-                            operating_mode: operating_mode(ctx),
+                            operating_mode: operating_mode(ctx, perm.read_permission())?,
                         })?;
                     }
                 }


### PR DESCRIPTION
This PR (or follow-ups) should also make it possible to remove the `VirtualBranchesHandle` entirely,
removing all consumers for the virtual-branches.toml file.

That way, the only consumer left is `RefMetadata`, which fetches the equivalent information from the database.
Related to #12646 as a co-located Sqlite actually doesn't always work.

This PR is part of the data-consistency plan.

### Prompt

> In `crate`, replace all usages of `VirtualBranchesHandle` with usages of the `ctx.workspace_*_with_perm(…)` family of functions.  Be sure to pass `perm` as parameter, only top-level API functions in `but-api` may create a guard or else suffer deadlocks. If you encounter functions that create the `but_ctx::Context` directly, this is an indicator that creating a guard here *should* be Ok, but validate it before doing so as it might be that the `Context` should not be newly created, but passed as reference in the function parameters.
The `ws` (`but_graph::projection::Workspace`) is used to access information about the workspace as substitute for the data returned by `VirtualBranchesHandle`.
`ws.lower_bound` is the workspace base that was previously computed on the fly with merge_base computations.

### Tasks

- [x] but-claude
- [x] gitbutler-operating-modes
