### PR TITLE
Update the AI Settings to reflect the most current models for BYOK. 

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -82,7 +82,7 @@
 		"@tauri-apps/plugin-deep-link": "~2.4.7",
 		"dayjs": "^1.11.13",
 		"ollama": "^0.6.3",
-		"openai": "^4.104.0",
+		"openai": "^6.27.0",
 		"reconnecting-websocket": "^4.4.0",
 		"redux-persist": "^6.0.0",
 		"rxjs": "catalog:"

--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -94,55 +94,31 @@
 
 	const openAIModelOptions = [
 		{
-			label: "GPT 5",
-			value: OpenAIModelName.GPT5,
-		},
-		{
 			label: "GPT 5 Mini",
 			value: OpenAIModelName.GPT5Mini,
 		},
 		{
-			label: "o3 Mini",
-			value: OpenAIModelName.O3mini,
+			label: "GPT 5 Nano (recommended)",
+			value: OpenAIModelName.GPT5Nano,
 		},
 		{
-			label: "o1 Mini",
-			value: OpenAIModelName.O1mini,
-		},
-		{
-			label: "GPT 4o mini",
-			value: OpenAIModelName.GPT4oMini,
-		},
-		{
-			label: "GPT 4.1",
-			value: OpenAIModelName.GPT4_1,
-		},
-		{
-			label: "GPT 4.1 mini (recommended)",
-			value: OpenAIModelName.GPT4_1Mini,
+			label: "GPT 5.4",
+			value: OpenAIModelName.GPT5,
 		},
 	];
 
 	const anthropicModelOptions = [
 		{
-			label: "Haiku",
+			label: "Haiku (recommended)",
 			value: AnthropicModelName.Haiku,
 		},
 		{
-			label: "Sonnet 3.5",
-			value: AnthropicModelName.Sonnet35,
+			label: "Sonnet",
+			value: AnthropicModelName.Sonnet,
 		},
 		{
-			label: "Sonnet 3.7 (recommended)",
-			value: AnthropicModelName.Sonnet37,
-		},
-		{
-			label: "Sonnet 4",
-			value: AnthropicModelName.Sonnet4,
-		},
-		{
-			label: "Opus 4",
-			value: AnthropicModelName.Opus4,
+			label: "Opus",
+			value: AnthropicModelName.Opus,
 		},
 	];
 

--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -59,7 +59,7 @@
 		modelKind = await aiService.getModelKind();
 
 		openAIKeyOption = await aiService.getOpenAIKeyOption();
-		openAIModelName = await aiService.getOpenAIModleName();
+		openAIModelName = await aiService.getOpenAIModelName();
 		openAIKey = await aiService.getOpenAIKey();
 		openAICustomEndpoint = await aiService.getOpenAICustomEndpoint();
 

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -33,6 +33,7 @@ export class OpenAIClient implements AIClient {
 			messages: prompt,
 			model: this.modelName,
 			stream: true,
+			reasoning_effort: "low",
 		});
 
 		const buffer: string[] = [];

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -33,7 +33,7 @@ import type { GitConfigSettings } from "@gitbutler/core/api";
 const defaultGitConfig = Object.freeze({
 	[GitAIConfigKey.ModelProvider]: ModelKind.OpenAI,
 	[GitAIConfigKey.OpenAIKeyOption]: KeyOption.ButlerAPI,
-	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT4oMini,
+	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT5Nano,
 	[GitAIConfigKey.AnthropicKeyOption]: KeyOption.ButlerAPI,
 	[GitAIConfigKey.AnthropicModelName]: AnthropicModelName.Haiku,
 });

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -154,10 +154,13 @@ export class AIService {
 	}
 
 	async getOpenAIModleName() {
-		return await this.gitConfig.getWithDefault<OpenAIModelName>(
+		const defaultModel = OpenAIModelName.GPT5Nano;
+		const stored = await this.gitConfig.getWithDefault<string>(
 			GitAIConfigKey.OpenAIModelName,
-			OpenAIModelName.GPT4oMini,
+			defaultModel,
 		);
+		const validModels: string[] = Object.values(OpenAIModelName);
+		return validModels.includes(stored) ? (stored as OpenAIModelName) : defaultModel;
 	}
 
 	async getAnthropicKeyOption() {
@@ -172,10 +175,13 @@ export class AIService {
 	}
 
 	async getAnthropicModelName() {
-		return await this.gitConfig.getWithDefault<AnthropicModelName>(
+		const defaultModel = AnthropicModelName.Haiku;
+		const stored = await this.gitConfig.getWithDefault<string>(
 			GitAIConfigKey.AnthropicModelName,
-			AnthropicModelName.Haiku,
+			defaultModel,
 		);
+		const validModels: string[] = Object.values(AnthropicModelName);
+		return validModels.includes(stored) ? (stored as AnthropicModelName) : defaultModel;
 	}
 
 	async getDiffLengthLimit() {

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -153,7 +153,7 @@ export class AIService {
 		return await this.secretsService.get(AISecretHandle.OpenAIKey);
 	}
 
-	async getOpenAIModleName() {
+	async getOpenAIModelName() {
 		const defaultModel = OpenAIModelName.GPT5Nano;
 		const stored = await this.gitConfig.getWithDefault<string>(
 			GitAIConfigKey.OpenAIModelName,
@@ -314,7 +314,7 @@ export class AIService {
 		}
 
 		if (modelKind === ModelKind.OpenAI) {
-			const openAIModelName = await this.getOpenAIModleName();
+			const openAIModelName = await this.getOpenAIModelName();
 			const openAIKey = await this.getOpenAIKey();
 			const openAICustomEndpoint = await this.getOpenAICustomEndpoint();
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -10,22 +10,16 @@ export enum ModelKind {
 
 // https://platform.openai.com/docs/models
 export enum OpenAIModelName {
-	O3mini = "o3-mini",
-	O1mini = "o1-mini",
-	GPT5 = "gpt-5",
+	GPT5 = "gpt-5.4",
 	GPT5Mini = "gpt-5-mini",
-	GPT4_1 = "gpt-4.1",
-	GPT4_1Mini = "gpt-4.1-mini",
-	GPT4oMini = "gpt-4o-mini",
+	GPT5Nano = "gpt-5-nano",
 }
 
 // https://docs.anthropic.com/en/docs/about-claude/models/overview
 export enum AnthropicModelName {
-	Haiku = "claude-3-5-haiku-20241022",
-	Sonnet35 = "claude-3-5-sonnet-20241022",
-	Sonnet37 = "claude-3-7-sonnet-20250219",
-	Sonnet4 = "claude-sonnet-4-0",
-	Opus4 = "claude-opus-4-0",
+	Haiku = "claude-haiku-4-5-20251001",
+	Sonnet = "claude-sonnet-4-6",
+	Opus = "claude-opus-4-6",
 }
 
 export enum MessageRole {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,8 +200,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       openai:
-        specifier: ^4.104.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.19.0)
+        specifier: ^6.27.0
+        version: 6.27.0(ws@8.19.0)
       reconnecting-websocket:
         specifier: ^4.4.0
         version: 4.4.0
@@ -4020,12 +4020,6 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
@@ -4470,10 +4464,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
@@ -5824,16 +5814,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -6085,9 +6068,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -6939,11 +6919,6 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -7025,12 +7000,12 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+  openai@6.27.0:
+    resolution: {integrity: sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -8565,9 +8540,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -8789,10 +8761,6 @@ packages:
 
   wdio-video-reporter@6.2.0:
     resolution: {integrity: sha512-b/LHQFluxIcP7foWW0gJ/5W6x1NsTVzJ2yiZZ+W4ETtYBUFU0Xfd2fYVC3q3Uxb3He6QkuNT+h0xCefJSZRyVg==}
-
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
 
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
@@ -12247,15 +12215,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 22.19.11
-      form-data: 4.0.5
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
@@ -12895,10 +12854,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   aggregate-error@4.0.1:
     dependencies:
@@ -14544,8 +14499,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -14553,11 +14506,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   forwarded-parse@2.1.2: {}
 
@@ -14861,10 +14809,6 @@ snapshots:
       - supports-color
 
   human-signals@8.0.1: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   iconv-corefoundation@1.1.7:
     dependencies:
@@ -15884,8 +15828,6 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-domexception@1.0.0: {}
-
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -15971,19 +15913,9 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.19.0):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+  openai@6.27.0(ws@8.19.0):
     optionalDependencies:
       ws: 8.19.0
-    transitivePeerDependencies:
-      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -17575,8 +17507,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
   undici-types@7.16.0:
@@ -17982,8 +17912,6 @@ snapshots:
       - allure-playwright
       - expect-webdriverio
       - webdriverio
-
-  web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@5.1.0: {}
 


### PR DESCRIPTION
🧢 Changes

- Updated OpenAI model names to GPT-5.4, GPT-5-mini, and GPT-5-nano variants
- Updated Anthropic model identifiers to Claude Haiku, Sonnet, and Opus releases
- Upgraded OpenAI SDK from 4.104.0 to 6.27.0
- Added `reasoning_effort: "low"` parameter to OpenAI configuration **this was needed in order to avoid "empty response" errors for Mini and Nano models. 
- Updated lockfile to reflect SDK upgrade and removed obsolete dependencies
- Fixed typo in `getOpenAIModelName` (used to be getOpenAIModleName) method across service and component files

## ☕️ Reasoning
Just getting the BYOK section of the AI settings up to date, and getting a better handle of this section so we (I) can learn and propose more meaningful changes. 

## Tested with 

Tested the functionality on a play repo to test commit message generation, branch name generation, and PR generation with model one by one. 

- OpenAI 
 - GPT 5.4, Mini, and Nano 
- Claude 
 - Haiku, Sonnet and Opus 