### PR TITLE
stage, unstage: support path prefixes

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -987,7 +987,7 @@ pub(crate) fn handle_amend(
 }
 
 /// Handler for `but stage <file_or_hunk> <branch>` - runs `but rub <file_or_hunk> <branch>`
-/// Validates that file_or_hunk is uncommitted and branch is a branch.
+/// Validates that file_or_hunk is uncommitted or a path prefix, and that branch is a branch.
 pub(crate) fn handle_stage(
     ctx: &mut Context,
     out: &mut OutputChannel,
@@ -998,10 +998,10 @@ pub(crate) fn handle_stage(
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
     let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)?;
 
-    // Validate that all files are uncommitted
+    // Validate that all files are uncommitted or a path prefix
     for file in &files {
         match file {
-            CliId::Uncommitted(_) => {
+            CliId::Uncommitted(_) | CliId::PathPrefix { .. } => {
                 // Valid type for stage
             }
             _ => {
@@ -1142,7 +1142,8 @@ pub(crate) fn handle_stage_tui(
 }
 
 /// Handler for `but unstage <file_or_hunk> [branch]` - runs `but rub <file_or_hunk> zz`
-/// Validates that file_or_hunk is uncommitted. Optionally validates it's assigned to the specified branch.
+/// Validates that file_or_hunk is uncommitted or a path prefix. Optionally
+/// validates it's assigned to the specified branch.
 pub(crate) fn handle_unstage(
     ctx: &mut Context,
     out: &mut OutputChannel,
@@ -1152,10 +1153,10 @@ pub(crate) fn handle_unstage(
     let id_map = IdMap::new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
 
-    // Validate that all files are uncommitted
+    // Validate that all files are uncommitted or a path prefix
     for file in &files {
         match file {
-            CliId::Uncommitted(_) => {
+            CliId::Uncommitted(_) | CliId::PathPrefix { .. } => {
                 // Valid type for unstage
             }
             _ => {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -365,6 +365,10 @@ impl<'a> Node<'a> for &'a StackWithId {
         id_map: &'a IdMap,
         _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        // Parse known suffixes.
+        if element.ends_with('/') {
+            return Ok(id_map.parse_uncommitted_path_prefix(self.id, element));
+        }
         for uncommitted_file in id_map.uncommitted_files.values() {
             let hunk_assignment = uncommitted_file.hunk_assignments.first();
             // TODO once the set of allowed CLI IDs is determined and the

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -569,6 +569,23 @@ fn stage_command() -> anyhow::Result<()> {
 }
 
 #[test]
+fn stage_command_path_prefix() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("path/a.txt", "text\n");
+    env.but("stage path/ A")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Staged hunk(s) → [A].
+
+"#]]);
+    Ok(())
+}
+
+#[test]
 fn unstage_command() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
 
@@ -625,6 +642,28 @@ fn unstage_command() -> anyhow::Result<()> {
 
 "#]]);
 
+    Ok(())
+}
+
+#[test]
+fn unstage_command_path_prefix() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    env.file("path/a.txt", "text\n");
+
+    // First stage the file to A
+    env.but("stage path/a.txt A").assert().success();
+
+    // Now unstage it, giving a path prefix
+    env.but("unstage A@{stack}:path/ A")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Unstaged hunk(s)
+
+"#]]);
     Ok(())
 }
 


### PR DESCRIPTION
Support path prefixes in the `stage` and `unstage` commands.