### PR TITLE
ci: add smoke test for version compatibility

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -445,8 +445,15 @@ jobs:
             --header "X-Auth-Token: ${BOT_AUTH_TOKEN}" \
             --data "$payload"
 
-  create-git-tag:
+  smoke-test-version-compatibility:
     needs: [notify-gitbutler-api, build-tauri, publish-tauri]
+    uses: ./.github/workflows/smoke-test-version-compatibility.yaml
+    with:
+      channel: ${{ needs.build-tauri.outputs.channel }}
+      expected_nightly_version: ${{ needs.publish-tauri.outputs.version }}
+
+  create-git-tag:
+    needs: [smoke-test-version-compatibility, build-tauri, publish-tauri]
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed to push tags

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -70,6 +70,16 @@ jobs:
             install_script:
               - 'scripts/install.sh'
 
+  # This smoke test is here only because we have somewhat poor visibility on the scheduled nightly
+  # builds (whether they fail or succeed). It's my hope that by having this as a non-required check
+  # on every push, we'll be quicker to detect that there is an incompatibility.
+  #
+  # It should absolutely _not_ be a required check, however, as it checks nightly <-> release. The
+  # fact that the latest nightly is incompatible with the latest release cannot possibly be related
+  # to the current push. This is just a signal for us that we should check it out.
+  smoke-test-adjacent-release-compatibility:
+    uses: ./.github/workflows/smoke-test-version-compatibility.yaml
+
   prettier:
     needs: changes
     if: ${{ needs.changes.outputs.node == 'true' || needs.changes.outputs.docs == 'true' }}

--- a/.github/workflows/smoke-test-version-compatibility.yaml
+++ b/.github/workflows/smoke-test-version-compatibility.yaml
@@ -1,0 +1,51 @@
+name: "Smoke test version compatibility"
+on:
+  workflow_call:
+    inputs:
+      channel:
+        type: string
+        description: If publishing a new release, the channel should go here
+        default: ""
+      expected_nightly_version:
+        type: string
+        description: If publishing a new nightly, the version should go here. This is ignored if `channel != nightly`.
+        default: ""
+
+jobs:
+  smoke-test-adjacent-release-compatibility:
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-15 # [macOs, ARM64] - no way to run macOS x86_64 on GH Actions
+          - platform: ubuntu-22.04 # [linux, x64]
+          - platform: ubuntu-22.04-arm # [linux, ARM64]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Smoke test latest nightly <-> latest release upgrade/downgrade compatibility
+        # We can only perform this post-upload check _properly_ when building nightly, as the release
+        # build has a manual step required to actually publish the release in the API. Without that
+        # manual step we cannot install the release with the installer, so there is no way to
+        # validate against a mainline release here. The best we can do is latest nightly vs latest
+        # release.
+        #
+        # A careful release process therefore involves building a nightly first on the exact commit
+        # we intend to do a release on. If you don't do that, this test cannot be fully trusted.
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          EXPECTED_NIGHTLY_VERSION: ${{ inputs.expected_nightly_version }}
+        run: |
+          release_version="$(curl -s https://app.gitbutler.com/releases | jq -r .version)"
+          nightly_version="$(curl -s https://app.gitbutler.com/releases/nightly | jq -r .version)"
+          if [[ "$CHANNEL" == "nightly" ]] && [[ "$nightly_version" != "$EXPECTED_NIGHTLY_VERSION" ]]; then
+            echo "Expected latest nightly to be the current build $EXPECTED_NIGHTLY_VERSION, but was $nightly_version"
+            exit 1
+          fi
+
+          ./scripts/validate-version-compatibility.sh "$release_version" "$nightly_version"

--- a/crates/but-installer/src/lib.rs
+++ b/crates/but-installer/src/lib.rs
@@ -97,11 +97,14 @@ fn run_installation_impl(config: InstallerConfig, interactive: bool) -> Result<(
         }
         VersionRequest::Specific(version) => {
             info(&format!("Installing version: {version}"));
-            Some(Channel::Release)
+            None
         }
         VersionRequest::Release => {
-            info(&format!("Latest version: {}", release.version));
-            None
+            info(&format!(
+                "Installing latest release version: {}",
+                release.version
+            ));
+            Some(Channel::Release)
         }
     };
 

--- a/scripts/validate-version-compatibility.sh
+++ b/scripts/validate-version-compatibility.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Validate that two versions of the CLI are compatible with a simple smoke test.
+#
+# We make few assertions here, we rely mostly on commands exiting non-zero if something goes wrong.
+#
+# Note that every `but` command is piping to cat. This is a li'l backwards compatible hack to ensure
+# that we don't get any prompts, as the pipe is detected as not being a tty even in the very
+# earliest versions of the CLI.
+
+set -o errexit
+set -o pipefail
+
+old_version="$1"
+new_version="$2"
+
+if [ -z "$old_version" ] || [ -z "$new_version" ]; then
+  echo "usage: validate-version-compatibility.sh <old_version> <new_version>"
+  exit 1
+fi
+
+function smoke_test() {
+  but setup | cat # we currently need a call to setup when moving between release and nightly, not entirely sure why
+  echo "hello" >> test.txt
+  but commit -m "Commit with version: $(but --version)" | cat
+  but status | cat
+}
+
+function banner_message() {
+  echo ""
+  echo "### $1 ###" | tr '[:lower:]' '[:upper:]'
+  echo ""
+}
+
+banner_message "Performing initial setup of '$old_version'"
+echo "$(git rev-parse --show-toplevel)/scripts/install.sh" | bash -s "$old_version"
+but config metrics disable
+
+tmpdir=$(mktemp -d)
+git clone https://github.com/gitbutlerapp/gitbutler "$tmpdir/test" --depth 100 # depth is pretty arbitrary, we just want a non-empty repo
+cd "$tmpdir/test"
+
+but setup | cat
+but config user set name "Smoke Testingsson"
+but config user set email "example@example.com"
+but branch new test-branch
+smoke_test
+
+banner_message "Upgrading to '$new_version'"
+but update install "$new_version" | cat
+smoke_test
+
+banner_message "Downgrading to '$old_version'"
+but update install "$old_version" | cat
+smoke_test
+
+banner_message "Ensure versions are represented in commit messages"
+num_old_version_commits=$(but status | grep "Commit with version:.*$old_version" | wc -l)
+num_new_version_commits=$(but status | grep "Commit with version:.*$new_version" | wc -l)
+
+echo "Found $num_old_version_commits commits with $old_version"
+if [[ "$num_old_version_commits" -ne 2 ]]; then
+  echo "Expected 2 commits with $old_version!"
+  exit 1
+fi
+
+echo "Found $num_new_version_commits commits with $new_version"
+if [[ "$num_new_version_commits" -ne 1 ]]; then
+  echo "Expected 1 commits with $new_version!"
+  exit 1
+fi
+
+banner_message "No obvious errors detected, test run successful!"


### PR DESCRIPTION
## 🧢 Changes
Adds in a smoke test that runs on publish to validate compatibility with the last mainline release. See comments in the code for details.

Edit: I decided to run the smoke tests for the `push.yaml` workflow as well, as we really don't keep good track of the nightly builds right now. [The build yesterday failed](https://github.com/gitbutlerapp/gitbutler/actions/runs/22651021691), for example (spurious BS error), and no one brought it up.

On push the smoke test isn't actually checking the pushed code, it's still checking latest nightly <-> latest release. So if it fails it cannot possibly have anything to do with the push that triggered the failure, hence the check is not required.

[Here is an example run](https://github.com/gitbutlerapp/gitbutler/actions/runs/22714105179/job/65859288555?pr=12686), more can be found in the checks below!