### PR TITLE
Fix scrollbar jitter when scrolling up in VirtualList

### DIFF
--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -455,6 +455,28 @@
 			}
 
 			await tick();
+
+			// Synchronously measure items that just entered at the top and
+			// compensate scrollTop before the browser paints. This preempts
+			// the ResizeObserver (which fires one frame late) and prevents
+			// visible jitter when measured heights differ from estimates.
+			if (start < oldStart && viewport) {
+				let heightDrift = 0;
+				for (let i = start; i < Math.min(oldStart, end); i++) {
+					const el = visibleRowElements?.[i - start];
+					if (!el) continue;
+					const measured = el.clientHeight;
+					const estimated = heightMap[i] || defaultHeight;
+					if (measured !== estimated) {
+						heightDrift += measured - estimated;
+						heightMap[i] = measured;
+					}
+				}
+				if (heightDrift !== 0) {
+					viewport.scrollTop += heightDrift;
+					skipNextScrollEvent = true;
+				}
+			}
 		}
 
 		if (visibleStart !== visibleRange.start || visibleEnd !== visibleRange.end) {
@@ -604,9 +626,11 @@
 			offset.top !== viewport.scrollTop &&
 			renderRange.start === index
 		) {
+			const compensation = heightMap[index] - oldHeight;
+			if (compensation === 0) return;
 			// When scrolling up, compensate for the height change of the topmost
 			// visible element to prevent content from jumping downward.
-			viewport.scrollBy({ top: heightMap[index] - oldHeight });
+			viewport.scrollBy({ top: compensation });
 		} else if ((lastJumpToIndex !== undefined || startIndex) && lastScrollDirection === undefined) {
 			// After jumping to an index, maintain position as off-viewport elements
 			// resize. Scroll direction is undefined during jumps.

--- a/packages/ui/src/lib/components/scroll/Scrollbar.svelte
+++ b/packages/ui/src/lib/components/scroll/Scrollbar.svelte
@@ -138,7 +138,9 @@
 			throw new Error("window.ResizeObserver is missing.");
 		}
 
-		const observerSize = new ResizeObserver(() => updateTrack());
+		const observerSize = new ResizeObserver(() => {
+			updateTrack();
+		});
 		observerSize.observe(viewport);
 
 		const content = viewport.children.item(0);
@@ -146,13 +148,21 @@
 			throw new Error("Expected to find content container");
 		}
 
-		// Sometimes the content size changes before scrollTop, so we
-		// compensate here to avoid jumpiness. The position will be reset
-		// on next scroll event.
+		// Sometimes the content size changes before the browser fires a
+		// scroll event, so we compensate here to avoid thumb jumpiness.
+		// However, if viewport.scrollTop has already been adjusted by
+		// another component (e.g. VirtualList's scroll compensation),
+		// we must use the actual value to avoid double-compensating.
 		const observerContentSize = new ResizeObserver(() => {
 			if (lastHeight) {
 				const diff = content.scrollHeight - lastHeight;
-				scrollTop = viewport.scrollTop + diff;
+				// If viewport.scrollTop diverged from our last-known value,
+				// another component (e.g. VirtualList) already compensated.
+				if (viewport.scrollTop !== scrollTop) {
+					scrollTop = viewport.scrollTop;
+				} else if (diff !== 0) {
+					scrollTop = viewport.scrollTop + diff;
+				}
 			}
 			lastHeight = content.scrollHeight;
 		});


### PR DESCRIPTION
When the VirtualList render range expanded upward, newly-added items
could have actual heights differing from estimates. The
ResizeObserver would correct the scroll position one frame late, causing
visible jitter. Fix by synchronously measuring new items after tick()
and compensating scrollTop before the browser paints.Also fix
Scrollbar's contentResize observer double-compensating itsthumb position
when VirtualList had already adjusted scrollTop.