### PR TITLE
feat/enable-drawer-disable-edit-conflict

### DIFF
--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -141,6 +141,8 @@
 		return modeService !== undefined && !isReadOnly;
 	}
 
+	let drawer = $state<ReturnType<typeof Drawer>>();
+
 	function cancelEdit() {
 		setMode("view");
 	}
@@ -149,6 +151,7 @@
 <ReduxResult {stackId} {projectId} result={commitQuery.result} {onerror}>
 	{#snippet children(commit, env)}
 		<Drawer
+			bind:this={drawer}
 			bind:clientHeight
 			testId={TestId.CommitDrawer}
 			persistId="commit-view-drawer-{projectId}-{stackId}-{commitKey.commitId}"
@@ -194,7 +197,10 @@
 						size="tag"
 						kind="ghost"
 						icon="edit"
-						onclick={() => setMode("edit")}
+						onclick={() => {
+							drawer?.open();
+							setMode("edit");
+						}}
 						tooltip={isReadOnly ? "Read-only mode" : "Edit commit message"}
 						disabled={isReadOnly}
 					/>
@@ -207,7 +213,10 @@
 							commitStatus: commit.state.type,
 							commitUrl: forge.current.commitUrl(commit.id),
 							onUncommitClick: () => handleUncommit(),
-							onEditMessageClick: () => setMode("edit"),
+							onEditMessageClick: () => {
+								drawer?.open();
+								setMode("edit");
+							},
 						}
 					: undefined}
 				{#if data}

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -192,6 +192,9 @@
 
 			{#snippet actions()}
 				{#if canEdit()}
+					{@const isEditingMessage =
+						projectState.exclusiveAction.current?.type === "edit-commit-message" &&
+						projectState.exclusiveAction.current.commitId === commit.id}
 					<Button
 						testId={TestId.CommitDrawerActionEditMessage}
 						size="tag"
@@ -202,7 +205,7 @@
 							setMode("edit");
 						}}
 						tooltip={isReadOnly ? "Read-only mode" : "Edit commit message"}
-						disabled={isReadOnly}
+						disabled={isReadOnly || isEditingMessage}
 					/>
 				{/if}
 				{@const data = isLocalAndRemoteCommit(commit)

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -223,6 +223,12 @@
 			max-height: none;
 		}
 
+		&.rounded.collapsed {
+			:global(.drawer-header) {
+				border-bottom-color: var(--clr-bg-2);
+			}
+		}
+
 		&.highlighted {
 			&::after {
 				z-index: 1;


### PR DESCRIPTION


https://github.com/user-attachments/assets/b71dd9b3-a61c-40b1-81d9-f84adee23d5f



---

This pull request updates the `CommitView.svelte` component to improve the user experience when editing commit messages. The main change ensures that the commit drawer is always opened when entering edit mode, and disables the edit button while an edit is already in progress.

**Enhancements to commit editing workflow:**

* The `drawer` reference is now bound to the `Drawer` component instance, allowing programmatic control of the drawer's open state. [[1]](diffhunk://#diff-c060a1e93e654d493e56c9b6787b242ae308f3edaf3d0e089b2187f8065d9ed9R144-R145) [[2]](diffhunk://#diff-c060a1e93e654d493e56c9b6787b242ae308f3edaf3d0e089b2187f8065d9ed9R154)
* When the edit button is clicked, the drawer is explicitly opened before switching to edit mode, ensuring the UI is always ready for editing.
* The edit button is now disabled if an edit operation is already in progress for the current commit, preventing multiple concurrent edits.
* The same drawer-opening logic is applied when editing is triggered from the commit actions menu, ensuring consistent behavior across entry points.