### PR TITLE
Make clear how the text-entry will appear in the Claude chat view

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -110,6 +110,8 @@
 	const claudeSettings = $derived($settingsService?.claude);
 
 	const claudeAvailable = $derived(claudeCodeService.checkAvailable(undefined));
+	// const canEnterChat = $derived(claudeAvailable.status === "available" && !!projectRegistered);
+	const canEnterChat = $derived(!!projectRegistered);
 
 	let clearContextModal = $state<Modal>();
 	let modelContextMenu = $state<ContextMenu>();
@@ -495,9 +497,15 @@
 								Let's build something amazing
 							{/snippet}
 							{#snippet caption()}
-								Your canvas is clear
-								<br />
-								Let the code take shape
+								{#if canEnterChat}
+									Your canvas is clear
+									<br />
+									Let the code take shape
+								{:else}
+									Run `claude` once
+									<br />
+									to initialise the chat
+								{/if}
 							{/snippet}
 						</EmptyStatePlaceholder>
 					</div>


### PR DESCRIPTION
I am sure this is an untypical case, as the user must:

- have setup claude in GitButler
- not have run `claude` ever in the project before

Then the previous message was quite 'poetic', but not helpful in figuring out how to start a chat.

Now it says exactly what's expected by the code.
