### PR TITLE
Fix getTodos to handle non-array input and thinking blocks

### DIFF
--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -670,10 +670,14 @@ export function getTodos(events: ClaudeMessage[]): ClaudeTodo[] {
 		if (event.payload.source !== "claude") continue;
 		const content = event.payload.data;
 		if (content.type !== "assistant") continue;
-		const msgContent = content.message.content[0]!;
-		if (msgContent.type !== "tool_use") continue;
-		if (msgContent.name !== "TodoWrite") continue;
-		todos = (msgContent.input as { todos: ClaudeTodo[] }).todos;
+		const todoContent = content.message.content.find(
+			(c) => c.type === "tool_use" && c.name === "TodoWrite",
+		);
+		if (!todoContent || todoContent.type !== "tool_use") continue;
+		const maybeTodos = (todoContent.input as { todos: ClaudeTodo[] }).todos;
+		if (Array.isArray(maybeTodos)) {
+			todos = maybeTodos;
+		}
 		break;
 	}
 	return todos ?? [];


### PR DESCRIPTION
Two fixes to prevent a runtime TypeError in `CodegenRow` when reading todos from AI-generated messages, which was only surfacing in nightly builds.

**1. Guard against non-array `todos`**

`getTodos()` was type-asserting `msgContent.input` without any runtime validation. If `input.todos` was truthy but not an array, the `?? []` fallback wouldn't trigger, causing a crash on `.filter()` downstream.

**2. Scan all content items, not just `content[0]`**

Claude Code can emit a `thinking` block before the `TodoWrite` tool_use in the message content array. The previous code only checked `content[0]`, so any message where a thinking block came first would be silently skipped — meaning todos would never be found in nightly builds that use extended thinking. Now uses `.find()` to locate the `TodoWrite` entry regardless of position.