### PR TITLE
fix(but,linux): finalize `but` for Linux

### DIFF
--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -17,6 +17,9 @@ doctest = false
 
 [features]
 default = ["legacy"]
+## A very specific utility flag to make clear that the 'but' binary is managed by a package manager.
+## When set, the CLI cannot self-manage itself and commands like `but update install` are disabled.
+packaged-but-distribution = []
 legacy = [
     "but-workspace/legacy",
     "but-api/legacy",

--- a/crates/but/src/args/update.rs
+++ b/crates/but/src/args/update.rs
@@ -30,7 +30,7 @@ pub enum Subcommands {
     /// Linux: Installs and updates only the CLI itself.
     ///
     /// Note: For other platforms and install forms, see <https://gitbutler.com/downloads>
-    #[cfg(unix)]
+    #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
     Install {
         /// What to install: "nightly", "release", or a version like "0.18.7"
         ///

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1065,6 +1065,17 @@ impl CliDisplay for but_update::AvailableUpdate {
             self.available_version.green().bold()
         );
 
+        let upgrade_hint = {
+            #[cfg(feature = "packaged-but-distribution")]
+            {
+                "upgrade with your package manager"
+            }
+            #[cfg(not(feature = "packaged-but-distribution"))]
+            {
+                "upgrade with `but update install`"
+            }
+        };
+
         if verbose {
             if let Some(url) = &self.url {
                 format!(
@@ -1079,7 +1090,7 @@ impl CliDisplay for but_update::AvailableUpdate {
             format!(
                 "Update available: {} {}",
                 version_info,
-                "(you can run `but update install` or `but update suppress` to dismiss)".dimmed()
+                format!("({upgrade_hint} or `but update suppress` to dismiss)").dimmed(),
             )
         }
     }

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "packaged-but-distribution")))]
 use but_installer::VersionRequest;
 use but_settings::AppSettings;
 use but_update::{AppName, CheckUpdateStatus, check_status};
@@ -15,7 +15,7 @@ pub fn handle(
     match cmd {
         update::Subcommands::Check => check_for_updates(out, app_settings),
         update::Subcommands::Suppress { days } => suppress_updates(out, days),
-        #[cfg(unix)]
+        #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
         update::Subcommands::Install { target } => install(out, target),
     }
 }
@@ -55,13 +55,26 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
         )?;
     } else {
         let current_version = option_env!("VERSION").unwrap_or("0.0.0");
+
+        let install_hint = {
+            #[cfg(feature = "packaged-but-distribution")]
+            {
+                "Install it with your package manager"
+            }
+            #[cfg(not(feature = "packaged-but-distribution"))]
+            {
+                "Install it with 'but update install'"
+            }
+        };
+
         writeln!(
             writer,
-            "{} A new version is available: {} {} {}. Install it with 'but update install'",
+            "{} A new version is available: {} {} {}. {}",
             "→".yellow().bold(),
             current_version.dimmed(),
             "→".dimmed(),
-            status.latest_version.green().bold()
+            status.latest_version.green().bold(),
+            install_hint,
         )?;
 
         if let Some(notes) = &status.release_notes {
@@ -72,6 +85,8 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
             }
         }
 
+        // currently always shows the AppImage URL on Linux, which is rarely what you want
+        #[cfg(not(target_os = "linux"))]
         if let Some(url) = &status.url {
             writeln!(writer)?;
             writeln!(writer, "Download: {}", url.cyan())?;
@@ -109,7 +124,7 @@ fn suppress_updates(out: &mut OutputChannel, days: u32) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "packaged-but-distribution")))]
 fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
     // Installation requires interactive output and cannot be used with JSON mode
     // because the installer writes directly to stdout/stderr

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -401,7 +401,40 @@ impl<T> ResultMetricsExt for anyhow::Result<T> {
             return self.map(|_| ());
         };
 
-        let binary_path = std::env::current_exe().unwrap_or_default();
+        let binary_path = {
+            #[cfg(target_os = "linux")]
+            {
+                // Under Linux, the /proc/self/exe magic symlink is maintained by the kernel to
+                // point to the executable. The kernel keeps the executable's inode alive even if
+                // the file has been moved or deleted, and therefore this symlink can be executed
+                // as long as the process is running.
+                //
+                // Resolving the symlink with std::env::current_exe() and executing that fails if
+                // the binary has been removed, which is the case when emitting metrics for the
+                // `update install` command (the executable removes itself at the end of the
+                // command).
+                std::path::PathBuf::from("/proc/self/exe")
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                // Under macOS and Windows, there's no equivalent to Linux's /proc/self/exe, so we
+                // can't easily refer to the "current process' program" like we can there.
+                //
+                // On macOS, std::env::current_exe() is implemented with _NSGetExecutablePath,
+                // which provides the path the executable was launched with, so in the `but update
+                // install` case, metrics will actually be emitted with the _new_ version rather
+                // than the one that actually ran the command. The only way around this is to emit
+                // metrics before cleaning up the old version, but that does not seem worthwhile at
+                // the moment.
+                //
+                // On Windows, current_exe() is implemented with GetModuleFileNameW, which also
+                // returns the path with which the executable was launched, and so has the same
+                // problem. Although at the time of writing, `update install` is not implemented
+                // for Windows.
+                std::env::current_exe()?
+            }
+        };
+
         tokio::process::Command::new(binary_path)
             .arg("metrics")
             .arg("--command-name")

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -99,7 +99,7 @@ default = ["custom-protocol", "devtools", "opener"]
 ## If enabled, we will pretend to be `but` when the binary filename is `but`.
 builtin-but = ["dep:but", "but-action/builtin-but"]
 ## A very specific utility flag to make clear that the 'but' binary is managed by a package manager.
-packaged-but-distribution = []
+packaged-but-distribution = ["but?/packaged-but-distribution"]
 ## Disable the auto-updater in the frontend.
 ##
 ## Note that it will still be compiled into the backend, so the technical capability of auto-updates remains.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -181,18 +181,19 @@ trap 'rm -rf "$TMP_DIR"' exit
 CONFIG_PATH=$(readlink -f "$PWD/../crates/gitbutler-tauri/tauri.conf.$CHANNEL.json")
 
 if [ "$OS" = "windows" ]; then
-  # WARNING: `builtin-but` doesn't work on Windows, see https://github.com/gitbutlerapp/gitbutler/issues/11461.
-  #          Should it be re-added, please ensure that `but` is built
-  #          as part of the 'beforeBuildCommand' in tauri.conf AND it must be injected
-  #          via 'inject-git-binaries.sh'.
-  EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid", "but"]'
+	# WARNING: `builtin-but` doesn't work on Windows, see https://github.com/gitbutlerapp/gitbutler/issues/11461.
+	#          Should it be re-added, please ensure that `but` is built
+	#          as part of the 'beforeBuildCommand' in tauri.conf AND it must be injected
+	#          via 'inject-git-binaries.sh'.
+	EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid", "but"]'
 	FEATURES="windows"
-else
-  # we need to include the gitbutler-git-setsid dummy binary as
-  # installers bundled with version <=0.19.3 will validate that it's there for macOS.
-  #
-  # As it doesn't hurt on Linux we'll just let it sit there.
-  EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid"]'
+elif [ "$OS" = "linux" ]; then
+	EXTERNAL_BIN='["gitbutler-git-askpass"]'
+	FEATURES="builtin-but packaged-but-distribution"
+elif [ "$OS" = "macos" ]; then
+	# we need to include the gitbutler-git-setsid dummy binary as
+	# installers bundled with version <=0.19.3 will validate that it's there for macOS.
+	EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid"]'
 	FEATURES="builtin-but"
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -195,6 +195,9 @@ elif [ "$OS" = "macos" ]; then
 	# installers bundled with version <=0.19.3 will validate that it's there for macOS.
 	EXTERNAL_BIN='["gitbutler-git-askpass", "gitbutler-git-setsid"]'
 	FEATURES="builtin-but"
+else
+	echo "Unsupported OS: $OS"
+	exit 1
 fi
 
 # update the version in the tauri release config


### PR DESCRIPTION
## 🧢 Changes
This PR introduces some final touches to make `but` on Linux a better experience. This is mostly related to distribution, and should be the final touches necessary to make `but` on Linux nice.

See the commits and their commit messages for the fixes.