### PR TITLE
export-schema: Correct the feature toggle

### DIFF
--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -41,7 +41,6 @@ export-schema = [
     "but-workspace/export-schema",
     "but-hunk-assignment/export-schema",
     "gitbutler-project/export-schema",
-    "gitbutler-branch/export-schema",
     "gitbutler-branch-actions/export-schema",
 ]
 ## Make legacy functionality available.

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 export-schema = [
   "but-workspace/export-schema",
   "gitbutler-project/export-schema",
+  "gitbutler-branch/export-schema",
 ]
 
 [dependencies]


### PR DESCRIPTION
The feature flag for generating the branch listing types now is
correctly hooked-up. If enabled in branch-actions -> branch is also
enabled.