### PR TITLE
but-skill-improvements

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -42,7 +42,8 @@ but <mutation> ... --json --status-after
 - Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --json --status-after`
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --json --status-after`
 - Amend: `but amend <file-id> <commit-id> --json --status-after`
-- Reorder: `but move <source-commit-id> <target-commit-id> --json --status-after`
+- Reorder commits: `but move <source-commit-id> <target-commit-id> --json --status-after` (**commit IDs**, not branch names)
+- Stack branches: `but branch move <branch-name> <target-branch-name>` (**branch names**, not IDs — e.g. `but branch move feature/frontend feature/backend`)
 - Push: `but push` or `but push <branch-id>`
 - Pull: `but pull --check --json` then `but pull --json --status-after`
 
@@ -54,6 +55,7 @@ but <mutation> ... --json --status-after
 2. Find the `cliId` for each file you want to commit.
 3. `but commit <branch> -m "<msg>" --changes <id1>,<id2> --json --status-after`
    Use `-c` to create the branch if it doesn't exist. Omit IDs you don't want committed.
+4. **Check the `--status-after` output** for remaining uncommitted changes. If the file still appears in `unassignedChanges` or `assignedChanges` after commit, it may be dependency-locked to another branch. See "Stacked dependency / commit-lock recovery" below.
 
 ### Amend into existing commit
 
@@ -61,19 +63,65 @@ but <mutation> ... --json --status-after
 2. Locate file ID and target commit ID.
 3. `but amend <file-id> <commit-id> --json --status-after`
 
-### Reorder commits
+### Reorder commits (not branches)
+
+**`but move` reorders commits within a branch. To stack branches, use `but branch move` instead.**
 
 1. `but status --json`
-2. `but move <commit-a> <commit-b> --json --status-after`
+2. `but move <commit-a> <commit-b> --json --status-after` — uses commit IDs like `c3`, `c5`
 3. Refresh IDs from the returned status, then run the inverse: `but move <commit-b> <commit-a> --json --status-after`
+
+### Stack existing branches
+
+To make one existing branch depend on (stack on top of) another, use `but branch move`:
+
+```bash
+but branch move feature/frontend feature/backend
+```
+
+This moves the frontend branch on top of the backend branch in one step.
+
+**DO NOT** use `uncommit` + `branch delete` + `branch new -a` to stack existing branches. That approach fails because git branch names persist even after `but branch delete`. Always use `but branch move`.
+
+**To unstack** (make a stacked branch independent again):
+
+```bash
+but branch new temp-unstack              # create an empty dummy branch
+but branch move feature/logging temp-unstack   # move the branch to the dummy
+but branch delete temp-unstack           # delete the dummy, leaving branch independent
+```
+
+**Note:** `but branch move` uses branch **names** (like `feature/frontend`), while `but move` uses commit **IDs** (like `c3`). Do not confuse them. Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
 
 ### Stacked dependency / commit-lock recovery
 
-If your change depends on another branch, or `but commit` fails with a lock error:
+A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
+- `but commit` succeeds but the file still appears in `unassignedChanges` in the `--status-after` output
+- The file shows as "unassigned" instead of being staged to any branch
 
-1. `but status --json` — confirm stack context.
-2. `but branch new <child-branch> -a <base-branch>`
-3. Continue mutations on the aligned branch.
+**Recovery:** Stack your branch on the dependency branch, then commit:
+
+1. `but status --json` — identify which branch originally owns the file (check commit history).
+2. `but branch move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
+3. `but status --json` — the file should now be assignable. Commit it.
+4. `but commit <branch> -m "<msg>" --changes <id> --json --status-after`
+
+**If `but branch move` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status --json` to confirm both branches still exist and are applied, then retry `but branch move` with exact branch names from the status output.
+
+### Resolve conflicts after reorder/move
+
+**NEVER use `git add`, `git commit`, `git checkout --theirs`, `git checkout --ours`, or any git write commands during resolution.** Only use `but resolve` commands and edit files directly with the Edit tool.
+
+If `but move` causes conflicts (`"conflicted": true` in status):
+
+1. `but status --json` — find commits with `"conflicted": true`.
+2. `but resolve <commit-id>` — enter resolution mode. This puts conflict markers in the files.
+3. **Read the conflicted files** to see the `<<<<<<<` / `=======` / `>>>>>>>` markers.
+4. **Edit the files** to resolve conflicts by choosing the correct content and removing markers.
+5. `but resolve finish` — finalize. Do NOT run this without editing the files first.
+6. Repeat for any remaining conflicted commits.
+
+**Common mistakes:** Do NOT use `but amend` on conflicted commits (it won't work). Do NOT skip step 4 — you must actually edit the files to remove conflict markers before finishing.
 
 ## Git-to-But Map
 
@@ -84,14 +132,17 @@ If your change depends on another branch, or `but commit` fails with a lock erro
 | `git checkout -b` | `but branch new <name>` |
 | `git push` | `but push` |
 | `git rebase -i` | `but move`, `but squash`, `but reword` |
+| `git rebase --onto` | `but branch move <branch> <new-base>` |
 | `git cherry-pick` | `but pick` |
 
 ## Notes
 
 - Prefer explicit IDs over file paths for mutations.
 - `--changes` accepts comma-separated values (`--changes a1,b2`) or repeated flags (`--changes a1 --changes b2`), not space-separated.
-- Read-only git inspection (`git log`, `git blame`) is allowed.
+- Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
 - After a successful `--status-after`, don't run a redundant `but status` unless you need new IDs.
+- Use `but show <branch-id> --json` to see commit details for a branch, including per-commit file changes and line counts.
+- **Per-commit file counts**: `but status --json` does NOT include per-commit file counts. Use `but show <branch-id> --json` or `git show --stat <commit-hash>` to get them.
 - Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a failed attempt.
 - Run `but skill check` only when command behavior diverges from this skill, not as routine preflight.
 - For command syntax and flags: `references/reference.md`

--- a/crates/but/skill/SKILL.with-link.md
+++ b/crates/but/skill/SKILL.with-link.md
@@ -130,7 +130,8 @@ but link resolve --block-id <id> --agent-id <id>
 - Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --json --status-after`
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --json --status-after`
 - Amend: `but amend <file-id> <commit-id> --json --status-after`
-- Reorder: `but move <source-commit-id> <target-commit-id> --json --status-after`
+- Reorder commits: `but move <source-commit-id> <target-commit-id> --json --status-after` (**commit IDs**, not branch names)
+- Stack branches: `but branch move <branch-name> <target-branch-name>` (**branch names**, not IDs — e.g. `but branch move feature/frontend feature/backend`)
 - Push: `but push` or `but push <branch-id>`
 - Pull: `but pull --check --json` then `but pull --json --status-after`
 
@@ -167,6 +168,7 @@ Use this for PR review, comment triage, investigation, or validation-only work.
 2. Find the `cliId` for each file you want to commit.
 3. `but commit <branch> -m "<msg>" --changes <id1>,<id2> --json --status-after`
    Use `-c` to create the branch if it doesn't exist. Omit IDs you don't want committed.
+4. **Check the `--status-after` output** for remaining uncommitted changes. If the file still appears in `unassignedChanges` or `assignedChanges` after commit, it may be dependency-locked to another branch. See "Stacked dependency / commit-lock recovery" below.
 
 ### Amend into existing commit
 
@@ -180,14 +182,28 @@ Use this for PR review, comment triage, investigation, or validation-only work.
 2. `but move <commit-a> <commit-b> --json --status-after`
 3. Refresh IDs from the returned status, then run the inverse: `but move <commit-b> <commit-a> --json --status-after`
 
+### Stack existing branches
+
+To make one existing branch depend on (stack on top of) another:
+
+1. `but status --json` — confirm both branches exist and note their full branch names.
+2. `but branch move <child-branch-name> <base-branch-name>` — uses full branch names (e.g. `feature/frontend`), NOT CLI IDs.
+
+**Note:** `but branch move` uses branch **names** (like `feature/frontend`), while `but move` uses commit **IDs** (like `c3`). Do not confuse them.
+
 ### Stacked dependency / commit-lock recovery
 
-If your change depends on another agent's branch, or `but commit` fails with a lock error:
+A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
+- `but commit` succeeds but the file still appears in `unassignedChanges` in the `--status-after` output
+- The file shows as "unassigned" instead of being staged to any branch
 
-1. `but status --json` — confirm stack context.
-2. `but link post "Blocked on <base-branch>: <reason>" --agent-id <id>`
-3. `but branch new <child-branch> -a <base-branch>`
-4. Continue mutations on the aligned branch.
+**Recovery:** Stack your branch on the dependency branch, then commit:
+
+1. `but status --json` — identify which branch originally owns the file.
+2. `but link post "Blocked on <base-branch>: dependency lock" --agent-id <id>`
+3. `but branch move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
+4. `but status --json` — the file should now be assignable.
+5. `but commit <branch> -m "<msg>" --changes <id> --json --status-after`
 
 ## Git-to-But Map
 
@@ -204,8 +220,10 @@ If your change depends on another agent's branch, or `but commit` fails with a l
 
 - Prefer explicit IDs over file paths for mutations.
 - `--changes` accepts comma-separated values (`--changes a1,b2`) or repeated flags (`--changes a1 --changes b2`), not space-separated.
-- Read-only git inspection (`git log`, `git blame`) is allowed.
+- Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
 - After a successful `--status-after`, don't run a redundant `but status` unless you need new IDs.
+- Use `but show <branch-id> --json` to see commit details for a branch (includes per-commit file changes and line counts automatically in JSON mode).
+- **Per-commit file counts**: `but status --json` does NOT include per-commit file counts. Use `but show <branch-id> --json` or `git show --stat <commit-hash>` to get them.
 - Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a failed attempt.
 - Run `but skill check` only when command behavior diverges from this skill, not as routine preflight.
 - For coordination protocol details: `references/link.md`

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -85,7 +85,9 @@ Example: Adding a new API endpoint and updating button styles are independent.
 
 ### Stacked Branches (Dependent Work)
 
-Create with `but branch new <name> -a <anchor>`:
+**To stack an existing branch** on top of another: `but branch move <child-branch-name> <parent-branch-name>` — this is the primary way to stack branches.
+
+**To create a new stacked branch** from scratch: `but branch new <name> -a <anchor>` — only use this when the child branch doesn't exist yet.
 
 ```
 main ── authentication ── user-profile ── settings-page
@@ -99,6 +101,12 @@ Use when:
 - Creating a series of related changes
 
 Example: User profile page needs authentication to be implemented first.
+
+**Stacking two existing branches:** If both branches already exist and you need to make one depend on the other, use `but branch move`:
+```bash
+but branch move feature/frontend feature/backend
+# Now frontend is stacked on top of backend — both in the same stack
+```
 
 **Dependency tracking:** GitButler automatically tracks which changes depend on which commits. You can't stage dependent changes to the wrong branch.
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -173,7 +173,34 @@ but branch new feature-b    # Creates branch bv
 but move c3 bv --json --status-after    # Move c3 to top of branch bv
 ```
 
-## Example 5: Using Marks for Focused Work
+## Example 5: Stacking Existing Branches
+
+**Scenario:** Two independent branches exist, but one now depends on the other. Stack them.
+
+```bash
+# 1. Check current state — two independent branches in separate stacks
+but status --json
+
+# Output:
+# Stack 1: feature/backend (bu) — 2 commits
+# Stack 2: feature/frontend (bv) — 1 commit
+
+# 2. Frontend now depends on backend API — stack frontend on backend
+#    IMPORTANT: Use full branch NAMES here, not CLI IDs
+but branch move feature/frontend feature/backend
+
+# Result: Both branches are now in the same stack:
+# Stack 1: feature/backend → feature/frontend (stacked)
+
+# 3. Continue working — commits go to the right branch
+but status --json
+but commit bu -m "Add caching layer" --changes <id> --json --status-after   # To backend
+but commit bv -m "Add dialog component" --changes <id> --json --status-after # To frontend
+```
+
+**Key point:** `but branch move` takes full branch **names** (like `feature/frontend`), NOT CLI IDs (like `bv`). This is different from `but move` which takes commit IDs.
+
+## Example 6: Using Marks for Focused Work
 
 **Scenario:** Working on a large refactor, want all changes to automatically stage to that branch.
 
@@ -216,7 +243,7 @@ but show c5 --json    # Shows accumulated changes
 but unmark
 ```
 
-## Example 6: Conflict Resolution
+## Example 7: Conflict Resolution
 
 **Scenario:** After `but pull`, conflicts appear in a commit.
 
@@ -241,8 +268,11 @@ but resolve c3
 # Entering resolution mode for commit c3
 # Fix conflicts in: api/users.js, api/validation.js
 
-# 4. Edit files to resolve conflicts
-# (open files, remove <<< === >>> markers)
+# 4. Read each conflicted file and edit to resolve
+# IMPORTANT: You MUST edit the files — do NOT just run `but resolve finish`
+# NEVER use `git add`, `git checkout --theirs/--ours`, or any git write command — just edit the files directly with the Edit tool, then `but resolve finish`
+cat api/users.js           # Read to see conflict markers
+# (edit to remove <<<<<<< ======= >>>>>>> markers and keep correct content)
 
 # 5. Check progress
 but resolve status
@@ -260,7 +290,7 @@ but resolve finish
 # Back to normal workspace mode
 ```
 
-## Example 7: Complete Feature Development Workflow
+## Example 8: Complete Feature Development Workflow
 
 **Scenario:** Building a complete feature from start to finish.
 
@@ -308,7 +338,7 @@ but pr new bu --json
 but pull --json
 ```
 
-## Example 8: Working with Applied/Unapplied Branches
+## Example 9: Working with Applied/Unapplied Branches
 
 **Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
 
@@ -343,7 +373,7 @@ but apply bw
 but resolve ...
 ```
 
-## Example 9: Fixing History Before Pushing
+## Example 10: Fixing History Before Pushing
 
 **Scenario:** Made several commits, realized you need to reword messages and reorder.
 
@@ -381,7 +411,7 @@ but squash c2 c3 --json --status-after    # Combine error handling commits
 but push bu --json
 ```
 
-## Example 10: Daily Development Workflow
+## Example 11: Daily Development Workflow
 
 **Typical day working with GitButler:**
 
@@ -427,7 +457,7 @@ but absorb bu --json --status-after          # Absorb all changes staged to bu
 but push bu --with-force --json   # Force push updated history
 ```
 
-## Example 11: Recovering from Mistakes
+## Example 12: Recovering from Mistakes
 
 **Scenario:** Made changes you didn't mean to, need to undo.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -131,6 +131,18 @@ but branch show <id> --check  # Check if branch merges cleanly into upstream
 but branch show <id> -r       # Fetch and display review information (PRs/MRs)
 ```
 
+### `but branch move <branch> <target-branch>`
+
+Move an existing branch on top of another branch, stacking them.
+
+```bash
+but branch move feature/frontend feature/backend    # Stack frontend on top of backend
+```
+
+**This is the primary command for stacking existing branches.** Use it when two branches already exist and one needs to depend on the other. Uses full branch **names**, not CLI IDs.
+
+Alias: `but stack <branch> <target-branch>`
+
 ### `but pick <source> [target]`
 
 Cherry-pick commits from unapplied branches into applied branches.
@@ -343,7 +355,7 @@ but discard <hunk-id>         # Discard hunk changes
 
 ## Conflict Resolution
 
-When commits have conflicts (shown in `but status`):
+When commits have conflicts (shown in `but status` — look for `conflicted: true`):
 
 ### `but resolve <commit>`
 
@@ -379,10 +391,14 @@ but resolve cancel
 
 **Workflow:**
 
-1. `but resolve <commit>` - Enter mode
-2. Edit files to resolve conflicts
-3. `but resolve status` - Check progress
-4. `but resolve finish` - Complete
+1. `but status --json` — identify conflicted commits (look for `conflicted: true`)
+2. `but resolve <commit-id>` — enter resolution mode for the conflicted commit
+3. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content
+4. `but resolve status` — verify no conflicts remain
+5. `but resolve finish` — finalize and return to normal mode
+6. If multiple commits are conflicted, repeat steps 2-5 for each one
+
+**Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
 
 ## Remote Operations
 

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -239,8 +239,10 @@ fn show_branch(
     branch_name: &str,
     verbose: bool,
 ) -> Result<()> {
-    // Get the commits for the branch
-    let (commits, base_commit_info) = get_branch_commits(ctx, branch_name, verbose)?;
+    // In JSON mode, always include file info (verbose) so agents and tools
+    // get complete data without needing to pass extra flags.
+    let effective_verbose = verbose || out.is_json();
+    let (commits, base_commit_info) = get_branch_commits(ctx, branch_name, effective_verbose)?;
 
     // Get the stack chain (branches this branch is stacked on)
     let stack_chain = get_stack_chain(ctx, branch_name)?;


### PR DESCRIPTION
Improvements in but-bench scores (https://github.com/gitbutlerapp/but-bench) compared to master

Scenario | Before | After | Δ
-- | -- | -- | --
reorder-in-stack | 0/1 (33%) | 5/5 (86%) | +52% ⬆
resolve-conflict | 0/1 (33%) | 4/5 (71%) | +38% ⬆
status-comprehension | 0/1 (33%) | 4/5 (71%) | +38% ⬆
absorb → status-comp (12 others) | 1/1 (67%) | 5/5 (86%) | +19% ⬆
dependency-lock-recovery | 0/1 (33%) | 1/5 (29%) | -5% =
stacked-branch-commit | 0/1 (33%) | 0/5 (14%) | never worked


Metric | Scenario | Before | After | Change
-- | -- | -- | -- | --
VC calls | move-branch-between-stacks | 54 | 8 | -85%
VC calls | move-across-stacks | 11 | 4 | -64%
VC calls | reorder-with-conflict | 9 | 6 | -33%
Agentic turns | move-branch-between-stacks | 68 | 11 | -84%
Agentic turns | move-across-stacks | 13 | 6 | -54%
VC errors | move-branch-between-stacks | 7.0 | 0.0 | eliminated
VC errors | move-across-stacks | 1.0 | 0.0 | eliminated
VC errors | reorder-with-conflict | 1.0 | 0.0 | eliminated
VC errors | squash-commits | 1.0 | 0.0 | eliminated
Retries | move-branch-between-stacks | 4.0 | 0.0 | eliminated
Redundant status | move-branch-between-stacks | 5.0 | 0.0 | eliminated
Non-VC fallbacks | move-branch-between-stacks | 11 | 0 | eliminated
--json usage | move-across-stacks | 50% | 93% | +43%
VC wall time | move-branch-between-stacks | 404s | 157s | -61%

