### PR TITLE
but-db: gate future DB rejection on forward-compat version

### DIFF
--- a/crates/but-db/src/cache/table/update.rs
+++ b/crates/but-db/src/cache/table/update.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 
-use crate::{AppCacheHandle, M, Transaction};
+use crate::{AppCacheHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     2026_01_19__15_00_00,
+    SchemaVersion::Zero,
     "CREATE TABLE `update-check`(
     `id` INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
     `checked_at` TIMESTAMP NOT NULL,

--- a/crates/but-db/src/cache/tests.rs
+++ b/crates/but-db/src/cache/tests.rs
@@ -1,4 +1,4 @@
-use crate::M;
+use crate::{M, SchemaVersion};
 
 mod open_with_migrations_infallible {
     use super::{migrations, table_exists};
@@ -58,6 +58,7 @@ mod open_with_migrations_infallible {
 fn migrations() -> impl Iterator<Item = M<'static>> + Clone {
     Some(M::up(
         1,
+        SchemaVersion::Zero,
         "CREATE TABLE `foo`(
             `id` TEXT NOT NULL PRIMARY KEY
         );",

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -14,6 +14,13 @@
 //! final shape of the data, along with the shape of the corresponding Rust structure, which helps with
 //! precision and type-safety.
 //!
+//! Each migration also passes a [`SchemaVersion`] into [`M::up`]. That version is about
+//! forward-compatibility, not ordering. Keep the current version when older binaries can
+//! still open the database safely after the migration, for example when the change is
+//! additive or only affects data that older code ignores. Add the next schema-version
+//! variant only when an older binary must reject the migrated database, for example after
+//! dropping or repurposing persisted data that older code still depends on.
+//!
 //! ## ORM Types - for `Connection` and `Transaction`
 //!
 //! All ORM types are split into read-only and mutating versions, and they are thin wrappers around a
@@ -101,6 +108,31 @@ pub struct M<'a> {
     up: &'a str,
     /// The creation time of the `up` field, in a format like `20250529110746`, so it's suitable for sorting
     up_created_at: u64,
+    /// The forward-compatibility schema version after this migration has been applied.
+    schema_version: SchemaVersion,
+}
+
+/// Documents the forward-compatibility boundary associated with a migration.
+///
+/// The numeric migration id remains the source of truth for ordering. This enum exists so
+/// each migration must state whether it crosses into a new forward-incompatible database
+/// shape or remains readable by older client binaries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SchemaVersion {
+    /// The current forward-compatible schema line.
+    ///
+    /// Keep using `Zero` for migrations that older binaries can still tolerate after the
+    /// migration runs, such as adding tables or columns that they don't require.
+    ///
+    /// Switch to `One` only once a migration makes the database unsafe for binaries that only
+    /// understand `Zero`, such as removing or reinterpreting persisted data they still use.
+    Zero = 0,
+    /// The first forward-incompatible schema line.
+    ///
+    /// Use `One` once a migration requires older `Zero`-only binaries to reject the
+    /// database, and keep using it until the next forward-incompatible boundary is introduced.
+    /// Document here WHY the schema is breaking application forward compatibility.
+    One = 1,
 }
 
 /// A structure to receive an application-wide cache.

--- a/crates/but-db/src/migration.rs
+++ b/crates/but-db/src/migration.rs
@@ -60,30 +60,10 @@ pub fn run<'m>(
     }
 
     // Bail early if our read detects that nothing is to be done
-    let maybe_num_applied_versions = num_applied_versions(&trans, &migrations).ok();
-    if let Some(count) = maybe_num_applied_versions
-        && count == migrations.len()
-        && db_schema_version == application_schema_version
-    {
-        return Ok(0);
-    }
-
-    let db_schema_version = db_forward_compatibility_version(&trans)?;
-    if db_schema_version > application_schema_version {
-        return Err(backoff::Error::permanent(
-            rusqlite::Error::ToSqlConversionFailure(
-                format!(
-                    "Database forward-compatibility version is {db_schema_version}, but this binary only supports up to {application_schema_version}"
-                )
-                .into(),
-            ),
-        ));
-    }
     let should_bump_forward_compatibility_version = db_schema_version != application_schema_version;
-
     let maybe_num_applied_versions = num_applied_versions(&trans, &migrations).ok();
     if let Some(count) = maybe_num_applied_versions
-        && count == migrations.len()
+        && count >= migrations.len()
     {
         if should_bump_forward_compatibility_version {
             set_db_forward_compatibility_version(&trans, application_schema_version)?;

--- a/crates/but-db/src/migration.rs
+++ b/crates/but-db/src/migration.rs
@@ -1,7 +1,7 @@
 use rusqlite::ErrorCode;
 use tracing::instrument;
 
-use crate::M;
+use crate::{M, SchemaVersion};
 
 /// The error produced when running migrations.
 pub type Error = backoff::Error<rusqlite::Error>;
@@ -35,21 +35,60 @@ pub fn run<'m>(
     conn: &mut rusqlite::Connection,
     migrations: impl IntoIterator<Item = M<'m>>,
 ) -> Result<usize, Error> {
-    let trans = conn
-        // Use deferred to allow ourselves to read first without running into locks.
-        // That read can determine that nothing needs to be done, saving a lot of time.
-        .transaction_with_behavior(rusqlite::TransactionBehavior::Deferred)
-        .map_err(transient_if_locked)?;
     let migrations = {
         let mut v: Vec<_> = migrations.into_iter().collect();
         v.sort_by_key(|m| m.up_created_at);
         v
     };
+    let trans = conn
+        // Use deferred to allow ourselves to read first without running into locks.
+        // That read can determine that nothing needs to be done, saving a lot of time.
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Deferred)
+        .map_err(transient_if_locked)?;
+
+    let application_schema_version = highest_application_schema_version(&migrations);
+    let db_schema_version = db_forward_compatibility_version(&trans)?;
+    if db_schema_version > application_schema_version {
+        return Err(backoff::Error::permanent(
+            rusqlite::Error::ToSqlConversionFailure(
+                format!(
+                    "Database forward-compatibility version is {db_schema_version}, but this binary only supports up to {application_schema_version}"
+                )
+                .into(),
+            ),
+        ));
+    }
+
     // Bail early if our read detects that nothing is to be done
     let maybe_num_applied_versions = num_applied_versions(&trans, &migrations).ok();
     if let Some(count) = maybe_num_applied_versions
         && count == migrations.len()
+        && db_schema_version == application_schema_version
     {
+        return Ok(0);
+    }
+
+    let db_schema_version = db_forward_compatibility_version(&trans)?;
+    if db_schema_version > application_schema_version {
+        return Err(backoff::Error::permanent(
+            rusqlite::Error::ToSqlConversionFailure(
+                format!(
+                    "Database forward-compatibility version is {db_schema_version}, but this binary only supports up to {application_schema_version}"
+                )
+                .into(),
+            ),
+        ));
+    }
+    let should_bump_forward_compatibility_version = db_schema_version != application_schema_version;
+
+    let maybe_num_applied_versions = num_applied_versions(&trans, &migrations).ok();
+    if let Some(count) = maybe_num_applied_versions
+        && count == migrations.len()
+    {
+        if should_bump_forward_compatibility_version {
+            set_db_forward_compatibility_version(&trans, application_schema_version)?;
+            trans.commit().map_err(transient_if_locked)?;
+        }
         return Ok(0);
     }
 
@@ -82,8 +121,36 @@ pub fn run<'m>(
         count += 1;
     }
 
+    if should_bump_forward_compatibility_version {
+        set_db_forward_compatibility_version(&trans, application_schema_version)?;
+    }
+
     trans.commit().map_err(transient_if_locked)?;
     Ok(count)
+}
+
+fn db_forward_compatibility_version(conn: &rusqlite::Connection) -> Result<u32, Error> {
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(transient_if_locked)
+}
+
+fn set_db_forward_compatibility_version(
+    conn: &rusqlite::Connection,
+    application_schema_version: u32,
+) -> Result<(), Error> {
+    conn.execute_batch(&format!(
+        "PRAGMA user_version = {application_schema_version};"
+    ))
+    .map_err(transient_if_locked)?;
+    Ok(())
+}
+
+fn highest_application_schema_version(migrations: &[M]) -> u32 {
+    migrations
+        .iter()
+        .map(|migration| migration.schema_version as u32)
+        .max()
+        .unwrap_or(SchemaVersion::Zero as u32)
 }
 
 fn num_applied_versions(conn: &rusqlite::Connection, migrations: &[M]) -> Result<usize, Error> {
@@ -105,14 +172,7 @@ fn num_applied_versions(conn: &rusqlite::Connection, migrations: &[M]) -> Result
             .parse()
             .map_err(|_| backoff::Error::permanent(rusqlite::Error::InvalidQuery))?;
 
-        let err: Option<String> = if idx >= migrations.len() {
-            format!(
-                "Cannot reduce migration count: database has {num_existing} migrations but only {actual} provided",
-                actual = migrations.len(),
-                num_existing = existing_versions.len()
-            )
-            .into()
-        } else {
+        let err: Option<String> = if idx < migrations.len() {
             let candidate_m = migrations[idx];
             (candidate_m.up_created_at != existing_version).then(|| {
                 format!(
@@ -121,6 +181,8 @@ fn num_applied_versions(conn: &rusqlite::Connection, migrations: &[M]) -> Result
                     actual = candidate_m.up_created_at
                 )
             })
+        } else {
+            None
         };
         if let Some(err) = err {
             return Err(backoff::Error::permanent(
@@ -144,12 +206,18 @@ fn transient_if_locked(err: rusqlite::Error) -> Error {
 }
 
 impl<'a> M<'a> {
-    /// Create a new migration with `created_at_for_sorting` in a format like `20250529110746`, and the `up_sql`
-    /// which is Sqlite compatible SQL to create or update tables.
-    pub const fn up(created_at_for_sorting: u64, up_sql: &'a str) -> Self {
+    /// Create a new migration with `created_at_for_sorting` in a format like `20250529110746`,
+    /// a documented forward-compatibility `schema_version`, and the `up_sql` which is Sqlite
+    /// compatible SQL to create or update tables.
+    pub const fn up(
+        created_at_for_sorting: u64,
+        schema_version: SchemaVersion,
+        up_sql: &'a str,
+    ) -> Self {
         M {
             up: up_sql,
             up_created_at: created_at_for_sorting,
+            schema_version,
         }
     }
 }

--- a/crates/but-db/src/table/butler_actions.rs
+++ b/crates/but-db/src/table/butler_actions.rs
@@ -2,11 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[
     M::up(
         20250529110746,
+        SchemaVersion::Zero,
         "CREATE TABLE `butler_actions`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,
@@ -24,6 +25,7 @@ CREATE INDEX `idx_butler_actions_created_at` ON `butler_actions`(`created_at`);
     ),
     M::up(
         20250530112246,
+        SchemaVersion::Zero,
         "ALTER TABLE `butler_actions` DROP COLUMN `external_prompt`;
 ALTER TABLE `butler_actions` ADD COLUMN `external_summary` TEXT NOT NULL;
 ALTER TABLE `butler_actions` ADD COLUMN `external_prompt` TEXT;
@@ -31,10 +33,12 @@ ALTER TABLE `butler_actions` ADD COLUMN `external_prompt` TEXT;
     ),
     M::up(
         20250616090656,
+        SchemaVersion::Zero,
         "ALTER TABLE `butler_actions` ADD COLUMN `source` TEXT;",
     ),
     M::up(
         20250619181700,
+        SchemaVersion::Zero,
         "ALTER TABLE `butler_actions` DROP COLUMN `handler_prompt`;",
     ),
 ];

--- a/crates/but-db/src/table/ci_checks.rs
+++ b/crates/but-db/src/table/ci_checks.rs
@@ -2,10 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20260105095934,
+    SchemaVersion::Zero,
     "CREATE TABLE `ci_checks`(
 	`id` BIGINT NOT NULL PRIMARY KEY,
 	`name` TEXT NOT NULL,

--- a/crates/but-db/src/table/claude.rs
+++ b/crates/but-db/src/table/claude.rs
@@ -3,11 +3,12 @@
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[
     M::up(
         20250703203544,
+        SchemaVersion::Zero,
         "CREATE TABLE `claude_code_sessions`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,
@@ -16,6 +17,7 @@ pub(crate) const M: &[M<'static>] = &[
     ),
     M::up(
         20250811130145,
+        SchemaVersion::Zero,
         "CREATE TABLE `claude_sessions`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`current_id` TEXT NOT NULL UNIQUE,
@@ -36,9 +38,14 @@ CREATE TABLE `claude_messages`(
 CREATE INDEX index_claude_messages_on_session_id ON claude_messages (session_id);
 CREATE INDEX index_claude_messages_on_created_at ON claude_messages (created_at);",
     ),
-    M::up(20250812093543, "DROP TABLE IF EXISTS `claude_code_sessions`;"),
+    M::up(
+        20250812093543,
+        SchemaVersion::Zero,
+        "DROP TABLE IF EXISTS `claude_code_sessions`;",
+    ),
     M::up(
         20250817195624,
+        SchemaVersion::Zero,
         "CREATE TABLE `claude_permission_requests`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,
@@ -50,10 +57,12 @@ CREATE INDEX index_claude_messages_on_created_at ON claude_messages (created_at)
     ),
     M::up(
         20250821095340,
+        SchemaVersion::Zero,
         "ALTER TABLE claude_sessions ADD COLUMN in_gui BOOLEAN NOT NULL DEFAULT FALSE;",
     ),
     M::up(
         20250821142109,
+        SchemaVersion::Zero,
         "-- Add session_ids column to claude_sessions table to track all session IDs used
 ALTER TABLE claude_sessions ADD COLUMN session_ids TEXT NOT NULL DEFAULT '[]';
 
@@ -62,6 +71,7 @@ UPDATE claude_sessions SET session_ids = json_array(current_id);",
     ),
     M::up(
         20251106102333,
+        SchemaVersion::Zero,
         r#"-- Replace approved (bool) and scope (text) with a single decision (text) column
 ALTER TABLE `claude_permission_requests` ADD COLUMN `decision` TEXT;
 
@@ -78,12 +88,14 @@ ALTER TABLE `claude_permission_requests` DROP COLUMN `approved`;"#,
     ),
     M::up(
         20251107134016,
+        SchemaVersion::Zero,
         "-- Add permissions columns to claude_sessions table to track approved and denied permissions
 ALTER TABLE claude_sessions ADD COLUMN approved_permissions TEXT NOT NULL DEFAULT '[]';
 ALTER TABLE claude_sessions ADD COLUMN denied_permissions TEXT NOT NULL DEFAULT '[]';",
     ),
     M::up(
         20251110103940,
+        SchemaVersion::Zero,
         "-- Add use_wildcard column to claude_permission_requests table
 ALTER TABLE `claude_permission_requests` ADD COLUMN `use_wildcard` BOOLEAN NOT NULL DEFAULT 0;",
     ),

--- a/crates/but-db/src/table/file_write_locks.rs
+++ b/crates/but-db/src/table/file_write_locks.rs
@@ -2,10 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20250704130757,
+    SchemaVersion::Zero,
     "CREATE TABLE `file_write_locks`(
 	`path` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,

--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -2,10 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20260101223932,
+    SchemaVersion::Zero,
     "-- Your SQL goes here
 CREATE TABLE `forge_reviews`(
 	`html_url` TEXT NOT NULL,

--- a/crates/but-db/src/table/gerrit_metadata.rs
+++ b/crates/but-db/src/table/gerrit_metadata.rs
@@ -3,10 +3,11 @@
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20251015212443,
+    SchemaVersion::Zero,
     "CREATE TABLE `gerrit_metadata`(
 	`change_id` TEXT NOT NULL PRIMARY KEY,
 	`commit_id` TEXT NOT NULL,

--- a/crates/but-db/src/table/hunk_assignments.rs
+++ b/crates/but-db/src/table/hunk_assignments.rs
@@ -2,11 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[
     M::up(
         20250526145725,
+        SchemaVersion::Zero,
         "CREATE TABLE `hunk_assignments`(
 	`hunk_header` TEXT,
 	`path` TEXT NOT NULL,
@@ -18,10 +19,12 @@ pub(crate) const M: &[M<'static>] = &[
     ),
     M::up(
         20250603111503,
+        SchemaVersion::Zero,
         "ALTER TABLE `hunk_assignments` ADD COLUMN `id` TEXT;",
     ),
     M::up(
         20250607113323,
+        SchemaVersion::Zero,
         "ALTER TABLE `hunk_assignments` DROP COLUMN `hunk_locks`;",
     ),
 ];

--- a/crates/but-db/src/table/mod.rs
+++ b/crates/but-db/src/table/mod.rs
@@ -1,4 +1,4 @@
-use crate::M;
+use crate::{M, SchemaVersion};
 
 pub(crate) mod butler_actions;
 pub(crate) mod ci_checks;
@@ -15,6 +15,7 @@ pub(crate) mod workspace_rules;
 pub(crate) const M_FULLY_REMOVED: &[M<'static>] = &[
     M::up(
         20251013092749,
+        SchemaVersion::Zero,
         "CREATE TABLE `worktrees`(
 	`path` TEXT NOT NULL PRIMARY KEY,
 	`reference` TEXT NOT NULL,
@@ -25,6 +26,7 @@ pub(crate) const M_FULLY_REMOVED: &[M<'static>] = &[
     ),
     M::up(
         20251014144801,
+        SchemaVersion::Zero,
         "-- Create new table with BLOB columns
 CREATE TABLE `worktrees_new`(
 	`path` BLOB NOT NULL PRIMARY KEY,
@@ -42,6 +44,7 @@ ALTER TABLE worktrees_new RENAME TO worktrees;
     ),
     M::up(
         20251015105125,
+        SchemaVersion::Zero,
         "-- Create new table with updated schema
 CREATE TABLE `worktrees_new`(
 	`path` BLOB NOT NULL PRIMARY KEY,
@@ -57,6 +60,7 @@ ALTER TABLE worktrees_new RENAME TO worktrees;",
     ),
     M::up(
         20251017092314,
+        SchemaVersion::Zero,
         "-- Drop worktrees table as metadata is now stored in .git/worktrees/ as files
 DROP TABLE IF EXISTS worktrees;",
     ),

--- a/crates/but-db/src/table/virtual_branches.rs
+++ b/crates/but-db/src/table/virtual_branches.rs
@@ -1,7 +1,8 @@
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20260219130000,
+    SchemaVersion::Zero,
     "CREATE TABLE `vb_state`(
 	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
 	`initialized` INTEGER NOT NULL DEFAULT 0,

--- a/crates/but-db/src/table/workflows.rs
+++ b/crates/but-db/src/table/workflows.rs
@@ -2,10 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20250619192246,
+    SchemaVersion::Zero,
     "CREATE TABLE `workflows`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,

--- a/crates/but-db/src/table/workspace_rules.rs
+++ b/crates/but-db/src/table/workspace_rules.rs
@@ -3,10 +3,11 @@
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
-use crate::{DbHandle, M, Transaction};
+use crate::{DbHandle, M, SchemaVersion, Transaction};
 
 pub(crate) const M: &[M<'static>] = &[M::up(
     20250717150441,
+    SchemaVersion::Zero,
     "CREATE TABLE `workspace_rules`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`created_at` TIMESTAMP NOT NULL,

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -1,17 +1,37 @@
 mod run {
     use std::time::{Duration, Instant};
 
-    use but_db::{M, migration};
+    use but_db::{M, SchemaVersion, migration};
 
     use crate::migration::util::{dump_data, dump_schema};
+    const ZERO: SchemaVersion = SchemaVersion::Zero;
+
+    fn run_with_backoff<'a>(
+        conn: &mut rusqlite::Connection,
+        migrations: &[M<'a>],
+    ) -> Result<usize, migration::Error> {
+        let mut count = 0;
+        let policy = backoff::ExponentialBackoffBuilder::new()
+            .with_initial_interval(Duration::from_millis(10))
+            .with_randomization_factor(0.0)
+            .with_multiplier(1.0)
+            .with_max_interval(Duration::from_millis(10))
+            .with_max_elapsed_time(Some(Duration::from_secs(1)))
+            .build();
+        backoff::retry(policy, || {
+            count = migration::run(conn, migrations.iter().copied())?;
+            Ok::<_, migration::Error>(())
+        })?;
+        Ok(count)
+    }
 
     #[test]
     fn all_or_nothing() -> anyhow::Result<()> {
         let mut db = rusqlite::Connection::open_in_memory()?;
 
         let (good, bad) = (
-            M::up(0, "CREATE TABLE T1 ( first TEXT PRIMARY KEY );"),
-            M::up(1, "bad"),
+            M::up(0, ZERO, "CREATE TABLE T1 ( first TEXT PRIMARY KEY );"),
+            M::up(1, ZERO, "bad"),
         );
         let err = migration::run(&mut db, [good, bad]).unwrap_err();
         assert!(matches!(err, backoff::Error::Permanent(_)));
@@ -30,8 +50,8 @@ mod run {
         let mut db2 = rusqlite::Connection::open(&db_path)?;
 
         let migrations = [
-            M::up(0, "CREATE TABLE T1 ( first TEXT PRIMARY KEY );"),
-            M::up(1, "CREATE TABLE T2 ( first TEXT PRIMARY KEY );"),
+            M::up(0, ZERO, "CREATE TABLE T1 ( first TEXT PRIMARY KEY );"),
+            M::up(1, ZERO, "CREATE TABLE T2 ( first TEXT PRIMARY KEY );"),
         ];
 
         {
@@ -41,6 +61,7 @@ mod run {
             let busy_timeout = Duration::from_millis(100);
             db2.busy_timeout(busy_timeout)?;
             let err = migration::run(&mut db2, migrations).unwrap_err();
+            let elapsed = start.elapsed();
             assert!(
                 matches!(
                     err,
@@ -52,9 +73,8 @@ mod run {
                 "it wants to write, but can't, but knows it's a locking issue"
             );
             assert!(
-                start.elapsed() >= busy_timeout,
-                "busy timeout should block: {:?}",
-                start.elapsed()
+                elapsed < busy_timeout / 2,
+                "initial migration attempt should fail before busy_timeout when the deferred read snapshot cannot be upgraded: {elapsed:?}"
             );
         }
 
@@ -97,7 +117,7 @@ mod run {
     }
 
     #[test]
-    fn waits_for_locks_with_busy_timeout_in_threads() -> anyhow::Result<()> {
+    fn initialization_retries_lock_failures_with_backoff_in_threads() -> anyhow::Result<()> {
         use rusqlite::TransactionBehavior;
 
         let tmp = tempfile::TempDir::new()?;
@@ -116,8 +136,12 @@ mod run {
 
                 started_tx.send(())?;
                 let start = Instant::now();
-                let migrations = [M::up(0, "CREATE TABLE T1 ( first TEXT PRIMARY KEY );")];
-                let count = migration::run(&mut db, migrations)?;
+                let migrations = [M::up(
+                    0,
+                    ZERO,
+                    "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+                )];
+                let count = run_with_backoff(&mut db, &migrations)?;
                 assert_eq!(count, 1, "migration succeeds once the lock is released");
                 Ok(start.elapsed())
             }
@@ -144,8 +168,8 @@ mod run {
         let mut db = rusqlite::Connection::open_in_memory()?;
 
         let (old, new) = (
-            M::up(0, "CREATE TABLE T1 ( first VARCHAR(50) PRIMARY KEY )"),
-            M::up(1, "ALTER TABLE `T1` ADD COLUMN `two` TEXT"),
+            M::up(0, ZERO, "CREATE TABLE T1 ( first VARCHAR(50) PRIMARY KEY )"),
+            M::up(1, ZERO, "ALTER TABLE `T1` ADD COLUMN `two` TEXT"),
         );
         let incorrectly_ordered = [new, old];
         let count = migration::run(&mut db, incorrectly_ordered)?;
@@ -174,13 +198,97 @@ mod run {
         first | two
         "#);
 
-        let err = migration::run(&mut db, [old]).expect_err("cannot omit prior migrations");
-        assert!(matches!(err, backoff::Error::Permanent(_)));
+        let count = migration::run(&mut db, [old])
+            .expect("older migration list is accepted if DB is compatible");
+        assert_eq!(
+            count, 0,
+            "extra migrations in the DB are tolerated when forward-compatibility allows it"
+        );
 
-        let newer_new = M::up(2, "ALTER TABLE `T1` ADD COLUMN `two` TEXT");
+        let newer_new = M::up(2, ZERO, "ALTER TABLE `T1` ADD COLUMN `two` TEXT");
         let err = migration::run(&mut db, [old, /* 'new' missing */ newer_new])
             .expect_err("cannot skip a migration");
         assert!(matches!(err, backoff::Error::Permanent(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_forward_incompatible_database() -> anyhow::Result<()> {
+        let mut db = rusqlite::Connection::open_in_memory()?;
+
+        db.execute_batch(&format!(
+            "PRAGMA user_version = {};",
+            SchemaVersion::One as u32
+        ))?;
+        let err = migration::run(
+            &mut db,
+            [M::up(
+                0,
+                ZERO,
+                "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+            )],
+        )
+        .expect_err("future forward-compatibility version must be rejected");
+        assert!(matches!(err, backoff::Error::Permanent(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn schema_version_is_derived_from_passed_migrations() -> anyhow::Result<()> {
+        let mut db = rusqlite::Connection::open_in_memory()?;
+        let forward_incompatible = [M::up(
+            0,
+            SchemaVersion::One,
+            "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+        )];
+
+        migration::run(&mut db, forward_incompatible)?;
+        let version: u32 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        assert_eq!(version, SchemaVersion::One as u32);
+
+        let err = migration::run(
+            &mut db,
+            [M::up(
+                0,
+                ZERO,
+                "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+            )],
+        )
+        .expect_err("older binaries must reject newer schema versions");
+        assert!(matches!(err, backoff::Error::Permanent(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn schema_version_bumps_even_if_all_migrations_are_already_applied() -> anyhow::Result<()> {
+        let mut db = rusqlite::Connection::open_in_memory()?;
+        let compatible = [M::up(
+            0,
+            ZERO,
+            "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+        )];
+        migration::run(&mut db, compatible)?;
+
+        let initial_version: u32 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        assert_eq!(initial_version, ZERO as u32);
+
+        let forward_incompatible = [M::up(
+            0,
+            SchemaVersion::One,
+            "CREATE TABLE T1 ( first TEXT PRIMARY KEY );",
+        )];
+        let count = migration::run(&mut db, forward_incompatible)?;
+        assert_eq!(
+            count, 0,
+            "no SQL migration reruns when only the schema version changes"
+        );
+
+        let bumped_version: u32 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        assert_eq!(
+            bumped_version,
+            SchemaVersion::One as u32,
+            "schema version is still bumped when the migration list is otherwise up-to-date"
+        );
         Ok(())
     }
 

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -86,6 +86,12 @@ mod run {
 
             let count = migration::run(&mut db2, migrations)?;
             assert_eq!(count, 0, "It reads first which doesn't run into the lock");
+
+            let count = migration::run(&mut db2, [migrations[0]])?;
+            assert_eq!(
+                count, 0,
+                "older compatible migration lists also stay read-only despite extra migration rows in the DB"
+            );
         }
 
         insta::assert_snapshot!(dump_schema(&db1)?, @"
@@ -288,6 +294,35 @@ mod run {
             bumped_version,
             SchemaVersion::One as u32,
             "schema version is still bumped when the migration list is otherwise up-to-date"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn schema_version_bumps_even_if_database_has_extra_migrations() -> anyhow::Result<()> {
+        let mut db = rusqlite::Connection::open_in_memory()?;
+        let first_sql = "CREATE TABLE T1 ( first TEXT PRIMARY KEY );";
+        let compatible = [
+            M::up(0, ZERO, first_sql),
+            M::up(1, ZERO, "CREATE TABLE T2 ( first TEXT PRIMARY KEY );"),
+        ];
+        migration::run(&mut db, compatible)?;
+
+        let initial_version: u32 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        assert_eq!(initial_version, ZERO as u32);
+
+        let forward_incompatible = [M::up(0, SchemaVersion::One, first_sql)];
+        let count = migration::run(&mut db, forward_incompatible)?;
+        assert_eq!(
+            count, 0,
+            "no SQL migration reruns when only the schema version changes and the DB already has extra compatible migrations"
+        );
+
+        let bumped_version: u32 = db.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        assert_eq!(
+            bumped_version,
+            SchemaVersion::One as u32,
+            "schema version is still bumped when the DB contains additional compatible migrations"
         );
         Ok(())
     }


### PR DESCRIPTION
## Tasks

* [x] make sure the VORM can automatically increment the version if it thinks it's backward-incompatible.
* [x] refaciew
* [x] try it by hand in dev mode
* [x] review

## Notes for the Reviewer

It works as advertised, as a migration will not prevent opening the database anymore if the major schema version doesn't change anymore.

https://github.com/user-attachments/assets/283e844c-f5b4-4d24-a1de-1aadc0d0c8cf

This does, however, change semantics as accessing the `user_data` will prevent a busy-timeout now, which now causes the backoff based retries to actually kick in and prevent stomping on each others feet during migrations that way.

## Prompt

> In crates/but-db/src/migration.rs:110 we fail hard we see a database version of the future. Change it to only fail like this if a newly added database variable (doesn't need migration) is larger from the one that the crate was compiled with. This way, future versions can signal that they are not forward-compatible.

## Summary
- stop failing just because `__diesel_schema_migrations` has extra rows from a newer app
- add a dedicated forward-compatibility gate using `PRAGMA user_version`
- fail only when DB `user_version` is greater than the crate-compiled compatibility version
- keep version mismatch checks for overlapping migration prefixes

## Testing
- cargo test -p but-db --test db migration::run:: -- --nocapture
- cargo test -p but-db migration
