### PR TITLE
Run workflows for stacked PRs

### DIFF
--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches: [master]
     paths-ignore:
       - "apps/web/**"
   workflow_dispatch:

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches: [master]
   workflow_dispatch:
     inputs:
       sha:


### PR DESCRIPTION
Currently these workflows don't run for stacked PRs (e.g. B which depends on A), and they still won't run even after dependant PRs have been merged because the `pull_request` event doesn't listen to base changes. I think we want to run these workflows for all PRs, not just PRs at the bottom of stacks (i.e. where `master` is the base)?