### PR TITLE
feat(cli): allow entering edit mode from CLI

### DIFF
--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -1,3 +1,4 @@
+import { parseError } from "$lib/error/parser";
 import { hasBackendExtra } from "$lib/state/backendQuery";
 import { invalidatesList, providesList, ReduxTag } from "$lib/state/tags";
 import { InjectionToken } from "@gitbutler/core/context";
@@ -140,8 +141,17 @@ function injectEndpoints(api: BackendApi) {
 						`project://${arg.projectId}/worktree_changes`,
 						async (_) => {
 							if (finished) return;
-							const changes = await invoke<TreeChange[]>("edit_changes_from_initial", arg);
-							lifecycleApi.updateCachedData(() => changes);
+							try {
+								const changes = await invoke<TreeChange[]>("edit_changes_from_initial", arg);
+								lifecycleApi.updateCachedData(() => changes);
+							} catch (error: unknown) {
+								// Edit mode may have been exited (e.g. via CLI) before this
+								// listener was unsubscribed. Silently ignore that specific race.
+								const { message } = parseError(error);
+								if (!message.includes("Expected to be in edit mode")) {
+									throw error;
+								}
+							}
 						},
 					);
 					// The `cacheEntryRemoved` promise resolves when the result is removed

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -396,6 +396,50 @@ but resolve cancel
 
 **Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
 
+## Edit Mode
+
+Edit any commit in your stack by checking it out, making changes, and saving.
+
+### `but edit-mode <commit>`
+
+Enter edit mode for a commit.
+
+```bash
+but edit-mode <commit-id>
+```
+
+### `but edit-mode status`
+
+Show files changed during the edit session.
+
+```bash
+but edit-mode status
+```
+
+### `but edit-mode finish`
+
+Save changes and return to workspace mode.
+
+```bash
+but edit-mode finish
+```
+
+### `but edit-mode cancel`
+
+Cancel edit and return to workspace mode.
+
+```bash
+but edit-mode cancel
+but edit-mode cancel --force  # discard changes
+```
+
+**Workflow:**
+
+1. `but edit-mode <commit>` - Enter edit mode
+2. Make your changes to files
+3. `but edit-mode status` - Check changes
+4. `but edit-mode finish` - Save
+
 ## Remote Operations
 
 ### `but push [branch]`

--- a/crates/but/src/args/edit_mode.rs
+++ b/crates/but/src/args/edit_mode.rs
@@ -1,0 +1,22 @@
+/// Subcommands for the `but edit-mode` command.
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+    /// Show the status of the edit session, listing changed files.
+    Status,
+
+    /// Save changes and return to workspace mode.
+    ///
+    /// This commits the edited changes, rebases any commits on top of the
+    /// edited commit, and returns to the normal workspace.
+    Finish,
+
+    /// Cancel the edit session and return to workspace mode.
+    ///
+    /// This discards all changes made during editing and restores
+    /// the workspace to its pre-edit state.
+    Cancel {
+        /// Forcibly remove any changes made
+        #[clap(short = 'f', long)]
+        force: bool,
+    },
+}

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -12,6 +12,7 @@ pub enum CommandName {
     Rub,
     Diff,
     Edit,
+    EditMode,
     Show,
     Commit,
     CommitEmpty,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -750,6 +750,32 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Config(config::Platform),
 
+    /// Edit a commit in your stack.
+    ///
+    /// This enters edit mode, checking out the specified commit so you can
+    /// make changes to it directly. When finished, save your changes to
+    /// rebase the stack, or cancel to discard changes.
+    ///
+    /// ## Workflow
+    ///
+    /// 1. Enter edit mode: `but edit-mode <commit-id>`
+    /// 2. Make changes to files as needed
+    /// 3. Check what has changed: `but edit-mode status`
+    /// 4. Save changes: `but edit-mode finish`
+    ///    Or cancel: `but edit-mode cancel`
+    ///
+    /// When in edit mode, `but status` will also show that you're editing a commit.
+    ///
+    #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
+    EditMode {
+        /// Subcommand to run (defaults to entering edit mode)
+        #[clap(subcommand)]
+        cmd: Option<edit_mode::Subcommands>,
+        /// Commit ID to enter edit mode for (when no subcommand is provided)
+        commit: Option<String>,
+    },
+
     /// Resolve conflicts in a commit.
     ///
     /// When a commit is in a conflicted state (marked with conflicts during rebase),
@@ -1131,6 +1157,8 @@ pub mod actions {
     }
 }
 
+#[cfg(feature = "legacy")]
+pub mod edit_mode;
 pub mod forge;
 pub mod metrics;
 #[cfg(feature = "legacy")]

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -30,7 +30,14 @@ pub fn print_grouped(out: &mut dyn std::fmt::Write) -> std::fmt::Result {
         (
             "Editing Commits".yellow(),
             vec![
-                "rub", "absorb", "reword", "uncommit", "amend", "squash", "move",
+                "rub",
+                "absorb",
+                "reword",
+                "uncommit",
+                "amend",
+                "squash",
+                "move",
+                "edit-mode",
             ],
         ),
         (

--- a/crates/but/src/command/legacy/edit_mode.rs
+++ b/crates/but/src/command/legacy/edit_mode.rs
@@ -1,0 +1,283 @@
+use std::fmt::Write;
+
+use anyhow::{Context as _, Result, bail};
+use bstr::ByteSlice;
+use but_api::legacy::modes::{
+    abort_edit_and_return_to_workspace, enter_edit_mode,
+    save_edit_and_return_to_workspace_with_output,
+};
+use but_core::ui::TreeStatus;
+use but_ctx::Context;
+use colored::Colorize;
+use gitbutler_edit_mode::commands::changes_from_initial;
+use gitbutler_operating_modes::OperatingMode;
+
+use crate::{IdMap, args::edit_mode::Subcommands, id::CliId, utils::OutputChannel};
+
+fn current_operating_mode(ctx: &mut Context) -> Result<OperatingMode> {
+    Ok(but_api::legacy::modes::operating_mode(ctx)?.operating_mode)
+}
+
+/// Handle the `but edit-mode` command and its subcommands.
+pub(crate) fn handle(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    cmd: Option<Subcommands>,
+    commit_id: Option<String>,
+) -> Result<()> {
+    match cmd {
+        Some(Subcommands::Status) => show_status(ctx, out),
+        Some(Subcommands::Finish) => finish_edit(ctx, out),
+        Some(Subcommands::Cancel { force }) => cancel_edit(ctx, out, force),
+        None => {
+            if let Some(commit_id_str) = commit_id {
+                enter_edit(ctx, out, &commit_id_str)
+            } else {
+                let mode = current_operating_mode(ctx)?;
+                if matches!(mode, OperatingMode::Edit(_)) {
+                    show_status(ctx, out)
+                } else {
+                    show_workflow_help(out)
+                }
+            }
+        }
+    }
+}
+
+fn enter_edit(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &str) -> Result<()> {
+    use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
+
+    let id_map = IdMap::new_from_context(ctx, None)?;
+    let matches = id_map.parse_using_context(commit_id_str, ctx)?;
+
+    if matches.is_empty() {
+        bail!(
+            "Commit '{commit_id_str}' not found. Try running 'but status' to see available commits."
+        );
+    }
+
+    if matches.len() > 1 {
+        bail!(
+            "Commit ID '{commit_id_str}' is ambiguous. Please provide more characters to uniquely identify the commit."
+        );
+    }
+
+    let commit_gix_oid = match &matches[0] {
+        CliId::Commit { commit_id, .. } => *commit_id,
+        _ => bail!("'{commit_id_str}' does not refer to a commit"),
+    };
+
+    // Find which stack this commit belongs to
+    let stacks = but_api::legacy::workspace::stacks(ctx, None)?;
+    let gix_repo = ctx.repo.get()?;
+    let mut found_stack_id = None;
+    'outer: for stack in &stacks {
+        for head in &stack.heads {
+            let traversal = head
+                .tip
+                .attach(&gix_repo)
+                .ancestors()
+                .sorting(Sorting::BreadthFirst)
+                .all()?;
+
+            for info in traversal {
+                let info = info?;
+                if info.id == commit_gix_oid {
+                    found_stack_id = stack.id;
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    let stack_id = found_stack_id.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not find stack containing commit {}",
+            &commit_gix_oid.to_string()[..7]
+        )
+    })?;
+
+    drop(gix_repo);
+
+    enter_edit_mode(ctx, commit_gix_oid, stack_id).context("Failed to enter edit mode")?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{} {}",
+            "Entering edit mode for commit".bold(),
+            commit_gix_oid.to_string()[..7].cyan()
+        )?;
+    }
+
+    show_status(ctx, out)
+}
+
+fn show_status(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    show_status_impl(ctx, out)
+}
+
+/// Show edit status without prompting (for use by `but status`).
+pub(crate) fn show_edit_status(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    show_status_impl(ctx, out)
+}
+
+fn show_status_impl(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let mode = current_operating_mode(ctx)?;
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        return show_workflow_help(out);
+    }
+
+    let mut progress = out.progress_channel();
+
+    writeln!(
+        progress,
+        "{}\n - make your changes\n - save with {}\n - OR cancel with {}\n",
+        "You are currently in edit mode.".bold(),
+        "but edit-mode finish".green().bold(),
+        "but edit-mode cancel".red().bold()
+    )?;
+
+    show_changed_files(ctx, out)?;
+
+    Ok(())
+}
+
+fn show_changed_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let changes = changes_from_initial(ctx)?;
+    let mut progress = out.progress_channel();
+
+    if changes.is_empty() {
+        writeln!(progress, "{}", "No changes made yet.".dimmed())?;
+    } else {
+        writeln!(progress, "{}:", "Changed files".yellow().bold())?;
+        for change in &changes {
+            let indicator = match &change.status {
+                TreeStatus::Addition { .. } => "+".green(),
+                TreeStatus::Deletion { .. } => "-".red(),
+                TreeStatus::Modification { .. } => "~".yellow(),
+                TreeStatus::Rename { .. } => "→".cyan(),
+            };
+            writeln!(progress, "  {} {}", indicator, change.path.to_str_lossy())?;
+        }
+    }
+
+    if let Some(json_out) = out.for_json() {
+        let files: Vec<String> = changes
+            .iter()
+            .map(|c| c.path.to_str_lossy().to_string())
+            .collect();
+        json_out.write_value(serde_json::json!({
+            "changed_files": files,
+            "changed_count": files.len(),
+        }))?;
+    }
+
+    Ok(())
+}
+
+fn finish_edit(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+    let mode = current_operating_mode(ctx)?;
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        return show_workflow_help(out);
+    }
+
+    // Capture conflicted commits before the rebase
+    let conflicts_before = super::resolve::find_conflicted_commits(ctx)?;
+
+    save_edit_and_return_to_workspace_with_output(ctx)
+        .context("Failed to save edit and return to workspace")?;
+
+    if let Some(human_out) = out.for_human() {
+        writeln!(human_out, "{}", "Edit saved successfully!".green().bold())?;
+        writeln!(human_out, "The commit has been updated with your changes.")?;
+    }
+
+    // Check for new conflicts introduced during the rebase
+    super::resolve::check_for_new_conflicts_after_rebase(ctx, out, conflicts_before)?;
+
+    Ok(())
+}
+
+fn cancel_edit(ctx: &mut Context, out: &mut OutputChannel, force: bool) -> Result<()> {
+    let mode = current_operating_mode(ctx)?;
+    if !matches!(mode, OperatingMode::Edit(_)) {
+        return show_workflow_help(out);
+    }
+
+    if !force && !changes_from_initial(ctx)?.is_empty() {
+        bail!(
+            "There are changes that differ from the original commit you were editing. Canceling will drop those changes.\n\nIf you want to go through with this, please re-run with `--force`.\n\nIf you want to keep the changes you have made, consider finishing the edit with `but edit-mode finish`."
+        )
+    }
+
+    abort_edit_and_return_to_workspace(ctx, force)
+        .context("Failed to cancel edit and return to workspace")?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "{}", "Edit cancelled.".yellow())?;
+        writeln!(out, "All changes made during editing have been discarded.")?;
+    }
+
+    Ok(())
+}
+
+fn show_workflow_help(out: &mut OutputChannel) -> Result<()> {
+    if let Some(out) = out.for_human() {
+        writeln!(out, "{}", "Edit Mode Workflow".bold().underline())?;
+        writeln!(out)?;
+        writeln!(out, "This command lets you edit any commit in your stack.")?;
+        writeln!(out)?;
+        writeln!(out, "{}", "To edit a commit:".bold())?;
+        writeln!(out)?;
+        writeln!(out, "  {} Enter edit mode for a commit:", "1.".bold())?;
+        writeln!(out, "     {}", "but edit-mode <commit>".green())?;
+        writeln!(out)?;
+        writeln!(out, "  {} Make your changes to the files", "2.".bold())?;
+        writeln!(out)?;
+        writeln!(out, "  {} Check what has changed:", "3.".bold())?;
+        writeln!(out, "     {}", "but edit-mode status".green())?;
+        writeln!(out)?;
+        writeln!(out, "  {} Save or cancel:", "4.".bold())?;
+        writeln!(out, "     {}", "but edit-mode finish".green())?;
+        writeln!(out, "     {}", "OR".dimmed())?;
+        writeln!(out, "     {}", "but edit-mode cancel".green())?;
+        writeln!(out)?;
+        writeln!(out, "{}", "Example:".bold())?;
+        writeln!(out, "  {} (find commits)", "but status".green())?;
+        writeln!(out, "  {} (enter edit mode)", "but edit-mode 55".green())?;
+        writeln!(out, "  {} (make changes)", "vim src/file.rs".dimmed())?;
+        writeln!(out, "  {} (check changes)", "but edit-mode status".green())?;
+        writeln!(out, "  {} (save)", "but edit-mode finish".green())?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "workflow": [
+                {
+                    "step": 1,
+                    "description": "Enter edit mode for a commit",
+                    "command": "but edit-mode <commit>"
+                },
+                {
+                    "step": 2,
+                    "description": "Make your changes to the files"
+                },
+                {
+                    "step": 3,
+                    "description": "Check what has changed",
+                    "command": "but edit-mode status"
+                },
+                {
+                    "step": 4,
+                    "description": "Save or cancel",
+                    "command": "but edit-mode finish"
+                }
+            ],
+            "other_commands": {
+                "cancel": "but edit-mode cancel",
+                "view_status": "but status"
+            }
+        }))?;
+    }
+
+    Ok(())
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -12,6 +12,7 @@ pub mod commit;
 pub mod commit_message_prep;
 pub mod diff;
 pub mod discard;
+pub mod edit_mode;
 pub mod forge;
 pub mod mark;
 pub mod mcp;

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -383,14 +383,14 @@ fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) ->
 
 /// Structure to hold information about a conflicted commit
 #[derive(Debug)]
-struct ConflictedCommit {
-    commit_oid: gix::ObjectId,
-    commit_short_id: String,
-    commit_message: String,
+pub(crate) struct ConflictedCommit {
+    pub(crate) commit_oid: gix::ObjectId,
+    pub(crate) commit_short_id: String,
+    pub(crate) commit_message: String,
 }
 
 /// Check for new conflicts introduced during rebase and report them
-fn check_for_new_conflicts_after_rebase(
+pub(crate) fn check_for_new_conflicts_after_rebase(
     ctx: &mut Context,
     out: &mut OutputChannel,
     conflicts_before: BTreeMap<String, Vec<ConflictedCommit>>,
@@ -469,7 +469,9 @@ fn check_for_new_conflicts_after_rebase(
 }
 
 /// Find all conflicted commits across all stacks, grouped by branch
-fn find_conflicted_commits(ctx: &mut Context) -> Result<BTreeMap<String, Vec<ConflictedCommit>>> {
+pub(crate) fn find_conflicted_commits(
+    ctx: &mut Context,
+) -> Result<BTreeMap<String, Vec<ConflictedCommit>>> {
     use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
 
     let stacks = but_api::legacy::workspace::stacks(ctx, None)?;

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -123,9 +123,23 @@ struct StatusContext<'a> {
     mode: &'a gitbutler_operating_modes::OperatingMode,
 }
 
-fn show_edit_mode_status(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
-    // Delegate to the resolve status logic to show actual conflict details
-    crate::command::legacy::resolve::show_resolve_status(ctx, out)
+fn show_edit_mode_status(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    metadata: &gitbutler_operating_modes::EditModeMetadata,
+) -> anyhow::Result<()> {
+    use gitbutler_commit::commit_ext::CommitExt as _;
+
+    let gix_repo = ctx.repo.get()?;
+    let commit = gix_repo.find_commit(metadata.commit_oid)?;
+    if commit.is_conflicted() {
+        drop(commit);
+        drop(gix_repo);
+        return crate::command::legacy::resolve::show_resolve_status(ctx, out);
+    }
+    drop(commit);
+    drop(gix_repo);
+    crate::command::legacy::edit_mode::show_edit_status(ctx, out)
 }
 
 pub(crate) async fn worktree(
@@ -136,9 +150,10 @@ pub(crate) async fn worktree(
 ) -> anyhow::Result<()> {
     // Check if we're in edit mode first, before doing any expensive operations
     let mode = but_api::legacy::modes::operating_mode(ctx)?.operating_mode;
-    if let gitbutler_operating_modes::OperatingMode::Edit(_metadata) = mode {
-        // In edit mode, show the conflict resolution status
-        return show_edit_mode_status(ctx, out);
+    if let gitbutler_operating_modes::OperatingMode::Edit(metadata) = mode {
+        // In edit mode, show either conflict resolution status (for conflicted commits)
+        // or the general edit-mode status for non-conflicted commits.
+        return show_edit_mode_status(ctx, out, &metadata);
     }
 
     let status_ctx = build_status_context(ctx, out, &mode, flags, render_mode).await?;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1153,6 +1153,21 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
+        Subcommands::EditMode { cmd, commit } => {
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
+            command::legacy::edit_mode::handle(&mut ctx, out, cmd, commit)
+                .context("Failed to handle edit mode.")
+                .emit_metrics(metrics_ctx)
+                .show_root_cause_error_then_exit_without_destructors(output)
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Resolve { cmd, commit } => {
             let mut ctx = setup::init_ctx(
                 &args,

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -211,6 +211,8 @@ impl Subcommands {
                 skill::Subcommands::Check { .. } => SkillCheck,
             },
             Subcommands::Edit { .. } => Edit,
+            #[cfg(feature = "legacy")]
+            Subcommands::EditMode { .. } => EditMode,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
         }
     }

--- a/crates/but/tests/but/command/edit_mode.rs
+++ b/crates/but/tests/but/command/edit_mode.rs
@@ -1,0 +1,147 @@
+use anyhow::Context as _;
+use snapbox::str;
+
+use crate::utils::{CommandExt as _, Sandbox};
+
+fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+    let output = env.but("--json status").allow_json().output()?;
+    serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
+}
+
+fn find_branch<'a>(
+    status: &'a serde_json::Value,
+    branch_name: &str,
+) -> anyhow::Result<&'a serde_json::Value> {
+    status["stacks"]
+        .as_array()
+        .context("status.stacks should be an array")?
+        .iter()
+        .flat_map(|stack| {
+            stack["branches"]
+                .as_array()
+                .into_iter()
+                .flat_map(|branches| branches.iter())
+        })
+        .find(|branch| branch["name"].as_str() == Some(branch_name))
+        .context("expected branch in status output")
+}
+
+fn current_branch_name(env: &Sandbox) -> anyhow::Result<String> {
+    let repo = env.open_repo()?;
+    let _ = repo
+        .rev_parse_single("HEAD")
+        .context("HEAD should resolve")?;
+    repo.head_name()?
+        .map(|name| name.as_ref().shorten().to_string())
+        .context("HEAD should point to a branch")
+}
+
+/// Enter edit mode for a non-conflicted commit on branchB.
+/// Creates branchB with two commits, then enters edit mode on the first one.
+fn enter_edit_mode_for_commit(env: &Sandbox) -> anyhow::Result<String> {
+    env.but("branch new branchB").assert().success();
+
+    env.file("test-file.txt", "line 1\nline 2\nline 3\n");
+    env.but("commit -m 'first commit' branchB")
+        .assert()
+        .success();
+
+    env.file("test-file.txt", "line 1\nline 2\nline 3\nline 4\n");
+    env.but("commit -m 'second commit' branchB")
+        .assert()
+        .success();
+
+    let status = status_json(env)?;
+    let branch = find_branch(&status, "branchB")?;
+    let first_commit_cli_id = branch["commits"]
+        .as_array()
+        .context("branch commits should be an array")?
+        .iter()
+        .find(|commit| commit["message"].as_str() == Some("first commit"))
+        .and_then(|commit| commit["cliId"].as_str())
+        .context("should find first commit cli id")?
+        .to_string();
+
+    env.but(format!("edit-mode {first_commit_cli_id}"))
+        .assert()
+        .success();
+
+    Ok(first_commit_cli_id)
+}
+
+#[test]
+fn edit_mode_enter_and_status() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    enter_edit_mode_for_commit(&env)?;
+
+    assert_eq!(current_branch_name(&env)?, "gitbutler/edit");
+
+    env.but("edit-mode status")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
+
+    // `but status` should also succeed in edit mode (non-conflicted commit shows edit-mode status)
+    env.but("status").assert().success().stderr_eq(str![""]);
+
+    Ok(())
+}
+
+#[test]
+fn edit_mode_finish() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    enter_edit_mode_for_commit(&env)?;
+
+    // Make a change
+    env.file("test-file.txt", "line 1\nline 2 modified\nline 3\n");
+
+    env.but("edit-mode finish")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
+
+    assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
+    Ok(())
+}
+
+#[test]
+fn edit_mode_cancel_no_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    enter_edit_mode_for_commit(&env)?;
+
+    env.but("edit-mode cancel")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
+
+    assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
+    Ok(())
+}
+
+#[test]
+fn edit_mode_cancel_requires_force_when_changes_were_made() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    enter_edit_mode_for_commit(&env)?;
+
+    env.file("test-file.txt", "modified content\n");
+
+    env.but("edit-mode cancel")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to handle edit mode. There are changes that differ from the original commit you were editing. Canceling will drop those changes.
+
+If you want to go through with this, please re-run with `--force`.
+
+If you want to keep the changes you have made, consider finishing the edit with `but edit-mode finish`.
+
+"#]]);
+
+    env.but("edit-mode cancel --force")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
+
+    assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -13,6 +13,8 @@ mod commit;
 mod cursor;
 #[cfg(feature = "legacy")]
 mod diff;
+#[cfg(feature = "legacy")]
+mod edit_mode;
 mod format;
 mod gui;
 mod help;


### PR DESCRIPTION
this PR was written by Claude Code with assistance and review from myself

## 🧢 Changes

this PR introduces a new `edit-mode` subcommand that lets you enter edit mode via the CLI. this is meant to mirror the current functionality in the GUI where you can right click on a commit and click "Edit commit" to enter edit mode.

## ☕️ Reasoning

while i do enjoy using the GUI, i would like to be able to allow my AI agents to use edit mode directly, and sometimes its just easier to use a CLI. seeing as the functionality was all there and simply missing a dedicated command to interact with it, i took the opportunity to implement this.

the reason why i named this `edit-mode` instead of `edit` is to avoid conflicts with the existing hidden `edit` subcommand


the structure of both the code & the output is meant to align with what already exists in the resolve mode command. i did not extract shared code between the resolve and edit-mode commands but if you want me to do that i can do so, most of the code is basically the same. that being said the actual amount of code involved is pretty small to begin with.

there is a small frontend change here as well to solve what seemed to me to be a race condition. if you exit edit mode (or resolve mode) from the CLI, sometimes the app would show errors like this:

<img width="319" height="476" alt="errors" src="https://github.com/user-attachments/assets/7bf7bbeb-f29d-4366-84cd-dd2e571bc576" />

it seems that the app would sometimes receive the `worktree_changes` event before it had unmounted the `EditMode` UI due to the mode changing, resulting in the error message above. im open to suggestions on a better solution, but this seems like a reasonable approach for a simple race condition like this
