### PR TITLE
dist(linux): add but symlinks to rpm and deb packages

### DIFF
--- a/crates/gitbutler-tauri/rpm-postinstall.sh
+++ b/crates/gitbutler-tauri/rpm-postinstall.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Create a 'but' symlink so the CLI is available as /usr/bin/but.
+#
+# Ideally this symlink would be a proper tracked file in the RPM (like VS Code
+# does since 2022: https://github.com/microsoft/vscode/pull/142907), but Tauri
+# does not expose any way to add symlinks to packages even though the underlying
+# rpm-rs crate supports them. Repackaging the RPM after the fact to inject a
+# tracked symlink is possible but painful, so we use a postinstall script as a
+# pragmatic workaround for now.
+#
+# We should consider contributing a patch upstream to Tauri to add support for
+# adding this symlink as part of Tauri's bundling.
+#
+# We should also consider just building the RPM package from scratch. VS Code
+# has a really good spec template that we could draw inspiration from. This
+# would give us full control, and it really isn't hard.
+SYMLINK=/usr/bin/but
+TARGET=gitbutler-tauri
+
+if [ ! -e "$SYMLINK" ] && [ ! -L "$SYMLINK" ]; then
+    # Symlink does not exist; create it
+    ln -s "$TARGET" "$SYMLINK"
+elif [ -L "$SYMLINK" ]; then
+    CURRENT_TARGET=$(readlink "$SYMLINK")
+    case "$CURRENT_TARGET" in
+        *gitbutler-tauri)
+            # Points to gitbutler-tauri; update to current location
+            ln -sf "$TARGET" "$SYMLINK"
+            ;;
+        *)
+            echo "Error: $SYMLINK already exists and points to '$CURRENT_TARGET', not '$TARGET'" >&2
+            exit 1
+            ;;
+    esac
+else
+    # Path exists but is not a symlink
+    echo "Error: $SYMLINK already exists and is not a symlink" >&2
+    exit 1
+fi

--- a/crates/gitbutler-tauri/rpm-preremove.sh
+++ b/crates/gitbutler-tauri/rpm-preremove.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Clean up the 'but' symlink created by the postinstall script.
+#
+# RPM passes $1 as the number of package instances that will remain after this
+# action completes:
+#   0 = full uninstall
+#   >0 = upgrade (new version already installed or about to be)
+# We only remove the symlink on a full uninstall; during an upgrade the
+# postinstall script of the new package will recreate/update it.
+
+# Skip removal during upgrades
+if [ "${1:-0}" -ge 1 ]; then
+    exit 0
+fi
+
+SYMLINK=/usr/bin/but
+
+if [ -L "$SYMLINK" ]; then
+    CURRENT_TARGET=$(readlink "$SYMLINK")
+    case "$CURRENT_TARGET" in
+        *gitbutler-tauri)
+            rm -f "$SYMLINK"
+            ;;
+        *)
+            echo "Warning: $SYMLINK points to '$CURRENT_TARGET', not gitbutler-tauri; leaving it alone" >&2
+            ;;
+    esac
+elif [ -e "$SYMLINK" ]; then
+    echo "Warning: $SYMLINK exists but is not a symlink; leaving it alone" >&2
+fi

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -29,7 +29,9 @@
 				"compression": {
 					"type": "zstd",
 					"level": 3
-				}
+				},
+				"postInstallScript": "rpm-postinstall.sh",
+				"preRemoveScript": "rpm-preremove.sh"
 			},
 			"deb": {
 				"depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"],

--- a/scripts/add-but-symlink-to-deb.sh
+++ b/scripts/add-but-symlink-to-deb.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Repackages a .deb file to include a 'but' symlink pointing to 'gitbutler-tauri'
+# in /usr/bin/. The symlink is added as a proper tracked file in the package so
+# dpkg knows about it.
+#
+# We need this as Tauri currently resolves symlinks when bundling, so we can't
+# easily add in a symlink with Tauri-native packaging short of using a
+# postinstall script. That solution is itself not great as then the package
+# manager can't track the symlink, so it's better for everyone to just add it
+# into the package itself.
+#
+# The .deb file is modified in place.
+
+set -euo pipefail
+
+DEB_PATH="${1:-}"
+
+if [ -z "$DEB_PATH" ]; then
+	echo "Usage: $0 <path-to-deb>" >&2
+	exit 1
+fi
+
+if [ ! -f "$DEB_PATH" ]; then
+	echo "error: file not found: $DEB_PATH" >&2
+	exit 1
+fi
+
+DEB_PATH="$(readlink -f "$DEB_PATH")"
+
+WORK_DIR="$(mktemp -d)"
+readonly WORK_DIR
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "repackaging $DEB_PATH to add /usr/bin/but symlink..."
+
+dpkg-deb -R "$DEB_PATH" "$WORK_DIR/pkg"
+
+if [ ! -f "$WORK_DIR/pkg/usr/bin/gitbutler-tauri" ]; then
+	echo "error: /usr/bin/gitbutler-tauri not found in package" >&2
+	exit 1
+fi
+
+ln -sf gitbutler-tauri "$WORK_DIR/pkg/usr/bin/but"
+
+dpkg-deb --root-owner-group -Zgzip -b "$WORK_DIR/pkg" "$DEB_PATH"
+
+echo "done: $DEB_PATH now contains /usr/bin/but -> gitbutler-tauri"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -259,6 +259,8 @@ elif [ "$OS" = "linux" ]; then
 	RPM="$(find "$BUNDLE_DIR/rpm" -name \*.rpm)"
 	BUT_CLI="$(readlink -f "$BUILD_DIR/but")"
 
+	"$PWD/add-but-symlink-to-deb.sh" "$DEB"
+
 	cp "$APPIMAGE" "$RELEASE_DIR"
 	cp "$APPIMAGE_UPDATER" "$RELEASE_DIR"
 	cp "$APPIMAGE_UPDATER_SIG" "$RELEASE_DIR"


### PR DESCRIPTION
Tauri does not support adding symlinks when bundling deb and rpm, so we need to do it ourselves.

For the deb package, we repackage the output produced by Tauri and add in the symlink. This is the preferable approach as it allows the package manager to track the symlink as a file, and it can scream bloody murder of there's a file collision with another package. It's a very simple script due to deb packages being so simple.

Repackaging an rpm package is a bit of a pain mostly due to how the metadata works. It's not worthwhile to pull in that kind of complexity at this time, so we instead resort to a postinstall/preremove script combination. This is a poor man's solution as the package manager cannot track the symlink, and so it may conflict with other packages without (see this PR in VS Code that fixes that exact problem: https://github.com/microsoft/vscode/pull/142907).

For the future, we should either a) contribute an upstream fix to Tauri to allow for adding symlinks in both deb and rpm packages, or b) take more control over our packaging and just build the packages from scratch (it's not hard for either of deb or rpm).