### PR TITLE
fix: always canonicalize paths for comparison when resolving project

### DIFF
--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -295,14 +295,10 @@ impl Project {
                 // longest first
                 .reverse()
         });
-        let resolved_path = if worktree_dir.is_relative() {
-            worktree_dir
-                .canonicalize()
-                .context("Failed to canonicalize path")?
-        } else {
-            worktree_dir.to_path_buf()
-        };
 
+        let resolved_path = worktree_dir
+            .canonicalize()
+            .context("Failed to canonicalize path")?;
         let Some(project) = projects.into_iter().find(|p| {
             // Canonicalize project path for comparison
             match p.worktree_dir.canonicalize() {

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -298,7 +298,7 @@ impl Project {
 
         let resolved_path = worktree_dir
             .canonicalize()
-            .context("Failed to canonicalize path")?;
+            .with_context(|| format!("Failed to canonicalize path '{}'", worktree_dir.display()))?;
         let Some(project) = projects.into_iter().find(|p| {
             // Canonicalize project path for comparison
             match p.worktree_dir.canonicalize() {


### PR DESCRIPTION
It's incorrect to compare non-canonicalized paths to canonicalized paths on any platform. Absolute != canonical. For example, `/`, `/..` and `/usr/..` are all absolute and all canonicalize to `/`.

On Windows it's even more complex as paths can have e.g. the `\\?\` prefix to indicate it's an extended path, and the implementation of `canonicalize()` will attach that prefix.

This caused an issue on Windows where new-style Project Handles wouldn't work. We'd compare the non-canonicalized absolute path encoded in the Project Handle with the canonicalized path of the project worktree as written out in projects.json.