### PR TITLE
Fix but sdk types

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -128,7 +128,7 @@
 			projectId,
 			stackId,
 			seriesName: branchName,
-			strategy: "rebase",
+			integrationStrategy: { type: "rebase" },
 		});
 	}
 

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -94,6 +94,8 @@
 		skipForcePushProtection: boolean;
 		gerritFlags: GerritPushFlag[];
 	}) {
+		if (!stackId) return;
+
 		const { withForce, skipForcePushProtection, gerritFlags } = args;
 		try {
 			const pushResult = await pushStack({

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -157,6 +157,8 @@
 	async function pushIfNeeded(
 		branchName: string,
 	): Promise<[string | undefined, BranchPushResult | undefined]> {
+		if (!stackId) return [undefined, undefined];
+
 		if (pushBeforeCreate) {
 			const firstPush = branchDetails?.pushStatus === "completelyUnpushed";
 			const withForce = partialStackRequestsForcePush(branchName, branches);

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -105,7 +105,9 @@ on fetching and pushing for ways to resolve the problem.
 	}
 }
 
-export type SeriesIntegrationStrategy = "merge" | "rebase";
+export type SeriesIntegrationStrategy = {
+	type: "merge" | "rebase";
+};
 
 export interface BranchPushResult {
 	/**
@@ -149,7 +151,7 @@ type BackendCreateCommitOutcome = {
 export type CreateCommitOutcome = {
 	newCommit: string | null;
 	pathsToRejectedChanges: [RejectionReason, string][];
-	replacedCommits?: ReplacedCommit[];
+	commitMapping: ReplacedCommit[];
 };
 
 type BackendCommitRewordResult = {
@@ -170,7 +172,7 @@ function normalizeCreateCommitOutcome(response: BackendCreateCommitOutcome): Cre
 	return {
 		newCommit: response.newCommit ?? null,
 		pathsToRejectedChanges: response.pathsToRejectedChanges,
-		replacedCommits: Object.entries(response.replacedCommits),
+		commitMapping: Object.entries(response.replacedCommits),
 	};
 }
 
@@ -1175,7 +1177,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				BranchPushResult,
 				{
 					projectId: string;
-					stackId?: string;
+					stackId: string;
 					withForce: boolean;
 					skipForcePushProtection: boolean;
 					branch: string;
@@ -1410,7 +1412,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				query: (args) => args,
 			}),
 			absorb: build.mutation<
-				void,
+				number,
 				{ projectId: string; absorptionPlan: HunkAssignment.CommitAbsorption[] }
 			>({
 				extraOptions: {
@@ -1479,9 +1481,6 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 						...commitChangesTags,
 					];
 				},
-				transformResponse: (a: BackendMoveChangesResult) => ({
-					replacedCommits: Object.entries(a.replacedCommits),
-				}),
 			}),
 			commitMoveChangesBetween: build.mutation<
 				{
@@ -1523,9 +1522,6 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 					actionName: "Uncommit Changes",
 				},
 				query: (args) => args,
-				transformResponse: (a: BackendMoveChangesResult) => ({
-					replacedCommits: Object.entries(a.replacedCommits),
-				}),
 				invalidatesTags(_result, _error, args) {
 					return [
 						invalidatesList(ReduxTag.HeadSha),
@@ -1594,7 +1590,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 					projectId: string;
 					stackId: string;
 					branchName: string;
-					prNumber: number;
+					prNumber?: number;
 				}
 			>({
 				extraOptions: {
@@ -1727,7 +1723,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 					projectId: string;
 					stackId: string;
 					seriesName: string;
-					strategy: SeriesIntegrationStrategy | undefined;
+					integrationStrategy: SeriesIntegrationStrategy | undefined;
 				}
 			>({
 				extraOptions: {
@@ -1738,6 +1734,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.HeadSha),
 					invalidatesList(ReduxTag.WorktreeChanges),
+					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesItem(ReduxTag.BranchChanges, args.stackId),
 				],
 			}),
@@ -1766,6 +1763,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.HeadSha),
+					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesItem(ReduxTag.IntegrationSteps, args.stackId + args.branchName),
 					invalidatesItem(ReduxTag.BranchDetails, args.branchName),
 					invalidatesItem(ReduxTag.BranchChanges, args.stackId),

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -19,6 +19,35 @@ use tracing::instrument;
 
 use crate::json::HexHash;
 
+mod json {
+    use but_workspace::legacy::MoveChangesResult;
+    use serde::Serialize;
+
+    use crate::json::HexHash;
+
+    /// UI type for a move changes between commits result.
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    /// UI type for a move changes between commits result
+    pub struct UIMoveChangesResult {
+        /// Commits that have been mapped from one thing to another
+        pub replaced_commits: Vec<(HexHash, HexHash)>,
+    }
+
+    impl From<MoveChangesResult> for UIMoveChangesResult {
+        fn from(value: MoveChangesResult) -> Self {
+            let MoveChangesResult { replaced_commits } = value;
+
+            Self {
+                replaced_commits: replaced_commits
+                    .into_iter()
+                    .map(|(x, y)| (x.into(), y.into()))
+                    .collect(),
+            }
+        }
+    }
+}
+
 #[but_api(napi, try_from = but_workspace::ui::RefInfo)]
 #[instrument(err(Debug))]
 pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
@@ -383,25 +412,6 @@ pub fn discard_worktree_changes(
         tracing::warn!(?refused, "Failed to discard at least one hunk");
     }
     Ok(refused)
-}
-
-mod json {
-    use but_workspace::legacy::MoveChangesResult;
-
-    pub use crate::commit::json::UIMoveChangesResult;
-
-    impl From<MoveChangesResult> for UIMoveChangesResult {
-        fn from(value: MoveChangesResult) -> Self {
-            let MoveChangesResult { replaced_commits } = value;
-
-            Self {
-                replaced_commits: replaced_commits
-                    .into_iter()
-                    .map(|(x, y)| (x.into(), y.into()))
-                    .collect(),
-            }
-        }
-    }
 }
 
 #[but_api(json::UIMoveChangesResult)]


### PR DESCRIPTION
`UIMoveCommitResult` was used in more places than expected.

This commit restores the legacy functions to use their origional signatures for now to avoid unexpected issues.

I’ve also done a pass to try and make sure all the other types are faithful and made some tweaks.