### PR TITLE
editor: disconnect_segment_from

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -1,5 +1,7 @@
 //! Operations for mutating the editor
 
+use std::collections::HashSet;
+
 use anyhow::{Result, anyhow};
 use petgraph::{Direction, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
@@ -22,6 +24,112 @@ pub enum InsertSide {
     ///
     /// IE: Any parent commits will become a parent of what is getting inserted.
     Below,
+}
+
+/// Defines the start and end of a segment by pointing to it's parent-most and child-most nodes.
+#[derive(Debug, Clone)]
+pub struct SegmentDelimiter<C, P>
+where
+    C: ToSelector,
+    P: ToSelector,
+{
+    /// The child-most node contained within the segment being defined.
+    pub child: C,
+    /// The parent-most node contained within the segment being defined.
+    pub parent: P,
+}
+
+/// A set of some selectors
+#[derive(Debug, Clone)]
+pub struct SomeSelectors {
+    selectors: Vec<AnySelector>,
+}
+
+impl SomeSelectors {
+    /// Creates a set of selectors from different selector input types.
+    ///
+    /// Errors out if the selectors iterator is empty.
+    pub fn new<T>(selectors: impl IntoIterator<Item = T>) -> Result<Self>
+    where
+        T: Into<AnySelector>,
+    {
+        let selectors: Vec<AnySelector> = selectors.into_iter().map(Into::into).collect();
+
+        if selectors.is_empty() {
+            return Err(anyhow!("Invalid selector set: This cannot be empty"));
+        }
+
+        Ok(Self { selectors })
+    }
+
+    /// Returns selectors as a slice.
+    pub fn as_slice(&self) -> &[AnySelector] {
+        &self.selectors
+    }
+}
+
+/// A heterogeneous selector input.
+#[derive(Debug, Clone)]
+pub enum AnySelector {
+    /// A selector that already points into the current graph revision.
+    Selector(Selector),
+    /// A commit id that should resolve to a pick step.
+    Commit(gix::ObjectId),
+    /// A reference name that should resolve to a reference step.
+    Reference(gix::refs::FullName),
+}
+
+impl ToSelector for AnySelector {
+    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
+        match self {
+            Self::Selector(selector) => selector.to_selector(editor),
+            Self::Commit(id) => editor.select_commit(*id),
+            Self::Reference(reference) => editor.select_reference(reference.as_ref()),
+        }
+    }
+}
+
+impl From<Selector> for AnySelector {
+    fn from(value: Selector) -> Self {
+        Self::Selector(value)
+    }
+}
+
+impl From<gix::ObjectId> for AnySelector {
+    fn from(value: gix::ObjectId) -> Self {
+        Self::Commit(value)
+    }
+}
+
+impl From<gix::refs::FullName> for AnySelector {
+    fn from(value: gix::refs::FullName) -> Self {
+        Self::Reference(value)
+    }
+}
+
+impl<T> TryFrom<Vec<T>> for SomeSelectors
+where
+    T: Into<AnySelector>,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<T>) -> std::result::Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Defines a set of node children or parents, to perform an action on.
+///
+/// Currently, this is used in the disconnect functionality.
+#[derive(Debug, Clone, Default)]
+pub enum SelectorSet {
+    /// Select all of the children or parents.
+    #[default]
+    All,
+    /// No children or parents should be selected.
+    None,
+    /// A subset of children or parents should be selected.
+    Some(SomeSelectors),
 }
 
 /// An enum that is helpful for describing where something should be inserted
@@ -123,49 +231,221 @@ impl Editor {
         Ok(old)
     }
 
-    /// Connect all the children of A to all the parents of B
+    /// Disconnect a segment from a parent segment.
     ///
-    /// This removes all the children edges of A and all the parent edges of B.
-    /// The intended usage is to 'remove' a segment from the graph.
+    /// `target` - The segment to disconnect.
+    /// `children_to_disconnect` - Child nodes to disconnect from `target.child`.
+    /// If `SelectorSet::All`, all incoming children of `target.child` are disconnected.
     ///
-    /// It's possible for both targets to be the same.
-    pub fn disconnect(
+    /// `parents_to_disconnect` - Parent nodes to disconnect from `target.parent`.
+    /// If `SelectorSet::All`, all outgoing parents of `target.parent` are disconnected.
+    ///
+    /// `target` delimiter's child and parent can be the same node.
+    /// This is the way to disconnect a single node.
+    ///
+    /// Returns an error when:
+    /// - `parents_to_disconnect` is `SelectorSet::None`
+    /// - `parents_to_disconnect` contains any parent that is not a direct parent of `target.parent`
+    /// - `children_to_disconnect` contains any child that is not a direct parent of `target.child`
+    pub fn disconnect_segment_from<C, P>(
         &mut self,
-        target_a: impl ToSelector,
-        target_b: impl ToSelector,
-    ) -> Result<()> {
-        let target_a = self
-            .history
-            .normalize_selector(target_a.to_selector(self)?)?;
-        let target_b = self
-            .history
-            .normalize_selector(target_b.to_selector(self)?)?;
+        target: SegmentDelimiter<C, P>,
+        children_to_disconnect: SelectorSet,
+        parents_to_disconnect: SelectorSet,
+    ) -> Result<()>
+    where
+        C: ToSelector,
+        P: ToSelector,
+    {
+        let SegmentDelimiter { child, parent } = target;
+        let target_child = self.history.normalize_selector(child.to_selector(self)?)?;
+        let target_parent = self.history.normalize_selector(parent.to_selector(self)?)?;
+        let children_to_disconnect = match children_to_disconnect {
+            SelectorSet::All => None,
+            SelectorSet::None => Some(Vec::new()),
+            SelectorSet::Some(children) => Some(
+                children
+                    .as_slice()
+                    .iter()
+                    .map(|from_child| from_child.to_selector(self))
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .map(|selector| self.history.normalize_selector(selector))
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+        };
+
+        let parents_to_disconnect = match parents_to_disconnect {
+            SelectorSet::All => None,
+            SelectorSet::None => {
+                return Err(anyhow!(
+                    "Invalid parents to disconnect: SelectorSet::None is not allowed"
+                ));
+            }
+            SelectorSet::Some(parents) => Some(
+                parents
+                    .as_slice()
+                    .iter()
+                    .map(|from_parent| from_parent.to_selector(self))
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .map(|selector| self.history.normalize_selector(selector))
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+        };
 
         // Edges to children.
         let incoming_edges = self
             .graph
-            .edges_directed(target_a.id, Direction::Incoming)
+            .edges_directed(target_child.id, Direction::Incoming)
             .map(|e| (e.id(), e.weight().to_owned(), e.source()))
             .collect::<Vec<_>>();
 
         // Edges to parents.
         let outgoing_edges = self
             .graph
-            .edges_directed(target_b.id, Direction::Outgoing)
+            .edges_directed(target_parent.id, Direction::Outgoing)
             .map(|e| (e.id(), e.weight().to_owned(), e.target()))
             .collect::<Vec<_>>();
 
-        // Disconnect all parents from the target node.
-        for (edge_id, _, _) in &outgoing_edges {
-            self.graph.remove_edge(*edge_id);
+        // All available parents
+        let available_parents = outgoing_edges
+            .iter()
+            .map(|(_, _, edge_target)| *edge_target)
+            .collect::<HashSet<_>>();
+        let available_children = incoming_edges
+            .iter()
+            .map(|(_, _, edge_source)| *edge_source)
+            .collect::<HashSet<_>>();
+
+        // 1. Verify that all parents and children to disconnect are directly connected to the target segment.
+        if let Some(parents_to_disconnect) = parents_to_disconnect.as_ref() {
+            for selector in parents_to_disconnect {
+                if !available_parents.contains(&selector.id) {
+                    return Err(anyhow!(
+                        "Invalid parent delimitation: requested parent is not a direct parent of target.parent"
+                    ));
+                }
+            }
         }
 
-        // Connect all the children to all parents.
+        if let Some(children_to_disconnect) = children_to_disconnect.as_ref() {
+            for selector in children_to_disconnect {
+                if !available_children.contains(&selector.id) {
+                    return Err(anyhow!(
+                        "Invalid parent delimitation: requested child is not a direct parent of target.child"
+                    ));
+                }
+            }
+        }
+
+        let parent_ids_to_disconnect = parents_to_disconnect
+            .as_ref()
+            .map(|parents| parents.iter().map(|s| s.id).collect::<HashSet<_>>());
+        let child_ids_to_disconnect = children_to_disconnect
+            .as_ref()
+            .map(|children| children.iter().map(|s| s.id).collect::<HashSet<_>>());
+
+        let mut disconnected_parent_edges = Vec::new();
+        // 2. Disconnect parents.
+        for (edge_id, edge_weight, edge_target) in outgoing_edges {
+            let should_disconnect = parent_ids_to_disconnect
+                .as_ref()
+                .is_none_or(|ids| ids.contains(&edge_target));
+            if should_disconnect {
+                self.graph.remove_edge(edge_id);
+                disconnected_parent_edges.push((edge_weight, edge_target));
+            }
+        }
+
+        // 3. Disconnect children and reconnect to the disconnected parents.
         for (edge_id, _, edge_source) in incoming_edges {
-            self.graph.remove_edge(edge_id);
-            for (_, parent_edge_weight, parent_edge_target) in &outgoing_edges {
-                self.graph
-                    .add_edge(edge_source, *parent_edge_target, parent_edge_weight.clone());
+            let should_disconnect = child_ids_to_disconnect
+                .as_ref()
+                .is_none_or(|ids| ids.contains(&edge_source));
+            if should_disconnect {
+                self.reconnect_edges_to_parents(&disconnected_parent_edges, edge_id, edge_source);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove the child edge, and reconnect to the right parents.
+    fn reconnect_edges_to_parents(
+        &mut self,
+        disconnected_parent_edges: &[(Edge, petgraph::prelude::NodeIndex)],
+        child_edge_id: petgraph::prelude::EdgeIndex,
+        child_node: petgraph::prelude::NodeIndex,
+    ) {
+        // Remove the child edge.
+        self.graph.remove_edge(child_edge_id);
+        // Reconnect the child node to all the disconnected parents.
+        for (parent_edge_weight, edge_target) in disconnected_parent_edges {
+            self.graph
+                .add_edge(child_node, *edge_target, parent_edge_weight.clone());
+        }
+    }
+
+    /// Insert a segement relative to a selector.
+    ///
+    /// The segment is described by its delimiter: First (parent-most) and last (child-most) node.
+    ///
+    /// If inserted above, all the target selector's children will be disconnected and reconnected to the last
+    /// node of the segment.
+    ///
+    pub fn insert_segment<C, P>(
+        &mut self,
+        target: impl ToSelector,
+        delimiter: SegmentDelimiter<C, P>,
+        side: InsertSide,
+    ) -> Result<()>
+    where
+        C: ToSelector,
+        P: ToSelector,
+    {
+        let SegmentDelimiter { child, parent } = delimiter;
+        let target = self.history.normalize_selector(target.to_selector(self)?)?;
+        let child = self.history.normalize_selector(child.to_selector(self)?)?;
+        let parent = self.history.normalize_selector(parent.to_selector(self)?)?;
+
+        match side {
+            InsertSide::Above => {
+                // Children edges of target.
+                let edges = self
+                    .graph
+                    .edges_directed(target.id, Direction::Incoming)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.source()))
+                    .collect::<Vec<_>>();
+
+                // Connect all target's children with the child-most node in the given segment.
+                for (edge_id, edge_weight, edge_source) in edges {
+                    self.graph.remove_edge(edge_id);
+                    // TODO: we should test for weight collisions
+                    self.graph.add_edge(edge_source, child.id, edge_weight);
+                }
+
+                // Connect the target to the parent-most node in the given segment.
+                // TODO: we should test for weight collisions
+                self.graph.add_edge(parent.id, target.id, Edge { order: 0 });
+            }
+            InsertSide::Below => {
+                let edges = self
+                    .graph
+                    .edges_directed(target.id, Direction::Outgoing)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.target()))
+                    .collect::<Vec<_>>();
+
+                // Connectt all target's parents to the parent-most node in the given segment.
+                for (edge_id, edge_weight, edge_target) in edges {
+                    self.graph.remove_edge(edge_id);
+                    // TODO: we should test for weight collisions
+                    self.graph.add_edge(parent.id, edge_target, edge_weight);
+                }
+
+                // Connect the target to the child-most node in the given segment.
+                // TODO: we should test for weight collisions
+                self.graph.add_edge(target.id, child.id, Edge { order: 0 });
             }
         }
 
@@ -229,5 +509,23 @@ impl Editor {
                 })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn empty_selector_set_creation_fails() {
+        let empty_parent_set = SomeSelectors::new(Vec::<gix::ObjectId>::new())
+            .expect_err("expected empty selector set creation to fail");
+        assert!(
+            empty_parent_set
+                .to_string()
+                .contains("Invalid selector set: This cannot be empty"),
+            "unexpected error: {empty_parent_set:#}"
+        );
     }
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step};
+use but_rebase::graph_rebase::{GraphExt, Step, mutate};
 use but_testsupport::{git_status, visualize_commit_graph_all};
 use gix::prelude::ObjectIdExt;
 
@@ -29,7 +29,12 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
         .select_commit(b)
         .context("Failed to find commit b in editor graph")?;
 
-    editor.disconnect(b_selector, b_selector)?;
+    let target = mutate::SegmentDelimiter {
+        child: b_selector,
+        parent: b_selector,
+    };
+
+    editor.disconnect_segment_from(target, mutate::SelectorSet::All, mutate::SelectorSet::All)?;
     editor.replace(b_selector, Step::None)?;
 
     let outcome = editor.rebase()?;
@@ -69,7 +74,16 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
         .select_commit(a)
         .context("Failed to find commit a in editor graph")?;
 
-    editor.disconnect(b_selector, a_selector)?;
+    let delimiter = mutate::SegmentDelimiter {
+        child: b_selector,
+        parent: a_selector,
+    };
+
+    editor.disconnect_segment_from(
+        delimiter,
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::All,
+    )?;
     editor.replace(b_selector, Step::None)?;
     editor.replace(a_selector, Step::None)?;
 
@@ -108,7 +122,16 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
         .select_commit(a)
         .context("Failed to find commit a in editor graph")?;
 
-    editor.disconnect(a_selector, a_selector)?;
+    let delimiter = mutate::SegmentDelimiter {
+        child: a_selector,
+        parent: a_selector,
+    };
+
+    editor.disconnect_segment_from(
+        delimiter,
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::All,
+    )?;
     editor.replace(a_selector, Step::None)?;
 
     let outcome = editor.rebase()?;
@@ -158,7 +181,16 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
         .select_commit(merge)
         .context("Failed to find merge commit M in editor graph")?;
 
-    editor.disconnect(merge_selector, merge_selector)?;
+    let delimiter = mutate::SegmentDelimiter {
+        child: merge_selector,
+        parent: merge_selector,
+    };
+
+    editor.disconnect_segment_from(
+        delimiter,
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::All,
+    )?;
     editor.replace(merge_selector, Step::None)?;
 
     let outcome = editor.rebase()?;
@@ -210,6 +242,373 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
     * 7674a5e (tag: base, main) base
     ");
     insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side() -> Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   d1cc4c7 (HEAD -> with-two-children) tip
+    |\  
+    | * ce6aca9 (C2) C2: second child
+    * | f94f259 (C1) C1: first child
+    |/  
+    *   c5d1178 (M) M: merge two parents
+    |\  
+    | * 392a8f8 (P2) P2: second merge parent
+    * | bc0e772 (P1) P1: first merge parent
+    |/  
+    * 7674a5e (tag: base, main) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let merge = repo.rev_parse_single("M")?.detach();
+    let m_reference = "refs/heads/M".try_into()?;
+    let child_one = repo.rev_parse_single("C1")?.detach();
+    let parent_one = "refs/heads/P1".try_into()?;
+    let m_reference_selector = editor
+        .select_reference(m_reference)
+        .context("Failed to find P1 reference in editor graph")?;
+    let merge_commit_selector = editor
+        .select_commit(merge)
+        .context("Failed to find merge commit M in editor graph")?;
+    let child_one_selector = editor
+        .select_commit(child_one)
+        .context("Failed to find C1 referent in editor graph")?;
+    let parent_one_selector = editor
+        .select_reference(parent_one)
+        .context("Failed to find P1 reference in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: m_reference_selector,
+        parent: merge_commit_selector,
+    };
+
+    editor.disconnect_segment_from(
+        delimiter,
+        mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
+        mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+    )?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    let p1 = repo.rev_parse_single("P1")?.detach();
+    let m = repo.rev_parse_single("M")?.detach();
+    let c1_expected_parents = HashSet::from([p1]);
+    let c2_expected_parents = HashSet::from([m]);
+
+    let c1 = repo.rev_parse_single("C1")?.detach();
+    let c1_commit = but_core::Commit::from_id(c1.attach(&repo))?;
+    let c1_parents = c1_commit
+        .inner
+        .parents
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        c1_parents, c1_expected_parents,
+        "C1 should have both merge parents after removing M"
+    );
+
+    let c2 = repo.rev_parse_single("C2")?.detach();
+    let c2_commit = but_core::Commit::from_id(c2.attach(&repo))?;
+    let c2_parents = c2_commit
+        .inner
+        .parents
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        c2_parents, c2_expected_parents,
+        "C2 should have both merge parents after removing M"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   3305e26 (HEAD -> with-two-children) tip
+    |\  
+    | * 0e87cd3 (C2) C2: second child
+    | * 3089592 (M) M: merge two parents
+    | * 392a8f8 (P2) P2: second merge parent
+    * | f928700 (C1) C1: first child
+    * | bc0e772 (P1) P1: first merge parent
+    |/  
+    * 7674a5e (tag: base, main) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+#[test]
+fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   d1cc4c7 (HEAD -> with-two-children) tip
+    |\  
+    | * ce6aca9 (C2) C2: second child
+    * | f94f259 (C1) C1: first child
+    |/  
+    *   c5d1178 (M) M: merge two parents
+    |\  
+    | * 392a8f8 (P2) P2: second merge parent
+    * | bc0e772 (P1) P1: first merge parent
+    |/  
+    * 7674a5e (tag: base, main) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let merge = repo.rev_parse_single("M")?.detach();
+    let m_reference = "refs/heads/M".try_into()?;
+    let parent_one = "refs/heads/P1".try_into()?;
+    let m_reference_selector = editor
+        .select_reference(m_reference)
+        .context("Failed to find P1 reference in editor graph")?;
+    let merge_commit_selector = editor
+        .select_commit(merge)
+        .context("Failed to find merge commit M in editor graph")?;
+    let parent_one_selector = editor
+        .select_reference(parent_one)
+        .context("Failed to find P1 reference in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: m_reference_selector,
+        parent: merge_commit_selector,
+    };
+
+    editor.disconnect_segment_from(
+        delimiter,
+        mutate::SelectorSet::None,
+        mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+    )?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    let p1 = repo.rev_parse_single("P1")?.detach();
+    let p2 = repo.rev_parse_single("P2")?.detach();
+    let m = repo.rev_parse_single("M")?.detach();
+    let c1 = repo.rev_parse_single("C1")?.detach();
+    let c2 = repo.rev_parse_single("C2")?.detach();
+
+    let c1_commit = but_core::Commit::from_id(c1.attach(&repo))?;
+    let c1_parents = c1_commit
+        .inner
+        .parents
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        c1_parents,
+        HashSet::from([m]),
+        "C1 should have M as its only parent"
+    );
+
+    let c2_commit = but_core::Commit::from_id(c2.attach(&repo))?;
+    let c2_parents = c2_commit
+        .inner
+        .parents
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        c2_parents,
+        HashSet::from([m]),
+        "C2 should have M as its only parent"
+    );
+
+    let m_commit = but_core::Commit::from_id(m.attach(&repo))?;
+    let m_parents = m_commit
+        .inner
+        .parents
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        m_parents,
+        HashSet::from([p2]),
+        "M should have P2 as its only parent"
+    );
+
+    let refs_to_check = ["with-two-children", "C1", "C2", "M", "P2", "P1", "base"];
+    for reference in refs_to_check {
+        let commit_id = repo.rev_parse_single(reference)?.detach();
+        let commit = but_core::Commit::from_id(commit_id.attach(&repo))?;
+        assert!(
+            !commit.inner.parents.contains(&p1),
+            "{reference} should not list P1 as a parent"
+        );
+    }
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * bc0e772 (P1) P1: first merge parent
+    | *   2eac185 (HEAD -> with-two-children) tip
+    | |\  
+    | | * 0e87cd3 (C2) C2: second child
+    | * | 76e6d3c (C1) C1: first child
+    | |/  
+    | * 3089592 (M) M: merge two parents
+    | * 392a8f8 (P2) P2: second merge parent
+    |/  
+    * 7674a5e (tag: base, main) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn disconnect_fails_when_parents_to_disconnect_is_none() -> Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+
+    let before = visualize_commit_graph_all(&repo)?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let merge = repo.rev_parse_single("M")?.detach();
+    let m_reference = "refs/heads/M".try_into()?;
+    let child_one = repo.rev_parse_single("C1")?.detach();
+    let m_reference_selector = editor
+        .select_reference(m_reference)
+        .context("Failed to find M reference in editor graph")?;
+    let merge_commit_selector = editor
+        .select_commit(merge)
+        .context("Failed to find merge commit M in editor graph")?;
+    let child_one_selector = editor
+        .select_commit(child_one)
+        .context("Failed to find C1 referent in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: m_reference_selector,
+        parent: merge_commit_selector,
+    };
+
+    let err = editor
+        .disconnect_segment_from(
+            delimiter,
+            mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
+            mutate::SelectorSet::None,
+        )
+        .expect_err("expected disconnect to fail for parents=SelectorSet::None");
+    assert!(
+        err.to_string()
+            .contains("Invalid parents to disconnect: SelectorSet::None is not allowed"),
+        "unexpected error: {err:#}"
+    );
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    let after = visualize_commit_graph_all(&repo)?;
+    assert_eq!(before, after, "graph should remain unchanged on failure");
+
+    Ok(())
+}
+
+#[test]
+fn disconnect_fails_fast_if_parent_to_disconnect_is_not_direct_parent() -> Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+
+    let before = visualize_commit_graph_all(&repo)?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let merge = repo.rev_parse_single("M")?.detach();
+    let m_reference = "refs/heads/M".try_into()?;
+    let child_one = repo.rev_parse_single("C1")?.detach();
+    let m_reference_selector = editor
+        .select_reference(m_reference)
+        .context("Failed to find M reference in editor graph")?;
+    let merge_commit_selector = editor
+        .select_commit(merge)
+        .context("Failed to find merge commit M in editor graph")?;
+    let child_one_selector = editor
+        .select_commit(child_one)
+        .context("Failed to find C1 referent in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: m_reference_selector,
+        parent: merge_commit_selector,
+    };
+
+    let err = editor
+        .disconnect_segment_from(
+            delimiter,
+            mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
+            mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
+        )
+        .expect_err("expected disconnect to fail for non-parent selector");
+    assert!(
+        err.to_string()
+            .contains("requested parent is not a direct parent"),
+        "unexpected error: {err:#}"
+    );
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    let after = visualize_commit_graph_all(&repo)?;
+    assert_eq!(before, after, "graph should remain unchanged on failure");
+
+    Ok(())
+}
+
+#[test]
+fn disconnect_fails_fast_if_child_to_disconnect_is_not_direct_child() -> Result<()> {
+    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+
+    let before = visualize_commit_graph_all(&repo)?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let merge = repo.rev_parse_single("M")?.detach();
+    let m_reference = "refs/heads/M".try_into()?;
+    let parent_one = "refs/heads/P1".try_into()?;
+    let m_reference_selector = editor
+        .select_reference(m_reference)
+        .context("Failed to find M reference in editor graph")?;
+    let merge_commit_selector = editor
+        .select_commit(merge)
+        .context("Failed to find merge commit M in editor graph")?;
+    let parent_one_selector = editor
+        .select_reference(parent_one)
+        .context("Failed to find P1 reference in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: m_reference_selector,
+        parent: merge_commit_selector,
+    };
+
+    let err = editor
+        .disconnect_segment_from(
+            delimiter,
+            mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+            mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+        )
+        .expect_err("expected disconnect to fail for non-child selector");
+    assert!(
+        err.to_string()
+            .contains("requested child is not a direct parent"),
+        "unexpected error: {err:#}"
+    );
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    let after = visualize_commit_graph_all(&repo)?;
+    assert_eq!(before, after, "graph should remain unchanged on failure");
 
     Ok(())
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -1,0 +1,28 @@
+//! These tests exercise the insert segment operation.
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+use but_graph::Graph;
+use but_rebase::graph_rebase::{GraphExt, Step, mutate};
+use but_testsupport::{git_status, visualize_commit_graph_all};
+use gix::prelude::ObjectIdExt;
+
+use crate::utils::{fixture_writable, standard_options};
+
+#[test]
+fn insert_single_node_segment_above() -> Result<()> {
+    let (repo, _tmp, _meta) = fixture_writable("three-branches-merged")?;
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/
+    * / add59d2 (A) A: 10 lines on top
+    |/
+    * 8f0d338 (tag: base) base
+    ");
+}


### PR DESCRIPTION
Re-implement the diconnect functionality in the following way:

- `target`: We define a segment we want to disconnect, by the top and
  bottom nodes
- `from`: We define where we want to disconnect the segment from. This
  needs to be a direct parent of the target.
  
  If we start with a graph like this:

  There's a merge commit (M) with two parents P1 and P2, and two children C1 and C2.
  
```
*   d1cc4c7 (HEAD -> with-two-children) tip
|\  
| * ce6aca9 (C2) C2: second child
* | f94f259 (C1) C1: first child
|/  
*   c5d1178 (M) M: merge two parents
|\  
| * 392a8f8 (P2) P2: second merge parent
* | bc0e772 (P1) P1: first merge parent
|/  
* 7674a5e (tag: base, main) base
```

And then we disconnect M from the following parent:

```
child: C1
parent: P1
```
You get this:
```
*   3305e26 (HEAD -> with-two-children) tip
|\  
| * 0e87cd3 (C2) C2: second child
| * 3089592 (M) M: merge two parents
| * 392a8f8 (P2) P2: second merge parent
* | f928700 (C1) C1: first child
* | bc0e772 (P1) P1: first merge parent
|/  
* 7674a5e (tag: base, main) base
```