### PR TITLE
unapply: Create a the correct snapshot

### DIFF
--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -104,7 +104,7 @@
 			case "ApplyBranch":
 				return { text: `Apply branch "${entryTrailer("name")}"`, icon: "branch" };
 			case "UnapplyBranch":
-				return { text: `Unapply branch "${trailer("name")}"`, icon: "branch" };
+				return { text: `Unapply branch "${trailer("branch")}"`, icon: "branch" };
 			case "ReorderBranches":
 				return {
 					text: `Reorder branches "${trailer("before")}" and "${trailer("after")}"`,

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -2,10 +2,6 @@
 
 use anyhow::{Context as _, bail};
 use but_core::ref_metadata::StackId;
-use gitbutler_oplog::{
-    OplogExt,
-    entry::{OperationKind, SnapshotDetails, Trailer},
-};
 
 use crate::{
     CliId, IdMap,
@@ -117,23 +113,6 @@ fn find_stack_by_branch_name(
     bail!("Branch '{branch_name}' not found in any applied stack");
 }
 
-/// Create a snapshot in the oplog before performing an unapply operation
-fn create_snapshot(ctx: &mut but_ctx::Context, branches: &[String]) {
-    let mut guard = ctx.exclusive_worktree_access();
-
-    // Create trailers with branch names
-    let trailers: Vec<Trailer> = branches
-        .iter()
-        .map(|name| Trailer {
-            key: "branch".to_string(),
-            value: name.clone(),
-        })
-        .collect();
-
-    let details = SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(trailers);
-    let _snapshot = ctx.create_snapshot(details, guard.write_permission()).ok();
-}
-
 /// Confirm with the user and unapply the stack.
 fn confirm_and_unapply_stack(
     ctx: &mut but_ctx::Context,
@@ -153,9 +132,6 @@ fn confirm_and_unapply_stack(
     {
         bail!("Aborted unapply operation.");
     }
-
-    // Create snapshot before destructive operation
-    create_snapshot(ctx, branches);
 
     but_api::legacy::virtual_branches::unapply_stack(ctx, sid)?;
 

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -10,7 +10,7 @@ use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
 use gitbutler_operating_modes::ensure_open_workspace_mode;
 use gitbutler_oplog::{
     OplogExt, SnapshotExt,
-    entry::{OperationKind, SnapshotDetails},
+    entry::{OperationKind, SnapshotDetails, Trailer},
 };
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, RemoteRefname};
@@ -196,7 +196,20 @@ pub fn unapply_stack(
 ) -> Result<String> {
     ctx.verify(perm)?;
     ensure_open_workspace_mode(ctx, perm.read_permission())
-        .context("Deleting a branch order requires open workspace mode")?;
+        .context("Unapplying a stack requires open workspace mode")?;
+    let stack = ctx.virtual_branches().get_stack_in_workspace(stack_id)?;
+
+    let trailers: Vec<Trailer> = stack
+        .heads
+        .iter()
+        .map(|head| Trailer {
+            key: "branch".to_string(),
+            value: head.name.to_string(),
+        })
+        .collect();
+
+    let details = SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(trailers);
+    let _snapshot = ctx.create_snapshot(details, perm).ok();
     let branch_manager = ctx.branch_manager();
     // NB: unapply_without_saving is also called from save_and_unapply
     let branch_name = branch_manager.unapply(

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -3,7 +3,6 @@ use but_core::{DiffSpec, RepositoryExt};
 use but_ctx::access::RepoExclusive;
 use but_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_cherry_pick::GixRepositoryExt as _;
-use gitbutler_oplog::SnapshotExt;
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::StackId;
@@ -35,8 +34,6 @@ impl BranchManager<'_> {
                 .full_name()?
                 .to_string());
         }
-
-        _ = self.ctx.snapshot_branch_deletion(stack.name(), perm);
 
         let git2_repo = self.ctx.git2_repo.get()?;
 


### PR DESCRIPTION
Create the correct snapshot when unapplying a stack.

- Remove the ‘delete branch’ snapshot.
- Remvoe the ‘unapply snapshot’ at the but CLI level.
- The unapply API create a snapshot for unapply.

<img width="587" height="324" alt="Screenshot 2026-03-11 at 09 59 21" src="https://github.com/user-attachments/assets/db624aeb-abe2-444a-8a26-cd31036a9ce6" />
