### PR TITLE
feat(api): add optional order parameter to branch creation

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -25,6 +25,8 @@
 	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
 	import { persisted } from "@gitbutler/shared/persisted";
+
+	const addToLeftmost = persisted<boolean>(false, "branch-placement-leftmost");
 	import { AsyncButton, Button, Modal, TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
@@ -80,6 +82,7 @@
 				branch: branchRef,
 				remote: remoteRef,
 				prNumber,
+				order: $addToLeftmost ? 0 : undefined,
 			});
 			handleCreateBranchFromBranchOutcome(outcome);
 			await baseBranchService.refreshBaseBranch(projectId);

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -25,17 +25,14 @@
 	import { combineResults } from "$lib/state/helpers";
 	import { inject } from "@gitbutler/core/context";
 	import { persisted } from "@gitbutler/shared/persisted";
-
-	const addToLeftmost = persisted<boolean>(false, "branch-placement-leftmost");
 	import { AsyncButton, Button, Modal, TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
 	import type { BranchFilterOption, SidebarEntrySubject } from "$lib/branches/branchListing";
+
 	type Props = {
 		projectId: string;
 	};
-
-	const { projectId }: Props = $props();
 
 	type BranchesSelection =
 		| {
@@ -48,6 +45,9 @@
 		| { type: "pr"; prNumber: number }
 		| { type: "target"; commitId?: string };
 
+	const { projectId }: Props = $props();
+
+	const addToLeftmost = persisted<boolean>(false, "branch-placement-leftmost");
 	const stackService = inject(STACK_SERVICE);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);

--- a/apps/desktop/src/components/BranchesViewPR.svelte
+++ b/apps/desktop/src/components/BranchesViewPR.svelte
@@ -11,6 +11,7 @@
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
 	import { inject } from "@gitbutler/core/context";
+	import { persisted } from "@gitbutler/shared/persisted";
 	import { Button, Modal, TestId, Textbox } from "@gitbutler/ui";
 	import type { DetailedPullRequest } from "$lib/forge/interface/types";
 
@@ -33,6 +34,8 @@
 
 	const remotesService = inject(REMOTES_SERVICE);
 	const stackService = inject(STACK_SERVICE);
+
+	const addToLeftmost = persisted<boolean>(false, "branch-placement-leftmost");
 
 	let createRemoteModal = $state<Modal>();
 	let inputRemoteName = $state<string>();
@@ -71,6 +74,7 @@
 				branch: remoteRef,
 				remote: remoteRef,
 				prNumber,
+				order: $addToLeftmost ? 0 : undefined,
 			});
 
 			handleCreateBranchFromBranchOutcome(outcome);

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1727,7 +1727,7 @@ function injectEndpoints(api: ClientState["backendApi"], uiState: UiState) {
 			}),
 			createVirtualBranchFromBranch: build.mutation<
 				CreateBranchFromBranchOutcome,
-				{ projectId: string; branch: string; remote?: string; prNumber?: number }
+				{ projectId: string; branch: string; remote?: string; prNumber?: number; order?: number }
 			>({
 				extraOptions: {
 					command: "create_virtual_branch_from_branch",

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -109,9 +109,10 @@ pub fn create_virtual_branch_from_branch(
     branch: Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
+    order: Option<usize>,
 ) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome> {
     let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch(
-        ctx, &branch, remote, pr_number,
+        ctx, &branch, remote, pr_number, order,
     )?;
     Ok(outcome.into())
 }

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -473,6 +473,7 @@ pub fn split_branch(
         &refname,
         None,
         None,
+        None,
         guard.write_permission(),
     )?;
 

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -189,6 +189,7 @@ pub mod stacks {
                 &ref_name,
                 Some(remote_ref_name),
                 None,
+                None,
             )?;
 
             let repo = ctx.repo.get()?;

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1155,6 +1155,7 @@ pub fn split_branch(
         &refname,
         None,
         None,
+        None,
         guard.write_permission(),
     )?;
 

--- a/crates/but/src/command/legacy/branch/apply.rs
+++ b/crates/but/src/command/legacy/branch/apply.rs
@@ -33,6 +33,7 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
             ref_name,
             remote_ref_name,
             None,
+            None,
         )?;
         r
     } else if let Some((remote_ref, r)) = find_remote_reference(&repo, branch_name)? {
@@ -47,6 +48,7 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
             ctx,
             ref_name,
             Some(remote_ref.clone()),
+            None,
             None,
         )?;
         r
@@ -90,6 +92,7 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
                     ref_name,
                     remote_ref_name,
                     None,
+                    None,
                 )?;
                 r
             }
@@ -109,6 +112,7 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
                     ctx,
                     ref_name,
                     Some(remote_ref),
+                    None,
                     None,
                 )?;
                 r

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -421,6 +421,7 @@ pub fn create_virtual_branch_from_branch(
     branch: &Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
+    order: Option<usize>,
 ) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
@@ -431,6 +432,7 @@ pub fn create_virtual_branch_from_branch(
         branch,
         remote,
         pr_number,
+        order,
         guard.write_permission(),
     )
 }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -101,6 +101,7 @@ impl BranchManager<'_> {
         target: &Refname,
         upstream_branch: Option<RemoteRefname>,
         pr_number: Option<usize>,
+        order: Option<usize>,
         perm: &mut RepoExclusive,
     ) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
         let branch_name = target
@@ -129,7 +130,7 @@ impl BranchManager<'_> {
                         OnWorkspaceMergeConflict::MaterializeAndReportConflictingStacks,
                     workspace_reference_naming: WorkspaceReferenceNaming::Default,
                     uncommitted_changes: UncommitedWorktreeChanges::KeepAndAbortOnConflict,
-                    order: None,
+                    order,
                     new_stack_id: None,
                 },
             )?;
@@ -211,7 +212,7 @@ impl BranchManager<'_> {
             .peel_to_commit()
             .context("failed to peel to commit")?;
 
-        let order = vb_state.next_order_index()?;
+        let order = order.unwrap_or(vb_state.next_order_index()?);
 
         let mut branch = if let Some(mut branch) = vb_state
             .find_by_top_reference_name_where_not_in_workspace(&target.to_string())?

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -136,6 +136,7 @@ pub(crate) fn tear_off_branch(
             &Refname::Local(LocalRefname::new(subject_branch_name, None)),
             None,
             None,
+            None,
             perm,
         )?;
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -106,6 +106,7 @@ fn rebase_commit() {
             &unapplied_branch,
             None,
             None,
+            None,
         )
         .unwrap();
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -34,6 +34,7 @@ fn no_conflicts() {
         &"refs/remotes/origin/branch".parse().unwrap(),
         None,
         None,
+        None,
     )
     .map(|o| o.0)
     .unwrap();
@@ -88,6 +89,7 @@ fn conflicts_with_uncommited() {
     let new_branch_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
         ctx,
         &"refs/remotes/origin/branch".parse().unwrap(),
+        None,
         None,
         None,
     )
@@ -148,6 +150,7 @@ fn conflicts_with_commited() {
         &"refs/remotes/origin/branch".parse().unwrap(),
         None,
         None,
+        None,
     )
     .map(|o| o.0)
     .unwrap();
@@ -179,6 +182,7 @@ fn from_default_target() {
             &"refs/remotes/origin/master".parse().unwrap(),
             None,
             None,
+            None,
         )
         .unwrap_err()
         .to_string(),
@@ -205,6 +209,7 @@ fn from_non_existent_branch() {
         gitbutler_branch_actions::create_virtual_branch_from_branch(
             ctx,
             &"refs/remotes/origin/branch".parse().unwrap(),
+            None,
             None,
             None,
         )
@@ -245,6 +250,7 @@ fn from_state_remote_branch() {
     let _ = gitbutler_branch_actions::create_virtual_branch_from_branch(
         ctx,
         &"refs/remotes/origin/branch".parse().unwrap(),
+        None,
         None,
         None,
     )

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -66,6 +66,7 @@ fn apply_by_name(ctx: &mut Context, branch_name: String) -> Result<()> {
                 .context("local reference name was missing")?,
             None,
             None,
+            None,
             guard.write_permission(),
         )?,
     )
@@ -83,6 +84,7 @@ fn apply_from_branch(ctx: &mut Context, branch_name: String) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     debug_print(ctx.branch_manager().create_virtual_branch_from_branch(
         &target,
+        None,
         None,
         None,
         guard.write_permission(),


### PR DESCRIPTION
Addressing this issue https://discord.com/channels/1060193121130000425/1073202153163857920/1478838727085391953

cc @nshcr

---

This pull request introduces support for specifying the placement order when creating a virtual branch from an existing branch, allowing users to optionally add new branches to the leftmost position in the UI. The change propagates a new `order` parameter through the frontend, API, and backend, and updates all relevant function signatures and test cases to accommodate this new functionality.

**Frontend enhancements:**

* Added a persisted setting (`addToLeftmost`) in both `BranchesView.svelte` and `BranchesViewPR.svelte` to allow users to choose whether new branches are added to the leftmost position. When enabled, the `order` parameter is set to `0` when creating a branch. [[1]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dR28-R29) [[2]](diffhunk://#diff-3e7c7bee1729bee5bdfbfaec0b02713b88eba6fda82b2b00927f2292b3a7dd37R38-R39) [[3]](diffhunk://#diff-2e2869045c3f1150d5d4a178aac081279cce2835a7c84cae9cddd5da053ce07dR85) [[4]](diffhunk://#diff-3e7c7bee1729bee5bdfbfaec0b02713b88eba6fda82b2b00927f2292b3a7dd37R77)

**API and backend changes:**

* Extended the `createVirtualBranchFromBranch` mutation and all related Rust function signatures to accept an optional `order` parameter, ensuring the order is applied when creating the branch. [[1]](diffhunk://#diff-2f57c312e708b3f09f7f3427d0c094930ac2e09b811405798374e6df479e1f7fL1730-R1730) [[2]](diffhunk://#diff-2037d5ad64f057c5cc27bdd232578b51644edb69d0da7e84bd896186c8478ecaR112-R115) [[3]](diffhunk://#diff-b08096669836e42b7521a61470854929b49b271e25ee1afd9073a2c74d0204bbR424) [[4]](diffhunk://#diff-e141d30d01a2bff9f111eaa35b89768a539cf69f708a3307855a661c6ef14626R104)
* Updated the backend logic to use the provided `order` if specified, or fall back to the default ordering logic. [[1]](diffhunk://#diff-e141d30d01a2bff9f111eaa35b89768a539cf69f708a3307855a661c6ef14626L214-R215) [[2]](diffhunk://#diff-e141d30d01a2bff9f111eaa35b89768a539cf69f708a3307855a661c6ef14626L132-R133) [[3]](diffhunk://#diff-b08096669836e42b7521a61470854929b49b271e25ee1afd9073a2c74d0204bbR435)

**Test and CLI updates:**

* Updated all relevant test cases and CLI commands to pass the new `order` parameter, ensuring compatibility and correctness throughout the codebase. [[1]](diffhunk://#diff-fde4a5b2c7ad826fbf317aea6a11d66cdbe81d1b3aecc1ab59a079c99c093f70R476) [[2]](diffhunk://#diff-94c870ff2a5f5be78b9b9a6f49986d6edbdaa864d792fca2b3611901799ca278R192) [[3]](diffhunk://#diff-43b69967e8c5e54db4f3d323a57097fbbb7d28f74c24cbc259434cd2c5ec7ccdR1158) [[4]](diffhunk://#diff-3f3ae5a343e6ac5774ec3fb787e3a958455ca1179a2ae91a21bf5e87353c5aafR36) [[5]](diffhunk://#diff-3f3ae5a343e6ac5774ec3fb787e3a958455ca1179a2ae91a21bf5e87353c5aafR52) [[6]](diffhunk://#diff-3f3ae5a343e6ac5774ec3fb787e3a958455ca1179a2ae91a21bf5e87353c5aafR95) [[7]](diffhunk://#diff-3f3ae5a343e6ac5774ec3fb787e3a958455ca1179a2ae91a21bf5e87353c5aafR116) [[8]](diffhunk://#diff-37b4ea6abd27786b0ec0e2aafeb2bbfaa6d6dff93013a2928703c1c379fff6dfR139) [[9]](diffhunk://#diff-3c44a77afbf4586705bea7afc198a1633442f34877642a95fdc6fa94d50bfb7cR109) [[10]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R37) [[11]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R94) [[12]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R153) [[13]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R185) [[14]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R214) [[15]](diffhunk://#diff-88a1a2c78c22c74c065e31c9d6aff43fb286eba65465941e889afde2ca956e39R255) [[16]](diffhunk://#diff-7635b6f893795da527d6ec780fc2d71fb9f62a310b0a2faa9bc5ecac45a0e237R69) [[17]](diffhunk://#diff-7635b6f893795da527d6ec780fc2d71fb9f62a310b0a2faa9bc5ecac45a0e237R89)