### PR TITLE
feat(cli): show diff in editor for `commit` and `reword`

### DIFF
--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -40,6 +40,15 @@ pub struct Platform {
         conflicts_with = "only"
     )]
     pub changes: Vec<String>,
+    /// Always show diff inside the editor.
+    ///
+    /// By default the diff will be shown unless it's large. The diff will always be shown if
+    /// `--diff` is passed, regardless of the size of the diff.
+    #[clap(long = "diff", default_value_t, conflicts_with_all = &["no_diff", "message", "message_file", "ai"])]
+    pub diff: bool,
+    /// Never show the diff inside the editor.
+    #[clap(long = "no-diff", default_value_t, conflicts_with_all = &["diff", "message", "message_file", "ai"])]
+    pub no_diff: bool,
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -476,6 +476,15 @@ pub enum Subcommands {
         /// Format the existing commit message to 72-char line wrapping without opening an editor
         #[clap(short = 'f', long = "format", conflicts_with = "message")]
         format: bool,
+        /// Always show diff inside the editor.
+        ///
+        /// By default the diff will be shown unless it's large. The diff will always be shown if
+        /// `--diff` is passed, regardless of the size of the diff.
+        #[clap(long = "diff", default_value_t, conflicts_with_all = &["no_diff", "format"])]
+        diff: bool,
+        /// Never show the diff inside the editor.
+        #[clap(long = "no-diff", default_value_t, conflicts_with_all = &["diff", "format"])]
+        no_diff: bool,
     },
 
     /// Commands for viewing and managing operation history.

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod commit;
 mod reword;
 
 #[test]

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod reword;
+
 #[test]
 fn clap() {
     use clap::CommandFactory;

--- a/crates/but/src/args/tests/commit.rs
+++ b/crates/but/src/args/tests/commit.rs
@@ -1,0 +1,47 @@
+use clap::Parser as _;
+
+use crate::args::{Args, Subcommands};
+
+#[test]
+fn basic() {
+    let args = Args::try_parse_from(["but", "commit"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Commit(commit_args) = cmd else {
+        panic!("expected commit command. Got {cmd:?}");
+    };
+
+    assert!(!commit_args.diff);
+    assert!(!commit_args.no_diff);
+}
+
+#[test]
+fn always_show_diff() {
+    let args = Args::try_parse_from(["but", "commit", "--diff"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Commit(commit_args) = cmd else {
+        panic!("expected commit command. Got {cmd:?}");
+    };
+
+    assert!(commit_args.diff);
+    assert!(!commit_args.no_diff);
+}
+
+#[test]
+fn never_show_diff() {
+    let args = Args::try_parse_from(["but", "commit", "--no-diff"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Commit(commit_args) = cmd else {
+        panic!("expected commit command. Got {cmd:?}");
+    };
+
+    assert!(!commit_args.diff);
+    assert!(commit_args.no_diff);
+}
+
+#[test]
+fn conflicting_diff_flags() {
+    assert!(Args::try_parse_from(["but", "commit", "--diff", "--no-diff"]).is_err());
+}

--- a/crates/but/src/args/tests/reword.rs
+++ b/crates/but/src/args/tests/reword.rs
@@ -1,0 +1,57 @@
+use clap::Parser as _;
+
+use crate::args::{Args, Subcommands};
+
+#[test]
+fn basic() {
+    let args = Args::try_parse_from(["but", "reword", "a"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Reword {
+        target,
+        message,
+        format,
+        diff,
+        no_diff,
+    } = cmd
+    else {
+        panic!("expected reword command. Got {cmd:?}");
+    };
+
+    assert_eq!(target, "a");
+    assert_eq!(message, None);
+    assert!(!format);
+    assert!(!diff);
+    assert!(!no_diff);
+}
+
+#[test]
+fn always_show_diff() {
+    let args = Args::try_parse_from(["but", "reword", "a", "--diff"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Reword { diff, no_diff, .. } = cmd else {
+        panic!("expected reword command. Got {cmd:?}");
+    };
+
+    assert!(diff);
+    assert!(!no_diff);
+}
+
+#[test]
+fn never_show_diff() {
+    let args = Args::try_parse_from(["but", "reword", "a", "--no-diff"]).unwrap();
+    let cmd = args.cmd.unwrap();
+
+    let Subcommands::Reword { diff, no_diff, .. } = cmd else {
+        panic!("expected reword command. Got {cmd:?}");
+    };
+
+    assert!(!diff);
+    assert!(no_diff);
+}
+
+#[test]
+fn conflicting_diff_flags() {
+    assert!(Args::try_parse_from(["but", "reword", "a", "--diff", "--no-diff"]).is_err());
+}

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -694,6 +694,9 @@ fn get_commit_message_from_editor(
     }
     template.push_str("#\n");
 
+    // TODO(david): show diff in editor
+    let todo_ = ();
+
     // Read the result from the editor and strip comments
     let lossy_message =
         tui::get_text::from_editor_no_comments("commit_msg", &template)?.to_string();

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -11,6 +11,7 @@ use but_rebase::graph_rebase::mutate::InsertSide;
 use colored::Colorize;
 use gitbutler_repo::hooks;
 
+use super::{ShowDiffInEditor, estimate_diff_blob_size};
 use crate::{
     CliId, IdMap,
     command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
@@ -293,6 +294,7 @@ pub(crate) fn commit(
     create_branch: bool,
     no_hooks: bool,
     generate_message: Option<Option<String>>,
+    show_diff_in_editor: ShowDiffInEditor,
 ) -> anyhow::Result<()> {
     let id_map = IdMap::new_from_context(ctx, None)?;
 
@@ -393,7 +395,7 @@ pub(crate) fn commit(
                 "In JSON mode, a commit message must be provided via --message (-m), --message-file, or --ai (-i)"
             );
         }
-        get_commit_message_from_editor(&files_to_commit, &changes)?
+        get_commit_message_from_editor(ctx, &files_to_commit, &changes, show_diff_in_editor)?
     };
 
     if commit_message.trim().is_empty() {
@@ -678,8 +680,10 @@ fn prompt_for_stack_selection(
 }
 
 fn get_commit_message_from_editor(
+    ctx: &mut but_ctx::Context,
     files_to_commit: &[FileAssignment],
     changes: &[TreeChange],
+    show_diff_in_editor: ShowDiffInEditor,
 ) -> anyhow::Result<String> {
     // Generate commit message template
     let mut template = String::new();
@@ -694,12 +698,32 @@ fn get_commit_message_from_editor(
     }
     template.push_str("#\n");
 
-    // TODO(david): show diff in editor
-    let todo_ = ();
+    // Compute diff for the editor if requested
+    let should_show_diff = show_diff_in_editor.should_show_diff(|| {
+        // Convert ui::TreeChange to core::TreeChange for blob size estimation
+        let core_changes: Vec<but_core::TreeChange> = changes
+            .iter()
+            .filter(|c| files_to_commit.iter().any(|f| f.path == c.path_bytes))
+            .cloned()
+            .map(but_core::TreeChange::from)
+            .collect();
+        estimate_diff_blob_size(&core_changes, ctx)
+    })?;
+
+    let diff_text = if should_show_diff {
+        let diff = generate_unified_diff(ctx, files_to_commit, changes)?;
+        if diff.is_empty() { None } else { Some(diff) }
+    } else {
+        None
+    };
 
     // Read the result from the editor and strip comments
-    let lossy_message =
-        tui::get_text::from_editor_no_comments("commit_msg", &template)?.to_string();
+    let lossy_message = tui::get_text::from_editor_no_comments_as_patch(
+        "commit_msg",
+        &template,
+        diff_text.as_deref(),
+    )?
+    .to_string();
     Ok(lossy_message)
 }
 

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -1054,7 +1054,7 @@ HTML comments are stripped before submit.
 
     template.push_str(&format!("<!-- GITBUTLER INSTRUCTIONS{instructions}-->"));
 
-    let content = get_text::from_editor("pr_message", &template, ".md")?.to_string();
+    let content = get_text::from_editor("pr_message", &template, None, ".md")?.to_string();
     let content_without_comments = get_text::strip_html_comments(&content);
     let message = parse_review_message(&content_without_comments)?;
     Ok((message.title, message.body))

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -1,6 +1,8 @@
 //! Commands in need of being ported to the non-legacy world.
 //! Doing so means that no legacy-APIs are used.
 
+use anyhow::Result;
+
 pub mod absorb;
 pub mod actions;
 pub mod ai;
@@ -27,3 +29,113 @@ pub mod status;
 pub mod teardown;
 pub mod unapply;
 pub mod worktree;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum ShowDiffInEditor {
+    /// The user requested we always show the diff.
+    Always,
+    /// The user requested we never show the diff.
+    Never,
+    /// The user didn't specify a preference.
+    Unspecified,
+}
+
+impl ShowDiffInEditor {
+    pub(crate) fn from_args(diff: bool, no_diff: bool) -> Option<Self> {
+        match (diff, no_diff) {
+            (true, true) => None,
+            (true, false) => Some(Self::Always),
+            (false, true) => Some(Self::Never),
+            (false, false) => Some(Self::Unspecified),
+        }
+    }
+
+    /// Decide whether the diff should be shown in the editor.
+    ///
+    /// For `Always`/`Never` the answer is immediate. For `Unspecified`, the provided
+    /// `estimate_blob_size` closure is called to compute the total blob size and compare
+    /// it against `MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED`.
+    pub(crate) fn should_show_diff(
+        self,
+        estimate_blob_size: impl FnOnce() -> Result<u64>,
+    ) -> Result<bool> {
+        match self {
+            Self::Always => Ok(true),
+            Self::Never => Ok(false),
+            Self::Unspecified => {
+                let total_blob_size = estimate_blob_size()?;
+                Ok(total_blob_size <= MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED)
+            }
+        }
+    }
+}
+
+/// The maximum total blob size (in bytes) for which we'll show the diff in the editor
+/// when the user hasn't specified a preference. This uses object header lookups
+/// which are cheap compared to actually computing diffs.
+///
+/// 900KB is very roughly 15,000 lines at ~60 bytes per line. Just to protect the user from
+/// stalling their system if they accidentally commit a big log file.
+pub(crate) const MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED: u64 = 900_000;
+
+/// Sum the blob sizes involved in the given tree changes using cheap object header lookups.
+/// For modifications/renames, uses the larger of the two sides as an upper bound.
+pub(crate) fn estimate_diff_blob_size(
+    changes: &[but_core::TreeChange],
+    ctx: &but_ctx::Context,
+) -> Result<u64> {
+    fn blob_size(repo: &gix::Repository, id: &gix::ObjectId) -> u64 {
+        repo.find_header(*id).map(|h| h.size()).unwrap_or(0)
+    }
+
+    let repo = ctx.repo.get()?;
+
+    Ok(changes
+        .iter()
+        .map(|change| match &change.status {
+            but_core::TreeStatus::Addition { state, .. } => blob_size(&repo, &state.id),
+            but_core::TreeStatus::Deletion { previous_state } => {
+                blob_size(&repo, &previous_state.id)
+            }
+            but_core::TreeStatus::Modification {
+                previous_state,
+                state,
+                ..
+            }
+            | but_core::TreeStatus::Rename {
+                previous_state,
+                state,
+                ..
+            } => {
+                let a = blob_size(&repo, &previous_state.id);
+                let b = blob_size(&repo, &state.id);
+                a.max(b)
+            }
+        })
+        .fold(0, |a, b| a.saturating_add(b)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_show_diff_in_editor() {
+        assert_eq!(
+            Some(ShowDiffInEditor::Always),
+            ShowDiffInEditor::from_args(true, false)
+        );
+
+        assert_eq!(
+            Some(ShowDiffInEditor::Never),
+            ShowDiffInEditor::from_args(false, true)
+        );
+
+        assert_eq!(
+            Some(ShowDiffInEditor::Unspecified),
+            ShowDiffInEditor::from_args(false, false)
+        );
+
+        assert_eq!(None, ShowDiffInEditor::from_args(true, true));
+    }
+}

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use bstr::BString;
+use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
 use but_ctx::Context;
 use gix::prelude::ObjectIdExt;
@@ -12,6 +12,7 @@ pub(crate) fn reword_target(
     target: &str,
     message: Option<&str>,
     format: bool,
+    show_diff_in_editor: ShowDiffInEditor,
 ) -> Result<()> {
     let id_map = IdMap::new_from_context(ctx, None)?;
 
@@ -40,7 +41,7 @@ pub(crate) fn reword_target(
             edit_branch_name(ctx, name, out, message)?;
         }
         CliId::Commit { commit_id: oid, .. } => {
-            edit_commit_message_by_id(ctx, *oid, out, message, format)?;
+            edit_commit_message_by_id(ctx, *oid, out, message, format, show_diff_in_editor)?;
         }
         _ => {
             bail!(
@@ -51,6 +52,27 @@ pub(crate) fn reword_target(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum ShowDiffInEditor {
+    /// The user requested we always show the diff.
+    Always,
+    /// The user requested we never show the diff.
+    Never,
+    /// The user didn't specify a preference.
+    Unspecified,
+}
+
+impl ShowDiffInEditor {
+    pub(crate) fn from_args(diff: bool, no_diff: bool) -> Option<Self> {
+        match (diff, no_diff) {
+            (true, true) => None,
+            (true, false) => Some(Self::Always),
+            (false, true) => Some(Self::Never),
+            (false, false) => Some(Self::Unspecified),
+        }
+    }
 }
 
 fn edit_branch_name(
@@ -99,12 +121,21 @@ fn prepare_provided_message(msg: Option<&str>, entity: &str) -> Option<Result<St
     })
 }
 
+/// The maximum total blob size (in bytes) for which we'll show the diff in the editor
+/// when the user hasn't specified a preference. This uses object header lookups
+/// which are cheap compared to actually computing diffs.
+///
+/// 900KB is very roughly 15,000 lines at ~60 bytes per line. Just to protect the user from
+/// stalling their system if they accidentally commit a big log file.
+const MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED: u64 = 900_000;
+
 fn edit_commit_message_by_id(
     ctx: &mut Context,
     commit_oid: gix::ObjectId,
     out: &mut OutputChannel,
     message: Option<&str>,
     format: bool,
+    show_diff_in_editor: ShowDiffInEditor,
 ) -> Result<()> {
     // Get commit details directly - no need to iterate through stacks
     let commit_details = but_api::diff::commit_details(ctx, commit_oid, ComputeLineStats::No)?;
@@ -121,8 +152,28 @@ fn edit_commit_message_by_id(
         prepare_provided_message(message, "commit message").unwrap_or_else(|| {
             let changed_files = get_changed_files_from_commit_details(&commit_details);
 
+            let should_show_diff = match show_diff_in_editor {
+                ShowDiffInEditor::Always => true,
+                ShowDiffInEditor::Never => false,
+                ShowDiffInEditor::Unspecified => {
+                    let total_blob_size =
+                        estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)?;
+                    total_blob_size <= MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED
+                }
+            };
+            let diff = should_show_diff
+                .then(|| {
+                    commit_details
+                        .diff_with_first_parent
+                        .iter()
+                        .map(|change| change.unified_diff(&*ctx.repo.get()?, 3))
+                        .filter_map(|diff| diff.transpose())
+                        .collect::<Result<Vec<_>>>()
+                })
+                .transpose()?;
+
             // Open editor with current message and file list
-            get_commit_message_from_editor(&current_message, &changed_files)
+            get_commit_message_from_editor(&current_message, &changed_files, diff.as_deref())
         })?
     };
 
@@ -149,6 +200,40 @@ fn edit_commit_message_by_id(
     Ok(())
 }
 
+/// Sum the blob sizes involved in the given tree changes using cheap object header lookups.
+/// For modifications/renames, uses the larger of the two sides as an upper bound.
+fn estimate_diff_blob_size(changes: &[but_core::TreeChange], ctx: &mut Context) -> Result<u64> {
+    fn blob_size(repo: &gix::Repository, id: &gix::ObjectId) -> u64 {
+        repo.find_header(*id).map(|h| h.size()).unwrap_or(0)
+    }
+
+    let repo = ctx.repo.get()?;
+
+    Ok(changes
+        .iter()
+        .map(|change| match &change.status {
+            but_core::TreeStatus::Addition { state, .. } => blob_size(&repo, &state.id),
+            but_core::TreeStatus::Deletion { previous_state } => {
+                blob_size(&repo, &previous_state.id)
+            }
+            but_core::TreeStatus::Modification {
+                previous_state,
+                state,
+                ..
+            }
+            | but_core::TreeStatus::Rename {
+                previous_state,
+                state,
+                ..
+            } => {
+                let a = blob_size(&repo, &previous_state.id);
+                let b = blob_size(&repo, &state.id);
+                a.max(b)
+            }
+        })
+        .fold(0, |a, b| a.saturating_add(b)))
+}
+
 fn get_changed_files_from_commit_details(
     commit_details: &but_core::diff::CommitDetails,
 ) -> Vec<String> {
@@ -173,6 +258,7 @@ fn get_changed_files_from_commit_details(
 fn get_commit_message_from_editor(
     current_message: &str,
     changed_files: &[String],
+    diff: Option<&[BString]>,
 ) -> Result<String> {
     // Generate commit message template with current message
     let mut template = String::new();
@@ -190,9 +276,22 @@ fn get_commit_message_from_editor(
     }
     template.push_str("#\n");
 
+    let mut template_rest = String::new();
+    if let Some(diff) = diff
+        && !diff.is_empty()
+    {
+        for line in diff {
+            template_rest.push_str(&line.to_str_lossy());
+        }
+    }
+
     // Read the result and strip comments
-    let lossy_message =
-        tui::get_text::from_editor_no_comments("commit_msg", &template)?.to_string();
+    let lossy_message = tui::get_text::from_editor_no_comments_as_patch(
+        "commit_msg",
+        &template,
+        Some(template_rest.as_str()).filter(|s| !s.is_empty()),
+    )?
+    .to_string();
 
     if lossy_message.is_empty() {
         bail!("Aborting due to empty commit message");
@@ -223,9 +322,10 @@ fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     mod prepare_provided_message {
-        use super::super::*;
+        use super::*;
 
         #[test]
         fn empty_is_fails() {
@@ -248,5 +348,24 @@ mod tests {
                 "Aborting due to empty message"
             );
         }
+    }
+    #[test]
+    fn test_show_diff_in_editor() {
+        assert_eq!(
+            Some(ShowDiffInEditor::Always),
+            ShowDiffInEditor::from_args(true, false)
+        );
+
+        assert_eq!(
+            Some(ShowDiffInEditor::Never),
+            ShowDiffInEditor::from_args(false, true)
+        );
+
+        assert_eq!(
+            Some(ShowDiffInEditor::Unspecified),
+            ShowDiffInEditor::from_args(false, false)
+        );
+
+        assert_eq!(None, ShowDiffInEditor::from_args(true, true));
     }
 }

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -4,6 +4,7 @@ use but_api::diff::ComputeLineStats;
 use but_ctx::Context;
 use gix::prelude::ObjectIdExt;
 
+use super::{ShowDiffInEditor, estimate_diff_blob_size};
 use crate::{CliId, IdMap, tui, utils::OutputChannel};
 
 pub(crate) fn reword_target(
@@ -38,6 +39,9 @@ pub(crate) fn reword_target(
             if format {
                 bail!("--format flag can only be used with commits, not branches");
             }
+            if !matches!(show_diff_in_editor, ShowDiffInEditor::Unspecified) {
+                bail!("--diff and --no-diff flags can only be used with commits, not branches");
+            }
             edit_branch_name(ctx, name, out, message)?;
         }
         CliId::Commit { commit_id: oid, .. } => {
@@ -52,27 +56,6 @@ pub(crate) fn reword_target(
     }
 
     Ok(())
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum ShowDiffInEditor {
-    /// The user requested we always show the diff.
-    Always,
-    /// The user requested we never show the diff.
-    Never,
-    /// The user didn't specify a preference.
-    Unspecified,
-}
-
-impl ShowDiffInEditor {
-    pub(crate) fn from_args(diff: bool, no_diff: bool) -> Option<Self> {
-        match (diff, no_diff) {
-            (true, true) => None,
-            (true, false) => Some(Self::Always),
-            (false, true) => Some(Self::Never),
-            (false, false) => Some(Self::Unspecified),
-        }
-    }
 }
 
 fn edit_branch_name(
@@ -121,14 +104,6 @@ fn prepare_provided_message(msg: Option<&str>, entity: &str) -> Option<Result<St
     })
 }
 
-/// The maximum total blob size (in bytes) for which we'll show the diff in the editor
-/// when the user hasn't specified a preference. This uses object header lookups
-/// which are cheap compared to actually computing diffs.
-///
-/// 900KB is very roughly 15,000 lines at ~60 bytes per line. Just to protect the user from
-/// stalling their system if they accidentally commit a big log file.
-const MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED: u64 = 900_000;
-
 fn edit_commit_message_by_id(
     ctx: &mut Context,
     commit_oid: gix::ObjectId,
@@ -152,15 +127,9 @@ fn edit_commit_message_by_id(
         prepare_provided_message(message, "commit message").unwrap_or_else(|| {
             let changed_files = get_changed_files_from_commit_details(&commit_details);
 
-            let should_show_diff = match show_diff_in_editor {
-                ShowDiffInEditor::Always => true,
-                ShowDiffInEditor::Never => false,
-                ShowDiffInEditor::Unspecified => {
-                    let total_blob_size =
-                        estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)?;
-                    total_blob_size <= MAX_DIFF_BLOB_SIZE_FOR_EDITOR_IF_UNSPECIFIED
-                }
-            };
+            let should_show_diff = show_diff_in_editor.should_show_diff(|| {
+                estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)
+            })?;
             let diff = should_show_diff
                 .then(|| {
                     commit_details
@@ -198,40 +167,6 @@ fn edit_commit_message_by_id(
     }
 
     Ok(())
-}
-
-/// Sum the blob sizes involved in the given tree changes using cheap object header lookups.
-/// For modifications/renames, uses the larger of the two sides as an upper bound.
-fn estimate_diff_blob_size(changes: &[but_core::TreeChange], ctx: &mut Context) -> Result<u64> {
-    fn blob_size(repo: &gix::Repository, id: &gix::ObjectId) -> u64 {
-        repo.find_header(*id).map(|h| h.size()).unwrap_or(0)
-    }
-
-    let repo = ctx.repo.get()?;
-
-    Ok(changes
-        .iter()
-        .map(|change| match &change.status {
-            but_core::TreeStatus::Addition { state, .. } => blob_size(&repo, &state.id),
-            but_core::TreeStatus::Deletion { previous_state } => {
-                blob_size(&repo, &previous_state.id)
-            }
-            but_core::TreeStatus::Modification {
-                previous_state,
-                state,
-                ..
-            }
-            | but_core::TreeStatus::Rename {
-                previous_state,
-                state,
-                ..
-            } => {
-                let a = blob_size(&repo, &previous_state.id);
-                let b = blob_size(&repo, &state.id);
-                a.max(b)
-            }
-        })
-        .fold(0, |a, b| a.saturating_add(b)))
 }
 
 fn get_changed_files_from_commit_details(
@@ -348,24 +283,5 @@ mod tests {
                 "Aborting due to empty message"
             );
         }
-    }
-    #[test]
-    fn test_show_diff_in_editor() {
-        assert_eq!(
-            Some(ShowDiffInEditor::Always),
-            ShowDiffInEditor::from_args(true, false)
-        );
-
-        assert_eq!(
-            Some(ShowDiffInEditor::Never),
-            ShowDiffInEditor::from_args(false, true)
-        );
-
-        assert_eq!(
-            Some(ShowDiffInEditor::Unspecified),
-            ShowDiffInEditor::from_args(false, false)
-        );
-
-        assert_eq!(None, ShowDiffInEditor::from_args(true, true));
     }
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -861,7 +861,11 @@ async fn match_subcommand(
             target,
             message,
             format,
+            diff,
+            no_diff,
         } => {
+            use crate::command::legacy::reword::ShowDiffInEditor;
+
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -876,6 +880,9 @@ async fn match_subcommand(
                 &target,
                 message.as_deref(),
                 format,
+                // clap's `conflicts_with` should prevent this being `None` but better safe than
+                // sorry
+                ShowDiffInEditor::from_args(diff, no_diff).unwrap_or(ShowDiffInEditor::Unspecified),
             )
             .emit_metrics(metrics_ctx)
         }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -38,6 +38,7 @@ use colored::Colorize;
 use gix::date::time::CustomFormat;
 
 use crate::{
+    command::legacy::ShowDiffInEditor,
     setup::{BackgroundSync, InitCtxOptions},
     utils::{
         OneshotMetricsContext, OutputChannel, ResultErrorExt, ResultJsonExt, ResultMetricsExt,
@@ -740,6 +741,12 @@ async fn match_subcommand(
                     if commit_args.ai.is_some() {
                         anyhow::bail!("--ai cannot be used with 'commit empty'.");
                     }
+                    if commit_args.diff {
+                        anyhow::bail!("--diff cannot be used with 'commit empty'.");
+                    }
+                    if commit_args.no_diff {
+                        anyhow::bail!("--no-diff cannot be used with 'commit empty'.");
+                    }
                     // Note: --paths with commit empty is rejected by clap at parse time
                     // because --paths is not a flag on the empty subcommand
 
@@ -843,6 +850,8 @@ async fn match_subcommand(
                         commit_args.create,
                         commit_args.no_hooks,
                         commit_args.ai.clone(),
+                        ShowDiffInEditor::from_args(commit_args.diff, commit_args.no_diff)
+                            .unwrap_or(ShowDiffInEditor::Unspecified),
                     )
                     .emit_metrics(metrics_ctx)
                 }
@@ -864,8 +873,6 @@ async fn match_subcommand(
             diff,
             no_diff,
         } => {
-            use crate::command::legacy::reword::ShowDiffInEditor;
-
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {

--- a/crates/but/src/tui/get_text.rs
+++ b/crates/but/src/tui/get_text.rs
@@ -1,10 +1,12 @@
 //! Various functions that involve launching the Git editor (i.e. `GIT_EDITOR`).
 //!
 //! When no external editor is configured, falls back to the built-in TUI editor.
-use std::ffi::OsStr;
+use std::{ffi::OsStr, io::Write as _};
 
-use anyhow::{Result, bail};
+use anyhow::{Context as _, Result, bail};
 use bstr::{BStr, BString, ByteSlice};
+
+const REST_TEXT_MARKER: &str = "# --- ignore-rest ---";
 
 /// Launches the user's preferred text editor to edit some `initial_text`,
 /// identified by a `filename_safe_intent` to help the user understand what's wanted of them.
@@ -12,16 +14,36 @@ use bstr::{BStr, BString, ByteSlice};
 ///
 /// Returns the edited text (*without known encoding*), with comment lines (starting with `#`) removed.
 pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str) -> Result<BString> {
-    let content = from_editor(filename_safe_intent, initial_text, ".txt")?;
+    let content = from_editor(filename_safe_intent, initial_text, None, ".txt")?;
+    let filtered_lines = filter_content_from_editor(content.as_bstr());
+    Ok(filtered_lines.into_iter().collect())
+}
 
-    // Strip comment lines (starting with '#')
-    let filtered_lines: Vec<&BStr> = content
+/// Like `from_editor_no_comments` but uses ".patch" file extension that enables syntax
+/// highlighting in some editors.
+///
+/// If `diff_text` is `Some`, appends it after a `REST_TEXT_MARKER` separator line in the editor.
+/// The marker and everything below it is automatically stripped from the returned text.
+///
+/// Returns the edited text (*without known encoding*), with comment lines (starting with `#`) removed.
+pub fn from_editor_no_comments_as_patch(
+    filename_safe_intent: &str,
+    initial_text: &str,
+    diff_text: Option<&str>,
+) -> Result<BString> {
+    let content = from_editor(filename_safe_intent, initial_text, diff_text, ".patch")?;
+    let filtered_lines = filter_content_from_editor(content.as_bstr());
+    Ok(filtered_lines.into_iter().collect())
+}
+
+/// Strip comment lines (starting with '#') and everything below `REST_TEXT_MARKER`.
+fn filter_content_from_editor(content: &BStr) -> Vec<&BStr> {
+    content
         .lines_with_terminator()
+        .take_while(|line| !line.trim_start().starts_with_str(REST_TEXT_MARKER))
         .filter(|line| !line.trim_start().starts_with_str("#"))
         .map(|line| line.as_bstr())
-        .collect();
-
-    Ok(filtered_lines.into_iter().collect())
+        .collect()
 }
 
 /// Launches the user's preferred text editor to edit some `initial_text`,
@@ -35,9 +57,10 @@ pub fn from_editor_no_comments(filename_safe_intent: &str, initial_text: &str) -
 pub fn from_editor(
     filename_safe_intent: &str,
     initial_text: &str,
+    rest_text: Option<&str>,
     file_suffix: &str,
 ) -> Result<BString> {
-    const ALLOWED_SUFFIXES: &[&str] = &[".txt", ".md"]; // feel free to add more allowed suffixes
+    const ALLOWED_SUFFIXES: &[&str] = &[".txt", ".md", ".patch"]; // feel free to add more allowed suffixes
     if !ALLOWED_SUFFIXES.contains(&file_suffix) {
         bail!(
             "File suffix '{}' is not allowed. Must be one of: {}",
@@ -47,10 +70,14 @@ pub fn from_editor(
     }
 
     match get_editor_command() {
-        Some(editor_cmd) => {
-            from_external_editor(&editor_cmd, filename_safe_intent, initial_text, file_suffix)
-        }
-        None => from_builtin_editor(filename_safe_intent, initial_text),
+        Some(editor_cmd) => from_external_editor(
+            &editor_cmd,
+            filename_safe_intent,
+            initial_text,
+            rest_text,
+            file_suffix,
+        ),
+        None => from_builtin_editor(filename_safe_intent, initial_text, rest_text),
     }
 }
 
@@ -59,14 +86,24 @@ fn from_external_editor(
     editor_cmd: &str,
     filename_safe_intent: &str,
     initial_text: &str,
+    rest_text: Option<&str>,
     file_suffix: &str,
 ) -> Result<BString> {
     // Create a temporary file with the initial text
-    let tempfile = tempfile::Builder::new()
+    let mut tempfile = tempfile::Builder::new()
         .prefix(&format!("but_{filename_safe_intent}_"))
         .suffix(file_suffix)
         .tempfile()?;
-    std::fs::write(&tempfile, initial_text)?;
+
+    write!(&mut tempfile, "{initial_text}")?;
+
+    if let Some(rest_text) = rest_text {
+        if !initial_text.ends_with('\n') {
+            writeln!(&mut tempfile)?;
+        }
+        writeln!(&mut tempfile, "{REST_TEXT_MARKER}")?;
+        writeln!(&mut tempfile, "{rest_text}")?;
+    }
 
     // The editor command is allowed to be a shell expression, e.g. "code --wait" is somewhat common.
     // We need to execute within a shell to make sure we don't get "No such file or directory" errors.
@@ -81,11 +118,18 @@ fn from_external_editor(
     if !status.success() {
         bail!("Editor exited with non-zero status");
     }
-    Ok(std::fs::read(&tempfile)?.into())
+
+    Ok(std::fs::read(&tempfile)
+        .context("failed to read contents of commit message file")?
+        .into())
 }
 
 /// Launch the built-in TUI editor.
-fn from_builtin_editor(filename_safe_intent: &str, initial_text: &str) -> Result<BString> {
+fn from_builtin_editor(
+    filename_safe_intent: &str,
+    initial_text: &str,
+    rest_text: Option<&str>,
+) -> Result<BString> {
     // Determine editor mode based on the intent
     let mode = if filename_safe_intent.contains("commit") {
         super::editor::EditorMode::CommitMessage
@@ -95,7 +139,19 @@ fn from_builtin_editor(filename_safe_intent: &str, initial_text: &str) -> Result
         super::editor::EditorMode::PullRequest
     };
 
-    match super::editor::run_builtin_editor(filename_safe_intent, initial_text, mode)? {
+    let editor_output = if let Some(rest_text) = rest_text {
+        let mut initial_text = initial_text.to_owned();
+        if !initial_text.ends_with('\n') {
+            initial_text.push('\n');
+        }
+        initial_text.push_str(REST_TEXT_MARKER);
+        initial_text.push('\n');
+        initial_text.push_str(rest_text);
+        super::editor::run_builtin_editor(filename_safe_intent, &initial_text, mode)?
+    } else {
+        super::editor::run_builtin_editor(filename_safe_intent, initial_text, mode)?
+    };
+    match editor_output {
         Some(content) => Ok(content.into()),
         None => bail!("Editor cancelled"),
     }
@@ -255,7 +311,7 @@ mod tests {
         // The controlling terminal tends to go insane when this test fails, but at least it
         // doesn't hang forever :)
         let (tx, rx) = std::sync::mpsc::channel();
-        thread::spawn(move || tx.send(from_editor("filename", "", ".notasuffix")));
+        thread::spawn(move || tx.send(from_editor("filename", "", None, ".notasuffix")));
         let err = rx
             .recv_timeout(Duration::from_secs(1))
             .expect("Test timed out after 1 second")
@@ -327,5 +383,40 @@ This should remain
         let stripped = strip_html_comments(input);
 
         assert_eq!(stripped, expected_output)
+    }
+
+    #[test]
+    fn test_filter_content_from_editor() {
+        let raw_content = BString::from(format!(
+            r#"commit message
+
+here is a longer description about the commit
+
+1. It does the thing
+2. It does the other thing
+
+# this line will be ignored
+# as will this
+{REST_TEXT_MARKER}
+all
+this
+will
+be
+ignored"#
+        ));
+        let filtered_content = filter_content_from_editor(raw_content.as_bstr());
+
+        assert_eq!(
+            filtered_content,
+            Vec::from([
+                "commit message\n",
+                "\n",
+                "here is a longer description about the commit\n",
+                "\n",
+                "1. It does the thing\n",
+                "2. It does the other thing\n",
+                "\n",
+            ])
+        );
     }
 }


### PR DESCRIPTION
Makes `but commit` an `but reword` show the diff in the editor. I think its generally useful to refer to changes while writing the commit message. Vim will also autocomplete words from the current buffer so having the diff inline effectively seeds that.

Adds `--diff` and `--no-diff` flags. If no flags are passed it'll show the diff unless its large (so if you accidentally commit a log file you don't stall your system). If `--diff` is passed it'll always show the diff regardless of the size. If `--no-diff` is passed it'll never show the diff. The two flags are mutually exclusive.

Looks like this in my editor:

<img width="582" height="595" alt="image" src="https://github.com/user-attachments/assets/d551f938-288f-4185-b61f-55d3ebace253" />

In builtin editor:

<img width="546" height="596" alt="image" src="https://github.com/user-attachments/assets/c1ee1758-c128-4e2c-99db-99bb81115597" />

I wanna try this in a few other editors but should be good to review.