### PR TITLE
docs: add but-schemars annotation examples and helper renames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ members = [
     "crates/but-claude",            # 📄Orchestrate `claude` instances
     # 👉but at least one item lacks documentation.
     "crates/but-path",              # 📄Provide paths interesting to the application, with global redirects for testing.
-    # 👉Lacks docs and tests, and overview, but still useful and simple enough to 'just works'
-    "crates/but-serde",             # 📄Serde attributes for ser-de of custom datatypes.
-    # 👉Lacks docs and tests. Centralized simple utility schema generation modules.
+    # 👉Lacks tests, and overview, but still useful and simple enough to 'just works'
+    "crates/but-serde",             # 📄Serde attributes for serialisation and deserialisation of custom datatypes.
+    # 👉Lacks tests. Centralized simple utility schema generation modules.
     "crates/but-schemars",          # 📄`schemars` json schema generation utilities.
     # 👉Feels overengingeered, uses `but-ctx` and legacy crates.
     "crates/but-worktrees",         # 📄Worktree creation and removal;

--- a/crates/but-api/src/legacy/config.rs
+++ b/crates/but-api/src/legacy/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use but_api_macros::but_api;
 use but_core::{RepositoryExt, settings::git::ui::GitConfigSettings};
-use but_serde::bstring_opt_lossy;
+use but_serde::bstring_lossy_opt;
 use gix::bstr::BString;
 use serde::Serialize;
 use tracing::instrument;
@@ -39,10 +39,10 @@ pub fn store_author_globally_if_unset(
 #[derive(Clone, Serialize)]
 pub struct AuthorInfo {
     /// The name of the author.
-    #[serde(with = "bstring_opt_lossy")]
+    #[serde(with = "bstring_lossy_opt")]
     pub name: Option<BString>,
     /// The email of the author.
-    #[serde(with = "bstring_opt_lossy")]
+    #[serde(with = "bstring_lossy_opt")]
     pub email: Option<BString>,
 }
 

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -421,7 +421,7 @@ pub struct IgnoredWorktreeChange {
     #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     pub path: BString,
     /// The status that caused this change to be ignored.

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -89,7 +89,7 @@ pub struct TreeChange {
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_for_frontend")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     pub path: BStringForFrontend,
     /// Something silently carried back and forth between the frontend and the backend.
@@ -150,7 +150,7 @@ pub enum TreeStatus {
         #[cfg_attr(feature = "export-ts", ts(type = "string"))]
         #[cfg_attr(
             feature = "export-schema",
-            schemars(schema_with = "but_schemars::bstring_for_frontend")
+            schemars(schema_with = "but_schemars::bstring_lossy")
         )]
         previous_path: BStringForFrontend,
         /// Something silently carried back and forth between the frontend and the backend.

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -40,7 +40,7 @@ pub struct DiffHunk {
     #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     pub diff: BString,
 }

--- a/crates/but-hunk-dependency/src/ranges/mod.rs
+++ b/crates/but-hunk-dependency/src/ranges/mod.rs
@@ -38,7 +38,7 @@ pub struct CalculationError {
     #[serde(serialize_with = "but_serde::bstring_lossy::serialize")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     pub path: BString,
 }

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -1,57 +1,213 @@
-//! Schemars utilities for json schema generation
+//! Schemars utilities for JSON schema generation.
+//!
+//! Each helper in this crate is meant to be used from
+//! `#[schemars(schema_with = "...")]` on the field whose runtime type should be
+//! exported as a simpler JSON shape.
+//!
+//! Put the annotation on the field itself, next to the matching `serde`
+//! override when there is one:
+//!
+//! ```rust
+//! #[derive(serde::Serialize, schemars::JsonSchema)]
+//! struct Example {
+//!     #[serde(with = "but_serde::object_id")]
+//!     #[schemars(schema_with = "but_schemars::object_id")]
+//!     id: gix::ObjectId,
+//! }
+//! ```
+//!
+//! The examples below intentionally show the concrete field type that should
+//! carry each annotation.
 
+/// Use on `Option<StackId>` fields that should appear as `string | null`.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::stack_id_opt")]
+///     id: Option<but_core::ref_metadata::StackId>,
+/// }
+/// ```
 pub fn stack_id_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<String>>()
 }
 
+/// Use on `StackId` fields that should appear as `string`.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::stack_id")]
+///     id: but_core::ref_metadata::StackId,
+/// }
+/// ```
 pub fn stack_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on *lossy* `BString` fields serialized with `but_serde::bstring_lossy`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::bstring_lossy")]
+///     #[schemars(schema_with = "but_schemars::bstring")]
+///     name: bstr::BString,
+/// }
+/// ```
 pub fn bstring(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on optional *lossy* `BString` fields serialized with
+/// `but_serde::bstring_opt_lossy`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::bstring_opt_lossy")]
+///     #[schemars(schema_with = "but_schemars::bstring_opt")]
+///     linked_worktree_id: Option<bstr::BString>,
+/// }
+/// ```
 pub fn bstring_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<String>>()
 }
 
+/// Use on `gix::ObjectId` fields serialized with `but_serde::object_id`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id")]
+///     #[schemars(schema_with = "but_schemars::object_id")]
+///     id: gix::ObjectId,
+/// }
+/// ```
 pub fn object_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on `Vec<gix::ObjectId>` fields serialized with `but_serde::object_id_vec`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id_vec")]
+///     #[schemars(schema_with = "but_schemars::object_id_vec")]
+///     parent_ids: Vec<gix::ObjectId>,
+/// }
+/// ```
 pub fn object_id_vec(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Vec<String>>()
 }
 
+/// Use on `gix::refs::FullName` fields serialized with
+/// `but_serde::fullname_lossy`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::fullname_lossy")]
+///     #[schemars(schema_with = "but_schemars::ref_full_name")]
+///     reference: gix::refs::FullName,
+/// }
+/// ```
 pub fn ref_full_name(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on `url::Url` fields that should appear as strings in schema output.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::url")]
+///     gravatar_url: url::Url,
+/// }
+/// ```
 pub fn url(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on project identifier fields that serialize as strings.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::project_id")]
+///     id: gitbutler_project::ProjectId,
+/// }
+/// ```
 pub fn project_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on `DefaultTrue` wrapper fields that should appear as booleans.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(default)]
+///     #[schemars(schema_with = "but_schemars::default_true")]
+///     ok_with_force_push: DefaultTrue,
+/// }
+/// ```
 pub fn default_true(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<bool>()
 }
 
+/// Use on legacy `git2::Oid` fields serialized with `but_serde::oid`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::oid")]
+///     #[schemars(schema_with = "but_schemars::oid")]
+///     id: git2::Oid,
+/// }
+/// ```
 pub fn oid(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
+/// Use on `Option<gix::ObjectId>` fields serialized with `but_serde::object_id_opt`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id_opt")]
+///     #[schemars(schema_with = "but_schemars::object_id_opt")]
+///     base: Option<gix::ObjectId>,
+/// }
+/// ```
 pub fn object_id_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<String>>()
 }
 
+/// Use on raw `BString` byte payloads that should appear as `number[]`.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::bstring_bytes")]
+///     path_bytes: bstr::BString,
+/// }
+/// ```
 pub fn bstring_bytes(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Vec<u8>>()
 }
 
+/// Use on optional raw `BString` byte payloads that should appear as
+/// `number[] | null`.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::bstring_bytes_opt")]
+///     previous_path: Option<bstr::BString>,
+/// }
+/// ```
 pub fn bstring_bytes_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<Vec<u8>>>()
 }
@@ -63,10 +219,29 @@ struct GixTime {
     offset: i32,
 }
 
+/// Use on optional `gix::date::Time` fields that should keep the same
+/// `{ seconds, offset }` shape as the serialized value.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::gix_time_opt")]
+///     created_at: Option<gix::date::Time>,
+/// }
+/// ```
 pub fn gix_time_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<GixTime>>()
 }
 
+/// Use on `BStringForFrontend` fields that serialize to plain strings.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::bstring_for_frontend")]
+///     path: but_serde::BStringForFrontend,
+/// }
+/// ```
 pub fn bstring_for_frontend(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
@@ -82,6 +257,16 @@ enum EntryKindSchema {
     Commit,
 }
 
+/// Use on `gix::object::tree::EntryKind` fields that should export the stable
+/// enum used by the frontend.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::entry_kind")]
+///     kind: gix::object::tree::EntryKind,
+/// }
+/// ```
 pub fn entry_kind(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<EntryKindSchema>()
 }
@@ -95,10 +280,28 @@ struct SerdeErrorSchema {
     source: Option<Box<SerdeErrorSchema>>,
 }
 
+/// Use on `serde_error::Error` fields.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::serde_error")]
+///     error: serde_error::Error,
+/// }
+/// ```
 pub fn serde_error(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<SerdeErrorSchema>()
 }
 
+/// Use on `Option<serde_error::Error>` fields.
+///
+/// ```rust
+/// #[derive(schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::serde_error_opt")]
+///     error: Option<serde_error::Error>,
+/// }
+/// ```
 pub fn serde_error_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<SerdeErrorSchema>>()
 }

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -45,32 +45,40 @@ pub fn stack_id(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
-/// Use on *lossy* `BString` fields serialized with `but_serde::bstring_lossy`.
+/// Use on string-like fields that serialize lossily as plain strings.
+///
+/// This applies to:
+/// - `BString` fields serialized with `but_serde::bstring_lossy`
+/// - `BStringForFrontend` fields serialized as strings
 ///
 /// ```rust
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::bstring_lossy")]
-///     #[schemars(schema_with = "but_schemars::bstring")]
+///     #[schemars(schema_with = "but_schemars::bstring_lossy")]
 ///     name: bstr::BString,
 /// }
 /// ```
-pub fn bstring(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
+pub fn bstring_lossy(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 
 /// Use on optional *lossy* `BString` fields serialized with
-/// `but_serde::bstring_opt_lossy`.
+/// `but_serde::bstring_lossy_opt`.
+/// 
+/// This applies to:
+/// - `BString` fields serialized with `but_serde::bstring_lossy`
+/// - `BStringForFrontend` fields serialized as strings
 ///
 /// ```rust
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
-///     #[serde(with = "but_serde::bstring_opt_lossy")]
-///     #[schemars(schema_with = "but_schemars::bstring_opt")]
+///     #[serde(with = "but_serde::bstring_lossy_opt")]
+///     #[schemars(schema_with = "but_schemars::bstring_lossy_opt")]
 ///     linked_worktree_id: Option<bstr::BString>,
 /// }
 /// ```
-pub fn bstring_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
+pub fn bstring_lossy_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<String>>()
 }
 
@@ -231,19 +239,6 @@ struct GixTime {
 /// ```
 pub fn gix_time_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<Option<GixTime>>()
-}
-
-/// Use on `BStringForFrontend` fields that serialize to plain strings.
-///
-/// ```rust
-/// #[derive(schemars::JsonSchema)]
-/// struct Example {
-///     #[schemars(schema_with = "but_schemars::bstring_for_frontend")]
-///     path: but_serde::BStringForFrontend,
-/// }
-/// ```
-pub fn bstring_for_frontend(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
-    generate.subschema_for::<String>()
 }
 
 #[derive(schemars::JsonSchema)]

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -65,7 +65,7 @@ pub fn bstring_lossy(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 
 /// Use on optional *lossy* `BString` fields serialized with
 /// `but_serde::bstring_lossy_opt`.
-/// 
+///
 /// This applies to:
 /// - `BString` fields serialized with `but_serde::bstring_lossy`
 /// - `BStringForFrontend` fields serialized as strings
@@ -117,11 +117,11 @@ pub fn object_id_vec(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
 /// #[derive(serde::Serialize, schemars::JsonSchema)]
 /// struct Example {
 ///     #[serde(with = "but_serde::fullname_lossy")]
-///     #[schemars(schema_with = "but_schemars::ref_full_name")]
+///     #[schemars(schema_with = "but_schemars::fullname_lossy")]
 ///     reference: gix::refs::FullName,
 /// }
 /// ```
-pub fn ref_full_name(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
+pub fn fullname_lossy(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     generate.subschema_for::<String>()
 }
 

--- a/crates/but-serde/src/lib.rs
+++ b/crates/but-serde/src/lib.rs
@@ -49,7 +49,7 @@ pub mod bstring_vec_lossy {
     }
 }
 
-pub mod bstring_opt_lossy {
+pub mod bstring_lossy_opt {
     use bstr::{BString, ByteSlice};
     use serde::Serialize;
 

--- a/crates/but-serde/src/lib.rs
+++ b/crates/but-serde/src/lib.rs
@@ -1,8 +1,36 @@
+//! Serde utilities for JSON serialization and deserialization.
+//!
+//! Each helper in this crate is meant to be used from `#[serde(with = "...")]`
+//! or `#[serde(serialize_with = "...")]` on the field whose runtime type should
+//! be exported as a simpler JSON shape.
+//!
+//! Put the annotation on the field itself:
+//!
+//! ```rust
+//! #[derive(serde::Serialize, serde::Deserialize)]
+//! struct Example {
+//!     #[serde(with = "but_serde::object_id")]
+//!     id: gix::ObjectId,
+//! }
+//! ```
+//!
+//! The examples below intentionally show the concrete field type that should
+//! carry each annotation.
+
 use serde::Serialize;
 
 mod bstring;
 pub use bstring::BStringForFrontend;
 
+/// Use on *lossy* `BString` fields that should serialize as JSON strings.
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::bstring_lossy")]
+///     name: bstr::BString,
+/// }
+/// ```
 pub mod bstring_lossy {
     use bstr::{BString, ByteSlice};
     use serde::Serialize;
@@ -15,6 +43,15 @@ pub mod bstring_lossy {
     }
 }
 
+/// Use on `gix::refs::FullName` fields that should serialize as JSON strings.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::fullname_lossy")]
+///     reference: gix::refs::FullName,
+/// }
+/// ```
 pub mod fullname_lossy {
     use bstr::ByteSlice;
     use serde::{Deserialize, Deserializer, Serialize};
@@ -36,6 +73,15 @@ pub mod fullname_lossy {
     }
 }
 
+/// Use on `Vec<BString>` fields that should serialize as `string[]`.
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::bstring_vec_lossy")]
+///     paths: Vec<bstr::BString>,
+/// }
+/// ```
 pub mod bstring_vec_lossy {
     use bstr::{BString, ByteSlice};
     use serde::Serialize;
@@ -49,6 +95,16 @@ pub mod bstring_vec_lossy {
     }
 }
 
+/// Use on optional `BString` fields that should serialize lossily as
+/// `string | null`.
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::bstring_lossy_opt")]
+///     linked_worktree_id: Option<bstr::BString>,
+/// }
+/// ```
 pub mod bstring_lossy_opt {
     use bstr::{BString, ByteSlice};
     use serde::Serialize;
@@ -61,6 +117,16 @@ pub mod bstring_lossy_opt {
     }
 }
 
+/// Use on `Vec<gix::remote::Name<'static>>` fields that should serialize as
+/// `string[]`.
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(serialize_with = "but_serde::as_string_lossy_vec_remote_name")]
+///     remotes: Vec<gix::remote::Name<'static>>,
+/// }
+/// ```
 pub fn as_string_lossy_vec_remote_name<S>(
     v: &[gix::remote::Name<'static>],
     s: S,
@@ -73,6 +139,15 @@ where
 }
 
 #[cfg(feature = "legacy")]
+/// Use on legacy `git2::Time` fields that should serialize as Unix seconds.
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(serialize_with = "but_serde::as_time_seconds_from_unix_epoch")]
+///     created_at: git2::Time,
+/// }
+/// ```
 pub fn as_time_seconds_from_unix_epoch<S>(v: &git2::Time, s: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -81,6 +156,15 @@ where
 }
 
 #[cfg(feature = "legacy")]
+/// Use on `Option<git2::Oid>` fields serialized as `string | null`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::oid_opt")]
+///     base: Option<git2::Oid>,
+/// }
+/// ```
 pub mod oid_opt {
     use serde::{Deserialize, Deserializer, Serialize};
 
@@ -104,6 +188,15 @@ pub mod oid_opt {
     }
 }
 
+/// Use on `Option<gix::ObjectId>` fields serialized as `string | null`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id_opt")]
+///     base: Option<gix::ObjectId>,
+/// }
+/// ```
 pub mod object_id_opt {
     use serde::{Deserialize, Deserializer, Serialize};
 
@@ -127,13 +220,20 @@ pub mod object_id_opt {
     }
 }
 
-/// use like `#[serde(with = "but_serde::object_id")]` to serialize [`gix::ObjectId`].
+/// Use on `gix::ObjectId` fields serialized as hex strings.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id")]
+///     id: gix::ObjectId,
+/// }
+/// ```
 pub mod object_id {
     use std::str::FromStr;
 
     use serde::{Deserialize, Deserializer, Serialize};
 
-    /// serialize an object ID as hex-string.
     pub fn serialize<S>(v: &gix::ObjectId, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -141,7 +241,6 @@ pub mod object_id {
         v.to_string().serialize(s)
     }
 
-    /// deserialize an object ID from hex-string.
     pub fn deserialize<'de, D>(d: D) -> Result<gix::ObjectId, D::Error>
     where
         D: Deserializer<'de>,
@@ -151,12 +250,20 @@ pub mod object_id {
     }
 }
 
+/// Use on `Vec<gix::ObjectId>` fields serialized as `string[]`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::object_id_vec")]
+///     parent_ids: Vec<gix::ObjectId>,
+/// }
+/// ```
 pub mod object_id_vec {
     use std::str::FromStr;
 
     use serde::{Deserialize, Deserializer, Serialize};
 
-    /// serialize an object ID as hex-string.
     pub fn serialize<S>(v: &[gix::ObjectId], s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -165,7 +272,6 @@ pub mod object_id_vec {
         vec.serialize(s)
     }
 
-    /// deserialize an object ID from hex-string.
     pub fn deserialize<'de, D>(d: D) -> Result<Vec<gix::ObjectId>, D::Error>
     where
         D: Deserializer<'de>,
@@ -183,6 +289,15 @@ pub mod object_id_vec {
 }
 
 #[cfg(feature = "legacy")]
+/// Use on `Vec<git2::Oid>` fields serialized as `string[]`.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::oid_vec")]
+///     parent_ids: Vec<git2::Oid>,
+/// }
+/// ```
 pub mod oid_vec {
     use serde::{Deserialize, Deserializer, Serialize};
 
@@ -211,6 +326,15 @@ pub mod oid_vec {
 }
 
 #[cfg(feature = "legacy")]
+/// Use on `git2::Oid` fields serialized as hex string.
+///
+/// ```rust
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::oid")]
+///     id: git2::Oid,
+/// }
+/// ```
 pub mod oid {
     use serde::{Deserialize, Deserializer, Serialize};
 

--- a/crates/but-workspace/src/legacy/ui.rs
+++ b/crates/but-workspace/src/legacy/ui.rs
@@ -19,7 +19,7 @@ pub struct StackHeadInfo {
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     pub name: BString,
     /// The tip of the branch.

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -242,7 +242,7 @@ pub struct BranchDetails {
     #[serde(with = "but_serde::fullname_lossy")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::ref_full_name")
+        schemars(schema_with = "but_schemars::fullname_lossy")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     /// The full reference of the branch

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -89,7 +89,7 @@ pub struct Commit {
     #[serde(with = "but_serde::bstring_lossy")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub message: BString,
@@ -184,7 +184,7 @@ pub struct UpstreamCommit {
     #[serde(with = "but_serde::bstring_lossy")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub message: BString,
@@ -235,7 +235,7 @@ pub struct BranchDetails {
     #[serde(with = "but_serde::bstring_lossy")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring")
+        schemars(schema_with = "but_schemars::bstring_lossy")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string"))]
     pub name: BString,
@@ -249,18 +249,18 @@ pub struct BranchDetails {
     pub reference: gix::refs::FullName,
     /// The id of the linked worktree that has the reference of `name` checked out.
     /// Note that we don't list the main worktree here.
-    #[serde(with = "but_serde::bstring_opt_lossy")]
+    #[serde(with = "but_serde::bstring_lossy_opt")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_opt")
+        schemars(schema_with = "but_schemars::bstring_lossy_opt")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub linked_worktree_id: Option<BString>,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
-    #[serde(with = "but_serde::bstring_opt_lossy")]
+    #[serde(with = "but_serde::bstring_lossy_opt")]
     #[cfg_attr(
         feature = "export-schema",
-        schemars(schema_with = "but_schemars::bstring_opt")
+        schemars(schema_with = "but_schemars::bstring_lossy_opt")
     )]
     #[cfg_attr(feature = "export-ts", ts(type = "string | null"))]
     pub remote_tracking_branch: Option<BString>,
@@ -328,7 +328,7 @@ pub struct Branch {
     #[serde(with = "but_serde::bstring_lossy")]
     pub name: BString,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
-    #[serde(with = "but_serde::bstring_opt_lossy")]
+    #[serde(with = "but_serde::bstring_lossy_opt")]
     pub remote_tracking_branch: Option<BString>,
     /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
     pub pr_number: Option<usize>,

--- a/crates/but/src/command/legacy/mcp_internal/stack.rs
+++ b/crates/but/src/command/legacy/mcp_internal/stack.rs
@@ -119,7 +119,7 @@ pub struct BranchDetails {
     #[serde(with = "but_serde::bstring_lossy")]
     pub name: BString,
     /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
-    #[serde(with = "but_serde::bstring_opt_lossy")]
+    #[serde(with = "but_serde::bstring_lossy_opt")]
     pub remote_tracking_branch: Option<BString>,
     /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
     pub pr_number: Option<usize>,

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -67,7 +67,7 @@ pub struct EditModeMetadata {
 #[serde(rename_all = "camelCase")]
 pub struct OutsideWorkspaceMetadata {
     /// The name of the currently checked out branch or None if in detached head state.
-    #[serde(with = "but_serde::bstring_opt_lossy")]
+    #[serde(with = "but_serde::bstring_lossy_opt")]
     pub branch_name: Option<BString>,
     /// The paths of any files that would conflict with the workspace as it currently is
     pub worktree_conflicts: Vec<BStringForFrontend>,


### PR DESCRIPTION
## Tasks

* [x] review

## Summary
- add crate-level guidance for pairing `schemars(schema_with = ...)` with the field it documents
- add per-helper rustdoc examples showing the concrete field type and annotation placement
- rename the lossy string/full-name schema helpers to match the paired `but_serde` helpers

## Testing
- cargo check -p but-schemars