### PR TITLE
graph editor: insert segment

### DIFF
--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -418,16 +418,46 @@ impl Editor {
                     .map(|e| (e.id(), e.weight().to_owned(), e.source()))
                     .collect::<Vec<_>>();
 
+                // Find the child node of the highest order from the child-most node in the segment being inserted.
+                let chubbiest_grand_child = self
+                    .graph
+                    .edges_directed(child.id, Direction::Incoming)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.source()))
+                    .max_by_key(|gc| gc.1.order);
+
                 // Connect all target's children with the child-most node in the given segment.
                 for (edge_id, edge_weight, edge_source) in edges {
                     self.graph.remove_edge(edge_id);
-                    // TODO: we should test for weight collisions
-                    self.graph.add_edge(edge_source, child.id, edge_weight);
+                    // Avoid weight collision by adding the order value of the highest order child plus one,
+                    // accommodating for order 0.
+                    let new_weight =
+                        if let Some((_, grand_child_weight, _)) = chubbiest_grand_child.as_ref() {
+                            Edge {
+                                order: edge_weight.order + grand_child_weight.order + 1,
+                            }
+                        } else {
+                            edge_weight
+                        };
+                    self.graph.add_edge(edge_source, child.id, new_weight);
                 }
 
+                // Find the parent node of the highest order from the parent-most node in the segment being inserted.
+                let chubbiest_grand_parent = self
+                    .graph
+                    .edges_directed(parent.id, Direction::Outgoing)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.target()))
+                    .max_by_key(|gc| gc.1.order);
+
+                let new_weight =
+                    if let Some((_, grand_parent_weight, _)) = chubbiest_grand_parent.as_ref() {
+                        Edge {
+                            order: grand_parent_weight.order + 1,
+                        }
+                    } else {
+                        Edge { order: 0 }
+                    };
                 // Connect the target to the parent-most node in the given segment.
-                // TODO: we should test for weight collisions
-                self.graph.add_edge(parent.id, target.id, Edge { order: 0 });
+                self.graph.add_edge(parent.id, target.id, new_weight);
             }
             InsertSide::Below => {
                 let edges = self
@@ -436,16 +466,47 @@ impl Editor {
                     .map(|e| (e.id(), e.weight().to_owned(), e.target()))
                     .collect::<Vec<_>>();
 
-                // Connectt all target's parents to the parent-most node in the given segment.
+                // Find the parent node of the highest order from the parent-most node in the segment being inserted.
+                let chubbiest_grand_parent = self
+                    .graph
+                    .edges_directed(parent.id, Direction::Outgoing)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.target()))
+                    .max_by_key(|gc| gc.1.order);
+
+                // Connect all target's parents to the parent-most node in the given segment.
                 for (edge_id, edge_weight, edge_target) in edges {
                     self.graph.remove_edge(edge_id);
-                    // TODO: we should test for weight collisions
-                    self.graph.add_edge(parent.id, edge_target, edge_weight);
+                    // Avoid weight collision by adding the order value of the highest order parent plus one,
+                    // accommodating for order 0.
+                    let new_weight = if let Some((_, grand_parent_weight, _)) =
+                        chubbiest_grand_parent.as_ref()
+                    {
+                        Edge {
+                            order: edge_weight.order + grand_parent_weight.order + 1,
+                        }
+                    } else {
+                        edge_weight
+                    };
+                    self.graph.add_edge(parent.id, edge_target, new_weight);
                 }
 
+                // Find the child node of the highest order from the child-most node in the segment being inserted.
+                let chubbiest_grand_child = self
+                    .graph
+                    .edges_directed(child.id, Direction::Incoming)
+                    .map(|e| (e.id(), e.weight().to_owned(), e.source()))
+                    .max_by_key(|gc| gc.1.order);
+
+                let new_weight =
+                    if let Some((_, grand_child_weight, _)) = chubbiest_grand_child.as_ref() {
+                        Edge {
+                            order: grand_child_weight.order + 1,
+                        }
+                    } else {
+                        Edge { order: 0 }
+                    };
                 // Connect the target to the child-most node in the given segment.
-                // TODO: we should test for weight collisions
-                self.graph.add_edge(target.id, child.id, Edge { order: 0 });
+                self.graph.add_edge(target.id, child.id, new_weight);
             }
         }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -1,28 +1,254 @@
 //! These tests exercise the insert segment operation.
-use std::collections::HashSet;
-
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step, mutate};
-use but_testsupport::{git_status, visualize_commit_graph_all};
-use gix::prelude::ObjectIdExt;
+use but_rebase::graph_rebase::{GraphExt, mutate};
+use but_testsupport::{git_status, visualize_commit_graph, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn insert_single_node_segment_above() -> Result<()> {
-    let (repo, _tmp, _meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
-    |\ \
+    |\ \  
     | | * 930563a (C) C: add another 10 lines to new file
     | | * 68a2fc3 C: add 10 lines to new file
     | | * 984fd1c C: new file with 10 lines
     | * | a748762 (B) B: another 10 lines at the bottom
     | * | 62e05ba B: 10 lines at the bottom
-    | |/
+    | |/  
     * / add59d2 (A) A: 10 lines on top
-    |/
+    |/  
     * 8f0d338 (tag: base) base
     ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let a_selector = editor
+        .select_commit(a)
+        .context("Failed to find commit a in editor graph")?;
+    let b = "refs/heads/B".try_into()?;
+    let b_selector = editor
+        .select_reference(b)
+        .context("Failed to find reference b in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: a_selector,
+        parent: a_selector,
+    };
+
+    editor.insert_segment(b_selector, delimiter, mutate::InsertSide::Above)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   5ae394a (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\  
+    | * 930563a (C) C: add another 10 lines to new file
+    | * 68a2fc3 C: add 10 lines to new file
+    | * 984fd1c C: new file with 10 lines
+    * |   77b07be (A) A: 10 lines on top
+    |\ \  
+    | |/  
+    |/|   
+    | * a748762 (B) B: another 10 lines at the bottom
+    | * 62e05ba B: 10 lines at the bottom
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn insert_single_node_segment_below() -> Result<()> {
+    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \  
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/  
+    * / add59d2 (A) A: 10 lines on top
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let a_selector = editor
+        .select_commit(a)
+        .context("Failed to find commit a in editor graph")?;
+    let b = repo.rev_parse_single("B")?.detach();
+    let b_selector = editor
+        .select_commit(b)
+        .context("Failed to find commit b in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: a_selector,
+        parent: a_selector,
+    };
+
+    editor.insert_segment(b_selector, delimiter, mutate::InsertSide::Below)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   e22f751 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \  
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | 743ea2e (B) B: another 10 lines at the bottom
+    |/ /  
+    * |   507ce96 (A) A: 10 lines on top
+    |\ \  
+    | |/  
+    |/|   
+    | * 62e05ba B: 10 lines at the bottom
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn insert_multi_node_segment_above() -> Result<()> {
+    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \  
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/  
+    * / add59d2 (A) A: 10 lines on top
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let a_selector = editor
+        .select_commit(a)
+        .context("Failed to find commit a in editor graph")?;
+    let b = repo.rev_parse_single("B")?.detach();
+    let b_selector = editor
+        .select_commit(b)
+        .context("Failed to find commit b in editor graph")?;
+    let b_parent = repo.rev_parse_single("B~")?.detach();
+    let b_parent_selector = editor
+        .select_commit(b_parent)
+        .context("Failed to find parent of commit b in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: b_selector,
+        parent: b_parent_selector,
+    };
+
+    editor.insert_segment(a_selector, delimiter, mutate::InsertSide::Above)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   b7346f3 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\  
+    | * 930563a (C) C: add another 10 lines to new file
+    | * 68a2fc3 C: add 10 lines to new file
+    | * 984fd1c C: new file with 10 lines
+    * | 4670c6d (B, A) B: another 10 lines at the bottom
+    * |   1470cfe B: 10 lines at the bottom
+    |\ \  
+    | |/  
+    |/|   
+    | * add59d2 A: 10 lines on top
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn insert_multi_node_segment_below() -> Result<()> {
+    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \  
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/  
+    * / add59d2 (A) A: 10 lines on top
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut editor = graph.to_editor(&repo)?;
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let a_selector = editor
+        .select_commit(a)
+        .context("Failed to find commit a in editor graph")?;
+    let b = repo.rev_parse_single("B")?.detach();
+    let b_selector = editor
+        .select_commit(b)
+        .context("Failed to find commit b in editor graph")?;
+    let b_parent = repo.rev_parse_single("B~")?.detach();
+    let b_parent_selector = editor
+        .select_commit(b_parent)
+        .context("Failed to find parent of commit b in editor graph")?;
+
+    let delimiter = mutate::SegmentDelimiter {
+        child: b_selector,
+        parent: b_parent_selector,
+    };
+
+    editor.insert_segment(a_selector, delimiter, mutate::InsertSide::Below)?;
+
+    let outcome = editor.rebase()?;
+    outcome.materialize()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *-.   78624ea (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \  
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    * | | e4c78ba (A) A: 10 lines on top
+    |/ /  
+    * | a748762 (B) B: another 10 lines at the bottom
+    * | 62e05ba B: 10 lines at the bottom
+    |/  
+    * 8f0d338 (tag: base) base
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -10,6 +10,7 @@ mod conflictable_restriction;
 mod disconnect;
 mod editor_creation;
 mod insert;
+mod insert_segment;
 mod materialize;
 mod multiple_operations;
 mod parents_must_be_references_restriction;


### PR DESCRIPTION
- Insert a segment above or below a target node.
- Avoid edge-weight collisions.
- Test it