### PR TITLE
fix: expand collapsed stacks after app reload

### DIFF
--- a/apps/desktop/src/components/CollapseStackButton.svelte
+++ b/apps/desktop/src/components/CollapseStackButton.svelte
@@ -8,14 +8,16 @@
 	}
 
 	let { disabled, isFolded, onClick }: Props = $props();
+
+	const label = $derived(isFolded ? "Expand stack" : "Collapse stack");
 </script>
 
-<Tooltip text={isFolded ? "Expand stack" : "Collapse stack"}>
+<Tooltip text={label}>
 	<button
 		class="collapse-button"
 		class:isFolded
 		type="button"
-		aria-label={isFolded ? "Expand stack" : "Collapse stack"}
+		aria-label={label}
 		onclick={onClick}
 		{disabled}
 	>

--- a/apps/desktop/src/components/CollapseStackButton.svelte
+++ b/apps/desktop/src/components/CollapseStackButton.svelte
@@ -1,21 +1,27 @@
 <script lang="ts">
 	import { persisted } from "@gitbutler/shared/persisted";
 	import { Tooltip } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	interface Props {
 		stackId?: string;
 		projectId: string;
 		disabled?: boolean;
 		isFolded?: boolean;
-		onToggle?: (toggleFn: () => void) => void;
+		onClick?: () => void;
 	}
 
-	const { stackId, projectId, disabled, isFolded, onToggle }: Props = $props();
+	let { stackId, projectId, disabled, isFolded, onClick }: Props = $props();
 
 	// Persisted folded stacks state per project (without expiration)
-	const foldedStacks = persisted<string[]>([], `folded-stacks-${projectId}`);
+	const foldedStacks = persisted<string[]>([], `folded-stacks-${untrack(() => projectId)}`);
 
 	function toggleFold() {
+		if (onClick) {
+			onClick();
+			return;
+		}
+
 		if (!stackId || disabled) return;
 
 		const currentFolded = $foldedStacks;
@@ -29,13 +35,6 @@
 			}
 		}
 	}
-
-	// Call onToggle callback with toggleFold function if provided
-	$effect(() => {
-		if (onToggle) {
-			onToggle(toggleFold);
-		}
-	});
 </script>
 
 <Tooltip text={isFolded ? "Expand stack" : "Collapse stack"}>

--- a/apps/desktop/src/components/CollapseStackButton.svelte
+++ b/apps/desktop/src/components/CollapseStackButton.svelte
@@ -1,40 +1,13 @@
 <script lang="ts">
-	import { persisted } from "@gitbutler/shared/persisted";
 	import { Tooltip } from "@gitbutler/ui";
-	import { untrack } from "svelte";
 
 	interface Props {
-		stackId?: string;
-		projectId: string;
 		disabled?: boolean;
 		isFolded?: boolean;
 		onClick?: () => void;
 	}
 
-	let { stackId, projectId, disabled, isFolded, onClick }: Props = $props();
-
-	// Persisted folded stacks state per project (without expiration)
-	const foldedStacks = persisted<string[]>([], `folded-stacks-${untrack(() => projectId)}`);
-
-	function toggleFold() {
-		if (onClick) {
-			onClick();
-			return;
-		}
-
-		if (!stackId || disabled) return;
-
-		const currentFolded = $foldedStacks;
-		if (isFolded) {
-			// Unfold: remove from folded list
-			foldedStacks.set(currentFolded.filter((id) => id !== stackId));
-		} else {
-			// Fold: add to folded list
-			if (!currentFolded.includes(stackId)) {
-				foldedStacks.set([...currentFolded, stackId]);
-			}
-		}
-	}
+	let { disabled, isFolded, onClick }: Props = $props();
 </script>
 
 <Tooltip text={isFolded ? "Expand stack" : "Collapse stack"}>
@@ -43,7 +16,7 @@
 		class:isFolded
 		type="button"
 		aria-label="Collapse stack"
-		onclick={toggleFold}
+		onclick={onClick}
 		{disabled}
 	>
 		<div class="collapse-icon">

--- a/apps/desktop/src/components/CollapseStackButton.svelte
+++ b/apps/desktop/src/components/CollapseStackButton.svelte
@@ -15,7 +15,7 @@
 		class="collapse-button"
 		class:isFolded
 		type="button"
-		aria-label="Collapse stack"
+		aria-label={isFolded ? "Expand stack" : "Collapse stack"}
 		onclick={onClick}
 		{disabled}
 	>

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -8,10 +8,6 @@
 	};
 
 	const { branchNames, onUnfold }: Props = $props();
-
-	function handleDoubleClick() {
-		onUnfold();
-	}
 </script>
 
 <div
@@ -20,7 +16,7 @@
 	data-remove-from-panning
 	data-drag-handle
 	draggable="true"
-	ondblclick={handleDoubleClick}
+	ondblclick={onUnfold}
 >
 	<CollapseStackButton isFolded onClick={onUnfold} />
 

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -6,16 +6,13 @@
 		stackId?: string;
 		branchNames?: string[];
 		projectId: string;
+		onUnfold: () => void;
 	};
 
-	const { stackId, branchNames, projectId }: Props = $props();
-
-	let toggleFold: (() => void) | undefined = $state();
+	const { stackId, branchNames, projectId, onUnfold }: Props = $props();
 
 	function handleDoubleClick() {
-		if (toggleFold) {
-			toggleFold();
-		}
+		onUnfold();
 	}
 </script>
 
@@ -27,7 +24,7 @@
 	draggable="true"
 	ondblclick={handleDoubleClick}
 >
-	<CollapseStackButton {stackId} {projectId} isFolded onToggle={(fn) => (toggleFold = fn)} />
+	<CollapseStackButton {stackId} {projectId} isFolded onClick={onUnfold} />
 
 	<div class="drag-handle-icon">
 		<Icon name="drag-horizontal" />

--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -3,13 +3,11 @@
 	import { Icon } from "@gitbutler/ui";
 
 	type Props = {
-		stackId?: string;
 		branchNames?: string[];
-		projectId: string;
 		onUnfold: () => void;
 	};
 
-	const { stackId, branchNames, projectId, onUnfold }: Props = $props();
+	const { branchNames, onUnfold }: Props = $props();
 
 	function handleDoubleClick() {
 		onUnfold();
@@ -24,7 +22,7 @@
 	draggable="true"
 	ondblclick={handleDoubleClick}
 >
-	<CollapseStackButton {stackId} {projectId} isFolded onClick={onUnfold} />
+	<CollapseStackButton isFolded onClick={onUnfold} />
 
 	<div class="drag-handle-icon">
 		<Icon name="drag-horizontal" />

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -85,7 +85,7 @@
 	let stackElements = $state<Record<string, HTMLElement>>({});
 
 	let laneWidths = $state<number[]>([]);
-	let lineHights = $state<number[]>([]);
+	let lineHeights = $state<number[]>([]);
 	let isNotEnoughHorzSpace = $derived(
 		(lanesScrollableWidth ?? 0) < laneWidths.length * (laneWidths[0] ?? 0),
 	);
@@ -262,7 +262,7 @@
 						onFoldStack={() => foldStack(stack.id)}
 						topBranchName={stack.heads.at(0)?.name}
 						bind:clientWidth={laneWidths[i]}
-						bind:clientHeight={lineHights[i]}
+						bind:clientHeight={lineHeights[i]}
 						onVisible={(visible) => {
 							if (visible) {
 								visibleIndexes = [...visibleIndexes, i];

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -20,10 +20,10 @@
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { throttle } from "$lib/utils/misc";
 	import { inject } from "@gitbutler/core/context";
-	import { persisted } from "@gitbutler/shared/persisted";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { resizeObserver } from "@gitbutler/ui/utils/resizeObserver";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
+	import { untrack } from "svelte";
 	import { flip } from "svelte/animate";
 	import type { Stack } from "$lib/stacks/stack";
 
@@ -41,8 +41,34 @@
 	const stackService = inject(STACK_SERVICE);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
 
-	// Persisted folded stacks state per project (without expiration)
-	const foldedStacks = persisted<string[]>([], `folded-stacks-${projectId}`);
+	// Persisted folded stacks state per project using pure $state + localStorage
+	const storageKey = `folded-stacks-${untrack(() => projectId)}`;
+
+	function readFoldedStacks(): string[] {
+		try {
+			const raw = localStorage.getItem(storageKey);
+			return raw ? JSON.parse(raw) : [];
+		} catch {
+			return [];
+		}
+	}
+
+	let foldedStackIds = $state<string[]>(readFoldedStacks());
+
+	function writeFoldedStacks(ids: string[]): void {
+		localStorage.setItem(storageKey, JSON.stringify(ids));
+		foldedStackIds = ids;
+	}
+
+	function unfoldStack(stackId: string | null | undefined): void {
+		if (!stackId) return;
+		writeFoldedStacks(foldedStackIds.filter((id) => id !== stackId));
+	}
+
+	function foldStack(stackId: string | null | undefined): void {
+		if (!stackId || foldedStackIds.includes(stackId)) return;
+		writeFoldedStacks([...foldedStackIds, stackId]);
+	}
 
 	let lanesScrollableEl = $state<HTMLDivElement>();
 	let lanesScrollableWidth = $state<number>(0);
@@ -195,7 +221,7 @@
 				onmousedown={onReorderMouseDown}
 				ondragstart={(e) => {
 					if (!stack.id) return;
-					const isCollapsedLane = $foldedStacks.includes(stack.id);
+					const isCollapsedLane = foldedStackIds.includes(stack.id);
 					onReorderStart(
 						e,
 						stack.id,
@@ -214,17 +240,19 @@
 					onReorderEnd();
 				}}
 			>
-				{#if stack.id && $foldedStacks.includes(stack.id)}
+				{#if stack.id && foldedStackIds.includes(stack.id)}
 					<CollapsedLane
 						stackId={stack.id}
 						branchNames={stack.heads.map((head) => head.name)}
 						{projectId}
+						onUnfold={() => unfoldStack(stack.id)}
 					/>
 				{:else}
 					<StackView
 						{projectId}
 						laneId={stack.id || "banana"}
 						stackId={stack.id ?? undefined}
+						onFoldStack={() => foldStack(stack.id)}
 						topBranchName={stack.heads.at(0)?.name}
 						bind:clientWidth={laneWidths[i]}
 						bind:clientHeight={lineHights[i]}

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -23,7 +23,6 @@
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { resizeObserver } from "@gitbutler/ui/utils/resizeObserver";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
-	import { untrack } from "svelte";
 	import { flip } from "svelte/animate";
 	import type { Stack } from "$lib/stacks/stack";
 
@@ -42,22 +41,29 @@
 	const dragStateService = inject(DRAG_STATE_SERVICE);
 
 	// Persisted folded stacks state per project using pure $state + localStorage
-	const storageKey = `folded-stacks-${untrack(() => projectId)}`;
+	const storageKey = $derived(`folded-stacks-${projectId}`);
 
-	function readFoldedStacks(): string[] {
+	function readFoldedStacks(key: string): string[] {
 		try {
-			const raw = localStorage.getItem(storageKey);
+			const raw = localStorage.getItem(key);
 			return raw ? JSON.parse(raw) : [];
 		} catch {
 			return [];
 		}
 	}
 
-	let foldedStackIds = $state<string[]>(readFoldedStacks());
+	// Track local writes separately so $derived can stay pure
+	let foldedOverride = $state<{ key: string; ids: string[] } | null>(null);
+
+	// Reactively pick from override (if for current key) or localStorage
+	const foldedStackIds = $derived.by(() => {
+		if (foldedOverride?.key === storageKey) return foldedOverride.ids;
+		return readFoldedStacks(storageKey);
+	});
 
 	function writeFoldedStacks(ids: string[]): void {
 		localStorage.setItem(storageKey, JSON.stringify(ids));
-		foldedStackIds = ids;
+		foldedOverride = { key: storageKey, ids };
 	}
 
 	function unfoldStack(stackId: string | null | undefined): void {

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -242,9 +242,7 @@
 			>
 				{#if stack.id && foldedStackIds.includes(stack.id)}
 					<CollapsedLane
-						stackId={stack.id}
 						branchNames={stack.heads.map((head) => head.name)}
-						{projectId}
 						onUnfold={() => unfoldStack(stack.id)}
 					/>
 				{:else}

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -46,7 +46,10 @@
 	function readFoldedStacks(key: string): string[] {
 		try {
 			const raw = localStorage.getItem(key);
-			return raw ? JSON.parse(raw) : [];
+			if (!raw) return [];
+			const parsed = JSON.parse(raw);
+			if (!Array.isArray(parsed)) return [];
+			return parsed.filter((id): id is string => typeof id === "string");
 		} catch {
 			return [];
 		}

--- a/apps/desktop/src/components/StackDragHandle.svelte
+++ b/apps/desktop/src/components/StackDragHandle.svelte
@@ -9,15 +9,16 @@
 		stackId?: string;
 		projectId: string;
 		disabled?: boolean;
+		onFold?: () => void;
 		onOptionsClick?: () => void;
 	};
 
-	let { stackId, projectId, disabled = false }: Props = $props();
+	let { stackId, projectId, disabled = false, onFold }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
 
 	// Get all stacks to determine if we can move left/right
-	const stacksQuery = stackService.stacks(projectId);
+	const stacksQuery = $derived(stackService.stacks(projectId));
 	const stacks = $derived(stacksQuery.response ?? []);
 
 	const currentStackIndex = $derived(
@@ -82,7 +83,7 @@
 </script>
 
 <div class="drag-handle-row" data-remove-from-panning data-drag-handle draggable="true">
-	<CollapseStackButton {stackId} {projectId} {disabled} />
+	<CollapseStackButton {stackId} {projectId} {disabled} onClick={onFold} />
 
 	<div class="drag-handle-icon">
 		<Icon name="drag-horizontal" />

--- a/apps/desktop/src/components/StackDragHandle.svelte
+++ b/apps/desktop/src/components/StackDragHandle.svelte
@@ -83,7 +83,7 @@
 </script>
 
 <div class="drag-handle-row" data-remove-from-panning data-drag-handle draggable="true">
-	<CollapseStackButton {stackId} {projectId} {disabled} onClick={onFold} />
+	<CollapseStackButton {disabled} onClick={onFold} />
 
 	<div class="drag-handle-icon">
 		<Icon name="drag-horizontal" />

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -56,6 +56,7 @@
 		projectId: string;
 		stackId: string | undefined;
 		laneId: string;
+		onFoldStack?: () => void;
 		topBranchName?: string;
 		onVisible: (visible: boolean) => void;
 		clientWidth?: number;
@@ -66,6 +67,7 @@
 		projectId,
 		stackId,
 		laneId,
+		onFoldStack,
 		topBranchName,
 		clientHeight = $bindable(),
 		clientWidth = $bindable(),
@@ -433,7 +435,12 @@
 				>
 					<div class="stack-v" data-fade-on-reorder>
 						<!-- If we are currently committing, we should keep this open so users can actually stop committing again :wink: -->
-						<StackDragHandle stackId={stableStackId} {projectId} disabled={isCommitting} />
+						<StackDragHandle
+							stackId={stableStackId}
+							{projectId}
+							disabled={isCommitting}
+							onFold={onFoldStack}
+						/>
 
 						<div
 							class="assignments-wrap"

--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -69,7 +69,7 @@ export function persisted<T>(initial: T, key: string): Persisted<T> {
 		synchronize(set);
 	});
 
-	async function set(value: T) {
+	function set(value: T) {
 		setAndPersist(value, thisStore.set);
 	}
 
@@ -148,7 +148,7 @@ export function persistWithExpiration<T>(
 		synchronize(set);
 	});
 
-	async function set(value: T) {
+	function set(value: T) {
 		setAndPersist(value, thisStore.set);
 	}
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/98dfb3fd-b966-4de7-b730-6cdaa389c4e9

---

This pull request refactors how the folded (collapsed) stack state is managed and propagated in the desktop app, simplifying the state flow and removing unnecessary indirection. The main focus is to move away from the `persisted` helper for folded stacks and instead use direct localStorage access and explicit prop callbacks, resulting in clearer, more maintainable code for folding/unfolding stack lanes.

**Folded stack state management:**

- Replaces usage of the `persisted` helper for folded stacks in `MultiStackView.svelte` with direct localStorage access and explicit `$state`, introducing `foldStack` and `unfoldStack` functions for manipulating the folded stack IDs.
- Updates all references from `$foldedStacks` to the new `foldedStackIds` state, ensuring consistent state usage throughout the file. [[1]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864L198-R224) [[2]](diffhunk://#diff-df4c6b036b880da73a5769c9c6c1231bb49ca5fbdbb79fa11068c2539bc86864L217-R255)

**Prop and callback refactoring:**

- Refactors `CollapseStackButton.svelte` to use an `onClick` prop instead of `onToggle`, and removes the effect that previously injected the toggle function into the parent. The button now calls `onClick` directly if provided. [[1]](diffhunk://#diff-9fb43ef4478f21214361233d0a2cbe07c6239236088fb9b3420e0bf0fc8b8af3R4-R24) [[2]](diffhunk://#diff-9fb43ef4478f21214361233d0a2cbe07c6239236088fb9b3420e0bf0fc8b8af3L32-L38)
- Updates `CollapsedLane.svelte` to accept an `onUnfold` prop and pass it directly to `CollapseStackButton` as `onClick`, simplifying the double-click unfold logic. [[1]](diffhunk://#diff-559e7ff2778c54bcb29cc34a331a154c10cb96477b788bc03dd67b30f6b38feaR9-R15) [[2]](diffhunk://#diff-559e7ff2778c54bcb29cc34a331a154c10cb96477b788bc03dd67b30f6b38feaL30-R27)
- Updates `StackDragHandle.svelte` and `StackView.svelte` to accept and propagate folding callbacks (`onFold`, `onFoldStack`), ensuring folding actions are handled via explicit props rather than implicit state. [[1]](diffhunk://#diff-122a46b02819b7a54b5d7b30b3ea9a24725d35b95ff97a9695782129589a9faeR12-R21) [[2]](diffhunk://#diff-122a46b02819b7a54b5d7b30b3ea9a24725d35b95ff97a9695782129589a9faeL85-R86) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R59) [[4]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R70) [[5]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L436-R443)

**Code hygiene:**

- Removes unnecessary async from the `set` function in `persisted.ts` and `persistWithExpiration`, making them synchronous for consistency. [[1]](diffhunk://#diff-b239137483bdedaac2dd03dbb298c42fea1f3680822819b36f13b1f52e7ff0baL72-R72) [[2]](diffhunk://#diff-b239137483bdedaac2dd03dbb298c42fea1f3680822819b36f13b1f52e7ff0baL151-R151)

These changes make the folding/unfolding stack logic more explicit, easier to follow, and less reliant on side effects or global state.