### PR TITLE
refactor(cli): move `status` printing into its own functions

### DIFF
--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -526,39 +526,27 @@ fn convert_branch_to_json(
     )
 }
 
-/// Build the complete WorkspaceStatus JSON structure
-#[expect(clippy::too_many_arguments)]
+/// Build the complete WorkspaceStatus JSON structure.
 pub(super) fn build_workspace_status_json(
-    stack_details: &[super::StackEntry],
-    worktree_changes: &[but_core::ui::TreeChange],
-    common_merge_base: &super::CommonMergeBase,
-    upstream_state: &Option<super::UpstreamState>,
-    last_fetched_ms: Option<u128>,
-    review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
-    ci_map: &BTreeMap<String, Vec<but_forge::CiCheck>>,
-    branch_merge_statuses: &BTreeMap<
-        String,
-        gitbutler_branch_actions::upstream_integration::BranchStatus,
-    >,
-    show_files: bool,
+    status: &super::StatusContext<'_>,
     repo: &gix::Repository,
-    id_map: &crate::IdMap,
-    base_branch: Option<&gitbutler_branch_actions::BaseBranch>,
-    show_upstream: bool,
 ) -> anyhow::Result<WorkspaceStatus> {
     let mut json_stacks = Vec::new();
     let mut json_unassigned_changes = Vec::new();
 
-    for (stack_id, (stack_with_id, assignments)) in stack_details {
+    for (stack_id, (stack_with_id, assignments)) in status.stack_details {
         if stack_id.is_none() {
-            json_unassigned_changes = convert_file_assignments(assignments, worktree_changes);
+            json_unassigned_changes =
+                convert_file_assignments(assignments, status.worktree_changes);
         } else if let (Some(stack_id), Some(stack_with_id)) = (stack_id, stack_with_id) {
-            let stack_cli_id = id_map
+            let stack_cli_id = status
+                .id_map
                 .resolve_stack(*stack_id)
                 .map(|id| id.to_short_string())
                 .unwrap_or_else(|| "unknown".to_string());
 
-            let json_assigned_changes = convert_file_assignments(assignments, worktree_changes);
+            let json_assigned_changes =
+                convert_file_assignments(assignments, status.worktree_changes);
 
             let json_branches = stack_with_id
                 .segments
@@ -567,10 +555,10 @@ pub(super) fn build_workspace_status_json(
                     convert_branch_to_json(
                         repo,
                         segment,
-                        show_files,
-                        review_map,
-                        ci_map,
-                        branch_merge_statuses,
+                        status.show_files,
+                        status.review_map,
+                        status.ci_map,
+                        status.branch_merge_statuses,
                     )
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -580,23 +568,22 @@ pub(super) fn build_workspace_status_json(
         }
     }
 
-    // Create a Commit object for the merge base
-    // We use the author signature from the commit we decoded earlier
-    let base_commit = repo.find_commit(common_merge_base.commit_id)?;
+    // Create a Commit object for the merge base.
+    let base_commit = repo.find_commit(status.common_merge_base_data.commit_id)?;
     let base_commit_decoded = base_commit.decode()?;
     let author: but_workspace::ui::Author = base_commit_decoded.author()?.into();
 
     let merge_base_commit = Commit::from_upstream_commit(
         but_workspace::ui::UpstreamCommit {
-            id: common_merge_base.commit_id,
-            created_at: common_merge_base.created_at,
-            message: common_merge_base.message.clone().into(),
+            id: status.common_merge_base_data.commit_id,
+            created_at: status.common_merge_base_data.created_at,
+            message: status.common_merge_base_data.message.clone().into(),
             author,
         },
         None,
     );
 
-    let upstream_state_json = if let Some(upstream) = upstream_state {
+    let upstream_state_json = if let Some(upstream) = status.upstream_state {
         // Create a Commit object for the latest upstream commit
         let upstream_commit = repo.find_commit(upstream.commit_id)?;
         let upstream_commit_decoded = upstream_commit.decode()?;
@@ -612,11 +599,11 @@ pub(super) fn build_workspace_status_json(
             None,
         );
 
-        let last_fetched = last_fetched_ms.map(|ts| i128_to_rfc3339(ts as i128));
+        let last_fetched = status.last_fetched_ms.map(|ts| i128_to_rfc3339(ts as i128));
 
-        // Populate upstream_commits if show_upstream flag is set and base_branch is available
-        let upstream_commits = if show_upstream {
-            base_branch.and_then(|bb| {
+        // Populate upstream_commits if show_upstream flag is set and base_branch is available.
+        let upstream_commits = if status.show_upstream {
+            status.base_branch.and_then(|bb| {
                 if bb.upstream_commits.is_empty() {
                     None
                 } else {
@@ -657,7 +644,7 @@ pub(super) fn build_workspace_status_json(
         }
     } else {
         // When up to date, use the merge base as the latest commit
-        let last_fetched = last_fetched_ms.map(|ts| i128_to_rfc3339(ts as i128));
+        let last_fetched = status.last_fetched_ms.map(|ts| i128_to_rfc3339(ts as i128));
 
         UpstreamState {
             behind: 0,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -91,15 +91,6 @@ pub(crate) async fn worktree(
         return show_edit_mode_status(ctx, out);
     }
 
-    // Check for available updates and display if present
-    if let Some(out) = out.for_human() {
-        let cache = ctx.app_cache.get_cache()?;
-        if let Ok(Some(update)) = but_update::available_update(&cache) {
-            writeln!(out, "{}", update.display_cli(verbose, out.is_paged()))?;
-            writeln!(out)?;
-        }
-    }
-
     // Process rules with exclusive access to create repo and workspace
     let head_info = {
         let mut guard = ctx.exclusive_worktree_access();
@@ -282,6 +273,8 @@ pub(crate) async fn worktree(
             .unwrap_or_default()
     };
 
+    print_update_notice(ctx, out, verbose)?;
+
     print_status(
         ctx,
         out,
@@ -315,6 +308,21 @@ pub(crate) async fn worktree(
         has_branches,
         &worktree_changes.worktree_changes.changes,
     )?;
+
+    Ok(())
+}
+
+/// Print update information for human output when a newer `but` version is available.
+fn print_update_notice(
+    ctx: &mut Context,
+    out: &mut dyn WriteWithUtils,
+    verbose: bool,
+) -> anyhow::Result<()> {
+    let cache = ctx.app_cache.get_cache()?;
+    if let Ok(Some(update)) = but_update::available_update(&cache) {
+        writeln!(out, "{}", update.display_cli(verbose, out.is_paged()))?;
+        writeln!(out)?;
+    }
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -270,6 +270,18 @@ pub(crate) async fn worktree(
     // Drop repo to release the borrow on ctx before printing status details.
     drop(repo);
 
+    // Format the last fetched time as relative time, unless NO_BG_TASKS is set
+    let last_checked_text = if std::env::var("NO_BG_TASKS").is_ok() {
+        String::new()
+    } else {
+        last_fetched_ms
+            .map(|ms| {
+                let relative_time = format_relative_time_verbose(std::time::SystemTime::now(), ms);
+                format!("(checked {relative_time})")
+            })
+            .unwrap_or_default()
+    };
+
     print_status(
         ctx,
         out,
@@ -283,66 +295,14 @@ pub(crate) async fn worktree(
         &branch_merge_statuses,
     )?;
 
-    // Format the last fetched time as relative time, unless NO_BG_TASKS is set
-    let last_checked_text = if std::env::var("NO_BG_TASKS").is_ok() {
-        String::new()
-    } else {
-        last_fetched_ms
-            .map(|ms| {
-                let relative_time = format_relative_time_verbose(std::time::SystemTime::now(), ms);
-                format!("(checked {relative_time})")
-            })
-            .unwrap_or_default()
-    };
-
-    // Display upstream state if there are new commits
-    if let Some(upstream) = &upstream_state {
-        let dot = "●".yellow();
-
-        if show_upstream {
-            // When showing detailed commits, only show count in summary
-            writeln!(
-                out,
-                "┊╭┄(upstream) ⏫ {} new commits{}",
-                upstream.behind_count,
-                last_checked_text.dimmed()
-            )?;
-
-            // Display detailed list of upstream commits
-            if let Some(ref base_branch) = base_branch
-                && !base_branch.upstream_commits.is_empty()
-            {
-                let repo = ctx.repo.get()?;
-                let commits = base_branch.upstream_commits.iter().take(8);
-                for commit in commits {
-                    // Measure prefix width using plain text (no ANSI codes)
-                    let commit_short = shorten_hex_object_id(&repo, &commit.id);
-                    let truncated_msg = out
-                        .truncate_if_unpaged(&commit.description.to_string().replace('\n', " "), 72)
-                        .dimmed();
-                    writeln!(out, "┊{dot} {} {truncated_msg}", commit_short.yellow())?;
-                }
-                let hidden_commits = base_branch.behind.saturating_sub(8);
-                if hidden_commits > 0 {
-                    writeln!(
-                        out,
-                        "┊    {}",
-                        format!("and {hidden_commits} more…").dimmed()
-                    )?;
-                }
-            }
-            writeln!(out, "┊┊")?;
-        } else {
-            // Without --upstream, show the summary with latest commit info
-            writeln!(
-                out,
-                "┊{dot} {} (upstream) ⏫ {} new commits {}",
-                upstream.latest_commit.dimmed(),
-                upstream.behind_count,
-                last_checked_text.dimmed()
-            )?;
-        }
-    }
+    print_upstream_state(
+        ctx,
+        out,
+        upstream_state.as_ref(),
+        show_upstream,
+        base_branch.as_ref(),
+        &last_checked_text,
+    )?;
 
     let first_line = common_merge_base_data.message.lines().next().unwrap_or("");
     let connector = if upstream_state.is_some() {
@@ -404,6 +364,68 @@ pub(crate) async fn worktree(
         } else {
             writeln!(out, "{}", "Hint: run `but help` for all commands".dimmed())?;
         }
+    }
+
+    Ok(())
+}
+
+/// Display upstream state information when upstream has commits ahead of the workspace base.
+fn print_upstream_state(
+    ctx: &mut Context,
+    out: &mut dyn WriteWithUtils,
+    upstream_state: Option<&UpstreamState>,
+    show_upstream: bool,
+    base_branch: Option<&gitbutler_branch_actions::base::BaseBranch>,
+    last_checked_text: &str,
+) -> anyhow::Result<()> {
+    let Some(upstream) = upstream_state else {
+        return Ok(());
+    };
+
+    let dot = "●".yellow();
+
+    if show_upstream {
+        // When showing detailed commits, only show count in summary
+        writeln!(
+            out,
+            "┊╭┄(upstream) ⏫ {} new commits{}",
+            upstream.behind_count,
+            last_checked_text.dimmed()
+        )?;
+
+        // Display detailed list of upstream commits
+        if let Some(base_branch) = base_branch
+            && !base_branch.upstream_commits.is_empty()
+        {
+            let repo = ctx.repo.get()?;
+            let commits = base_branch.upstream_commits.iter().take(8);
+            for commit in commits {
+                // Measure prefix width using plain text (no ANSI codes)
+                let commit_short = shorten_hex_object_id(&repo, &commit.id);
+                let truncated_msg = out
+                    .truncate_if_unpaged(&commit.description.to_string().replace('\n', " "), 72)
+                    .dimmed();
+                writeln!(out, "┊{dot} {} {truncated_msg}", commit_short.yellow())?;
+            }
+            let hidden_commits = base_branch.behind.saturating_sub(8);
+            if hidden_commits > 0 {
+                writeln!(
+                    out,
+                    "┊    {}",
+                    format!("and {hidden_commits} more…").dimmed()
+                )?;
+            }
+        }
+        writeln!(out, "┊┊")?;
+    } else {
+        // Without --upstream, show the summary with latest commit info
+        writeln!(
+            out,
+            "┊{dot} {} (upstream) ⏫ {} new commits {}",
+            upstream.latest_commit.dimmed(),
+            upstream.behind_count,
+            last_checked_text.dimmed()
+        )?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -70,6 +70,26 @@ struct UpstreamState {
     author_email: String,
 }
 
+#[derive(Copy, Clone)]
+struct StatusContext<'a> {
+    stack_details: &'a [StackEntry],
+    worktree_changes: &'a [ui::TreeChange],
+    common_merge_base_data: &'a CommonMergeBase,
+    upstream_state: Option<&'a UpstreamState>,
+    last_fetched_ms: Option<u128>,
+    review_map: &'a std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
+    ci_map: &'a BTreeMap<String, Vec<but_forge::CiCheck>>,
+    branch_merge_statuses: &'a BTreeMap<String, UpstreamBranchStatus>,
+    show_files: bool,
+    verbose: bool,
+    show_upstream: bool,
+    hint: bool,
+    has_branches: bool,
+    id_map: &'a IdMap,
+    base_branch: Option<&'a gitbutler_branch_actions::BaseBranch>,
+    mode: &'a gitbutler_operating_modes::OperatingMode,
+}
+
 fn show_edit_mode_status(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
     // Delegate to the resolve status logic to show actual conflict details
     crate::command::legacy::resolve::show_resolve_status(ctx, out)
@@ -234,22 +254,27 @@ pub(crate) async fn worktree(
     // Re-acquire repo for use after the async call
     let repo = ctx.repo.get()?;
 
+    let status_ctx = StatusContext {
+        stack_details: &stack_details,
+        worktree_changes: &worktree_changes.worktree_changes.changes,
+        common_merge_base_data: &common_merge_base_data,
+        upstream_state: upstream_state.as_ref(),
+        last_fetched_ms,
+        review_map: &review_map,
+        ci_map: &ci_map,
+        branch_merge_statuses: &branch_merge_statuses,
+        show_files,
+        verbose,
+        show_upstream,
+        hint,
+        has_branches,
+        id_map: &id_map,
+        base_branch: base_branch.as_ref(),
+        mode: &mode,
+    };
+
     if let Some(out) = out.for_json() {
-        let workspace_status = json::build_workspace_status_json(
-            &stack_details,
-            &worktree_changes.worktree_changes.changes,
-            &common_merge_base_data,
-            &upstream_state,
-            last_fetched_ms,
-            &review_map,
-            &ci_map,
-            &branch_merge_statuses,
-            show_files,
-            &repo,
-            &id_map,
-            base_branch.as_ref(),
-            show_upstream,
-        )?;
+        let workspace_status = json::build_workspace_status_json(&status_ctx, &repo)?;
         out.write_value(workspace_status)?;
         return Ok(());
     }
@@ -261,53 +286,32 @@ pub(crate) async fn worktree(
     // Drop repo to release the borrow on ctx before printing status details.
     drop(repo);
 
-    // Format the last fetched time as relative time, unless NO_BG_TASKS is set
-    let last_checked_text = if std::env::var("NO_BG_TASKS").is_ok() {
-        String::new()
-    } else {
-        last_fetched_ms
-            .map(|ms| {
-                let relative_time = format_relative_time_verbose(std::time::SystemTime::now(), ms);
-                format!("(checked {relative_time})")
-            })
-            .unwrap_or_default()
-    };
+    print_human_status(ctx, out, status_ctx)?;
 
-    print_update_notice(ctx, out, verbose)?;
+    Ok(())
+}
 
-    print_status(
-        ctx,
-        out,
-        stack_details,
-        &id_map,
-        &worktree_changes.worktree_changes.changes,
-        show_files,
-        verbose,
-        &review_map,
-        &ci_map,
-        &branch_merge_statuses,
-    )?;
+fn print_human_status(
+    ctx: &mut Context,
+    out: &mut dyn WriteWithUtils,
+    status_ctx: StatusContext<'_>,
+) -> anyhow::Result<()> {
+    print_update_notice(ctx, out, status_ctx)?;
 
-    print_upstream_state(
-        ctx,
-        out,
-        upstream_state.as_ref(),
-        show_upstream,
-        base_branch.as_ref(),
-        &last_checked_text,
-    )?;
+    print_worktree_status(ctx, out, status_ctx)?;
 
-    print_common_merge_base_summary(out, &common_merge_base_data, upstream_state.is_some())?;
+    print_upstream_state(ctx, out, status_ctx)?;
 
-    let not_on_workspace = print_outside_workspace_warning(&mode, out)?;
+    print_common_merge_base_summary(out, status_ctx)?;
 
-    print_hint(
-        out,
-        hint,
-        not_on_workspace,
-        has_branches,
-        &worktree_changes.worktree_changes.changes,
-    )?;
+    let not_on_workspace = matches!(
+        status_ctx.mode,
+        gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
+    );
+
+    print_outside_workspace_warning(not_on_workspace, out)?;
+
+    print_hint(out, not_on_workspace, status_ctx)?;
 
     Ok(())
 }
@@ -316,7 +320,7 @@ pub(crate) async fn worktree(
 fn print_update_notice(
     ctx: &mut Context,
     out: &mut dyn WriteWithUtils,
-    verbose: bool,
+    StatusContext { verbose, .. }: StatusContext<'_>,
 ) -> anyhow::Result<()> {
     let cache = ctx.app_cache.get_cache()?;
     if let Ok(Some(update)) = but_update::available_update(&cache) {
@@ -329,14 +333,9 @@ fn print_update_notice(
 
 /// Print a warning when operating outside the GitButler workspace.
 fn print_outside_workspace_warning(
-    mode: &gitbutler_operating_modes::OperatingMode,
+    not_on_workspace: bool,
     out: &mut dyn WriteWithUtils,
-) -> anyhow::Result<bool> {
-    let not_on_workspace = matches!(
-        mode,
-        gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
-    );
-
+) -> anyhow::Result<()> {
     if not_on_workspace {
         writeln!(
             out,
@@ -347,16 +346,19 @@ fn print_outside_workspace_warning(
         )?;
     }
 
-    Ok(not_on_workspace)
+    Ok(())
 }
 
 /// Print a contextual hint at the end of status output when hints are enabled.
 fn print_hint(
     out: &mut dyn WriteWithUtils,
-    hint: bool,
     not_on_workspace: bool,
-    has_branches: bool,
-    changes: &[ui::TreeChange],
+    StatusContext {
+        hint,
+        worktree_changes,
+        has_branches,
+        ..
+    }: StatusContext<'_>,
 ) -> anyhow::Result<()> {
     if !hint {
         return Ok(());
@@ -365,7 +367,7 @@ fn print_hint(
     writeln!(out)?;
 
     // Determine what hint to show based on workspace state
-    let has_uncommitted_files = !changes.is_empty();
+    let has_uncommitted_files = !worktree_changes.is_empty();
 
     // Check whether we're inside the workspace
     if not_on_workspace {
@@ -398,13 +400,28 @@ fn print_hint(
 fn print_upstream_state(
     ctx: &mut Context,
     out: &mut dyn WriteWithUtils,
-    upstream_state: Option<&UpstreamState>,
-    show_upstream: bool,
-    base_branch: Option<&gitbutler_branch_actions::base::BaseBranch>,
-    last_checked_text: &str,
+    StatusContext {
+        upstream_state,
+        last_fetched_ms,
+        show_upstream,
+        base_branch,
+        ..
+    }: StatusContext<'_>,
 ) -> anyhow::Result<()> {
     let Some(upstream) = upstream_state else {
         return Ok(());
+    };
+
+    // Format the last fetched time as relative time, unless NO_BG_TASKS is set.
+    let last_checked_text = if std::env::var("NO_BG_TASKS").is_ok() {
+        String::new()
+    } else {
+        last_fetched_ms
+            .map(|ms| {
+                let relative_time = format_relative_time_verbose(std::time::SystemTime::now(), ms);
+                format!("(checked {relative_time})")
+            })
+            .unwrap_or_default()
     };
 
     let dot = "●".yellow();
@@ -459,11 +476,18 @@ fn print_upstream_state(
 /// Print the common merge-base summary line at the bottom of the status tree.
 fn print_common_merge_base_summary(
     out: &mut dyn WriteWithUtils,
-    common_merge_base_data: &CommonMergeBase,
-    has_upstream_state: bool,
+    StatusContext {
+        common_merge_base_data,
+        upstream_state,
+        ..
+    }: StatusContext<'_>,
 ) -> anyhow::Result<()> {
     let first_line = common_merge_base_data.message.lines().next().unwrap_or("");
-    let connector = if has_upstream_state { "├╯" } else { "┴" };
+    let connector = if upstream_state.is_some() {
+        "├╯"
+    } else {
+        "┴"
+    };
     let first_line = out.truncate_if_unpaged(first_line, 40);
     writeln!(
         out,
@@ -477,20 +501,22 @@ fn print_common_merge_base_summary(
 }
 
 /// Print per-stack status sections for human-readable output.
-#[expect(clippy::too_many_arguments)]
-fn print_status(
+fn print_worktree_status(
     ctx: &mut Context,
     out: &mut dyn WriteWithUtils,
-    stack_details: Vec<StackEntry>,
-    id_map: &IdMap,
-    changes: &[ui::TreeChange],
-    show_files: bool,
-    verbose: bool,
-    review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
-    ci_map: &BTreeMap<String, Vec<but_forge::CiCheck>>,
-    branch_merge_statuses: &BTreeMap<String, UpstreamBranchStatus>,
+    StatusContext {
+        stack_details,
+        id_map,
+        worktree_changes,
+        show_files,
+        verbose,
+        review_map,
+        ci_map,
+        branch_merge_statuses,
+        ..
+    }: StatusContext<'_>,
 ) -> anyhow::Result<()> {
-    for (i, (stack_id, (stack_with_id, assignments))) in stack_details.into_iter().enumerate() {
+    for (i, (stack_id, (stack_with_id, assignments))) in stack_details.iter().enumerate() {
         let mut stack_mark = stack_id.and_then(|stack_id| {
             if crate::command::legacy::mark::stack_marked(ctx, stack_id).unwrap_or_default() {
                 Some("◀ Marked ▶".red().bold())
@@ -500,7 +526,7 @@ fn print_status(
         });
 
         // assignments to the stack
-        if let Some(stack_with_id) = &stack_with_id {
+        if let Some(stack_with_id) = stack_with_id {
             let branch_name = stack_with_id
                 .segments
                 .first()
@@ -508,20 +534,20 @@ fn print_status(
             let repo = ctx.repo.get()?;
             print_assignments(
                 &repo,
-                stack_id,
+                *stack_id,
                 id_map,
                 branch_name,
-                &assignments,
-                changes,
+                assignments,
+                worktree_changes,
                 false,
                 out,
             )?;
         }
 
         print_group(
-            &stack_with_id,
+            stack_with_id,
             assignments,
-            changes,
+            worktree_changes,
             show_files,
             verbose,
             &mut stack_mark,
@@ -570,7 +596,7 @@ fn print_assignments(
     stack: Option<StackId>,
     id_map: &IdMap,
     branch_name: Option<&BStr>,
-    assignments: &Vec<FileAssignment>,
+    assignments: &[FileAssignment],
     changes: &[ui::TreeChange],
     unstaged: bool,
     out: &mut dyn std::fmt::Write,
@@ -654,7 +680,7 @@ fn print_assignments(
 #[expect(clippy::too_many_arguments)]
 pub fn print_group(
     stack_with_id: &Option<StackWithId>,
-    assignments: Vec<FileAssignment>,
+    assignments: &[FileAssignment],
     changes: &[ui::TreeChange],
     show_files: bool,
     verbose: bool,
@@ -819,7 +845,7 @@ pub fn print_group(
             "unstaged changes".to_string().cyan().bold(),
             stack_mark.clone().unwrap_or_default()
         )?;
-        print_assignments(&repo, None, id_map, None, &assignments, changes, true, out)?;
+        print_assignments(&repo, None, id_map, None, assignments, changes, true, out)?;
     }
     if !first {
         writeln!(out, "├╯")?;

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -267,53 +267,21 @@ pub(crate) async fn worktree(
         return Ok(());
     };
 
-    // Drop repo to release the borrow on ctx before the loop
+    // Drop repo to release the borrow on ctx before printing status details.
     drop(repo);
 
-    for (i, (stack_id, (stack_with_id, assignments))) in stack_details.into_iter().enumerate() {
-        let mut stack_mark = stack_id.and_then(|stack_id| {
-            if crate::command::legacy::mark::stack_marked(ctx, stack_id).unwrap_or_default() {
-                Some("◀ Marked ▶".red().bold())
-            } else {
-                None
-            }
-        });
-
-        // assignments to the stack
-        if let Some(stack_with_id) = &stack_with_id {
-            let branch_name = stack_with_id
-                .segments
-                .first()
-                .map_or(Some(BStr::new(b"")), SegmentWithId::branch_name);
-            let repo = ctx.repo.get()?;
-            print_assignments(
-                &repo,
-                stack_id,
-                &id_map,
-                branch_name,
-                &assignments,
-                &worktree_changes.worktree_changes.changes,
-                false,
-                out,
-            )?;
-        }
-
-        print_group(
-            &stack_with_id,
-            assignments,
-            &worktree_changes.worktree_changes.changes,
-            show_files,
-            verbose,
-            &mut stack_mark,
-            ctx,
-            i == 0,
-            &review_map,
-            &ci_map,
-            &branch_merge_statuses,
-            out,
-            &id_map,
-        )?;
-    }
+    print_status(
+        ctx,
+        out,
+        stack_details,
+        &id_map,
+        &worktree_changes.worktree_changes.changes,
+        show_files,
+        verbose,
+        &review_map,
+        &ci_map,
+        &branch_merge_statuses,
+    )?;
 
     // Format the last fetched time as relative time, unless NO_BG_TASKS is set
     let last_checked_text = if std::env::var("NO_BG_TASKS").is_ok() {
@@ -436,6 +404,68 @@ pub(crate) async fn worktree(
         } else {
             writeln!(out, "{}", "Hint: run `but help` for all commands".dimmed())?;
         }
+    }
+
+    Ok(())
+}
+
+/// Print per-stack status sections for human-readable output.
+#[expect(clippy::too_many_arguments)]
+fn print_status(
+    ctx: &mut Context,
+    out: &mut dyn WriteWithUtils,
+    stack_details: Vec<StackEntry>,
+    id_map: &IdMap,
+    changes: &[ui::TreeChange],
+    show_files: bool,
+    verbose: bool,
+    review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
+    ci_map: &BTreeMap<String, Vec<but_forge::CiCheck>>,
+    branch_merge_statuses: &BTreeMap<String, UpstreamBranchStatus>,
+) -> anyhow::Result<()> {
+    for (i, (stack_id, (stack_with_id, assignments))) in stack_details.into_iter().enumerate() {
+        let mut stack_mark = stack_id.and_then(|stack_id| {
+            if crate::command::legacy::mark::stack_marked(ctx, stack_id).unwrap_or_default() {
+                Some("◀ Marked ▶".red().bold())
+            } else {
+                None
+            }
+        });
+
+        // assignments to the stack
+        if let Some(stack_with_id) = &stack_with_id {
+            let branch_name = stack_with_id
+                .segments
+                .first()
+                .map_or(Some(BStr::new(b"")), SegmentWithId::branch_name);
+            let repo = ctx.repo.get()?;
+            print_assignments(
+                &repo,
+                stack_id,
+                id_map,
+                branch_name,
+                &assignments,
+                changes,
+                false,
+                out,
+            )?;
+        }
+
+        print_group(
+            &stack_with_id,
+            assignments,
+            changes,
+            show_files,
+            verbose,
+            &mut stack_mark,
+            ctx,
+            i == 0,
+            review_map,
+            ci_map,
+            branch_merge_statuses,
+            out,
+            id_map,
+        )?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -306,10 +306,29 @@ pub(crate) async fn worktree(
 
     print_common_merge_base_summary(out, &common_merge_base_data, upstream_state.is_some())?;
 
+    let not_on_workspace = print_outside_workspace_warning(&mode, out)?;
+
+    print_hint(
+        out,
+        hint,
+        not_on_workspace,
+        has_branches,
+        &worktree_changes.worktree_changes.changes,
+    )?;
+
+    Ok(())
+}
+
+/// Print a warning when operating outside the GitButler workspace.
+fn print_outside_workspace_warning(
+    mode: &gitbutler_operating_modes::OperatingMode,
+    out: &mut dyn WriteWithUtils,
+) -> anyhow::Result<bool> {
     let not_on_workspace = matches!(
         mode,
         gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
     );
+
     if not_on_workspace {
         writeln!(
             out,
@@ -320,35 +339,48 @@ pub(crate) async fn worktree(
         )?;
     }
 
-    if hint {
-        writeln!(out)?;
+    Ok(not_on_workspace)
+}
 
-        // Determine what hint to show based on workspace state
-        let has_uncommitted_files = !worktree_changes.worktree_changes.changes.is_empty();
+/// Print a contextual hint at the end of status output when hints are enabled.
+fn print_hint(
+    out: &mut dyn WriteWithUtils,
+    hint: bool,
+    not_on_workspace: bool,
+    has_branches: bool,
+    changes: &[ui::TreeChange],
+) -> anyhow::Result<()> {
+    if !hint {
+        return Ok(());
+    }
 
-        // Check whether we're inside the workspace
-        if not_on_workspace {
-            writeln!(
-                out,
-                "{}",
-                "Hint: run `but setup` to switch back to GitButler managed mode.".dimmed()
-            )?;
-        } else if !has_branches {
-            writeln!(
-                out,
-                "{}",
-                "Hint: run `but branch new` to create a new branch to work on".dimmed()
-            )?;
-        } else if has_uncommitted_files {
-            writeln!(
-                out,
-                "{}",
-                "Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch"
-                    .dimmed()
-            )?;
-        } else {
-            writeln!(out, "{}", "Hint: run `but help` for all commands".dimmed())?;
-        }
+    writeln!(out)?;
+
+    // Determine what hint to show based on workspace state
+    let has_uncommitted_files = !changes.is_empty();
+
+    // Check whether we're inside the workspace
+    if not_on_workspace {
+        writeln!(
+            out,
+            "{}",
+            "Hint: run `but setup` to switch back to GitButler managed mode.".dimmed()
+        )?;
+    } else if !has_branches {
+        writeln!(
+            out,
+            "{}",
+            "Hint: run `but branch new` to create a new branch to work on".dimmed()
+        )?;
+    } else if has_uncommitted_files {
+        writeln!(
+            out,
+            "{}",
+            "Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch"
+                .dimmed()
+        )?;
+    } else {
+        writeln!(out, "{}", "Hint: run `but help` for all commands".dimmed())?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -304,27 +304,12 @@ pub(crate) async fn worktree(
         &last_checked_text,
     )?;
 
-    let first_line = common_merge_base_data.message.lines().next().unwrap_or("");
-    let connector = if upstream_state.is_some() {
-        "├╯"
-    } else {
-        "┴"
-    };
-    let first_line = out.truncate_if_unpaged(first_line, 40);
-    writeln!(
-        out,
-        "{} {} [{}] {} {first_line}",
-        connector,
-        common_merge_base_data.common_merge_base.dimmed(),
-        common_merge_base_data.target_name.green().bold(),
-        common_merge_base_data.commit_date.dimmed(),
-    )?;
+    print_common_merge_base_summary(out, &common_merge_base_data, upstream_state.is_some())?;
 
     let not_on_workspace = matches!(
         mode,
         gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
     );
-
     if not_on_workspace {
         writeln!(
             out,
@@ -428,6 +413,26 @@ fn print_upstream_state(
         )?;
     }
 
+    Ok(())
+}
+
+/// Print the common merge-base summary line at the bottom of the status tree.
+fn print_common_merge_base_summary(
+    out: &mut dyn WriteWithUtils,
+    common_merge_base_data: &CommonMergeBase,
+    has_upstream_state: bool,
+) -> anyhow::Result<()> {
+    let first_line = common_merge_base_data.message.lines().next().unwrap_or("");
+    let connector = if has_upstream_state { "├╯" } else { "┴" };
+    let first_line = out.truncate_if_unpaged(first_line, 40);
+    writeln!(
+        out,
+        "{} {} [{}] {} {first_line}",
+        connector,
+        common_merge_base_data.common_merge_base.dimmed(),
+        common_merge_base_data.target_name.green().bold(),
+        common_merge_base_data.commit_date.dimmed(),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
This moves all the printing that `but status` did into their functions rather than being contained inside the main subcommand handler.

Also moves all the required data into a `StatusContext` type so we don't have to pass so many arguments to the printing functions.

I'm investing what it would take to share the `but status` logic both for the regular CLI and a potential TUI. Nothing concrete yet, just experimenting, but this felt like a worth while refactoring nonetheless.