### PR TITLE
Numeric indexes for hunks (`fileid:number`)

### DIFF
--- a/crates/but/src/command/legacy/status/assignment.rs
+++ b/crates/but/src/command/legacy/status/assignment.rs
@@ -38,7 +38,7 @@ impl FileAssignment {
                     })
                     .assignments
             };
-            for hunk_assignment in &uncommitted_file.hunk_assignments {
+            for hunk_assignment in uncommitted_file.hunk_assignments() {
                 assignments.push(CLIHunkAssignment {
                     inner: hunk_assignment.clone(),
                     cli_id: uncommitted_file.short_id.clone(),

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -370,7 +370,8 @@ impl<'a> Node<'a> for &'a StackWithId {
             return Ok(id_map.parse_uncommitted_path_prefix(self.id, element));
         }
         for uncommitted_file in id_map.uncommitted_files.values() {
-            let hunk_assignment = uncommitted_file.hunk_assignments.first();
+            let hunk_assignments = uncommitted_file.hunk_assignments();
+            let hunk_assignment = hunk_assignments.first();
             // TODO once the set of allowed CLI IDs is determined and the
             // access patterns of `uncommitted_files` are known, change its data
             // structure to be more efficient than the current linear search.
@@ -465,7 +466,8 @@ impl IdMap {
                 reverse_hex,
                 UncommittedFile {
                     short_id: ShortId::default(),
-                    hunk_assignments,
+                    short_id_hunk_assignments: hunk_assignments
+                        .map(|hunk_assignment| (ShortId::default(), hunk_assignment)),
                 },
             );
             // Skip an ID for stability of other IDs below with respect to older
@@ -486,10 +488,13 @@ impl IdMap {
         assign_short_ids(&mut reverse_hex_short_ids)?;
 
         let mut uncommitted_hunks = HashMap::new();
-        for uncommitted_file in uncommitted_files.values() {
-            for hunk_assignment in uncommitted_file.hunk_assignments.iter() {
+        for uncommitted_file in uncommitted_files.values_mut() {
+            for (short_id, hunk_assignment) in uncommitted_file.short_id_hunk_assignments.iter_mut()
+            {
+                let new_short_id = id_usage.next_available()?.to_short_id();
+                short_id.push_str(&new_short_id);
                 uncommitted_hunks.insert(
-                    id_usage.next_available()?.to_short_id(),
+                    new_short_id,
                     UncommittedHunk {
                         hunk_assignment: hunk_assignment.clone(),
                     },
@@ -573,7 +578,8 @@ impl IdMap {
     ) -> Vec<Box<dyn Node<'a> + 'a>> {
         let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();
         for uncommitted_file in self.uncommitted_files.values() {
-            let hunk_assignment = uncommitted_file.hunk_assignments.first();
+            let hunk_assignments = uncommitted_file.hunk_assignments();
+            let hunk_assignment = hunk_assignments.first();
             // TODO once the set of allowed CLI IDs is determined and the
             // access patterns of `uncommitted_files` are known, change its data
             // structure to be more efficient than the current linear search.
@@ -1066,25 +1072,33 @@ pub struct UncommittedFile {
     pub short_id: ShortId,
     /// Every element has the same [HunkAssignment::stack_id] and [HunkAssignment::path_bytes],
     /// so the first assignment can be used to obtain both.
-    pub hunk_assignments: NonEmpty<HunkAssignment>,
+    pub short_id_hunk_assignments: NonEmpty<(ShortId, HunkAssignment)>,
 }
 
 impl UncommittedFile {
     /// Return the file's stack if it is associated to one, or `None` if the Stack is unknown/has no ID.
     pub fn stack_id(&self) -> Option<StackId> {
-        self.hunk_assignments.first().stack_id
+        self.hunk_assignments().first().stack_id
     }
     /// The path of the uncommitted file.
     pub fn path(&self) -> &BStr {
-        self.hunk_assignments.first().path_bytes.as_ref()
+        self.hunk_assignments().first().path_bytes.as_ref()
     }
     /// Turn this instance into a [CliId].
     pub fn to_id(&self) -> CliId {
         CliId::Uncommitted(UncommittedCliId {
-            hunk_assignments: self.hunk_assignments.clone(),
+            hunk_assignments: self
+                .hunk_assignments()
+                .map(|hunk_assignment| hunk_assignment.to_owned()),
             id: self.short_id.clone(),
             is_entire_file: true,
         })
+    }
+    /// Hunk assignments.
+    pub fn hunk_assignments(&self) -> NonEmpty<&HunkAssignment> {
+        self.short_id_hunk_assignments
+            .as_ref()
+            .map(|(_, hunk_assignment)| hunk_assignment)
     }
 }
 impl<'a> Node<'a> for &'a UncommittedFile {
@@ -1104,7 +1118,9 @@ impl<'a> Node<'a> for &'a UncommittedFile {
     ) -> anyhow::Result<Option<CliId>> {
         Ok(Some(CliId::Uncommitted(UncommittedCliId {
             id: self.short_id.clone(),
-            hunk_assignments: self.hunk_assignments.clone(),
+            hunk_assignments: self
+                .hunk_assignments()
+                .map(|hunk_assignment| hunk_assignment.to_owned()),
             is_entire_file: true,
         })))
     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -7,6 +7,7 @@
 #![forbid(missing_docs)]
 
 use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr as _;
 
 use bstr::{BStr, BString, ByteSlice};
 use but_core::{ChangeId, ref_metadata::StackId};
@@ -1104,10 +1105,20 @@ impl UncommittedFile {
 impl<'a> Node<'a> for &'a UncommittedFile {
     fn parse(
         self: Box<Self>,
-        _element: &str,
+        element: &str,
         _id_map: &'a IdMap,
         _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        if let Ok(index) = usize::from_str(element)
+            && let Some((short_id, hunk_assignment)) = self.short_id_hunk_assignments.get(index)
+        {
+            let cli_id = CliId::Uncommitted(UncommittedCliId {
+                id: short_id.to_owned(),
+                hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),
+                is_entire_file: false,
+            });
+            return Ok(vec![Box::new(Leaf { cli_id })]);
+        }
         Ok(Vec::new())
     }
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -790,10 +790,26 @@ impl IdMap {
     ) -> anyhow::Result<Vec<CliId>> {
         let mut cli_ids = Vec::new();
         if let Some((lhs, rhs)) = entity.split_once(':') {
-            for node in self.parse_element(lhs)? {
-                for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
-                    if let Some(cli_id) = node.to_cli_id(entity, self)? {
-                        cli_ids.push(cli_id);
+            if let Some((mhs, rhs)) = rhs.rsplit_once(':') {
+                // 2 colons is the limit. This allows filenames with
+                // colons to be specified in the middle part (e.g.
+                // `a:filename:with:colon:b` will parse to `a`,
+                // `filename:with:colon`, `b`).
+                for node in self.parse_element(lhs)? {
+                    for node in node.parse(mhs, self, &mut changes_in_commit_fn)? {
+                        for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
+                            if let Some(cli_id) = node.to_cli_id(entity, self)? {
+                                cli_ids.push(cli_id);
+                            }
+                        }
+                    }
+                }
+            } else {
+                for node in self.parse_element(lhs)? {
+                    for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
+                        if let Some(cli_id) = node.to_cli_id(entity, self)? {
+                            cli_ids.push(cli_id);
+                        }
                     }
                 }
             }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1332,6 +1332,33 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         ),
     ]
     "#);
+    // Files can also be accessed through zz
+    insta::assert_debug_snapshot!(id_map.parse("zz:uncommitted1.txt:0", Box::new(changed_paths_fn))?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "j0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
 
     Ok(())
 }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1256,6 +1256,87 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
 }
 
 #[test]
+fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
+    let stacks = vec![Stack {
+        id: Some(StackId::from_number_for_testing(1)),
+        ..stack([segment("foo", [id(2)], Some(id(1)), [])])
+    }];
+    let hunk_assignments = vec![
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-1,2", "+1,2")),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-3,2", "+3,2")),
+            ..hunk_assignment("uncommitted1.txt", None)
+        },
+        hunk_assignment("uncommitted2.txt", None),
+    ];
+    let id_map = IdMap::new(stacks, hunk_assignments)?;
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+
+    insta::assert_debug_snapshot!(id_map.parse("uncommitted1.txt:0", Box::new(changed_paths_fn))?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "j0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+    // Short IDs for the filename part also work; should return exactly the same as above
+    insta::assert_debug_snapshot!(id_map.parse("ro:0", Box::new(changed_paths_fn))?, @r#"
+    [
+        Uncommitted(
+            UncommittedCliId {
+                id: "j0",
+                hunk_assignments: NonEmpty {
+                    head: HunkAssignment {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        stack_id: None,
+                        hunk_locks: None,
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
+                    tail: [],
+                },
+                is_entire_file: false,
+            },
+        ),
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn commit_matches_are_deduplicated_by_commit_oid() -> anyhow::Result<()> {
     let commit_id = id(2);
     let stacks = vec![stack([segment(


### PR DESCRIPTION
@krlvi we talked about this previously and I was worried about filenames with colons in them, but I think I found a solution (limit the number of colons to 2). I'm going to automerge this, but we can change things if you want. If this works, what do you think about removing the old autogenerated IDs (e.g. `g0`) and using the colon IDs (e.g. `kl:0`) throughout?