### PR TITLE
but-rebase: fix duplicated tree hash in octopus merge error message

### DIFF
--- a/crates/but-rebase/src/merge.rs
+++ b/crates/but-rebase/src/merge.rs
@@ -78,7 +78,7 @@ pub fn octopus(
                             .join(", ")
                     )
                 } else {
-                    format!(" and tree {tree_to_merge}")
+                    format!(" and tree {}", successfully_merged[0])
                 }
             )
             .context(ConflictErrorContext {


### PR DESCRIPTION
The `octopus()` error message in `merge.rs` prints `tree_to_merge` twice when a 2-parent merge conflicts. The `else` branch (for `successfully_merged.len() == 1`) formats `" and tree {tree_to_merge}"`, duplicating the hash already in the outer string. Changed to reference `successfully_merged[0]` so the message shows both the ours and theirs tree IDs.

Before:
```
Encountered conflict when merging tree 8c869f1 and tree 8c869f1
```

After:
```
Encountered conflict when merging tree 8c869f1 and tree a3b72c4
```

Fixes #12791