### PR TITLE
Add svelte:boundary error boundaries to catch synchronous render errors

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -3,6 +3,7 @@
 	import ChromeHeader from "$components/ChromeHeader.svelte";
 	import ChromeSidebar from "$components/ChromeSidebar.svelte";
 	import EnsureAuthorInfo from "$components/EnsureAuthorInfo.svelte";
+	import ErrorBoundary from "$components/ErrorBoundary.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { inject } from "@gitbutler/core/context";
@@ -27,7 +28,9 @@
 				<EnsureAuthorInfo {projectId} />
 				<ChromeSidebar {projectId} disabled={sidebarDisabled} />
 				<div class="chrome-content">
-					{@render children2()}
+					<ErrorBoundary>
+						{@render children2()}
+					</ErrorBoundary>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/components/CodegenRow.svelte
+++ b/apps/desktop/src/components/CodegenRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CardOverlay from "$components/CardOverlay.svelte";
 	import Dropzone from "$components/Dropzone.svelte";
+	import ErrorBoundary from "$components/ErrorBoundary.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import { ATTACHMENT_SERVICE } from "$lib/codegen/attachmentService.svelte";
 	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
@@ -99,70 +100,77 @@
 	{#snippet overlay({ hovered, activated })}
 		<CardOverlay {hovered} {activated} label="Reference" />
 	{/snippet}
+	<ErrorBoundary compact>
+		{#if draft}
+			<!-- Draft mode: simple placeholder -->
+			<div class="codegen-row">
+				<Icon name="ai" color="var(--clr-theme-purple-element)" />
+				<h3 class="text-13 text-semibold truncate codegen-row__title">
+					AI session will start here
+				</h3>
+			</div>
+		{:else if projectId && messages && permissionRequests}
+			<ReduxResult {projectId} result={combineResults(messages.result, permissionRequests.result)}>
+				{#snippet children([messages, permissionReqs])}
+					{@const lastMessage = extractLastMessage(messages)}
+					{@const lastSummary = lastMessage ? truncate(lastMessage, 360, 8) : undefined}
+					{@const todos = getTodos(messages)}
+					{@const completedCount = todos.filter((t) => t.status === "completed").length}
+					{@const totalCount = todos.length}
+					{@const formattedMessages = formatMessages(
+						messages,
+						permissionReqs,
+						status === "running",
+					)}
+					{@const feedbackStatus = userFeedbackStatus(formattedMessages)}
+					{@const hasPendingQuestion = hasPendingAskUserQuestion(formattedMessages)}
+					{@const hasPendingApproval = feedbackStatus.waitingForFeedback}
+					{@const hasPendingAction = hasPendingApproval || hasPendingQuestion}
 
-	{#if draft}
-		<!-- Draft mode: simple placeholder -->
-		<div class="codegen-row">
-			<Icon name="ai" color="var(--clr-theme-purple-element)" />
-			<h3 class="text-13 text-semibold truncate codegen-row__title">AI session will start here</h3>
-		</div>
-	{:else if projectId && messages && permissionRequests}
-		<ReduxResult {projectId} result={combineResults(messages.result, permissionRequests.result)}>
-			{#snippet children([messages, permissionReqs])}
-				{@const lastMessage = extractLastMessage(messages)}
-				{@const lastSummary = lastMessage ? truncate(lastMessage, 360, 8) : undefined}
-				{@const todos = getTodos(messages)}
-				{@const completedCount = todos.filter((t) => t.status === "completed").length}
-				{@const totalCount = todos.length}
-				{@const formattedMessages = formatMessages(messages, permissionReqs, status === "running")}
-				{@const feedbackStatus = userFeedbackStatus(formattedMessages)}
-				{@const hasPendingQuestion = hasPendingAskUserQuestion(formattedMessages)}
-				{@const hasPendingApproval = feedbackStatus.waitingForFeedback}
-				{@const hasPendingAction = hasPendingApproval || hasPendingQuestion}
-
-				<button
-					type="button"
-					class="codegen-row"
-					class:selected
-					class:active
-					class:codegen-row--wiggle={hasPendingAction && !selected}
-					onclick={toggleSelection}
-					use:focusable={{
-						onAction: toggleSelection,
-						onActive: (value) => (active = value),
-						focusable: true,
-					}}
-				>
-					{#if selected}
-						<div
-							class="indicator"
-							class:selected
-							class:active
-							in:slide={{ axis: "x", duration: 150 }}
-						></div>
-					{/if}
-
-					<Icon
-						name={getCurrentIconName(hasPendingAction)}
-						color="var(--clr-theme-purple-element)"
-					/>
-					<h3 class="text-13 text-semibold truncate codegen-row__title">{lastSummary}</h3>
-
-					{#if hasPendingAction}
-						<Badge style="pop" tooltip="Waiting for action">Action needed</Badge>
-					{/if}
-
-					{#if totalCount > 1}
-						<span class="text-12 codegen-row__todos">Todos ({completedCount}/{totalCount})</span>
-
-						{#if completedCount === totalCount}
-							<Icon name="tick-circle" color="var(--clr-theme-safe-element)" />
+					<button
+						type="button"
+						class="codegen-row"
+						class:selected
+						class:active
+						class:codegen-row--wiggle={hasPendingAction && !selected}
+						onclick={toggleSelection}
+						use:focusable={{
+							onAction: toggleSelection,
+							onActive: (value) => (active = value),
+							focusable: true,
+						}}
+					>
+						{#if selected}
+							<div
+								class="indicator"
+								class:selected
+								class:active
+								in:slide={{ axis: "x", duration: 150 }}
+							></div>
 						{/if}
-					{/if}
-				</button>
-			{/snippet}
-		</ReduxResult>
-	{/if}
+
+						<Icon
+							name={getCurrentIconName(hasPendingAction)}
+							color="var(--clr-theme-purple-element)"
+						/>
+						<h3 class="text-13 text-semibold truncate codegen-row__title">{lastSummary}</h3>
+
+						{#if hasPendingAction}
+							<Badge style="pop" tooltip="Waiting for action">Action needed</Badge>
+						{/if}
+
+						{#if totalCount > 1}
+							<span class="text-12 codegen-row__todos">Todos ({completedCount}/{totalCount})</span>
+
+							{#if completedCount === totalCount}
+								<Icon name="tick-circle" color="var(--clr-theme-safe-element)" />
+							{/if}
+						{/if}
+					</button>
+				{/snippet}
+			</ReduxResult>
+		{/if}
+	</ErrorBoundary>
 </Dropzone>
 
 <style lang="postcss">

--- a/apps/desktop/src/components/ErrorBoundary.svelte
+++ b/apps/desktop/src/components/ErrorBoundary.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { logError } from "$lib/error/logError";
+	import { Icon } from "@gitbutler/ui";
+	import type { Snippet } from "svelte";
+
+	type Props = {
+		children: Snippet;
+		title?: string;
+		compact?: boolean;
+	};
+
+	const { children, title = "Something went wrong", compact = false }: Props = $props();
+</script>
+
+<svelte:boundary onerror={(e) => logError(e, { skipToast: true })}>
+	{@render children()}
+
+	{#snippet failed(error: unknown)}
+		{#if compact}
+			<div class="boundary-error compact">
+				<Icon name="warning" />
+				<span class="text-12 truncate boundary-error__title">{title}</span>
+			</div>
+		{:else}
+			<div class="boundary-error">
+				<p class="text-13 boundary-error__title">{title}</p>
+				{#if error instanceof Error && error.message}
+					<p class="text-12 boundary-error__message">{error.message}</p>
+				{/if}
+			</div>
+		{/if}
+	{/snippet}
+</svelte:boundary>
+
+<style lang="postcss">
+	.boundary-error {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		padding: 16px;
+		gap: 8px;
+	}
+
+	.boundary-error.compact {
+		flex-direction: row;
+		align-items: center;
+		height: 44px;
+		padding: 0 12px;
+		padding-left: 14px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+	}
+
+	.boundary-error__title {
+		color: var(--clr-text-1);
+	}
+
+	.compact .boundary-error__title {
+		flex: 1;
+		color: var(--clr-text-2);
+	}
+
+	.boundary-error__message {
+		color: var(--clr-text-2);
+	}
+</style>

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CollapsedLane from "$components/CollapsedLane.svelte";
 	import CreateBranchModal from "$components/CreateBranchModal.svelte";
+	import ErrorBoundary from "$components/ErrorBoundary.svelte";
 	import MultiStackOfflaneDropzone from "$components/MultiStackOfflaneDropzone.svelte";
 	import MultiStackPagination, { scrollToLane } from "$components/MultiStackPagination.svelte";
 	import Scrollbar from "$components/Scrollbar.svelte";
@@ -255,22 +256,24 @@
 						onUnfold={() => unfoldStack(stack.id)}
 					/>
 				{:else}
-					<StackView
-						{projectId}
-						laneId={stack.id || "banana"}
-						stackId={stack.id ?? undefined}
-						onFoldStack={() => foldStack(stack.id)}
-						topBranchName={stack.heads.at(0)?.name}
-						bind:clientWidth={laneWidths[i]}
-						bind:clientHeight={lineHeights[i]}
-						onVisible={(visible) => {
-							if (visible) {
-								visibleIndexes = [...visibleIndexes, i];
-							} else {
-								visibleIndexes = visibleIndexes.filter((index) => index !== i);
-							}
-						}}
-					/>
+					<ErrorBoundary title="Something went wrong in this stack">
+						<StackView
+							{projectId}
+							laneId={stack.id || "banana"}
+							stackId={stack.id ?? undefined}
+							onFoldStack={() => foldStack(stack.id)}
+							topBranchName={stack.heads.at(0)?.name}
+							bind:clientWidth={laneWidths[i]}
+							bind:clientHeight={lineHeights[i]}
+							onVisible={(visible) => {
+								if (visible) {
+									visibleIndexes = [...visibleIndexes, i];
+								} else {
+									visibleIndexes = visibleIndexes.filter((index) => index !== i);
+								}
+							}}
+						/>
+					</ErrorBoundary>
 				{/if}
 			</div>
 		{/each}

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ConfigurableScrollableContainer from "$components/ConfigurableScrollableContainer.svelte";
+	import ErrorBoundary from "$components/ErrorBoundary.svelte";
 	import PreviewHeader from "$components/PreviewHeader.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import AddedDirectories from "$components/codegen/AddedDirectories.svelte";
@@ -319,354 +320,356 @@
 </script>
 
 <div class="chat" use:focusable={{ vertical: true }}>
-	<ReduxResult result={claudeAvailable.result}>
-		{#snippet loading()}
-			<PreviewHeader {onclose}>
-				{#snippet content()}
-					<h3 class="text-14 text-semibold truncate">Chat for {branchName}</h3>
-				{/snippet}
-				{#snippet actions()}
-					<div class="flex gap-4 items-center">
-						<SkeletonBone width="2.5rem" height="1.2rem" />
-						<SkeletonBone width="1.5rem" height="1.2rem" />
+	<ErrorBoundary title="Something went wrong in the chat">
+		<ReduxResult result={claudeAvailable.result}>
+			{#snippet loading()}
+				<PreviewHeader {onclose}>
+					{#snippet content()}
+						<h3 class="text-14 text-semibold truncate">Chat for {branchName}</h3>
+					{/snippet}
+					{#snippet actions()}
+						<div class="flex gap-4 items-center">
+							<SkeletonBone width="2.5rem" height="1.2rem" />
+							<SkeletonBone width="1.5rem" height="1.2rem" />
+						</div>
+					{/snippet}
+				</PreviewHeader>
+
+				<div class="chat-skeleton">
+					<div class="chat-skeleton__user">
+						<SkeletonBone
+							width="80%"
+							height="3rem"
+							color="var(--clr-bg-3)"
+							opacity={0.4}
+							radius="var(--radius-ml) var(--radius-ml) 0 var(--radius-ml)"
+						/>
 					</div>
-				{/snippet}
-			</PreviewHeader>
+					<div class="chat-skeleton__assistant">
+						<SkeletonBone width="100%" height="1rem" />
+						<SkeletonBone width="90%" height="1rem" />
+						<SkeletonBone width="95%" height="1rem" />
+					</div>
+					<div class="chat-skeleton__user">
+						<SkeletonBone
+							width="50%"
+							height="3rem"
+							color="var(--clr-bg-3)"
+							opacity={0.4}
+							radius="var(--radius-ml) var(--radius-ml) 0 var(--radius-ml)"
+						/>
+					</div>
+					<div class="chat-skeleton__assistant">
+						<SkeletonBone width="90%" height="1rem" />
+						<SkeletonBone width="70%" height="1rem" />
+					</div>
+				</div>
 
-			<div class="chat-skeleton">
-				<div class="chat-skeleton__user">
-					<SkeletonBone
-						width="80%"
-						height="3rem"
-						color="var(--clr-bg-3)"
-						opacity={0.4}
-						radius="var(--radius-ml) var(--radius-ml) 0 var(--radius-ml)"
-					/>
-				</div>
-				<div class="chat-skeleton__assistant">
-					<SkeletonBone width="100%" height="1rem" />
-					<SkeletonBone width="90%" height="1rem" />
-					<SkeletonBone width="95%" height="1rem" />
-				</div>
-				<div class="chat-skeleton__user">
-					<SkeletonBone
-						width="50%"
-						height="3rem"
-						color="var(--clr-bg-3)"
-						opacity={0.4}
-						radius="var(--radius-ml) var(--radius-ml) 0 var(--radius-ml)"
-					/>
-				</div>
-				<div class="chat-skeleton__assistant">
-					<SkeletonBone width="90%" height="1rem" />
-					<SkeletonBone width="70%" height="1rem" />
-				</div>
-			</div>
-
-			<div class="dialog-wrapper">
-				<div class="input-skeleton">
-					<div class="input-skeleton__text"><SkeletonBone width="60%" height="1rem" /></div>
-					<div class="input-skeleton__actions">
-						<SkeletonBone width="4rem" height="var(--size-button)" radius="var(--radius-btn)" />
-						<div class="flex gap-8">
+				<div class="dialog-wrapper">
+					<div class="input-skeleton">
+						<div class="input-skeleton__text"><SkeletonBone width="60%" height="1rem" /></div>
+						<div class="input-skeleton__actions">
 							<SkeletonBone width="4rem" height="var(--size-button)" radius="var(--radius-btn)" />
-							<SkeletonBone
-								width="calc(var(--size-button) + 0.188rem)"
-								height="var(--size-button)"
-								color="var(--clr-theme-pop-element)"
-								radius="var(--radius-btn)"
-							/>
+							<div class="flex gap-8">
+								<SkeletonBone width="4rem" height="var(--size-button)" radius="var(--radius-btn)" />
+								<SkeletonBone
+									width="calc(var(--size-button) + 0.188rem)"
+									height="var(--size-button)"
+									color="var(--clr-theme-pop-element)"
+									radius="var(--radius-btn)"
+								/>
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
-		{/snippet}
-		{#snippet children(claudeAvailable)}
-			{@const todos = getTodos(events)}
+			{/snippet}
+			{#snippet children(claudeAvailable)}
+				{@const todos = getTodos(events)}
 
-			<!-- TODO: remove this header when we move to the workspace layout -->
-			<PreviewHeader {onclose}>
-				{#snippet content()}
-					<h3 class="text-14 text-semibold truncate">Chat for {branchName}</h3>
-				{/snippet}
+				<!-- TODO: remove this header when we move to the workspace layout -->
+				<PreviewHeader {onclose}>
+					{#snippet content()}
+						<h3 class="text-14 text-semibold truncate">Chat for {branchName}</h3>
+					{/snippet}
 
-				{#snippet actions()}
-					{@const stats = usageStats(events)}
-					{@const contextUsage = Math.round(stats.contextUtilization * 100)}
+					{#snippet actions()}
+						{@const stats = usageStats(events)}
+						{@const contextUsage = Math.round(stats.contextUtilization * 100)}
 
-					<div class="flex gap-10 items-center">
-						{#if stats.tokens > 0}
-							<Tooltip text="Tokens: {stats.tokens.toLocaleString()} / ${stats.cost.toFixed(2)}">
-								<span class="text-12 clr-text-2">
-									{formatCompactNumber(stats.tokens)}
-								</span>
-							</Tooltip>
+						<div class="flex gap-10 items-center">
+							{#if stats.tokens > 0}
+								<Tooltip text="Tokens: {stats.tokens.toLocaleString()} / ${stats.cost.toFixed(2)}">
+									<span class="text-12 clr-text-2">
+										{formatCompactNumber(stats.tokens)}
+									</span>
+								</Tooltip>
 
-							<Tooltip text="{contextUsage}% context used">
-								<div
-									class="context-utilization-scale"
-									style="--context-utilization: {contextUsage}"
-								>
-									<svg viewBox="0 0 17 17">
-										<circle class="bg-circle" cx="8.5" cy="8.5" r="6.5" />
-										<circle class="progress-circle" cx="8.5" cy="8.5" r="6.5" />
-									</svg>
-								</div>
-							</Tooltip>
-						{/if}
+								<Tooltip text="{contextUsage}% context used">
+									<div
+										class="context-utilization-scale"
+										style="--context-utilization: {contextUsage}"
+									>
+										<svg viewBox="0 0 17 17">
+											<circle class="bg-circle" cx="8.5" cy="8.5" r="6.5" />
+											<circle class="progress-circle" cx="8.5" cy="8.5" r="6.5" />
+										</svg>
+									</div>
+								</Tooltip>
+							{/if}
 
-						<KebabButton>
-							{#snippet contextMenu({ close })}
-								{@const isDisabled =
-									!hasRulesToClear ||
-									!events ||
-									events.length === 0 ||
-									["running", "compacting"].includes(currentStatus(events, isStackActive))}
+							<KebabButton>
+								{#snippet contextMenu({ close })}
+									{@const isDisabled =
+										!hasRulesToClear ||
+										!events ||
+										events.length === 0 ||
+										["running", "compacting"].includes(currentStatus(events, isStackActive))}
 
-								{#if onMcpSettings}
+									{#if onMcpSettings}
+										<ContextMenuSection>
+											<ContextMenuItem
+												label="MCP settings"
+												icon="mcp"
+												onclick={() => {
+													onMcpSettings?.();
+													close();
+												}}
+											/>
+										</ContextMenuSection>
+									{/if}
 									<ContextMenuSection>
 										<ContextMenuItem
-											label="MCP settings"
-											icon="mcp"
+											label="Clear context"
+											icon="eraser"
+											disabled={isDisabled}
 											onclick={() => {
-												onMcpSettings?.();
+												clearContextAndRules();
+												close();
+											}}
+										/>
+										<ContextMenuItem
+											label="Compact context"
+											icon="compact"
+											disabled={isDisabled}
+											onclick={() => {
+												compactContext();
 												close();
 											}}
 										/>
 									</ContextMenuSection>
-								{/if}
-								<ContextMenuSection>
-									<ContextMenuItem
-										label="Clear context"
-										icon="eraser"
-										disabled={isDisabled}
-										onclick={() => {
-											clearContextAndRules();
-											close();
-										}}
-									/>
-									<ContextMenuItem
-										label="Compact context"
-										icon="compact"
-										disabled={isDisabled}
-										onclick={() => {
-											compactContext();
-											close();
-										}}
-									/>
-								</ContextMenuSection>
-							{/snippet}
-						</KebabButton>
-					</div>
-				{/snippet}
-			</PreviewHeader>
-
-			<div class="chat-container">
-				{#if claudeAvailable.status !== "available" && formattedMessages.length === 0}
-					<ConfigurableScrollableContainer childrenWrapDisplay="contents">
-						<div class="no-agent-placeholder">
-							<div class="no-agent-placeholder__content">
-								{@html noClaudeCodeSvg}
-								<h2 class="text-serif-42">Connect Claude Code</h2>
-								<p class="text-13 text-body clr-text-2">
-									<br />
-									Click the button below to check if Claude Code is now available.
-								</p>
-
-								<ClaudeCheck />
-							</div>
-
-							<p class="text-12 text-body clr-text-2">
-								Having trouble connecting?
-								<br />
-								Check the <Link href="https://docs.claude.com/en/docs/claude-code/troubleshooting"
-									>troubleshooting guide</Link
-								> for common issues and solutions.
-							</p>
+								{/snippet}
+							</KebabButton>
 						</div>
-					</ConfigurableScrollableContainer>
-				{:else if !isStackActive && formattedMessages.length === 0}
-					<div class="chat-view__placeholder">
-						<EmptyStatePlaceholder
-							image={laneNewSvg}
-							width={320}
-							topBottomPadding={0}
-							bottomMargin={0}
-						>
-							{#snippet title()}
-								Let's build something amazing
-							{/snippet}
-							{#snippet caption()}
-								{#if canEnterChat}
-									Your canvas is clear
-									<br />
-									Let the code take shape
-								{:else}
-									Run `claude` once
-									<br />
-									to initialise the chat
-								{/if}
-							{/snippet}
-						</EmptyStatePlaceholder>
-					</div>
-				{:else}
-					<VirtualList
-						bind:this={virtualList}
-						grow
-						stickToBottom
-						showBottomButton
-						items={messagesForList}
-						visibility={$userSettings.scrollbarVisibilityState}
-						padding={{ left: 20, right: 20, top: 12, bottom: 12 }}
-						defaultHeight={65}
-						getId={(item) => item.createdAt}
-					>
-						{#snippet template(message)}
-							<CodegenClaudeMessage
-								{projectId}
-								{message}
-								{onPermissionDecision}
-								{toolCallExpandedState}
-							/>
-						{/snippet}
-						{@const thinkingStatus = currentStatus(events, isStackActive)}
-						{@const startAt = thinkingOrCompactingStartedAt(events)}
-						{#if ["running", "compacting"].includes(thinkingStatus) && startAt}
-							{@const status = userFeedbackStatus(formattedMessages)}
-							{#if status.waitingForFeedback}
-								<CodegenServiceMessageUseTool toolCall={status.toolCall} />
-							{:else if !pendingAskUserQuestion}
-								<CodegenServiceMessageThinking
-									{startAt}
-									msSpentWaiting={status.msSpentWaiting}
-									overrideWord={thinkingStatus === "compacting" ? "compacting" : undefined}
-								/>
-							{/if}
-						{/if}
-					</VirtualList>
-				{/if}
-				{#if todos.length > 0}
-					<CodegenTodoAccordion {todos} />
-				{/if}
-			</div>
-			{#if claudeAvailable.status !== "available"}
-				{#if formattedMessages.length > 0}
-					<CodegenChatClaudeNotAvaliableBanner
-						onSettingsBtnClick={() => {
-							uiState.global.modal.set({
-								type: "project-settings",
-								projectId,
-								selectedId: "agent",
-							});
-						}}
-					/>
-				{/if}
-			{:else if !projectRegistered}
-				{#if formattedMessages.length > 0}
-					<CodegenChatClaudeNotRegistered {onRetryConfig} />
-				{/if}
-			{:else}
-				{@const status = currentStatus(events, isStackActive)}
-				{@const laneState = uiState.lane(laneId)}
-				{@const addedDirs = laneState.addedDirs.current}
+					{/snippet}
+				</PreviewHeader>
 
-				<div class="dialog-wrapper">
-					{#if pendingAskUserQuestion}
-						<CodegenAskUserQuestion
-							questions={pendingAskUserQuestion.questions}
-							answered={pendingAskUserQuestion.answered}
-							onSubmitAnswers={async (answers) => {
-								await onAnswerQuestion?.(answers);
-							}}
-							onCancel={async () => {
-								dismissedAskUserQuestions = {
-									...dismissedAskUserQuestions,
-									[pendingAskUserQuestion.toolUseId]: true,
-								};
-								await onAbort?.();
-							}}
-						/>
-					{:else}
-						<AddedDirectories
-							{addedDirs}
-							onRemoveDir={(dir) => {
-								laneState.addedDirs.remove(dir);
-							}}
-						/>
+				<div class="chat-container">
+					{#if claudeAvailable.status !== "available" && formattedMessages.length === 0}
+						<ConfigurableScrollableContainer childrenWrapDisplay="contents">
+							<div class="no-agent-placeholder">
+								<div class="no-agent-placeholder__content">
+									{@html noClaudeCodeSvg}
+									<h2 class="text-serif-42">Connect Claude Code</h2>
+									<p class="text-13 text-body clr-text-2">
+										<br />
+										Click the button below to check if Claude Code is now available.
+									</p>
 
-						<CodegenInput
-							bind:this={inputRef}
-							{projectId}
-							{stackId}
-							branchName={stableBranchName}
-							value={initialPrompt || ""}
-							loading={["running", "compacting"].includes(status)}
-							compacting={status === "compacting"}
-							{onChange}
-							onSubmit={async (prompt) => {
-								await onSubmit?.(prompt);
-								setTimeout(() => {
-									virtualList?.scrollToBottom();
-								}, 100);
-							}}
-							{onAbort}
-							onCancel={onclose}
-						>
-							{#snippet actionsOnLeft()}
-								{@const permissionModeLabel = permissionModeOptions.find(
-									(a) => a.value === selectedPermissionMode,
-								)?.label}
-
-								<div class="flex m-right-4 gap-2">
-									<Button
-										bind:el={templateTrigger}
-										kind="ghost"
-										icon="script"
-										tooltip="Insert template"
-										onclick={(e) => templateContextMenu?.toggle(e)}
-									/>
-									<Button
-										bind:el={thinkingModeTrigger}
-										kind="ghost"
-										icon="thinking"
-										reversedDirection
-										onclick={() => thinkingModeContextMenu?.toggle()}
-										tooltip="Thinking mode"
-										children={selectedThinkingLevel === "normal" ? undefined : thinkingBtnText}
-									/>
-									<Button
-										bind:el={permissionModeTrigger}
-										kind="ghost"
-										icon={getPermissionModeIcon(selectedPermissionMode)}
-										shrinkable
-										onclick={() => permissionModeContextMenu?.toggle()}
-										tooltip={$settingsService?.claude.dangerouslyAllowAllPermissions
-											? "Permission modes disable when all permissions are allowed"
-											: permissionModeLabel}
-										disabled={$settingsService?.claude.dangerouslyAllowAllPermissions}
-									/>
+									<ClaudeCheck />
 								</div>
-							{/snippet}
 
-							{#snippet actionsOnRight()}
-								{#if !claudeSettings?.useConfiguredModel}
-									<Button
-										bind:el={modelTrigger}
-										kind="ghost"
-										icon="chevron-down"
-										shrinkable
-										onclick={() => modelContextMenu?.toggle()}
-									>
-										{modelOptions.find((a) => a.value === selectedModel)?.label}
-									</Button>
-								{/if}
+								<p class="text-12 text-body clr-text-2">
+									Having trouble connecting?
+									<br />
+									Check the <Link href="https://docs.claude.com/en/docs/claude-code/troubleshooting"
+										>troubleshooting guide</Link
+									> for common issues and solutions.
+								</p>
+							</div>
+						</ConfigurableScrollableContainer>
+					{:else if !isStackActive && formattedMessages.length === 0}
+						<div class="chat-view__placeholder">
+							<EmptyStatePlaceholder
+								image={laneNewSvg}
+								width={320}
+								topBottomPadding={0}
+								bottomMargin={0}
+							>
+								{#snippet title()}
+									Let's build something amazing
+								{/snippet}
+								{#snippet caption()}
+									{#if canEnterChat}
+										Your canvas is clear
+										<br />
+										Let the code take shape
+									{:else}
+										Run `claude` once
+										<br />
+										to initialise the chat
+									{/if}
+								{/snippet}
+							</EmptyStatePlaceholder>
+						</div>
+					{:else}
+						<VirtualList
+							bind:this={virtualList}
+							grow
+							stickToBottom
+							showBottomButton
+							items={messagesForList}
+							visibility={$userSettings.scrollbarVisibilityState}
+							padding={{ left: 20, right: 20, top: 12, bottom: 12 }}
+							defaultHeight={65}
+							getId={(item) => item.createdAt}
+						>
+							{#snippet template(message)}
+								<CodegenClaudeMessage
+									{projectId}
+									{message}
+									{onPermissionDecision}
+									{toolCallExpandedState}
+								/>
 							{/snippet}
-						</CodegenInput>
+							{@const thinkingStatus = currentStatus(events, isStackActive)}
+							{@const startAt = thinkingOrCompactingStartedAt(events)}
+							{#if ["running", "compacting"].includes(thinkingStatus) && startAt}
+								{@const status = userFeedbackStatus(formattedMessages)}
+								{#if status.waitingForFeedback}
+									<CodegenServiceMessageUseTool toolCall={status.toolCall} />
+								{:else if !pendingAskUserQuestion}
+									<CodegenServiceMessageThinking
+										{startAt}
+										msSpentWaiting={status.msSpentWaiting}
+										overrideWord={thinkingStatus === "compacting" ? "compacting" : undefined}
+									/>
+								{/if}
+							{/if}
+						</VirtualList>
+					{/if}
+					{#if todos.length > 0}
+						<CodegenTodoAccordion {todos} />
 					{/if}
 				</div>
-			{/if}
-		{/snippet}
-	</ReduxResult>
+				{#if claudeAvailable.status !== "available"}
+					{#if formattedMessages.length > 0}
+						<CodegenChatClaudeNotAvaliableBanner
+							onSettingsBtnClick={() => {
+								uiState.global.modal.set({
+									type: "project-settings",
+									projectId,
+									selectedId: "agent",
+								});
+							}}
+						/>
+					{/if}
+				{:else if !projectRegistered}
+					{#if formattedMessages.length > 0}
+						<CodegenChatClaudeNotRegistered {onRetryConfig} />
+					{/if}
+				{:else}
+					{@const status = currentStatus(events, isStackActive)}
+					{@const laneState = uiState.lane(laneId)}
+					{@const addedDirs = laneState.addedDirs.current}
+
+					<div class="dialog-wrapper">
+						{#if pendingAskUserQuestion}
+							<CodegenAskUserQuestion
+								questions={pendingAskUserQuestion.questions}
+								answered={pendingAskUserQuestion.answered}
+								onSubmitAnswers={async (answers) => {
+									await onAnswerQuestion?.(answers);
+								}}
+								onCancel={async () => {
+									dismissedAskUserQuestions = {
+										...dismissedAskUserQuestions,
+										[pendingAskUserQuestion.toolUseId]: true,
+									};
+									await onAbort?.();
+								}}
+							/>
+						{:else}
+							<AddedDirectories
+								{addedDirs}
+								onRemoveDir={(dir) => {
+									laneState.addedDirs.remove(dir);
+								}}
+							/>
+
+							<CodegenInput
+								bind:this={inputRef}
+								{projectId}
+								{stackId}
+								branchName={stableBranchName}
+								value={initialPrompt || ""}
+								loading={["running", "compacting"].includes(status)}
+								compacting={status === "compacting"}
+								{onChange}
+								onSubmit={async (prompt) => {
+									await onSubmit?.(prompt);
+									setTimeout(() => {
+										virtualList?.scrollToBottom();
+									}, 100);
+								}}
+								{onAbort}
+								onCancel={onclose}
+							>
+								{#snippet actionsOnLeft()}
+									{@const permissionModeLabel = permissionModeOptions.find(
+										(a) => a.value === selectedPermissionMode,
+									)?.label}
+
+									<div class="flex m-right-4 gap-2">
+										<Button
+											bind:el={templateTrigger}
+											kind="ghost"
+											icon="script"
+											tooltip="Insert template"
+											onclick={(e) => templateContextMenu?.toggle(e)}
+										/>
+										<Button
+											bind:el={thinkingModeTrigger}
+											kind="ghost"
+											icon="thinking"
+											reversedDirection
+											onclick={() => thinkingModeContextMenu?.toggle()}
+											tooltip="Thinking mode"
+											children={selectedThinkingLevel === "normal" ? undefined : thinkingBtnText}
+										/>
+										<Button
+											bind:el={permissionModeTrigger}
+											kind="ghost"
+											icon={getPermissionModeIcon(selectedPermissionMode)}
+											shrinkable
+											onclick={() => permissionModeContextMenu?.toggle()}
+											tooltip={$settingsService?.claude.dangerouslyAllowAllPermissions
+												? "Permission modes disable when all permissions are allowed"
+												: permissionModeLabel}
+											disabled={$settingsService?.claude.dangerouslyAllowAllPermissions}
+										/>
+									</div>
+								{/snippet}
+
+								{#snippet actionsOnRight()}
+									{#if !claudeSettings?.useConfiguredModel}
+										<Button
+											bind:el={modelTrigger}
+											kind="ghost"
+											icon="chevron-down"
+											shrinkable
+											onclick={() => modelContextMenu?.toggle()}
+										>
+											{modelOptions.find((a) => a.value === selectedModel)?.label}
+										</Button>
+									{/if}
+								{/snippet}
+							</CodegenInput>
+						{/if}
+					</div>
+				{/if}
+			{/snippet}
+		</ReduxResult>
+	</ErrorBoundary>
 </div>
 
 {#snippet thinkingBtnText()}

--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,30 +1,9 @@
-import { logErrorToFile } from "$lib/backend";
-import { SilentError } from "$lib/error/error";
-import { parseError } from "$lib/error/parser";
-import { showError } from "$lib/notifications/toasts";
+import { logError } from "$lib/error/logError";
 import { polyfillAbortSignalTimeout } from "$lib/polyfills/abortSignal";
-import { captureException } from "@sentry/sveltekit";
 import type { HandleClientError } from "@sveltejs/kit";
 
 // Apply polyfills before any code runs
 polyfillAbortSignalTimeout();
-
-const E2E_MESSAGES_TO_IGNORE_DURING_E2E = [
-	"Unable to autolaunch a dbus-daemon without a $DISPLAY for X11",
-];
-const E2E_MESSAGES_TO_IGNORE = [
-	// We can safely ignore this error. This is caused by tauri falling back from the custom protocol to http protocol.
-	"undefined is not an object (evaluating '[callbackId, data]')",
-];
-
-function shouldIgnoreError(error: unknown): boolean {
-	const { message } = parseError(error);
-	if (import.meta.env.VITE_E2E === "true") {
-		return E2E_MESSAGES_TO_IGNORE_DURING_E2E.some((entry) => message.includes(entry));
-	}
-
-	return E2E_MESSAGES_TO_IGNORE.includes(message);
-}
 
 // SvelteKit error handler.
 export function handleError({
@@ -42,56 +21,8 @@ export function handleError({
 	};
 }
 
-function loggableError(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
-	}
-
-	if (typeof error === "string") {
-		return error;
-	}
-	if (typeof error === "object" && error !== null) {
-		if ("message" in error && typeof error.message === "string") {
-			return error.message;
-		}
-		return JSON.stringify(error);
-	}
-	return String(error);
-}
-
 // Handler for unhandled errors inside promises.
 window.onunhandledrejection = (e: PromiseRejectionEvent) => {
 	e.preventDefault(); // Suppresses default console logger.
 	logError(e);
 };
-
-function logError(error: unknown) {
-	if (shouldIgnoreError(error)) {
-		return;
-	}
-
-	try {
-		captureException(error, {
-			mechanism: {
-				type: "sveltekit",
-				handled: false,
-			},
-		});
-
-		// Unwrap error if it's an unhandled promise rejection.
-		if (error instanceof PromiseRejectionEvent) {
-			error = error.reason;
-		}
-
-		if (!(error instanceof SilentError)) {
-			showError("Unhandled exception", error);
-		}
-
-		const logMessage = loggableError(error);
-		logErrorToFile(logMessage);
-
-		console.error(error);
-	} catch (err: unknown) {
-		console.error("Error while trying to log error.", err);
-	}
-}

--- a/apps/desktop/src/lib/error/logError.ts
+++ b/apps/desktop/src/lib/error/logError.ts
@@ -1,0 +1,75 @@
+import { logErrorToFile } from "$lib/backend";
+import { SilentError } from "$lib/error/error";
+import { parseError } from "$lib/error/parser";
+import { showError } from "$lib/notifications/toasts";
+import { captureException } from "@sentry/sveltekit";
+
+const E2E_MESSAGES_TO_IGNORE_DURING_E2E = [
+	"Unable to autolaunch a dbus-daemon without a $DISPLAY for X11",
+];
+const E2E_MESSAGES_TO_IGNORE = [
+	// We can safely ignore this error. This is caused by tauri falling back from the custom protocol to http protocol.
+	"undefined is not an object (evaluating '[callbackId, data]')",
+];
+
+function shouldIgnoreError(error: unknown): boolean {
+	const { message } = parseError(error);
+	if (import.meta.env.VITE_E2E === "true") {
+		return E2E_MESSAGES_TO_IGNORE_DURING_E2E.some((entry) => message.includes(entry));
+	}
+
+	return E2E_MESSAGES_TO_IGNORE.includes(message);
+}
+
+function loggableError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (typeof error === "string") {
+		return error;
+	}
+	if (typeof error === "object" && error !== null) {
+		if ("message" in error && typeof error.message === "string") {
+			return error.message;
+		}
+		return JSON.stringify(error);
+	}
+	return String(error);
+}
+
+type LogErrorOptions = {
+	/** If true, skip showing a toast notification (e.g. when a visual fallback is already shown). */
+	skipToast?: boolean;
+};
+
+export function logError(error: unknown, options?: LogErrorOptions) {
+	if (shouldIgnoreError(error)) {
+		return;
+	}
+
+	try {
+		captureException(error, {
+			mechanism: {
+				type: "sveltekit",
+				handled: false,
+			},
+		});
+
+		// Unwrap error if it's an unhandled promise rejection.
+		if (error instanceof PromiseRejectionEvent) {
+			error = error.reason;
+		}
+
+		if (!options?.skipToast && !(error instanceof SilentError)) {
+			showError("Unhandled exception", error);
+		}
+
+		const logMessage = loggableError(error);
+		logErrorToFile(logMessage);
+
+		console.error(error);
+	} catch (err: unknown) {
+		console.error("Error while trying to log error.", err);
+	}
+}


### PR DESCRIPTION
Introduce a reusable ErrorBoundary component that wraps content in a
<svelte:boundary> block. If a child component throws during mount or
reactive re-render, only the affected region shows a fallback UI
instead of crashing the entire application via the SvelteKit +error
route. Async errors (unhandled promise rejections) are unaffected and
continue to be handled by window.onunhandledrejection in hooks.client.ts.

ErrorBoundary supports a title prop for contextual messaging and a
compact variant for inline use (e.g. CodegenRow). It is applied in:

- MultiStackView (wrapping each StackView instance)
- CodegenMessages (wrapping the chat panel)
- CodegenRow (wrapping the AI session row)
- Chrome (wrapping the main content area)