### PR TITLE
Fix move between commits error

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1479,6 +1479,9 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 						...commitChangesTags,
 					];
 				},
+				transformResponse: (a: BackendMoveChangesResult) => ({
+					replacedCommits: Object.entries(a.replacedCommits),
+				}),
 			}),
 			commitMoveChangesBetween: build.mutation<
 				{


### PR DESCRIPTION
A recent refactor changed the response type, but this endpoint was
overlooked.