### PR TITLE
Updated branch creation implementation.

### DIFF
--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -1,12 +1,12 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
-use anyhow::Result;
-use but_graph::{Commit, CommitFlags, Graph, Segment, SegmentIndex};
+use anyhow::{Result, bail};
+use but_graph::{Commit, Graph, SegmentIndex};
 use petgraph::{Direction, visit::EdgeRef as _};
 
 use crate::graph_rebase::{
     Checkout, Edge, Editor, Pick, RevisionHistory, Selector, Step, StepGraph, StepGraphIndex,
-    SuccessfulRebase,
+    SuccessfulRebase, util,
 };
 
 /// Provides an extension for creating an Editor out of the segment graph
@@ -18,221 +18,214 @@ pub trait GraphExt {
 impl GraphExt for Graph {
     /// Creates an editor out of the segment graph.
     fn to_editor(&self, repo: &gix::Repository) -> Result<Editor> {
-        // TODO(CTO): Look into traversing "in workspace" segments that are not reachable from the entrypoint
-        // TODO(CTO): Look into stopping at the common base
+        // This first creates runs of nodes and associates them with the
+        // but-graph segments. We then do a second pass over all the segments
+        // and use the but_graph to connect up the runs. Finally, we validate
+        // that each Pick step's parents match the commit's actual parents,
+        // and if not, we disconnect and rewire directly to the correct
+        // parent commits.
+
+        // TODO(CTO): Look into traversing "in workspace" segments that are not
+        // reachable from the entrypoint TODO(CTO): Look into stopping at the
+        // common base
         let entrypoint = self.lookup_entrypoint()?;
-
-        // Commits in this list are ordered such that iterating in reverse will
-        // have any relevant parent commits already inserted in the graph.
-        let mut commits: Vec<Commit> = vec![];
-        // References are ordered from child-most to parent-most
-        let mut references: BTreeMap<gix::ObjectId, Vec<gix::refs::FullName>> = BTreeMap::new();
-
-        let mut head_refname = None;
         let workspace_commit_id = self.managed_entrypoint_commit(repo)?.map(|c| c.id);
 
-        let mut segment_ids = vec![];
+        let mut commits: Vec<Commit> = vec![];
+        let mut commit_to_idx = HashMap::<gix::ObjectId, SegmentIndex>::new();
+        let mut commit_to_pick_ix = HashMap::<gix::ObjectId, StepGraphIndex>::new();
+        let mut graph = StepGraph::new();
+        let mut head_selectors = vec![];
+        let mut references = vec![];
+        struct NodeSegment {
+            nodes: Vec<StepGraphIndex>,
+        }
+
+        let mut segments = HashMap::<SegmentIndex, NodeSegment>::new();
 
         self.visit_all_segments_including_start_until(
             entrypoint.segment_index,
             Direction::Outgoing,
             |segment| {
-                segment_ids.push(segment.id);
+                let mut nodes = vec![];
 
-                // Make a note to create a reference for named segments
-                if let Some(refname) = segment.ref_name()
-                    && let Some(commit) = find_nearest_commit(self, segment)
-                {
-                    references
-                        .entry(commit.id)
-                        .and_modify(|rs| rs.push(refname.to_owned()))
-                        .or_insert_with(|| vec![refname.to_owned()]);
-
-                    if head_refname.is_none() {
-                        head_refname = Some(refname.to_owned());
+                if let Some(reference) = segment.ref_name() {
+                    let refname = reference.to_owned();
+                    references.push(refname.clone());
+                    let ix = graph.add_node(Step::Reference {
+                        refname: refname.clone(),
+                    });
+                    if Some(reference) == entrypoint.segment.ref_name() {
+                        head_selectors.push(Selector {
+                            id: ix,
+                            revision: 0,
+                        });
                     }
+                    nodes.push(ix);
                 }
 
-                // Make a note to create a references that sit on commits
                 for commit in &segment.commits {
-                    if !commit.refs.is_empty() {
-                        commit.flags.contains(CommitFlags::InWorkspace);
-                        let refs = commit
-                            .refs
-                            .iter()
-                            .map(|r| r.ref_name.clone())
-                            .collect::<Vec<_>>();
-                        if let Some(entry) = references.get_mut(&commit.id) {
-                            entry.extend(refs);
-                        } else {
-                            references.insert(commit.id, refs);
+                    commits.push(commit.clone());
+                    commit_to_idx.insert(commit.id, segment.id);
+
+                    let refs = commit
+                        .refs
+                        .iter()
+                        .map(|r| r.ref_name.clone())
+                        .collect::<Vec<_>>();
+
+                    for reference in refs {
+                        references.push(reference.to_owned());
+                        let ix = graph.add_node(Step::Reference {
+                            refname: reference.clone(),
+                        });
+                        if let Some(previous_ix) = nodes.last() {
+                            graph.add_edge(*previous_ix, ix, Edge { order: 0 });
                         }
+                        nodes.push(ix);
                     }
+
+                    let pick = if workspace_commit_id == Some(commit.id) {
+                        Pick::new_workspace_pick(commit.id)
+                    } else {
+                        Pick::new_pick(commit.id)
+                    };
+                    let ix = graph.add_node(Step::Pick(pick));
+                    commit_to_pick_ix.insert(commit.id, ix);
+                    if let Some(previous_ix) = nodes.last() {
+                        graph.add_edge(*previous_ix, ix, Edge { order: 0 });
+                    }
+                    nodes.push(ix);
                 }
 
-                commits.extend(segment.commits.clone());
+                if nodes.is_empty() {
+                    tracing::debug!("Empty node added - this is probably impossible");
+                    let ix = graph.add_node(Step::None);
+                    nodes.push(ix);
+                }
+
+                segments.insert(segment.id, NodeSegment { nodes });
 
                 false
             },
         );
 
-        // Used for linking up all the commits.
-        // Each commit is considered to have a top and/or a bottom node. This is
-        // because in the node-adding step we will link together chains of
-        // ordered references on top of their related commits
-        struct StepChain {
-            top: StepGraphIndex,
-            bottom: StepGraphIndex,
-        }
-        let mut steps_for_commits: BTreeMap<gix::ObjectId, StepChain> = BTreeMap::new();
-        let mut graph = StepGraph::new();
-
         let commit_ids = commits.iter().map(|c| c.id).collect::<HashSet<_>>();
-
-        let mut head_selectors = vec![];
 
         for c in &commits {
             let has_no_parents = c.parent_ids.is_empty();
             let missing_parent_steps = c.parent_ids.iter().any(|p| !commit_ids.contains(p));
 
-            // If the commit has parents in the commit graph, but none of
-            // them are in the graph, this means but-graph did a partial
-            // traversal and we want to preserve the commit as it is.
-            let preserved_parents = if !has_no_parents && missing_parent_steps {
-                Some(c.parent_ids.clone())
-            } else {
-                None
-            };
-
-            let mut pick = if Some(c.id) == workspace_commit_id {
-                Pick::new_workspace_pick(c.id)
-            } else {
-                Pick::new_pick(c.id)
-            };
-            pick.preserved_parents = preserved_parents;
-            let mut ni = graph.add_node(Step::Pick(pick));
-            let base_ni = ni;
-
-            // Add and link references on top
-            if let Some(refs) = references.get_mut(&c.id) {
-                // We insert in reverse to preserve the child-most to
-                // parent-most ordering that the frontend sees in the step graph
-                for r in refs.iter().rev() {
-                    let ref_ni = graph.add_node(Step::Reference { refname: r.clone() });
-                    graph.add_edge(ref_ni, ni, Edge { order: 0 });
-                    ni = ref_ni;
-
-                    if Some(r) == head_refname.as_ref() {
-                        head_selectors.push(Selector {
-                            revision: 0,
-                            id: ref_ni,
-                        });
-                    }
-                }
-            }
-
-            steps_for_commits.insert(
-                c.id,
-                StepChain {
-                    top: ni,
-                    bottom: base_ni,
-                },
-            );
-        }
-
-        for sidx in segment_ids {
-            let s = &self[sidx];
-            for (idx, c) in s.commits.iter().enumerate() {
-                let mut parent_ids = if idx == s.commits.len() - 1 {
-                    find_segment_edge_commits(self, sidx)
-                } else {
-                    vec![CommitViaReference {
-                        commit: s.commits[idx + 1].id,
-                        // We always want to point to the references point to a
-                        // commit within a segment.
-                        via_reference: true,
-                    }]
+            // If the commit has parents, but at least one of them is not
+            // in the graph, this means but-graph did a partial traversal
+            // and we want to preserve the commit as it is.
+            if !has_no_parents && missing_parent_steps {
+                let Some(idx) = commit_to_pick_ix.get(&c.id) else {
+                    bail!("BUG: Listed commit does not have corresponding idx.");
                 };
 
-                // It seems like the but-graph doesn't always result in the
-                // parents being ordered correctly, so we need to correct this
-                // from the commit graph.
-                //
-                // I'm not sure on the circumstances that cause this.
-                parent_ids.sort_by_cached_key(|parent| {
-                    c.parent_ids
-                        .iter()
-                        .enumerate()
-                        .find(|id| *id.1 == parent.commit)
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(usize::MAX)
-                });
+                let Step::Pick(pick) = &mut graph[*idx] else {
+                    bail!("BUG: Listed commit does not have corresponding pick step.");
+                };
 
-                // Unless it's the workspace commit which can have virtual
-                // parents, if the parents inferred from the but graph with
-                // their extra information doesn't match reality, then we should
-                // ignore what the but-graph has told us and pull information
-                // from the commit graph directly.
-                if c.parent_ids != parent_ids.iter().map(|p| p.commit).collect::<Vec<_>>()
-                    && Some(c.id) != workspace_commit_id
-                {
-                    if let Some(StepChain { bottom, .. }) = steps_for_commits.get(&c.id)
-                        && let Step::Pick(Pick {
-                            preserved_parents, ..
-                        }) = &graph[*bottom]
-                        && preserved_parents.is_some()
-                    {
-                        // Don't warn if preserved parents is set, we don't need
-                        // to warn.
-                    } else {
-                        tracing::warn!(
-                            "but-graph inconsistent with the commit graph.\nParents for commit {} do not match.\n\nFound:{:?}\nExpected:{:?}\n\nThese IDs may be in memory, but may be helpful for debugging.",
-                            c.id,
-                            parent_ids
-                                .iter()
-                                .map(|p| p.commit.to_string())
-                                .collect::<Vec<_>>(),
-                            c.parent_ids
-                                .iter()
-                                .map(|p| p.to_string())
-                                .collect::<Vec<_>>(),
-                        );
-                    }
+                pick.preserved_parents = Some(c.parent_ids.clone());
+            };
+        }
 
-                    parent_ids = c
-                        .parent_ids
-                        .iter()
-                        .map(|p| CommitViaReference {
-                            commit: *p,
-                            via_reference: true,
-                        })
-                        .collect();
-                }
+        for sidx in segments.keys() {
+            let Some(source) = segments.get(sidx).and_then(|n| n.nodes.last()) else {
+                continue;
+            };
 
-                for (i, p) in parent_ids.iter().enumerate() {
-                    if let (
-                        Some(StepChain { bottom, .. }),
-                        Some(StepChain {
-                            top: top_p,
-                            bottom: bottom_p,
-                        }),
-                    ) = (
-                        steps_for_commits.get(&c.id),
-                        steps_for_commits.get(&p.commit),
-                    ) {
-                        if p.via_reference {
-                            graph.add_edge(*bottom, *top_p, Edge { order: i });
-                        } else {
-                            graph.add_edge(*bottom, *bottom_p, Edge { order: i });
-                        }
-                    }
-                }
+            'inner: for (order, edge) in self
+                .edges_directed(*sidx, Direction::Outgoing)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .enumerate()
+            {
+                let Some(target) = segments.get(&edge.target()).and_then(|n| n.nodes.first())
+                else {
+                    tracing::warn!(
+                        "Dropping parent edge for segment {sidx:?}: edge target {:?} has no nodes",
+                        edge.target()
+                    );
+                    continue 'inner;
+                };
+
+                graph.add_edge(*source, *target, Edge { order });
+            }
+        }
+
+        for c in &commits {
+            if Some(c.id) == workspace_commit_id {
+                continue;
+            }
+
+            let Some(&pick_ix) = commit_to_pick_ix.get(&c.id) else {
+                continue;
+            };
+
+            // Skip commits with preserved parents (partial traversal — already handled above)
+            if let Step::Pick(Pick {
+                preserved_parents: Some(_),
+                ..
+            }) = &graph[pick_ix]
+            {
+                continue;
+            }
+
+            // Resolve what the graph thinks are the parents of this pick
+            let graph_parents = util::collect_ordered_parents(&graph, pick_ix);
+            let graph_parent_ids: Vec<gix::ObjectId> = graph_parents
+                .iter()
+                .filter_map(|idx| match &graph[*idx] {
+                    Step::Pick(Pick { id, .. }) => Some(*id),
+                    _ => None,
+                })
+                .collect();
+
+            if graph_parent_ids == c.parent_ids {
+                continue;
+            }
+
+            tracing::warn!(
+                "but-graph inconsistent with the commit graph.\nParents for commit {} do not match.\n\nFound:{:?}\nExpected:{:?}\n\nThese IDs may be in memory, but may be helpful for debugging.",
+                c.id,
+                graph_parent_ids
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>(),
+                c.parent_ids
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>(),
+            );
+
+            let outgoing_edge_ids: Vec<_> = graph
+                .edges_directed(pick_ix, Direction::Outgoing)
+                .map(|e| e.id())
+                .collect();
+            for edge_id in outgoing_edge_ids {
+                graph.remove_edge(edge_id);
+            }
+
+            'inner: for (order, parent_id) in c.parent_ids.iter().enumerate() {
+                let Some(&target_ix) = commit_to_pick_ix.get(parent_id) else {
+                    tracing::warn!(
+                        "Dropping parent edge for commit {} (parent fix): parent {parent_id} not found in pick map",
+                        c.id
+                    );
+                    continue 'inner;
+                };
+
+                graph.add_edge(pick_ix, target_ix, Edge { order });
             }
         }
 
         Ok(Editor {
             graph,
-            initial_references: references.values().flatten().cloned().collect(),
+            initial_references: references,
             // TODO(CTO): We need to eventually list all worktrees that we own
             // here so we can `safe_checkout` them too.
             checkouts: head_selectors.into_iter().map(Checkout::Head).collect(),
@@ -253,79 +246,4 @@ impl SuccessfulRebase {
             history: self.history,
         }
     }
-}
-
-/// Find the commit that is nearest to the top of the segment via a first parent
-/// traversal.
-fn find_nearest_commit<'graph>(
-    graph: &'graph Graph,
-    segment: &'graph Segment,
-) -> Option<&'graph Commit> {
-    let mut target = Some(segment);
-    while let Some(s) = target {
-        if let Some(c) = s.commits.first() {
-            return Some(c);
-        }
-
-        target = graph
-            .segments_below_in_order(s.id)
-            .next()
-            .map(|s| &graph[s.1]);
-    }
-
-    None
-}
-
-/// When we try to find the parent commits of the bottom commit in a given
-/// segment, did we also encounter a reference that points to the commit.
-struct CommitViaReference {
-    commit: gix::ObjectId,
-    /// Between the source sidx did we encounter a reference that points to the
-    /// commit
-    via_reference: bool,
-}
-
-/// For a given segment, find what the but_graph considers to be the parent
-/// commits.
-///
-/// It also annotates whether a reference was found between the bottom of the
-/// starting sidx and each parent commit.
-fn find_segment_edge_commits(
-    graph: &but_graph::Graph,
-    sidx: SegmentIndex,
-) -> Vec<CommitViaReference> {
-    struct SegmentViaReference {
-        sidx: SegmentIndex,
-        via_reference: bool,
-    }
-
-    let mut potential_parents = graph
-        .edges_directed(sidx, Direction::Outgoing)
-        .map(|p| SegmentViaReference {
-            sidx: p.target(),
-            via_reference: graph[p.target()].ref_name().is_some(),
-        })
-        .collect::<Vec<_>>();
-
-    let mut parents = vec![];
-
-    while let Some(candidate) = potential_parents.pop() {
-        if let Some(commit) = graph[candidate.sidx].commits.first() {
-            parents.push(CommitViaReference {
-                commit: commit.id,
-                via_reference: candidate.via_reference || !commit.refs.is_empty(),
-            });
-            // Don't pursue the children
-            continue;
-        };
-
-        for edge in graph.edges_directed(candidate.sidx, Direction::Outgoing) {
-            potential_parents.push(SegmentViaReference {
-                sidx: edge.target(),
-                via_reference: candidate.via_reference || graph[edge.target()].ref_name().is_some(),
-            });
-        }
-    }
-
-    parents
 }

--- a/crates/but-rebase/tests/fixtures/scenario/workspace-with-three-empty-stacks.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/workspace-with-three-empty-stacks.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+source "$(dirname "$0")/shared.sh"
+
+git init
+
+git commit --allow-empty -m "init"
+
+# All three stacks point to the same base commit (init)
+git update-ref refs/heads/stack-1 HEAD
+git update-ref refs/heads/stack-2 HEAD
+git update-ref refs/heads/stack-3 HEAD
+
+# main advances with Commit X
+git commit --allow-empty -m "Commit X"
+
+# Setup remote tracking for main
+mkdir -p .git/refs/remotes/origin
+cp .git/refs/heads/main .git/refs/remotes/origin/main
+
+cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[branch "main"]
+  remote = "origin"
+  merge = refs/heads/main
+EOF
+
+# Create workspace commit merging all three stacks
+id=$(git commit-tree HEAD^{tree} -p stack-1 -p stack-2 -p stack-3 -m "GitButler Workspace Commit")
+git checkout -b gitbutler/workspace
+git reset --hard $id

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -333,6 +333,57 @@ fn workspace_with_empty_stack() -> Result<()> {
 }
 
 #[test]
+fn workspace_with_three_empty_stacks() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("workspace-with-three-empty-stacks")?;
+
+    add_stack_with_segments(&mut meta, 1, "stack-1", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 2, "stack-2", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 3, "stack-3", StackState::InWorkspace, &[]);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * a26ae77 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 1cf9cf4 (origin/main, main) Commit X
+    |/  
+    * fafd9d0 (stack-3, stack-2, stack-1) init
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    ├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+    │   └── ·a26ae77 (⌂|🏘|01)
+    │       ├── 📙►:4[1]:stack-1
+    │       │   └── ►:3[2]:anon:
+    │       │       └── ·fafd9d0 (⌂|🏘|✓|11)
+    │       ├── 📙►:5[1]:stack-2
+    │       │   └── →:3:
+    │       └── 📙►:6[1]:stack-3
+    │           └── →:3:
+    └── ►:1[0]:origin/main →:2:
+        └── ►:2[1]:main <> origin/main →:1:
+            └── ·1cf9cf4 (⌂|✓|10)
+                └── →:3:
+    ");
+
+    let editor = graph.to_editor(&repo)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/gitbutler/workspace
+    ● a26ae77 GitButler Workspace Commit
+    ├─┬─╮
+    ◎ │ │ refs/heads/stack-1
+    │ ◎ │ refs/heads/stack-2
+    │ │ ◎ refs/heads/stack-3
+    ├─┴─╯
+    ● fafd9d0 init
+    ╵
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn commit_with_two_parents() -> Result<()> {
     let (repo, _tmpdir, meta) = fixture_writable("single-commit")?;
 


### PR DESCRIPTION
This new algorithm is more closely tied to the but graph.

The old algirithm treated references like things that belonged to commits which made it hard to figure out which of the many permutations of inter-reference relations was the one we should express.

This new algirithm has an intermediate step which is more similar to the but-graph represenation which allows us to take the but-graph relations _when_ it’s accurate, before falling back to true commit parantage.