### PR TITLE
fix(cli): `but reword <branch>` would print trailing whitespace

### DIFF
--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -247,12 +247,13 @@ fn get_branch_name_from_editor(current_name: &str) -> Result<String> {
 
     let branch_name_lossy =
         tui::get_text::from_editor_no_comments("branch_name", &template)?.to_string();
+    let branch_name = branch_name_lossy.trim();
 
-    if branch_name_lossy.is_empty() {
+    if branch_name.is_empty() {
         bail!("Aborting due to empty branch name");
     }
 
-    Ok(branch_name_lossy)
+    Ok(branch_name.to_string())
 }
 
 #[cfg(test)]

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -74,6 +74,31 @@ Updated commit message for [..] (now [..])
 // Note: Branch rename test is omitted because the test scenario uses single-character
 // branch names ("A") which don't meet the 2-character minimum requirement for CLI IDs.
 // The branch rename functionality with -m flag is tested manually and works correctly.
+#[test]
+fn reword_branch_from_editor_trims_trailing_newlines_in_confirmation_output() -> anyhow::Result<()>
+{
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.setup_metadata(&["A"])?;
+    env.but("branch new branch-to-rename-123")
+        .assert()
+        .success();
+
+    env.file(
+        "editor.sh",
+        "#!/usr/bin/env bash\nprintf 'renamed-branch\\n\\n' > \"$1\"\n",
+    );
+    env.but("reword branch-to-rename-123")
+        .env("EDITOR", "bash editor.sh")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Renamed branch 'branch-to-rename-123' to 'renamed-branch'
+
+"#]]);
+
+    Ok(())
+}
 
 #[test]
 fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {


### PR DESCRIPTION
After using `but reword` to rename a branch a newline would be printed in the output:

```
Renamed branch 'dp-branch-1-123-alskdf' to 'dp-branch-1
 
' 
```

The actual renaming did discard the whitespace, was just the output that didn't.