### PR TITLE
Replace `#[allow(...)]` with `#[expect(...)]`

### DIFF
--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -59,7 +59,7 @@ impl AutoCommitEvent {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn auto_commit(
     project_id: ProjectHandleOrLegacyProjectId,
     repo: &gix::Repository,
@@ -135,7 +135,7 @@ pub(crate) fn auto_commit_simple(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn apply_commit_changes(
     project_id: Option<ProjectHandleOrLegacyProjectId>,
     repo: &gix::Repository,

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -40,7 +40,7 @@ pub fn branch_changes(
     branch_changes::branch_changes(ctx, llm, changes, model)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn auto_commit(
     project_id: ProjectHandleOrLegacyProjectId,
     repo: &gix::Repository,

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -297,7 +297,7 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         #input_fn
 
         const _: () = {
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             fn keep_json(_json: #json_ty) {}
         };
 

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -1,7 +1,6 @@
 //! In place of commands.rs
 use std::env;
 
-#[allow(unused_imports)]
 use anyhow::anyhow;
 use anyhow::{Context as _, Result, bail};
 use but_api_macros::but_api;

--- a/crates/but-bot/src/lib.rs
+++ b/crates/but-bot/src/lib.rs
@@ -22,7 +22,7 @@ pub fn bot(
     graph.start(&mut but_bot)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn forge_branch_chat(
     project_id: ProjectHandleOrLegacyProjectId,
     branch: String,

--- a/crates/but-claude/src/claude_transcript.rs
+++ b/crates/but-claude/src/claude_transcript.rs
@@ -30,7 +30,7 @@ pub struct AssistantMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum Record {
     #[serde(rename = "summary")]
     Summary {

--- a/crates/but-claude/src/permissions/patterns.rs
+++ b/crates/but-claude/src/permissions/patterns.rs
@@ -148,7 +148,6 @@ impl PathPattern {
 }
 
 /// What kind of pattern to serialize as.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum PathPatternKind {
     HomeRelative,

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -1590,7 +1590,7 @@ async fn handle_ask_user_question(
 ///    `can_use_tool` callback to work correctly with the SDK's streaming mode.
 /// 2. Performs file locking to track which files are being edited during the session,
 ///    preventing conflicts when Claude modifies files.
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 fn create_pretool_use_hook(
     sync_ctx: ThreadSafeContext,
     stack_id: but_core::ref_metadata::StackId,

--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -485,7 +485,7 @@ fn to_additive_hunks(
 ///
 /// Note that this algorithm is kind of the opposite of what people would expect if it's run where `to_additive_hunks()` works.
 /// But here we are… just making this work.
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 fn to_additive_hunks_fallback(
     hunks_to_keep: impl IntoIterator<Item = HunkHeader>,
     worktree_hunks: &[HunkHeader],

--- a/crates/but-core/src/worktree/checkout/tree.rs
+++ b/crates/but-core/src/worktree/checkout/tree.rs
@@ -20,7 +20,7 @@ impl Default for Lut {
     }
 }
 
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 impl Lut {
     /// Insert a node for each component in slash-separated `rela_path`.
     pub fn track_file(&mut self, rela_path: &BStr) {

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -380,7 +380,7 @@ impl Context {
     /// # IMPORTANT
     /// * if the workspace was changed, write the new workspace back into `&mut ws`.
     #[instrument(name = "Context::workspace_mut_and_db_mut", level = "debug", skip_all)]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn workspace_mut_and_db_mut(
         &mut self,
     ) -> anyhow::Result<(
@@ -442,7 +442,7 @@ impl Context {
     /// * if the workspace was changed, write it back into `&mut ws`.
     /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(name = "Context::workspace_and_db_mut", level = "debug", skip_all)]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn workspace_and_db_mut(
         &mut self,
     ) -> anyhow::Result<(
@@ -469,7 +469,6 @@ impl Context {
         level = "debug",
         skip_all
     )]
-    #[allow(clippy::type_complexity)]
     pub fn workspace_and_db_mut_with_perm(
         &mut self,
         _perm: &RepoShared,
@@ -501,7 +500,7 @@ impl Context {
     /// * if the workspace was changed, write it back into `&mut ws`.
     /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(name = "Context::workspace_mut_from_head", level = "debug", skip_all)]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn workspace_mut_and_db(
         &mut self,
     ) -> anyhow::Result<(
@@ -526,7 +525,6 @@ impl Context {
         level = "debug",
         skip_all
     )]
-    #[allow(clippy::type_complexity)]
     pub fn workspace_mut_and_db_with_perm(
         &self,
         _perm: &RepoExclusive,
@@ -558,7 +556,7 @@ impl Context {
     /// # IMPORTANT
     /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(name = "Context::workspace_from_head", level = "debug", skip_all)]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn workspace_and_db(
         &self,
     ) -> anyhow::Result<(
@@ -580,7 +578,6 @@ impl Context {
         level = "debug",
         skip_all
     )]
-    #[allow(clippy::type_complexity)]
     pub fn workspace_and_db_with_perm(
         &self,
         _perm: &RepoShared,

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -127,12 +127,10 @@ pub enum GitHubAccount {
         username: String,
         access_token: Sensitive<String>,
     },
-    #[allow(dead_code)]
     Pat {
         username: String,
         access_token: Sensitive<String>,
     },
-    #[allow(dead_code)]
     Enterprise {
         username: String,
         host: String,

--- a/crates/but-gitlab/src/token.rs
+++ b/crates/but-gitlab/src/token.rs
@@ -113,12 +113,10 @@ impl std::fmt::Display for GitlabAccountIdentifier {
 }
 
 pub enum GitLabAccount {
-    #[allow(dead_code)]
     Pat {
         username: String,
         access_token: Sensitive<String>,
     },
-    #[allow(dead_code)]
     SelfHosted {
         username: String,
         host: String,

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -87,7 +87,7 @@ impl HunkDependencies {
 fn hunk_dependency_diffs_schema(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
     /// A mirror of the tuple `(String, DiffHunk, Vec<HunkLock>)` for schema generation.
     #[derive(schemars::JsonSchema)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct HunkDependencyDiff(String, DiffHunk, Vec<HunkLock>);
 
     generate.subschema_for::<Vec<HunkDependencyDiff>>()

--- a/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
@@ -321,7 +321,7 @@ mod util {
 
     pub struct TestContext {
         // TODO: remove this once this has been ported to 'modern' code, i.e. uses `but-graph::projection::Workspace`.
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         pub tmpdir: Option<tempfile::TempDir>,
     }
 

--- a/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
@@ -911,7 +911,7 @@ mod util {
         pub ctx: Context,
         // TODO: make non-optional
         // TODO: remove once we don't need vb.toml anymore which is produced on the fly.
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         tmpdir: Option<tempfile::TempDir>,
     }
 }

--- a/crates/but-link/tests/claiming.rs
+++ b/crates/but-link/tests/claiming.rs
@@ -4,22 +4,21 @@ use std::time::Duration;
 use rusqlite::{Connection, params};
 use serde_json::json;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/services/acquire.rs"]
 mod acquire_impl;
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/cli.rs"]
 mod cli;
-#[allow(dead_code, unused_imports)]
+#[expect(dead_code, unused_imports)]
 #[path = "../src/db/mod.rs"]
 mod db;
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/payloads.rs"]
 mod payloads;
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/repo.rs"]
 mod repo;
-#[allow(dead_code)]
 #[path = "../src/text.rs"]
 mod text;
 

--- a/crates/but-link/tests/cli.rs
+++ b/crates/but-link/tests/cli.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/cli.rs"]
 mod cli_impl;
 

--- a/crates/but-link/tests/db.rs
+++ b/crates/but-link/tests/db.rs
@@ -1,13 +1,12 @@
 use rusqlite::{Connection, params};
 use serde_json::{Value, json};
 
-#[allow(dead_code, unused_imports)]
+#[expect(dead_code, unused_imports)]
 #[path = "../src/db/mod.rs"]
 mod db;
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/payloads.rs"]
 mod payloads;
-#[allow(dead_code)]
 #[path = "../src/text.rs"]
 mod text;
 

--- a/crates/but-link/tests/payloads.rs
+++ b/crates/but-link/tests/payloads.rs
@@ -1,7 +1,5 @@
-#[allow(dead_code)]
 #[path = "../src/payloads.rs"]
 mod payloads_impl;
-#[allow(dead_code)]
 #[path = "../src/text.rs"]
 mod text;
 

--- a/crates/but-link/tests/repo.rs
+++ b/crates/but-link/tests/repo.rs
@@ -1,7 +1,7 @@
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/cli.rs"]
 mod cli;
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[path = "../src/repo.rs"]
 mod repo_impl;
 

--- a/crates/but-meta/src/legacy/storage.rs
+++ b/crates/but-meta/src/legacy/storage.rs
@@ -586,7 +586,7 @@ fn snapshot_to_legacy(snapshot: &VirtualBranchesSnapshot) -> anyhow::Result<Virt
     })
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum TomlInfo {
     Missing,
     Parsed(ParsedToml),

--- a/crates/but-meta/src/virtual_branches_legacy_types.rs
+++ b/crates/but-meta/src/virtual_branches_legacy_types.rs
@@ -229,7 +229,7 @@ mod stack {
         #[derive(Deserialize)]
         enum CommitOrChangeIdHelper {
             CommitId(String),
-            #[allow(dead_code)]
+            #[expect(dead_code)]
             ChangeId(String),
         }
 

--- a/crates/but-project-handle/src/project_handle.rs
+++ b/crates/but-project-handle/src/project_handle.rs
@@ -250,7 +250,7 @@ mod tests {
             use std::os::unix::ffi::OsStrExt as _;
 
             let bytes = b"/tmp/\xF1\xF2\xF3\xC0\xC1\xC2";
-            #[allow(invalid_from_utf8)]
+            #[expect(invalid_from_utf8)]
             let res = std::str::from_utf8(bytes);
             assert!(res.is_err(), "this is illformed UTF8");
             let encoded = encode(bytes);

--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -307,7 +307,7 @@ fn commit_from_unconflicted_tree<'repo>(
     .attach(repo))
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn commit_from_conflicted_tree<'repo>(
     parents: &[gix::ObjectId],
     mut to_rebase: but_core::Commit<'repo>,

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -225,7 +225,6 @@ pub struct Editor {
 }
 
 /// Represents a successful rebase, and any valid, but potentially conflicting scenarios it had.
-#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct SuccessfulRebase {
     pub(crate) repo: gix::Repository,

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -221,7 +221,7 @@ pub fn bstring_bytes_opt(generate: &mut schemars::SchemaGenerator) -> schemars::
 }
 
 #[derive(schemars::JsonSchema)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct GixTime {
     seconds: i64,
     offset: i32,
@@ -243,7 +243,7 @@ pub fn gix_time_opt(generate: &mut schemars::SchemaGenerator) -> schemars::Schem
 
 #[derive(schemars::JsonSchema)]
 #[schemars(rename = "EntryKind")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum EntryKindSchema {
     Tree,
     Blob,
@@ -269,7 +269,7 @@ pub fn entry_kind(generate: &mut schemars::SchemaGenerator) -> schemars::Schema 
 /// Schema for `serde_error::Error` which serializes as `{description: string, source?: Error | null}`.
 #[derive(schemars::JsonSchema)]
 #[schemars(rename = "SerdeError")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct SerdeErrorSchema {
     description: String,
     source: Option<Box<SerdeErrorSchema>>,

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -127,7 +127,7 @@ pub struct Options {
     pub new_stack_id: Option<fn(&gix::refs::FullNameRef) -> StackId>,
 }
 
-#[allow(clippy::indexing_slicing)]
+#[expect(clippy::indexing_slicing)]
 pub(crate) mod function {
     use std::borrow::Cow;
 

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -141,7 +141,7 @@ pub mod merge {
                 tips.into_iter().map(|t| (I::Merge, t)).collect();
 
             let mut ran_merge_trials_loop_safety = false;
-            #[allow(clippy::indexing_slicing)]
+            #[expect(clippy::indexing_slicing)]
             'retry_loop: loop {
                 let mut prev_base_sidx = None;
                 let mut merge_tree_id = None;

--- a/crates/but-workspace/src/tree_manipulation/create_tree_without_diff.rs
+++ b/crates/but-workspace/src/tree_manipulation/create_tree_without_diff.rs
@@ -15,7 +15,6 @@ pub enum ChangesSource {
         id: gix::ObjectId,
     },
     /// Changes between two arbitrary trees
-    #[allow(dead_code)]
     Tree {
         /// The "after" tree ID
         after_id: gix::ObjectId,

--- a/crates/but-worktrees/tests/worktree/main.rs
+++ b/crates/but-worktrees/tests/worktree/main.rs
@@ -24,7 +24,7 @@ mod util {
         })
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub struct TestContext {
         pub ctx: Context,
         pub handle: VirtualBranchesHandle,

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -122,7 +122,7 @@ pub(crate) fn handle(
 }
 
 /// Absorb a single file into the appropriate commit
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn absorb_assignments(
     absorption_plan: Vec<CommitAbsorption>,
     guard: &mut RepoExclusiveGuard,

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -7,7 +7,7 @@ use gitbutler_branch_actions::BranchListingFilter;
 
 use crate::utils::OutputChannel;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn list(
     ctx: &mut but_ctx::Context,
     local: bool,
@@ -236,7 +236,7 @@ pub fn list(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn output_json(
     applied_stacks: &[but_workspace::legacy::ui::StackEntry],
     branches: &[gitbutler_branch_actions::BranchListing],

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -161,7 +161,7 @@ pub fn show_branches(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn list_branches(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -6,7 +6,6 @@ use tracing::instrument;
 
 use crate::utils::{OutputChannel, shorten_object_id};
 
-#[allow(clippy::too_many_arguments)]
 pub fn show(
     ctx: &mut Context,
     branch_id: &str,

--- a/crates/but/src/command/legacy/diff/show.rs
+++ b/crates/but/src/command/legacy/diff/show.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{IdMap, id::UncommittedCliId, utils::OutputChannel};
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub(crate) enum Filter {
     Unassigned,
     Uncommitted(UncommittedCliId),

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -278,7 +278,7 @@ pub fn set_review_template(
 /// Create a new forge review for a branch.
 /// If no branch is specified, prompts the user to select one.
 /// If there is only one branch without a an acco, asks for confirmation.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn create_review(
     ctx: &mut Context,
     branch: Option<String>,
@@ -447,7 +447,7 @@ fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<St
     Ok(branch_ids)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn handle_multiple_branches_in_workspace(
     ctx: &mut Context,
     review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
@@ -612,7 +612,7 @@ fn prompt_for_branch_selection(
     Ok(selected_branches)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn publish_reviews_for_branch_and_dependents(
     ctx: &mut Context,
     branch_name: &str,
@@ -857,7 +857,7 @@ pub fn parse_review_message(content: &str) -> anyhow::Result<ForgeReviewMessage>
     Ok(ForgeReviewMessage { title, body })
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn publish_review_for_branch(
     ctx: &mut Context,
     stack_id: Option<StackId>,

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -229,7 +229,6 @@ impl<'a> RubOperation<'a> {
 ///
 /// This function is the single source of truth for what operations are valid.
 /// Both `handle()` and disambiguation logic use this function.
-#[allow(private_interfaces)]
 pub(crate) fn route_operation<'a>(
     source: &'a CliId,
     target: &'a CliId,

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -314,7 +314,7 @@ fn squash_commits_internal(
 }
 
 /// Helper function to squash all commits in a branch into the bottom-most commit
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn squash_branch_commits(
     ctx: &mut Context,
     out: &mut OutputChannel,

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -289,7 +289,6 @@ impl From<Vec<but_forge::CiCheck>> for Ci {
 }
 
 impl Branch {
-    #[allow(clippy::too_many_arguments)]
     pub fn from_branch_details(
         repo: &gix::Repository,
         cli_id: String,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -590,7 +590,7 @@ fn ci_map(
     Ok(ci_map)
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn print_assignments(
     repo: &gix::Repository,
     stack: Option<StackId>,

--- a/crates/but/vendor/cli-prompts/examples/general.rs
+++ b/crates/but/vendor/cli-prompts/examples/general.rs
@@ -6,7 +6,7 @@ use cli_prompts::{
 #[derive(Debug)]
 enum CarModel {
     Audi,
-    #[allow(clippy::upper_case_acronyms)]
+    #[expect(clippy::upper_case_acronyms)]
     BMW,
     Chevrolet,
 }

--- a/crates/gitbutler-repo-actions/src/repository.rs
+++ b/crates/gitbutler-repo-actions/src/repository.rs
@@ -14,7 +14,7 @@ use gitbutler_repo::{
 use gitbutler_stack::{Stack, StackId};
 
 use crate::askpass;
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub trait RepoActionsExt {
     fn fetch(&self, remote_name: &str, askpass: Option<String>) -> Result<()>;
     /// Returns the stderr output of the git executable if used.

--- a/crates/gitbutler-tauri/src/claude.rs
+++ b/crates/gitbutler-tauri/src/claude.rs
@@ -14,7 +14,7 @@ use but_ctx::ProjectHandleOrLegacyProjectId;
 use tauri::State;
 use tracing::instrument;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 #[tauri::command(async)]
 #[instrument(skip(claude), err(Debug))]
 pub async fn claude_send_message(


### PR DESCRIPTION
`expect` works like `allow` except it fails if the lint isn't actually required. So helps to catch things like unnecessary `#[allow(dead_code)]`.

Done with search-n-replace and having an agent fixing `cargo clippy`.