### PR TITLE
feat(tui): render `but status` when exiting tui

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -153,20 +153,30 @@ pub(crate) async fn worktree(
         }
     }
 
-    let Some(human_out) = out.for_human() else {
-        return Ok(());
-    };
-
     match render_mode {
         StatusRenderMode::Oneshot => {
+            let Some(human_out) = out.for_human() else {
+                return Ok(());
+            };
+
             let mut output = StatusOutput::Immediate { out: human_out };
             build_status_output(ctx, &status_ctx, &mut output)?;
         }
         StatusRenderMode::Tui { debug } => {
+            if out.for_human().is_none() {
+                return Ok(());
+            }
+
             let mut lines = Vec::new();
             let mut output = StatusOutput::Buffer { lines: &mut lines };
             build_status_output(ctx, &status_ctx, &mut output)?;
-            tui::render_tui(ctx, out, &mode, flags, lines, debug).await?;
+            let final_lines = tui::render_tui(ctx, out, &mode, flags, lines, debug).await?;
+
+            if let Some(human_out) = out.for_human() {
+                for line in final_lines {
+                    render_oneshot::render_oneshot(line, human_out)?;
+                }
+            }
         }
     }
 

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -45,7 +45,7 @@ pub(super) async fn render_tui(
     flags: StatusFlags,
     status_lines: Vec<StatusOutputLine>,
     debug: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<StatusOutputLine>> {
     let mut guard = TerminalGuard::new(true)?;
 
     let mut app = App::new(status_lines, flags, debug);
@@ -95,7 +95,7 @@ pub(super) async fn render_tui(
         }
     }
 
-    Ok(())
+    Ok(app.status_lines)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
When the tui exist it leaves the output of `but status` in the
scrollback. Makes it easier to run any follow up commands.

