### PR TITLE
fix(cli): remove trailing whitespace from `but status` output

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -444,9 +444,9 @@ fn print_upstream_state(
             for commit in commits {
                 // Measure prefix width using plain text (no ANSI codes)
                 let commit_short = shorten_hex_object_id(&repo, &commit.id);
-                let truncated_msg = out
-                    .truncate_if_unpaged(&commit.description.to_string().replace('\n', " "), 72)
-                    .dimmed();
+                let message = commit.description.to_string().replace('\n', " ");
+                let message = message.trim_end();
+                let truncated_msg = out.truncate_if_unpaged(message, 72).dimmed();
                 writeln!(out, "┊{dot} {} {truncated_msg}", commit_short.yellow())?;
             }
             let hidden_commits = base_branch.behind.saturating_sub(8);
@@ -461,13 +461,16 @@ fn print_upstream_state(
         writeln!(out, "┊┊")?;
     } else {
         // Without --upstream, show the summary with latest commit info
-        writeln!(
-            out,
-            "┊{dot} {} (upstream) ⏫ {} new commits {}",
+        let mut line = format!(
+            "┊{dot} {} (upstream) ⏫ {} new commits",
             upstream.latest_commit.dimmed(),
             upstream.behind_count,
-            last_checked_text.dimmed()
-        )?;
+        );
+        if !last_checked_text.is_empty() {
+            line.push(' ');
+            line.push_str(&last_checked_text.dimmed().to_string());
+        }
+        writeln!(out, "{line}")?;
     }
 
     Ok(())
@@ -664,7 +667,13 @@ fn print_assignments(
             locks = format!("🔒 {locks}");
         }
         if unstaged {
-            writeln!(out, "┊   {id} {status} {path} {locks}")?;
+            if locks.is_empty() {
+                writeln!(out, "┊   {id} {status} {path}")?;
+            } else {
+                writeln!(out, "┊   {id} {status} {path} {locks}")?;
+            }
+        } else if locks.is_empty() {
+            writeln!(out, "┊  {} {id} {status} {path}", "│".dimmed())?;
         } else {
             writeln!(out, "┊  {} {id} {status} {path} {locks}", "│".dimmed())?;
         }
@@ -707,19 +716,17 @@ pub fn print_group(
             }
 
             let no_commits = if segment.workspace_commits.is_empty() {
-                "(no commits)".to_string()
+                Some("(no commits)".dimmed().italic().to_string())
             } else {
-                "".to_string()
-            }
-            .dimmed()
-            .italic();
+                None
+            };
 
             let review = segment
                 .branch_name()
                 .and_then(|branch_name| {
                     review::from_branch_details(review_map, branch_name, segment.pr_number())
                 })
-                .map(|r| format!(" {} ", r.display_cli(verbose, out.is_paged())))
+                .map(|r| format!(" {}", r.display_cli(verbose, out.is_paged())))
                 .unwrap_or_default();
 
             let ci = segment
@@ -753,17 +760,24 @@ pub fn print_group(
                     format!(" 📁 {base}", base = base.display()).into()
                 })
                 .unwrap_or_default();
-            writeln!(
-                out,
-                "┊{notch}┄{id} [{branch}{workspace}]{ci}{merge_status}{review} {no_commits} {stack_mark}",
-                stack_mark = stack_mark.clone().unwrap_or_default(),
+            let mut line = format!(
+                "┊{notch}┄{id} [{branch}{workspace}]{ci}{merge_status}{review}",
                 branch = segment
                     .branch_name()
                     .unwrap_or(BStr::new(""))
                     .to_string()
                     .green()
                     .bold(),
-            )?;
+            );
+            if let Some(no_commits) = no_commits {
+                line.push(' ');
+                line.push_str(&no_commits);
+            }
+            if let Some(stack_mark) = stack_mark.clone() {
+                line.push(' ');
+                line.push_str(&stack_mark.to_string());
+            }
+            writeln!(out, "{line}")?;
 
             *stack_mark = None; // Only show the stack mark for the first branch
             first = false;
@@ -838,13 +852,16 @@ pub fn print_group(
         }
     } else {
         let id = id_map.unassigned().to_short_string().bold().blue();
-        writeln!(
-            out,
-            "╭┄{} [{}] {}",
+        let mut line = format!(
+            "╭┄{} [{}]",
             id,
             "unstaged changes".to_string().cyan().bold(),
-            stack_mark.clone().unwrap_or_default()
-        )?;
+        );
+        if let Some(stack_mark) = stack_mark.clone() {
+            line.push(' ');
+            line.push_str(&stack_mark.to_string());
+        }
+        writeln!(out, "{line}")?;
         print_assignments(&repo, None, id_map, None, assignments, changes, true, out)?;
     }
     if !first {
@@ -951,17 +968,20 @@ fn print_commit(
         details_string
     };
 
+    let review_url = review_url.map(|r| format!("◖{}◗", r.underline().blue()));
+
     if verbose {
         // Verbose format: author and timestamp on first line, message on second line
-        writeln!(
-            out,
-            "┊{dot} {} {} {}",
-            details_string,
-            review_url
-                .map(|r| format!("◖{}◗", r.underline().blue()))
-                .unwrap_or_default(),
-            mark.unwrap_or_default()
-        )?;
+        let mut line = format!("┊{dot} {details_string}");
+        if let Some(review_url) = review_url {
+            line.push(' ');
+            line.push_str(&review_url);
+        }
+        if let Some(mark) = mark {
+            line.push(' ');
+            line.push_str(&mark.to_string());
+        }
+        writeln!(out, "{line}")?;
         let message =
             commit_message_display_cli(&commit.message, verbose, out.is_paged(), |truncated| {
                 if upstream_commit {
@@ -973,16 +993,16 @@ fn print_commit(
         writeln!(out, "┊│     {message}")?;
     } else {
         // Original format: everything on one line
-        let review_url = review_url
-            .map(|r| format!("◖{}◗", r.underline().blue()))
-            .unwrap_or_default();
-        writeln!(
-            out,
-            "┊{dot}   {} {} {}",
-            details_string,
-            review_url,
-            mark.unwrap_or_default()
-        )?;
+        let mut line = format!("┊{dot}   {details_string}");
+        if let Some(review_url) = review_url {
+            line.push(' ');
+            line.push_str(&review_url);
+        }
+        if let Some(mark) = mark {
+            line.push(' ');
+            line.push_str(&mark.to_string());
+        }
+        writeln!(out, "{line}")?;
     }
     if show_files {
         match commit_changes {

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -290,24 +290,24 @@ k0 a.txt│
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊   nk M a.txt 🔒 889385c, a7aa4ef, f4ea7f8
 ┊
-┊╭┄g0 [A]  
-┊●   a7aa4ef partial change to a.txt 3  
+┊╭┄g0 [A]
+┊●   a7aa4ef partial change to a.txt 3
 ┊│     a7:nk M a.txt
-┊●   889385c partial change to a.txt 2  
+┊●   889385c partial change to a.txt 2
 ┊│     88:nk M a.txt
-┊●   8dc39e0 partial change to a.txt 1  
+┊●   8dc39e0 partial change to a.txt 1
 ┊│     8d:nk M a.txt
-┊●   f4ea7f8 a.txt  
+┊●   f4ea7f8 a.txt
 ┊│     f4:nk A a.txt
-┊●   9477ae7 add A  
+┊●   9477ae7 add A
 ┊│     94:tm A A
 ├╯
 ┊
-┊╭┄h0 [B]  
-┊●   d3e2ba3 add B  
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
 ┊│     d3:pl A B
 ├╯
 ┊
@@ -342,24 +342,24 @@ Hint: you can run `but undo` to undo these changes
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   4822140 partial change to a.txt 3  
+┊╭┄g0 [A]
+┊●   4822140 partial change to a.txt 3
 ┊│     48:nk M a.txt
-┊●   4593422 partial change to a.txt 2  
+┊●   4593422 partial change to a.txt 2
 ┊│     45:nk M a.txt
-┊●   8dc39e0 partial change to a.txt 1  
+┊●   8dc39e0 partial change to a.txt 1
 ┊│     8d:nk M a.txt
-┊●   f4ea7f8 a.txt  
+┊●   f4ea7f8 a.txt
 ┊│     f4:nk A a.txt
-┊●   9477ae7 add A  
+┊●   9477ae7 add A
 ┊│     94:tm A A
 ├╯
 ┊
-┊╭┄h0 [B]  
-┊●   d3e2ba3 add B  
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
 ┊│     d3:pl A B
 ├╯
 ┊
@@ -463,17 +463,17 @@ Hint: you can run `but undo` to undo these changes
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   27686df [AUTO-COMMIT] Generated commit message  
-┊●   f4ea7f8 a.txt  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   27686df [AUTO-COMMIT] Generated commit message
+┊●   f4ea7f8 a.txt
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [B]  
-┊●   d3e2ba3 add B  
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -580,17 +580,17 @@ Hint: you can run `but undo` to undo these changes
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊   nk M a.txt 🔒 f4ea7f8
 ┊
-┊╭┄g0 [A]  
-┊●   5a72bff [AUTO-COMMIT] Generated commit message  
-┊●   f4ea7f8 a.txt  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   5a72bff [AUTO-COMMIT] Generated commit message
+┊●   f4ea7f8 a.txt
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [B]  
-┊●   d3e2ba3 add B  
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M

--- a/crates/but/tests/but/command/branch/move_branch.rs
+++ b/crates/but/tests/but/command/branch/move_branch.rs
@@ -21,18 +21,18 @@ fn move_branch_by_name_to_the_top_of_another() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [C]  
-┊●   3842fc0 add C  
+┊╭┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -57,17 +57,17 @@ Moved branch 'A' on top of 'C'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   afff88e add A  
+┊╭┄g0 [A]
+┊●   afff88e add A
 ┊│
-┊├┄h0 [C]  
-┊●   3842fc0 add C  
+┊├┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -99,18 +99,18 @@ fn move_branch_by_cli_id_to_the_top_of_another() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [C]  
-┊●   3842fc0 add C  
+┊╭┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -135,17 +135,17 @@ Moved branch 'A' on top of 'C'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   afff88e add A  
+┊╭┄g0 [A]
+┊●   afff88e add A
 ┊│
-┊├┄h0 [C]  
-┊●   3842fc0 add C  
+┊├┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -177,18 +177,18 @@ fn move_branch_by_cli_id_to_the_middle_of_another() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [C]  
-┊●   3842fc0 add C  
+┊╭┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -213,17 +213,17 @@ Moved branch 'A' on top of 'B'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [C]  
-┊●   c946b0e add C  
+┊╭┄g0 [C]
+┊●   c946b0e add C
 ┊│
-┊├┄h0 [A]  
-┊●   8f3ad84 add A  
+┊├┄h0 [A]
+┊●   8f3ad84 add A
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -255,18 +255,18 @@ fn move_branch_by_cli_id_from_the_bottom_to_the_top_of_another() -> anyhow::Resu
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [C]  
-┊●   3842fc0 add C  
+┊╭┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -291,18 +291,18 @@ Moved branch 'B' on top of 'A'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [B]  
-┊●   b40d58b add B  
+┊╭┄g0 [B]
+┊●   b40d58b add B
 ┊│
-┊├┄h0 [A]  
-┊●   9477ae7 add A  
+┊├┄h0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄i0 [C]  
-┊●   31e83cd add C  
+┊╭┄i0 [C]
+┊●   31e83cd add C
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -334,18 +334,18 @@ fn reorder_branch_within_stack() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [C]  
-┊●   3842fc0 add C  
+┊╭┄h0 [C]
+┊●   3842fc0 add C
 ┊│
-┊├┄i0 [B]  
-┊●   d3e2ba3 add B  
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -370,18 +370,18 @@ Moved branch 'B' on top of 'C'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [B]  
-┊●   958528a add B  
+┊╭┄h0 [B]
+┊●   958528a add B
 ┊│
-┊├┄i0 [C]  
-┊●   31e83cd add C  
+┊├┄i0 [C]
+┊●   31e83cd add C
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -410,14 +410,14 @@ fn move_empty_branch_to_top_of_another_stack() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [B] (no commits) 
+┊╭┄h0 [B] (no commits)
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -442,13 +442,13 @@ Moved branch 'B' on top of 'A'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [B] (no commits) 
+┊╭┄g0 [B] (no commits)
 ┊│
-┊├┄h0 [A]  
-┊●   9477ae7 add A  
+┊├┄h0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -477,14 +477,14 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ├╯
 ┊
-┊╭┄h0 [B] (no commits) 
+┊╭┄h0 [B] (no commits)
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M
@@ -509,13 +509,13 @@ Moved branch 'A' on top of 'B'.
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
-┊╭┄g0 [A]  
-┊●   9477ae7 add A  
+┊╭┄g0 [A]
+┊●   9477ae7 add A
 ┊│
-┊├┄h0 [B] (no commits) 
+┊├┄h0 [B] (no commits)
 ├╯
 ┊
 ┴ 0dc3733 [origin/main] 2000-01-02 add M

--- a/crates/but/tests/but/command/snapshots/status/classification/status-shows-no-commits-label.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/classification/status-shows-no-commits-label.stdout.term.svg
@@ -22,21 +22,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/classification/status-shows-pushed-commit-marker.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/classification/status-shows-pushed-commit-marker.stdout.term.svg
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan>   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan>   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/classification/status-shows-rewritten-branch-with-remote-and-local-commits.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/classification/status-shows-rewritten-branch-with-remote-and-local-commits.stdout.term.svg
@@ -23,23 +23,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">94</tspan><tspan class="dimmed">77ae7</tspan><tspan class="dimmed"> add A</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">94</tspan><tspan class="dimmed">77ae7</tspan><tspan class="dimmed"> add A</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">43</tspan><tspan class="dimmed">66169</tspan><tspan> add A amended  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">43</tspan><tspan class="dimmed">66169</tspan><tspan> add A amended</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/hints/status-hint-clean-workspace.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-hint-clean-workspace.stdout.term.svg
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/hints/status-hint-no-branches.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-hint-no-branches.stdout.term.svg
@@ -22,7 +22,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-hint-with-uncommitted-changes.stdout.term.svg
@@ -21,15 +21,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">xk</tspan><tspan> A </tspan><tspan class="fg-green">new-file.txt</tspan><tspan> </tspan>
+    <tspan x="10px" y="46px"><tspan>┊   </tspan><tspan class="fg-blue bold">xk</tspan><tspan> A </tspan><tspan class="fg-green">new-file.txt</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/hints/status-no-hint.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/hints/status-no-hint.stdout.term.svg
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-cli-ids.stdout.term.svg
@@ -22,39 +22,39 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+    <tspan x="10px" y="118px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/long-file-cli-ids-are-aligned.stdout.term.svg
@@ -21,43 +21,43 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>┊    </tspan><tspan class="fg-blue bold">yr</tspan><tspan> A </tspan><tspan class="fg-green">foo1</tspan><tspan> </tspan>
+    <tspan x="10px" y="46px"><tspan>┊    </tspan><tspan class="fg-blue bold">yr</tspan><tspan> A </tspan><tspan class="fg-green">foo1</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpr</tspan><tspan> A </tspan><tspan class="fg-green">foo23</tspan><tspan> </tspan>
+    <tspan x="10px" y="64px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpr</tspan><tspan> A </tspan><tspan class="fg-green">foo23</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpo</tspan><tspan> A </tspan><tspan class="fg-green">foo242</tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊   </tspan><tspan class="fg-blue bold">kpo</tspan><tspan> A </tspan><tspan class="fg-green">foo242</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="118px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c8</tspan><tspan class="dimmed">8a8e</tspan><tspan> add A13</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12  </tspan>
+    <tspan x="10px" y="154px"><tspan>┊●   </tspan><tspan class="fg-blue bold">a1</tspan><tspan class="dimmed">8ea48</tspan><tspan> add A12</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">0c</tspan><tspan class="dimmed">0fcbf</tspan><tspan> add A11</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c4</tspan><tspan class="dimmed">72887</tspan><tspan> add A10</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9  </tspan>
+    <tspan x="10px" y="208px"><tspan>┊●   </tspan><tspan class="fg-blue bold">81</tspan><tspan class="dimmed">88106</tspan><tspan> add A9</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8  </tspan>
+    <tspan x="10px" y="226px"><tspan>┊●   </tspan><tspan class="fg-blue bold">76</tspan><tspan class="dimmed">9f4a8</tspan><tspan> add A8</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">2a</tspan><tspan class="dimmed">98cfc</tspan><tspan> add A7</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6  </tspan>
+    <tspan x="10px" y="262px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d6</tspan><tspan class="dimmed">0e311</tspan><tspan> add A6</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊●   </tspan><tspan class="fg-blue bold">c6</tspan><tspan class="dimmed">7c49e</tspan><tspan> add A5</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4  </tspan>
+    <tspan x="10px" y="298px"><tspan>┊●   </tspan><tspan class="fg-blue bold">23</tspan><tspan class="dimmed">c280d</tspan><tspan> add A4</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3  </tspan>
+    <tspan x="10px" y="316px"><tspan>┊●   </tspan><tspan class="fg-blue bold">5c7</tspan><tspan class="dimmed">c6d7</tspan><tspan> add A3</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2  </tspan>
+    <tspan x="10px" y="334px"><tspan>┊●   </tspan><tspan class="fg-blue bold">12</tspan><tspan class="dimmed">99ac9</tspan><tspan> add A2</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1  </tspan>
+    <tspan x="10px" y="352px"><tspan>┊●   </tspan><tspan class="fg-blue bold">07</tspan><tspan class="dimmed">48e42</tspan><tspan> add A1</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/mark/status-shows-marked-stack.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/mark/status-shows-marked-stack.stdout.term.svg
@@ -23,15 +23,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan><tspan class="fg-red bold">◀ Marked ▶</tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan class="fg-red bold">◀ Marked ▶</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/remote-and-local-files.stdout.term.svg
@@ -23,31 +23,31 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">ma</tspan><tspan> [</tspan><tspan class="fg-green bold">main</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">28</tspan><tspan class="dimmed">baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">28</tspan><tspan class="dimmed">baf9a</tspan><tspan class="dimmed"> add only-on-remote</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     A </tspan><tspan class="fg-green">only-on-remote</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">64</tspan><tspan class="dimmed">3ade3</tspan><tspan> add only-on-local</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊│     </tspan><tspan class="fg-blue bold">64:tp</tspan><tspan> A </tspan><tspan class="fg-green">only-on-local</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -23,25 +23,25 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A]</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> author 2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊│     </tspan><tspan class="dimmed">A-remote </tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     A </tspan>
 </tspan>
@@ -49,9 +49,9 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="262px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B]</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="280px"><tspan>┊● </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>┊│     B </tspan>
 </tspan>
@@ -59,7 +59,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan>
+    <tspan x="10px" y="352px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -23,37 +23,37 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan> 📁 gitbutler/worktrees/A]</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>┊┊</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊╭┄┄</tspan><tspan class="fg-yellow">(upstream: on origin/A)</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan>   </tspan><tspan class="fg-blue bold dimmed">19</tspan><tspan class="dimmed">7ddce</tspan><tspan class="dimmed"> A-remote</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊-</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">4c</tspan><tspan class="dimmed">4624e</tspan><tspan> A</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B] </tspan><tspan> </tspan>
+    <tspan x="10px" y="226px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan> 📁 gitbutler/worktrees/B]</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan><tspan>  </tspan>
+    <tspan x="10px" y="244px"><tspan>┊●   </tspan><tspan class="fg-blue bold">3e</tspan><tspan class="dimmed">01e28</tspan><tspan> B</tspan><tspan class="italic dimmed"> (no changes)</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits </tspan>
+    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 new commits</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>├╯ </tspan><tspan class="dimmed">081bae9</tspan><tspan> [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-base</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
@@ -23,15 +23,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan><tspan> </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
@@ -39,21 +39,21 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊╭┄(upstream) ⏫ 10 new commits</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10 </tspan>
+    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9197958</tspan><tspan> </tspan><tspan class="dimmed">add upstream-9 </tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9197958</tspan><tspan> </tspan><tspan class="dimmed">add upstream-9</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">98d080b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-8 </tspan>
+    <tspan x="10px" y="208px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">98d080b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-8</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">31acdca</tspan><tspan> </tspan><tspan class="dimmed">add upstream-7 </tspan>
+    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">31acdca</tspan><tspan> </tspan><tspan class="dimmed">add upstream-7</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">f8b10b2</tspan><tspan> </tspan><tspan class="dimmed">add upstream-6 </tspan>
+    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">f8b10b2</tspan><tspan> </tspan><tspan class="dimmed">add upstream-6</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">3a1011f</tspan><tspan> </tspan><tspan class="dimmed">add upstream-5 </tspan>
+    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">3a1011f</tspan><tspan> </tspan><tspan class="dimmed">add upstream-5</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">172d23b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-4 </tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">172d23b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-4</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">4734996</tspan><tspan> </tspan><tspan class="dimmed">add upstream-3 </tspan>
+    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">4734996</tspan><tspan> </tspan><tspan class="dimmed">add upstream-3</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>┊    </tspan><tspan class="dimmed">and 2 more…</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
@@ -24,15 +24,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-red"> [⚠ upstream conflicts]</tspan><tspan> </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-red"> [⚠ upstream conflicts]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">92</tspan><tspan class="dimmed">83fc1</tspan><tspan> A-change  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">92</tspan><tspan class="dimmed">83fc1</tspan><tspan> A-change</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
@@ -40,7 +40,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊╭┄(upstream) ⏫ 1 new commits</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">bdfcf28</tspan><tspan> </tspan><tspan class="dimmed">main-change </tspan>
+    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">bdfcf28</tspan><tspan> </tspan><tspan class="dimmed">main-change</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>┊┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-empty.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-empty.stdout.term.svg
@@ -22,21 +22,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan class="italic dimmed">(no commits)</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>├╯</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
@@ -24,23 +24,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-magenta"> [⬆ integrated upstream]</tspan><tspan> </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-magenta"> [⬆ integrated upstream]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊</tspan><tspan class="fg-magenta">●</tspan><tspan>   </tspan><tspan class="fg-blue bold">75</tspan><tspan class="dimmed">6ee31</tspan><tspan> A-change  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊</tspan><tspan class="fg-magenta">●</tspan><tspan>   </tspan><tspan class="fg-blue bold">75</tspan><tspan class="dimmed">6ee31</tspan><tspan> A-change</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan><tspan> </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">53</tspan><tspan class="dimmed">6958e</tspan><tspan> B-change  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">53</tspan><tspan class="dimmed">6958e</tspan><tspan> B-change</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>
@@ -48,9 +48,9 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊╭┄(upstream) ⏫ 2 new commits</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9354ac4</tspan><tspan> </tspan><tspan class="dimmed">main-advance </tspan>
+    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9354ac4</tspan><tspan> </tspan><tspan class="dimmed">main-advance</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">756ee31</tspan><tspan> </tspan><tspan class="dimmed">A-change </tspan>
+    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">756ee31</tspan><tspan> </tspan><tspan class="dimmed">A-change</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>┊┊</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
@@ -23,21 +23,21 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream) ⏫ 10 new commits </tspan>
+    <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream) ⏫ 10 new commits</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>├╯ </tspan><tspan class="dimmed">0dc3733</tspan><tspan> [</tspan><tspan class="fg-green bold">origin/main</tspan><tspan>] </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add M</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
@@ -23,15 +23,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan><tspan> </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan><tspan class="fg-blue"> [✓ upstream merges cleanly]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
@@ -39,21 +39,21 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊╭┄(upstream) ⏫ 10 new commits</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10 </tspan>
+    <tspan x="10px" y="172px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9197958</tspan><tspan> </tspan><tspan class="dimmed">add upstream-9 </tspan>
+    <tspan x="10px" y="190px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">9197958</tspan><tspan> </tspan><tspan class="dimmed">add upstream-9</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">98d080b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-8 </tspan>
+    <tspan x="10px" y="208px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">98d080b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-8</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">31acdca</tspan><tspan> </tspan><tspan class="dimmed">add upstream-7 </tspan>
+    <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">31acdca</tspan><tspan> </tspan><tspan class="dimmed">add upstream-7</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">f8b10b2</tspan><tspan> </tspan><tspan class="dimmed">add upstream-6 </tspan>
+    <tspan x="10px" y="244px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">f8b10b2</tspan><tspan> </tspan><tspan class="dimmed">add upstream-6</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">3a1011f</tspan><tspan> </tspan><tspan class="dimmed">add upstream-5 </tspan>
+    <tspan x="10px" y="262px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">3a1011f</tspan><tspan> </tspan><tspan class="dimmed">add upstream-5</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">172d23b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-4 </tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">172d23b</tspan><tspan> </tspan><tspan class="dimmed">add upstream-4</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">4734996</tspan><tspan> </tspan><tspan class="dimmed">add upstream-3 </tspan>
+    <tspan x="10px" y="298px"><tspan>┊</tspan><tspan class="fg-yellow">●</tspan><tspan> </tspan><tspan class="fg-yellow">4734996</tspan><tspan> </tspan><tspan class="dimmed">add upstream-3</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>┊    </tspan><tspan class="dimmed">and 2 more…</tspan>
 </tspan>

--- a/crates/but/tests/but/journey.rs
+++ b/crates/but/tests/but/journey.rs
@@ -145,7 +145,7 @@ Learn more at https://docs.gitbutler.com/cli-overview
         .assert()
         .success()
         .stdout_eq(str![[r#"
-╭┄zz [unstaged changes] 
+╭┄zz [unstaged changes]
 ┊     no changes
 ┊
 ┴ 6f66116 [gb-local/main] 2000-01-02 Initial empty commit

--- a/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01-verbose.stdout.term.svg
@@ -22,15 +22,15 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊● </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊│     add A </tspan>
 </tspan>
@@ -38,9 +38,9 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="172px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan><tspan>  </tspan>
+    <tspan x="10px" y="190px"><tspan>┊● </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> author </tspan><tspan class="dimmed">2000-01-01 00:00:00 +0000</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>┊│     add B </tspan>
 </tspan>

--- a/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/status01.stdout.term.svg
@@ -22,23 +22,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>] </tspan>
+    <tspan x="10px" y="28px"><tspan>╭┄</tspan><tspan class="fg-blue bold">zz</tspan><tspan> [</tspan><tspan class="fg-cyan bold">unstaged changes</tspan><tspan>]</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan>┊     </tspan><tspan class="italic dimmed">no changes</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="82px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">g0</tspan><tspan> [</tspan><tspan class="fg-green bold">A</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A  </tspan>
+    <tspan x="10px" y="100px"><tspan>┊●   </tspan><tspan class="fg-blue bold">94</tspan><tspan class="dimmed">77ae7</tspan><tspan> add A</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan>├╯</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>] </tspan><tspan> </tspan>
+    <tspan x="10px" y="154px"><tspan>┊╭┄</tspan><tspan class="fg-blue bold">h0</tspan><tspan> [</tspan><tspan class="fg-green bold">B</tspan><tspan>]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B  </tspan>
+    <tspan x="10px" y="172px"><tspan>┊●   </tspan><tspan class="fg-blue bold">d3</tspan><tspan class="dimmed">e2ba3</tspan><tspan> add B</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>├╯</tspan>
 </tspan>


### PR DESCRIPTION
`but status` would output a bunch of trailing whitespace that got into the snapshot tests. In #12810 I have fixed that but figured I'd update the snapshots without the TUI implementation first to ensure the TUI doesn't change the output.