### PR TITLE
feat(view): pin clicked item until it leaves view

### DIFF
--- a/apps/desktop/src/components/FloatingDiffModal.svelte
+++ b/apps/desktop/src/components/FloatingDiffModal.svelte
@@ -12,6 +12,7 @@
 	import { DIFF_SERVICE } from "$lib/hunks/diffService.svelte";
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { type SelectionId } from "$lib/selection/key";
+	import { ScrollSelectionLock } from "$lib/selection/scrollSelectionLock.svelte";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { computeChangeStatus } from "$lib/utils/fileStatus";
 	import { inject } from "@gitbutler/core/context";
@@ -54,9 +55,15 @@
 	// so Svelte does not need to track mutations.
 	const diffExpandedState = new Map<string, boolean>();
 
+	function getInitialLockedIndex() {
+		return idSelection.collectionSize(selectionId) > 0 ? initialIndex : undefined;
+	}
+
 	let listMode: "list" | "tree" = $state("list");
 	// Seeded from prop once on mount; subsequent user selection is independent.
 	let selectedIndex = $state(initialIndex);
+	// Prevents VirtualList scroll events from overwriting a user-clicked selection.
+	const scrollLock = new ScrollSelectionLock(getInitialLockedIndex());
 	let headerElRef = $state<HTMLDivElement | undefined>(undefined);
 	let leftPanelEl = $state<HTMLDivElement | undefined>(undefined);
 	let virtualList = $state<VirtualList<TreeChange>>();
@@ -71,6 +78,7 @@
 	function selectChange(index: number) {
 		selectedIndex = index;
 		if (allInOneDiff) {
+			scrollLock.set(index);
 			// In virtual list mode, scroll to the selected file
 			virtualList?.jumpToIndex(index);
 		}
@@ -266,7 +274,9 @@
 						getId={(change) => change.path}
 						onVisibleChange={(range) => {
 							visibleRange = range;
-							if (range) selectedIndex = range.start;
+							if (range) {
+								selectedIndex = scrollLock.resolve(range);
+							}
 						}}
 					>
 						{#snippet template(change, index)}

--- a/apps/desktop/src/components/MultiDiffView.svelte
+++ b/apps/desktop/src/components/MultiDiffView.svelte
@@ -19,6 +19,7 @@
 	import { DIFF_SERVICE } from "$lib/hunks/diffService.svelte";
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { type SelectionId } from "$lib/selection/key";
+	import { ScrollSelectionLock } from "$lib/selection/scrollSelectionLock.svelte";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { computeChangeStatus } from "$lib/utils/fileStatus";
 	import { inject } from "@gitbutler/core/context";
@@ -63,15 +64,23 @@
 	// so Svelte does not need to track mutations. Persists across VirtualList recycles.
 	const diffExpandedState = new Map<string, boolean>();
 
+	function getInitialLockedIndex() {
+		if (startIndex === undefined) return undefined;
+		return idSelection.collectionSize(selectionId) > 0 ? startIndex : undefined;
+	}
+
 	let virtualList = $state<VirtualList<TreeChange>>();
 	let scrollContainer = $state<HTMLElement | null>(null);
 	let highlightedIndex = $state<number | undefined>(startIndex);
+	// Prevents VirtualList scroll events from overwriting a user-clicked selection.
+	const scrollLock = new ScrollSelectionLock(getInitialLockedIndex());
 	const menuState = new FileContextMenuState<ReturnType<typeof ChangedFilesContextMenu>>();
 	let floatingDiffOpen = $state(false);
 	let floatingDiffInitialIndex = $state(0);
 
 	export function jumpToIndex(index: number) {
 		highlightedIndex = index;
+		scrollLock.set(index);
 		if (allInOneDiff) {
 			virtualList?.jumpToIndex(index);
 		}
@@ -227,16 +236,18 @@
 				renderDistance={100}
 				onVisibleChange={(range) => {
 					if (range) {
-						highlightedIndex = range.start;
-						const firstVisibleChange = changes[range.start];
+						const activeIndex = scrollLock.resolve(range);
+
+						highlightedIndex = activeIndex;
+						const activeChange = changes[activeIndex];
 						const selectionSize = idSelection.collectionSize(selectionId);
 						const shouldFollowScrollSelection = selectionSize <= 1;
 						if (
-							firstVisibleChange &&
+							activeChange &&
 							shouldFollowScrollSelection &&
-							!idSelection.has(firstVisibleChange.path, selectionId)
+							!idSelection.has(activeChange.path, selectionId)
 						) {
-							idSelection.set(firstVisibleChange.path, selectionId, range.start);
+							idSelection.set(activeChange.path, selectionId, activeIndex);
 						}
 					}
 					onVisibleChange?.(range);

--- a/apps/desktop/src/lib/selection/scrollSelectionLock.svelte.ts
+++ b/apps/desktop/src/lib/selection/scrollSelectionLock.svelte.ts
@@ -1,0 +1,65 @@
+/**
+ * ScrollSelectionLock
+ *
+ * Prevents VirtualList's scroll-driven `onVisibleChange` events from overwriting a
+ * programmatically clicked selection before — and while — the target item is visible.
+ *
+ * Two-phase lifecycle:
+ *   Phase 1 — item not yet visible: hold the locked index, ignore range.start.
+ *   Phase 2 — item is visible:      keep it pinned while it stays in the viewport.
+ *   Release  — item leaves view:    clear the lock; caller resumes auto-follow.
+ *
+ * Usage:
+ *   const lock = new ScrollSelectionLock(initialIndex);
+ *
+ *   // on user click / programmatic jump:
+ *   lock.set(index);
+ *
+ *   // inside onVisibleChange:
+ *   const active = lock.resolve(range);   // use `active` as the authoritative index
+ */
+export class ScrollSelectionLock {
+	#index = $state<number | undefined>();
+	#hasBeenVisible = $state(false);
+
+	constructor(initialIndex?: number) {
+		this.#index = initialIndex;
+	}
+
+	/** Arm the lock for a new target index (call on click / jumpToIndex). */
+	set(index: number) {
+		this.#index = index;
+		this.#hasBeenVisible = false;
+	}
+
+	/**
+	 * Resolve the authoritative active index for this scroll event.
+	 * Pass the raw `range` from VirtualList's `onVisibleChange`.
+	 * Returns the index that should be treated as active.
+	 */
+	resolve(range: { start: number; end: number }): number {
+		if (this.#index === undefined) {
+			return range.start;
+		}
+
+		const lockVisible = this.#index >= range.start && this.#index < range.end;
+
+		if (!this.#hasBeenVisible) {
+			// Phase 1: item not yet in view — hold the lock.
+			if (lockVisible) {
+				this.#hasBeenVisible = true;
+			}
+			return this.#index;
+		}
+
+		if (lockVisible) {
+			// Phase 2: item still visible — stay pinned.
+			return this.#index;
+		}
+
+		// Release: item has left the viewport — resume auto-follow.
+		this.#index = undefined;
+		this.#hasBeenVisible = false;
+		return range.start;
+	}
+}


### PR DESCRIPTION
Addressing this issue https://discord.com/channels/1060193121130000425/1073202153163857920/1479426120448479338

https://github.com/user-attachments/assets/524cdff6-f847-467f-b7ae-e4c3f9315ba7

---

This pull request introduces an improved selection locking mechanism for both `FloatingDiffModal.svelte` and `MultiDiffView.svelte` components. The main goal is to ensure that when a user clicks to select a diff in all-in-one mode, the selection remains pinned to the chosen item until it leaves the visible range, providing a more predictable and user-friendly navigation experience. The changes implement a two-phase lock for selection and update the logic that determines which item is highlighted or selected as the user scrolls.

Selection Locking and Navigation Improvements:

* Added a two-phase selection lock mechanism (`lockedSelectionIndex` and `lockedSelectionHasBeenVisible`) in both `FloatingDiffModal.svelte` and `MultiDiffView.svelte`. This ensures that a user-selected item remains highlighted while it is visible, and the lock is released only when it scrolls out of view. [[1]](diffhunk://#diff-06e80a2a7f3d23d28aa278a54fa15415af811d0fcf8a4588dcdc8b02fc1dc7a5R57-R68) [[2]](diffhunk://#diff-86eaaa84135324a0cc77d6113b6dcbaf8fbf8571159088368ac475ce4a6ef5fdR66-R86)
* Updated the scroll and selection logic in the `onVisibleChange` handlers to respect the locked selection, switching the active index to the locked item when appropriate and releasing the lock when it leaves the visible range. [[1]](diffhunk://#diff-06e80a2a7f3d23d28aa278a54fa15415af811d0fcf8a4588dcdc8b02fc1dc7a5L269-R299) [[2]](diffhunk://#diff-86eaaa84135324a0cc77d6113b6dcbaf8fbf8571159088368ac475ce4a6ef5fdL230-R269)
* Modified the behavior of selection functions (such as `selectChange` and `jumpToIndex`) to activate the lock and reset its visibility state when a new item is selected. [[1]](diffhunk://#diff-06e80a2a7f3d23d28aa278a54fa15415af811d0fcf8a4588dcdc8b02fc1dc7a5R83-R84) [[2]](diffhunk://#diff-86eaaa84135324a0cc77d6113b6dcbaf8fbf8571159088368ac475ce4a6ef5fdR66-R86)

These changes make the selection behavior more intuitive, especially in virtualized list views, by maintaining user intent as the visible range changes during scrolling.