### PR TITLE
Restore gitbutler as default storage path for dev and nightly

### DIFF
--- a/crates/but-cherry-apply/tests/fixtures/scenario/shared.sh
+++ b/crates/but-cherry-apply/tests/fixtures/scenario/shared.sh
@@ -43,8 +43,8 @@ function init-repo-with-files-and-remote () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler.dev
-  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
+  mkdir .git/gitbutler
+  cat <<EOF >>.git/gitbutler/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"
@@ -62,4 +62,3 @@ function commit() {
   local message=${1:?first argument is the commit message}
   git commit -am "$message" --allow-empty
 }
-

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -25,8 +25,9 @@ pub trait RepositoryExt: Sized {
     /// * If the resolved path is outside of [`gix::Repository::git_dir`], the storage path
     ///   becomes `<configured-path>/<project-handle>` so multiple projects can share one base path
     ///   without clobbering each other. This also applies to relative paths like `../../shared`.
-    /// * Otherwise defaults to `<git-dir>/gitbutler` for release builds and
-    ///   `<git-dir>/gitbutler.<channel>` for non-release builds.
+    /// * Otherwise defaults to `<git-dir>/gitbutler` on all channels.
+    //    The idea is to support one storage location per channel once we can make sure that the previously
+    //    used metadata doesn't get lost, like the target branch, for instance by copying it over from stable.
     fn gitbutler_storage_path(&self) -> anyhow::Result<PathBuf>;
     /// Set all fields in `config` that are not `None` to disk into local repository configuration, or none of them.
     fn set_git_settings(&self, config: &GitConfigSettings) -> anyhow::Result<()>;

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -94,8 +94,8 @@ pub struct Context {
     /// against `gitdir`; paths that stay inside `gitdir` must live under a
     /// top-level directory whose name starts with `gitbutler`. Any resolved
     /// path outside `gitdir` gets a `<configured-path>/<project-handle>`
-    /// suffix. If that key is not configured, a channel-specific default is
-    /// used.
+    /// suffix. If that key is not configured, the default is `gitdir/gitbutler`
+    /// on all channels.
     pub project_data_dir: PathBuf,
     /// The directory to store application caches in.
     pub app_cache_dir: Option<PathBuf>,

--- a/crates/but-hunk-dependency/tests/fixtures/scenario/shared.sh
+++ b/crates/but-hunk-dependency/tests/fixtures/scenario/shared.sh
@@ -35,8 +35,8 @@ function setup-remote-and-vbtoml () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler.dev
-  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
+  mkdir .git/gitbutler
+  cat <<EOF >>.git/gitbutler/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -24,7 +24,7 @@ pub fn gitbutler_storage_path(repo: &gix::Repository) -> anyhow::Result<PathBuf>
         Some(Err(err)) => {
             Err(err).with_context(|| format!("{storage_key} contains an invalid path"))
         }
-        None => Ok(git_dir.join(default_gitbutler_storage_dir_name(&channel))),
+        None => Ok(git_dir.join(default_gitbutler_storage_dir_name())),
     }
 }
 
@@ -98,12 +98,8 @@ fn validate_in_git_storage_path(
     Ok(())
 }
 
-fn default_gitbutler_storage_dir_name(channel: &AppChannel) -> &'static str {
-    match channel {
-        AppChannel::Release => "gitbutler",
-        AppChannel::Nightly => "gitbutler.nightly",
-        AppChannel::Dev => "gitbutler.dev",
-    }
+fn default_gitbutler_storage_dir_name() -> &'static str {
+    "gitbutler"
 }
 
 fn storage_path_config_key_for_channel(channel: &AppChannel) -> &'static str {

--- a/crates/but-project-handle/tests/project-handle/storage_path.rs
+++ b/crates/but-project-handle/tests/project-handle/storage_path.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use but_path::AppChannel;
 use but_project_handle::{ProjectHandle, gitbutler_storage_path, storage_path_config_key};
 use but_testsupport::{CommandExt as _, git, gix_testtools, open_repo};
 use gix_testtools::tempfile::TempDir;
@@ -23,11 +22,7 @@ fn set_git_config(
 }
 
 fn default_storage_dir_name() -> &'static str {
-    match AppChannel::new() {
-        AppChannel::Release => "gitbutler",
-        AppChannel::Nightly => "gitbutler.nightly",
-        AppChannel::Dev => "gitbutler.dev",
-    }
+    "gitbutler"
 }
 
 #[test]

--- a/crates/but-worktrees/tests/fixtures/scenario/shared.sh
+++ b/crates/but-worktrees/tests/fixtures/scenario/shared.sh
@@ -41,8 +41,8 @@ function init-repo-with-files-and-remote () {
 EOF
 
   # Make sure the target is set.
-  mkdir .git/gitbutler.dev
-  cat <<EOF >>.git/gitbutler.dev/virtual_branches.toml
+  mkdir .git/gitbutler
+  cat <<EOF >>.git/gitbutler/virtual_branches.toml
 [default_target]
    branchName = "main"
    remoteName = "origin"
@@ -60,4 +60,3 @@ function commit() {
   local message=${1:?first argument is the commit message}
   git commit -am "$message" --allow-empty
 }
-

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -24,8 +24,8 @@ but-settings.workspace = true
 but-gerrit.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-rebase.workspace = true
-but-project-handle.workspace = true
 but-core = { workspace = true, features = ["legacy"] }
+but-project-handle.workspace = true
 but-graph.workspace = true
 but-oxidize.workspace = true
 but-forge.workspace = true

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -348,12 +348,12 @@ impl Project {
 
     /// Returns the path to the directory containing the `GitButler` state for this project.
     ///
-    /// By default this is `.git/gitbutler` for release builds and `.git/gitbutler.<channel>`
-    /// for non-release builds. It can be overridden by setting `gitbutler.storagePath`
-    /// on release, or `gitbutler.<channel>.storagePath` on non-release builds. Relative
-    /// configured values are resolved against `.git`; if they stay inside `.git`, they must
-    /// live under a top-level directory whose name starts with `gitbutler`. Any resolved path
-    /// outside `.git` gets a project-handle suffix to keep different projects isolated.
+    /// By default this is `.git/gitbutler` on all channels. It can be overridden by setting
+    /// `gitbutler.storagePath` on release, or `gitbutler.<channel>.storagePath` on non-release
+    /// builds. Relative configured values are resolved against `.git`; if they stay inside `.git`,
+    /// they must live under a top-level directory whose name starts with `gitbutler`. Any
+    /// resolved path outside `.git` gets a project-handle suffix to keep different projects
+    /// isolated.
     pub(crate) fn gb_dir(&self) -> anyhow::Result<PathBuf> {
         gix::open(self.git_dir())?.gitbutler_storage_path()
     }

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -311,10 +311,9 @@ pub mod read_only {
 }
 
 fn set_storage_path_for_testing(git_dir: &Path) -> anyhow::Result<()> {
-    git2::Repository::open(git_dir)?.config()?.set_str(
-        but_project_handle::storage_path_config_key(),
-        "gitbutler.dev",
-    )?;
+    git2::Repository::open(git_dir)?
+        .config()?
+        .set_str(but_project_handle::storage_path_config_key(), "gitbutler")?;
     Ok(())
 }
 

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -396,7 +396,7 @@ pub(crate) fn setup_config(config: &git2::Config) -> anyhow::Result<()> {
             local.set_str("user.name", "gitbutler-test")?;
             local.set_str("user.email", "gitbutler-test@example.com")?;
             let key = but_project_handle::storage_path_config_key();
-            local.set_str(key, "gitbutler.dev")?;
+            local.set_str(key, "gitbutler")?;
             Ok(())
         }
         Err(err) => Err(err.into()),


### PR DESCRIPTION
## Summary
- change the default per-project storage directory for nightly and dev back to `.git/gitbutler`
- keep channel-specific override keys intact, so explicit config still works as before
- update docs and tests to match the restored default

## Motivation
Channel-separated default storage paths cause surprising UI behavior for nightly users and can lose target sha/base metadata. Reusing `gitbutler` is the safer default again until project metadata can be copied safely from stable.

## Tasks

* [x] review