### PR TITLE
fix: use args method for Windows

### DIFF
--- a/crates/gitbutler-git/src/executor/tokio/mod.rs
+++ b/crates/gitbutler-git/src/executor/tokio/mod.rs
@@ -36,19 +36,10 @@ unsafe impl super::GitExecutor for TokioExecutor {
         cmd.kill_on_drop(true);
         cmd.current_dir(cwd);
 
-        #[cfg(not(windows))]
         cmd.args(args);
 
         #[cfg(windows)]
         {
-            // On Windows, we have to pass the arguments
-            // as-is using a special method since Windows
-            // seems to parse backslashes for some unknown
-            // reason.
-            for arg in args {
-                cmd.raw_arg(arg);
-            }
-
             // On windows, CLI applications that aren't the `windows` subsystem
             // will create and show a console window that pops up next to the
             // main application window when run. We disable this behavior when


### PR DESCRIPTION
I think the comment here is incorrect, the regular args method should handle arguments properly without any strangeness.

I'll be trying this out with the nightly tomorrow morning to see if it needs any more work, I don't have an easy way to build for Windows locally at present.