### PR TITLE
Refactor but-api transport return types so `but_api` macro performs the JSON conversion

### DIFF
--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -73,10 +73,12 @@ pub fn absorb_impl(
             repo,
             data_dir,
         )?;
-        for mapping in &outcome.commit_mapping {
-            commit_map.add_mapping(mapping.0, mapping.1);
+        if let Some(rebase_output) = &outcome.rebase_output {
+            for (_base, old, new) in &rebase_output.commit_mapping {
+                commit_map.add_mapping(*old, *new);
+            }
         }
-        total_rejected += outcome.paths_to_rejected_changes.len();
+        total_rejected += outcome.rejected_specs.len();
     }
     Ok(total_rejected)
 }

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -69,15 +69,13 @@ pub fn pr_template(
         .context("PR template was not valid UTF-8")
 }
 
-mod json {
-    /// Information about the project's review template.
-    #[derive(Debug, Clone, serde::Serialize)]
-    pub struct ReviewTemplateInfo {
-        /// The relative path to the review template within the repository.
-        pub path: String,
-        /// The content of the review template.
-        pub content: String,
-    }
+/// Information about the project's review template.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReviewTemplateInfo {
+    /// The relative path to the review template within the repository.
+    pub path: String,
+    /// The content of the review template.
+    pub content: String,
 }
 
 /// Get the review template content for the given project and relative path.
@@ -86,7 +84,7 @@ mod json {
 /// from the git config.
 #[but_api]
 #[instrument(err(Debug))]
-pub fn review_template(ctx: &Context) -> Result<Option<json::ReviewTemplateInfo>> {
+pub fn review_template(ctx: &Context) -> Result<Option<ReviewTemplateInfo>> {
     let project = gitbutler_project::get_validated(ctx.legacy_project.id.clone())?;
     let ctx = Context::new_from_legacy_project(project.clone())?;
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
@@ -117,7 +115,7 @@ pub fn review_template(ctx: &Context) -> Result<Option<json::ReviewTemplateInfo>
                 .content
                 .context("PR template was not valid UTF-8")?;
 
-            Ok(Some(json::ReviewTemplateInfo {
+            Ok(Some(ReviewTemplateInfo {
                 path: template_path,
                 content,
             }))

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -269,7 +269,7 @@ pub fn branch_details(
 /// hunks would fail.
 /// `stack_branch_name` is the short name of the reference that the UI knows is present in a given segment.
 /// It is necessary to insert the new commit into the right bucket.
-#[but_api]
+#[but_api(commit_engine::ui::CreateCommitOutcome)]
 #[instrument(err(Debug))]
 pub fn create_commit_from_worktree_changes(
     ctx: &mut but_ctx::Context,
@@ -278,7 +278,7 @@ pub fn create_commit_from_worktree_changes(
     worktree_changes: Vec<but_core::DiffSpec>,
     message: String,
     stack_branch_name: String,
-) -> Result<commit_engine::ui::CreateCommitOutcome> {
+) -> Result<commit_engine::CreateCommitOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     let snapshot_tree = ctx.prepare_snapshot(guard.read_permission());
 
@@ -302,8 +302,7 @@ pub fn create_commit_from_worktree_changes(
         )
     });
 
-    let outcome = outcome?;
-    Ok(outcome.into())
+    outcome
 }
 
 /// Amend all `changes` to `commit_id`, keeping its commit message exactly as is.
@@ -311,14 +310,14 @@ pub fn create_commit_from_worktree_changes(
 /// All `changes` are meant to be relative to the worktree.
 /// Note that submodules *must* be provided as diffspec without hunks, as attempting to generate
 /// hunks would fail.
-#[but_api]
+#[but_api(commit_engine::ui::CreateCommitOutcome)]
 #[instrument(err(Debug))]
 pub fn amend_commit_from_worktree_changes(
     ctx: &mut Context,
     stack_id: StackId,
     commit_id: gix::ObjectId,
     worktree_changes: Vec<but_core::DiffSpec>,
-) -> Result<commit_engine::ui::CreateCommitOutcome> {
+) -> Result<commit_engine::CreateCommitOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     let repo = ctx.repo.get()?;
     let data_dir = ctx.project_data_dir();
@@ -340,7 +339,7 @@ pub fn amend_commit_and_count_failures(
     guard: &mut RepoExclusiveGuard,
     repo: &gix::Repository,
     data_dir: &std::path::Path,
-) -> anyhow::Result<commit_engine::ui::CreateCommitOutcome> {
+) -> anyhow::Result<commit_engine::CreateCommitOutcome> {
     let app_settings = AppSettings::load_from_default_path_creating_without_customization()?;
     let outcome = but_workspace::legacy::commit_engine::create_commit_and_update_refs_with_project(
         repo,
@@ -358,7 +357,7 @@ pub fn amend_commit_and_count_failures(
     if !outcome.rejected_specs.is_empty() {
         tracing::warn!(?outcome.rejected_specs, "Failed to commit at least one hunk");
     }
-    Ok(outcome.into())
+    Ok(outcome)
 }
 
 /// Discard all worktree changes that match the specs in `worktree_changes`.
@@ -408,7 +407,7 @@ mod json {
     }
 }
 
-#[but_api]
+#[but_api(json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn move_changes_between_commits(
     ctx: &mut Context,
@@ -417,7 +416,7 @@ pub fn move_changes_between_commits(
     destination_stack_id: StackId,
     destination_commit_id: gix::ObjectId,
     changes: Vec<but_core::DiffSpec>,
-) -> Result<json::UIMoveChangesResult> {
+) -> Result<but_workspace::legacy::MoveChangesResult> {
     let mut guard = ctx.exclusive_worktree_access();
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::AmendCommit),
@@ -437,10 +436,10 @@ pub fn move_changes_between_commits(
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     update_workspace_commit(&vb_state, ctx, false)?;
 
-    Ok(result.into())
+    Ok(result)
 }
 
-#[but_api]
+#[but_api(json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn split_branch(
     ctx: &mut Context,
@@ -448,7 +447,7 @@ pub fn split_branch(
     source_branch_name: String,
     new_branch_name: String,
     file_changes_to_split_off: Vec<String>,
-) -> Result<json::UIMoveChangesResult> {
+) -> Result<but_workspace::legacy::MoveChangesResult> {
     let mut guard = ctx.exclusive_worktree_access();
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::SplitBranch),
@@ -482,10 +481,10 @@ pub fn split_branch(
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
     ws.refresh_from_head(&repo, &meta)?;
 
-    Ok(move_changes_result.into())
+    Ok(move_changes_result)
 }
 
-#[but_api]
+#[but_api(json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn split_branch_into_dependent_branch(
     ctx: &mut but_ctx::Context,
@@ -493,7 +492,7 @@ pub fn split_branch_into_dependent_branch(
     source_branch_name: String,
     new_branch_name: String,
     file_changes_to_split_off: Vec<String>,
-) -> Result<json::UIMoveChangesResult> {
+) -> Result<but_workspace::legacy::MoveChangesResult> {
     let mut guard = ctx.exclusive_worktree_access();
 
     let _ = ctx.create_snapshot(
@@ -513,7 +512,7 @@ pub fn split_branch_into_dependent_branch(
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     update_workspace_commit(&vb_state, ctx, false)?;
 
-    Ok(move_changes_result.into())
+    Ok(move_changes_result)
 }
 
 /// Uncommits the changes specified in the `diffspec`.
@@ -521,7 +520,7 @@ pub fn split_branch_into_dependent_branch(
 /// If `assign_to` is provided, the changes will be assigned to the stack
 /// specified.
 /// If `assign_to` is not provided, the changes will be unassigned.
-#[but_api]
+#[but_api(json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn uncommit_changes(
     ctx: &mut Context,
@@ -529,7 +528,7 @@ pub fn uncommit_changes(
     commit_id: gix::ObjectId,
     changes: Vec<but_core::DiffSpec>,
     assign_to: Option<StackId>,
-) -> Result<json::UIMoveChangesResult> {
+) -> Result<but_workspace::legacy::MoveChangesResult> {
     let mut guard = ctx.exclusive_worktree_access();
     let _ = ctx.create_snapshot(
         SnapshotDetails::new(OperationKind::DiscardChanges),
@@ -608,20 +607,20 @@ pub fn uncommit_changes(
         )?;
     }
 
-    Ok(result.into())
+    Ok(result)
 }
 
 /// This API allows the user to quickly "stash" a bunch of uncommitted changes - getting them out of the worktree.
 /// Unlike the regular stash, the user specifies a new branch where those changes will be 'saved'/committed.
 /// Immediately after the changes are committed, the branch is unapplied from the workspace, and the "stash" branch can be re-applied at a later time
 /// In theory it should be possible to specify an existing "dumping" branch for this, but currently this endpoint expects a new branch.
-#[but_api]
+#[but_api(commit_engine::ui::CreateCommitOutcome)]
 #[instrument(err(Debug))]
 pub fn stash_into_branch(
     ctx: &mut Context,
     branch_name: String,
     worktree_changes: Vec<but_core::DiffSpec>,
-) -> Result<commit_engine::ui::CreateCommitOutcome> {
+) -> Result<commit_engine::CreateCommitOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     let perm = guard.write_permission();
 
@@ -670,8 +669,7 @@ pub fn stash_into_branch(
         ctx.settings.feature_flags.cv3,
     )?;
 
-    let outcome = outcome?;
-    Ok(outcome.into())
+    outcome
 }
 
 /// Returns a new available branch name based on a simple template - user_initials-branch-count

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -19,9 +19,9 @@ use tracing::instrument;
 
 use crate::json::HexHash;
 
-#[but_api(napi)]
+#[but_api(napi, try_from = but_workspace::ui::RefInfo)]
 #[instrument(err(Debug))]
-pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::ui::RefInfo> {
+pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.legacy_meta()?;
     but_workspace::head_info(
@@ -32,10 +32,7 @@ pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::ui::RefInfo> {
             expensive_commit_info: true,
         },
     )
-    .and_then(|info| {
-        but_workspace::ui::RefInfo::for_ui(info, &repo)
-            .map(|ref_info| ref_info.pruned_to_entrypoint())
-    })
+    .map(|info| info.pruned_to_entrypoint())
 }
 
 #[but_api]

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -70,12 +70,13 @@ pub struct RefInfo {
     /// The name of the ref that points to a workspace commit,
     /// *or* the name of the first stack segment, along with worktree information.
     pub workspace_ref_info: Option<but_graph::RefInfo>,
-    /// Symbolic remote names known when the ref info was computed.
+    /// Symbolic remote names known when the ref info was created, based on all known remotes.
+    /// The order is shortest to longest.
     ///
     /// These are carried along so UI conversions can resolve remote-tracking references
-    /// without needing repository access. That is, they can now if `refs/remotes/name/foo/bar`
+    /// without needing repository access. That is, they can know if `refs/remotes/name/foo/bar`
     /// has the symbolic remote `name/foo` or just `name`.
-    pub symbolic_remote_names: Vec<String>,
+    pub symbolic_remote_names: gix::remote::Names<'static>,
     /// The stacks visible in the current workspace.
     ///
     /// This is an empty array if the `HEAD` is unborn.

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -70,6 +70,12 @@ pub struct RefInfo {
     /// The name of the ref that points to a workspace commit,
     /// *or* the name of the first stack segment, along with worktree information.
     pub workspace_ref_info: Option<but_graph::RefInfo>,
+    /// Symbolic remote names known when the ref info was computed.
+    ///
+    /// These are carried along so UI conversions can resolve remote-tracking references
+    /// without needing repository access. That is, they can now if `refs/remotes/name/foo/bar`
+    /// has the symbolic remote `name/foo` or just `name`.
+    pub symbolic_remote_names: Vec<String>,
     /// The stacks visible in the current workspace.
     ///
     /// This is an empty array if the `HEAD` is unborn.
@@ -116,6 +122,25 @@ pub struct RefInfo {
     pub ancestor_workspace_commit: Option<AncestorWorkspaceCommit>,
     /// The workspace represents what `HEAD` is pointing to.
     pub is_entrypoint: bool,
+}
+
+impl RefInfo {
+    /// Keep only the stack and segment that contains the entrypoint.
+    pub fn pruned_to_entrypoint(mut self) -> Self {
+        if self.is_entrypoint {
+            return self;
+        }
+        self.stacks
+            .retain(|s| s.segments.iter().any(|s| s.is_entrypoint));
+        if let Some(only_stack) = self.stacks.first_mut() {
+            let mut found_entrypoint = false;
+            only_stack.segments.retain(|s| {
+                found_entrypoint |= s.is_entrypoint;
+                found_entrypoint
+            })
+        }
+        self
+    }
 }
 
 /// Describes a workspace commit that is in the ancestry of a managed workspace reference,

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -463,9 +463,14 @@ pub(crate) mod function {
             }
             WorkspaceKind::AdHoc => (graph[id].ref_info.clone(), false, None),
         };
+        let is_entrypoint = graph.lookup_entrypoint()?.segment_index == id;
         let mut info = RefInfo {
             workspace_ref_info,
-            symbolic_remote_names: graph.symbolic_remote_names.clone(),
+            symbolic_remote_names: repo
+                .remote_names()
+                .into_iter()
+                .map(|n| n.into_owned().into())
+                .collect(),
             lower_bound: lower_bound_segment_id,
             extra_target,
             stacks: stacks
@@ -483,7 +488,7 @@ pub(crate) mod function {
             is_managed_ref: metadata.is_some(),
             is_managed_commit,
             ancestor_workspace_commit,
-            is_entrypoint: graph.lookup_entrypoint()?.segment_index == id,
+            is_entrypoint,
         };
 
         if let Some(info) = &info.ancestor_workspace_commit {

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -465,6 +465,7 @@ pub(crate) mod function {
         };
         let mut info = RefInfo {
             workspace_ref_info,
+            symbolic_remote_names: graph.symbolic_remote_names.clone(),
             lower_bound: lower_bound_segment_id,
             extra_target,
             stacks: stacks

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -191,10 +191,10 @@ pub(crate) mod inner {
 }
 
 impl inner::RefInfo {
-    /// The `repo` is used just to get ref-names, for convenience.
-    pub fn for_ui(
+    fn try_from_ref_info(
         crate::RefInfo {
             workspace_ref_info,
+            symbolic_remote_names,
             stacks,
             target_ref,
             target_commit: _,
@@ -205,9 +205,11 @@ impl inner::RefInfo {
             ancestor_workspace_commit: _,
             is_entrypoint,
         }: crate::RefInfo,
-        repo: &gix::Repository,
     ) -> anyhow::Result<Self> {
-        let remote_names = repo.remote_names();
+        let remote_names: gix::remote::Names<'static> = symbolic_remote_names
+            .iter()
+            .map(|name| std::borrow::Cow::Owned(name.clone().into()))
+            .collect();
         let stacks: Vec<_> = stacks
             .into_iter()
             .map(|stack| Stack::for_ui(stack, &remote_names))
@@ -222,6 +224,14 @@ impl inner::RefInfo {
             is_managed_commit,
             is_entrypoint,
         })
+    }
+}
+
+impl TryFrom<crate::RefInfo> for inner::RefInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: crate::RefInfo) -> Result<Self, Self::Error> {
+        Self::try_from_ref_info(value)
     }
 }
 

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -206,19 +206,15 @@ impl inner::RefInfo {
             is_entrypoint,
         }: crate::RefInfo,
     ) -> anyhow::Result<Self> {
-        let remote_names: gix::remote::Names<'static> = symbolic_remote_names
-            .iter()
-            .map(|name| std::borrow::Cow::Owned(name.clone().into()))
-            .collect();
         let stacks: Vec<_> = stacks
             .into_iter()
-            .map(|stack| Stack::for_ui(stack, &remote_names))
+            .map(|stack| Stack::for_ui(stack, &symbolic_remote_names))
             .collect::<Result<_, _>>()?;
         Ok(inner::RefInfo {
             workspace_ref: workspace_ref_info.map(|ri| ri.ref_name.into()),
             stacks,
             target: target_ref
-                .map(|t| Target::for_ui(t, &remote_names))
+                .map(|t| Target::for_ui(t, &symbolic_remote_names))
                 .transpose()?,
             is_managed_ref,
             is_managed_commit,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -30,13 +30,13 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
             "ws-ref-ws-commit-one-stack-ws-advanced",
             |_meta| {},
         )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 0d01196 (HEAD -> gitbutler/workspace) O1
     * 4979833 GitButler Workspace Commit
     * 3183e43 (main, B, A) M1
     ");
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡:2:anon: on 3183e43
         └── :2:anon:
@@ -91,7 +91,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:B on e5d0542 {1}
         └── 📙:2:B
@@ -100,7 +100,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     // Applying A is always a new stack then.
     let out =
         but_workspace::branch::apply(r("refs/heads/A"), &ws, &repo, &mut meta, default_options())?;
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -121,7 +121,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
             |_meta| {},
         )?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 6b40b15 (origin/feature) without-local-tracking
     | * 552e7dc (origin/main) only-on-remote
     |/  
@@ -174,7 +174,7 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     "#);
     let ws = out.workspace.into_owned();
     // both branches, main and feature, are available in the newly created workspace ref.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:2:feature on 3183e43 {2ec}
     │   └── 📙:2:feature
@@ -227,7 +227,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     ");
 
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:5:outside →:3: on 3183e43 {1}
     │   └── 📙:5:outside →:3:
@@ -253,7 +253,7 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     }
     "#);
 
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:feature on 3183e43 {2ec}
     │   └── 📙:4:feature
@@ -291,7 +291,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
@@ -310,7 +310,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     "#);
     // Note how it will create a new stack (to keep it simple),
     // in theory we could also add B as dependent branch.
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {42}
     │   └── 📙:3:B
@@ -371,7 +371,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     }
     "#);
 
-    insta::assert_snapshot!(graph_workspace(&out.workspace), @r"
+    insta::assert_snapshot!(graph_workspace(&out.workspace), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -401,7 +401,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:4:A on e5d0542 {41}
     │   └── 📙:4:A
@@ -425,7 +425,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         .graph
         .redo_traversal_with_overlay(&repo, &meta, Overlay::default())?
         .into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon: {41}
         └── :1:anon:
@@ -443,13 +443,13 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
         },
     )?;
     // A workspace commit was created, even though it does nothing.
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 6277161 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e5d0542 (origin/main, main, B, A) A
     ");
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡📙:2:A {41}
         └── 📙:2:A
@@ -475,7 +475,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     ");
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -518,7 +518,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     └── ≡📙:3:A on e5d0542 {41}
         └── 📙:3:A
@@ -537,7 +537,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
     ├── ≡📙:4:B on e5d0542 {42}
     │   └── 📙:4:B
@@ -600,7 +600,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
 
     let ws = out.workspace.into_owned();
     // This apply brings both branches into the existing workspace, and it's where HEAD points to.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:A on e5d0542 {41}
     │   └── 📙:3:A
@@ -621,7 +621,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
             meta.data_mut().default_target = None;
         })?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * bf53300 (A) add A
     | * b1540e5 (HEAD -> main) M
     |/  
@@ -652,7 +652,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:2:A on e31e6ca {41}
     │   └── 📙:2:A
@@ -689,7 +689,7 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
     ├── ≡📙:3:B on e31e6ca {42}
     │   └── 📙:3:B
@@ -722,7 +722,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
             "single-stack-two-segments",
             |_meta| {},
         )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f1889e7 (A2) add A2
     * 7de99e1 (A1) add A1
     | * 53ad0c2 (unrelated) add U1
@@ -758,7 +758,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     }
     "#);
     // TODO: should this not avoid creating a workspace commit?
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f1889e7 (A2) add A2
     * 7de99e1 (A1) add A1
     | * 6848743 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
@@ -780,7 +780,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A1 on 3183e43 {72}
     │   └── 📙:4:A1
@@ -810,7 +810,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     ├── ≡📙:4:A2 on 3183e43 {73}
     │   ├── 📙:4:A2
@@ -875,7 +875,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
             "detached-with-multiple-branches",
             |_meta| {},
         )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 49d4b34 (A) A1
     | * f57c528 (B) B1
     |/  
@@ -903,7 +903,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     └── ≡📙:2:C on 3183e43 {43}
         └── 📙:2:C
@@ -911,7 +911,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
     // A new workspace reference was created, and checked out, without enforcing a workspace commit
     // as there is no need.
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 49d4b34 (A) A1
     | * f57c528 (B) B1
     |/  
@@ -943,7 +943,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     ");
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:3:B on 3183e43 {42}
     │   └── 📙:3:B
@@ -973,7 +973,7 @@ fn detached_head_journey() -> anyhow::Result<()> {
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:B on 3183e43 {42}
     │   └── 📙:4:B
@@ -1009,7 +1009,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
                 add_stack_with_segments(meta, 2, "B", StackState::Inactive, &["D"]);
             },
         )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (HEAD -> main, origin/main) M
@@ -1034,7 +1034,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:E on 85efbe4 {1}
         └── 📙:4:E
@@ -1046,7 +1046,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let out =
         but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())?;
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {43}
     │   └── 📙:5:C
@@ -1072,7 +1072,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     let out =
         but_workspace::branch::apply(r("refs/heads/B"), &ws, &repo, &mut meta, default_options())?;
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:6:B on 7076dee {2}
     │   └── 📙:6:B
@@ -1089,7 +1089,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
         but_workspace::branch::apply(r("refs/heads/C"), &ws, &repo, &mut meta, default_options())
             .unwrap();
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:5:C on 7076dee {2}
     │   ├── 📙:5:C
@@ -1110,7 +1110,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             "no-ws-ref-stack-and-dependent-branch",
             |_meta| {},
         )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
     * 85efbe4 (HEAD -> main, origin/main) M
@@ -1134,14 +1134,14 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:3:A on 85efbe4 {41}
         └── 📙:3:A
             ├── ·f084d61 (🏘️) ►B, ►C
             └── ·7076dee (🏘️) ►D, ►E
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 773e030 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
@@ -1161,7 +1161,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     └── ≡📙:4:B on 85efbe4 {41}
         ├── 📙:4:B
@@ -1169,7 +1169,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
             ├── ·f084d61 (🏘️) ►C
             └── ·7076dee (🏘️) ►D, ►E
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * b390237 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f084d61 (C, B, A) A2
     * 7076dee (E, D) A1
@@ -1188,7 +1188,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
             |_meta| {},
         )?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * d3cce74 (clean-A) add A
     | * 115e41b (clean-B) add B
     |/  
@@ -1235,7 +1235,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
         ws = out.workspace.into_owned();
     }
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:clean-C on 85efbe4 {273}
     │   └── 📙:6:clean-C
@@ -1297,7 +1297,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     "#);
     let ws = out.workspace.into_owned();
     // By default, it fails and just reports the conflicting stacks, so it's the same as it was before.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:6:clean-C on 85efbe4 {273}
     │   └── 📙:6:clean-C
@@ -1355,7 +1355,7 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
 
     // Now the other stacks are unapplied.
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
     ├── ≡📙:5:conflict-hero on 85efbe4 {52d}
     │   └── 📙:5:conflict-hero
@@ -1498,7 +1498,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
 
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
     │   └── 📙:3:B
@@ -1530,7 +1530,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         standard_traversal_options_with_extra_target(&repo),
     )?
     .into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡👉📙:3:B on e5d0542 {2}
     │   └── 👉📙:3:B
@@ -1561,7 +1561,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
 
     // Now the workspace ref itself is checked out.
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     ├── ≡📙:3:B on e5d0542 {2}
     │   └── 📙:3:B
@@ -1584,7 +1584,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
         standard_traversal_options_with_extra_target(&repo),
     )?
     .into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡👉📙:2:B on e5d0542 {2}
         ├── 👉📙:2:B
@@ -1624,7 +1624,7 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     }
     "#);
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
     └── ≡📙:2:A on e5d0542 {41}
         └── 📙:2:A
@@ -1657,7 +1657,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     ");
 
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
@@ -1682,7 +1682,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     let ws =
         but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?
             .into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡👉📙:0:B on 85efbe4 {2}
     │   └── 👉📙:0:B
@@ -1724,7 +1724,7 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     "#);
 
     let ws = out.workspace.into_owned();
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
     ├── ≡📙:4:B on 85efbe4 {2}
     │   └── 📙:4:B
@@ -1749,7 +1749,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
         .sha = gix::hash::Kind::Sha1.null();
     let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
     └── ≡:1:anon:
         └── :1:anon:

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -64,7 +64,7 @@ mod with_workspace {
             .sha = gix::hash::Kind::Sha1.null();
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
         └── ≡:1:main
             └── :1:main
@@ -115,7 +115,7 @@ mod with_workspace {
             None,
         )
         .expect("it updates the workspace metadata legitimate the new ref at base");
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {41}
             └── 📙:3:A
@@ -137,7 +137,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
         │   └── 📙:4:B
@@ -155,7 +155,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {42}
         │   └── 📙:4:B
@@ -176,7 +176,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   └── 📙:5:B
@@ -198,7 +198,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   ├── 📙:5:B
@@ -214,7 +214,7 @@ mod with_workspace {
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   ├── 📙:5:B
@@ -232,7 +232,7 @@ mod with_workspace {
     #[test]
     fn journey_single_branch_segment_anchor() -> anyhow::Result<()> {
         let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-4-commits")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 05240ea (HEAD -> gitbutler/workspace) GitButler Workspace Commit
         * 43f9472 (A) A2
         * 6fdab32 A1
@@ -243,7 +243,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:3:A on bce0c5e
             └── :3:A
@@ -267,7 +267,7 @@ mod with_workspace {
         )?;
         // It handles this special case, by creating the necessary workspace metadata
         // if for some reason (like manual building) it's not set.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:4:A on bce0c5e {4cf}
             ├── :4:A
@@ -290,7 +290,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡:4:A on bce0c5e {4cf}
             ├── :4:A
@@ -318,7 +318,7 @@ mod with_workspace {
         // Note how 'Above' *a commit* means directly above, not on top of everything.
         // And as there are now two references on one commit, and one has metadata, the other one doesn't,
         // 'A' is moved to the background.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:3:above-A-commit on bce0c5e {4cf}
             ├── 📙:3:above-A-commit
@@ -344,7 +344,7 @@ mod with_workspace {
         )?;
 
         // And 'A' is back, with the desired order correctly restored.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
@@ -371,7 +371,7 @@ mod with_workspace {
         )?;
 
         // *Above a segment means what one would expect though.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
@@ -397,7 +397,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
@@ -423,7 +423,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         └── ≡📙:5:above-A-commit on bce0c5e {4cf}
             ├── 📙:5:above-A-commit
@@ -448,7 +448,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:B on bce0c5e {42}
         │   └── 📙:5:B
@@ -478,7 +478,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
@@ -511,7 +511,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
@@ -535,7 +535,7 @@ mod with_workspace {
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
         ├── ≡📙:5:above-B on bce0c5e {42}
         │   ├── 📙:5:above-B
@@ -553,7 +553,7 @@ mod with_workspace {
             └── 📙:14:bottom
         ");
 
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 05240ea (HEAD -> gitbutler/workspace) GitButler Workspace Commit
         * 43f9472 (above-A-commit, above-A, A) A2
         * 6fdab32 (below-A-commit, below-A, above-bottom) A1
@@ -567,7 +567,7 @@ mod with_workspace {
     fn journey_single_branch_no_ws_commit_segment_anchor() -> anyhow::Result<()> {
         let (_tmp, repo, mut meta) =
             named_writable_scenario("single-branch-3-commits-no-ws-commit")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * c2878fb (HEAD -> gitbutler/workspace, A) A2
         * 49d4b34 A1
         * 3183e43 (origin/main, main) M1
@@ -578,7 +578,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
@@ -600,7 +600,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:4:A on 3183e43 {0}
             ├── 📙:4:A
@@ -625,7 +625,7 @@ mod with_workspace {
 
         // We can create branches that would be on the base.
         // There are
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:4:A on 3183e43 {0}
             ├── 📙:4:A
@@ -651,7 +651,7 @@ mod with_workspace {
         )?;
 
         // Note how 'Above' *a commit* means directly above, not on top of everything.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:A on 3183e43 {0}
             ├── 📙:5:A
@@ -678,7 +678,7 @@ mod with_workspace {
         )?;
 
         // *Above a segment means what one would expect though.
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
@@ -706,7 +706,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
@@ -732,7 +732,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
@@ -758,7 +758,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:5:above-A on 3183e43 {0}
             ├── 📙:5:above-A
@@ -783,7 +783,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:B on 3183e43 {42}
         │   └── 📙:5:B
@@ -813,7 +813,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
@@ -846,7 +846,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
@@ -870,7 +870,7 @@ mod with_workspace {
         let meta = VirtualBranchesTomlMetadata::from_path(path)?;
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:5:above-B on 3183e43 {42}
         │   ├── 📙:5:above-B
@@ -888,7 +888,7 @@ mod with_workspace {
             └── 📙:14:bottom
         ");
 
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * c2878fb (HEAD -> gitbutler/workspace, above-A-commit, above-A, A) A2
         * 49d4b34 (below-A-commit, below-A, above-bottom) A1
         * 3183e43 (origin/main, main, bottom, below-B, above-B, B) M1
@@ -900,7 +900,7 @@ mod with_workspace {
     fn journey_single_branch_no_ws_commit_commit_anchor() -> anyhow::Result<()> {
         let (_tmp, repo, mut meta) =
             named_writable_scenario("single-branch-3-commits-no-ws-commit")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * c2878fb (HEAD -> gitbutler/workspace, A) A2
         * 49d4b34 A1
         * 3183e43 (origin/main, main) M1
@@ -911,7 +911,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
@@ -934,7 +934,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             ├── 📙:3:A
@@ -963,7 +963,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
         let ws = graph.into_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   └── 📙:4:B
@@ -987,7 +987,7 @@ mod with_workspace {
             stack_id_for_name,
             None,
         )?;
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   └── 📙:4:B
@@ -1013,7 +1013,7 @@ mod with_workspace {
             None,
         )?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         ├── ≡📙:4:B on 3183e43 {1}
         │   ├── 📙:4:B
@@ -1033,7 +1033,7 @@ mod with_workspace {
             "with-remotes-and-workspace",
             "single-branch-no-ws-commit",
         )?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * bce0c5e (HEAD -> gitbutler/workspace, main) M2
         * 3183e43 (origin/main) M1
         ");
@@ -1089,7 +1089,7 @@ mod with_workspace {
             "with-remotes-and-workspace",
             "single-branch-two-commits-no-ws-commit",
         )?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * bba50eb (extra) E1
         * c2878fb (HEAD -> gitbutler/workspace, A) A2
         * 49d4b34 A1
@@ -1101,7 +1101,7 @@ mod with_workspace {
         let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
         let ws = graph.into_workspace()?;
 
-        insta::assert_snapshot!(graph_workspace(&ws), @r"
+        insta::assert_snapshot!(graph_workspace(&ws), @"
         📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
         └── ≡📙:3:A on 3183e43 {0}
             └── 📙:3:A
@@ -1257,7 +1257,7 @@ fn errors() -> anyhow::Result<()> {
 
     let (repo, mut meta) =
         named_read_only_in_memory_scenario("with-remotes-no-workspace", "remote")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 89cc2d3 (A) change in A
     * d79bba9 new file in A
     * c166d42 (HEAD -> main) init-integration
@@ -1463,7 +1463,7 @@ fn errors() -> anyhow::Result<()> {
 #[test]
 fn journey_with_commits() -> anyhow::Result<()> {
     let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 281da94 (HEAD -> main) 3
     * 12995d7 2
     * 3d57fc1 1
@@ -1639,7 +1639,7 @@ fn journey_with_commits() -> anyhow::Result<()> {
 #[test]
 fn journey_anon_workspace() -> anyhow::Result<()> {
     let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-with-3-commits")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 281da94 (HEAD -> main) 3
     * 12995d7 2
     * 3d57fc1 1

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -74,14 +74,14 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
         },
     )?;
     insta::assert_snapshot!(desc, @"Single commit, target, no ws commit, but ws-reference and a named segment, and branches on each commit");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c2878fb (HEAD -> gitbutler/workspace, A2, A) A2
     * 49d4b34 (A1) A1
     * 3183e43 (origin/main, main) M1
     ");
 
     let mut ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡📙:3:A on 3183e43 {0}
         ├── 📙:3:A
@@ -108,7 +108,7 @@ fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
     }
 
     let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
     └── ≡:3:anon: on 3183e43
         └── :3:anon:
@@ -135,7 +135,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     )?;
 
     insta::assert_snapshot!(desc, @"Two commits in main, target setup, ws commit, many more usable branches");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 05240ea (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 43f9472 (A2-3, A2-2, A2-1, A) A2
     * 6fdab32 (A1-3, A1-2, A1-1) A1
@@ -143,7 +143,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
     * 3183e43 M1
     ");
     let mut ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:5:A on bce0c5e {0}
         ├── 📙:5:A
@@ -173,7 +173,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
         )?
         .expect("we deleted something");
     }
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:3:A1-1 on bce0c5e {0}
         ├── 📙:3:A1-1
@@ -198,7 +198,7 @@ fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
         .expect("we deleted something");
     }
     // Just one segment left.
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
     └── ≡📙:3:A1-3 on bce0c5e {0}
         └── 📙:3:A1-3
@@ -241,7 +241,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (HEAD -> gitbutler/workspace, main, E, D, C, B, A) M1");
 
     let ws = graph.into_workspace()?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
     │   ├── 📙:5:D
@@ -265,7 +265,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     )?
     .expect("we deleted something");
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
     │   ├── 📙:4:D
@@ -284,7 +284,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
     )?;
 
     let ws = ws.graph.into_workspace_of_redone_traversal(&repo, &meta)?;
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:5:D on 3183e43 {1}
     │   ├── 📙:5:D
@@ -310,7 +310,7 @@ fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
         "recreate ref - this time it's not visible as it lacks metadata",
     )?;
 
-    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
     ├── ≡📙:4:D on 3183e43 {1}
     │   ├── 📙:4:D

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -79,7 +79,7 @@ mod with_workspace {
         let repo =
             read_only_in_memory_scenario_named("with-remotes-no-workspace", "nothing-to-push")?;
 
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 89cc2d3 (HEAD -> A, origin/A) change in A
         * d79bba9 new file in A
         * c166d42 (origin/main, origin/HEAD, main) init-integration
@@ -131,7 +131,7 @@ mod with_workspace {
             "with-remotes-no-workspace",
             "remote-tracking-advanced-ff",
         )?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 89cc2d3 (origin/A) change in A
         * d79bba9 (HEAD -> A) new file in A
         * c166d42 (origin/main, origin/HEAD, main) init-integration
@@ -212,7 +212,7 @@ mod with_workspace {
     fn remote_tracking_diverged() -> anyhow::Result<()> {
         let repo =
             read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 1a265a4 (HEAD -> A) local change in A
         | * 89cc2d3 (origin/A) change in A
         |/  

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -12,7 +12,7 @@ use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_
 fn insert_below_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -26,7 +26,7 @@ fn insert_below_commit() -> Result<()> {
         .0
         .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 70ba329 (HEAD -> three) commit three
     * 0f4f9d0 (two) commit two
     * b3b14c2 
@@ -44,7 +44,7 @@ fn insert_below_commit() -> Result<()> {
 fn insert_above_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -58,7 +58,7 @@ fn insert_above_commit() -> Result<()> {
         .0
         .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 8e87ff3 (HEAD -> three) commit three
     * 024b774 (two) 
     * 16fd221 (origin/two) commit two
@@ -74,7 +74,7 @@ fn insert_above_commit() -> Result<()> {
 fn insert_below_reference() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -92,7 +92,7 @@ fn insert_below_reference() -> Result<()> {
     .0
     .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 8e87ff3 (HEAD -> three) commit three
     * 024b774 (two) 
     * 16fd221 (origin/two) commit two
@@ -108,7 +108,7 @@ fn insert_below_reference() -> Result<()> {
 fn insert_above_reference() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -126,7 +126,7 @@ fn insert_above_reference() -> Result<()> {
     .0
     .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 8e87ff3 (HEAD -> three) commit three
     * 024b774 
     * 16fd221 (origin/two, two) commit two

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -20,7 +20,7 @@ mod from_new_merge_with_metadata {
     fn without_conflict_journey() -> anyhow::Result<()> {
         let (repo, mut meta) =
             named_read_only_in_memory_scenario("various-heads-for-clean-merge", "")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * d3cce74 (add-A) add A
         | * 115e41b (add-B) add B
         |/  
@@ -43,7 +43,7 @@ mod from_new_merge_with_metadata {
         )?;
         let commit = out.workspace_commit_id.attach(&repo).object()?;
         // This commit is never signed.
-        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        insta::assert_snapshot!(commit.data.as_bstr(), @"
         tree f53c91092dbda83f3565e78c285f3e2ab0cfd968
         parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
         author GitButler <gitbutler@gitbutler.com> 946771200 +0000
@@ -107,7 +107,7 @@ mod from_new_merge_with_metadata {
         "#);
         let commit = out.workspace_commit_id.attach(&repo).object()?;
         // This commit is never signed.
-        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        insta::assert_snapshot!(commit.data.as_bstr(), @"
         tree 94e1f0c26d5b13dc3a95a88e64d82155373b5780
         parent 27ab782831b1145249092d54c520a15bb6425cda
         parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
@@ -154,7 +154,7 @@ mod from_new_merge_with_metadata {
     fn with_multi_line_conflict_journey() -> anyhow::Result<()> {
         let (repo, mut meta) =
             named_read_only_in_memory_scenario("various-heads-for-multi-line-merge-conflict", "")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * d3cce74 (clean-A) add A
         | * 115e41b (clean-B) add B
         |/  
@@ -263,7 +263,7 @@ mod from_new_merge_with_metadata {
     fn with_conflict_commits() -> anyhow::Result<()> {
         let (_tmp, mut graph, repo, mut meta, _description) =
             named_writable_scenario_with_description_and_graph("with-conflict", |_| {})?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 8450331 (HEAD -> main, tag: conflicted) GitButler WIP Commit
         * a047f81 (tag: normal) init
         ");
@@ -276,7 +276,7 @@ mod from_new_merge_with_metadata {
             "#,
             &repo,
         );
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * 8450331 (tag: conflicted, tip-conflicted) GitButler WIP Commit
         | * 8ab1c4d (HEAD -> unrelated) unrelated
         |/  
@@ -336,7 +336,7 @@ mod from_new_merge_with_metadata {
     fn with_conflict_journey() -> anyhow::Result<()> {
         let (repo, mut meta) =
             named_read_only_in_memory_scenario("various-heads-for-merge-conflict", "")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * d3cce74 (clean-A) add A
         | * 115e41b (clean-B) add B
         |/  
@@ -380,7 +380,7 @@ mod from_new_merge_with_metadata {
         "#);
         let commit = out.workspace_commit_id.attach(&repo).object()?;
         // In absence of a hero stack, the conflicting stack is simply not assigned.
-        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        insta::assert_snapshot!(commit.data.as_bstr(), @"
         tree fc2bf71918ed072ec412bdebb04ec7322f2cfb72
         parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
         parent 6777bd8aff28a87a07739e2f309d3699d93685f9
@@ -444,7 +444,7 @@ mod from_new_merge_with_metadata {
         }
         "#);
         let commit = out.workspace_commit_id.attach(&repo).object()?;
-        insta::assert_snapshot!(commit.data.as_bstr(), @r"
+        insta::assert_snapshot!(commit.data.as_bstr(), @"
         tree 39ba52245958cf3a0544caf68c75665b9ad6ea4f
         parent d3cce74a69ee3b0e1cbea65b53908d602d6bda26
         parent 115e41b0ffb7fcb56f91a9fb64cf4a7b786c1bea

--- a/crates/but-workspace/tests/workspace/commit/move_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_changes.rs
@@ -23,7 +23,7 @@ fn visualize_tree(id: gix::Id<'_>) -> String {
 fn move_changes_same_commit_is_noop() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -40,7 +40,7 @@ fn move_changes_same_commit_is_noop() -> Result<()> {
     outcome.rebase.materialize()?;
 
     // Graph should be unchanged
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -53,7 +53,7 @@ fn move_changes_same_commit_is_noop() -> Result<()> {
 fn move_file_from_head_to_parent() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -97,7 +97,7 @@ fn move_file_from_head_to_parent() -> Result<()> {
     ");
 
     // Graph structure should be maintained (commit hashes will change)
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 95562c2 (HEAD -> three) commit three
     * 88ba151 (two) commit two
     | * 16fd221 (origin/two) commit two
@@ -134,7 +134,7 @@ fn move_file_from_head_to_parent() -> Result<()> {
 fn move_file_from_parent_to_head() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -162,7 +162,7 @@ fn move_file_from_parent_to_head() -> Result<()> {
     ");
 
     // Graph structure should be maintained
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c7eb64b (HEAD -> three) commit three
     * 0f198e0 (two) commit two
     | * 16fd221 (origin/two) commit two
@@ -197,7 +197,7 @@ fn move_file_from_parent_to_head() -> Result<()> {
 fn move_file_between_non_adjacent_commits() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -226,7 +226,7 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
     ");
 
     // Graph structure should be maintained
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 4d3039f (HEAD -> three) commit three
     * 364d4a2 (two) commit two
     * 9bc8248 (one) commit one

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -9,7 +9,7 @@ use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_
 fn reword_head_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -22,7 +22,7 @@ fn reword_head_commit() -> Result<()> {
         .0
         .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f0a8655 (HEAD -> three) New name
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -37,7 +37,7 @@ fn reword_head_commit() -> Result<()> {
 fn reword_middle_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -50,7 +50,7 @@ fn reword_middle_commit() -> Result<()> {
         .0
         .materialize()?;
 
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9feebdd (HEAD -> three) commit three
     * ada51de (two) New name
     | * 16fd221 (origin/two) commit two
@@ -67,7 +67,7 @@ fn reword_middle_commit() -> Result<()> {
 fn reword_base_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -82,7 +82,7 @@ fn reword_base_commit() -> Result<()> {
 
     // We end up with two divergent histories here. This is to be expected if we
     // rewrite the very bottom commit in a repository.
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * fe9fe7a (HEAD -> three) commit three
     * 096a124 (two) commit two
     * 1121ebc (one) New name

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -19,7 +19,7 @@ fn diff_spec_for_file(path: &str) -> DiffSpec {
 fn uncommit_file_from_head() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -44,7 +44,7 @@ fn uncommit_file_from_head() -> Result<()> {
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained (commit hash will change)
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 832a93c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -65,7 +65,7 @@ fn uncommit_file_from_head() -> Result<()> {
 fn uncommit_file_from_parent() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -89,7 +89,7 @@ fn uncommit_file_from_parent() -> Result<()> {
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 2c4471e (HEAD -> three) commit three
     * 0f198e0 (two) commit two
     | * 16fd221 (origin/two) commit two
@@ -120,7 +120,7 @@ fn uncommit_file_from_parent() -> Result<()> {
 fn uncommit_file_from_root_commit() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -143,7 +143,7 @@ fn uncommit_file_from_root_commit() -> Result<()> {
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 72f5d24 (HEAD -> three) commit three
     * 0a49f31 (two) commit two
     * 7fcda42 (one) commit one
@@ -191,7 +191,7 @@ fn error_when_changes_not_found() -> Result<()> {
 fn uncommit_empty_changes_is_noop() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * c9f444c (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one
@@ -206,7 +206,7 @@ fn uncommit_empty_changes_is_noop() -> Result<()> {
     outcome.rebase.materialize()?;
 
     // Graph should be unchanged
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * fbb2bd1 (HEAD -> three) commit three
     * 16fd221 (origin/two, two) commit two
     * 8b426d0 (one) commit one

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -30,7 +30,7 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     ├── file:100644:3aac70f "5\n6\n7\n8\n"
     └── link:120000:c4c364c "nonexisting-target"
     "#);
-    insta::assert_snapshot!(cat_commit(head_commit)?, @r"
+    insta::assert_snapshot!(cat_commit(head_commit)?, @"
     tree 3fd29f0ca55ee4dc3ea6bf02a761c15fd6dc8428
     author author <author@example.com> 946684800 +0000
     committer committer <committer@example.com> 946771200 +0000
@@ -46,7 +46,7 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
             new_message: Some("init: amended".into()),
         },
     )?;
-    insta::assert_debug_snapshot!(&outcome, @r"
+    insta::assert_debug_snapshot!(&outcome, @"
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
@@ -71,7 +71,7 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     // It adjusts both the author and the committer date.
     // It does, however, leave the change-id as it's considered the ID of the commit itself,
     // which thus should never be removed.
-    insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @r"
+    insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @"
     tree e56fc9bacdd11ebe576b5d96d21127c423698126
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946771266 +0600
@@ -102,7 +102,7 @@ fn all_aspects_of_amended_commit_are_copied() -> anyhow::Result<()> {
     └── file:100644:1c9325b "40\n41\n42\n43\n44\n45\n46\n47\n48\n49\n50\n51\n52\n53\n54\n55\n56\n57\n58\n59\n60\n61\n62\n63\n64\n65\n66\n67\n68\n69\n70\n"
     "#);
     // We do not add a change-id to assure we operate correctly when doing similarity checks.
-    insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @r"
+    insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @"
     tree 5bbee6d0219923e795f7b0818dda2f33f16278b4
     parent 91ef6f6fc0a8b97fb456886c1cc3b2a3536ea2eb
     parent 7f389eda1b366f3d56ecc1300b3835727c3309b6

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -23,7 +23,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
             stack_segment: None,
         },
     )?;
-    insta::assert_debug_snapshot!(&outcome, @r"
+    insta::assert_debug_snapshot!(&outcome, @"
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
@@ -67,7 +67,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
         },
     )?;
 
-    insta::assert_debug_snapshot!(&outcome, @r"
+    insta::assert_debug_snapshot!(&outcome, @"
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
@@ -1078,7 +1078,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
             stack_segment: None,
         },
     )?;
-    insta::assert_debug_snapshot!(&outcome, @r"
+    insta::assert_debug_snapshot!(&outcome, @"
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
@@ -1117,7 +1117,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
         },
     )?;
 
-    insta::assert_debug_snapshot!(&outcome, @r"
+    insta::assert_debug_snapshot!(&outcome, @"
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -75,7 +75,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
         CONTEXT_LINES,
     )?;
     // The HEAD reference was updated.
-    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
+    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @"
     * e0c062a (HEAD -> main) second commit
     * a5e224f initial commit
     ");
@@ -114,7 +114,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
 
     // The HEAD reference was updated, along with all other tag-references that pointed to it.
     let new_commit = outcome.new_commit.expect("a new commit was created");
-    insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit)?, @"
     * 85e659c (HEAD -> main) third commit
     * e0c062a (tag: tag-that-should-not-move, another-tip) second commit
     * a5e224f initial commit
@@ -138,7 +138,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
 
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
-    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
+    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @"
     * b20dc52 (HEAD -> main) third commit
     * e0c062a (tag: tag-that-should-not-move, another-tip) second commit
     * a5e224f initial commit
@@ -230,7 +230,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     "#);
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
-    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
+    insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @"
     * 40c0670 (HEAD -> main, s2-b/second, s1-b/second) fourth commit
     * b20dc52 third commit
     * e0c062a (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
@@ -242,7 +242,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     └── not-yet-tracked:100644:d95f3ad "content\n"
     "#);
 
-    insta::assert_snapshot!(visualize_index(&index), @r"
+    insta::assert_snapshot!(visualize_index(&index), @"
     100644:aaa9a91 new-file
     100644:d95f3ad not-yet-tracked
     ");
@@ -265,7 +265,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     let uninitialized_stack_id = repo.rev_parse_single("@~2")?.detach();
     let initial_stack_id = repo.rev_parse_single("@~1")?.detach();
     let workspace_commit_id = repo.rev_parse_single("@")?.detach();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, workspace_commit_id)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, workspace_commit_id)?, @"
     * 47c9e16 (HEAD -> main) GitButler Workspace Commit
     * b451685 (feat1) insert 5 lines to the top
     * d15b5ae (tag: first-commit) init
@@ -460,7 +460,7 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
     "#);
 
     let head_commit = outcome.new_commit.unwrap();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @"
     * f8e488c (HEAD -> main) Add yet another line
     * fb83560 initial commit with two lines
     ");
@@ -511,7 +511,7 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
     )?;
 
     let head_commit = outcome.new_commit.unwrap();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @"
     * 992e0aa (HEAD -> main) add a part of an untracked file, again
     * f8e488c Add yet another line
     * fb83560 initial commit with two lines
@@ -565,7 +565,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     let mut vb = VirtualBranchesState::default();
     let initial_commit_id = repo.rev_parse_single("@~1")?.detach();
     let head_commit_id = repo.rev_parse_single("@")?.detach();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit_id)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit_id)?, @"
     * 8b9db84 (HEAD -> main) insert 10 lines to the top
     * ecd6722 (tag: first-commit, first-commit) init
     ");
@@ -598,7 +598,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     // it rewrites the history to the top of the stack.
     write_vrbranches_to_refs(&vb, &repo)?;
     let rewritten_head_id = repo.head_id()?.detach();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @"
     * 33f337f (HEAD -> main) insert 10 lines to the top
     * fd16d0f (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
@@ -690,7 +690,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
         CONTEXT_LINES,
     )?;
     let rewritten_head_id = repo.head_id()?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @"
     * d015f5e (HEAD -> main) insert 10 lines to the top
     * ce317cf (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
@@ -701,7 +701,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     └── file:100644:1c99002 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n40\n"
     "#);
 
-    insta::assert_snapshot!(visualize_index(&outcome.index.unwrap()), @r"
+    insta::assert_snapshot!(visualize_index(&outcome.index.unwrap()), @"
     100644:ccc87a0 .gitignore
     100644:1c99002 file
     ");
@@ -717,7 +717,7 @@ fn branch_tip_below_non_merge_workspace_commit() -> anyhow::Result<()> {
     let mut vb = VirtualBranchesState::default();
     let initial_commit_id = repo.rev_parse_single("@~1")?.detach();
     let head_commit_id = repo.rev_parse_single("@")?.detach();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit_id)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit_id)?, @"
     * 40ceac2 (HEAD -> main) insert 20 lines to the top
     * 4342edf (tag: first-commit) init
     ");
@@ -748,7 +748,7 @@ fn branch_tip_below_non_merge_workspace_commit() -> anyhow::Result<()> {
     )?;
 
     write_vrbranches_to_refs(&vb, &repo)?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @"
     * 77125e2 (HEAD -> main) insert 20 lines to the top
     * 11f452c (s1-b/init) extend lines to 110
     * 4342edf (tag: first-commit) init
@@ -865,7 +865,7 @@ fn insert_commits_into_workspace() -> anyhow::Result<()> {
     "#);
 
     let index = outcome.index.take().unwrap();
-    insta::assert_snapshot!(visualize_index(&index), @r"
+    insta::assert_snapshot!(visualize_index(&index), @"
     100644:1c99002 file
     100644:a11f0f8 other-file
     ");
@@ -1145,7 +1145,7 @@ fn merge_commit_remains_unsigned_in_remerge() -> anyhow::Result<()> {
     );
 
     let index = outcome.index.take().unwrap();
-    insta::assert_snapshot!(visualize_index(&index), @r"
+    insta::assert_snapshot!(visualize_index(&index), @"
     100644:ccc87a0 .gitignore
     100644:c8ebab8 file
     ");
@@ -1173,7 +1173,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_one_below_top() 
     );
     vb.branches.insert(stack.id, stack.clone());
 
-    insta::assert_snapshot!(visualize_commit_graph(&repo, branch_b)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, branch_b)?, @"
     * e399378 (HEAD -> main, C, B) 2
     * 2db94ad (A) 1
     ");
@@ -1197,7 +1197,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_one_below_top() 
     )?;
 
     write_vrbranches_to_refs(&vb, &repo)?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @"
     * 45a0e1b (HEAD -> main, C, B) replace 'file' with 5 lines
     * e399378 2
     * 2db94ad (A) 1
@@ -1228,7 +1228,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_top() -> anyhow:
     );
     vb.branches.insert(stack.id, stack.clone());
 
-    insta::assert_snapshot!(visualize_commit_graph(&repo, branch_b)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, branch_b)?, @"
     * e399378 (HEAD -> main, C, B) 2
     * 2db94ad (A) 1
     ");
@@ -1252,7 +1252,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_top() -> anyhow:
     )?;
 
     write_vrbranches_to_refs(&vb, &repo)?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @"
     * 45a0e1b (HEAD -> main, C) replace 'file' with 5 lines
     * e399378 (B) 2
     * 2db94ad (A) 1

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -26,6 +26,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(
@@ -122,6 +123,7 @@ fn detached() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
         workspace_ref_info: None,
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(
@@ -185,6 +187,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(
@@ -301,6 +304,7 @@ fn single_branch() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(
@@ -426,6 +430,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -26,7 +26,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -123,7 +123,7 @@ fn detached() -> anyhow::Result<()> {
     insta::assert_debug_snapshot!(&info, @r#"
     RefInfo {
         workspace_ref_info: None,
-        symbolic_remote_names: [],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -187,7 +187,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -304,7 +304,7 @@ fn single_branch() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -430,7 +430,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/branch_details.rs
@@ -6,7 +6,7 @@ use crate::ref_info::with_workspace_commit::read_only_in_memory_scenario;
 #[test]
 fn disjoint() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("disjoint")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 32791d2 (HEAD -> disjoint) disjoint init
     * fafd9d0 (origin/main, main) init
     ");

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -33,6 +33,7 @@ fn j01_unborn() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [],
             stacks: [
                 Stack {
                     id: Some(
@@ -88,6 +89,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [],
             stacks: [
                 Stack {
                     id: Some(
@@ -149,6 +151,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [],
             stacks: [
                 Stack {
                     id: Some(
@@ -203,6 +206,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [],
             stacks: [
                 Stack {
                     id: Some(
@@ -267,6 +271,9 @@ fn j04_create_workspace() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [],
             target_ref: Some(
                 TargetRef {
@@ -323,6 +330,9 @@ fn j05_empty_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -400,6 +410,9 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -465,6 +478,9 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -544,6 +560,9 @@ fn j07_push_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -628,6 +647,9 @@ fn j08_next_local_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -711,6 +733,9 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -801,6 +826,9 @@ fn j10_squash_merge_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -901,6 +929,9 @@ fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(
@@ -1009,6 +1040,9 @@ fn j12_local_only_multi_segment_squash_merge() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: Some(

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -33,7 +33,7 @@ fn j01_unborn() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [],
+            symbolic_remote_names: {},
             stacks: [
                 Stack {
                     id: Some(
@@ -89,7 +89,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [],
+            symbolic_remote_names: {},
             stacks: [
                 Stack {
                     id: Some(
@@ -130,7 +130,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
 #[test]
 fn j03_main_pushed() -> anyhow::Result<()> {
     let (repo, meta, description) = step("03-main-pushed")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     main was pushed so it can now serve as target.
 
     However, without an official workspace it still won't be acting as a target.
@@ -151,7 +151,9 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [],
+            symbolic_remote_names: {
+                "origin",
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -206,7 +208,9 @@ fn j03_main_pushed() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [],
+            symbolic_remote_names: {
+                "origin",
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -250,7 +254,7 @@ fn j03_main_pushed() -> anyhow::Result<()> {
 fn j04_create_workspace() -> anyhow::Result<()> {
     let (repo, meta, description) = step("04-create-workspace")?;
     insta::assert_snapshot!(description, @"An official workspace was created, with nothing in it");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * a26ae77 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * fafd9d0 (origin/main, main) init
     ");
@@ -271,9 +275,9 @@ fn j04_create_workspace() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [],
             target_ref: Some(
                 TargetRef {
@@ -308,7 +312,7 @@ fn j04_create_workspace() -> anyhow::Result<()> {
 fn j05_empty_stack() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("05-empty-stack")?;
     insta::assert_snapshot!(description, @"an empty stack with nothing in it");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * a26ae77 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * fafd9d0 (origin/main, main, S1) init
     ");
@@ -330,9 +334,9 @@ fn j05_empty_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -389,7 +393,7 @@ fn j05_empty_stack() -> anyhow::Result<()> {
 fn j06_create_commit_in_stack() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("06-create-commit-in-stack")?;
     insta::assert_snapshot!(description, @"Create a new commit in the newly added stack S1");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9a8283b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * ba16348 (S1) one
     * fafd9d0 (origin/main, main) init
@@ -410,9 +414,9 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -478,9 +482,9 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -539,7 +543,7 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
 fn j07_push_commit() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("07-push-commit")?;
     insta::assert_snapshot!(description, @"push S1 to the remote which is then up-to-date");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9a8283b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * ba16348 (origin/S1, S1) one
     * fafd9d0 (origin/main, main) init
@@ -560,9 +564,9 @@ fn j07_push_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -620,12 +624,12 @@ fn j07_push_commit() -> anyhow::Result<()> {
 #[test]
 fn j08_next_local_commit() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("08-new-local-commit")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     Create a new local commit right after the previous pushed one
 
       This leaves the stack in a state where it can be pushed.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9e1f264 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9f4d478 (S1) two
     * ba16348 (origin/S1) one
@@ -647,9 +651,9 @@ fn j08_next_local_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -709,7 +713,7 @@ fn j08_next_local_commit() -> anyhow::Result<()> {
 fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("09-rewritten-local-commit")?;
     insta::assert_snapshot!(description, @"The new local commit was rewritten after pushing it to the remote");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 4d23090 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 314cacb (S1) two
     | * 9a2fcdf (origin/S1) two
@@ -733,9 +737,9 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -794,12 +798,12 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
 #[test]
 fn j10_squash_merge_stack() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("10-squash-merge-stack")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     The remote squash-merges S1 *and* changes the 'file' so it looks entirely different in another commit.
 
       The squash merge should still be detected.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 4d23090 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 314cacb (S1) two
     | * 9a2fcdf (origin/S1) two
@@ -826,9 +830,9 @@ fn j10_squash_merge_stack() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -887,7 +891,7 @@ fn j10_squash_merge_stack() -> anyhow::Result<()> {
 #[test]
 fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("11-remote-only")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     The remote was reused and merged once more with more changes.
 
       After S1 was squash-merged, someone else reused the branch, pushed two commits
@@ -895,7 +899,7 @@ fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
 
       Here we assure that these integrated remote commits don't mess with our logic.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 4d23090 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 314cacb (S1) two
     | * 16d0628 (origin/S1) add other remote file
@@ -929,9 +933,9 @@ fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(
@@ -993,7 +997,7 @@ fn j11_squash_merge_remote_only() -> anyhow::Result<()> {
 #[test]
 fn j12_local_only_multi_segment_squash_merge() -> anyhow::Result<()> {
     let (repo, mut meta, description) = step("12-local-only-multi-segment-squash-merge")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     A new multi-segment stack is created without remote and squash merged locally.
 
       There is no need to add the local branches to the workspace officially, they are still picked up.
@@ -1040,9 +1044,9 @@ fn j12_local_only_multi_segment_squash_merge() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: Some(

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -13,12 +13,12 @@ use crate::ref_info::{
 #[test]
 fn two_commits_require_force_push() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("01-one-rewritten-one-local-after-push")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     A setup that demands for a force-push
 
     We change the name of the first commit and also need the similarity to be detected by changeset
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f9c2b14 (A) A2
     * e1f216e A1
@@ -41,9 +41,9 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -101,7 +101,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
 fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("01.5-one-rewritten-one-local-after-push-merge")?;
     insta::assert_snapshot!(description, @"On the remote, a rewritten/rebased commit we have locally is merged back into target.");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f9c2b14 (A) A2
     * e1f216e A1
@@ -126,9 +126,9 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -185,12 +185,12 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
 #[test]
 fn remote_diverged() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("02-diverged-remote")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     A setup that demands for a force-push
 
     The tip of the local branch isn't in the ancestry of the remote anymore.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * a62b0de (A) A2
     | * 0c06863 (origin/A) A3
@@ -213,9 +213,9 @@ fn remote_diverged() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -274,7 +274,7 @@ fn remote_diverged() -> anyhow::Result<()> {
 #[test]
 fn remote_diverged_merge() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("02.5-diverged-remote-merge")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     A remote sharing a commit with a stack and its own commit gets merged.
 
     We'd not want to see the remote unique commit anymore as it's also considered integrated.
@@ -310,9 +310,9 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -372,7 +372,7 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
 fn remote_behind() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("03-remote-one-behind")?;
     insta::assert_snapshot!(description, @"A can be pushed as it has local, unpushed commits");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * a62b0de (A) A2
     * 120a217 (origin/A) A1
@@ -393,9 +393,9 @@ fn remote_behind() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -483,9 +483,9 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -545,7 +545,7 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
 fn remote_ahead() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("04-remote-one-ahead-ff")?;
     insta::assert_snapshot!(description, @"There are no unpushed local commits, the remote is one ahead (FF)");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 8ee08de (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * a62b0de (origin/A) A2
     |/  
@@ -567,9 +567,9 @@ fn remote_ahead() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -628,7 +628,7 @@ fn remote_ahead() -> anyhow::Result<()> {
 fn remote_ahead_merge_ff() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("04.5-remote-one-ahead-ff-merge")?;
     insta::assert_snapshot!(description, @"Remote origin/A is merged back (fast-forward), bringing all into the target branch");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 8ee08de (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * a62b0de (origin/main, origin/A, main) A2
     |/  
@@ -654,9 +654,9 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -41,6 +41,9 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -123,6 +126,9 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -207,6 +213,9 @@ fn remote_diverged() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -301,6 +310,9 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -381,6 +393,9 @@ fn remote_behind() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -468,6 +483,9 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -549,6 +567,9 @@ fn remote_ahead() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -633,6 +654,9 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -10,12 +10,12 @@ use crate::ref_info::{
 #[test]
 fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("01-one-rewritten-one-local-after-push")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     two local commits pushed to a remote, then rebased onto target.
 
     The branch should then be considered integrated
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f9c2b14 (origin/A, A) A2
     * e1f216e A1
@@ -42,9 +42,9 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -101,12 +101,12 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
 #[test]
 fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("01-with-local-amended-after-integration")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     two local commits pushed to a remote, then rebased onto target, and local amended
 
     The branch should then *not* be considered integrated anymore as A2 has changed
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 4c3a992 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 5039218 (origin/A, A) A2
     * e1f216e A1
@@ -134,9 +134,9 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -193,13 +193,13 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
 #[test]
 fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("01-rewritten-local-commit-is-paired-with-remote")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     two local commits pushed to a remote, then changed locally.
 
     One is changed locally and matched by message, the other one is matched by change-id
     as the content is too different.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 0b1ed50 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * e9c9d74 (A) A2
     * 550b6ac A1
@@ -223,9 +223,9 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,
@@ -283,12 +283,12 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
 fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> {
     let (repo, meta, description) =
         scenario("01-one-rewritten-one-local-after-push-author-date-change")?;
-    insta::assert_snapshot!(description, @r"
+    insta::assert_snapshot!(description, @"
     two local commits pushed to a remote, then rebased onto target, but with the author date adjusted.
 
     This prevents quick-checks to work.
     ");
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f1caa51 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * f9c2b14 (origin/A, A) A2
     * e1f216e A1
@@ -315,9 +315,9 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
                     ),
                 },
             ),
-            symbolic_remote_names: [
+            symbolic_remote_names: {
                 "origin",
-            ],
+            },
             stacks: [
                 Stack {
                     id: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -42,6 +42,9 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -131,6 +134,9 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -217,6 +223,9 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,
@@ -306,6 +315,9 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
                     ),
                 },
             ),
+            symbolic_remote_names: [
+                "origin",
+            ],
             stacks: [
                 Stack {
                     id: None,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -277,7 +277,7 @@ mod stack_details {
         let (repo, mut meta) = read_only_in_memory_scenario(
             "three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-dependent",
         )?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * f8f33a7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
         * cbc6713 (origin/advanced-lane, on-top-of-dependent, dependent, advanced-lane) change
         * fafd9d0 (origin/main, main, lane) init

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -27,7 +27,7 @@ pub fn ref_info(
 #[test]
 fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     let (mut repo, mut meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * fb27086 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 89cc2d3 (origin/A) change in A
     |/  
@@ -52,9 +52,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -125,9 +125,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -202,9 +202,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -266,7 +266,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
 fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-dependent-branches-rebased-with-remotes")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * d909178 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 3ba6995 (B-on-A) change in B
     * f504e38 (A) change after push
@@ -292,9 +292,9 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -369,7 +369,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
     let (repo, mut meta) = read_only_in_memory_scenario(
         "two-dependent-branches-rebased-explicit-remote-in-extra-segment",
     )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * d909178 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 3ba6995 (B-on-A) change in B
     * f504e38 (A) change after push
@@ -397,9 +397,9 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -513,9 +513,9 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -625,9 +625,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -700,9 +700,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -777,7 +777,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
 fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Result<()> {
     let (mut repo, mut meta) =
         read_only_in_memory_scenario("two-dependent-branches-first-rebased-and-merged")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 0b6b861 (origin/main, origin/A) A
     | * 4f08b8d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * da597e8 (B) B
@@ -802,9 +802,9 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: None,
@@ -886,9 +886,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 ),
             },
         ),
-        symbolic_remote_names: [
-            "origin",
-        ],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: None,
@@ -958,7 +956,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
 #[test]
 fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("target-ahead-remote-rewritten")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 03d2336 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * d5d3a92 (A) unique local tip
     * 6ffd040 shared by name
@@ -988,9 +986,9 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1085,9 +1083,9 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1191,7 +1189,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
 fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("multiple-dependent-branches-per-stack-without-commit")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * cbc6713 (HEAD -> gitbutler/workspace, lane) change
     * fafd9d0 (origin/main, main, lane-segment-02, lane-segment-01, lane-2-segment-02, lane-2-segment-01, lane-2) init
     ");
@@ -1228,9 +1226,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1380,9 +1378,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1533,9 +1531,9 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1641,9 +1639,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: None,
@@ -1732,9 +1730,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1823,9 +1821,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -1897,7 +1895,7 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario(
         "three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-dependent",
     )?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f8f33a7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * cbc6713 (origin/advanced-lane, on-top-of-dependent, dependent, advanced-lane) change
     * fafd9d0 (origin/main, main, lane) init
@@ -1925,9 +1923,9 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2025,9 +2023,9 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2109,7 +2107,7 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
 fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-dependent-branches-with-one-commit-with-remotes")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 9b3cfd4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 788ad06 (origin/on-top-of-lane, on-top-of-lane) change on top
     * cbc6713 (origin/lane, lane) change
@@ -2138,9 +2136,9 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2213,7 +2211,7 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
 fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-dependent-branches-with-interesting-remote-setup")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * a221221 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * aadad9d (A) shared by name
     * 96a2408 (origin/main) another unrelated
@@ -2242,9 +2240,9 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2319,7 +2317,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
 fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-branches-one-advanced-ws-commit-on-top-of-stack")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * cbc6713 (HEAD -> gitbutler/workspace, advanced-lane) change
     * fafd9d0 (origin/main, main, lane) init
     ");
@@ -2343,9 +2341,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2433,9 +2431,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -2546,9 +2544,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
-        symbolic_remote_names: [
-            "origin",
-        ],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -2637,9 +2633,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
-        symbolic_remote_names: [
-            "origin",
-        ],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -2727,9 +2721,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
-        symbolic_remote_names: [
-            "origin",
-        ],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -2823,9 +2815,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
-        symbolic_remote_names: [
-            "origin",
-        ],
+        symbolic_remote_names: {},
         stacks: [
             Stack {
                 id: Some(
@@ -2905,7 +2895,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
 #[test]
 fn disjoint() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("disjoint")?;
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 32791d2 (HEAD -> disjoint) disjoint init
     * fafd9d0 (origin/main, main) init
     ");
@@ -2928,7 +2918,9 @@ fn disjoint() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [],
+        symbolic_remote_names: {
+            "origin",
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3001,9 +2993,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3123,9 +3115,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3245,9 +3237,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3368,9 +3360,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3480,7 +3472,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
 #[test]
 fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("empty-workspace-with-branch-below")?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, "HEAD")?, @r"
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "HEAD")?, @"
     * c7276fa (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * c166d42 (origin/main, origin/HEAD, unrelated, main) init-integration
     ");
@@ -3503,9 +3495,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3571,9 +3563,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3642,9 +3634,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [],
         target_ref: Some(
             TargetRef {
@@ -3687,9 +3679,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 worktree: None,
             },
         ),
-        symbolic_remote_names: [
+        symbolic_remote_names: {
             "origin",
-        ],
+        },
         stacks: [
             Stack {
                 id: Some(
@@ -3753,7 +3745,7 @@ fn advanced_workspace_multi_stack() -> anyhow::Result<()> {
 
     let opts = standard_options();
     let err = head_info(&repo, &meta, opts).unwrap_err();
-    insta::assert_snapshot!(err.to_string(), @r"
+    insta::assert_snapshot!(err.to_string(), @"
     Found 5 commit(s) on top of the workspace commit.
 
     Run the following command in your working directory to fix this while leaving your worktree unchanged.
@@ -3785,7 +3777,7 @@ fn advanced_workspace_single_stack() -> anyhow::Result<()> {
 
     let opts = standard_options();
     let err = head_info(&repo, &meta, opts).unwrap_err();
-    insta::assert_snapshot!(err.to_string(), @r"
+    insta::assert_snapshot!(err.to_string(), @"
     Found 5 commit(s) on top of the workspace commit.
 
     Run the following command in your working directory to fix this while leaving your worktree unchanged.

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -52,6 +52,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -122,6 +125,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -196,6 +202,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -283,6 +292,9 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -385,6 +397,9 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -498,6 +513,9 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -607,6 +625,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -679,6 +700,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -778,6 +802,9 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: None,
@@ -859,6 +886,9 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: None,
@@ -958,6 +988,9 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1052,6 +1085,9 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1192,6 +1228,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1341,6 +1380,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1491,6 +1533,9 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1596,6 +1641,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: None,
@@ -1684,6 +1732,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1772,6 +1823,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependent() -> 
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1871,6 +1925,9 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -1968,6 +2025,9 @@ fn single_commit_pushed_ws_commit_empty_dependent() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2078,6 +2138,9 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2179,6 +2242,9 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2277,6 +2343,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2364,6 +2433,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2474,6 +2546,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2562,6 +2637,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2649,6 +2727,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2742,6 +2823,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -2844,6 +2928,7 @@ fn disjoint() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [],
         stacks: [
             Stack {
                 id: Some(
@@ -2916,6 +3001,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3035,6 +3123,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3154,6 +3245,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3274,6 +3368,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3406,6 +3503,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3471,6 +3571,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(
@@ -3539,6 +3642,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 ),
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [],
         target_ref: Some(
             TargetRef {
@@ -3581,6 +3687,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 worktree: None,
             },
         ),
+        symbolic_remote_names: [
+            "origin",
+        ],
         stacks: [
             Stack {
                 id: Some(

--- a/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
@@ -7,7 +7,7 @@ use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario, writable_s
 #[test]
 fn all_file_types_from_unborn() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("unborn-untracked-all-file-types");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     ?? link
     ?? untracked
     ?? untracked-exe
@@ -28,7 +28,7 @@ fn all_file_types_from_unborn() -> anyhow::Result<()> {
 fn all_file_types_added_to_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("unborn-untracked-all-file-types");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     A  link
     A  untracked
     A  untracked-exe
@@ -50,7 +50,7 @@ fn all_file_types_added_to_index() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn all_file_types_deleted_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("delete-all-file-types-valid-submodule");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D .gitmodules
     D executable
     D link
@@ -65,7 +65,7 @@ fn all_file_types_deleted_in_worktree() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:a047f81 embedded-repository
     100755:86daf54 executable
@@ -74,7 +74,7 @@ fn all_file_types_deleted_in_worktree() -> anyhow::Result<()> {
     160000:a047f81 submodule
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -95,7 +95,7 @@ fn all_file_types_deleted_in_worktree() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn replace_dir_with_file_discard_all_in_order_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("replace-dir-with-submodule-with-file");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      D dir/executable
      D dir/file-to-remain
      D dir/link
@@ -111,7 +111,7 @@ fn replace_dir_with_file_discard_all_in_order_in_worktree() -> anyhow::Result<()
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:566c83a .gitmodules
     100755:86daf54 dir/executable
     100644:d95f3ad dir/file-to-remain
@@ -123,7 +123,7 @@ fn replace_dir_with_file_discard_all_in_order_in_worktree() -> anyhow::Result<()
     // Here we managed to check out the submodule as the order of worktree changes is `dir` first,
     // followed by all the individual items in the directory. One of these restores the submodule, which
     // starts out as empty directory.
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -146,7 +146,7 @@ fn replace_dir_with_file_discard_all_in_order_in_worktree() -> anyhow::Result<()
 fn replace_dir_with_file_discard_all_in_order_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("replace-dir-with-submodule-with-file");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     A  dir
     D  dir/executable
     D  dir/file-to-remain
@@ -162,7 +162,7 @@ fn replace_dir_with_file_discard_all_in_order_in_index() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:566c83a .gitmodules
     100755:86daf54 dir/executable
     100644:d95f3ad dir/file-to-remain
@@ -174,7 +174,7 @@ fn replace_dir_with_file_discard_all_in_order_in_index() -> anyhow::Result<()> {
     // Here we managed to check out the submodule as the order of worktree changes is `dir` first,
     // followed by all the individual items in the directory. One of these restores the submodule, which
     // starts out as empty directory.
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -196,7 +196,7 @@ fn replace_dir_with_file_discard_all_in_order_in_index() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn replace_dir_with_file_discard_just_the_file_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("replace-dir-with-submodule-with-file");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      D dir/executable
      D dir/file-to-remain
      D dir/link
@@ -208,7 +208,7 @@ fn replace_dir_with_file_discard_just_the_file_in_worktree() -> anyhow::Result<(
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:566c83a .gitmodules
     100755:86daf54 dir/executable
     100644:d95f3ad dir/file-to-remain
@@ -218,7 +218,7 @@ fn replace_dir_with_file_discard_just_the_file_in_worktree() -> anyhow::Result<(
     ");
 
     // It's a known shortcoming that submodules aren't re-populated during checkout.
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -241,7 +241,7 @@ fn replace_dir_with_file_discard_just_the_file_in_worktree() -> anyhow::Result<(
 fn conflicts_are_invisible() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("merge-with-two-branches-conflict");
     insta::assert_snapshot!(git_status(&repo)?, @"UU file");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:e69de29 file:1
     100644:e6c4914 file:2
     100644:e33f5e9 file:3
@@ -256,12 +256,12 @@ fn conflicts_are_invisible() -> anyhow::Result<()> {
 
     // Nothing was changed
     insta::assert_snapshot!(git_status(&repo)?, @"UU file");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:e69de29 file:1
     100644:e6c4914 file:2
     100644:e33f5e9 file:3
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     └── file:100644
@@ -274,7 +274,7 @@ fn conflicts_are_invisible() -> anyhow::Result<()> {
 fn replace_dir_with_file_discard_just_the_file_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("replace-dir-with-submodule-with-file");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     A  dir
     D  dir/executable
     D  dir/file-to-remain
@@ -286,7 +286,7 @@ fn replace_dir_with_file_discard_just_the_file_in_index() -> anyhow::Result<()> 
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:566c83a .gitmodules
     100755:86daf54 dir/executable
     100644:d95f3ad dir/file-to-remain
@@ -296,7 +296,7 @@ fn replace_dir_with_file_discard_just_the_file_in_index() -> anyhow::Result<()> 
     ");
 
     // It's a known shortcoming that submodules aren't re-populated during checkout.
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -316,12 +316,12 @@ fn replace_dir_with_file_discard_just_the_file_in_index() -> anyhow::Result<()> 
 #[cfg(unix)]
 fn all_file_types_modified_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-changed");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     M soon-executable
     T soon-file-not-link
     M soon-not-executable
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── fifo-should-be-ignored:10644
@@ -338,13 +338,13 @@ fn all_file_types_modified_in_worktree() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:d95f3ad soon-executable
     120000:c4c364c soon-file-not-link
     100755:86daf54 soon-not-executable
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── fifo-should-be-ignored:10644
@@ -360,12 +360,12 @@ fn all_file_types_modified_in_worktree() -> anyhow::Result<()> {
 fn all_file_types_modified_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-changed");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     M  soon-executable
     T  soon-file-not-link
     M  soon-not-executable
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── fifo-should-be-ignored:10644
@@ -382,13 +382,13 @@ fn all_file_types_modified_in_index() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:d95f3ad soon-executable
     120000:c4c364c soon-file-not-link
     100755:86daf54 soon-not-executable
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── fifo-should-be-ignored:10644
@@ -403,11 +403,11 @@ fn all_file_types_modified_in_index() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn modified_submodule_and_embedded_repo_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("modified-submodule-and-embedded-repo");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     M embedded-repository
     M submodule
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -420,7 +420,7 @@ fn modified_submodule_and_embedded_repo_in_worktree() -> anyhow::Result<()> {
         └── untracked:100644
     ");
     // The submdule has changed its state, but not what the parent-repository thinks about it as it wasn't added to the index
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:a047f81 embedded-repository
     160000:a047f81 submodule
@@ -437,13 +437,13 @@ fn modified_submodule_and_embedded_repo_in_worktree() -> anyhow::Result<()> {
     // when doing a status even though it should treat it like an 'anonymous submodule'.
     // However, the submodule itself is reset.
     insta::assert_snapshot!(git_status(&repo)?, @" M embedded-repository");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:a047f81 embedded-repository
     160000:a047f81 submodule
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644
@@ -463,11 +463,11 @@ fn modified_submodule_and_embedded_repo_in_worktree() -> anyhow::Result<()> {
 fn modified_submodule_and_embedded_repo_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("modified-submodule-and-embedded-repo");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     M  embedded-repository
     MM submodule
     ");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:6d5e0a5 embedded-repository
     160000:6d5e0a5 submodule
@@ -482,7 +482,7 @@ fn modified_submodule_and_embedded_repo_in_index() -> anyhow::Result<()> {
 
     // `gix status` is able to see the 'embedded-repository' if it's in the index, and we can reset it as well.
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:a047f81 embedded-repository
     160000:a047f81 submodule
@@ -496,7 +496,7 @@ fn modified_submodule_and_embedded_repo_in_index() -> anyhow::Result<()> {
 fn all_file_types_renamed_and_modified_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
     // Git doesn't detect renames between index/worktree, but we do.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      D executable
      D file
      D link
@@ -504,7 +504,7 @@ fn all_file_types_renamed_and_modified_in_worktree() -> anyhow::Result<()> {
     ?? file-renamed
     ?? link-renamed
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── executable-renamed:100755
@@ -521,13 +521,13 @@ fn all_file_types_renamed_and_modified_in_worktree() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:01e79c3 executable
     100644:3aac70f file
     120000:c4c364c link
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── executable:100755
@@ -543,18 +543,18 @@ fn all_file_types_renamed_and_modified_in_worktree() -> anyhow::Result<()> {
 fn all_file_types_renamed_modified_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     R  executable -> executable-renamed
     R  file -> file-renamed
     D  link
     A  link-renamed
     ");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:8a1218a executable-renamed
     100644:c5c4315 file-renamed
     120000:94e4e07 link-renamed
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── executable-renamed:100755
@@ -571,13 +571,13 @@ fn all_file_types_renamed_modified_in_index() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:01e79c3 executable
     100644:3aac70f file
     120000:c4c364c link
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── executable:100755
@@ -594,7 +594,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree() -> any
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-overwriting-existing");
     // This is actually misleading as `file-to-be-dir` seems missing even though it's now
     // a directory. It's untracked-state isn't visible.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      D dir-to-be-file/content
      D executable
      D file
@@ -616,7 +616,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree() -> any
     //   ? link-renamed
     //   D other-file
     //   M to-be-overwritten
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:100755
@@ -634,7 +634,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree() -> any
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:e69de29 dir-to-be-file/content
     100755:01e79c3 executable
     100644:3aac70f file
@@ -643,7 +643,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree() -> any
     100644:dcefb7d other-file
     100644:e69de29 to-be-overwritten
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:40755
@@ -665,7 +665,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_index() -> anyhow
     git(&repo).args(["add", "."]).run();
     // This is actually misleading as `file-to-be-dir` seems missing even though it's now
     // a directory. It's untracked-state isn't visible.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     R  executable -> dir-to-be-file
     D  dir-to-be-file/content
     D  file-to-be-dir
@@ -686,7 +686,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_index() -> anyhow
     //  D  link
     //  A  link-renamed
     //  D  other-file
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:100755
@@ -704,7 +704,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_index() -> anyhow
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:e69de29 dir-to-be-file/content
     100755:01e79c3 executable
     100644:3aac70f file
@@ -713,7 +713,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_index() -> anyhow
     100644:dcefb7d other-file
     100644:e69de29 to-be-overwritten
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:40755
@@ -737,7 +737,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-overwriting-existing");
     // This is actually misleading as `file-to-be-dir` seems missing even though it's now
     // a directory. It's untracked-state isn't visible.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      D dir-to-be-file/content
      D executable
      D file
@@ -749,7 +749,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
     ?? link-renamed
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:100755
@@ -780,11 +780,11 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
     // In case of the executable, we see only what would be a directory in the index, so we end up restoring
     // nothing either.
     // This could be improved at some cost, so let's go with the two-step process for now.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D dir-to-be-file/content
     D file-to-be-dir
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── executable:100755
@@ -806,7 +806,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:e69de29 dir-to-be-file/content
     100755:01e79c3 executable
     100644:3aac70f file
@@ -815,7 +815,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
     100644:dcefb7d other-file
     100644:e69de29 to-be-overwritten
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── dir-to-be-file:40755
@@ -834,7 +834,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
 #[cfg(unix)]
 fn folder_with_all_file_types_moved_upwards_in_worktree() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("move-directory-into-sibling-file");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D a/b/executable
     D a/b/file
     D a/b/link
@@ -846,7 +846,7 @@ fn folder_with_all_file_types_moved_upwards_in_worktree() -> anyhow::Result<()> 
     //   R a/b/file → a/sibling/file
     //   R a/b/link → a/sibling/link
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     └── a:40755
@@ -865,13 +865,13 @@ fn folder_with_all_file_types_moved_upwards_in_worktree() -> anyhow::Result<()> 
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:01e79c3 a/b/executable
     100644:3aac70f a/b/file
     120000:c4c364c a/b/link
     100644:a0d4277 a/sibling
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     └── a:40755
@@ -888,7 +888,7 @@ fn folder_with_all_file_types_moved_upwards_in_worktree() -> anyhow::Result<()> 
 #[cfg(unix)]
 fn folder_with_all_file_types_moved_upwards_in_worktree_discard_selected() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("move-directory-into-sibling-file");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D a/b/executable
     D a/b/file
     D a/b/link
@@ -914,13 +914,13 @@ fn folder_with_all_file_types_moved_upwards_in_worktree_discard_selected() -> an
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:01e79c3 a/b/executable
     100644:3aac70f a/b/file
     120000:c4c364c a/b/link
     100644:a0d4277 a/sibling
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     └── a:40755
@@ -938,7 +938,7 @@ fn folder_with_all_file_types_moved_upwards_in_worktree_discard_selected() -> an
 fn folder_with_all_file_types_moved_upwards_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("move-directory-into-sibling-file");
     git(&repo).args(["add", "."]).run();
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D  a/sibling
     R  a/b/executable -> a/sibling/executable
     R  a/b/file -> a/sibling/file
@@ -953,13 +953,13 @@ fn folder_with_all_file_types_moved_upwards_in_index() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:01e79c3 a/b/executable
     100644:3aac70f a/b/file
     120000:c4c364c a/b/link
     100644:a0d4277 a/sibling
     ");
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     └── a:40755
@@ -977,7 +977,7 @@ fn folder_with_all_file_types_moved_upwards_in_index() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn all_file_types_deleted_in_index() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("delete-all-file-types-valid-submodule");
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     D .gitmodules
     D executable
     D link
@@ -993,7 +993,7 @@ fn all_file_types_deleted_in_index() -> anyhow::Result<()> {
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100644:51f8807 .gitmodules
     160000:a047f81 embedded-repository
     100755:86daf54 executable
@@ -1002,7 +1002,7 @@ fn all_file_types_deleted_in_index() -> anyhow::Result<()> {
     160000:a047f81 submodule
     ");
 
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── .gitmodules:100644

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -45,7 +45,7 @@ fn dropped_hunks() -> anyhow::Result<()> {
 #[test]
 fn non_modifications_trigger_error() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("deletion-addition-untracked")?;
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
     A  added-to-index
      D to-be-deleted
     D  to-be-deleted-in-index
@@ -83,7 +83,7 @@ fn from_end() -> anyhow::Result<()> {
     let mut hunk_info = Vec::new();
     let filename = "file-in-index";
     let file_content = || std::fs::read(repo.workdir().unwrap().join(filename)).map(BString::from);
-    insta::assert_snapshot!(file_content()?, @r"
+    insta::assert_snapshot!(file_content()?, @"
     1
     2
     3
@@ -107,7 +107,7 @@ fn from_end() -> anyhow::Result<()> {
         .find(|change| change.path == filename)
     {
         let previous_text = previous_change_text(&repo, &change)?;
-        insta::allow_duplicates!(insta::assert_snapshot!(previous_text, @r"
+        insta::allow_duplicates!(insta::assert_snapshot!(previous_text, @"
         5
         6
         7
@@ -298,7 +298,7 @@ fn from_selections() -> anyhow::Result<()> {
     assert_eq!(dropped, [], "all sub-hunks could be associated");
 
     let file_content: BString = std::fs::read(repo.workdir().unwrap().join(filename))?.into();
-    insta::assert_snapshot!(file_content, @r"
+    insta::assert_snapshot!(file_content, @"
     1
     3
     4
@@ -328,7 +328,7 @@ fn from_selections_with_context() -> anyhow::Result<()> {
         1,
         "one big hunk with context and everything, similar to what the UI sees"
     );
-    insta::assert_snapshot!(hunks[0].diff, @r"
+    insta::assert_snapshot!(hunks[0].diff, @"
     @@ -1,14 +1,16 @@
     +1
     +2
@@ -383,7 +383,7 @@ fn from_selections_with_context() -> anyhow::Result<()> {
     assert_eq!(dropped.len(), 0, "all sub-hunks could be associated");
 
     let file_content = read_file_content()?;
-    insta::assert_snapshot!(file_content, @r"
+    insta::assert_snapshot!(file_content, @"
     1
     6
     7
@@ -410,7 +410,7 @@ fn from_selections_with_context() -> anyhow::Result<()> {
     );
     let actual = read_file_content()?;
     // The order of old/new additions or removals do matter also doesn't matter, the result is stable.
-    insta::assert_snapshot!(actual, @r"
+    insta::assert_snapshot!(actual, @"
     1
     6
     7
@@ -440,7 +440,7 @@ fn hunk_removal_of_additions_single_line() -> anyhow::Result<()> {
         1,
         "one big hunk with context and everything, similar to what the UI sees"
     );
-    insta::assert_snapshot!(hunks[0].diff, @r"
+    insta::assert_snapshot!(hunks[0].diff, @"
     @@ -1,0 +1,10 @@
     +1
     +2
@@ -469,7 +469,7 @@ fn hunk_removal_of_additions_single_line() -> anyhow::Result<()> {
     assert_eq!(dropped.len(), 0, "all sub-hunks could be associated");
 
     let file_content: BString = std::fs::read(repo.workdir().unwrap().join(filename))?.into();
-    insta::assert_snapshot!(file_content, @r"
+    insta::assert_snapshot!(file_content, @"
     1
     2
     3
@@ -494,7 +494,7 @@ fn hunk_removal_of_removal_single_line() -> anyhow::Result<()> {
         1,
         "one big hunk with context and everything, similar to what the UI sees"
     );
-    insta::assert_snapshot!(hunks[0].diff, @r"
+    insta::assert_snapshot!(hunks[0].diff, @"
     @@ -1,10 +1,0 @@
     -1
     -2
@@ -537,7 +537,7 @@ fn hunk_removal_of_modifications() -> anyhow::Result<()> {
         1,
         "one big hunk with context and everything, similar to what the UI sees"
     );
-    insta::assert_snapshot!(hunks[0].diff, @r"
+    insta::assert_snapshot!(hunks[0].diff, @"
     @@ -1,10 +1,10 @@
     -1
     -2
@@ -580,7 +580,7 @@ fn hunk_removal_of_modifications() -> anyhow::Result<()> {
     assert_eq!(dropped.len(), 0, "all sub-hunks could be associated");
 
     let file_content: BString = std::fs::read(repo.workdir().unwrap().join(filename))?.into();
-    insta::assert_snapshot!(file_content, @r"
+    insta::assert_snapshot!(file_content, @"
     11
     12
     13
@@ -601,7 +601,7 @@ fn hunk_removal_of_modifications() -> anyhow::Result<()> {
 fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
     // Note that one of these renames can't be detected by Git but is visible to us.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      M file
     M  file-in-index
     RM file-to-be-renamed-in-index -> file-renamed-in-index
@@ -609,7 +609,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     ?? file-renamed
     ");
 
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:3d3b36f file
     100755:cb89473 file-in-index
     100644:3d3b36f file-renamed-in-index
@@ -617,7 +617,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     ");
 
     let workdir = repo.workdir().unwrap();
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(workdir)?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(workdir)?, @"
     .
     ├── .git:40755
     ├── file:100644
@@ -711,7 +711,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
 
     // Only the data is undone; the executable bit change can be undone in the next discard,
     // making this a two-step process. This seems valuable as it gives users a choice.
-    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @"
     .
     ├── .git:40755
     ├── file:100644
@@ -736,7 +736,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
 
     // Notably, discarding all hunks leaves the renamed file in place, but without modifications.
     // Executable bits stay and can be discarded in a separate step.
-    insta::assert_snapshot!(git_status(&repo)?, @r"
+    insta::assert_snapshot!(git_status(&repo)?, @"
      M file
     MM file-in-index
     R  file-to-be-renamed-in-index -> file-renamed-in-index
@@ -744,7 +744,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     ?? file-renamed
     ");
     // The index still only holds what was in the index before, but is representing the changed worktree.
-    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @"
     100755:3d3b36f file
     100755:cb89473 file-in-index
     100644:3d3b36f file-renamed-in-index

--- a/crates/but-workspace/tests/workspace/ui.rs
+++ b/crates/but-workspace/tests/workspace/ui.rs
@@ -137,11 +137,9 @@ mod changes_in_branch {
             "passing strange ref-names still causes an error - they must exist"
         );
 
-        let mut ref_info = ui::RefInfo::for_ui(
-            but_workspace::head_info(&repo, &*meta, Default::default())?,
-            &repo,
-        )?
-        .pruned_to_entrypoint();
+        let mut ref_info: ui::RefInfo =
+            but_workspace::head_info(&repo, &*meta, Default::default())?.try_into()?;
+        ref_info = ref_info.pruned_to_entrypoint();
         insta::assert_json_snapshot!(&ref_info, @r#"
         {
           "workspaceRef": {

--- a/crates/but-workspace/tests/workspace/ui.rs
+++ b/crates/but-workspace/tests/workspace/ui.rs
@@ -8,7 +8,7 @@ mod changes_in_branch {
     #[test]
     fn multiple_inside_and_outside_of_workspace() -> anyhow::Result<()> {
         let (repo, meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
-        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
         * fb27086 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
         | * 89cc2d3 (origin/A) change in A
         |/  
@@ -118,7 +118,7 @@ mod changes_in_branch {
         "#);
 
         // Nothing here, it's the target.
-        insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/remotes/origin/main"))?, @r"
+        insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/remotes/origin/main"))?, @"
         TreeChanges {
             changes: [],
             stats: TreeStats {


### PR DESCRIPTION
Motivated by #12756

### Tasks

* [x] pick low-hanging fruit
* [x] see if `head_info` can be corrected
