### PR TITLE
move branch: propagate the commit mappings

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use but_api_macros::but_api;
 use but_core::{RefMetadata, ui::TreeChanges, worktree::checkout::UncommitedWorktreeChanges};
 use but_ctx::Context;
@@ -9,9 +11,17 @@ use but_workspace::branch::{
 };
 use tracing::instrument;
 
+/// Outcome after moving a branch.
+pub struct MoveBranchResult {
+    /// Commits that were replaced while transplanting a branch.
+    pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+}
+
 /// JSON transport types for branch APIs.
 pub mod json {
     use serde::Serialize;
+
+    use crate::{branch::MoveBranchResult, json::HexHash};
 
     /// JSON sibling of [`but_workspace::branch::apply::Outcome`].
     #[derive(Debug, Serialize)]
@@ -41,6 +51,32 @@ pub mod json {
                 workspace_changed,
                 applied_branches: applied_branches.into_iter().map(Into::into).collect(),
                 workspace_ref_created,
+            }
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    #[serde(rename_all = "camelCase")]
+    /// UI type for moving a branch.
+    pub struct UIMoveBranchResult {
+        /// Commits that have been replaced after transplanting a branch.
+        /// Maps `oldId → newId`.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, String>")
+        )]
+        pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+    }
+
+    impl From<MoveBranchResult> for UIMoveBranchResult {
+        fn from(value: MoveBranchResult) -> Self {
+            Self {
+                replaced_commits: value
+                    .replaced_commits
+                    .into_iter()
+                    .map(|(old, new)| (old.into(), new.into()))
+                    .collect(),
             }
         }
     }
@@ -110,13 +146,13 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
 }
 
 /// Move a branch on top of another
-#[but_api]
+#[but_api(json::UIMoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn move_branch(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
     target_branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<MoveBranchResult> {
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
         ctx,
         SnapshotDetails::new(OperationKind::MoveBranch),
@@ -136,14 +172,14 @@ fn move_branch_impl(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
     target_branch: &gix::refs::FullNameRef,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
     let (_guard, repo, mut workspace, _) = ctx.workspace_mut_and_db()?;
     let editor = workspace.graph.to_editor(&repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(&workspace, editor, subject_branch, target_branch)?;
 
-    rebase.materialize()?;
+    let materialization = rebase.materialize()?;
     if let Some((ws_meta, ref_name)) = ws_meta.zip(workspace.ref_name()) {
         let mut md = meta.workspace(ref_name)?;
         *md = ws_meta;
@@ -151,5 +187,7 @@ fn move_branch_impl(
     }
     workspace.refresh_from_head(&repo, &meta)?;
 
-    Ok(())
+    Ok(MoveBranchResult {
+        replaced_commits: materialization.history.commit_mappings(),
+    })
 }

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, bail};
 use but_graph::projection::{Stack, StackSegment};
 use but_rebase::graph_rebase::{
     Editor, Selector, SuccessfulRebase,
@@ -162,11 +162,16 @@ fn get_disconnect_parameters(
         }
     };
 
+    // The delimiter for the segment we want to move, is the reference selector
+    // as the child, and the last commit inside the branch as the parent.
+    // If the branch is empty, we take the reference selector as the parent as well.
     let delimiter = SegmentDelimiter {
         child: delimiter_child,
         parent: delimiter_parent,
     };
 
+    // The parent segment in the stack if any.
+    // This will be `None` if the branch we want to move is at the bottom of the stack.
     let stack_base_segment = subject_segment.base_segment_id.and_then(|base_segment_id| {
         source_stack
             .segments
@@ -174,6 +179,9 @@ fn get_disconnect_parameters(
             .find(|segment| segment.id == base_segment_id)
     });
 
+    // The parent segment in the graph.
+    // If the `stack_base_segment` is `None` but there's a `base_segment_id` defined, it means we'll find it in the
+    // graph data, and it's probably the target branch, which is not included in the workspace.
     let graph_base_segment = subject_segment
         .base_segment_id
         .map(|segment_idx| &workspace.graph[segment_idx]);
@@ -194,8 +202,13 @@ fn get_disconnect_parameters(
         let reference_selector = editor.select_reference(ref_name)?;
         let selectors = SomeSelectors::new(vec![reference_selector])?;
         SelectorSet::Some(selectors)
+    } else if subject_segment.base_segment_id.is_some() {
+        // Base segment could not be found, but there is an ID defined. Error out.
+        bail!(
+            "Failed to find the base segment of the subject we want to move, even if it seems to be defined"
+        );
     } else {
-        // No parents could be determined. Detach all.
+        // Nothing found. Remove all parents.
         SelectorSet::All
     };
 
@@ -214,6 +227,10 @@ fn get_disconnect_parameters(
     let child_segment = source_stack.segments.get(index_of_segment - 1).context(
         "BUG: Unable to find child segment of subject segment but expected it to exist.",
     )?;
+
+    // If branch stacked on top of the branch we want to move is empty, we only need to disconnect
+    // the reference from it.
+    // Otherwise, disconnect the last commit on the segment.
     let child_selector = match child_segment.commits.last() {
         Some(last_commit) => editor
             .select_commit(last_commit.id)


### PR DESCRIPTION
- The API returns the commit mappings
- Add more docs on how the parents and children to disconnect are
  determined
- If no parent can be determined to disconnect, error out.