### PR TITLE
Add dedicated trybuild based testing for but-api macro crate

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -339,6 +339,8 @@ jobs:
             cargo check -p gitbutler-tauri --no-default-features --features "$feature"
           done
         name: Test Tauri and Check Tauri App Features
+      - name: Test but-api-macros feature matrix
+        run: make test-but-api-macros
 
   check-rust-windows:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "but-api-macros-tests"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "but-api-macros",
+ "but-ctx",
+ "but-error",
+ "futures",
+ "gix",
+ "napi",
+ "napi-derive",
+ "serde",
+ "serde_json",
+ "tauri",
+ "trybuild",
+]
+
+[[package]]
 name = "but-bot"
 version = "0.1.0"
 dependencies = [
@@ -10042,6 +10061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tauri"
 version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10901,6 +10926,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10914,6 +10954,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -11187,6 +11236,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.0.3+spec-1.1.0",
+]
 
 [[package]]
 name = "ts-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tokio",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
     # the non-legacy code should be matching Exemplary standards of documentation
     "crates/but-api",               # 📄A project-based API to used by all clients (CLI, GUI, etc)
     "crates/but-api-macros",        # 📄A utility to generate exactly the code we need in the `but-api`.
+    "crates/but-api-macros/tests",  # 📄Compile-time coverage for all `#[but_api]` macro features.
 
     ##
     ### Binaries

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,12 @@ clippy:
 .PHONY: clippy-fix
 clippy-fix:
 	cargo clippy --workspace --all-targets --fix --allow-dirty
+
+# Test: compile-time coverage for `but-api-macros` across relevant feature combinations.
+.PHONY: test-but-api-macros
+test-but-api-macros:
+	set -x
+	cargo test -p but-api-macros-tests
+	cargo test -p but-api-macros-tests --features legacy
+	cargo test -p but-api-macros-tests --features tauri
+	cargo test -p but-api-macros-tests --features napi

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ clippy-fix:
 # Test: compile-time coverage for `but-api-macros` across relevant feature combinations.
 .PHONY: test-but-api-macros
 test-but-api-macros:
-	set -x
 	cargo test -p but-api-macros-tests
 	cargo test -p but-api-macros-tests --features legacy
 	cargo test -p but-api-macros-tests --features tauri

--- a/crates/but-api-macros/tests/Cargo.toml
+++ b/crates/but-api-macros/tests/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 default = []
 legacy = []
 tauri = ["dep:tauri", "legacy"]
-napi = ["dep:napi", "dep:napi-derive", "legacy"]
+napi = ["dep:napi", "dep:napi-derive", "dep:tokio", "legacy"]
 
 [dependencies]
 but-api-macros = { path = ".." }
@@ -28,6 +28,7 @@ bstr = { workspace = true, features = ["serde"] }
 tauri = { version = "^2.9.5", features = ["unstable"], optional = true }
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"], optional = true }
 napi-derive = { version = "3.0.0", optional = true }
+tokio = { workspace = true, optional = true, features = ["rt"] }
 
 [dev-dependencies]
 trybuild = "1.0.114"

--- a/crates/but-api-macros/tests/Cargo.toml
+++ b/crates/but-api-macros/tests/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "but-api-macros-tests"
+version = "0.0.0"
+edition.workspace = true
+authors.workspace = true
+publish = false
+rust-version.workspace = true
+
+[lib]
+doctest = false
+
+[features]
+default = []
+legacy = []
+tauri = ["dep:tauri", "legacy"]
+napi = ["dep:napi", "dep:napi-derive", "legacy"]
+
+[dependencies]
+but-api-macros = { path = ".." }
+but-error.workspace = true 
+but-ctx = { workspace = true , features = ["legacy"] }
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+gix.workspace = true
+futures.workspace = true
+bstr = { workspace = true, features = ["serde"] }
+tauri = { version = "^2.9.5", features = ["unstable"], optional = true }
+napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"], optional = true }
+napi-derive = { version = "3.0.0", optional = true }
+
+[dev-dependencies]
+trybuild = "1.0.114"
+
+[lints]
+workspace = true

--- a/crates/but-api-macros/tests/Cargo.toml
+++ b/crates/but-api-macros/tests/Cargo.toml
@@ -35,3 +35,6 @@ trybuild = "1.0.114"
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["futures", "napi", "napi-derive", "tauri", "but-error", "tokio"]

--- a/crates/but-api-macros/tests/src/lib.rs
+++ b/crates/but-api-macros/tests/src/lib.rs
@@ -3,9 +3,8 @@
 //! This crate exists to give trybuild UI tests a small, controlled environment that
 //! resembles the parts of `but-api` the `#[but_api]` macro expands against.
 //! In particular it provides lightweight stand-ins for modules and types the *macro*
-//! references directly (for example `json`, `panic_capture`, `but_ctx`, and
-//! `but_error`) so expansion can be validated without depending on the full `but-api`
-//! crate graph.
+//! references directly (for example `json`, `panic_capture`) so expansion can be
+//! validated without depending on the full `but-api` crate graph.
 //!
 //! Keep this crate intentionally minimal. Extend it only when macro output starts
 //! referencing new paths, traits, or conversion behavior that existing test shims

--- a/crates/but-api-macros/tests/src/lib.rs
+++ b/crates/but-api-macros/tests/src/lib.rs
@@ -1,0 +1,129 @@
+//! Support library for `but-api-macros` compile-time tests.
+//!
+//! This crate exists to give trybuild UI tests a small, controlled environment that
+//! resembles the parts of `but-api` the `#[but_api]` macro expands against.
+//! In particular it provides lightweight stand-ins for modules and types the *macro*
+//! references directly (for example `json`, `panic_capture`, `but_ctx`, and
+//! `but_error`) so expansion can be validated without depending on the full `but-api`
+//! crate graph.
+//!
+//! Keep this crate intentionally minimal. Extend it only when macro output starts
+//! referencing new paths, traits, or conversion behavior that existing test shims
+//! cannot satisfy.
+
+use std::str::FromStr;
+
+pub mod panic_capture {
+    pub fn panic_payload_to_anyhow(
+        function_name: &str,
+        _payload: Box<dyn std::any::Any + Send>,
+    ) -> anyhow::Error {
+        anyhow::anyhow!("panic captured in {function_name}")
+    }
+}
+
+pub mod json {
+    use std::str::FromStr;
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+    #[serde(transparent)]
+    pub struct HexHash(pub String);
+
+    impl std::fmt::Display for HexHash {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl From<gix::ObjectId> for HexHash {
+        fn from(value: gix::ObjectId) -> Self {
+            Self(value.to_hex().to_string())
+        }
+    }
+
+    impl From<HexHash> for gix::ObjectId {
+        fn from(value: HexHash) -> Self {
+            gix::ObjectId::from_hex(value.0.as_bytes())
+                .expect("HexHash test helper must always store valid object id hex")
+        }
+    }
+
+    impl FromStr for HexHash {
+        type Err = gix::hash::decode::Error;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let _ = gix::ObjectId::from_hex(s.as_bytes())?;
+            Ok(Self(s.to_owned()))
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct Error(pub anyhow::Error);
+
+    impl std::fmt::Display for Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    impl From<anyhow::Error> for Error {
+        fn from(value: anyhow::Error) -> Self {
+            Self(value)
+        }
+    }
+
+    impl From<serde_json::Error> for Error {
+        fn from(value: serde_json::Error) -> Self {
+            Self(value.into())
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct UiValue {
+    pub value: i32,
+}
+
+impl From<i32> for UiValue {
+    fn from(value: i32) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct UiValueTry {
+    pub value: i32,
+}
+
+impl TryFrom<i32> for UiValueTry {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(Self { value })
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ComplexParam {
+    pub a: i32,
+    pub b: i32,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ComplexResult {
+    pub combined: i32,
+}
+
+impl From<(usize, isize)> for ComplexResult {
+    fn from((u, i): (usize, isize)) -> Self {
+        Self {
+            combined: u as i32 + i as i32,
+        }
+    }
+}
+
+pub fn oid_from_hex(hex: &str) -> gix::ObjectId {
+    gix::ObjectId::from_str(hex).expect("test literal object ids are valid")
+}

--- a/crates/but-api-macros/tests/tests/trybuild.rs
+++ b/crates/but-api-macros/tests/tests/trybuild.rs
@@ -1,0 +1,32 @@
+#[cfg(not(any(feature = "tauri", feature = "napi")))]
+#[test]
+fn macro_features_compile_without_optional_features() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/default_*.rs");
+    t.compile_fail("tests/ui/fail/base_*.rs");
+}
+
+#[cfg(all(feature = "legacy", not(any(feature = "tauri", feature = "napi"))))]
+#[test]
+fn macro_features_compile_with_legacy() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/legacy_*.rs");
+}
+
+#[cfg(feature = "tauri")]
+#[test]
+fn macro_features_compile_with_tauri() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail/tauri_*.rs");
+}
+
+#[cfg(feature = "napi")]
+#[test]
+fn macro_features_compile_with_napi() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/default_*.rs");
+    t.pass("tests/ui/pass/legacy_*.rs");
+    t.pass("tests/ui/pass/napi_*.rs");
+    t.compile_fail("tests/ui/fail/base_*.rs");
+    t.compile_fail("tests/ui/fail/napi_*.rs");
+}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.rs
@@ -1,0 +1,13 @@
+// Case: invalid attribute key; only `try_from = ...` is currently accepted in name-value form.
+// Extend when: additional named macro attributes are introduced.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api(from = json::HexHash)]
+fn wrong_attr() -> anyhow::Result<gix::ObjectId> {
+    Ok(gix::ObjectId::null(gix::hash::Kind::Sha1))
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.stderr
@@ -1,0 +1,5 @@
+error: Need `try_from = path` to use try-from instead of from
+ --> tests/ui/fail/base_invalid_attr_key.rs:8:11
+  |
+8 | #[but_api(from = json::HexHash)]
+  |           ^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_invalid_attr_key.stderr
@@ -1,4 +1,4 @@
-error: Need `try_from = path` to use try-from instead of from
+error: Expected `try_from = Type`; only `try_from` is supported as a key
  --> tests/ui/fail/base_invalid_attr_key.rs:8:11
   |
 8 | #[but_api(from = json::HexHash)]

--- a/crates/but-api-macros/tests/tests/ui/fail/base_non_result_return.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_non_result_return.rs
@@ -1,0 +1,13 @@
+// Case: annotated functions must return `Result<...>`.
+// Extend when: macro support for non-`Result` return types is added.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+fn not_result() -> i32 {
+    1
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_non_result_return.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_non_result_return.stderr
@@ -1,0 +1,5 @@
+error: expected Result<T> or Result<T, E>
+ --> tests/ui/fail/base_non_result_return.rs:9:20
+  |
+9 | fn not_result() -> i32 {
+  |                    ^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_receiver_self.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_receiver_self.rs
@@ -1,0 +1,17 @@
+// Case: methods with `self` receivers are unsupported by this macro.
+// Extend when: method receiver support (`self`, `&self`, `&mut self`) is implemented.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+struct Api;
+
+impl Api {
+    #[but_api]
+    fn method(&self, value: i32) -> anyhow::Result<i32> {
+        Ok(value)
+    }
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_receiver_self.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_receiver_self.stderr
@@ -1,0 +1,5 @@
+error: Cannot handle &self, &mut self or self
+  --> tests/ui/fail/base_receiver_self.rs:12:15
+   |
+12 |     fn method(&self, value: i32) -> anyhow::Result<i32> {
+   |               ^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_reference_not_context.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_reference_not_context.rs
@@ -1,0 +1,13 @@
+// Case: references are restricted; only `Context` references are allowed remap targets.
+// Extend when: additional reference parameter types become supported.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+fn wrong_reference(_value: &String) -> anyhow::Result<String> {
+    Ok("ok".into())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_reference_not_context.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_reference_not_context.stderr
@@ -1,0 +1,5 @@
+error: Only `&Context` or `&but_ctx::Context` may be references
+ --> tests/ui/fail/base_reference_not_context.rs:9:28
+  |
+9 | fn wrong_reference(_value: &String) -> anyhow::Result<String> {
+  |                            ^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.rs
@@ -1,13 +1,12 @@
-// Case: list-form combination `#[but_api(napi, try_from = ...)]` currently fails to parse.
-// This snapshots current behavior so parser changes are explicit.
-// Extend when: list-form napi+conversion attributes become supported.
+// Case: list-form `napi` with an unsupported key should fail macro option parsing.
+// Extend when: accepted list-form keys for `napi` change.
 
 use but_api_macros::but_api;
 
 pub use but_api_macros_tests::{json, panic_capture};
 
-#[but_api(napi, try_from = json::HexHash)]
-pub fn unsupported_napi_attr_list() -> anyhow::Result<json::HexHash> {
+#[but_api(napi, from = json::HexHash)]
+pub fn invalid_napi_attr_list_key() -> anyhow::Result<json::HexHash> {
     Ok(json::HexHash(
         "0123456789abcdef0123456789abcdef01234567".into(),
     ))

--- a/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.rs
@@ -1,0 +1,16 @@
+// Case: list-form combination `#[but_api(napi, try_from = ...)]` currently fails to parse.
+// This snapshots current behavior so parser changes are explicit.
+// Extend when: list-form napi+conversion attributes become supported.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api(napi, try_from = json::HexHash)]
+pub fn unsupported_napi_attr_list() -> anyhow::Result<json::HexHash> {
+    Ok(json::HexHash(
+        "0123456789abcdef0123456789abcdef01234567".into(),
+    ))
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/ui/fail/napi_list_attr_unsupported.rs:9:15
+  |
+9 | #[but_api(napi, try_from = json::HexHash)]
+  |               ^

--- a/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/napi_list_attr_unsupported.stderr
@@ -1,5 +1,5 @@
-error: unexpected token
- --> tests/ui/fail/napi_list_attr_unsupported.rs:9:15
+error: Expected `try_from = Type`; only `try_from` is supported as a key
+ --> tests/ui/fail/napi_list_attr_unsupported.rs:8:17
   |
-9 | #[but_api(napi, try_from = json::HexHash)]
-  |               ^
+8 | #[but_api(napi, from = json::HexHash)]
+  |                 ^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/tauri_reexport_conflict.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/tauri_reexport_conflict.rs
@@ -1,0 +1,16 @@
+// Case: tauri-enabled expansion currently conflicts for this shape (`__cmd__*` re-export).
+// This snapshots current compile failure to make future behavior changes intentional.
+// Extend when: tauri module/export generation semantics are changed or fixed.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+pub fn ping(name: String) -> anyhow::Result<String> {
+    Ok(name)
+}
+
+fn main() {
+    let _ = tauri_ping::ping;
+}

--- a/crates/but-api-macros/tests/tests/ui/fail/tauri_reexport_conflict.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/tauri_reexport_conflict.stderr
@@ -1,0 +1,25 @@
+error[E0255]: the name `__cmd__ping_json` is defined multiple times
+  --> tests/ui/fail/tauri_reexport_conflict.rs:10:8
+   |
+ 9 | #[but_api]
+   | ---------- previous definition of the macro `__cmd__ping_json` here
+10 | pub fn ping(name: String) -> anyhow::Result<String> {
+   |        ^^^^ `__cmd__ping_json` reimported here
+   |
+   = note: `__cmd__ping_json` must be defined only once in the macro namespace of this module
+
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+ --> tests/ui/fail/tauri_reexport_conflict.rs:9:1
+  |
+9 | #[but_api]
+  | ^^^^^^^^^^
+  |
+  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+  = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+note: the macro is defined here
+ --> tests/ui/fail/tauri_reexport_conflict.rs:9:1
+  |
+9 | #[but_api]
+  | ^^^^^^^^^^
+  = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
+  = note: this error originates in the attribute macro `but_api` which comes from the expansion of the attribute macro `tauri::command` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/but-api-macros/tests/tests/ui/pass/default_async.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_async.rs
@@ -1,0 +1,20 @@
+// Case: async function expansion with panic-capture wrapper.
+// It verifies async `<fn>_json` and, under `legacy`, async `<fn>_cmd` generation.
+// Extend when: async wrapper call path or panic handling integration changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+pub async fn sum_async(left: i32, right: i32) -> anyhow::Result<i32> {
+    Ok(left + right)
+}
+
+fn main() {
+    let _future = sum_async_json(1, 2);
+    #[cfg(feature = "legacy")]
+    {
+        let _future = sum_async_cmd(serde_json::json!({ "left": 1, "right": 2 }));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/default_from_conversion.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_from_conversion.rs
@@ -1,0 +1,19 @@
+// Case: `#[but_api(Type)]` using infallible `From` conversion for result values.
+// Extend when: conversion mode selection, or converted JSON return typing, changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiValue, json, panic_capture};
+
+#[but_api(UiValue)]
+pub fn value() -> anyhow::Result<i32> {
+    Ok(42)
+}
+
+fn main() {
+    let _ = value_json();
+    #[cfg(feature = "legacy")]
+    {
+        let _ = value_cmd(serde_json::json!({}));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/default_option_conversion.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_option_conversion.rs
@@ -1,0 +1,20 @@
+// Case: `Result<Option<T>>` plus explicit `From` conversion.
+// It verifies option-aware conversion (`Option<T>` -> `Option<JsonT>`) is generated.
+// Extend when: option conversion rules or output typing for optional returns changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiValue, json, panic_capture};
+
+#[but_api(UiValue)]
+pub fn maybe_value(flag: bool) -> anyhow::Result<Option<i32>> {
+    Ok(flag.then_some(9))
+}
+
+fn main() {
+    let _ = maybe_value_json(true);
+    #[cfg(feature = "legacy")]
+    {
+        let _ = maybe_value_cmd(serde_json::json!({ "flag": true }));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/default_plain.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_plain.rs
@@ -1,0 +1,20 @@
+// Case: baseline `#[but_api]` expansion without explicit return conversion.
+// It verifies that `<fn>_json` always exists, and `<fn>_cmd` exists under `legacy`.
+// Extend when: default wrapper signatures or generated function naming changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+pub fn sum(left: i32, right: i32) -> anyhow::Result<i32> {
+    Ok(left + right)
+}
+
+fn main() {
+    let _ = sum_json(1, 2);
+    #[cfg(feature = "legacy")]
+    {
+        let _ = sum_cmd(serde_json::json!({ "left": 1, "right": 2 }));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/default_try_from_conversion.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_try_from_conversion.rs
@@ -1,0 +1,19 @@
+// Case: `#[but_api(try_from = Type)]` using fallible `TryFrom` conversion.
+// Extend when: try-conversion error propagation or return typing changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiValueTry, json, panic_capture};
+
+#[but_api(try_from = UiValueTry)]
+pub fn value_checked() -> anyhow::Result<i32> {
+    Ok(7)
+}
+
+fn main() {
+    let _ = value_checked_json();
+    #[cfg(feature = "legacy")]
+    {
+        let _ = value_checked_cmd(serde_json::json!({}));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/legacy_context_and_object_id.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/legacy_context_and_object_id.rs
@@ -1,0 +1,61 @@
+// Case: legacy-only parameter remapping for context/object-id style inputs.
+// It verifies:
+// - `Context`/`&Context`/`&mut Context`/`ThreadSafeContext` -> `project_id` remapping
+// - `gix::ObjectId` -> `json::HexHash` remapping
+// in both `_json` and `_cmd` wrappers.
+// Extend when: supported context-like input forms, parameter naming, or remap types change.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, oid_from_hex, panic_capture};
+
+#[but_api]
+pub fn with_context_and_oid(
+    _ctx: but_ctx::Context,
+    commit: gix::ObjectId,
+) -> anyhow::Result<json::HexHash> {
+    Ok(json::HexHash::from(commit))
+}
+
+#[but_api]
+pub fn with_context_ref(_ctx: &but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+#[but_api]
+pub fn with_context_mut(_ctx: &mut but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+#[but_api]
+pub fn with_thread_safe_context(
+    _ctx: but_ctx::ThreadSafeContext,
+    value: i32,
+) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+fn main() {
+    let project_id: but_ctx::LegacyProjectId =
+        "d7377618-b9cd-4964-a3c3-05c58ed5602b".parse().unwrap();
+    let oid = oid_from_hex("0123456789abcdef0123456789abcdef01234567");
+    let hash = json::HexHash::from(oid);
+
+    let _ = with_context_and_oid_json(project_id.clone(), hash.clone());
+    let _ = with_context_ref_json(project_id.clone(), 1);
+    let _ = with_context_mut_json(project_id.clone(), 2);
+    let _ = with_thread_safe_context_json(project_id.clone(), 3);
+
+    let _ = with_context_and_oid_cmd(
+        serde_json::json!({ "projectId": project_id.to_string(), "commit": hash.to_string() }),
+    );
+    let _ = with_context_ref_cmd(
+        serde_json::json!({ "projectId": project_id.to_string(), "value": 1 }),
+    );
+    let _ = with_context_mut_cmd(
+        serde_json::json!({ "projectId": project_id.to_string(), "value": 2 }),
+    );
+    let _ = with_thread_safe_context_cmd(
+        serde_json::json!({ "projectId": project_id.to_string(), "value": 3 }),
+    );
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/napi_context_and_oid.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/napi_context_and_oid.rs
@@ -1,0 +1,17 @@
+// Case: `#[but_api(napi)]` generation with legacy context remapping plus ObjectId input.
+// It verifies `_napi` function/module creation and napi-safe parameter conversion codepaths.
+// Extend when: napi context/object-id conversion behavior or exported naming changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api(napi)]
+pub fn napi_ctx_and_oid(_ctx: but_ctx::Context, oid: gix::ObjectId) -> anyhow::Result<String> {
+    Ok(oid.to_hex().to_string())
+}
+
+fn main() {
+    let _ = napi_ctx_and_oid_napi;
+    let _ = napi_napi_ctx_and_oid::napi_ctx_and_oid;
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/napi_parameter_mappings.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/napi_parameter_mappings.rs
@@ -1,0 +1,25 @@
+// Case: `#[but_api(napi)]` parameter remapping matrix.
+// It covers simple types, `usize`/`isize` numeric remap, complex serde value remap, and `BString`.
+// Extend when: napi argument type mapping, conversion, or `ts_arg_type` generation rules change.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{ComplexParam, json, panic_capture};
+
+#[but_api(napi)]
+pub fn napi_surface(
+    name: String,
+    flag: bool,
+    count: usize,
+    delta: isize,
+    payload: ComplexParam,
+    bytes: bstr::BString,
+) -> anyhow::Result<(usize, isize)> {
+    let _ = (name, flag, payload, bytes);
+    Ok((count, delta))
+}
+
+fn main() {
+    let _ = napi_surface_napi;
+    let _ = napi_napi_surface::napi_surface;
+}


### PR DESCRIPTION
The `#[but_api]` proc macro has multiple expansion paths (`legacy`, `tauri`, `napi`) but had no dedicated compile-time coverage. Regressions were easy to introduce and only showed up downstream in `but-api` consumers.

Add a separate `but-api-macros/tests` crate that mirrors `but-api` feature flags and uses `trybuild` to verify pass/fail behavior for each macro capability. This makes feature-specific expansion changes explicit and catches breakage at the macro boundary

This is originally part of https://github.com/gitbutlerapp/gitbutler/pull/12647, but I want to bring it in early as it's independent.

### Tasks

* [x] review
