### PR TITLE
fix(but): add dummy setsid binary for old macos installer compat

### DIFF
--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -14,6 +14,11 @@ name = "gitbutler-git-askpass"
 path = "src/bin/askpass.rs"
 test = false
 
+[[bin]] # we need this binary only for backwards compatibility with old bundled CLI installers that validate that it's there
+name = "gitbutler-git-setsid"
+path = "src/bin/noop.rs"
+test = false
+
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio"]

--- a/crates/gitbutler-git/src/bin/noop.rs
+++ b/crates/gitbutler-git/src/bin/noop.rs
@@ -1,0 +1,4 @@
+//! This is just a dummy NOOP implementation that is used to produce an effectively empty binary
+//! for backwards compatibility with old installers.
+
+pub fn main() {}

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -20,17 +20,20 @@ CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
 # BINARIES
 ASKPASS="gitbutler-git-askpass"
+SETSID="gitbutler-git-setsid"
 BUT="but"
 
-if [ -f "$TARGET_ROOT/$ASKPASS.exe" ]; then
+if [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ]; then
     log injecting windows gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
+    cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
     if [ -f "$TARGET_ROOT/$BUT.exe" ]; then
       cp -v "$TARGET_ROOT/$BUT.exe" "$CRATE_ROOT/$BUT-${TRIPLE}.exe"
     fi
-elif [ -f "$TARGET_ROOT/$ASKPASS" ]; then
+elif [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/$ASKPASS" "$CRATE_ROOT/$ASKPASS-${TRIPLE}"
+    cp -v "$TARGET_ROOT/$SETSID" "$CRATE_ROOT/$SETSID-${TRIPLE}"
 else
     log gitbutler-git binaries are not built
     exit 1

--- a/crates/gitbutler-tauri/tauri.conf.nightly-local.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly-local.json
@@ -13,7 +13,7 @@
 			"icons/nightly/icon.icns",
 			"icons/nightly/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-askpass"]
+		"externalBin": ["gitbutler-git-askpass", "gitbutler-git-setsid"]
 	},
 	"plugins": {
 		"updater": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -185,10 +185,14 @@ if [ "$OS" = "windows" ]; then
   #          Should it be re-added, please ensure that `but` is built
   #          as part of the 'beforeBuildCommand' in tauri.conf AND it must be injected
   #          via 'inject-git-binaries.sh'.
-  EXTERNAL_BIN='["gitbutler-git-askpass", "but"]'
+  EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid", "but"]'
 	FEATURES="windows"
 else
-  EXTERNAL_BIN='["gitbutler-git-askpass"]'
+  # we need to include the gitbutler-git-setsid dummy binary as
+  # installers bundled with version <=0.19.3 will validate that it's there for macOS.
+  #
+  # As it doesn't hurt on Linux we'll just let it sit there.
+  EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid"]'
 	FEATURES="builtin-but"
 fi
 


### PR DESCRIPTION
The macos installer in version <=0.19.3 validates that the gitbutler-git-setsid binary is present, so we're re-adding it as a dummy binary to ensure that old installers keep working.