### PR TITLE
Refactor JSON types

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -28,10 +28,19 @@ pub mod json {
 
     impl<'a> From<but_workspace::branch::apply::Outcome<'a>> for ApplyOutcome {
         fn from(value: but_workspace::branch::apply::Outcome<'a>) -> Self {
+            let workspace_changed = value.workspace_changed();
+            let but_workspace::branch::apply::Outcome {
+                workspace: _,
+                applied_branches,
+                workspace_ref_created,
+                workspace_merge: _,
+                conflicting_stack_ids: _,
+            } = value;
+
             ApplyOutcome {
-                workspace_changed: value.workspace_changed(),
-                applied_branches: value.applied_branches.into_iter().map(Into::into).collect(),
-                workspace_ref_created: value.workspace_ref_created,
+                workspace_changed,
+                applied_branches: applied_branches.into_iter().map(Into::into).collect(),
+                workspace_ref_created,
             }
         }
     }

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -69,9 +69,10 @@ pub mod json {
 
     impl From<MoveChangesResult> for UIMoveChangesResult {
         fn from(value: MoveChangesResult) -> Self {
+            let MoveChangesResult { replaced_commits } = value;
+
             Self {
-                replaced_commits: value
-                    .replaced_commits
+                replaced_commits: replaced_commits
                     .into_iter()
                     .map(|(old, new)| (old.into(), new.into()))
                     .collect(),
@@ -104,15 +105,19 @@ pub mod json {
 
     impl From<CommitCreateResult> for UICommitCreateResult {
         fn from(value: CommitCreateResult) -> Self {
+            let CommitCreateResult {
+                new_commit,
+                rejected_specs,
+                replaced_commits,
+            } = value;
+
             Self {
-                new_commit: value.new_commit.map(Into::into),
-                paths_to_rejected_changes: value
-                    .rejected_specs
+                new_commit: new_commit.map(Into::into),
+                paths_to_rejected_changes: rejected_specs
                     .into_iter()
                     .map(|(reason, diff)| (reason, diff.path.into()))
                     .collect(),
-                replaced_commits: value
-                    .replaced_commits
+                replaced_commits: replaced_commits
                     .into_iter()
                     .map(|(old, new)| (old.into(), new.into()))
                     .collect(),
@@ -139,10 +144,14 @@ pub mod json {
 
     impl From<CommitRewordResult> for UICommitRewordResult {
         fn from(value: CommitRewordResult) -> Self {
+            let CommitRewordResult {
+                new_commit,
+                replaced_commits,
+            } = value;
+
             Self {
-                new_commit: value.new_commit.into(),
-                replaced_commits: value
-                    .replaced_commits
+                new_commit: new_commit.into(),
+                replaced_commits: replaced_commits
                     .into_iter()
                     .map(|(old, new)| (old.into(), new.into()))
                     .collect(),
@@ -169,10 +178,14 @@ pub mod json {
 
     impl From<CommitInsertBlankResult> for UICommitInsertBlankResult {
         fn from(value: CommitInsertBlankResult) -> Self {
+            let CommitInsertBlankResult {
+                new_commit,
+                replaced_commits,
+            } = value;
+
             Self {
-                new_commit: value.new_commit.into(),
-                replaced_commits: value
-                    .replaced_commits
+                new_commit: new_commit.into(),
+                replaced_commits: replaced_commits
                     .into_iter()
                     .map(|(old, new)| (old.into(), new.into()))
                     .collect(),

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -11,8 +11,6 @@ use but_rebase::graph_rebase::{
 };
 use tracing::instrument;
 
-use crate::json;
-
 /// Outcome after creating a commit
 pub struct CommitCreateResult {
     /// If the commit was successfully created. This should only be none if all the DiffSpecs were rejected.
@@ -43,6 +41,144 @@ pub struct CommitInsertBlankResult {
     pub new_commit: gix::ObjectId,
     /// Commits that were replaced by this operation. Maps `old_id → new_id`.
     pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+}
+
+/// JSON transport types for commit APIs.
+pub mod json {
+    use serde::Serialize;
+
+    use crate::json::HexHash;
+
+    use super::{
+        CommitCreateResult, CommitInsertBlankResult, CommitRewordResult, MoveChangesResult,
+    };
+
+    /// UI type for a move changes between commits result.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct UIMoveChangesResult {
+        /// Commits that have been mapped from one thing to another.
+        /// Maps `oldId → newId`.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, String>")
+        )]
+        pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+    }
+
+    impl From<MoveChangesResult> for UIMoveChangesResult {
+        fn from(value: MoveChangesResult) -> Self {
+            Self {
+                replaced_commits: value
+                    .replaced_commits
+                    .into_iter()
+                    .map(|(old, new)| (old.into(), new.into()))
+                    .collect(),
+            }
+        }
+    }
+
+    /// UI type for creating a commit in the rebase graph.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct UICommitCreateResult {
+        /// The new commit if one was created.
+        #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
+        pub new_commit: Option<HexHash>,
+        /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
+        #[cfg_attr(feature = "export-schema", schemars(with = "Vec<(String, String)>"))]
+        pub paths_to_rejected_changes: Vec<(
+            but_core::tree::create_tree::RejectionReason,
+            but_serde::BStringForFrontend,
+        )>,
+        /// Commits that have been replaced as a side-effect of the create/amend.
+        /// Maps `oldId → newId`.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, String>")
+        )]
+        pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+    }
+
+    impl From<CommitCreateResult> for UICommitCreateResult {
+        fn from(value: CommitCreateResult) -> Self {
+            Self {
+                new_commit: value.new_commit.map(Into::into),
+                paths_to_rejected_changes: value
+                    .rejected_specs
+                    .into_iter()
+                    .map(|(reason, diff)| (reason, diff.path.into()))
+                    .collect(),
+                replaced_commits: value
+                    .replaced_commits
+                    .into_iter()
+                    .map(|(old, new)| (old.into(), new.into()))
+                    .collect(),
+            }
+        }
+    }
+
+    /// UI type for rewording a commit.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct UICommitRewordResult {
+        /// The new commit ID after rewording.
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+        pub new_commit: HexHash,
+        /// Commits that have been replaced as a side-effect of the reword.
+        /// Maps `oldId → newId`.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, String>")
+        )]
+        pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+    }
+
+    impl From<CommitRewordResult> for UICommitRewordResult {
+        fn from(value: CommitRewordResult) -> Self {
+            Self {
+                new_commit: value.new_commit.into(),
+                replaced_commits: value
+                    .replaced_commits
+                    .into_iter()
+                    .map(|(old, new)| (old.into(), new.into()))
+                    .collect(),
+            }
+        }
+    }
+
+    /// UI type for inserting a blank commit.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub struct UICommitInsertBlankResult {
+        /// The new blank commit ID.
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+        pub new_commit: HexHash,
+        /// Commits that have been replaced as a side-effect of the insertion.
+        /// Maps `oldId → newId`.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, String>")
+        )]
+        pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+    }
+
+    impl From<CommitInsertBlankResult> for UICommitInsertBlankResult {
+        fn from(value: CommitInsertBlankResult) -> Self {
+            Self {
+                new_commit: value.new_commit.into(),
+                replaced_commits: value
+                    .replaced_commits
+                    .into_iter()
+                    .map(|(old, new)| (old.into(), new.into()))
+                    .collect(),
+            }
+        }
+    }
 }
 
 /// Rewords a commit

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -32,14 +32,14 @@ pub mod json {
     }
 
     impl From<but_core::diff::CommitDetails> for CommitDetails {
-        fn from(
-            but_core::diff::CommitDetails {
+        fn from(value: but_core::diff::CommitDetails) -> Self {
+            let but_core::diff::CommitDetails {
                 commit,
                 diff_with_first_parent,
                 line_stats,
                 conflict_entries,
-            }: but_core::diff::CommitDetails,
-        ) -> Self {
+            } = value;
+
             CommitDetails {
                 commit: commit.into(),
                 changes: diff_with_first_parent.into_iter().map(Into::into).collect(),

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -1,4 +1,11 @@
-//! JSON types and utilities to produce decent JSON from API types.
+//! Shared JSON types and utilities to produce decent JSON from API types.
+//!
+//! This module is reserved for general-purpose transport helpers and JSON types
+//! that are shared across API modules.
+//!
+//! If a JSON type only mirrors one API submodule, define it next to that API in
+//! a local `json` module instead of adding it here. See `crate::branch::json`,
+//! `crate::commit::json`, and `crate::diff::json` for the intended pattern.
 pub use error::{Error, ToJsonError, UnmarkedError};
 use gix::refs::Target;
 use schemars::{self, JsonSchema};
@@ -123,10 +130,6 @@ mod hex_hash {
     }
 }
 pub use hex_hash::{HexHash, HexHashString};
-
-use crate::commit::{
-    CommitCreateResult, CommitInsertBlankResult, CommitRewordResult, MoveChangesResult,
-};
 
 mod error {
     //! Utilities to control which errors show in the frontend.
@@ -429,133 +432,6 @@ impl From<gix::refs::Reference> for Reference {
                 Target::Object(_) => None,
                 Target::Symbolic(rn) => Some(rn.into()),
             },
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-/// UI type for a move changes between commits result
-pub struct UIMoveChangesResult {
-    /// Commits that have been mapped from one thing to another.
-    /// Maps `oldId → newId`.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(with = "std::collections::BTreeMap<String, String>")
-    )]
-    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
-}
-
-impl From<MoveChangesResult> for UIMoveChangesResult {
-    fn from(value: MoveChangesResult) -> Self {
-        Self {
-            replaced_commits: value
-                .replaced_commits
-                .into_iter()
-                .map(|(old, new)| (old.into(), new.into()))
-                .collect(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-/// UI type for creating a commit in the rebase graph.
-pub struct UICommitCreateResult {
-    /// The new commit if one was created.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
-    pub new_commit: Option<HexHash>,
-    /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<(String, String)>"))]
-    pub paths_to_rejected_changes: Vec<(
-        but_core::tree::create_tree::RejectionReason,
-        but_serde::BStringForFrontend,
-    )>,
-    /// Commits that have been replaced as a side-effect of the create/amend.
-    /// Maps `oldId → newId`.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(with = "std::collections::BTreeMap<String, String>")
-    )]
-    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
-}
-
-impl From<CommitCreateResult> for UICommitCreateResult {
-    fn from(value: CommitCreateResult) -> Self {
-        Self {
-            new_commit: value.new_commit.map(Into::into),
-            paths_to_rejected_changes: value
-                .rejected_specs
-                .into_iter()
-                .map(|(r, d)| (r, d.path.into()))
-                .collect(),
-            replaced_commits: value
-                .replaced_commits
-                .into_iter()
-                .map(|(old, new)| (old.into(), new.into()))
-                .collect(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-/// UI type for rewording a commit.
-pub struct UICommitRewordResult {
-    /// The new commit ID after rewording.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
-    pub new_commit: HexHash,
-    /// Commits that have been replaced as a side-effect of the reword.
-    /// Maps `oldId → newId`.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(with = "std::collections::BTreeMap<String, String>")
-    )]
-    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
-}
-
-impl From<CommitRewordResult> for UICommitRewordResult {
-    fn from(value: CommitRewordResult) -> Self {
-        Self {
-            new_commit: value.new_commit.into(),
-            replaced_commits: value
-                .replaced_commits
-                .into_iter()
-                .map(|(old, new)| (old.into(), new.into()))
-                .collect(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
-/// UI type for inserting a blank commit.
-pub struct UICommitInsertBlankResult {
-    /// The new blank commit ID.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
-    pub new_commit: HexHash,
-    /// Commits that have been replaced as a side-effect of the insertion.
-    /// Maps `oldId → newId`.
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(with = "std::collections::BTreeMap<String, String>")
-    )]
-    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
-}
-
-impl From<CommitInsertBlankResult> for UICommitInsertBlankResult {
-    fn from(value: CommitInsertBlankResult) -> Self {
-        Self {
-            new_commit: value.new_commit.into(),
-            replaced_commits: value
-                .replaced_commits
-                .into_iter()
-                .map(|(old, new)| (old.into(), new.into()))
-                .collect(),
         }
     }
 }

--- a/crates/but-api/src/legacy/users.rs
+++ b/crates/but-api/src/legacy/users.rs
@@ -17,8 +17,20 @@ mod json {
         pub locale: Option<String>,
         pub created_at: String,
         pub updated_at: String,
+        /// GitButler access token.
+        ///
+        /// SECURITY: This is a secret credential. Do **not** log it, include it in telemetry,
+        /// or expose it outside of a trusted/local API boundary. This struct is intended to be
+        /// serialized only for trusted clients that need to perform authenticated GitButler
+        /// API requests on behalf of the user.
         pub access_token: String,
         pub role: Option<String>,
+        /// GitHub OAuth access token.
+        ///
+        /// SECURITY: This is a secret credential. Do **not** log it, include it in telemetry,
+        /// or expose it outside of a trusted/local API boundary. This struct is intended to be
+        /// serialized only for trusted clients that need to perform authenticated GitHub
+        /// operations on behalf of the user.
         pub github_access_token: Option<String>,
         pub github_username: Option<String>,
     }

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -392,7 +392,7 @@ pub fn discard_worktree_changes(
 mod json {
     use but_workspace::legacy::MoveChangesResult;
 
-    pub use crate::json::UIMoveChangesResult;
+    pub use crate::commit::json::UIMoveChangesResult;
 
     impl From<MoveChangesResult> for UIMoveChangesResult {
         fn from(value: MoveChangesResult) -> Self {

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -396,9 +396,10 @@ mod json {
 
     impl From<MoveChangesResult> for UIMoveChangesResult {
         fn from(value: MoveChangesResult) -> Self {
+            let MoveChangesResult { replaced_commits } = value;
+
             Self {
-                replaced_commits: value
-                    .replaced_commits
+                replaced_commits: replaced_commits
                     .into_iter()
                     .map(|(x, y)| (x.into(), y.into()))
                     .collect(),

--- a/crates/but-api/src/schema.rs
+++ b/crates/but-api/src/schema.rs
@@ -139,19 +139,19 @@ pub fn collect_all_schemas() -> Vec<(&'static str, schemars::Schema)> {
             },
             TypeSchemaEntry {
                 name: "UICommitCreateResult",
-                schema_fn: || schema_for!(crate::json::UICommitCreateResult),
+                schema_fn: || schema_for!(crate::commit::json::UICommitCreateResult),
             },
             TypeSchemaEntry {
                 name: "UIMoveChangesResult",
-                schema_fn: || schema_for!(crate::json::UIMoveChangesResult),
+                schema_fn: || schema_for!(crate::commit::json::UIMoveChangesResult),
             },
             TypeSchemaEntry {
                 name: "UICommitInsertBlankResult",
-                schema_fn: || schema_for!(crate::json::UICommitInsertBlankResult),
+                schema_fn: || schema_for!(crate::commit::json::UICommitInsertBlankResult),
             },
             TypeSchemaEntry {
                 name: "UICommitRewordResult",
-                schema_fn: || schema_for!(crate::json::UICommitRewordResult),
+                schema_fn: || schema_for!(crate::commit::json::UICommitRewordResult),
             },
         ]
         .into_iter()


### PR DESCRIPTION
This is a follow-up to #12735 to improve the maintainability of JSON types in `but-api`.

- **Localise JSON types and co-locate them in their respective modules**
- **Prefer destructuring when converting Rust types to JSON types**
