### PR TITLE
move commit using the graph

### DIFF
--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -304,6 +304,21 @@ impl Workspace {
         })
     }
 
+    /// Try to find a commit in the workspace and return it along with the segment and stack containing it.
+    pub fn find_commit_and_containers(
+        &self,
+        commit_id: &gix::ObjectId,
+    ) -> Option<(&Stack, &StackSegment, &StackCommit)> {
+        self.stacks.iter().find_map(|stack| {
+            stack.segments.iter().find_map(|seg| {
+                seg.commits
+                    .iter()
+                    .find(|commit| commit.id == *commit_id)
+                    .map(|commit| (stack, seg, commit))
+            })
+        })
+    }
+
     /// Like [`Self::find_segment_and_stack_by_refname`], but fails with an error.
     pub fn try_find_segment_and_stack_by_refname(
         &self,

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -16,6 +16,8 @@ pub mod move_changes;
 pub use move_changes::function::{MoveChangesOutcome, move_changes_between_commits};
 pub mod uncommit_changes;
 pub use uncommit_changes::function::{UncommitChangesOutcome, uncommit_changes};
+pub mod move_commit;
+pub use move_commit::function::move_commit;
 
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
 #[derive(Clone)]

--- a/crates/but-workspace/src/commit/move_commit.rs
+++ b/crates/but-workspace/src/commit/move_commit.rs
@@ -1,0 +1,147 @@
+//! Move a commit within or across branches and stacks.
+
+pub(crate) mod function {
+    use anyhow::{Context, bail};
+    use but_rebase::graph_rebase::{
+        Editor, SuccessfulRebase, ToCommitSelector, ToSelector,
+        mutate::{InsertSide, SegmentDelimiter, SelectorSet, SomeSelectors},
+    };
+
+    /// Move a commit.
+    ///
+    /// The subject commit will be detached from the source segment, and inserted relative
+    /// to a given anchor (branch or commit).
+    pub fn move_commit(
+        workspace: &but_graph::projection::Workspace,
+        mut editor: Editor,
+        subject_commit: impl ToCommitSelector,
+        anchor: impl ToSelector,
+        side: InsertSide,
+    ) -> anyhow::Result<SuccessfulRebase> {
+        let (subject_commit_selector, subject_commit) =
+            editor.find_selectable_commit(subject_commit)?;
+
+        let Some(subject) = workspace.find_commit_and_containers(&subject_commit.id) else {
+            bail!("Failed to find the commit to move in the workspace.");
+        };
+
+        let (source_stack, source_segment, _) = subject;
+
+        let commit_delimiter = SegmentDelimiter {
+            child: subject_commit_selector,
+            parent: subject_commit_selector,
+        };
+
+        // Step 1: Determine the parents and children to disconnect.
+        let index_of_subject_commit = source_segment
+            .commits
+            .iter()
+            .position(|commit| commit.id == subject_commit.id)
+            .context("BUG: Subject commit is not in the source segment.")?;
+
+        let child_to_disconnect =
+            determine_child_selector(&editor, source_segment, index_of_subject_commit)?;
+
+        let parent_to_disconnect = determine_parent_selector(
+            workspace,
+            &editor,
+            source_stack,
+            source_segment,
+            index_of_subject_commit,
+        )?;
+
+        editor.disconnect_segment_from(
+            commit_delimiter.clone(),
+            child_to_disconnect,
+            parent_to_disconnect,
+            false,
+        )?;
+        editor.insert_segment(anchor, commit_delimiter, side)?;
+        editor.rebase()
+    }
+
+    /// Determine which children to disconnect, based on the position of the subject commit in the segment.
+    fn determine_child_selector(
+        editor: &Editor,
+        source_segment: &but_graph::projection::StackSegment,
+        index_of_subject_commit: usize,
+    ) -> Result<SelectorSet, anyhow::Error> {
+        let child_to_disconnect = if index_of_subject_commit == 0 {
+            // The commit is at the top of the branch.
+            // We just need to disconnect the ref from it.
+            let ref_name = source_segment
+                .ref_name()
+                .context("Source segment doesn't have a reference name.")?;
+            let reference_selector = editor.select_reference(ref_name)?;
+            let selectors = SomeSelectors::new(vec![reference_selector])?;
+            SelectorSet::Some(selectors)
+        } else if let Some(child_of_subject) =
+            source_segment.commits.get(index_of_subject_commit - 1)
+        {
+            let child_commit_selector = editor.select_commit(child_of_subject.id)?;
+            let selectors = SomeSelectors::new(vec![child_commit_selector])?;
+            SelectorSet::Some(selectors)
+        } else {
+            bail!(
+                "BUG: Subject commit is not the first child in segment but also can't find its child."
+            );
+        };
+        Ok(child_to_disconnect)
+    }
+
+    /// Determine which parents to disconnect, based on the position of the subject commit in the segment
+    /// and the position of the source segment in the source stack.
+    fn determine_parent_selector(
+        workspace: &but_graph::projection::Workspace,
+        editor: &Editor,
+        source_stack: &but_graph::projection::Stack,
+        source_segment: &but_graph::projection::StackSegment,
+        index_of_subject_commit: usize,
+    ) -> Result<SelectorSet, anyhow::Error> {
+        let parent_to_disconnect = if index_of_subject_commit == source_segment.commits.len() - 1 {
+            // Subject commit is the last one, then we need to disconnect the parent ref.
+            // If this is `None` but the `base_segment_id` is defined, it means that the parent segment lives
+            // outside the workspace and it's probably the target branch.
+            let stack_base_segment_ref_name =
+                source_segment.base_segment_id.and_then(|base_segment_id| {
+                    source_stack.segments.iter().find_map(|segment| {
+                        if segment.id == base_segment_id {
+                            segment.ref_name()
+                        } else {
+                            None
+                        }
+                    })
+                });
+
+            // Look for the base segment in the graph data, as a fallback if there's no stack segment found.
+            let graph_base_segment_ref_name = source_segment
+                .base_segment_id
+                .map(|base_segment_id| &workspace.graph[base_segment_id])
+                .and_then(|segment| segment.ref_name());
+
+            match stack_base_segment_ref_name.or(graph_base_segment_ref_name) {
+                Some(ref_name) => {
+                    let reference_selector = editor.select_reference(ref_name)?;
+                    let selectors = SomeSelectors::new(vec![reference_selector])?;
+                    SelectorSet::Some(selectors)
+                }
+                None => {
+                    // No explicit base segment/ref available (e.g., root commit or traversal stopped early).
+                    // Fall back to disconnecting from all parents; downstream code can handle this.
+                    SelectorSet::All
+                }
+            }
+        } else if let Some(parent_of_subject) =
+            source_segment.commits.get(index_of_subject_commit + 1)
+        {
+            let parent_commit_selector = editor.select_commit(parent_of_subject.id)?;
+            let selectors = SomeSelectors::new(vec![parent_commit_selector])?;
+            SelectorSet::Some(selectors)
+        } else {
+            bail!(
+                "BUG: Subject commit is not the last commit in the segment but can't find its parent either."
+            )
+        };
+        Ok(parent_to_disconnect)
+    }
+}

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -2,6 +2,7 @@ mod commit_amend;
 mod commit_create;
 mod insert_blank_commit;
 mod move_changes;
+mod move_commit;
 mod reword;
 mod uncommit_changes;
 

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1,0 +1,797 @@
+use but_rebase::graph_rebase::{GraphExt, mutate::InsertSide};
+use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
+};
+
+#[test]
+fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let c_commit = repo.rev_parse_single("C")?.detach();
+    let c_commit_selector = editor.select_commit(c_commit)?;
+
+    // Put C commit at the top of A
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        c_commit_selector,
+        a_commit_selector,
+        InsertSide::Above,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_c_commit = commit_mapping.get(&c_commit);
+    let tip_of_a_branch = repo.rev_parse_single("A")?.detach();
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_a_branch),
+        new_c_commit,
+        "The tip of A should be the C commit"
+    );
+
+    assert_eq!(
+        tip_of_c_branch, b_commit,
+        "The tip of C should be the B commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   26fdd46 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * c813d8d (C, B) B
+    * | 3db8c14 (A) C
+    * | 09d8e52 A
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:C on 85efbe4 {2}
+    │   ├── 📙:5:C
+    │   └── 📙:6:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            ├── ·3db8c14 (🏘️)
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let b_commit_selector = editor.select_commit(b_commit)?;
+    let c_commit = repo.rev_parse_single("C")?.detach();
+
+    // Put B commit at the top of A
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        b_commit_selector,
+        a_commit_selector,
+        InsertSide::Above,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_b_commit = commit_mapping.get(&b_commit);
+    let new_c_commit = commit_mapping.get(&c_commit);
+    let tip_of_a_branch = repo.rev_parse_single("A")?.detach();
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_a_branch),
+        new_b_commit,
+        "The tip of A should be the B commit"
+    );
+
+    assert_eq!(
+        Some(&tip_of_c_branch),
+        new_c_commit,
+        "The tip of C should be the the rebased C commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   ac869ab (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9f14615 (C) C
+    * | 698ccd3 (A) B
+    * | 09d8e52 A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·9f14615 (🏘️)
+    │   └── 📙:5:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            ├── ·698ccd3 (🏘️)
+            └── ·09d8e52 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let c_commit = repo.rev_parse_single("C")?.detach();
+    let c_commit_selector = editor.select_commit(c_commit)?;
+
+    // Put C commit below the A commit
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        c_commit_selector,
+        a_commit_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_a_commit = commit_mapping.get(&a_commit);
+    let tip_of_a_branch = repo.rev_parse_single("A")?.detach();
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_a_branch),
+        new_a_commit,
+        "The tip of A should be the rebased A commit"
+    );
+
+    assert_eq!(
+        tip_of_c_branch, b_commit,
+        "The tip of C should be the B commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   45976fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * c813d8d (C, B) B
+    * | 9bb60db (A) A
+    * | 9f14615 C
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:C on 85efbe4 {2}
+    │   ├── 📙:5:C
+    │   └── 📙:6:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            ├── ·9bb60db (🏘️)
+            └── ·9f14615 (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let b_commit_selector = editor.select_commit(b_commit)?;
+    let c_commit = repo.rev_parse_single("C")?.detach();
+
+    // Put B commit below the A commit
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        b_commit_selector,
+        a_commit_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_a_commit = commit_mapping.get(&a_commit);
+    let new_c_commit = commit_mapping.get(&c_commit);
+    let tip_of_a_branch = repo.rev_parse_single("A")?.detach();
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_a_branch),
+        new_a_commit,
+        "The tip of A should be the rebased A commit"
+    );
+
+    assert_eq!(
+        Some(&tip_of_c_branch),
+        new_c_commit,
+        "The tip of C should be the the rebased C commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   dbabd50 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9f14615 (C) C
+    * | 3df48f1 (A) A
+    * | c813d8d B
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·9f14615 (🏘️)
+    │   └── 📙:5:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            ├── ·3df48f1 (🏘️)
+            └── ·c813d8d (🏘️)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let c_commit = repo.rev_parse_single("C")?.detach();
+    let c_commit_selector = editor.select_commit(c_commit)?;
+
+    // Put A commit at the top of the branch C
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        a_commit_selector,
+        c_commit_selector,
+        InsertSide::Above,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_a_commit = commit_mapping.get(&a_commit);
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_c_branch),
+        new_a_commit,
+        "The tip of C should be the rebased A commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   9b0c3a5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 8dbfefa (C) A
+    | * 09bc93e C
+    | * c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main, A) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:3:C on 85efbe4 {2}
+    │   ├── 📙:3:C
+    │   │   ├── ·8dbfefa (🏘️)
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:4:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:5:A on 85efbe4 {1}
+        └── 📙:5:A
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_commit = repo.rev_parse_single("B")?.detach();
+    let b_commit_selector = editor.select_commit(b_commit)?;
+    let c_commit = repo.rev_parse_single("C")?.detach();
+
+    // Put A commit below the B commit
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        a_commit_selector,
+        b_commit_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_b_commit = commit_mapping.get(&b_commit);
+    let new_c_commit = commit_mapping.get(&c_commit);
+    let tip_of_b_branch = repo.rev_parse_single("B")?.detach();
+    let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_b_branch),
+        new_b_commit,
+        "The tip of B should be the rebased B commit"
+    );
+
+    assert_eq!(
+        Some(&tip_of_c_branch),
+        new_c_commit,
+        "The tip of C should be the rebased C commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   202b05f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * f603807 (C) C
+    | * 698ccd3 (B) B
+    | * 09d8e52 A
+    |/  
+    * 85efbe4 (origin/main, main, A) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:3:C on 85efbe4 {2}
+    │   ├── 📙:3:C
+    │   │   └── ·f603807 (🏘️)
+    │   └── 📙:4:B
+    │       ├── ·698ccd3 (🏘️)
+    │       └── ·09d8e52 (🏘️)
+    └── ≡📙:5:A on 85efbe4 {1}
+        └── 📙:5:A
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_commit_to_empty_branch() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph("ws-with-empty-stack", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["B"]);
+        })?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let a_commit = repo.rev_parse_single("A")?.detach();
+    let a_commit_selector = editor.select_commit(a_commit)?;
+    let b_ref_name = "refs/heads/B".try_into()?;
+    let b_ref_selector = editor.select_reference(b_ref_name)?;
+
+    // Put A commit in branch B
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        a_commit_selector,
+        b_ref_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let tip_of_b_branch = repo.rev_parse_single("B")?.detach();
+
+    assert_eq!(
+        tip_of_b_branch, a_commit,
+        "The tip of B should be the rebased A commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (B) A
+    |/  
+    * 85efbe4 (origin/main, main, A) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:3:B on 85efbe4 {2}
+    │   └── 📙:3:B
+    │       └── ·09d8e52 (🏘️)
+    └── ≡📙:4:A on 85efbe4 {1}
+        └── 📙:4:A
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:three[🌳] <> ✓!
+    └── ≡:0:three[🌳] {1}
+        ├── :0:three[🌳]
+        │   └── ·c9f444c
+        ├── :1:two <> origin/two →:2:
+        │   └── ❄️16fd221
+        └── :3:one
+            └── ❄8b426d0
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let three_commit = repo.rev_parse_single("three")?.detach();
+    let three_commit_selector = editor.select_commit(three_commit)?;
+    let two_ref_name = "refs/heads/two".try_into()?;
+    let two_ref_selector = editor.select_reference(two_ref_name)?;
+
+    // Put commit three at the top of branch two
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        three_commit_selector,
+        two_ref_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    rebase.materialize()?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let tip_of_three_branch = repo.rev_parse_single("three")?.detach();
+    let tip_of_two_branch = repo.rev_parse_single("two")?.detach();
+
+    assert_eq!(
+        tip_of_three_branch, three_commit,
+        "The tip of 'three' should be the three commit"
+    );
+
+    assert_eq!(
+        tip_of_two_branch, three_commit,
+        "The tip of 'two' should be the three commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three, two) commit three
+    * 16fd221 (origin/two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:three[🌳] <> ✓!
+    └── ≡:0:three[🌳] {1}
+        ├── :0:three[🌳]
+        │   ├── ·c9f444c ►two
+        │   └── ·16fd221
+        └── :3:one
+            └── ·8b426d0
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, meta, _description) =
+        named_writable_scenario_with_description_and_graph("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:three[🌳] <> ✓!
+    └── ≡:0:three[🌳] {1}
+        ├── :0:three[🌳]
+        │   └── ·c9f444c
+        ├── :1:two <> origin/two →:2:
+        │   └── ❄️16fd221
+        └── :3:one
+            └── ❄8b426d0
+    ");
+
+    let editor = ws.graph.to_editor(&repo)?;
+    let three_commit = repo.rev_parse_single("three")?.detach();
+    let three_commit_selector = editor.select_commit(three_commit)?;
+    let two_commit = repo.rev_parse_single("two")?.detach();
+    let two_commit_selector = editor.select_commit(two_commit)?;
+
+    // Put commit three below commit two
+    let rebase = but_workspace::commit::move_commit(
+        &ws,
+        editor,
+        three_commit_selector,
+        two_commit_selector,
+        InsertSide::Below,
+    )?;
+
+    // Materialize the operation
+    let materialization = rebase.materialize()?;
+    let commit_mappings = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_commit_two = commit_mappings.get(&two_commit);
+    let tip_of_three_branch = repo.rev_parse_single("three")?.detach();
+    let tip_of_two_branch = repo.rev_parse_single("two")?.detach();
+
+    assert_eq!(
+        Some(&tip_of_three_branch),
+        new_commit_two,
+        "The tip of 'three' should be the rebased two commit"
+    );
+
+    assert_eq!(
+        Some(&tip_of_two_branch),
+        new_commit_two,
+        "The tip of 'two' should be the rebased two commit"
+    );
+
+    // Branches 'three' and 'two' now point to the updated 'two' commit,
+    // which is now a child of three.
+    // The origin two branch has not been yet updated and still points to the original 'two' commit.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * b8c85c3 (HEAD -> three, two) commit two
+    * fc5e5e6 commit three
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (one) commit one
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    ⌂:0:three[🌳] <> ✓!
+    └── ≡:0:three[🌳] {1}
+        ├── :0:three[🌳]
+        │   ├── ·b8c85c3 ►two
+        │   └── ·fc5e5e6
+        └── :2:one
+            └── ·8b426d0
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
Add a workspace function that allow to move and reorder commits relative to other commits or references

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 1 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #12777 👈 
<!-- GitButler Footer Boundary Bottom -->

