### PR TITLE
Increase GitHub check runs page size to 100

### DIFF
--- a/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
@@ -84,6 +84,7 @@ function injectEndpoints(api: GitHubApi) {
 							extra: api.extra,
 							parameters: {
 								ref,
+								per_page: 100,
 							},
 						});
 					}


### PR DESCRIPTION
Looks like for the gitbutler repo 30 is not enough. Ideally it would..
be configurable, but until then we need to set it to max.