### PR TITLE
Fix package name for `svelte-comment-injector`

### DIFF
--- a/packages/svelte-comment-injector/README.md
+++ b/packages/svelte-comment-injector/README.md
@@ -16,7 +16,7 @@ A Svelte preprocessor that injects an HTML comment at the top of every component
 ## 📦 Installation
 
 ```bash
-npm install svelte-devtools-comment --save-dev
+npm install @gitbutler/svelte-comment-injector --save-dev
 ```
 
 ## ⚙️ Usage

--- a/packages/svelte-comment-injector/README.md
+++ b/packages/svelte-comment-injector/README.md
@@ -25,7 +25,7 @@ Add the preprocessor to your Svelte configuration:
 
 ```js
 // svelte.config.js
-import svelteInjectComment from "svelte-devtools-comment";
+import svelteInjectComment from "@gitbutler/svelte-comment-injector";
 
 export default {
 	preprocess: [svelteInjectComment()],
@@ -39,7 +39,7 @@ You can customize the comment format by passing options to the preprocessor:
 
 ```js
 // svelte.config.js
-import svelteInjectComment from "svelte-devtools-comment";
+import svelteInjectComment from "@gitbutler/svelte-comment-injector";
 
 export default {
 	preprocess: [


### PR DESCRIPTION
## 🧢 Changes

This PR fixes references to the `svelte-comment-injector` package name.

## ☕️ Reasoning

This package is [not published as `svelte-devtools-comment` on NPM](https://www.npmjs.com/package/svelte-devtools-comment) but instead as [`@gitbutler/svelte-comment-injector`](https://www.npmjs.com/package/@gitbutler/svelte-comment-injector), causing the `npm install` command (as it currently is in the README) to fail as well as the imports.