### PR TITLE
Respect CARGO_TARGET_DIR in tests

### DIFF
--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -317,7 +317,10 @@ fn set_storage_path_for_testing(git_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 use gix::{bstr::ByteSlice, prelude::ObjectIdExt};
 use once_cell::sync::Lazy;
@@ -330,13 +333,11 @@ pub(crate) static DRIVER: Lazy<PathBuf> = Lazy::new(|| {
         .expect("cargo should run fine");
     assert!(res.success(), "cargo invocation should be successful");
 
-    let path = Path::new("../../target")
-        .join("debug")
-        .join(if cfg!(windows) {
-            "gitbutler-cli.exe"
-        } else {
-            "gitbutler-cli"
-        });
+    let path = cargo_target_dir().join("debug").join(if cfg!(windows) {
+        "gitbutler-cli.exe"
+    } else {
+        "gitbutler-cli"
+    });
     assert!(
         path.is_file(),
         "Expecting driver to be located at {path:?} - we also assume a certain crate location"
@@ -353,7 +354,7 @@ pub(crate) static BUT_DRIVER: Lazy<PathBuf> = Lazy::new(|| {
         .expect("cargo should run fine");
     assert!(res.success(), "cargo invocation should be successful");
 
-    let path = Path::new("../../target")
+    let path = cargo_target_dir()
         .join("debug")
         .join(if cfg!(windows) { "but.exe" } else { "but" });
     assert!(
@@ -363,6 +364,14 @@ pub(crate) static BUT_DRIVER: Lazy<PathBuf> = Lazy::new(|| {
     path.canonicalize()
         .expect("canonicalization works as the CWD is valid and there are no symlinks to resolve")
 });
+
+fn cargo_target_dir() -> PathBuf {
+    let cargo_target_dir_env_var = std::env::var_os("CARGO_TARGET_DIR");
+    let target_dir = cargo_target_dir_env_var
+        .as_deref()
+        .unwrap_or_else(|| OsStr::new("../../target"));
+    PathBuf::from(target_dir)
+}
 
 /// A secrets store to prevent secrets to be written into the systems own store.
 ///

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -1,10 +1,11 @@
-pub const VAR_NO_CLEANUP: &str = "GITBUTLER_TESTS_NO_CLEANUP";
-
 use but_ctx::Context;
 use but_oxidize::OidExt;
 use but_workspace::{legacy::StacksFilter, ui::StackDetails};
 use gitbutler_stack::StackId;
 use gix::bstr::BStr;
+
+pub const VAR_NO_CLEANUP: &str = "GITBUTLER_TESTS_NO_CLEANUP";
+
 /// Direct access to lower-level utilities for cases where this is enough.
 ///
 /// Prefer to use [`read_only`] and [`writable`] otherwise.


### PR DESCRIPTION
## 🧢 Changes

Makes `DRIVER` in gitbutler-testsupport not blindly assume that the built binary ends up in `../../target`. It’ll first check if `CARGO_TARGET_DIR` is set and if so, use that.

## ☕️ Reasoning

I like setting `CARGO_TARGET_DIR` to share build artifacts between crates. I find this especially useful with git worktrees because you don’t need to rebuild everything from scratch in the worktree dir.