### PR TITLE
Support Agent tool type in codegen messages

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenServiceMessageUseTool.svelte
+++ b/apps/desktop/src/components/codegen/CodegenServiceMessageUseTool.svelte
@@ -10,6 +10,8 @@
 		switch (toolCall.name) {
 			case "Task":
 				return "start a subagent";
+			case "Agent":
+				return "start a subagent";
 			case "Bash":
 				return "run a command";
 			case "Glob":
@@ -36,6 +38,8 @@
 	const actionName = $derived.by(() => {
 		switch (toolCall.name) {
 			case "Task":
+				return "subagent request";
+			case "Agent":
 				return "subagent request";
 			case "Bash":
 				return "command";

--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -77,6 +77,7 @@ export type ToolCallName =
 	| "Grep"
 	| "Glob"
 	| "Task"
+	| "Agent"
 	| "TodoWrite"
 	| "WebFetch"
 	| "WebSearch"

--- a/apps/desktop/src/lib/utils/codegenTools.ts
+++ b/apps/desktop/src/lib/utils/codegenTools.ts
@@ -32,6 +32,9 @@ export function getToolIcon(toolName: string): IconName {
 	if (name.includes("exit")) {
 		return "logout";
 	}
+	if (name.includes("agent")) {
+		return "spinner";
+	}
 	if (name.includes("task")) {
 		return "spinner";
 	}
@@ -46,6 +49,8 @@ export function getToolLabel(toolName: string): string {
 	switch (toolName) {
 		case "AskUserQuestion":
 			return "Ask user";
+		case "Agent":
+			return "Subagent";
 		default:
 			return toolName;
 	}
@@ -67,6 +72,7 @@ const KNOWN_TOOLS = [
 	"AskUserQuestion",
 	"Skill",
 	"NotebookEdit",
+	"Agent",
 	"EnterPlanMode",
 	"ExitPlanMode",
 ] as const;
@@ -95,6 +101,12 @@ export function formatToolCall(toolCall: ToolCall): string {
 
 		case "Task":
 			return input["description"] || "Running subtask";
+
+		case "Agent": {
+			const agentType = input["subagent_type"] || "agent";
+			const desc = input["description"];
+			return desc ? `${agentType}: ${desc}` : `Running ${agentType} agent`;
+		}
 
 		case "TodoWrite": {
 			const todos = input["todos"];


### PR DESCRIPTION
Add handling for the Agent tool type across codegen components and utilities to properly display and describe subagent actions.