### PR TITLE
Daily CLI analytics limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-cursor",
+ "but-db",
  "but-forge",
  "but-forge-storage",
  "but-gerrit",

--- a/crates/but-db/src/cache/mod.rs
+++ b/crates/but-db/src/cache/mod.rs
@@ -16,6 +16,7 @@ mod table;
 
 #[rustfmt::skip]
 pub use table::{
+    analytics::{AnalyticsHandle, AnalyticsHandleMut},
     update::{CachedCheckResult, CheckUpdateStatus},
 };
 

--- a/crates/but-db/src/cache/table/analytics.rs
+++ b/crates/but-db/src/cache/table/analytics.rs
@@ -1,0 +1,158 @@
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+
+use crate::{AppCacheHandle, M, SchemaVersion, Transaction};
+
+pub(crate) const M: &[M<'static>] = &[M::up(
+    2026_03_12__12_00_00,
+    SchemaVersion::Zero,
+    "CREATE TABLE `analytics`(
+    `id` INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
+    `current_period_started_at` TIMESTAMP,
+    `events_sent` INTEGER
+);",
+)];
+
+/// The singleton row id for the analytics cache table.
+const SINGLETON_RECORD_ID: u8 = 1;
+/// The duration of the analytics counting period.
+const ANALYTICS_PERIOD_DURATION: Duration = Duration::hours(24);
+
+/// Read-only access to the analytics cache table.
+pub struct AnalyticsHandle<'conn> {
+    conn: &'conn rusqlite::Connection,
+}
+
+/// Mutating access to the analytics cache table.
+pub struct AnalyticsHandleMut<'conn> {
+    sp: rusqlite::Savepoint<'conn>,
+}
+
+impl AppCacheHandle {
+    /// Return a handle for read-only analytics cache access.
+    pub fn analytics(&self) -> AnalyticsHandle<'_> {
+        AnalyticsHandle { conn: &self.conn }
+    }
+
+    /// Return a handle for mutating analytics cache access.
+    pub fn analytics_mut(&mut self) -> rusqlite::Result<AnalyticsHandleMut<'_>> {
+        Ok(AnalyticsHandleMut {
+            sp: self.conn.savepoint()?,
+        })
+    }
+}
+
+impl Transaction<'_> {
+    /// Return a handle for read-only analytics cache access.
+    pub fn analytics(&self) -> AnalyticsHandle<'_> {
+        AnalyticsHandle { conn: self.inner() }
+    }
+
+    /// Return a handle for mutating analytics cache access.
+    pub fn analytics_mut(&mut self) -> rusqlite::Result<AnalyticsHandleMut<'_>> {
+        Ok(AnalyticsHandleMut {
+            sp: self.inner_mut().savepoint()?,
+        })
+    }
+}
+
+impl AnalyticsHandle<'_> {
+    /// Return the number of events sent in the current 24-hour period.
+    ///
+    /// If the period has not started yet, the stored row is incomplete, or the
+    /// recorded period is older than 24 hours, this returns `0`.
+    pub fn get_current_period(&self) -> u64 {
+        self.try_get_current_period().unwrap_or(0)
+    }
+
+    /// Like [`Self::get_current_period`], but fallible.
+    pub fn try_get_current_period(&self) -> rusqlite::Result<u64> {
+        self.try_get_current_period_at(Utc::now())
+    }
+
+    /// Like [`Self::try_get_current_period`], but evaluates the period at `now`.
+    pub fn try_get_current_period_at(&self, now: DateTime<Utc>) -> rusqlite::Result<u64> {
+        let mut stmt = self.conn.prepare(
+            "SELECT current_period_started_at, events_sent
+             FROM `analytics`
+             WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query([SINGLETON_RECORD_ID])?;
+
+        let Some(row) = rows.next()? else {
+            return Ok(0);
+        };
+
+        let current_period_started_at: Option<NaiveDateTime> = row.get(0)?;
+        let events_sent: Option<i64> = row.get(1)?;
+        Ok(current_period_value(
+            current_period_started_at,
+            events_sent,
+            now,
+        ))
+    }
+}
+
+impl AnalyticsHandleMut<'_> {
+    /// Enable read-only access functions.
+    pub fn to_ref(&self) -> AnalyticsHandle<'_> {
+        AnalyticsHandle { conn: &self.sp }
+    }
+
+    /// Record one sent event in the current 24-hour period.
+    ///
+    /// If there is no usable singleton row yet, or the stored period is older
+    /// than 24 hours, the period is reset to `now` and the count becomes `1`.
+    pub fn record_event_sent(self) -> rusqlite::Result<()> {
+        self.record_event_sent_at(Utc::now())
+    }
+
+    /// Like [`Self::record_event_sent`], but uses the provided timestamp.
+    pub fn record_event_sent_at(self, now: DateTime<Utc>) -> rusqlite::Result<()> {
+        let sp = self.sp;
+        let current_count = AnalyticsHandle { conn: &sp }.try_get_current_period_at(now)?;
+
+        if current_count == 0 {
+            sp.execute(
+                "INSERT INTO `analytics` (id, current_period_started_at, events_sent)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(id) DO UPDATE SET
+                    current_period_started_at = excluded.current_period_started_at,
+                    events_sent = excluded.events_sent",
+                rusqlite::params![SINGLETON_RECORD_ID, now.naive_utc(), 1_i64],
+            )?;
+        } else {
+            let next_count = i64::try_from(current_count + 1).unwrap_or(i64::MAX);
+            sp.execute(
+                "UPDATE `analytics`
+                 SET events_sent = ?1
+                 WHERE id = ?2",
+                rusqlite::params![next_count, SINGLETON_RECORD_ID],
+            )?;
+        }
+
+        sp.commit()?;
+        Ok(())
+    }
+}
+
+/// Compute the current period event count for the stored values at `now`.
+fn current_period_value(
+    current_period_started_at: Option<NaiveDateTime>,
+    events_sent: Option<i64>,
+    now: DateTime<Utc>,
+) -> u64 {
+    let Some(current_period_started_at) = current_period_started_at else {
+        return 0;
+    };
+    let Some(events_sent) = events_sent else {
+        return 0;
+    };
+    let current_period_started_at =
+        DateTime::from_naive_utc_and_offset(current_period_started_at, Utc);
+
+    if now - current_period_started_at >= ANALYTICS_PERIOD_DURATION {
+        return 0;
+    }
+
+    u64::try_from(events_sent).unwrap_or(0)
+}

--- a/crates/but-db/src/cache/table/mod.rs
+++ b/crates/but-db/src/cache/table/mod.rs
@@ -1,6 +1,7 @@
 use crate::M;
 
 /// The migrations to run for application wide caches.
-pub const APP_MIGRATIONS: &[&[M<'static>]] = &[update::M];
+pub const APP_MIGRATIONS: &[&[M<'static>]] = &[analytics::M, update::M];
 
+pub(crate) mod analytics;
 pub(crate) mod update;

--- a/crates/but-db/tests/db/cache/table/analytics.rs
+++ b/crates/but-db/tests/db/cache/table/analytics.rs
@@ -1,0 +1,89 @@
+use chrono::{DateTime, Duration};
+
+use crate::cache::in_memory_cache;
+
+#[test]
+fn get_current_period_returns_zero_when_missing() -> anyhow::Result<()> {
+    let cache = in_memory_cache();
+
+    assert_eq!(cache.analytics().try_get_current_period()?, 0);
+    assert_eq!(cache.analytics().get_current_period(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn get_current_period_returns_zero_when_period_expired() -> anyhow::Result<()> {
+    let mut cache = in_memory_cache();
+    let started_at = DateTime::from_timestamp(1_000_000, 0).unwrap();
+    cache.analytics_mut()?.record_event_sent_at(started_at)?;
+
+    let current_period = cache
+        .analytics()
+        .try_get_current_period_at(started_at + Duration::hours(24))?;
+
+    assert_eq!(current_period, 0);
+    Ok(())
+}
+
+#[test]
+fn record_event_sent_initializes_period() -> anyhow::Result<()> {
+    let mut cache = in_memory_cache();
+    let now = DateTime::from_timestamp(1_000_000, 0).unwrap();
+
+    cache.analytics_mut()?.record_event_sent_at(now)?;
+
+    let current_period = cache.analytics().try_get_current_period_at(now)?;
+    assert_eq!(current_period, 1);
+
+    Ok(())
+}
+
+#[test]
+fn record_event_sent_increments_within_period() -> anyhow::Result<()> {
+    let mut cache = in_memory_cache();
+    let started_at = DateTime::from_timestamp(1_000_000, 0).unwrap();
+
+    cache.analytics_mut()?.record_event_sent_at(started_at)?;
+    cache
+        .analytics_mut()?
+        .record_event_sent_at(started_at + Duration::hours(23))?;
+
+    let current_period = cache
+        .analytics()
+        .try_get_current_period_at(started_at + Duration::hours(23))?;
+
+    assert_eq!(current_period, 2);
+    Ok(())
+}
+
+#[test]
+fn record_event_sent_resets_after_period_expires() -> anyhow::Result<()> {
+    let mut cache = in_memory_cache();
+    let started_at = DateTime::from_timestamp(1_000_000, 0).unwrap();
+
+    cache.analytics_mut()?.record_event_sent_at(started_at)?;
+    let next_period = started_at + Duration::hours(25);
+    cache.analytics_mut()?.record_event_sent_at(next_period)?;
+
+    let current_period = cache.analytics().try_get_current_period_at(next_period)?;
+
+    assert_eq!(current_period, 1);
+    Ok(())
+}
+
+#[test]
+fn get_current_period_returns_zero_when_row_is_partial() -> anyhow::Result<()> {
+    let tmp = tempfile::TempDir::new()?;
+    let cache = but_db::AppCacheHandle::new_in_directory(Some(tmp.path()));
+    let conn = rusqlite::Connection::open(tmp.path().join("app-cache.sqlite"))?;
+    conn.execute(
+        "INSERT INTO `analytics` (id, current_period_started_at, events_sent)
+         VALUES (?1, NULL, NULL)",
+        [1],
+    )?;
+    drop(conn);
+
+    assert_eq!(cache.analytics().try_get_current_period()?, 0);
+    Ok(())
+}

--- a/crates/but-db/tests/db/cache/table/mod.rs
+++ b/crates/but-db/tests/db/cache/table/mod.rs
@@ -1,1 +1,2 @@
+mod analytics;
 mod update;

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -65,6 +65,7 @@ but-api = { workspace = true, features = ["path-bytes"] }
 but-graph.workspace = true
 but-llm.workspace = true
 but-link.workspace = true
+but-db.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, env};
 
+use but_db::AppCacheHandle;
 use but_settings::AppSettings;
 use clap::ValueEnum;
 use command_group::AsyncCommandGroup;
@@ -338,7 +339,7 @@ impl BackgroundMetrics {
             tokio::task::spawn(async move {
                 let client = client_future.await;
                 while let Some(event) = receiver.recv().await {
-                    do_capture(&client, event, &app_settings).await.ok();
+                    do_capture(&client, &app_settings, event).await.ok();
                 }
             });
         }
@@ -356,16 +357,35 @@ impl BackgroundMetrics {
 /// Capture an event *only* if `app_settings.telemetry.app_metrics_enabled` is `true`.
 pub async fn capture_event_blocking(app_settings: &AppSettings, event: Event) {
     if let Some(client) = posthog_client(app_settings.clone()) {
-        do_capture(&client.await, event, app_settings).await.ok();
+        do_capture(&client.await, app_settings, event).await.ok();
     }
+}
+
+fn should_send_metrics() -> anyhow::Result<bool> {
+    let app_cache_dir = but_path::app_cache_dir().ok();
+    let mut cache = AppCacheHandle::new_in_directory(app_cache_dir);
+    let mut tx = cache.deferred_transaction()?;
+    let count = tx.analytics().get_current_period();
+    // 1000 posthog events have been collected in the last day, we are probably
+    // in a tight loop.
+    if count >= 1000 {
+        return Ok(false);
+    }
+    tx.analytics_mut()?.record_event_sent()?;
+    tx.commit()?;
+    Ok(true)
 }
 
 /// Note that `client` is *only* available if telemetry is enabled.
 async fn do_capture(
     client: &Client,
-    event: Event,
     app_settings: &AppSettings,
-) -> Result<(), posthog_rs::Error> {
+    event: Event,
+) -> anyhow::Result<()> {
+    if !tokio::task::spawn_blocking(should_send_metrics).await?? {
+        return Ok(());
+    }
+
     if event.event_name.sample_rate() < rand::rng().sample::<f32, _>(OpenClosed01) {
         return Ok(());
     }
@@ -381,7 +401,10 @@ async fn do_capture(
     for (key, prop) in event.props {
         let _ = posthog_event.insert_prop(key, prop);
     }
-    client.capture(posthog_event).await
+    client
+        .capture(posthog_event)
+        .await
+        .map_err(|_| anyhow::anyhow!("Failed to capture posthog event"))
 }
 
 fn machine() -> String {


### PR DESCRIPTION
We’ve had issues with CLi users putting out _way_ too many posthog events. As a starting point, we’re assuming that a normal user probably isn’t making more than 1000 invocations. This should protect us against people who might be running us inside of a tight loop.

I thought it was reasonable to use the app-cache database for this purpose. Because of threading issues, I ened up making one sync function that does the app-cache work that I’m running in a blocking-allowed thread.

If there is a better alternative I’m happy to make the switch.