### PR TITLE
chore(tui): break up large `try_handle_message` method

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -173,336 +173,360 @@ impl App {
             Message::Noop => {}
             Message::MoveCursorUp => self.cursor.move_up(&self.status_lines, &self.mode),
             Message::MoveCursorDown => self.cursor.move_down(&self.status_lines, &self.mode),
-            Message::StartRub => {
-                let Some(selected_line) = self.cursor.selected_line(&self.status_lines) else {
-                    return Ok(());
-                };
-
-                let Some(cli_id) = selected_line.data.cli_id() else {
-                    return Ok(());
-                };
-
-                let available_targets = self
-                    .status_lines
-                    .iter()
-                    .filter_map(|line| line.data.cli_id())
-                    .filter(|target| *target == cli_id || route_operation(cli_id, target).is_some())
-                    .cloned()
-                    .collect::<Vec<_>>();
-
-                self.mode = Mode::Rub {
-                    source: Arc::clone(cli_id),
-                    available_targets,
-                };
-
-                if self
-                    .cursor
-                    .selected_line(&self.status_lines)
-                    .is_some_and(|line| cursor::is_selectable_in_mode(line, &self.mode))
-                {
-                    return Ok(());
-                }
-
-                let previous_cursor = self.cursor;
-                self.cursor.move_down(&self.status_lines, &self.mode);
-                if self.cursor == previous_cursor {
-                    self.cursor.move_up(&self.status_lines, &self.mode);
-                }
-            }
+            Message::StartRub => self.handle_start_rub(),
             Message::EnterNormalMode => {
                 self.mode = Mode::Normal;
             }
-            Message::ToggleFiles => {
-                self.flags.show_files = !self.flags.show_files;
-                messages.push(Message::Reload(None));
-            }
-            Message::ConfirmRub => {
-                if let Mode::Rub { source, .. } = &self.mode
-                    && let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
-                    && let Some(target) = selected_line.data.cli_id()
-                    && let Some(operation) = route_operation(source, target)
-                {
-                    with_noop_output(|out| operation.execute(ctx, out))?;
-                }
-
-                messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
-            }
+            Message::ToggleFiles => self.handle_toggle_files(messages),
+            Message::ConfirmRub => self.handle_confirm_rub(ctx, messages)?,
             Message::Reload(select_after_reload) => {
-                {
-                    let meta = ctx.meta()?;
-                    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
-                    ws.refresh_from_head(&repo, &meta)?;
-                }
-
-                let mut new_lines = Vec::new();
-
-                build_status_context(
-                    ctx,
-                    out,
-                    mode,
-                    self.flags,
-                    crate::command::legacy::status::StatusRenderMode::Tui {
-                        debug: self.debug_enabled,
-                    },
-                )
-                .await
-                .and_then(|status_ctx| {
-                    build_status_output(
-                        ctx,
-                        &status_ctx,
-                        &mut StatusOutput::Buffer {
-                            lines: &mut new_lines,
-                        },
-                    )
-                })?;
-
-                self.cursor = if let Some(select_after_reload) = select_after_reload {
-                    match select_after_reload {
-                        SelectAfterReload::Commit(commit_id) => {
-                            Cursor::select(commit_id, &new_lines)
-                        }
-                    }
-                } else {
-                    self.cursor
-                        .selection_cli_id_for_reload(&self.status_lines, self.flags.show_files)
-                        .and_then(|previously_selected_cli_id| {
-                            Cursor::restore(previously_selected_cli_id, &new_lines)
-                        })
-                }
-                .unwrap_or_else(|| Cursor::new(&new_lines));
-
-                self.status_lines = new_lines;
+                self.handle_reload(ctx, out, mode, select_after_reload)
+                    .await?
             }
-            Message::ShowError(err) => {
-                self.errors.push(AppError {
-                    inner: err,
-                    dismiss_at: Instant::now() + Duration::from_secs(5),
-                });
-            }
-            Message::CreateEmptyCommit => {
-                if !matches!(self.mode, Mode::Normal) {
-                    return Ok(());
-                }
-
-                let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
-                    return Ok(());
-                };
-
-                match &selection.data {
-                    StatusOutputLineData::Branch { cli_id } => {
-                        let CliId::Branch { name, .. } = &**cli_id else {
-                            return Ok(());
-                        };
-
-                        let full_name = {
-                            let repo = ctx.repo.get()?;
-                            let reference = repo.find_reference(name)?;
-                            reference.name().to_owned()
-                        };
-
-                        let commit_result = commit_insert_blank(
-                            ctx,
-                            RelativeTo::Reference(full_name),
-                            InsertSide::Below,
-                        )?;
-
-                        messages.push(Message::Reload(Some(SelectAfterReload::Commit(
-                            commit_result.new_commit,
-                        ))));
-                    }
-                    StatusOutputLineData::Commit { cli_id } => {
-                        let CliId::Commit { commit_id, .. } = &**cli_id else {
-                            return Ok(());
-                        };
-
-                        let commit_result = commit_insert_blank(
-                            ctx,
-                            RelativeTo::Commit(*commit_id),
-                            InsertSide::Above,
-                        )?;
-
-                        messages.push(Message::Reload(Some(SelectAfterReload::Commit(
-                            commit_result.new_commit,
-                        ))));
-                    }
-                    StatusOutputLineData::UpdateNotice
-                    | StatusOutputLineData::Connector
-                    | StatusOutputLineData::StagedChanges { .. }
-                    | StatusOutputLineData::StagedFile { .. }
-                    | StatusOutputLineData::UnstagedChanges { .. }
-                    | StatusOutputLineData::UnstagedFile { .. }
-                    | StatusOutputLineData::CommitMessage
-                    | StatusOutputLineData::EmptyCommitMessage
-                    | StatusOutputLineData::File { .. }
-                    | StatusOutputLineData::MergeBase
-                    | StatusOutputLineData::UpstreamChanges
-                    | StatusOutputLineData::Warning
-                    | StatusOutputLineData::Hint
-                    | StatusOutputLineData::NoAssignmentsUnstaged => {}
-                }
-            }
+            Message::ShowError(err) => self.handle_show_error(err),
+            Message::CreateEmptyCommit => self.handle_create_empty_commit(ctx, messages)?,
             Message::RewordWithEditor => {
-                if !matches!(self.mode, Mode::Normal) {
-                    return Ok(());
-                }
-                let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
-                    return Ok(());
-                };
-
-                let cli_id = match &selection.data {
-                    StatusOutputLineData::Commit { cli_id } => cli_id,
-                    StatusOutputLineData::UpdateNotice
-                    | StatusOutputLineData::Connector
-                    | StatusOutputLineData::StagedChanges { .. }
-                    | StatusOutputLineData::StagedFile { .. }
-                    | StatusOutputLineData::UnstagedChanges { .. }
-                    | StatusOutputLineData::UnstagedFile { .. }
-                    | StatusOutputLineData::Branch { .. }
-                    | StatusOutputLineData::CommitMessage
-                    | StatusOutputLineData::EmptyCommitMessage
-                    | StatusOutputLineData::File { .. }
-                    | StatusOutputLineData::MergeBase
-                    | StatusOutputLineData::UpstreamChanges
-                    | StatusOutputLineData::Warning
-                    | StatusOutputLineData::Hint
-                    | StatusOutputLineData::NoAssignmentsUnstaged => {
-                        return Ok(());
-                    }
-                };
-
-                let CliId::Commit { commit_id, .. } = &**cli_id else {
-                    return Ok(());
-                };
-
-                let commit_details =
-                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
-                let current_message = commit_details.commit.inner.message.to_string();
-
-                let _suspend_guard = guard.suspend()?;
-                let new_message = get_commit_message_from_editor(
-                    ctx,
-                    commit_details,
-                    current_message.clone(),
-                    ShowDiffInEditor::Unspecified,
-                )?;
-
-                let Some(new_message) = new_message else {
-                    return Ok(());
-                };
-
-                if new_message == current_message {
-                    return Ok(());
-                }
-
-                let reword_result = but_api::commit::commit_reword_only(
-                    ctx,
-                    *commit_id,
-                    BString::from(new_message),
-                )
-                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
-
-                messages.push(Message::Reload(Some(SelectAfterReload::Commit(
-                    reword_result.new_commit,
-                ))));
+                self.handle_reword_with_editor(ctx, guard, messages)?;
             }
-            Message::StartRewordInline => {
-                if !matches!(self.mode, Mode::Normal) {
-                    return Ok(());
-                }
-                let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
-                    return Ok(());
-                };
-
-                let cli_id = match &selection.data {
-                    StatusOutputLineData::Commit { cli_id } => cli_id,
-                    StatusOutputLineData::UpdateNotice
-                    | StatusOutputLineData::Connector
-                    | StatusOutputLineData::StagedChanges { .. }
-                    | StatusOutputLineData::StagedFile { .. }
-                    | StatusOutputLineData::UnstagedChanges { .. }
-                    | StatusOutputLineData::UnstagedFile { .. }
-                    | StatusOutputLineData::Branch { .. }
-                    | StatusOutputLineData::CommitMessage
-                    | StatusOutputLineData::EmptyCommitMessage
-                    | StatusOutputLineData::File { .. }
-                    | StatusOutputLineData::MergeBase
-                    | StatusOutputLineData::UpstreamChanges
-                    | StatusOutputLineData::Warning
-                    | StatusOutputLineData::Hint
-                    | StatusOutputLineData::NoAssignmentsUnstaged => {
-                        return Ok(());
-                    }
-                };
-
-                let CliId::Commit { commit_id, .. } = &**cli_id else {
-                    return Ok(());
-                };
-
-                let commit_details =
-                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
-                let current_message = commit_details.commit.inner.message.to_string();
-
-                if current_message.split_once('\n').is_some() {
-                    messages.push(Message::RewordWithEditor);
-                    return Ok(());
-                }
-
-                let first_line = current_message.lines().next().unwrap_or("").to_string();
-
-                let mut textarea = TextArea::from([first_line]);
-                textarea.set_cursor_line_style(Style::default()); // remove underline
-                textarea.move_cursor(CursorMove::End);
-
-                self.mode = Mode::InlineReword {
-                    commit_id: *commit_id,
-                    textarea: Box::new(textarea),
-                };
-            }
-            Message::RewordInlineInput(ev) => {
-                if let Mode::InlineReword { textarea, .. } = &mut self.mode {
-                    textarea.input(ev);
-                }
-            }
-            Message::ConfirmInlineReword => {
-                let Mode::InlineReword {
-                    commit_id,
-                    textarea,
-                } = &self.mode
-                else {
-                    return Ok(());
-                };
-
-                let commit_details =
-                    but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
-                let current_message = commit_details.commit.inner.message.to_string();
-                let new_subject = textarea
-                    .lines()
-                    .first()
-                    .map(std::string::String::as_str)
-                    .unwrap_or("");
-
-                let new_message = new_subject.to_string();
-
-                if new_message == current_message {
-                    messages.push(Message::EnterNormalMode);
-                    return Ok(());
-                }
-
-                let reword_result = but_api::commit::commit_reword_only(
-                    ctx,
-                    *commit_id,
-                    BString::from(new_message),
-                )
-                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
-
-                messages.extend([
-                    Message::EnterNormalMode,
-                    Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
-                ]);
-            }
+            Message::StartRewordInline => self.handle_start_reword_inline(ctx, messages)?,
+            Message::RewordInlineInput(ev) => self.handle_reword_inline_input(ev),
+            Message::ConfirmInlineReword => self.handle_confirm_inline_reword(ctx, messages)?,
         }
 
         Ok(())
+    }
+
+    /// Handles transitioning into rub mode and selecting a valid rub target.
+    fn handle_start_rub(&mut self) {
+        if !matches!(self.mode, Mode::Normal) {
+            return;
+        }
+
+        let Some(selected_line) = self.cursor.selected_line(&self.status_lines) else {
+            return;
+        };
+
+        let Some(cli_id) = selected_line.data.cli_id() else {
+            return;
+        };
+
+        let available_targets = self
+            .status_lines
+            .iter()
+            .filter_map(|line| line.data.cli_id())
+            .filter(|target| *target == cli_id || route_operation(cli_id, target).is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        self.mode = Mode::Rub {
+            source: Arc::clone(cli_id),
+            available_targets,
+        };
+
+        if self
+            .cursor
+            .selected_line(&self.status_lines)
+            .is_some_and(|line| cursor::is_selectable_in_mode(line, &self.mode))
+        {
+            return;
+        }
+
+        let previous_cursor = self.cursor;
+        self.cursor.move_down(&self.status_lines, &self.mode);
+        if self.cursor == previous_cursor {
+            self.cursor.move_up(&self.status_lines, &self.mode);
+        }
+    }
+
+    /// Handles toggling file visibility and requests a status reload.
+    fn handle_toggle_files(&mut self, messages: &mut Vec<Message>) {
+        self.flags.show_files = !self.flags.show_files;
+        messages.push(Message::Reload(None));
+    }
+
+    /// Handles confirming the currently selected rub operation.
+    fn handle_confirm_rub(
+        &mut self,
+        ctx: &mut Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        if let Mode::Rub { source, .. } = &self.mode
+            && let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
+            && let Some(target) = selected_line.data.cli_id()
+            && let Some(operation) = route_operation(source, target)
+        {
+            with_noop_output(|out| operation.execute(ctx, out))?;
+        }
+
+        messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
+        Ok(())
+    }
+
+    /// Handles reloading status output and restoring selection.
+    async fn handle_reload(
+        &mut self,
+        ctx: &mut Context,
+        out: &mut OutputChannel,
+        mode: &OperatingMode,
+        select_after_reload: Option<SelectAfterReload>,
+    ) -> anyhow::Result<()> {
+        {
+            let meta = ctx.meta()?;
+            let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+            ws.refresh_from_head(&repo, &meta)?;
+        }
+
+        let mut new_lines = Vec::new();
+
+        build_status_context(
+            ctx,
+            out,
+            mode,
+            self.flags,
+            crate::command::legacy::status::StatusRenderMode::Tui {
+                debug: self.debug_enabled,
+            },
+        )
+        .await
+        .and_then(|status_ctx| {
+            build_status_output(
+                ctx,
+                &status_ctx,
+                &mut StatusOutput::Buffer {
+                    lines: &mut new_lines,
+                },
+            )
+        })?;
+
+        self.cursor = if let Some(select_after_reload) = select_after_reload {
+            match select_after_reload {
+                SelectAfterReload::Commit(commit_id) => Cursor::select(commit_id, &new_lines),
+            }
+        } else {
+            self.cursor
+                .selection_cli_id_for_reload(&self.status_lines, self.flags.show_files)
+                .and_then(|previously_selected_cli_id| {
+                    Cursor::restore(previously_selected_cli_id, &new_lines)
+                })
+        }
+        .unwrap_or_else(|| Cursor::new(&new_lines));
+
+        self.status_lines = new_lines;
+        Ok(())
+    }
+
+    /// Handles showing a transient UI error.
+    fn handle_show_error(&mut self, err: Arc<anyhow::Error>) {
+        self.errors.push(AppError {
+            inner: err,
+            dismiss_at: Instant::now() + Duration::from_secs(5),
+        });
+    }
+
+    /// Handles creating an empty commit relative to the current selection.
+    fn handle_create_empty_commit(
+        &mut self,
+        ctx: &mut Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        if !matches!(self.mode, Mode::Normal) {
+            return Ok(());
+        }
+
+        let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+            return Ok(());
+        };
+
+        match &selection.data {
+            StatusOutputLineData::Branch { cli_id } => {
+                let CliId::Branch { name, .. } = &**cli_id else {
+                    return Ok(());
+                };
+
+                let full_name = {
+                    let repo = ctx.repo.get()?;
+                    let reference = repo.find_reference(name)?;
+                    reference.name().to_owned()
+                };
+
+                let commit_result =
+                    commit_insert_blank(ctx, RelativeTo::Reference(full_name), InsertSide::Below)?;
+
+                messages.push(Message::Reload(Some(SelectAfterReload::Commit(
+                    commit_result.new_commit,
+                ))));
+            }
+            StatusOutputLineData::Commit { cli_id } => {
+                let CliId::Commit { commit_id, .. } = &**cli_id else {
+                    return Ok(());
+                };
+
+                let commit_result =
+                    commit_insert_blank(ctx, RelativeTo::Commit(*commit_id), InsertSide::Above)?;
+
+                messages.push(Message::Reload(Some(SelectAfterReload::Commit(
+                    commit_result.new_commit,
+                ))));
+            }
+            StatusOutputLineData::UpdateNotice
+            | StatusOutputLineData::Connector
+            | StatusOutputLineData::StagedChanges { .. }
+            | StatusOutputLineData::StagedFile { .. }
+            | StatusOutputLineData::UnstagedChanges { .. }
+            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::CommitMessage
+            | StatusOutputLineData::EmptyCommitMessage
+            | StatusOutputLineData::File { .. }
+            | StatusOutputLineData::MergeBase
+            | StatusOutputLineData::UpstreamChanges
+            | StatusOutputLineData::Warning
+            | StatusOutputLineData::Hint
+            | StatusOutputLineData::NoAssignmentsUnstaged => {}
+        }
+
+        Ok(())
+    }
+
+    /// Handles opening the full-screen commit reword editor for the selected commit.
+    fn handle_reword_with_editor(
+        &mut self,
+        ctx: &mut Context,
+        guard: &mut TerminalGuard,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        if !matches!(self.mode, Mode::Normal) {
+            return Ok(());
+        }
+
+        let Some(commit_id) = self.selected_commit_id() else {
+            return Ok(());
+        };
+
+        let commit_details = but_api::diff::commit_details(ctx, commit_id, ComputeLineStats::No)?;
+        let current_message = commit_details.commit.inner.message.to_string();
+
+        let _suspend_guard = guard.suspend()?;
+        let new_message = get_commit_message_from_editor(
+            ctx,
+            commit_details,
+            current_message.clone(),
+            ShowDiffInEditor::Unspecified,
+        )?;
+
+        let Some(new_message) = new_message else {
+            return Ok(());
+        };
+
+        if new_message == current_message {
+            return Ok(());
+        }
+
+        let reword_result =
+            but_api::commit::commit_reword_only(ctx, commit_id, BString::from(new_message))
+                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
+
+        messages.push(Message::Reload(Some(SelectAfterReload::Commit(
+            reword_result.new_commit,
+        ))));
+        Ok(())
+    }
+
+    /// Handles entering inline reword mode for single-line commit messages.
+    fn handle_start_reword_inline(
+        &mut self,
+        ctx: &mut Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        if !matches!(self.mode, Mode::Normal) {
+            return Ok(());
+        }
+
+        let Some(commit_id) = self.selected_commit_id() else {
+            return Ok(());
+        };
+
+        let commit_details = but_api::diff::commit_details(ctx, commit_id, ComputeLineStats::No)?;
+        let current_message = commit_details.commit.inner.message.to_string();
+
+        if current_message.split_once('\n').is_some() {
+            messages.push(Message::RewordWithEditor);
+            return Ok(());
+        }
+
+        let first_line = current_message.lines().next().unwrap_or("").to_string();
+        let mut textarea = TextArea::from([first_line]);
+        textarea.set_cursor_line_style(Style::default());
+        textarea.move_cursor(CursorMove::End);
+
+        self.mode = Mode::InlineReword {
+            commit_id,
+            textarea: Box::new(textarea),
+        };
+
+        Ok(())
+    }
+
+    /// Handles key input while inline reword mode is active.
+    fn handle_reword_inline_input(&mut self, ev: Event) {
+        if let Mode::InlineReword { textarea, .. } = &mut self.mode {
+            textarea.input(ev);
+        }
+    }
+
+    /// Handles confirming an inline commit reword.
+    fn handle_confirm_inline_reword(
+        &mut self,
+        ctx: &mut Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        let Mode::InlineReword {
+            commit_id,
+            textarea,
+        } = &self.mode
+        else {
+            messages.push(Message::EnterNormalMode);
+            return Ok(());
+        };
+
+        let commit_details = but_api::diff::commit_details(ctx, *commit_id, ComputeLineStats::No)?;
+        let current_message = commit_details.commit.inner.message.to_string();
+        let new_subject = textarea
+            .lines()
+            .first()
+            .map(std::string::String::as_str)
+            .unwrap_or("");
+        let new_message = new_subject.to_string();
+
+        if new_message == current_message {
+            messages.push(Message::EnterNormalMode);
+            return Ok(());
+        }
+
+        let reword_result =
+            but_api::commit::commit_reword_only(ctx, *commit_id, BString::from(new_message))
+                .with_context(|| format!("failed to reword {}", commit_id.to_hex_with_len(7)))?;
+
+        messages.extend([
+            Message::EnterNormalMode,
+            Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
+        ]);
+
+        Ok(())
+    }
+
+    /// Returns the currently selected commit id when the selected line is a commit.
+    fn selected_commit_id(&self) -> Option<gix::ObjectId> {
+        let selection = self.cursor.selected_line(&self.status_lines)?;
+
+        let StatusOutputLineData::Commit { cli_id } = &selection.data else {
+            return None;
+        };
+
+        let CliId::Commit { commit_id, .. } = &**cli_id else {
+            return None;
+        };
+
+        Some(*commit_id)
     }
 
     fn render(&self, frame: &mut Frame) {


### PR DESCRIPTION
This method was getting quite unwieldy, so this just breaks it up into separate individual methods for each message. 