### PR TITLE
move branches, but make it *graphic*

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1638,7 +1638,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				}
 			>({
 				extraOptions: {
-					command: "move_branch",
+					command: "move_branch_legacy",
 					actionName: "Move Branch",
 				},
 				query: (args) => args,

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -108,16 +108,39 @@ pub fn move_branch(
     subject_branch: &gix::refs::FullNameRef,
     target_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<()> {
-    let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+        ctx,
+        SnapshotDetails::new(OperationKind::MoveBranch),
+    )
+    .ok();
 
+    let move_branch_result = move_branch_impl(ctx, subject_branch, target_branch);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| move_branch_result.is_ok()) {
+        let mut guard = ctx.exclusive_worktree_access();
+        snapshot.commit(ctx, guard.write_permission()).ok();
+    }
+    move_branch_result
+}
+
+/// Move the branch, updating the workspace and the metadata.
+fn move_branch_impl(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+    target_branch: &gix::refs::FullNameRef,
+) -> anyhow::Result<()> {
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, mut workspace, _) = ctx.workspace_mut_and_db()?;
+    let editor = workspace.graph.to_editor(&repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(&ws, editor, &mut meta, subject_branch, target_branch)?;
+        but_workspace::branch::move_branch(&workspace, editor, subject_branch, target_branch)?;
 
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
-    ws.refresh_from_head(&repo, &meta)?;
+    if let Some((ws_meta, ref_name)) = ws_meta.zip(workspace.ref_name()) {
+        let mut md = meta.workspace(ref_name)?;
+        *md = ws_meta;
+        meta.set_workspace(&md)?;
+    }
+    workspace.refresh_from_head(&repo, &meta)?;
 
     Ok(())
 }

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1,7 +1,8 @@
 use but_api_macros::but_api;
-use but_core::{ui::TreeChanges, worktree::checkout::UncommitedWorktreeChanges};
+use but_core::{RefMetadata, ui::TreeChanges, worktree::checkout::UncommitedWorktreeChanges};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
+use but_rebase::graph_rebase::GraphExt;
 use but_workspace::branch::{
     OnWorkspaceMergeConflict,
     apply::{WorkspaceMerge, WorkspaceReferenceNaming},
@@ -97,4 +98,26 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
     let (_guard, repo, ws, _) = ctx.workspace_and_db()?;
     let branch = repo.find_reference(&branch)?;
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, branch.name())
+}
+
+/// Move a branch on top of another
+#[but_api]
+#[instrument(err(Debug))]
+pub fn move_branch(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+    target_branch: &gix::refs::FullNameRef,
+) -> anyhow::Result<()> {
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+    let editor = ws.graph.to_editor(&repo)?;
+
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(&ws, editor, &mut meta, subject_branch, target_branch)?;
+
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    Ok(())
 }

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -399,7 +399,7 @@ pub fn move_commit(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn move_branch(
+pub fn move_branch_legacy(
     ctx: &mut but_ctx::Context,
     target_stack_id: StackId,
     target_branch_name: String,

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -242,6 +242,9 @@ impl Editor {
     /// `target` delimiter's child and parent can be the same node.
     /// This is the way to disconnect a single node.
     ///
+    /// All disconnected children will be reconnected to all the disconnected parents unless
+    /// the `skip_reconnect_step` is set to true.
+    ///
     /// Returns an error when:
     /// - `parents_to_disconnect` is `SelectorSet::None`
     /// - `parents_to_disconnect` contains any parent that is not a direct parent of `target.parent`
@@ -251,6 +254,7 @@ impl Editor {
         target: SegmentDelimiter<C, P>,
         children_to_disconnect: SelectorSet,
         parents_to_disconnect: SelectorSet,
+        skip_reconnect_step: bool,
     ) -> Result<()>
     where
         C: ToSelector,
@@ -363,7 +367,12 @@ impl Editor {
                 .as_ref()
                 .is_none_or(|ids| ids.contains(&edge_source));
             if should_disconnect {
-                self.reconnect_edges_to_parents(&disconnected_parent_edges, edge_id, edge_source);
+                // Remove the child edge.
+                self.graph.remove_edge(edge_id);
+                // Reconnect the child node to all the disconnected parents.
+                if !skip_reconnect_step {
+                    self.reconnect_edges_to_parents(&disconnected_parent_edges, edge_source);
+                }
             }
         }
 
@@ -374,11 +383,8 @@ impl Editor {
     fn reconnect_edges_to_parents(
         &mut self,
         disconnected_parent_edges: &[(Edge, petgraph::prelude::NodeIndex)],
-        child_edge_id: petgraph::prelude::EdgeIndex,
         child_node: petgraph::prelude::NodeIndex,
     ) {
-        // Remove the child edge.
-        self.graph.remove_edge(child_edge_id);
         // Reconnect the child node to all the disconnected parents.
         for (parent_edge_weight, edge_target) in disconnected_parent_edges {
             self.graph

--- a/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
@@ -34,7 +34,12 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
         parent: b_selector,
     };
 
-    editor.disconnect_segment_from(target, mutate::SelectorSet::All, mutate::SelectorSet::All)?;
+    editor.disconnect_segment_from(
+        target,
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::All,
+        false,
+    )?;
     editor.replace(b_selector, Step::None)?;
 
     let outcome = editor.rebase()?;
@@ -83,6 +88,7 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
         delimiter,
         mutate::SelectorSet::All,
         mutate::SelectorSet::All,
+        false,
     )?;
     editor.replace(b_selector, Step::None)?;
     editor.replace(a_selector, Step::None)?;
@@ -131,6 +137,7 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
         delimiter,
         mutate::SelectorSet::All,
         mutate::SelectorSet::All,
+        false,
     )?;
     editor.replace(a_selector, Step::None)?;
 
@@ -190,6 +197,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
         delimiter,
         mutate::SelectorSet::All,
         mutate::SelectorSet::All,
+        false,
     )?;
     editor.replace(merge_selector, Step::None)?;
 
@@ -294,6 +302,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
         delimiter,
         mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
         mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+        false,
     )?;
 
     let outcome = editor.rebase()?;
@@ -389,6 +398,7 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
         delimiter,
         mutate::SelectorSet::None,
         mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+        false,
     )?;
 
     let outcome = editor.rebase()?;
@@ -498,6 +508,7 @@ fn disconnect_fails_when_parents_to_disconnect_is_none() -> Result<()> {
             delimiter,
             mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
             mutate::SelectorSet::None,
+            false,
         )
         .expect_err("expected disconnect to fail for parents=SelectorSet::None");
     assert!(
@@ -547,6 +558,7 @@ fn disconnect_fails_fast_if_parent_to_disconnect_is_not_direct_parent() -> Resul
             delimiter,
             mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
             mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![child_one_selector])?),
+            false,
         )
         .expect_err("expected disconnect to fail for non-parent selector");
     assert!(
@@ -596,6 +608,7 @@ fn disconnect_fails_fast_if_child_to_disconnect_is_not_direct_child() -> Result<
             delimiter,
             mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
             mutate::SelectorSet::Some(mutate::SomeSelectors::new(vec![parent_one_selector])?),
+            false,
         )
         .expect_err("expected disconnect to fail for non-child selector");
     assert!(

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -463,8 +463,10 @@ pub async fn run() {
             post(json_response(legacy::virtual_branches::move_commit_cmd)),
         )
         .route(
-            "/move_branch",
-            post(json_response(legacy::virtual_branches::move_branch_cmd)),
+            "/move_branch_legacy",
+            post(json_response(
+                legacy::virtual_branches::move_branch_legacy_cmd,
+            )),
         )
         .route(
             "/tear_off_branch",

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -487,3 +487,7 @@ pub use remove_reference::function::remove_reference;
 /// related types for creating a workspace reference.
 pub mod create_reference;
 pub use create_reference::function::create_reference;
+
+/// Functions and types related to moving branches across stacks.
+pub mod move_branch;
+pub use move_branch::function::move_branch;

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -9,11 +9,12 @@ use but_rebase::graph_rebase::{
 ///
 /// Returned by [function::move_branch()].
 #[derive(Debug)]
-pub struct Outcome<WorkspaceMeta> {
+pub struct Outcome {
     /// A successful rebase result for continuing operations.
     pub rebase: SuccessfulRebase,
     /// The updated workspace metadata that accompanies the move operation.
-    pub ws_meta: WorkspaceMeta,
+    /// It should replace the actual workspace metadata to configure moved 'virtual' branches segments, if `Some()`.
+    pub ws_meta: Option<but_core::ref_metadata::Workspace>,
 }
 
 pub(super) mod function {
@@ -23,13 +24,11 @@ pub(super) mod function {
     use super::Outcome;
     use anyhow::Context;
     use anyhow::bail;
-    use but_core::RefMetadata;
-    use but_core::ref_metadata::Workspace;
     use but_graph::projection::WorkspaceKind;
     use but_rebase::graph_rebase::Editor;
     use gix::refs::FullNameRef;
 
-    /// Move a branch between stacks in the workspace.
+    /// Move a branch between stacks in the `workspace`.
     ///
     /// `subject_branch_name` is the full reference name of the branch to move.
     ///
@@ -38,13 +37,12 @@ pub(super) mod function {
     ///
     /// Returns:
     /// - Successful rebase
-    pub fn move_branch<M: RefMetadata>(
+    pub fn move_branch(
         workspace: &but_graph::projection::Workspace,
         mut editor: Editor,
-        meta: &mut M,
         subject_branch_name: &FullNameRef,
         target_branch_name: &FullNameRef,
-    ) -> anyhow::Result<Outcome<M::Handle<Workspace>>> {
+    ) -> anyhow::Result<Outcome> {
         let Some(source) = workspace.find_segment_and_stack_by_refname(subject_branch_name) else {
             bail!(
                 "Couldn't find branch to move in workspace with reference name: {subject_branch_name}"
@@ -62,17 +60,20 @@ pub(super) mod function {
             bail!("Couldn't find workspace head.")
         };
 
-        let workspace_ref = match &workspace.kind {
-            WorkspaceKind::Managed { ref_info }
-            | WorkspaceKind::ManagedMissingWorkspaceCommit { ref_info } => {
-                ref_info.ref_name.clone()
+        // We're currently stopping the move branch operations imperatively at this stage, in order to
+        // reduce the scope of this first iteration of moving the branches.
+        // TODO: Enable and test that we can move branches in any kind of workspace.
+        match &workspace.kind {
+            WorkspaceKind::Managed { .. } => {}
+            WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
+                bail!("Moving branches currently need a workspace commit")
             }
             WorkspaceKind::AdHoc => {
                 bail!("Moving branches in non-managed workspaces is not supported");
             }
         };
 
-        let mut ws_meta = meta.workspace(workspace_ref.as_ref())?;
+        let mut ws_meta = workspace.metadata.clone();
 
         let (source_stack, subject_segment) = source;
         let (_, target_segment) = destination;
@@ -107,15 +108,14 @@ pub(super) mod function {
 
         // Update the workspace meta if any of the branches we're handling is empty.
         // This is needed in order to disambiguate the intended operation.
-        let ws_meta = if subject_segment.commits.is_empty() || target_segment.commits.is_empty() {
+        if let Some(ws_meta) = ws_meta.as_mut()
+            && (subject_segment.commits.is_empty() || target_segment.commits.is_empty())
+        {
             ws_meta.remove_segment(subject_branch_name);
             ws_meta.insert_new_segment_above_anchor_if_not_present(
                 subject_branch_name,
                 target_branch_name,
             );
-            ws_meta
-        } else {
-            ws_meta
         };
 
         Ok(Outcome {
@@ -178,29 +178,25 @@ fn get_disconnect_parameters(
         .base_segment_id
         .map(|segment_idx| &workspace.graph[segment_idx]);
 
-    let parents_to_disconnect = match (stack_base_segment, graph_base_segment) {
-        (Some(stack_base_segment), _) => {
-            // Base segment is part of the source stack.
-            let base_segment_ref_name = stack_base_segment
-                .ref_name()
-                .context("Base segment doesn't have a ref name.")?;
-            let reference_selector = editor.select_reference(base_segment_ref_name)?;
-            let selectors = SomeSelectors::new(vec![reference_selector])?;
-            SelectorSet::Some(selectors)
-        }
-        (None, Some(graph_base_segment)) => {
-            // Base segment is outside of workspace (probably target branch).
-            let ref_name = graph_base_segment
-                .ref_name()
-                .context("Graph base segment doesn't have a ref name.")?;
-            let reference_selector = editor.select_reference(ref_name)?;
-            let selectors = SomeSelectors::new(vec![reference_selector])?;
-            SelectorSet::Some(selectors)
-        }
-        (None, None) => {
-            // No parents could be determined. Detach all.
-            SelectorSet::All
-        }
+    let parents_to_disconnect = if let Some(stack_base_segment) = stack_base_segment {
+        // Base segment is part of the source stack.
+        let base_segment_ref_name = stack_base_segment
+            .ref_name()
+            .context("Base segment doesn't have a ref name.")?;
+        let reference_selector = editor.select_reference(base_segment_ref_name)?;
+        let selectors = SomeSelectors::new(vec![reference_selector])?;
+        SelectorSet::Some(selectors)
+    } else if let Some(graph_base_segment) = graph_base_segment {
+        // Base segment is outside of workspace (probably target branch).
+        let ref_name = graph_base_segment
+            .ref_name()
+            .context("Graph base segment doesn't have a ref name.")?;
+        let reference_selector = editor.select_reference(ref_name)?;
+        let selectors = SomeSelectors::new(vec![reference_selector])?;
+        SelectorSet::Some(selectors)
+    } else {
+        // No parents could be determined. Detach all.
+        SelectorSet::All
     };
 
     if index_of_segment == 0 {

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -1,0 +1,239 @@
+use anyhow::Context;
+use but_graph::projection::{Stack, StackSegment};
+use but_rebase::graph_rebase::{
+    Editor, Selector, SuccessfulRebase,
+    mutate::{SegmentDelimiter, SelectorSet, SomeSelectors},
+};
+
+/// Outcome of moving branches between stacks.
+///
+/// Returned by [function::move_branch()].
+#[derive(Debug)]
+pub struct Outcome<WorkspaceMeta> {
+    /// A successful rebase result for continuing operations.
+    pub rebase: SuccessfulRebase,
+    /// The updated workspace metadata that accompanies the move operation.
+    pub ws_meta: WorkspaceMeta,
+}
+
+pub(super) mod function {
+
+    use super::get_disconnect_parameters;
+
+    use super::Outcome;
+    use anyhow::Context;
+    use anyhow::bail;
+    use but_core::RefMetadata;
+    use but_core::ref_metadata::Workspace;
+    use but_graph::projection::WorkspaceKind;
+    use but_rebase::graph_rebase::Editor;
+    use gix::refs::FullNameRef;
+
+    /// Move a branch between stacks in the workspace.
+    ///
+    /// `subject_branch_name` is the full reference name of the branch to move.
+    ///
+    /// `target_branch_name` is the full reference name of the branch to move the subject
+    /// branch on top of.
+    ///
+    /// Returns:
+    /// - Successful rebase
+    pub fn move_branch<M: RefMetadata>(
+        workspace: &but_graph::projection::Workspace,
+        mut editor: Editor,
+        meta: &mut M,
+        subject_branch_name: &FullNameRef,
+        target_branch_name: &FullNameRef,
+    ) -> anyhow::Result<Outcome<M::Handle<Workspace>>> {
+        let Some(source) = workspace.find_segment_and_stack_by_refname(subject_branch_name) else {
+            bail!(
+                "Couldn't find branch to move in workspace with reference name: {subject_branch_name}"
+            );
+        };
+
+        let Some(destination) = workspace.find_segment_and_stack_by_refname(target_branch_name)
+        else {
+            bail!(
+                "Couldn't find target branch to move in workspace with reference name: {target_branch_name}"
+            );
+        };
+
+        let Some(workspace_head) = workspace.tip_commit().map(|commit| commit.id) else {
+            bail!("Couldn't find workspace head.")
+        };
+
+        let workspace_ref = match &workspace.kind {
+            WorkspaceKind::Managed { ref_info }
+            | WorkspaceKind::ManagedMissingWorkspaceCommit { ref_info } => {
+                ref_info.ref_name.clone()
+            }
+            WorkspaceKind::AdHoc => {
+                bail!("Moving branches in non-managed workspaces is not supported");
+            }
+        };
+
+        let mut ws_meta = meta.workspace(workspace_ref.as_ref())?;
+
+        let (source_stack, subject_segment) = source;
+        let (_, target_segment) = destination;
+        let target_segment_ref_name = target_segment
+            .ref_name()
+            .context("Target segment doesn't have a ref")?;
+        let target_selector = editor
+            .select_reference(target_segment_ref_name)
+            .context("Failed to find target reference in graph.")?;
+
+        let (subject_delimiter, children_to_disconnect, parents_to_disconnect) =
+            get_disconnect_parameters(
+                workspace,
+                &editor,
+                source_stack,
+                subject_segment,
+                workspace_head,
+            )?;
+
+        let skip_reconnect_step = source_stack.segments.len() == 1;
+        editor.disconnect_segment_from(
+            subject_delimiter.clone(),
+            children_to_disconnect,
+            parents_to_disconnect,
+            skip_reconnect_step,
+        )?;
+        editor.insert_segment(
+            target_selector,
+            subject_delimiter,
+            but_rebase::graph_rebase::mutate::InsertSide::Above,
+        )?;
+
+        // Update the workspace meta if any of the branches we're handling is empty.
+        // This is needed in order to disambiguate the intended operation.
+        let ws_meta = if subject_segment.commits.is_empty() || target_segment.commits.is_empty() {
+            ws_meta.remove_segment(subject_branch_name);
+            ws_meta.insert_new_segment_above_anchor_if_not_present(
+                subject_branch_name,
+                target_branch_name,
+            );
+            ws_meta
+        } else {
+            ws_meta
+        };
+
+        Ok(Outcome {
+            rebase: editor.rebase()?,
+            ws_meta,
+        })
+    }
+}
+
+/// Get the right disconnect parameters for the given subject segment and source stack.
+///
+/// This function determines which are the right parents and children to disconnect,
+/// as well as the right segment delimiter to move.
+fn get_disconnect_parameters(
+    workspace: &but_graph::projection::Workspace,
+    editor: &Editor,
+    source_stack: &Stack,
+    subject_segment: &StackSegment,
+    workspace_head: gix::ObjectId,
+) -> anyhow::Result<(
+    SegmentDelimiter<Selector, Selector>,
+    SelectorSet,
+    SelectorSet,
+)> {
+    let index_of_segment = source_stack
+        .segments
+        .iter()
+        .position(|segment| segment.id == subject_segment.id)
+        .context("BUG: Unable to find subject segment on source stack.")?;
+
+    let subject_segment_ref_name = subject_segment
+        .ref_name()
+        .context("Subject segment doesn't have a ref name.")?;
+    let delimiter_child = editor
+        .select_reference(subject_segment_ref_name)
+        .context("Failed to find subject reference in graph.")?;
+    let delimiter_parent = match subject_segment.commits.last() {
+        Some(last_commit) => editor
+            .select_commit(last_commit.id)
+            .context("Failed to find last commit in subject segment in graph.")?,
+        None => {
+            // Subject segment is empty, move only the reference
+            delimiter_child
+        }
+    };
+
+    let delimiter = SegmentDelimiter {
+        child: delimiter_child,
+        parent: delimiter_parent,
+    };
+
+    let stack_base_segment = subject_segment.base_segment_id.and_then(|base_segment_id| {
+        source_stack
+            .segments
+            .iter()
+            .find(|segment| segment.id == base_segment_id)
+    });
+
+    let graph_base_segment = subject_segment
+        .base_segment_id
+        .map(|segment_idx| &workspace.graph[segment_idx]);
+
+    let parents_to_disconnect = match (stack_base_segment, graph_base_segment) {
+        (Some(stack_base_segment), _) => {
+            // Base segment is part of the source stack.
+            let base_segment_ref_name = stack_base_segment
+                .ref_name()
+                .context("Base segment doesn't have a ref name.")?;
+            let reference_selector = editor.select_reference(base_segment_ref_name)?;
+            let selectors = SomeSelectors::new(vec![reference_selector])?;
+            SelectorSet::Some(selectors)
+        }
+        (None, Some(graph_base_segment)) => {
+            // Base segment is outside of workspace (probably target branch).
+            let ref_name = graph_base_segment
+                .ref_name()
+                .context("Graph base segment doesn't have a ref name.")?;
+            let reference_selector = editor.select_reference(ref_name)?;
+            let selectors = SomeSelectors::new(vec![reference_selector])?;
+            SelectorSet::Some(selectors)
+        }
+        (None, None) => {
+            // No parents could be determined. Detach all.
+            SelectorSet::All
+        }
+    };
+
+    if index_of_segment == 0 {
+        // This is the top-most segment in the stack, so the parent is the workspace commit.
+        let workspace_head_selector = editor
+            .select_commit(workspace_head)
+            .context("Failed to find workspace head in graph.")?;
+        let selectors = SomeSelectors::new(vec![workspace_head_selector])?;
+        let children_to_disconnect = SelectorSet::Some(selectors);
+
+        return Ok((delimiter, children_to_disconnect, parents_to_disconnect));
+    }
+
+    // Segment on top of the subject segment in the stack.
+    let child_segment = source_stack.segments.get(index_of_segment - 1).context(
+        "BUG: Unable to find child segment of subject segment but expected it to exist.",
+    )?;
+    let child_selector = match child_segment.commits.last() {
+        Some(last_commit) => editor
+            .select_commit(last_commit.id)
+            .context("Failed to find last commit of child segment in graph."),
+        None => {
+            // The segment on top of the subject segment is empty. Select the reference.
+            let child_segment_ref_name = child_segment
+                .ref_name()
+                .context("Child segment doesn't have a ref name.")?;
+            editor
+                .select_reference(child_segment_ref_name)
+                .context("Failed to find child segment reference in graph.")
+        }
+    }?;
+    let selectors = SomeSelectors::new(vec![child_selector])?;
+    let children_to_disconnect = SelectorSet::Some(selectors);
+
+    Ok((delimiter, children_to_disconnect, parents_to_disconnect))
+}

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-single-stack-double-stack.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-single-stack-double-stack.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside:
+# - One with a single branch with a single commit
+# - Another with two branches, each with a single commit
+git init
+commit M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit A
+git checkout B
+  commit B
+git checkout B -b C
+  commit C
+create_workspace_commit_once A C

--- a/crates/but-workspace/tests/fixtures/scenario/ws-with-empty-stack.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-with-empty-stack.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside, one empty and one with a commit.
+git init
+commit M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit A
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/branch/mod.rs
+++ b/crates/but-workspace/tests/workspace/branch/mod.rs
@@ -1,4 +1,5 @@
 /// Various journeys with apply, unapply and commit operations.
 mod apply_unapply_commit_uncommit;
 mod create_reference;
+mod move_branch;
 mod remove_reference;

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1,0 +1,485 @@
+use but_core::RefMetadata;
+use but_rebase::graph_rebase::GraphExt;
+use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
+};
+
+#[test]
+fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put C on top of A
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/C".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   26fdd46 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * c813d8d (B) B
+    * | 3db8c14 (C) C
+    * | 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:B on 85efbe4 {2}
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:4:C on 85efbe4 {1}
+        ├── 📙:4:C
+        │   └── ·3db8c14 (🏘️)
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/B".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   ac869ab (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9f14615 (C) C
+    * | 698ccd3 (B) B
+    * | 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   └── 📙:4:C
+    │       └── ·9f14615 (🏘️)
+    └── ≡📙:5:B on 85efbe4 {1}
+        ├── 📙:5:B
+        │   └── ·698ccd3 (🏘️)
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put A on top of C
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/A".try_into()?,
+            "refs/heads/C".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 263392f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 8dbfefa (A) A
+    * 09bc93e (C) C
+    * c813d8d (B) B
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:3:A on 85efbe4 {1}
+        ├── 📙:3:A
+        │   └── ·8dbfefa (🏘️)
+        ├── 📙:4:C
+        │   └── ·09bc93e (🏘️)
+        └── 📙:5:B
+            └── ·c813d8d (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn reorder_branch_in_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put B on top of C
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/B".try_into()?,
+            "refs/heads/C".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   82661e2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 2c58ac6 (B) B
+    | * 9f14615 (C) C
+    * | 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:B on 85efbe4 {2}
+    │   ├── 📙:5:B
+    │   │   └── ·2c58ac6 (🏘️)
+    │   └── 📙:4:C
+    │       └── ·9f14615 (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put A on top of B, and below C
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/A".try_into()?,
+            "refs/heads/B".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 35a28f3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 531d8aa (C) C
+    * 3df48f1 (A) A
+    * c813d8d (B) B
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:C on 85efbe4 {2}
+        ├── 📙:4:C
+        │   └── ·531d8aa (🏘️)
+        ├── 📙:3:A
+        │   └── ·3df48f1 (🏘️)
+        └── 📙:5:B
+            └── ·c813d8d (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_empty_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("ws-with-empty-stack", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put B on top of A
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/B".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * ee3cff8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 09d8e52 (B, A) A
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:4:B on 85efbe4 {2}
+        ├── 📙:4:B
+        └── 📙:5:A
+            └── ·09d8e52 (🏘️)
+    ");
+    Ok(())
+}
+
+#[test]
+fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("ws-with-empty-stack", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    // Put A on top of B
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            "refs/heads/A".try_into()?,
+            "refs/heads/B".try_into()?,
+        )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+
+    ws.refresh_from_head(&repo, &meta)?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * ee3cff8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 09d8e52 (A) A
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    └── ≡📙:3:A on 85efbe4 {1}
+        ├── 📙:3:A
+        │   └── ·09d8e52 (🏘️)
+        └── 📙:4:B
+    ");
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -45,14 +45,13 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/C".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -118,14 +117,13 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/B".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -192,14 +190,13 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/A".try_into()?,
             "refs/heads/C".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -263,14 +260,13 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/B".try_into()?,
             "refs/heads/C".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -337,14 +333,13 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/A".try_into()?,
             "refs/heads/B".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -400,14 +395,13 @@ fn move_empty_branch() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/B".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -457,15 +451,13 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
         but_workspace::branch::move_branch(
             &ws,
             editor,
-            &mut meta,
             "refs/heads/A".try_into()?,
             "refs/heads/B".try_into()?,
         )?;
 
     // Materialize the operation
     rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
-
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     ws.refresh_from_head(&repo, &meta)?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -481,5 +473,18 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
         │   └── ·09d8e52 (🏘️)
         └── 📙:4:B
     ");
+    Ok(())
+}
+
+fn set_workspace_metadata(
+    meta: &mut impl RefMetadata,
+    ws: &but_graph::projection::Workspace,
+    ws_meta: Option<but_core::ref_metadata::Workspace>,
+) -> anyhow::Result<()> {
+    if let Some((ws_meta, ref_name)) = ws_meta.zip(ws.ref_name()) {
+        let mut md = meta.workspace(ref_name)?;
+        *md = ws_meta;
+        meta.set_workspace(&md)?;
+    }
     Ok(())
 }

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -119,6 +119,20 @@ pub enum Subcommands {
         #[clap(long)]
         check: bool,
     },
+    /// Move a branch on top of another branch, effectively stacking them.
+    ///
+    /// This allows you to e.g. create a stack out of two branches.
+    ///
+    /// Just specify the branch to move (or take out of a stack) and insert it into another stack,
+    /// on top of another branch.
+    Move {
+        /// The name or CLI ID of the branch to move
+        #[clap(value_name = "BRANCH")]
+        branch: String,
+        /// The name or CLI ID of the branch to move the branch on top of
+        #[clap(value_name = "TARGET_BRANCH")]
+        target_branch: String,
+    },
     /// Apply a branch to the workspace (non-legacy path)
     ///
     /// If you want to apply an unapplied branch to your workspace so you

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -30,6 +30,7 @@ pub enum CommandName {
     BranchShow,
     BranchUnapply,
     BranchApply,
+    BranchMove,
     ClaudePreTool,
     ClaudePostTool,
     ClaudeStop,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -345,6 +345,17 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Branch(branch::Platform),
 
+    /// Move branches on top of others to stack them.
+    #[clap(verbatim_doc_comment)]
+    Stack {
+        /// The branch being moved.
+        #[clap(value_name = "BRANCH")]
+        branch: String,
+        /// The branch to move the other on top of.
+        #[clap(value_name = "TARGET_BRANCH")]
+        target_branch: String,
+    },
+
     /// Commands for managing worktrees.
     ///
     /// GitButler worktrees allow you to have multiple working directories

--- a/crates/but/src/command/branch/mod.rs
+++ b/crates/but/src/command/branch/mod.rs
@@ -1,20 +1,6 @@
-use crate::{args::branch::Subcommands, utils::OutputChannel};
-use but_ctx::Context;
-
+#[cfg(not(feature = "legacy"))]
 mod apply;
+mod move_branch;
+#[cfg(not(feature = "legacy"))]
 pub use apply::apply;
-
-pub fn handle(
-    cmd: Option<Subcommands>,
-    ctx: Context,
-    out: &mut OutputChannel,
-) -> anyhow::Result<()> {
-    match cmd {
-        None => {
-            todo!("implement list and call recursively")
-        }
-        Some(cmd) => match cmd {
-            Subcommands::Apply { branch_name } => apply(ctx, &branch_name, out),
-        },
-    }
-}
+pub use move_branch::move_branch;

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -1,0 +1,101 @@
+use anyhow::{Context, bail};
+use but_core::RefMetadata;
+use but_rebase::graph_rebase::GraphExt;
+
+use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
+
+/// Move a branch on top of another
+pub fn move_branch(
+    mut ctx: but_ctx::Context,
+    branch: &str,
+    target_branch: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let id_map = IdMap::new_from_context(&mut ctx, None)?;
+    let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
+        .context("Failed to determine information for the branch to move.")?;
+    let target_branch_name = resolve_branch_information(&mut ctx, &id_map, target_branch)
+        .context("Failed to determine information for the target branch.")?;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+    let editor = ws.graph.to_editor(&repo)?;
+
+    let branch_ref_name_str = &format!("refs/heads/{branch_name}");
+    let target_ref_name_str = &format!("refs/heads/{target_branch_name}");
+
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            &ws,
+            editor,
+            &mut meta,
+            branch_ref_name_str.try_into()?,
+            target_ref_name_str.try_into()?,
+        )?;
+    rebase.materialize()?;
+    meta.set_workspace(&ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "Moved branch '{branch_name}' on top of '{target_branch_name}'."
+        )?;
+    }
+
+    Ok(())
+}
+
+fn resolve_branch_information(
+    ctx: &mut but_ctx::Context,
+    id_map: &IdMap,
+    branch_selector: &str,
+) -> anyhow::Result<String> {
+    let branch_cli_ids = parse_sources(ctx, id_map, branch_selector)?;
+    let branch_name = match &branch_cli_ids.as_slice() {
+        &[single_clid] => {
+            // TODO: Check that it's a branch CLI ID.
+            match single_clid {
+                CliId::Branch { name, .. } => name,
+                CliId::Commit { .. } => {
+                    bail!(
+                        "Unable to resolve branch information from commit selector: {branch_selector}"
+                    );
+                }
+                CliId::CommittedFile { .. } => {
+                    bail!(
+                        "Unable to resolve branch information from committed file selector: {branch_selector}"
+                    );
+                }
+                CliId::PathPrefix { .. } => {
+                    bail!(
+                        "Unable to resolve branch information from path prefix selector: {branch_selector}"
+                    );
+                }
+                CliId::Stack { .. } => {
+                    // TODO: Should we select the top branch?
+                    bail!(
+                        "Unable to resolve branch information from stack selector: {branch_selector}"
+                    );
+                }
+                CliId::Unassigned { .. } => {
+                    bail!(
+                        "Unable to resolve branch information from unassigned area selector: {branch_selector}"
+                    );
+                }
+                CliId::Uncommitted(..) => {
+                    bail!(
+                        "Unable to resolve branch information from uncommitted change selector: {branch_selector}"
+                    );
+                }
+            }
+        }
+        _ => {
+            // If there's 0 or more than one CLI ID found, we can't determine the branch information reliably.
+            bail!("Unable to resolve the branch information from selector: {branch_selector}");
+        }
+    };
+
+    Ok(branch_name.clone())
+}

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -1,8 +1,5 @@
-use anyhow::{Context, bail};
-use but_core::RefMetadata;
-use but_rebase::graph_rebase::GraphExt;
-
 use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
+use anyhow::{Context, bail};
 
 /// Move a branch on top of another
 pub fn move_branch(
@@ -17,25 +14,14 @@ pub fn move_branch(
     let target_branch_name = resolve_branch_information(&mut ctx, &id_map, target_branch)
         .context("Failed to determine information for the target branch.")?;
 
-    let mut guard = ctx.exclusive_worktree_access();
-    let mut meta = ctx.meta()?;
-    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
-    let editor = ws.graph.to_editor(&repo)?;
-
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
     let target_ref_name_str = &format!("refs/heads/{target_branch_name}");
 
-    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(
-            &ws,
-            editor,
-            &mut meta,
-            branch_ref_name_str.try_into()?,
-            target_ref_name_str.try_into()?,
-        )?;
-    rebase.materialize()?;
-    meta.set_workspace(&ws_meta)?;
-    ws.refresh_from_head(&repo, &meta)?;
+    but_api::branch::move_branch(
+        &mut ctx,
+        branch_ref_name_str.try_into()?,
+        target_ref_name_str.try_into()?,
+    )?;
 
     if let Some(out) = out.for_human() {
         writeln!(
@@ -55,7 +41,6 @@ fn resolve_branch_information(
     let branch_cli_ids = parse_sources(ctx, id_map, branch_selector)?;
     let branch_name = match &branch_cli_ids.as_slice() {
         &[single_clid] => {
-            // TODO: Check that it's a branch CLI ID.
             match single_clid {
                 CliId::Branch { name, .. } => name,
                 CliId::Commit { .. } => {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,12 +1,10 @@
 use anyhow::bail;
-use branch::Subcommands;
 use but_api::json::HexHash;
 use but_core::ref_metadata::StackId;
 use colored::Colorize;
 
 use crate::{
     CliId, IdMap,
-    args::branch,
     utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
 
@@ -15,182 +13,184 @@ mod json;
 mod list;
 mod show;
 
-pub fn handle(
-    cmd: Option<Subcommands>,
+pub fn delete(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
-) -> anyhow::Result<()> {
-    match cmd {
-        None => handle(
-            Some(Subcommands::List {
-                filter: None,
-                local: false,
-                remote: false,
-                all: false,
-                no_ahead: false,
-                review: false,
-                no_check: false,
-                empty: false,
-            }),
-            ctx,
-            out,
-        ),
-        Some(Subcommands::List {
-            filter,
-            local,
-            remote,
-            all,
-            no_ahead,
-            review,
-            no_check,
-            empty,
-        }) => {
-            let ahead = !no_ahead; // Invert the flag
-            let check = !no_check; // Invert the flag
-            list::list(
-                ctx, local, remote, all, ahead, review, filter, out, check, empty,
-            )?;
-            Ok(())
+    branch_name: String,
+    force: bool,
+) -> Result<(), anyhow::Error> {
+    let stacks = but_api::legacy::workspace::stacks(
+        ctx,
+        Some(but_workspace::legacy::StacksFilter::InWorkspace),
+    )?;
+
+    // Find which stack this branch belongs to
+    for stack_entry in &stacks {
+        if stack_entry.heads.iter().all(|b| b.name != *branch_name) {
+            // Not found in this stack,
+            continue;
         }
-        Some(Subcommands::Show {
-            branch_id,
-            review,
-            files,
-            ai,
-            check,
-        }) => {
-            show::show(ctx, &branch_id, out, review, files, ai, check)?;
-            Ok(())
-        }
-        Some(Subcommands::New {
-            branch_name,
-            anchor,
-        }) => {
-            let id_map = IdMap::new_from_context(ctx, None)?;
-            // Get branch name or use canned name
-            let branch_name = branch_name
-                .map(Ok)
-                .unwrap_or_else(|| but_api::legacy::workspace::canned_branch_name(ctx))?;
 
-            // Store anchor string for JSON output
-            let anchor_for_json = anchor.clone();
-
-            let anchor = if let Some(anchor_str) = anchor {
-                // Use the new create_reference API when anchor is provided
-
-                // Resolve the anchor string to a CliId
-                let anchor_ids = id_map.parse_using_context(&anchor_str, ctx)?;
-                if anchor_ids.is_empty() {
-                    return Err(anyhow::anyhow!("Could not find anchor: {anchor_str}"));
-                }
-                if anchor_ids.len() > 1 {
-                    return Err(anyhow::anyhow!(
-                        "Ambiguous anchor '{anchor_str}', matches multiple items"
-                    ));
-                }
-                let anchor_id = &anchor_ids[0];
-
-                // Create the anchor for create_reference
-                // as dependent branch
-                match anchor_id {
-                    CliId::Commit { commit_id: oid, .. } => {
-                        Some(but_api::legacy::stack::create_reference::Anchor::AtCommit {
-                            commit_id: HexHash(*oid),
-                            position: but_workspace::branch::create_reference::Position::Above,
-                        })
-                    }
-                    CliId::Branch { name, .. } => Some(
-                        but_api::legacy::stack::create_reference::Anchor::AtReference {
-                            short_name: name.clone(),
-                            position: but_workspace::branch::create_reference::Position::Above,
-                        },
-                    ),
-                    _ => {
-                        return Err(anyhow::anyhow!(
-                            "Invalid anchor type: {}, expected commit or branch",
-                            anchor_id.kind_for_humans()
-                        ));
-                    }
-                }
-            } else {
-                // Create an independent branch
-                None
-            };
-
-            let anchor_display = {
-                let repo = ctx.repo.get()?;
-                anchor.as_ref().map(|anchor_ref| match anchor_ref {
-                    but_api::legacy::stack::create_reference::Anchor::AtReference {
-                        short_name,
-                        ..
-                    } => short_name.clone(),
-                    but_api::legacy::stack::create_reference::Anchor::AtCommit {
-                        commit_id,
-                        ..
-                    } => shorten_object_id(&repo, commit_id.0),
-                })
-            };
-
-            but_api::legacy::stack::create_reference(
-                ctx,
-                but_api::legacy::stack::create_reference::Request {
-                    new_name: branch_name.clone(),
-                    anchor,
-                },
-            )?;
-
-            if let Some(out) = out.for_human() {
-                if let Some(anchor_name) = anchor_display {
-                    writeln!(
-                        out,
-                        "{} {} stacked on {}",
-                        "✓ Created branch".green(),
-                        branch_name.yellow(),
-                        anchor_name.dimmed()
-                    )?;
-                } else {
-                    writeln!(
-                        out,
-                        "{} {}",
-                        "✓ Created branch".green(),
-                        branch_name.yellow()
-                    )?;
-                }
-            } else if let Some(out) = out.for_shell() {
-                writeln!(out, "{branch_name}")?;
-            } else if let Some(out) = out.for_json() {
-                let value = json::BranchNewOutput {
-                    branch: branch_name.clone(),
-                    anchor: anchor_for_json,
-                };
-                out.write_value(value)?;
-            }
-            Ok(())
-        }
-        Some(Subcommands::Delete { branch_name, force }) => {
-            let stacks = but_api::legacy::workspace::stacks(
-                ctx,
-                Some(but_workspace::legacy::StacksFilter::InWorkspace),
-            )?;
-
-            // Find which stack this branch belongs to
-            for stack_entry in &stacks {
-                if stack_entry.heads.iter().all(|b| b.name != *branch_name) {
-                    // Not found in this stack,
-                    continue;
-                }
-
-                if let Some(sid) = stack_entry.id {
-                    return confirm_branch_deletion(ctx, sid, &branch_name, force, out);
-                }
-            }
-
-            if let Some(out) = out.for_human() {
-                writeln!(out, "Branch '{branch_name}' not found in any stack")?;
-            }
-            Ok(())
+        if let Some(sid) = stack_entry.id {
+            return confirm_branch_deletion(ctx, sid, &branch_name, force, out);
         }
     }
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Branch '{branch_name}' not found in any stack")?;
+    }
+    Ok(())
+}
+
+pub fn new(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    branch_name: Option<String>,
+    anchor: Option<String>,
+) -> Result<(), anyhow::Error> {
+    let id_map = IdMap::new_from_context(ctx, None)?;
+    // Get branch name or use canned name
+    let branch_name = branch_name
+        .map(Ok)
+        .unwrap_or_else(|| but_api::legacy::workspace::canned_branch_name(ctx))?;
+
+    // Store anchor string for JSON output
+    let anchor_for_json = anchor.clone();
+
+    let anchor = if let Some(anchor_str) = anchor {
+        // Use the new create_reference API when anchor is provided
+
+        // Resolve the anchor string to a CliId
+        let anchor_ids = id_map.parse_using_context(&anchor_str, ctx)?;
+        if anchor_ids.is_empty() {
+            return Err(anyhow::anyhow!("Could not find anchor: {anchor_str}"));
+        }
+        if anchor_ids.len() > 1 {
+            return Err(anyhow::anyhow!(
+                "Ambiguous anchor '{anchor_str}', matches multiple items"
+            ));
+        }
+        let anchor_id = &anchor_ids[0];
+
+        // Create the anchor for create_reference
+        // as dependent branch
+        match anchor_id {
+            CliId::Commit { commit_id: oid, .. } => {
+                Some(but_api::legacy::stack::create_reference::Anchor::AtCommit {
+                    commit_id: HexHash(*oid),
+                    position: but_workspace::branch::create_reference::Position::Above,
+                })
+            }
+            CliId::Branch { name, .. } => Some(
+                but_api::legacy::stack::create_reference::Anchor::AtReference {
+                    short_name: name.clone(),
+                    position: but_workspace::branch::create_reference::Position::Above,
+                },
+            ),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid anchor type: {}, expected commit or branch",
+                    anchor_id.kind_for_humans()
+                ));
+            }
+        }
+    } else {
+        // Create an independent branch
+        None
+    };
+
+    let anchor_display = {
+        let repo = ctx.repo.get()?;
+        anchor.as_ref().map(|anchor_ref| match anchor_ref {
+            but_api::legacy::stack::create_reference::Anchor::AtReference {
+                short_name, ..
+            } => short_name.clone(),
+            but_api::legacy::stack::create_reference::Anchor::AtCommit { commit_id, .. } => {
+                shorten_object_id(&repo, commit_id.0)
+            }
+        })
+    };
+
+    but_api::legacy::stack::create_reference(
+        ctx,
+        but_api::legacy::stack::create_reference::Request {
+            new_name: branch_name.clone(),
+            anchor,
+        },
+    )?;
+
+    if let Some(out) = out.for_human() {
+        if let Some(anchor_name) = anchor_display {
+            writeln!(
+                out,
+                "{} {} stacked on {}",
+                "✓ Created branch".green(),
+                branch_name.yellow(),
+                anchor_name.dimmed()
+            )?;
+        } else {
+            writeln!(
+                out,
+                "{} {}",
+                "✓ Created branch".green(),
+                branch_name.yellow()
+            )?;
+        }
+    } else if let Some(out) = out.for_shell() {
+        writeln!(out, "{branch_name}")?;
+    } else if let Some(out) = out.for_json() {
+        let value = json::BranchNewOutput {
+            branch: branch_name.clone(),
+            anchor: anchor_for_json,
+        };
+        out.write_value(value)?;
+    }
+    Ok(())
+}
+
+pub fn show_branches(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    branch_id: String,
+    review: bool,
+    files: bool,
+    ai: bool,
+    check: bool,
+) -> Result<(), anyhow::Error> {
+    show::show(ctx, &branch_id, out, review, files, ai, check)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn list_branches(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    filter: Option<String>,
+    local: bool,
+    remote: bool,
+    all: bool,
+    no_ahead: bool,
+    review: bool,
+    no_check: bool,
+    empty: bool,
+) -> Result<(), anyhow::Error> {
+    let ahead = !no_ahead;
+    // Invert the flag
+    let check = !no_check;
+    // Invert the flag
+    list::list(
+        ctx, local, remote, all, ahead, review, filter, out, check, empty,
+    )?;
+    Ok(())
+}
+
+pub fn handle_no_subcommand(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+) -> Result<(), anyhow::Error> {
+    list_branches(
+        ctx, out, None, false, false, false, false, false, false, false,
+    )
 }
 
 fn confirm_branch_deletion(

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -3,7 +3,6 @@
 pub mod legacy;
 
 pub mod alias;
-#[cfg(not(feature = "legacy"))]
 pub mod branch;
 pub mod completions;
 pub mod config;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -322,104 +322,116 @@ async fn match_subcommand(
         Subcommands::Link(link_args) => {
             but_link::handle(link_args, &args.current_dir).emit_metrics(metrics_ctx)
         }
-        Subcommands::Branch(branch::Platform { cmd }) => match cmd {
-            #[cfg(not(feature = "legacy"))]
-            None => todo!("implement list and call recursively"),
-            #[cfg(feature = "legacy")]
-            None => {
-                let mut ctx = setup::init_ctx(
-                    &args,
-                    InitCtxOptions {
-                        background_sync: BackgroundSync::Enabled,
-                        ..Default::default()
-                    },
-                    out,
-                )?;
-                command::legacy::branch::handle_no_subcommand(&mut ctx, out)
-            }
-            #[cfg(feature = "legacy")]
-            Some(branch::Subcommands::List {
-                filter,
-                local,
-                remote,
-                all,
-                no_ahead,
-                review,
-                no_check,
-                empty,
-            }) => {
-                let mut ctx = setup::init_ctx(
-                    &args,
-                    InitCtxOptions {
-                        background_sync: BackgroundSync::Enabled,
-                        ..Default::default()
-                    },
-                    out,
-                )?;
-                command::legacy::branch::list_branches(
-                    &mut ctx, out, filter, local, remote, all, no_ahead, review, no_check, empty,
-                )
-            }
-            #[cfg(feature = "legacy")]
-            Some(branch::Subcommands::Show {
-                branch_id,
-                review,
-                files,
-                ai,
-                check,
-            }) => {
-                let mut ctx = setup::init_ctx(
-                    &args,
-                    InitCtxOptions {
-                        background_sync: BackgroundSync::Enabled,
-                        ..Default::default()
-                    },
-                    out,
-                )?;
-                command::legacy::branch::show_branches(
-                    &mut ctx, out, branch_id, review, files, ai, check,
-                )
-            }
-            #[cfg(feature = "legacy")]
-            Some(branch::Subcommands::New {
-                branch_name,
-                anchor,
-            }) => {
-                let mut ctx = setup::init_ctx(
-                    &args,
-                    InitCtxOptions {
-                        background_sync: BackgroundSync::Enabled,
-                        ..Default::default()
-                    },
-                    out,
-                )?;
-                command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
-            }
-            #[cfg(feature = "legacy")]
-            Some(branch::Subcommands::Delete { branch_name, force }) => {
-                let mut ctx = setup::init_ctx(
-                    &args,
-                    InitCtxOptions {
-                        background_sync: BackgroundSync::Enabled,
-                        ..Default::default()
-                    },
-                    out,
-                )?;
-                command::legacy::branch::delete(&mut ctx, out, branch_name, force)
-            }
-            #[cfg(not(feature = "legacy"))]
-            Some(branch::Subcommands::Apply { branch_name }) => {
-                let ctx = but_ctx::Context::discover(&args.current_dir)?;
-                command::branch::apply(ctx, &branch_name, out)
-            }
-            Some(branch::Subcommands::Move {
-                branch,
-                target_branch,
-            }) => {
-                let ctx = but_ctx::Context::discover(&args.current_dir)?;
-                command::branch::move_branch(ctx, &branch, &target_branch, out)
-            }
-        },
+        Subcommands::Stack {
+            branch,
+            target_branch,
+        } => {
+            let ctx = but_ctx::Context::discover(&args.current_dir)?;
+            command::branch::move_branch(ctx, &branch, &target_branch, out)
+                .emit_metrics(metrics_ctx)
+        }
+        Subcommands::Branch(branch::Platform { cmd }) => {
+            let result = match cmd {
+                #[cfg(not(feature = "legacy"))]
+                None => todo!("implement list and call recursively"),
+                #[cfg(feature = "legacy")]
+                None => {
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Enabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::legacy::branch::handle_no_subcommand(&mut ctx, out)
+                }
+                #[cfg(feature = "legacy")]
+                Some(branch::Subcommands::List {
+                    filter,
+                    local,
+                    remote,
+                    all,
+                    no_ahead,
+                    review,
+                    no_check,
+                    empty,
+                }) => {
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Enabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::legacy::branch::list_branches(
+                        &mut ctx, out, filter, local, remote, all, no_ahead, review, no_check,
+                        empty,
+                    )
+                }
+                #[cfg(feature = "legacy")]
+                Some(branch::Subcommands::Show {
+                    branch_id,
+                    review,
+                    files,
+                    ai,
+                    check,
+                }) => {
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Enabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::legacy::branch::show_branches(
+                        &mut ctx, out, branch_id, review, files, ai, check,
+                    )
+                }
+                #[cfg(feature = "legacy")]
+                Some(branch::Subcommands::New {
+                    branch_name,
+                    anchor,
+                }) => {
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Enabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
+                }
+                #[cfg(feature = "legacy")]
+                Some(branch::Subcommands::Delete { branch_name, force }) => {
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Enabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::legacy::branch::delete(&mut ctx, out, branch_name, force)
+                }
+                #[cfg(not(feature = "legacy"))]
+                Some(branch::Subcommands::Apply { branch_name }) => {
+                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                    command::branch::apply(ctx, &branch_name, out)
+                }
+                Some(branch::Subcommands::Move {
+                    branch,
+                    target_branch,
+                }) => {
+                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                    command::branch::move_branch(ctx, &branch, &target_branch, out)
+                }
+            };
+            result.emit_metrics(metrics_ctx)
+        }
         #[cfg(feature = "legacy")]
         Subcommands::Mcp { internal } => {
             if internal {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -322,18 +322,104 @@ async fn match_subcommand(
         Subcommands::Link(link_args) => {
             but_link::handle(link_args, &args.current_dir).emit_metrics(metrics_ctx)
         }
-        Subcommands::Branch(branch::Platform { cmd }) => {
-            cfg_if! {
-                if #[cfg(feature = "legacy")]  {
-                    let mut ctx = setup::init_ctx(&args, InitCtxOptions { background_sync: BackgroundSync::Enabled, ..Default::default() }, out)?;
-                    command::legacy::branch::handle(cmd, &mut ctx, out)
-                        .emit_metrics(metrics_ctx)
-                } else {
-                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
-                    command::branch::handle(cmd, ctx, out)
-                }
+        Subcommands::Branch(branch::Platform { cmd }) => match cmd {
+            #[cfg(not(feature = "legacy"))]
+            None => todo!("implement list and call recursively"),
+            #[cfg(feature = "legacy")]
+            None => {
+                let mut ctx = setup::init_ctx(
+                    &args,
+                    InitCtxOptions {
+                        background_sync: BackgroundSync::Enabled,
+                        ..Default::default()
+                    },
+                    out,
+                )?;
+                command::legacy::branch::handle_no_subcommand(&mut ctx, out)
             }
-        }
+            #[cfg(feature = "legacy")]
+            Some(branch::Subcommands::List {
+                filter,
+                local,
+                remote,
+                all,
+                no_ahead,
+                review,
+                no_check,
+                empty,
+            }) => {
+                let mut ctx = setup::init_ctx(
+                    &args,
+                    InitCtxOptions {
+                        background_sync: BackgroundSync::Enabled,
+                        ..Default::default()
+                    },
+                    out,
+                )?;
+                command::legacy::branch::list_branches(
+                    &mut ctx, out, filter, local, remote, all, no_ahead, review, no_check, empty,
+                )
+            }
+            #[cfg(feature = "legacy")]
+            Some(branch::Subcommands::Show {
+                branch_id,
+                review,
+                files,
+                ai,
+                check,
+            }) => {
+                let mut ctx = setup::init_ctx(
+                    &args,
+                    InitCtxOptions {
+                        background_sync: BackgroundSync::Enabled,
+                        ..Default::default()
+                    },
+                    out,
+                )?;
+                command::legacy::branch::show_branches(
+                    &mut ctx, out, branch_id, review, files, ai, check,
+                )
+            }
+            #[cfg(feature = "legacy")]
+            Some(branch::Subcommands::New {
+                branch_name,
+                anchor,
+            }) => {
+                let mut ctx = setup::init_ctx(
+                    &args,
+                    InitCtxOptions {
+                        background_sync: BackgroundSync::Enabled,
+                        ..Default::default()
+                    },
+                    out,
+                )?;
+                command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
+            }
+            #[cfg(feature = "legacy")]
+            Some(branch::Subcommands::Delete { branch_name, force }) => {
+                let mut ctx = setup::init_ctx(
+                    &args,
+                    InitCtxOptions {
+                        background_sync: BackgroundSync::Enabled,
+                        ..Default::default()
+                    },
+                    out,
+                )?;
+                command::legacy::branch::delete(&mut ctx, out, branch_name, force)
+            }
+            #[cfg(not(feature = "legacy"))]
+            Some(branch::Subcommands::Apply { branch_name }) => {
+                let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                command::branch::apply(ctx, &branch_name, out)
+            }
+            Some(branch::Subcommands::Move {
+                branch,
+                target_branch,
+            }) => {
+                let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                command::branch::move_branch(ctx, &branch, &target_branch, out)
+            }
+        },
         #[cfg(feature = "legacy")]
         Subcommands::Mcp { internal } => {
             if internal {

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -73,6 +73,7 @@ impl Subcommands {
             Subcommands::Pull { .. } => Pull,
             #[cfg(feature = "legacy")]
             Subcommands::Fetch => Pull,
+            Subcommands::Stack { .. } => BranchMove,
             Subcommands::Branch(branch::Platform { cmd }) => match cmd {
                 None => BranchList,
                 #[cfg(feature = "legacy")]

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -83,6 +83,7 @@ impl Subcommands {
                 Some(branch::Subcommands::Delete { .. }) => BranchDelete,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Show { .. }) => BranchShow,
+                Some(branch::Subcommands::Move { .. }) => BranchMove,
                 #[cfg(not(feature = "legacy"))]
                 Some(branch::Subcommands::Apply { .. }) => BranchApply,
             },

--- a/crates/but/tests/but/command/branch/mod.rs
+++ b/crates/but/tests/but/command/branch/mod.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod move_branch;
 #[cfg(feature = "legacy")]
 mod new;
 mod unapply;

--- a/crates/but/tests/but/command/branch/move_branch.rs
+++ b/crates/but/tests/but/command/branch/move_branch.rs
@@ -1,0 +1,528 @@
+use crate::utils::Sandbox;
+use snapbox::str;
+
+#[test]
+fn move_branch_by_name_to_the_top_of_another() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   49b2841 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    * | 3842fc0 (C) add C
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch A on top of C
+    env.but("branch move A C")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'A' on top of 'C'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   afff88e add A  
+┊│
+┊├┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn move_branch_by_cli_id_to_the_top_of_another() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   49b2841 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    * | 3842fc0 (C) add C
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch A on top of C
+    env.but("branch move g0 h0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'A' on top of 'C'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   afff88e add A  
+┊│
+┊├┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn move_branch_by_cli_id_to_the_middle_of_another() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   49b2841 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    * | 3842fc0 (C) add C
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch A on top of B
+    env.but("branch move g0 i0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'A' on top of 'B'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [C]  
+┊●   c946b0e add C  
+┊│
+┊├┄h0 [A]  
+┊●   8f3ad84 add A  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn move_branch_by_cli_id_from_the_bottom_to_the_top_of_another() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   49b2841 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    * | 3842fc0 (C) add C
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch B on top of A
+    env.but("branch move i0 g0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'B' on top of 'A'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [B]  
+┊●   b40d58b add B  
+┊│
+┊├┄h0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄i0 [C]  
+┊●   31e83cd add C  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn reorder_branch_within_stack() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   49b2841 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    * | 3842fc0 (C) add C
+    * | d3e2ba3 (B) add B
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [C]  
+┊●   3842fc0 add C  
+┊│
+┊├┄i0 [B]  
+┊●   d3e2ba3 add B  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch B on top of C
+    env.but("branch move i0 h0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'B' on top of 'C'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [B]  
+┊●   958528a add B  
+┊│
+┊├┄i0 [C]  
+┊●   31e83cd add C  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn move_empty_branch_to_top_of_another_stack() -> anyhow::Result<()> {
+    let env =
+        Sandbox::open_or_init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   802f604 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main, B) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [B] (no commits) 
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch B on top of A
+    env.but("branch move h0 g0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'B' on top of 'A'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [B] (no commits) 
+┊│
+┊├┄h0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}
+
+#[test]
+fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
+    let env =
+        Sandbox::open_or_init_scenario_with_target_and_default_settings("two-stacks-one-empty")?;
+    insta::assert_snapshot!(env.git_log()?, @r"
+    *   802f604 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9477ae7 (A) add A
+    |/  
+    * 0dc3733 (origin/main, origin/HEAD, main, B) add M
+    ");
+
+    env.setup_metadata(&["A", "B"])?;
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+├╯
+┊
+┊╭┄h0 [B] (no commits) 
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move branch B on top of A
+    env.but("branch move g0 h0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'A' on top of 'B'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Check that the operation succeeded.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes] 
+┊     no changes
+┊
+┊╭┄g0 [A]  
+┊●   9477ae7 add A  
+┊│
+┊├┄h0 [B] (no commits) 
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+    Ok(())
+}

--- a/crates/but/tests/fixtures/scenario/two-stacks-one-empty.sh
+++ b/crates/but/tests/fixtures/scenario/two-stacks-one-empty.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside.
+# One with one commit, one empty
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit-file A
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but/tests/fixtures/scenario/two-stacks-one-single-and-ready-to-mingle-one-double.sh
+++ b/crates/but/tests/fixtures/scenario/two-stacks-one-single-and-ready-to-mingle-one-double.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside.
+# One with one branch and one commit.
+# Another with two branches, each with one commit inside.
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit-file A
+git checkout B
+  commit-file B
+git checkout B -b C
+  commit-file C
+create_workspace_commit_once A C

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -286,7 +286,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_squash_commits::squash_commits,
                 legacy::virtual_branches::tauri_fetch_from_remotes::fetch_from_remotes,
                 legacy::virtual_branches::tauri_move_commit::move_commit,
-                legacy::virtual_branches::tauri_move_branch::move_branch,
+                legacy::virtual_branches::tauri_move_branch_legacy::move_branch_legacy,
                 legacy::virtual_branches::tauri_tear_off_branch::tear_off_branch,
                 legacy::virtual_branches::tauri_normalize_branch_name::normalize_branch_name,
                 legacy::virtual_branches::tauri_upstream_integration_statuses::upstream_integration_statuses,


### PR DESCRIPTION
Implement the new way of moving branches by using the graph and new rebase engine.

- Add mutation primitives for disconnecting and inserting segments in the graph
- Add an API that enables moving branches using the graph (and mark the previous version as legacy)
- Add a but command for moving branches

### Usage of the but command
```
but branch move [branch-to-move] [target-branch]
# or 
but stack [brach-to-move] [target-branch]
```

### Tests
- Test at the graph operation level
- Test at the move-branch API level
- Test at the but CLI level

fixes GB-1089
