### PR TITLE
tauri: scope menu shortcuts to focused window

### DIFF
--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1,7 +1,6 @@
 import { isReduxError } from "$lib/state/reduxError";
 import { getName, getVersion, getVersion as tauriGetVersion } from "@tauri-apps/api/app";
 import { invoke as invokeTauri } from "@tauri-apps/api/core";
-import { listen as listenTauri } from "@tauri-apps/api/event";
 import { documentDir as documentDirTauri } from "@tauri-apps/api/path";
 import { join as joinPathTauri } from "@tauri-apps/api/path";
 import { getCurrentWindow, Window } from "@tauri-apps/api/window";
@@ -297,7 +296,8 @@ async function tauriInvoke<T>(command: string, params: Record<string, unknown> =
 }
 
 function tauriListen<T>(event: EventName, handle: EventCallback<T>) {
-	const unlisten = listenTauri(event, handle);
+	const appWindow = getCurrentWindow();
+	const unlisten = appWindow.listen(event, handle);
 	return async () => await unlisten.then((unlistenFn) => unlistenFn());
 }
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -192,8 +192,21 @@ fn main() -> anyhow::Result<()> {
                 app_handle.manage(app_settings);
                 app_handle.manage(claude);
 
-                tauri_app.on_menu_event(move |_handle, event| {
-                    menu::handle_event(&window.clone(), &event)
+                tauri_app.on_menu_event(move |handle, event| {
+                    let target_window = handle
+                        .webview_windows()
+                        .into_values()
+                        .find(|webview| webview.is_focused().unwrap_or(false))
+                        .or_else(|| handle.get_webview_window("main"));
+
+                    if let Some(webview) = target_window {
+                        menu::handle_event(&webview, &event);
+                    } else {
+                        tracing::warn!(
+                            menu_event = %event.id().as_ref(),
+                            "no webview window available to handle menu event"
+                        );
+                    }
                 });
 
                 let app_handle_for_deep_link = app_handle.clone();

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -5,7 +5,7 @@ use but_settings::AppSettingsWithDiskSync;
 #[cfg(target_os = "macos")]
 use tauri::menu::AboutMetadata;
 use tauri::{
-    AppHandle, Emitter, Manager, Runtime, WebviewWindow,
+    AppHandle, Emitter, EventTarget, Manager, Runtime, WebviewWindow,
     menu::{Menu, MenuEvent, MenuItemBuilder, PredefinedMenuItem, Submenu, SubmenuBuilder},
 };
 use tracing::instrument;
@@ -416,7 +416,7 @@ pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
 }
 
 fn emit<R: Runtime>(window: &WebviewWindow<R>, event: &str, shortcut: &str) {
-    if let Err(err) = window.emit(event, shortcut) {
+    if let Err(err) = window.emit_to(EventTarget::window(window.label()), event, shortcut) {
         tracing::error!(error = ?err, "failed to emit event");
     }
 }


### PR DESCRIPTION
This PR fixes an issue where, when multiple GitButler window instances are open, all instances respond to the same shortcut key event.

The root cause was that menu shortcut events were broadcast to all windows by default, and the front-end listeners were also attached globally. This PR scopes the menu shortcut emission to the focused window and updates the front-end listener target to the Window instance, preventing the broadcast behavior so that only the active window handles the shortcut.

Comparison video before and after the fix:

https://github.com/user-attachments/assets/15dc70ee-5c4f-4fc0-9d3a-bdf0ad9991b7