### PR TITLE
feat(tui): reword commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-svg"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22d9f3dea8bbda97c75bd0f0203e23f1e190d6d6f27a40e10063946dc4d4362"
+checksum = "26b9ec8c976eada1b0f9747a3d7cc4eae3bef10613e443746e7487f26c872fde"
 dependencies = [
  "anstyle",
  "anstyle-lossy",
@@ -809,6 +809,7 @@ dependencies = [
  "posthog-rs",
  "rand 0.9.2",
  "ratatui",
+ "ratatui-textarea",
  "regex",
  "rmcp",
  "schemars 1.2.1",
@@ -8507,6 +8508,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-textarea"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de236b7cc74b3f7dea227b3fbad97bf459cddf552b6503d888fb9a106eda59ab"
+dependencies = [
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "unicode-width",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11380,9 +11393,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -142,6 +142,7 @@ nonempty.workspace = true
 itertools.workspace = true
 self_cell.workspace = true
 rand.workspace = true
+ratatui-textarea = "0.8.0"
 
 [dev-dependencies]
 but-graph.workspace = true

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -45,7 +45,14 @@ pub(crate) fn reword_target(
             edit_branch_name(ctx, name, out, message)?;
         }
         CliId::Commit { commit_id: oid, .. } => {
-            edit_commit_message_by_id(ctx, *oid, out, message, format, show_diff_in_editor)?;
+            edit_commit_message_by_id_and_reword_commit(
+                ctx,
+                *oid,
+                out,
+                message,
+                format,
+                show_diff_in_editor,
+            )?;
         }
         _ => {
             bail!(
@@ -104,7 +111,39 @@ fn prepare_provided_message(msg: Option<&str>, entity: &str) -> Option<Result<St
     })
 }
 
-fn edit_commit_message_by_id(
+pub(crate) fn get_commit_message_from_editor(
+    ctx: &mut Context,
+    commit_details: but_core::diff::CommitDetails,
+    current_message: String,
+    show_diff_in_editor: ShowDiffInEditor,
+) -> Result<Option<String>> {
+    let changed_files = get_changed_files_from_commit_details(&commit_details);
+
+    let should_show_diff = show_diff_in_editor.should_show_diff(|| {
+        estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)
+    })?;
+    let diff = should_show_diff
+        .then(|| {
+            commit_details
+                .diff_with_first_parent
+                .iter()
+                .map(|change| change.unified_diff(&*ctx.repo.get()?, 3))
+                .filter_map(|diff| diff.transpose())
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?;
+
+    let new_message =
+        actually_get_commit_message_from_editor(&current_message, &changed_files, diff.as_deref())?;
+
+    if new_message.trim() == current_message.trim() {
+        Ok(None)
+    } else {
+        Ok(Some(new_message.trim().to_owned()))
+    }
+}
+
+fn edit_commit_message_by_id_and_reword_commit(
     ctx: &mut Context,
     commit_oid: gix::ObjectId,
     out: &mut OutputChannel,
@@ -122,51 +161,42 @@ fn edit_commit_message_by_id(
             bail!("Cannot use both --format and --message flags together");
         }
         // Format the current message without opening an editor
-        but_action::commit_format::format_commit_message(&current_message)
+        Some(but_action::commit_format::format_commit_message(
+            &current_message,
+        ))
+    } else if let Some(message) = prepare_provided_message(message, "commit message") {
+        Some(message?)
     } else {
-        prepare_provided_message(message, "commit message").unwrap_or_else(|| {
-            let changed_files = get_changed_files_from_commit_details(&commit_details);
+        get_commit_message_from_editor(
+            ctx,
+            commit_details,
+            current_message.clone(),
+            show_diff_in_editor,
+        )?
+    }
+    .filter(|new_message| new_message.trim() != current_message.trim());
 
-            let should_show_diff = show_diff_in_editor.should_show_diff(|| {
-                estimate_diff_blob_size(&commit_details.diff_with_first_parent, ctx)
-            })?;
-            let diff = should_show_diff
-                .then(|| {
-                    commit_details
-                        .diff_with_first_parent
-                        .iter()
-                        .map(|change| change.unified_diff(&*ctx.repo.get()?, 3))
-                        .filter_map(|diff| diff.transpose())
-                        .collect::<Result<Vec<_>>>()
-                })
-                .transpose()?;
+    if let Some(new_message) = new_message {
+        let new_commit_oid =
+            but_api::commit::commit_reword_only(ctx, commit_oid, BString::from(new_message))?;
 
-            // Open editor with current message and file list
-            get_commit_message_from_editor(&current_message, &changed_files, diff.as_deref())
-        })?
-    };
+        if let Some(out) = out.for_human() {
+            let repo = ctx.repo.get()?;
+            writeln!(
+                out,
+                "Updated commit message for {} (now {})",
+                commit_oid.attach(&repo).shorten_or_id(),
+                new_commit_oid.new_commit.attach(&repo).shorten_or_id()
+            )?;
+        }
 
-    if new_message.trim() == current_message.trim() {
+        Ok(())
+    } else {
         if let Some(out) = out.for_human() {
             writeln!(out, "No changes to commit message - nothing to be done")?;
         }
-        return Ok(());
+        Ok(())
     }
-
-    let new_commit_oid =
-        but_api::commit::commit_reword_only(ctx, commit_oid, BString::from(new_message))?;
-
-    if let Some(out) = out.for_human() {
-        let repo = ctx.repo.get()?;
-        writeln!(
-            out,
-            "Updated commit message for {} (now {})",
-            commit_oid.attach(&repo).shorten_or_id(),
-            new_commit_oid.new_commit.attach(&repo).shorten_or_id()
-        )?;
-    }
-
-    Ok(())
 }
 
 fn get_changed_files_from_commit_details(
@@ -190,7 +220,7 @@ fn get_changed_files_from_commit_details(
     files
 }
 
-fn get_commit_message_from_editor(
+fn actually_get_commit_message_from_editor(
     current_message: &str,
     changed_files: &[String],
     diff: Option<&[BString]>,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -13,14 +13,16 @@ use gitbutler_stack::StackId;
 use gix::date::time::CustomFormat;
 use ratatui::{
     style::{Modifier, Style},
-    text::{Line, Span},
+    text::Span,
 };
 use serde::Serialize;
 
 use crate::{
     CLI_DATE, CliId, IdMap,
-    command::legacy::forge::review,
-    command::legacy::status::output::{StatusOutput, StatusOutputLine},
+    command::legacy::{
+        forge::review,
+        status::output::{CommitLineContent, StatusOutput, StatusOutputLine},
+    },
     id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
     utils::{
@@ -1121,74 +1123,46 @@ fn print_commit(
         "commit",
     )?;
 
-    let details_spans = if upstream_commit {
-        let mut spans = details_line.spans.into_iter();
-        if let Some(first) = spans.next() {
-            let mut out = Vec::from([Span::styled(
-                first.content,
-                first.style.add_modifier(Modifier::DIM),
-            )]);
-            if let Some(second) = spans.next() {
-                out.push(Span::styled(
-                    second.content,
-                    second.style.add_modifier(Modifier::DIM),
-                ));
-            }
-            let mut dim_text = String::new();
-
-            for span in spans {
-                let style = span.style.add_modifier(Modifier::DIM);
-                let is_dim_only =
-                    style.fg.is_none() && style.bg.is_none() && style.add_modifier == Modifier::DIM;
-                if is_dim_only {
-                    dim_text.push_str(&span.content);
-                } else {
-                    if !dim_text.is_empty() {
-                        out.push(Span::styled(
-                            std::mem::take(&mut dim_text),
-                            Style::default().dim(),
-                        ));
-                    }
-                    out.push(Span::styled(span.content, style));
-                }
-            }
-
-            if !dim_text.is_empty() {
-                out.push(Span::styled(dim_text, Style::default().dim()));
-            }
-            out
-        } else {
-            Vec::new()
-        }
+    let details_line = if upstream_commit {
+        dim_commit_line_content(details_line)
     } else {
-        details_line.spans
+        details_line
     };
 
     if status_ctx.flags.verbose {
         output.commit(
             Vec::from([Span::raw("┊"), dot, Span::raw(" ")]),
-            details_spans
-                .into_iter()
-                .chain(review_url.as_ref().into_iter().flat_map(|review_url| {
-                    [
-                        Span::raw(" "),
-                        Span::raw("◖"),
-                        Span::styled(review_url.to_owned(), Style::default().underlined().blue()),
-                        Span::raw("◗"),
-                    ]
-                }))
-                .chain(
-                    marked
-                        .then(|| {
-                            [
-                                Span::raw(" "),
-                                Span::styled("◀ Marked ▶", Style::default().red().bold()),
-                            ]
-                        })
-                        .into_iter()
-                        .flatten(),
-                )
-                .collect(),
+            CommitLineContent {
+                sha: details_line.sha,
+                author: details_line.author,
+                message: details_line.message,
+                suffix: details_line
+                    .suffix
+                    .into_iter()
+                    .chain(review_url.as_ref().into_iter().flat_map(|review_url| {
+                        [
+                            Span::raw(" "),
+                            Span::raw("◖"),
+                            Span::styled(
+                                review_url.to_owned(),
+                                Style::default().underlined().blue(),
+                            ),
+                            Span::raw("◗"),
+                        ]
+                    }))
+                    .chain(
+                        marked
+                            .then(|| {
+                                [
+                                    Span::raw(" "),
+                                    Span::styled("◀ Marked ▶", Style::default().red().bold()),
+                                ]
+                            })
+                            .into_iter()
+                            .flatten(),
+                    )
+                    .collect(),
+            },
             commit_cli_id.clone(),
         )?;
         let (message, is_empty_message) = commit_message_display_cli(
@@ -1212,28 +1186,37 @@ fn print_commit(
     } else {
         output.commit(
             Vec::from([Span::raw("┊"), dot, Span::raw("   ")]),
-            details_spans
-                .into_iter()
-                .chain(review_url.as_ref().into_iter().flat_map(|review_url| {
-                    [
-                        Span::raw(" "),
-                        Span::raw("◖"),
-                        Span::styled(review_url.to_owned(), Style::default().underlined().blue()),
-                        Span::raw("◗"),
-                    ]
-                }))
-                .chain(
-                    marked
-                        .then(|| {
-                            [
-                                Span::raw(" "),
-                                Span::styled("◀ Marked ▶", Style::default().red().bold()),
-                            ]
-                        })
-                        .into_iter()
-                        .flatten(),
-                )
-                .collect(),
+            CommitLineContent {
+                sha: details_line.sha,
+                author: details_line.author,
+                message: details_line.message,
+                suffix: details_line
+                    .suffix
+                    .into_iter()
+                    .chain(review_url.as_ref().into_iter().flat_map(|review_url| {
+                        [
+                            Span::raw(" "),
+                            Span::raw("◖"),
+                            Span::styled(
+                                review_url.to_owned(),
+                                Style::default().underlined().blue(),
+                            ),
+                            Span::raw("◗"),
+                        ]
+                    }))
+                    .chain(
+                        marked
+                            .then(|| {
+                                [
+                                    Span::raw(" "),
+                                    Span::styled("◀ Marked ▶", Style::default().red().bold()),
+                                ]
+                            })
+                            .into_iter()
+                            .flatten(),
+                    )
+                    .collect(),
+            },
             commit_cli_id.clone(),
         )?;
     }
@@ -1304,7 +1287,7 @@ fn display_cli_commit_details(
     has_changes: bool,
     verbose: bool,
     is_paged: bool,
-) -> (Line<'static>, bool) {
+) -> (CommitLineContent, bool) {
     let commit_id_short = shorten_object_id(repo, commit.id);
     let end_id = if short_id.len() >= commit_id_short.len() {
         Span::raw("")
@@ -1319,16 +1302,19 @@ fn display_cli_commit_details(
     };
     let start_id = Span::styled(short_id.to_string(), Style::default().blue().bold());
 
-    let conflicted_span = if commit.has_conflicts {
-        Span::styled(" {conflicted}", Style::default().red())
+    let no_changes = if has_changes {
+        None
     } else {
-        Span::raw("")
+        Some(Span::styled(
+            "(no changes)",
+            Style::default().dim().italic(),
+        ))
     };
 
-    let no_changes = if has_changes {
-        Span::raw("")
+    let conflicted = if commit.has_conflicts {
+        Some(Span::styled("{conflicted}", Style::default().red()))
     } else {
-        Span::styled(" (no changes)", Style::default().dim().italic())
+        None
     };
 
     if verbose {
@@ -1336,27 +1322,92 @@ fn display_cli_commit_details(
         let created_at = commit.author.time;
         let formatted_time = created_at.format_or_unix(CLI_DATE);
         (
-            Line::from_iter([
-                start_id,
-                end_id,
-                Span::raw(" "),
-                Span::raw(commit.author.name.to_string()),
-                Span::raw(" "),
-                Span::styled(formatted_time, Style::default().dim()),
-                no_changes,
-                conflicted_span,
-            ]),
+            CommitLineContent {
+                sha: Vec::from_iter([start_id, end_id]),
+                author: Vec::from_iter([Span::raw(" "), Span::raw(commit.author.name.to_string())]),
+                message: Vec::new(),
+                suffix: Vec::from_iter(
+                    [
+                        Span::raw(" "),
+                        Span::styled(formatted_time, Style::default().dim()),
+                    ]
+                    .into_iter()
+                    .chain(maybe_with_leading_space(no_changes, conflicted)),
+                ),
+            },
             false,
         )
     } else {
         let (message, is_empty_message) =
             commit_message_display_cli(&commit.message, verbose, is_paged, Span::raw);
-        let message = Span::styled(format!(" {}", message.content), message.style);
+        let message = Span::styled(format!("{}", message.content), message.style);
         (
-            Line::from_iter([start_id, end_id, message, no_changes, conflicted_span]),
+            CommitLineContent {
+                sha: Vec::from([start_id, end_id]),
+                author: Vec::new(),
+                message: Vec::from_iter([Span::raw(" "), message]),
+                suffix: maybe_with_leading_space(no_changes, conflicted),
+            },
             is_empty_message,
         )
     }
+}
+
+fn maybe_with_leading_space(
+    a: Option<Span<'static>>,
+    b: Option<Span<'static>>,
+) -> Vec<Span<'static>> {
+    fn with_leading_space(span: Span<'static>) -> Span<'static> {
+        Span::styled(format!(" {}", span.content), span.style)
+    }
+
+    match (a, b) {
+        (None, None) => Vec::new(),
+        (None, Some(b)) => Vec::from([with_leading_space(b)]),
+        (Some(a), None) => Vec::from([with_leading_space(a)]),
+        (Some(a), Some(b)) => Vec::from([with_leading_space(a), with_leading_space(b)]),
+    }
+}
+
+fn dim_commit_line_content(content: CommitLineContent) -> CommitLineContent {
+    let sha = dim_spans(content.sha);
+    let mut author = dim_spans(content.author);
+    let message = dim_spans(content.message);
+    let mut suffix = dim_spans(content.suffix);
+
+    if message.is_empty()
+        && let (Some(last_author), Some(first_suffix)) = (author.last_mut(), suffix.first())
+        && last_author.style == first_suffix.style
+    {
+        let first_suffix = suffix.remove(0);
+        last_author.content.to_mut().push_str(&first_suffix.content);
+    }
+
+    CommitLineContent {
+        sha,
+        author,
+        message,
+        suffix,
+    }
+}
+
+fn dim_spans(spans: Vec<Span<'static>>) -> Vec<Span<'static>> {
+    let mut output: Vec<Span<'static>> = Vec::new();
+
+    for span in spans {
+        let style = span.style.add_modifier(Modifier::DIM);
+        let content = span.content.into_owned();
+
+        if let Some(last) = output.last_mut()
+            && last.style == style
+        {
+            last.content.to_mut().push_str(&content);
+        } else {
+            output.push(Span::styled(content, style));
+        }
+    }
+
+    output
 }
 
 /// Return the plain (uncolored, unstyled) message text.

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -19,12 +19,12 @@ impl StatusOutput<'_> {
     fn push_line(
         &mut self,
         connector: Option<Vec<Span<'static>>>,
-        line: Vec<Span<'static>>,
+        content: StatusOutputContent,
         data: StatusOutputLineData,
     ) -> anyhow::Result<()> {
         let output_line = StatusOutputLine {
             connector,
-            line,
+            content,
             data,
         };
 
@@ -41,13 +41,17 @@ impl StatusOutput<'_> {
     }
 
     pub(super) fn update_notice(&mut self, line: Vec<Span<'static>>) -> anyhow::Result<()> {
-        self.push_line(None, line, StatusOutputLineData::UpdateNotice)
+        self.push_line(
+            None,
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::UpdateNotice,
+        )
     }
 
     pub(super) fn connector(&mut self, connector: Vec<Span<'static>>) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            <_>::default(),
+            StatusOutputContent::Plain(<_>::default()),
             StatusOutputLineData::Connector,
         )
     }
@@ -60,7 +64,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::StagedChanges {
                 cli_id: Arc::new(id),
             },
@@ -75,7 +79,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::StagedFile {
                 cli_id: Arc::new(id),
             },
@@ -90,7 +94,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::UnstagedChanges {
                 cli_id: Arc::new(id),
             },
@@ -105,7 +109,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::UnstagedFile {
                 cli_id: Arc::new(id),
             },
@@ -120,7 +124,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::Branch {
                 cli_id: Arc::new(id),
             },
@@ -135,7 +139,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::File {
                 cli_id: Arc::new(id),
             },
@@ -145,12 +149,12 @@ impl StatusOutput<'_> {
     pub(super) fn commit(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: Vec<Span<'static>>,
+        line: CommitLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Commit(line),
             StatusOutputLineData::Commit {
                 cli_id: Arc::new(id),
             },
@@ -162,7 +166,11 @@ impl StatusOutput<'_> {
         connector: Vec<Span<'static>>,
         line: Vec<Span<'static>>,
     ) -> anyhow::Result<()> {
-        self.push_line(Some(connector), line, StatusOutputLineData::CommitMessage)
+        self.push_line(
+            Some(connector),
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::CommitMessage,
+        )
     }
 
     pub(super) fn empty_commit_message(
@@ -172,17 +180,25 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::EmptyCommitMessage,
         )
     }
 
     pub(super) fn warning(&mut self, line: Vec<Span<'static>>) -> anyhow::Result<()> {
-        self.push_line(None, line, StatusOutputLineData::Warning)
+        self.push_line(
+            None,
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::Warning,
+        )
     }
 
     pub(super) fn hint(&mut self, line: Vec<Span<'static>>) -> anyhow::Result<()> {
-        self.push_line(None, line, StatusOutputLineData::Hint)
+        self.push_line(
+            None,
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::Hint,
+        )
     }
 
     pub(super) fn no_assignments_unstaged(
@@ -192,7 +208,7 @@ impl StatusOutput<'_> {
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            line,
+            StatusOutputContent::Plain(line),
             StatusOutputLineData::NoAssignmentsUnstaged,
         )
     }
@@ -202,7 +218,11 @@ impl StatusOutput<'_> {
         connector: Vec<Span<'static>>,
         line: Vec<Span<'static>>,
     ) -> anyhow::Result<()> {
-        self.push_line(Some(connector), line, StatusOutputLineData::MergeBase)
+        self.push_line(
+            Some(connector),
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::MergeBase,
+        )
     }
 
     pub(super) fn upstream_changes(
@@ -210,8 +230,30 @@ impl StatusOutput<'_> {
         connector: Vec<Span<'static>>,
         line: Vec<Span<'static>>,
     ) -> anyhow::Result<()> {
-        self.push_line(Some(connector), line, StatusOutputLineData::UpstreamChanges)
+        self.push_line(
+            Some(connector),
+            StatusOutputContent::Plain(line),
+            StatusOutputLineData::UpstreamChanges,
+        )
     }
+}
+
+/// The non-connector content rendered for one status line.
+#[derive(Debug)]
+pub(super) enum StatusOutputContent {
+    /// Generic status content represented as one flat list of spans.
+    Plain(Vec<Span<'static>>),
+    /// Structured content for commit rows where SHA and message are split.
+    Commit(CommitLineContent),
+}
+
+/// Structured content for a commit row in status output.
+#[derive(Debug, Default)]
+pub(super) struct CommitLineContent {
+    pub(super) sha: Vec<Span<'static>>,
+    pub(super) author: Vec<Span<'static>>,
+    pub(super) message: Vec<Span<'static>>,
+    pub(super) suffix: Vec<Span<'static>>,
 }
 
 #[derive(Debug)]
@@ -231,8 +273,8 @@ pub(super) struct StatusOutputLine {
     /// ┊● 7cd07f6 (upstream) ⏫ 1 new commits (checked 34 seconds ago) | Some("┊● ")
     /// ├╯ 8678259 [origin/main] 2026-03-11 nix                         | Some("├╯ ")
     pub(super) connector: Option<Vec<Span<'static>>>,
-    /// The content of the line such as the commit, branch, etc.
-    pub(super) line: Vec<Span<'static>>,
+    /// The content of the line such as the commit, branch, or file.
+    pub(super) content: StatusOutputContent,
     /// The backing data associated with this line.
     ///
     /// This tells the TUI what data the actual line is showing. Used for performing operations on

--- a/crates/but/src/command/legacy/status/render_oneshot.rs
+++ b/crates/but/src/command/legacy/status/render_oneshot.rs
@@ -1,10 +1,13 @@
 use colored::{ColoredString, Colorize};
-use ratatui::{
-    style::{Color, Modifier, Style},
-    text::Line,
-};
+use ratatui::style::{Color, Modifier, Style};
 
-use crate::{command::legacy::status::StatusOutputLine, utils::WriteWithUtils};
+use crate::{
+    command::legacy::status::{
+        StatusOutputLine,
+        output::{CommitLineContent, StatusOutputContent},
+    },
+    utils::WriteWithUtils,
+};
 
 /// Print one line of status output.
 ///
@@ -15,20 +18,35 @@ pub(super) fn render_oneshot(
 ) -> anyhow::Result<()> {
     let StatusOutputLine {
         connector,
-        line: content_line,
+        content,
         data: _,
     } = line;
 
     let should_colorize = colored::control::SHOULD_COLORIZE.should_colorize();
 
-    let mut line = Line::default();
-    if let Some(connector) = connector {
-        line.extend(connector);
+    let mut spans = Vec::new();
+    if let Some(mut connector) = connector {
+        spans.append(&mut connector);
     }
-    line.extend(content_line);
+    match content {
+        StatusOutputContent::Plain(mut content) => {
+            spans.append(&mut content);
+        }
+        StatusOutputContent::Commit(CommitLineContent {
+            mut sha,
+            mut author,
+            mut message,
+            mut suffix,
+        }) => {
+            spans.append(&mut sha);
+            spans.append(&mut author);
+            spans.append(&mut message);
+            spans.append(&mut suffix);
+        }
+    }
 
-    for span in line.spans {
-        let style = line.style.patch(span.style);
+    for span in spans {
+        let style = span.style;
         let rendered = render_span_with_colored(&span.content, style, should_colorize);
         write!(out, "{rendered}")?;
         if should_colorize && style_has_effect(style) {

--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -139,5 +139,7 @@ pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> boo
                     .cli_id()
                     .is_some_and(|cli_id| available_targets.contains(cli_id))
         }
+        // its not possible to move the cursor in this mode
+        Mode::InlineReword { .. } => false,
     }
 }

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -66,6 +66,18 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
     },
     KeyBind {
         chord: KeyChord {
+            modifiers: KeyModifiers::SHIFT,
+            keys: &[KeyCode::Enter],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::RewordWithEditor,
+        modes: KeyBindMode::Only(&[ModeDiscriminants::Normal]),
+        short_description: "reword",
+        code_display: "shift+enter",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
             modifiers: KeyModifiers::NONE,
             keys: &[KeyCode::Char('f')],
         },
@@ -97,7 +109,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         message: &Message::Reload(None),
         modes: KeyBindMode::Only(&[ModeDiscriminants::Normal]),
         short_description: "reload",
-        code_display: "ctrl-r",
+        code_display: "ctrl+r",
         hidden: false,
     },
     KeyBind {

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -19,11 +19,23 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
     KeyBind {
         chord: KeyChord {
             modifiers: KeyModifiers::NONE,
+            keys: &[KeyCode::Enter],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::ConfirmInlineReword,
+        modes: KeyBindMode::Only(&[ModeDiscriminants::InlineReword]),
+        short_description: "confirm",
+        code_display: "enter",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
+            modifiers: KeyModifiers::NONE,
             keys: &[KeyCode::Char('j'), KeyCode::Down],
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorDown,
-        modes: KeyBindMode::All,
+        modes: KeyBindMode::AllExceptInlineReword,
         short_description: "down",
         code_display: "↓/j",
         hidden: false,
@@ -35,7 +47,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorUp,
-        modes: KeyBindMode::All,
+        modes: KeyBindMode::AllExceptInlineReword,
         short_description: "up",
         code_display: "↑/k",
         hidden: false,
@@ -66,6 +78,18 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
     },
     KeyBind {
         chord: KeyChord {
+            modifiers: KeyModifiers::NONE,
+            keys: &[KeyCode::Enter],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::StartRewordInline,
+        modes: KeyBindMode::Only(&[ModeDiscriminants::Normal]),
+        short_description: "reword inline",
+        code_display: "enter",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
             modifiers: KeyModifiers::SHIFT,
             keys: &[KeyCode::Enter],
         },
@@ -83,7 +107,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::ToggleFiles,
-        modes: KeyBindMode::All,
+        modes: KeyBindMode::AllExceptInlineReword,
         short_description: "files",
         code_display: "f",
         hidden: false,
@@ -119,7 +143,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::Quit,
-        modes: KeyBindMode::All,
+        modes: KeyBindMode::AllExceptInlineReword,
         short_description: "quit",
         code_display: "q",
         hidden: false,
@@ -177,7 +201,7 @@ impl KeyBind {
 
     pub(super) fn available_in_mode(self, mode: &Mode) -> bool {
         match self.modes {
-            KeyBindMode::All => true,
+            KeyBindMode::AllExceptInlineReword => !matches!(mode, Mode::InlineReword { .. }),
             KeyBindMode::Only(supported_modes) => supported_modes
                 .iter()
                 .copied()
@@ -196,8 +220,10 @@ pub(super) struct KeyChord {
 /// The modes a key binding is available in.
 #[derive(Debug, Copy, Clone)]
 pub(super) enum KeyBindMode {
-    /// Available in all modes.
-    All,
+    /// Available in all modes except inline reword.
+    ///
+    /// Inline reword is special since it shows a text area that eats all inputs.
+    AllExceptInlineReword,
     /// Available in all modes except normal mode.
     AllExceptNormal,
     /// Only available in these modes.

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -18,6 +18,7 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap},
 };
+use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::{
     CliId,
@@ -38,7 +39,7 @@ use crate::{
     utils::OutputChannel,
 };
 
-use super::output::StatusOutputLineData;
+use super::output::{StatusOutputContent, StatusOutputLineData};
 
 mod cursor;
 mod key_bind;
@@ -381,13 +382,17 @@ impl App {
                 let new_message = get_commit_message_from_editor(
                     ctx,
                     commit_details,
-                    current_message,
+                    current_message.clone(),
                     ShowDiffInEditor::Unspecified,
                 )?;
 
                 let Some(new_message) = new_message else {
                     return Ok(());
                 };
+
+                if new_message == current_message {
+                    return Ok(());
+                }
 
                 let reword_result = but_api::commit::commit_reword_only(
                     ctx,
@@ -399,6 +404,101 @@ impl App {
                 messages.push(Message::Reload(Some(SelectAfterReload::Commit(
                     reword_result.new_commit,
                 ))));
+            }
+            Message::StartRewordInline => {
+                if !matches!(self.mode, Mode::Normal) {
+                    return Ok(());
+                }
+                let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+                    return Ok(());
+                };
+
+                let cli_id = match &selection.data {
+                    StatusOutputLineData::Commit { cli_id } => cli_id,
+                    StatusOutputLineData::UpdateNotice
+                    | StatusOutputLineData::Connector
+                    | StatusOutputLineData::StagedChanges { .. }
+                    | StatusOutputLineData::StagedFile { .. }
+                    | StatusOutputLineData::UnstagedChanges { .. }
+                    | StatusOutputLineData::UnstagedFile { .. }
+                    | StatusOutputLineData::Branch { .. }
+                    | StatusOutputLineData::CommitMessage
+                    | StatusOutputLineData::EmptyCommitMessage
+                    | StatusOutputLineData::File { .. }
+                    | StatusOutputLineData::MergeBase
+                    | StatusOutputLineData::UpstreamChanges
+                    | StatusOutputLineData::Warning
+                    | StatusOutputLineData::Hint
+                    | StatusOutputLineData::NoAssignmentsUnstaged => {
+                        return Ok(());
+                    }
+                };
+
+                let CliId::Commit { commit_id, .. } = &**cli_id else {
+                    return Ok(());
+                };
+
+                let commit_details =
+                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
+                let current_message = commit_details.commit.inner.message.to_string();
+
+                if current_message.split_once('\n').is_some() {
+                    messages.push(Message::RewordWithEditor);
+                    return Ok(());
+                }
+
+                let first_line = current_message.lines().next().unwrap_or("").to_string();
+
+                let mut textarea = TextArea::from([first_line]);
+                textarea.set_cursor_line_style(Style::default()); // remove underline
+                textarea.move_cursor(CursorMove::End);
+
+                self.mode = Mode::InlineReword {
+                    commit_id: *commit_id,
+                    textarea: Box::new(textarea),
+                };
+            }
+            Message::RewordInlineInput(ev) => {
+                if let Mode::InlineReword { textarea, .. } = &mut self.mode {
+                    textarea.input(ev);
+                }
+            }
+            Message::ConfirmInlineReword => {
+                let Mode::InlineReword {
+                    commit_id,
+                    textarea,
+                } = &self.mode
+                else {
+                    return Ok(());
+                };
+
+                let commit_details =
+                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
+                let current_message = commit_details.commit.inner.message.to_string();
+                let new_subject = textarea
+                    .lines()
+                    .first()
+                    .map(std::string::String::as_str)
+                    .unwrap_or("");
+
+                let new_message = new_subject.to_string();
+
+                if new_message == current_message {
+                    messages.push(Message::EnterNormalMode);
+                    return Ok(());
+                }
+
+                let reword_result = but_api::commit::commit_reword_only(
+                    ctx,
+                    *commit_id,
+                    BString::from(new_message),
+                )
+                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
+
+                messages.extend([
+                    Message::EnterNormalMode,
+                    Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
+                ]);
             }
         }
 
@@ -431,6 +531,8 @@ impl App {
 
         frame.render_widget(list, content_area);
 
+        self.render_inline_reword(content_area, frame);
+
         self.render_errors(content_area, frame);
 
         if let Some(debug_area) = debug_area {
@@ -445,7 +547,7 @@ impl App {
     ) -> ListItem<'_> {
         let StatusOutputLine {
             connector,
-            line: content_line,
+            content,
             data,
         } = tui_line;
 
@@ -457,7 +559,7 @@ impl App {
 
         if is_selected {
             match &self.mode {
-                Mode::Normal => {}
+                Mode::Normal | Mode::InlineReword { .. } => {}
                 Mode::Rub {
                     source,
                     available_targets: _,
@@ -483,7 +585,7 @@ impl App {
             }
         } else {
             match &self.mode {
-                Mode::Normal => {}
+                Mode::Normal | Mode::InlineReword { .. } => {}
                 Mode::Rub {
                     source,
                     available_targets: _,
@@ -497,9 +599,30 @@ impl App {
             }
         }
 
+        let content_spans = match content {
+            StatusOutputContent::Plain(spans) => spans.clone(),
+            StatusOutputContent::Commit(commit_content) => {
+                let mut spans = Vec::new();
+                spans.extend(commit_content.sha.iter().cloned());
+                spans.extend(commit_content.author.iter().cloned());
+                spans.extend(commit_content.message.iter().cloned());
+                spans.extend(commit_content.suffix.iter().cloned());
+                spans
+            }
+        };
+
         match &self.mode {
             Mode::Normal => {
-                line.extend(content_line.clone());
+                line.extend(content_spans);
+            }
+            Mode::InlineReword { .. } => {
+                if is_selected {
+                    if let StatusOutputContent::Commit(commit_content) = content {
+                        line.extend(commit_content.sha.iter().cloned());
+                    }
+                } else {
+                    line.extend(content_spans);
+                }
             }
             Mode::Rub {
                 source: _,
@@ -510,14 +633,12 @@ impl App {
                 } else {
                     false
                 };
-
                 if can_rub_here {
-                    line.extend(content_line.clone());
+                    line.extend(content_spans);
                 } else {
                     line.extend(
-                        content_line
-                            .iter()
-                            .cloned()
+                        content_spans
+                            .into_iter()
                             .map(|span| span.style(Style::default().dim())),
                     );
                 }
@@ -535,6 +656,9 @@ impl App {
         let mode_span = match self.mode {
             Mode::Normal => Span::styled("  normal  ", Style::default().black().on_green()),
             Mode::Rub { .. } => Span::styled("  rub  ", Style::default().black().on_magenta()),
+            Mode::InlineReword { .. } => {
+                Span::styled("  reword  ", Style::default().black().on_blue())
+            }
         };
 
         let padding = Span::raw(" ");
@@ -578,6 +702,41 @@ impl App {
         }
     }
 
+    fn render_inline_reword(&self, area: Rect, frame: &mut Frame) {
+        let Mode::InlineReword { textarea, .. } = &self.mode else {
+            return;
+        };
+        let Some((idx, (line, _))) = self
+            .cursor
+            .iter_lines(&self.status_lines)
+            .enumerate()
+            .find(|(_, (_, is_selected))| *is_selected)
+        else {
+            return;
+        };
+        let StatusOutputLineData::Commit { .. } = &line.data else {
+            return;
+        };
+        let Some(connector) = &line.connector else {
+            return;
+        };
+        let StatusOutputContent::Commit(commit_content) = &line.content else {
+            return;
+        };
+        let connector_and_sha_width = connector
+            .iter()
+            .chain(&commit_content.sha)
+            .map(|span| span.width() as u16)
+            .sum::<u16>();
+        let padding_between_sha_and_message = 1;
+
+        let start_x = connector_and_sha_width + padding_between_sha_and_message;
+        let x = area.x.saturating_add(start_x);
+        let width = area.right().saturating_sub(x);
+        let area = Rect::new(x, area.y.saturating_add(idx as u16), width, 1);
+        frame.render_widget(&**textarea, area);
+    }
+
     fn render_debug(&self, area: Rect, frame: &mut Frame) {
         let list = List::new(
             std::iter::once(ListItem::new(format!("Renders: {}", self.renders))).chain(
@@ -594,9 +753,20 @@ impl App {
 fn event_to_messages(ev: Event, key_binds: &[KeyBind], mode: &Mode, messages: &mut Vec<Message>) {
     match ev {
         Event::Key(key) => {
+            let mut handled = false;
             for key_bind in key_binds.iter().copied() {
                 if key_bind.matches(&key, mode) {
                     messages.push(key_bind.message.clone());
+                    handled = true;
+                }
+            }
+
+            if !handled {
+                match mode {
+                    Mode::InlineReword { .. } => {
+                        messages.push(Message::RewordInlineInput(ev));
+                    }
+                    Mode::Normal | Mode::Rub { .. } => {}
                 }
             }
         }
@@ -621,6 +791,9 @@ enum Message {
     ShowError(Arc<anyhow::Error>),
     CreateEmptyCommit,
     RewordWithEditor,
+    StartRewordInline,
+    ConfirmInlineReword,
+    RewordInlineInput(Event),
 }
 
 #[derive(Debug, Default, strum::EnumDiscriminants)]
@@ -630,6 +803,10 @@ enum Mode {
     Rub {
         source: Arc<CliId>,
         available_targets: Vec<Arc<CliId>>,
+    },
+    InlineReword {
+        commit_id: gix::ObjectId,
+        textarea: Box<TextArea<'static>>,
     },
 }
 

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -3,7 +3,12 @@ use std::{
     time::{Duration, Instant},
 };
 
-use but_api::commit::{commit_insert_blank, ui::RelativeTo};
+use anyhow::Context as _;
+use bstr::BString;
+use but_api::{
+    commit::{commit_insert_blank, ui::RelativeTo},
+    diff::ComputeLineStats,
+};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use crossterm::event::{self, Event};
@@ -18,6 +23,8 @@ use crate::{
     CliId,
     args::OutputFormat,
     command::legacy::{
+        ShowDiffInEditor,
+        reword::get_commit_message_from_editor,
         rub::{RubOperation, route_operation},
         status::{
             StatusFlags, StatusOutput, StatusOutputLine, build_status_context, build_status_output,
@@ -76,7 +83,7 @@ pub(super) async fn render_tui(
             }
 
             for msg in messages.drain(..) {
-                app.handle_message(ctx, out, mode, &mut other_messages, msg)
+                app.handle_message(ctx, out, mode, &mut guard, &mut other_messages, msg)
                     .await;
             }
             std::mem::swap(&mut messages, &mut other_messages);
@@ -135,10 +142,14 @@ impl App {
         ctx: &mut Context,
         out: &mut OutputChannel,
         mode: &OperatingMode,
+        guard: &mut TerminalGuard,
         messages: &mut Vec<Message>,
         msg: Message,
     ) {
-        if let Err(err) = self.try_handle_message(ctx, out, mode, messages, msg).await {
+        if let Err(err) = self
+            .try_handle_message(ctx, out, mode, guard, messages, msg)
+            .await
+        {
             messages.push(Message::ShowError(Arc::new(err)));
         }
     }
@@ -148,6 +159,7 @@ impl App {
         ctx: &mut Context,
         out: &mut OutputChannel,
         mode: &OperatingMode,
+        guard: &mut TerminalGuard,
         messages: &mut Vec<Message>,
         msg: Message,
     ) -> anyhow::Result<()> {
@@ -328,6 +340,66 @@ impl App {
                     | StatusOutputLineData::NoAssignmentsUnstaged => {}
                 }
             }
+            Message::RewordWithEditor => {
+                if !matches!(self.mode, Mode::Normal) {
+                    return Ok(());
+                }
+                let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+                    return Ok(());
+                };
+
+                let cli_id = match &selection.data {
+                    StatusOutputLineData::Commit { cli_id } => cli_id,
+                    StatusOutputLineData::UpdateNotice
+                    | StatusOutputLineData::Connector
+                    | StatusOutputLineData::StagedChanges { .. }
+                    | StatusOutputLineData::StagedFile { .. }
+                    | StatusOutputLineData::UnstagedChanges { .. }
+                    | StatusOutputLineData::UnstagedFile { .. }
+                    | StatusOutputLineData::Branch { .. }
+                    | StatusOutputLineData::CommitMessage
+                    | StatusOutputLineData::EmptyCommitMessage
+                    | StatusOutputLineData::File { .. }
+                    | StatusOutputLineData::MergeBase
+                    | StatusOutputLineData::UpstreamChanges
+                    | StatusOutputLineData::Warning
+                    | StatusOutputLineData::Hint
+                    | StatusOutputLineData::NoAssignmentsUnstaged => {
+                        return Ok(());
+                    }
+                };
+
+                let CliId::Commit { commit_id, .. } = &**cli_id else {
+                    return Ok(());
+                };
+
+                let commit_details =
+                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
+                let current_message = commit_details.commit.inner.message.to_string();
+
+                let _suspend_guard = guard.suspend()?;
+                let new_message = get_commit_message_from_editor(
+                    ctx,
+                    commit_details,
+                    current_message,
+                    ShowDiffInEditor::Unspecified,
+                )?;
+
+                let Some(new_message) = new_message else {
+                    return Ok(());
+                };
+
+                let reword_result = but_api::commit::commit_reword_only(
+                    ctx,
+                    *commit_id,
+                    BString::from(new_message),
+                )
+                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
+
+                messages.push(Message::Reload(Some(SelectAfterReload::Commit(
+                    reword_result.new_commit,
+                ))));
+            }
         }
 
         Ok(())
@@ -493,7 +565,7 @@ impl App {
 
     fn render_errors(&self, area: Rect, frame: &mut Frame) {
         for (idx, err) in self.errors.iter().rev().enumerate() {
-            let formatted_err = format!("{}", err.inner);
+            let formatted_err = format!("{:#}", err.inner);
             render_error_popup(
                 frame,
                 area,
@@ -548,6 +620,7 @@ enum Message {
     ToggleFiles,
     ShowError(Arc<anyhow::Error>),
     CreateEmptyCommit,
+    RewordWithEditor,
 }
 
 #[derive(Debug, Default, strum::EnumDiscriminants)]

--- a/crates/but/src/tui/mod.rs
+++ b/crates/but/src/tui/mod.rs
@@ -28,6 +28,7 @@ type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync>;
 
 /// RAII guard that ensures the terminal is restored to its original state,
 /// even if an error occurs or a panic is caught.
+#[must_use]
 pub(crate) struct TerminalGuard {
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
     mouse_captured: bool,
@@ -80,6 +81,28 @@ impl TerminalGuard {
     pub fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<io::Stdout>> {
         &mut self.terminal
     }
+
+    /// Temporarily leaves raw mode and the alternate screen to run an external interactive program.
+    ///
+    /// This can for example be used to suspend a TUI and bring up and editor or run an external
+    /// command.
+    ///
+    /// Returns a RAII guard that restores terminal state when dropped.
+    pub fn suspend(&mut self) -> anyhow::Result<SuspendGuard<'_>> {
+        disable_raw_mode()?;
+
+        if self.mouse_captured {
+            crossterm::execute!(
+                self.terminal.backend_mut(),
+                DisableMouseCapture,
+                LeaveAlternateScreen
+            )?;
+        } else {
+            crossterm::execute!(self.terminal.backend_mut(), LeaveAlternateScreen)?;
+        }
+
+        Ok(SuspendGuard(self))
+    }
 }
 
 impl Drop for TerminalGuard {
@@ -100,5 +123,25 @@ impl Drop for TerminalGuard {
         if let Some(hook) = self.original_hook.lock().ok().and_then(|mut h| h.take()) {
             std::panic::set_hook(hook);
         }
+    }
+}
+
+/// RAII guard that resumes terminal state suspended by [`TerminalGuard::suspend`].
+#[must_use]
+pub(crate) struct SuspendGuard<'a>(&'a mut TerminalGuard);
+
+impl Drop for SuspendGuard<'_> {
+    fn drop(&mut self) {
+        _ = enable_raw_mode();
+        if self.0.mouse_captured {
+            _ = crossterm::execute!(
+                self.0.terminal.backend_mut(),
+                EnterAlternateScreen,
+                EnableMouseCapture
+            );
+        } else {
+            _ = crossterm::execute!(self.0.terminal.backend_mut(), EnterAlternateScreen);
+        }
+        _ = self.0.terminal.clear();
     }
 }

--- a/crates/but/src/tui/mod.rs
+++ b/crates/but/src/tui/mod.rs
@@ -84,7 +84,7 @@ impl TerminalGuard {
 
     /// Temporarily leaves raw mode and the alternate screen to run an external interactive program.
     ///
-    /// This can for example be used to suspend a TUI and bring up and editor or run an external
+    /// This can for example be used to suspend a TUI and bring up an editor or run an external
     /// command.
     ///
     /// Returns a RAII guard that restores terminal state when dropped.


### PR DESCRIPTION
Pressing enter on a commit shows a textarea where you can edit the commit message inline. Pressing enter again confirms. Thus you cannot add a more than one line commit message. To do that you press shift+enter which prints up an editor.

Pressing enter, to inline edit, on an existing commit message with multiple lines opens the editor anyway. That way we don't have to ever show more than one line of message in the TUI which would make the layout more complicated.