### PR TITLE
Fix initSettleMs blocking when items render at final height immediately

### DIFF
--- a/apps/desktop/src/components/MultiDiffView.svelte
+++ b/apps/desktop/src/components/MultiDiffView.svelte
@@ -220,10 +220,10 @@
 				{startIndex}
 				grow
 				items={changes}
-				defaultHeight={102}
+				defaultHeight={173}
 				visibility="scroll"
 				renderDistance={100}
-				initSettleMs={1000}
+				initSettleMs={500}
 				onVisibleChange={(range) => {
 					if (range) {
 						const activeIndex = scrollLock.resolve(range);

--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -216,8 +216,17 @@
 	 * Resolves immediately when the observer fires, so items that resize fast
 	 * don't block initialization.
 	 */
-	function settle(index: number): Promise<void> {
+	function settle(index: number, measuredHeight: number): Promise<void> {
 		if (initSettleMs <= 0) return Promise.resolve();
+
+		// If the measured height already differs significantly from
+		// defaultHeight, the item rendered its final content directly
+		// (skipping the skeleton/loading placeholder). No async expansion
+		// is expected, so we can proceed immediately.
+		if (Math.abs(measuredHeight - defaultHeight) > 1) {
+			return Promise.resolve();
+		}
+
 		const gen = initGeneration;
 		return new Promise((resolve) => {
 			function done() {
@@ -432,7 +441,7 @@
 				if (isFull(renderDistance)) break;
 
 				// Wait for async resize before deciding if the viewport is full.
-				await settle(i);
+				await settle(i, measuredHeight);
 				if (!viewport || generation !== initGeneration) return;
 				if (heightMap[i] !== measuredHeight && isFull(renderDistance)) break;
 			}
@@ -462,7 +471,7 @@
 
 				if (isFull(2 * renderDistance)) break;
 
-				await settle(i);
+				await settle(i, measuredHeight);
 				if (!viewport || generation !== initGeneration) return;
 
 				// Item is above startingAt — its growth pushes content down.

--- a/packages/ui/tests/VirtualList.spec.ts
+++ b/packages/ui/tests/VirtualList.spec.ts
@@ -1862,3 +1862,42 @@ test("should settle faster when ResizeObserver fires before timeout", async ({ m
 	expect(await getVisibleItemIndices(viewport)).toContain(0);
 	expect(await viewport.locator(".async-content").count()).toBeGreaterThan(0);
 });
+
+test("should not wait full initSettleMs when items render at final height immediately", async ({
+	mount,
+}) => {
+	// Reproduces the bug seen in MultiDiffView: jumpToIndex renders items
+	// whose final height differs from defaultHeight but that have no async
+	// expansion. settle() should skip the wait when it detects that the
+	// measured height diverged from defaultHeight by more than 1px (meaning
+	// the item rendered its final content directly, not a skeleton).
+	const component = await mount(VirtualListTestWrapper, {
+		props: {
+			itemCount: 50,
+			defaultHeight: 30,
+			// No asyncContent — items render at final size immediately (100px
+			// from CSS min-height, which differs from defaultHeight: 30).
+			initSettleMs: 2000,
+		},
+	});
+
+	const viewport = component.locator(".viewport");
+	await waitForScrollStability(viewport);
+
+	// jumpToIndex triggers initializeAt which calls settle() per item.
+	const input = component.getByTestId("jump-to-index-input");
+	await input.fill("25");
+	const startTime = Date.now();
+	await component.getByTestId("jump-to-index-button").click();
+	await waitForScrollStability(viewport);
+	const elapsed = Date.now() - startTime;
+
+	// Without the fix, each item blocks for the full 2000ms settle timeout.
+	// With ~2 items needing settle, that's 4000ms+.
+	// With the fix, settle skips immediately when it detects the item
+	// rendered at a height far from defaultHeight, so this completes fast.
+	expect(elapsed).toBeLessThan(2000);
+
+	const indices = await getVisibleItemIndices(viewport);
+	expect(indices).toContain(25);
+});


### PR DESCRIPTION
When an item's measured height differs from defaultHeight by more than 1px,
settle() now resolves immediately rather than waiting for the full initSettleMs
timeout. Items that render at their final size directly (skipping the skeleton
phase) will never trigger a ResizeObserver height change, so the timeout was
always wasted for them. The 1px tolerance keeps the wait active for items that
genuinely render at the skeleton/placeholder height.

Also reduces MultiDiffView initSettleMs from 1000ms to 500ms, and adds a
regression test covering the jumpToIndex case where this bug was observed.