### PR TITLE
possible fix for #12778

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -64,11 +64,28 @@ impl Snapshot {
             .then(|| gix::discover(self.path.parent().expect("at least a file")).ok())
             .flatten();
         let repo = repo.or(discovered_repo.as_ref());
-        if self.changed_at.is_some()
-            || self.has_null_head_hash()
-            || self.clone().enforce_constraints(repo)
-        {
-            let data = self.to_consistent_data(reconcile, repo);
+        let mut projected_workspace = None;
+        self.write_if_changed_with_projection(reconcile, repo, &mut projected_workspace)
+    }
+
+    fn write_if_changed_with_projection(
+        &mut self,
+        reconcile: ReconcileWithWorkspace,
+        repo: Option<&gix::Repository>,
+        projected_workspace: &mut Option<Option<but_graph::projection::Workspace>>,
+    ) -> anyhow::Result<()> {
+        if self.changed_at.is_some() || self.has_null_head_hash() || {
+            let mut snapshot = self.clone();
+            snapshot.enforce_constraints(
+                repo,
+                self.project_workspace_if_uncached(repo, projected_workspace),
+            )
+        } {
+            let data = self.to_consistent_data(
+                reconcile,
+                repo,
+                self.project_workspace_if_uncached(repo, projected_workspace),
+            );
             storage::write_virtual_branches_and_sync(&self.path, &data)?;
             self.content = data;
             self.changed_at.take();
@@ -106,6 +123,7 @@ impl Snapshot {
         &self,
         reconcile: ReconcileWithWorkspace,
         repo: Option<&gix::Repository>,
+        projected_workspace: Option<&but_graph::projection::Workspace>,
     ) -> VirtualBranches {
         // EVIL HACK: assure we fill-in the CommitIDs of heads or else everything breaks.
         //            this probably won't be needed once no old code is running, and by then
@@ -115,9 +133,11 @@ impl Snapshot {
             .as_ref()
             .filter(|_| matches!(reconcile, ReconcileWithWorkspace::Allow))
         {
-            clone.reconcile_and_fix_vb_toml(repo).ok();
+            clone
+                .reconcile_and_fix_vb_toml(repo, projected_workspace)
+                .ok();
         }
-        clone.enforce_constraints(repo);
+        clone.enforce_constraints(repo, projected_workspace);
         clone.content
     }
 
@@ -135,12 +155,28 @@ impl Snapshot {
     /// * Use `repo` to fill in object hashes which were set with `<null>`
     /// * each ref-name is used once, unless the workspace projection shows duplicates
     ///   refer to the same segment.
-    fn enforce_constraints(&mut self, repo: Option<&gix::Repository>) -> bool {
+    fn enforce_constraints(
+        &mut self,
+        repo: Option<&gix::Repository>,
+        projected_workspace: Option<&but_graph::projection::Workspace>,
+    ) -> bool {
         let mut changed = false;
         let mut empty_stacks_to_remove = Vec::new();
         let null_id = gix::hash::Kind::Sha1.null();
-        let projected_segment_ids =
-            repo.and_then(|repo| self.projected_segment_ids_by_head_name(repo));
+        let projected_segment_ids = projected_workspace
+            .filter(|workspace| workspace.kind.has_managed_commit())
+            .map(|workspace| {
+                workspace
+                    .stacks
+                    .iter()
+                    .flat_map(|stack| stack.segments.iter())
+                    .filter_map(|segment| {
+                        segment
+                            .ref_name()
+                            .map(|ref_name| (ref_name.shorten().to_string(), segment.id))
+                    })
+                    .collect::<BTreeMap<_, _>>()
+            });
         let mut seen_refnames = BTreeMap::<String, Option<but_graph::SegmentIndex>>::new();
         for (stack_id, stack) in self
             .content
@@ -208,23 +244,15 @@ impl Snapshot {
         changed
     }
 
-    /// Note that the returned map is from `short name -> segment index`.
-    fn projected_segment_ids_by_head_name(
+    fn project_workspace_if_uncached<'a>(
         &self,
-        repo: &gix::Repository,
-    ) -> Option<BTreeMap<String, but_graph::SegmentIndex>> {
-        let ws = self.project_workspace(repo).ok()?;
-        ws.kind.has_managed_commit().then(|| {
-            ws.stacks
-                .iter()
-                .flat_map(|stack| stack.segments.iter())
-                .filter_map(|segment| {
-                    segment
-                        .ref_name()
-                        .map(|ref_name| (ref_name.shorten().to_string(), segment.id))
-                })
-                .collect()
-        })
+        repo: Option<&gix::Repository>,
+        cache: &'a mut Option<Option<but_graph::projection::Workspace>>,
+    ) -> Option<&'a but_graph::projection::Workspace> {
+        if cache.is_none() {
+            *cache = Some(repo.and_then(|repo| self.project_workspace(repo).ok()));
+        }
+        cache.as_ref().and_then(Option::as_ref)
     }
 
     fn project_workspace(
@@ -249,8 +277,12 @@ impl Snapshot {
         graph.into_workspace()
     }
 
-    #[instrument(level = "debug", skip(self, repo))]
-    fn reconcile_and_fix_vb_toml(&mut self, repo: &gix::Repository) -> anyhow::Result<()> {
+    #[instrument(level = "debug", skip(self, repo, projected_workspace))]
+    fn reconcile_and_fix_vb_toml(
+        &mut self,
+        repo: &gix::Repository,
+        projected_workspace: Option<&but_graph::projection::Workspace>,
+    ) -> anyhow::Result<()> {
         fn make_heads_match(ws_stack: &but_graph::projection::Stack, vb_stack: &mut Stack) -> bool {
             // Always leave extra segments.
 
@@ -304,7 +336,13 @@ impl Snapshot {
             vb_stack.heads != previous_heads
         }
 
-        let ws = self.project_workspace(repo)?;
+        let owned_workspace;
+        let ws = if let Some(workspace) = projected_workspace {
+            workspace
+        } else {
+            owned_workspace = self.project_workspace(repo)?;
+            &owned_workspace
+        };
         if !ws.kind.has_managed_commit() {
             tracing::debug!("Avoiding workspace->vb-toml reconciliation in unmanaged workspace");
             return Ok(());
@@ -447,13 +485,20 @@ impl VirtualBranchesTomlMetadata {
     /// `repo` is expected to be the repository this instance relates to.
     /// Consume this instance to prevent double-reconciliation which also happens on drop.
     pub fn write_reconciled(mut self, repo: &gix::Repository) -> anyhow::Result<()> {
+        let mut projected_workspace = None;
         // First possibly change our data…
-        self.snapshot.reconcile_and_fix_vb_toml(repo)?;
+        self.snapshot.reconcile_and_fix_vb_toml(
+            repo,
+            self.snapshot
+                .project_workspace_if_uncached(Some(repo), &mut projected_workspace),
+        )?;
 
         // Then write changes back.
-        let res = self
-            .snapshot
-            .write_if_changed(ReconcileWithWorkspace::Disallow, Some(repo));
+        let res = self.snapshot.write_if_changed_with_projection(
+            ReconcileWithWorkspace::Disallow,
+            Some(repo),
+            &mut projected_workspace,
+        );
         self.write_on_drop = false;
         res
     }

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -2,7 +2,7 @@ use std::{
     any::Any,
     cell::RefCell,
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet, btree_map},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     time::Instant,
@@ -54,12 +54,21 @@ impl Snapshot {
         })
     }
 
-    fn write_if_changed(&mut self, reconcile: ReconcileWithWorkspace) -> anyhow::Result<()> {
+    fn write_if_changed(
+        &mut self,
+        reconcile: ReconcileWithWorkspace,
+        repo: Option<&gix::Repository>,
+    ) -> anyhow::Result<()> {
+        let discovered_repo = repo
+            .is_none()
+            .then(|| gix::discover(self.path.parent().expect("at least a file")).ok())
+            .flatten();
+        let repo = repo.or(discovered_repo.as_ref());
         if self.changed_at.is_some()
             || self.has_null_head_hash()
-            || self.clone().enforce_constraints(None)
+            || self.clone().enforce_constraints(repo)
         {
-            let data = self.to_consistent_data(reconcile);
+            let data = self.to_consistent_data(reconcile, repo);
             storage::write_virtual_branches_and_sync(&self.path, &data)?;
             self.content = data;
             self.changed_at.take();
@@ -67,8 +76,12 @@ impl Snapshot {
         Ok(())
     }
 
-    fn try_write_if_changed(&mut self, reconcile: ReconcileWithWorkspace) {
-        let res = self.write_if_changed(reconcile);
+    fn try_write_if_changed(
+        &mut self,
+        reconcile: ReconcileWithWorkspace,
+        repo: Option<&gix::Repository>,
+    ) {
+        let res = self.write_if_changed(reconcile, repo);
         if let Err(err) = res {
             tracing::error!(
                 "Could not write back changes to virtual branches toml file to '{}': {err}",
@@ -89,11 +102,14 @@ impl Snapshot {
     /// The fixes here aren't relevant for the ref-metadata, but important for storage.
     /// Instead of trying to maintain this, let's just fix it before writing.
     /// `reconcile` controls if the data should also be reconciled.
-    fn to_consistent_data(&self, reconcile: ReconcileWithWorkspace) -> VirtualBranches {
+    fn to_consistent_data(
+        &self,
+        reconcile: ReconcileWithWorkspace,
+        repo: Option<&gix::Repository>,
+    ) -> VirtualBranches {
         // EVIL HACK: assure we fill-in the CommitIDs of heads or else everything breaks.
         //            this probably won't be needed once no old code is running, and by then
         //            we should move away from this anyway and have a DB backed implementation.
-        let repo = gix::discover(self.path.parent().expect("at least a file")).ok();
         let mut clone = self.clone();
         if let Some(repo) = repo
             .as_ref()
@@ -101,7 +117,7 @@ impl Snapshot {
         {
             clone.reconcile_and_fix_vb_toml(repo).ok();
         }
-        clone.enforce_constraints(repo.as_ref());
+        clone.enforce_constraints(repo);
         clone.content
     }
 
@@ -117,37 +133,22 @@ impl Snapshot {
     /// Enforce data constraints and return `true` if this instance changed.
     /// * ensure stack.name is set with the top-most segment name.
     /// * Use `repo` to fill in object hashes which were set with `<null>`
-    /// * each ref-name is used once, and first user wins.
+    /// * each ref-name is used once, unless the workspace projection shows duplicates
+    ///   refer to the same segment.
     fn enforce_constraints(&mut self, repo: Option<&gix::Repository>) -> bool {
         let mut changed = false;
         let mut empty_stacks_to_remove = Vec::new();
-        let mut seen_refnames = BTreeSet::new();
+        let null_id = gix::hash::Kind::Sha1.null();
+        let projected_segment_ids =
+            repo.and_then(|repo| self.projected_segment_ids_by_head_name(repo));
+        let mut seen_refnames = BTreeMap::<String, Option<but_graph::SegmentIndex>>::new();
         for (stack_id, stack) in self
             .content
             .branches
             .iter_mut()
             .sorted_by(|(_, a), (_, b)| order_then_name(&&**a, &&**b))
         {
-            let head_indices_to_remove: Vec<_> = stack
-                .heads
-                .iter()
-                .enumerate()
-                .filter_map(|(head_idx, head)| {
-                    (!seen_refnames.insert(head.name.clone())).then_some(head_idx)
-                })
-                .collect();
-            for head_idx in head_indices_to_remove.into_iter().rev() {
-                let head = stack.heads.remove(head_idx);
-                tracing::warn!(
-                    "Removed '{head_name}' from stack {stack_id} as it was already used in another stack",
-                    head_name = head.name
-                );
-                changed = true;
-            }
-
             if let Some(repo) = repo {
-                let null_id = gix::hash::Kind::Sha1.null();
-
                 for segment in &mut stack.heads {
                     if segment.head == null_id {
                         let Ok(mut r) = repo.find_reference(&segment.name) else {
@@ -161,6 +162,39 @@ impl Snapshot {
                 }
             }
 
+            let head_indices_to_remove: Vec<_> = stack
+                .heads
+                .iter()
+                .enumerate()
+                .filter_map(|(head_idx, head)| {
+                    let projected_segment_id = projected_segment_ids
+                        .as_ref()
+                        .and_then(|ids| ids.get(&head.name).copied());
+                    match seen_refnames.entry(head.name.clone()) {
+                        btree_map::Entry::Vacant(entry) => {
+                            entry.insert(projected_segment_id);
+                            None
+                        }
+                        btree_map::Entry::Occupied(entry) => {
+                            let preserve_duplicate = entry
+                                .get()
+                                .as_ref()
+                                .zip(projected_segment_id)
+                                .is_some_and(|(seen, current)| *seen == current);
+                            (!preserve_duplicate).then_some(head_idx)
+                        }
+                    }
+                })
+                .collect();
+            for head_idx in head_indices_to_remove.into_iter().rev() {
+                let head = stack.heads.remove(head_idx);
+                tracing::warn!(
+                    "Removed '{head_name}' from stack {stack_id} as it was already used in another stack",
+                    head_name = head.name
+                );
+                changed = true;
+            }
+
             if stack.heads.is_empty() {
                 empty_stacks_to_remove.push(*stack_id);
             }
@@ -172,6 +206,47 @@ impl Snapshot {
             changed = true;
         }
         changed
+    }
+
+    /// Note that the returned map is from `short name -> segment index`.
+    fn projected_segment_ids_by_head_name(
+        &self,
+        repo: &gix::Repository,
+    ) -> Option<BTreeMap<String, but_graph::SegmentIndex>> {
+        let ws = self.project_workspace(repo).ok()?;
+        ws.kind.has_managed_commit().then(|| {
+            ws.stacks
+                .iter()
+                .flat_map(|stack| stack.segments.iter())
+                .filter_map(|segment| {
+                    segment
+                        .ref_name()
+                        .map(|ref_name| (ref_name.shorten().to_string(), segment.id))
+                })
+                .collect()
+        })
+    }
+
+    fn project_workspace(
+        &self,
+        repo: &gix::Repository,
+    ) -> anyhow::Result<but_graph::projection::Workspace> {
+        let mut reference = repo.find_reference(INTEGRATION_BRANCH)?;
+        let commit_id = reference.peel_to_commit()?.id();
+        let sideeffect_free_meta = std::mem::ManuallyDrop::new(VirtualBranchesTomlMetadata {
+            snapshot: Snapshot {
+                changed_at: None,
+                ..self.clone()
+            },
+            write_on_drop: false,
+        });
+        let graph = but_graph::Graph::from_commit_traversal(
+            commit_id,
+            reference.name().to_owned(),
+            &*sideeffect_free_meta,
+            but_graph::init::Options::limited(),
+        )?;
+        graph.into_workspace()
     }
 
     #[instrument(level = "debug", skip(self, repo))]
@@ -229,22 +304,7 @@ impl Snapshot {
             vb_stack.heads != previous_heads
         }
 
-        let mut reference = repo.find_reference("refs/heads/gitbutler/workspace")?;
-        let commit_id = reference.peel_to_commit()?.id();
-        let sideeffect_free_meta = std::mem::ManuallyDrop::new(VirtualBranchesTomlMetadata {
-            snapshot: Snapshot {
-                changed_at: None,
-                ..self.clone()
-            },
-        });
-        let graph = but_graph::Graph::from_commit_traversal(
-            commit_id,
-            reference.name().to_owned(),
-            &*sideeffect_free_meta,
-            but_graph::init::Options::limited(),
-        )?;
-
-        let ws = graph.into_workspace()?;
+        let ws = self.project_workspace(repo)?;
         if !ws.kind.has_managed_commit() {
             tracing::debug!("Avoiding workspace->vb-toml reconciliation in unmanaged workspace");
             return Ok(());
@@ -276,6 +336,7 @@ impl Snapshot {
             }
             stack_id
         };
+        let original_stack_ids: Vec<_> = self.content.branches.keys().copied().collect();
         let ws_stacks_to_represent_in_vb_toml: Vec<_> = ws
             .stacks
             .iter()
@@ -317,12 +378,9 @@ impl Snapshot {
             }
         }
 
-        let stack_ids_to_mark_outside_workspace: Vec<_> = sideeffect_free_meta
-            .data()
-            .branches
-            .keys()
+        let stack_ids_to_mark_outside_workspace: Vec<_> = original_stack_ids
+            .into_iter()
             .filter(|stack_id| !seen.contains(stack_id))
-            .copied()
             .collect();
         for stack_id_not_in_workspace in stack_ids_to_mark_outside_workspace {
             let vb_stack = self
@@ -350,6 +408,10 @@ impl Snapshot {
 pub struct VirtualBranchesTomlMetadata {
     // What is currently in memory for query or editing.
     snapshot: Snapshot,
+    // Invariant: this stays `true` for normal metadata instances so `Drop` persists pending
+    // changes. It is set to `false` only in consuming explicit-write paths after the final write
+    // has already happened, which means no further mutations of this instance are possible.
+    write_on_drop: bool,
 }
 
 /// Lifecycle
@@ -361,6 +423,7 @@ impl VirtualBranchesTomlMetadata {
         let path = path.into();
         Ok(Self {
             snapshot: Snapshot::from_path(path)?,
+            write_on_drop: true,
         })
     }
 
@@ -370,9 +433,7 @@ impl VirtualBranchesTomlMetadata {
     pub fn path(&self) -> &Path {
         &self.snapshot.path
     }
-}
 
-impl VirtualBranchesTomlMetadata {
     /// Validate and fix workspace stack `in_workspace` status of `virtual_branches.toml`
     /// so they match what's actually in the workspace.
     /// If there is a change, the data is written back once instantly.
@@ -390,8 +451,11 @@ impl VirtualBranchesTomlMetadata {
         self.snapshot.reconcile_and_fix_vb_toml(repo)?;
 
         // Then write changes back.
-        self.snapshot
-            .write_if_changed(ReconcileWithWorkspace::Disallow)
+        let res = self
+            .snapshot
+            .write_if_changed(ReconcileWithWorkspace::Disallow, Some(repo));
+        self.write_on_drop = false;
+        res
     }
 
     /// Write pending changes without reconciling the metadata against the workspace.
@@ -400,7 +464,7 @@ impl VirtualBranchesTomlMetadata {
     /// deterministic across cold and warm fixture creation paths.
     pub fn write_unreconciled(&mut self) -> anyhow::Result<()> {
         self.snapshot
-            .write_if_changed(ReconcileWithWorkspace::Disallow)
+            .write_if_changed(ReconcileWithWorkspace::Disallow, None)
     }
 }
 
@@ -427,8 +491,10 @@ impl VirtualBranchesTomlMetadata {
 // Emergency-behaviour in case the application winds down, we don't want data-loss (at least a chance).
 impl Drop for VirtualBranchesTomlMetadata {
     fn drop(&mut self) {
-        self.snapshot
-            .try_write_if_changed(ReconcileWithWorkspace::Allow);
+        if self.write_on_drop {
+            self.snapshot
+                .try_write_if_changed(ReconcileWithWorkspace::Allow, None);
+        }
     }
 }
 

--- a/crates/but-meta/tests/fixtures/scenario/ws/multi-lane-with-shared-segment.sh
+++ b/crates/but-meta/tests/fixtures/scenario/ws/multi-lane-with-shared-segment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE[0]%/*}/../shared.sh"
+
+set -eu -o pipefail
+
+git init
+    commit M1
+git checkout -b shared
+    commit S1
+    commit S2
+    commit S3
+git checkout -b A
+    git branch B
+    git branch C
+    commit A1
+git checkout B
+    commit B1
+    commit B2
+git checkout C
+    commit C1
+    commit C2
+    commit C3
+git checkout -b D
+    commit D1
+create_workspace_commit_once A B D
+git checkout -b soon-remote-main main
+    commit M2
+
+git checkout gitbutler/workspace
+setup_remote_tracking soon-remote-main main "move"

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -8,7 +8,10 @@ use but_core::{
         WorkspaceStack, WorkspaceStackBranch,
     },
 };
-use but_meta::{VirtualBranchesTomlMetadata, virtual_branches_legacy_types::Target};
+use but_meta::{
+    VirtualBranchesTomlMetadata,
+    virtual_branches_legacy_types::{Stack as LegacyStack, StackBranch, Target},
+};
 use but_testsupport::{
     debug_str,
     gix_testtools::tempfile::{TempDir, tempdir},
@@ -1306,15 +1309,16 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
     )?;
     insta::assert_snapshot!(but_testsupport::graph_workspace_determinisitcally(&graph.into_workspace()?), @"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 3183e43
-    └── ≡📙:2:main[🌳] <> origin/main →:1: on 3183e43 {1}
+    ├── ≡📙:4:confidence on 3183e43 {1}
+    │   └── 📙:4:confidence
+    └── ≡📙:2:main[🌳] <> origin/main →:1: on 3183e43
         └── 📙:2:main[🌳] <> origin/main →:1:
             └── ❄️bce0c5e (🏘️|✓)
     ");
 
     let (actual, _uuids) = sanitize_uuids_and_timestamps_with_mapping(debug_str(&ws.stacks));
-    // Now both stacks are outside workspace, as is indicated by the workspace above.
-    // Also, their uniqueness constraint is enforced.
-    // AND: The above is no more and it's all just weird.
+    // Reconciliation now preserves the explicitly-written stack layout instead of allowing the
+    // drop-time write path to collapse it again.
     insta::assert_snapshot!(actual, @r#"
     [
         WorkspaceStack {
@@ -1331,38 +1335,70 @@ fn dlib_rs_auto_fix() -> anyhow::Result<()> {
             ],
             workspacecommit_relation: Merged,
         },
+        WorkspaceStack {
+            id: 2,
+            branches: [
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/main",
+                    archived: false,
+                },
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/confidence",
+                    archived: false,
+                },
+            ],
+            workspacecommit_relation: Outside,
+        },
+        WorkspaceStack {
+            id: 3,
+            branches: [
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/confidence",
+                    archived: false,
+                },
+            ],
+            workspacecommit_relation: Merged,
+        },
     ]
     "#);
 
-    // Now that there is one stack left, we can manipulate it and look at vb.toml data directly.
-    // AND: this makes no sense with the lack of a `Stack::name` field.
+    // Mutate one concrete stack and verify that persisted key/id mismatches are normalized on reload.
     store
         .data_mut()
         .branches
         .values_mut()
-        .next()
-        .expect("exactly one")
+        .find(|stack| stack.in_workspace && stack.heads.iter().any(|head| head.name == "main"))
+        .expect("a reconciled in-workspace stack with 'main' exists")
         .id = StackId::from_number_for_testing(8);
     // Now the ID and the ID used for storage are out of sync.
-    snapbox::assert_data_eq!(
-        debug_str(&store.data().branches),
-        snapbox::str![[r#"
-{
-    1819a203-26ef-477c-ac56-2d07a034ddb8: Stack {
-...
-        id: 00000000-0000-0000-0000-000000000008,
-...
-}
-"#]]
+    let mismatched_stack = store
+        .data()
+        .branches
+        .iter()
+        .find(|(stack_id, stack)| {
+            **stack_id != stack.id && stack.id == StackId::from_number_for_testing(8)
+        })
+        .map(|(stack_id, stack)| (*stack_id, stack.id));
+    assert!(
+        mismatched_stack.is_some(),
+        "a persisted stack should be writable even if its stored key and inner id diverge temporarily",
     );
     store.write_reconciled(&repo)?;
 
-    let _store = VirtualBranchesTomlMetadata::from_path(path)?;
+    let store = VirtualBranchesTomlMetadata::from_path(path)?;
 
     // now the ID is in sync again
-    // AND: this test makes no sense anymore… . Maybe the test was too tuned to a particular thing?
-    //      Now there are two branches here, because the names are all off and strange in this data.
-    //      Let's just hope we get to DB backed metadata soon so all this can go away.
+    let mismatched_ids: Vec<_> = store
+        .data()
+        .branches
+        .iter()
+        .filter_map(|(stack_id, stack)| (*stack_id != stack.id).then_some((*stack_id, stack.id)))
+        .collect();
+    assert_eq!(
+        mismatched_ids,
+        Vec::<(StackId, StackId)>::new(),
+        "reloading should restore key/id consistency in persisted legacy metadata",
+    );
     Ok(())
 }
 
@@ -1457,6 +1493,118 @@ fn legacy_change_id_deserializes_as_null_sha() -> anyhow::Result<()> {
         stack.heads[0].head,
         gix::hash::Kind::Sha1.null(),
         "legacy ChangeId should deserialize as null SHA to allow loading old toml files"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn removes_duplicate_heads_even_if_they_point_to_the_same_commit() -> anyhow::Result<()> {
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    let head = gix::ObjectId::from_str("1111111111111111111111111111111111111111")?;
+
+    let first = LegacyStack::new_with_just_heads(
+        vec![StackBranch {
+            head,
+            name: "shared".into(),
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }],
+        0,
+        true,
+    );
+    let second = LegacyStack::new_with_just_heads(
+        vec![StackBranch {
+            head,
+            name: "shared".into(),
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }],
+        1,
+        true,
+    );
+    let first_id = first.id;
+    let second_id = second.id;
+    store.data_mut().branches.insert(first_id, first);
+    store.data_mut().branches.insert(second_id, second);
+    store.set_changed_to_necessitate_write();
+
+    let path = store.path().to_owned();
+    drop(store);
+
+    let store = VirtualBranchesTomlMetadata::from_path(path)?;
+    let shared_heads = store
+        .data()
+        .branches
+        .values()
+        .flat_map(|stack| stack.heads.iter())
+        .filter(|head| head.name == "shared")
+        .count();
+    assert_eq!(
+        shared_heads, 1,
+        "without a workspace projection, duplicate names still use first-wins cleanup",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_duplicate_heads_if_they_map_to_the_same_workspace_segment() -> anyhow::Result<()> {
+    let repo = but_testsupport::read_only_in_memory_scenario("ws/multi-lane-with-shared-segment")?;
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    store.data_mut().default_target = Some(Target {
+        branch: RemoteRefname::new("origin", "main"),
+        remote_url: "https://example.com/example-org/example-repo".to_string(),
+        sha: gix::hash::Kind::Sha1.null(),
+        push_remote_name: Some("origin".into()),
+    });
+
+    let stack_a = LegacyStack::new_with_just_heads(
+        vec![
+            StackBranch::new_with_zero_head("shared".into(), None, None, false),
+            StackBranch::new_with_zero_head("A".into(), None, None, false),
+        ],
+        0,
+        true,
+    );
+    let stack_b = LegacyStack::new_with_just_heads(
+        vec![
+            StackBranch::new_with_zero_head("shared".into(), None, None, false),
+            StackBranch::new_with_zero_head("B".into(), None, None, false),
+        ],
+        1,
+        true,
+    );
+    let stack_d = LegacyStack::new_with_just_heads(
+        vec![
+            StackBranch::new_with_zero_head("shared".into(), None, None, false),
+            StackBranch::new_with_zero_head("C".into(), None, None, false),
+            StackBranch::new_with_zero_head("D".into(), None, None, false),
+        ],
+        2,
+        true,
+    );
+    store.data_mut().branches.insert(stack_a.id, stack_a);
+    store.data_mut().branches.insert(stack_b.id, stack_b);
+    store.data_mut().branches.insert(stack_d.id, stack_d);
+    store.set_changed_to_necessitate_write();
+
+    let path = store.path().to_owned();
+    store.write_reconciled(&repo)?;
+
+    let store = VirtualBranchesTomlMetadata::from_path(path)?;
+    let shared_heads = store
+        .data()
+        .branches
+        .values()
+        .flat_map(|stack| stack.heads.iter())
+        .filter(|head| head.name == "shared")
+        .count();
+    assert_eq!(
+        shared_heads, 3,
+        "repo-backed cleanup should preserve duplicate names when they resolve to the same projected segment",
     );
 
     Ok(())


### PR DESCRIPTION
### Tasks

* [x] refaciew
* [x] validate in GUI

### Review Notes

This entire reconciliation business is temporary, as I am actively working on making it completely unnecessary by removing the underlying vb.toml data store *and* the data schema from the database mirror.

However, this change makes it work properly with shared segments, which was a real bug before. Performance wise, this fix is the same as before, i.e. one workspace projection (and graph traversal) each time vb.toml is written through RefMetadata, i.e. modern algorithms.