### PR TITLE
Add `.` for `unmark` command help message

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -391,7 +391,7 @@ pub enum Subcommands {
         delete: bool,
     },
 
-    /// Removes any marks from the workspace
+    /// Removes any marks from the workspace.
     ///
     /// This will unmark anything that has been marked by the `but mark` command.
     ///


### PR DESCRIPTION
## 🧢 Changes

Appends a period symbol `.` for `unmark` command help message

No period, not good :(
<img width="705" height="73" alt="image" src="https://github.com/user-attachments/assets/5ff1515d-8e38-4b49-892e-c4ac92e75ddb" />

