### PR TITLE
Fix svelte related bug where UI can freeze

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -144,6 +144,9 @@
 	const commitQuery = $derived(
 		commitId ? stackService.commitById(stableProjectId, stableStackId, commitId) : undefined,
 	);
+	const commitFiles = $derived(
+		commitId ? stackService.commitChanges(stableProjectId, commitId) : undefined,
+	);
 	const runHooks = $derived(projectRunCommitHooks(stableProjectId));
 	const isCommitView = $derived(!!(branchName && commitId));
 
@@ -606,7 +609,6 @@
 									})
 								: { amendHandler: undefined, squashHandler: undefined, hunkHandler: undefined }}
 						{#if branchName && commitId}
-							{@const commitFiles = stackService.commitChanges(projectId, commitId)}
 							<Dropzone
 								handlers={[amendHandler, squashHandler, hunkHandler].filter(isDefined)}
 								fillHeight


### PR DESCRIPTION
The reactive `commitId` variable updates inside the if statement before
the {if} block, which causes errors on component unmounting. This showed
in the real world when flipping back and forth between commit view and
branch view.