### PR TITLE
feat(tui): move cursor between sections

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -124,6 +124,57 @@ impl Cursor {
             self.0 = idx;
         }
     }
+
+    /// Moves the cursor to the next selectable jump-target line after the current cursor position.
+    pub(super) fn move_next_section(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
+        if let Some((idx, _)) = lines
+            .iter()
+            .enumerate()
+            .skip(self.0 + 1)
+            .find(|(_, line)| is_jump_target_in_mode(line, mode))
+        {
+            self.0 = idx;
+        }
+    }
+
+    /// Moves the cursor to the previous selectable jump-target line before the current cursor position.
+    ///
+    /// If the current line is inside a section (for example, a file or commit row), moving to the
+    /// previous section skips the current section header and jumps to the section before it.
+    pub(super) fn move_previous_section(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
+        let current_line_is_jump_target = lines
+            .get(self.0)
+            .is_some_and(|line| is_jump_target_in_mode(line, mode));
+
+        let previous_jump_targets: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .rev()
+            .skip(lines.len() - self.0)
+            .filter_map(|(idx, line)| is_jump_target_in_mode(line, mode).then_some(idx))
+            .collect();
+
+        let target_idx = if current_line_is_jump_target {
+            previous_jump_targets.first().copied()
+        } else {
+            previous_jump_targets.get(1).copied()
+        };
+
+        if let Some(target_idx) = target_idx {
+            self.0 = target_idx;
+        }
+    }
+}
+
+/// Returns true if a line is selectable and is a jump target in the given mode.
+fn is_jump_target_in_mode(line: &StatusOutputLine, mode: &Mode) -> bool {
+    is_selectable_in_mode(line, mode)
+        && matches!(
+            line.data,
+            StatusOutputLineData::Branch { .. }
+                | StatusOutputLineData::StagedChanges { .. }
+                | StatusOutputLineData::UnstagedChanges { .. }
+        )
 }
 
 pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> bool {
@@ -139,7 +190,89 @@ pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> boo
                     .cli_id()
                     .is_some_and(|cli_id| available_targets.contains(cli_id))
         }
-        // its not possible to move the cursor in this mode
+        // its not possible to move the cursor in these modes
         Mode::InlineReword { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::Cursor;
+    use crate::{
+        CliId,
+        command::legacy::status::{
+            output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
+            tui::Mode,
+        },
+    };
+
+    fn line(data: StatusOutputLineData) -> StatusOutputLine {
+        StatusOutputLine {
+            connector: None,
+            content: StatusOutputContent::Plain(Vec::new()),
+            data,
+        }
+    }
+
+    #[test]
+    fn move_previous_section_skips_current_section_when_cursor_is_inside_it() {
+        let lines = vec![
+            line(StatusOutputLineData::UnstagedChanges {
+                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
+            }),
+            line(StatusOutputLineData::UnstagedFile {
+                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
+            }),
+            line(StatusOutputLineData::StagedChanges {
+                cli_id: Arc::new(CliId::Unassigned { id: "s0".into() }),
+            }),
+            line(StatusOutputLineData::StagedFile {
+                cli_id: Arc::new(CliId::Unassigned { id: "s1".into() }),
+            }),
+        ];
+
+        let mut cursor = Cursor(3);
+        cursor.move_previous_section(&lines, &Mode::Normal);
+
+        assert_eq!(cursor, Cursor(0));
+    }
+
+    #[test]
+    fn move_previous_section_moves_to_immediate_previous_when_already_on_section_header() {
+        let lines = vec![
+            line(StatusOutputLineData::UnstagedChanges {
+                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
+            }),
+            line(StatusOutputLineData::UnstagedFile {
+                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
+            }),
+            line(StatusOutputLineData::StagedChanges {
+                cli_id: Arc::new(CliId::Unassigned { id: "s0".into() }),
+            }),
+        ];
+
+        let mut cursor = Cursor(2);
+        cursor.move_previous_section(&lines, &Mode::Normal);
+
+        assert_eq!(cursor, Cursor(0));
+    }
+
+    #[test]
+    fn move_previous_section_does_not_move_when_only_current_section_exists_above_cursor() {
+        let lines = vec![
+            line(StatusOutputLineData::UnstagedChanges {
+                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
+            }),
+            line(StatusOutputLineData::UnstagedFile {
+                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
+            }),
+        ];
+
+        let mut cursor = Cursor(1);
+        cursor.move_previous_section(&lines, &Mode::Normal);
+
+        assert_eq!(cursor, Cursor(1));
     }
 }

--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -5,6 +5,9 @@ use crate::{
     command::legacy::status::{StatusOutputLine, output::StatusOutputLineData, tui::Mode},
 };
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(super) struct Cursor(usize);
 
@@ -103,6 +106,10 @@ impl Cursor {
     }
 
     pub(super) fn move_up(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
+        if self.0 >= lines.len() {
+            return;
+        }
+
         if let Some((idx, _)) = lines
             .iter()
             .enumerate()
@@ -115,6 +122,10 @@ impl Cursor {
     }
 
     pub(super) fn move_down(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
+        if self.0 >= lines.len() {
+            return;
+        }
+
         if let Some((idx, _)) = lines
             .iter()
             .enumerate()
@@ -127,6 +138,10 @@ impl Cursor {
 
     /// Moves the cursor to the next selectable jump-target line after the current cursor position.
     pub(super) fn move_next_section(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
+        if self.0 >= lines.len() {
+            return;
+        }
+
         if let Some((idx, _)) = lines
             .iter()
             .enumerate()
@@ -142,9 +157,11 @@ impl Cursor {
     /// If the current line is inside a section (for example, a file or commit row), moving to the
     /// previous section skips the current section header and jumps to the section before it.
     pub(super) fn move_previous_section(&mut self, lines: &[StatusOutputLine], mode: &Mode) {
-        let current_line_is_jump_target = lines
-            .get(self.0)
-            .is_some_and(|line| is_jump_target_in_mode(line, mode));
+        if self.0 >= lines.len() {
+            return;
+        }
+
+        let current_line_is_section_header = lines.get(self.0).is_some_and(is_section_header);
 
         let previous_jump_targets: Vec<usize> = lines
             .iter()
@@ -154,7 +171,7 @@ impl Cursor {
             .filter_map(|(idx, line)| is_jump_target_in_mode(line, mode).then_some(idx))
             .collect();
 
-        let target_idx = if current_line_is_jump_target {
+        let target_idx = if current_line_is_section_header {
             previous_jump_targets.first().copied()
         } else {
             previous_jump_targets.get(1).copied()
@@ -166,15 +183,19 @@ impl Cursor {
     }
 }
 
+/// Returns true if a line is a section header row.
+fn is_section_header(line: &StatusOutputLine) -> bool {
+    matches!(
+        line.data,
+        StatusOutputLineData::Branch { .. }
+            | StatusOutputLineData::StagedChanges { .. }
+            | StatusOutputLineData::UnstagedChanges { .. }
+    )
+}
+
 /// Returns true if a line is selectable and is a jump target in the given mode.
 fn is_jump_target_in_mode(line: &StatusOutputLine, mode: &Mode) -> bool {
-    is_selectable_in_mode(line, mode)
-        && matches!(
-            line.data,
-            StatusOutputLineData::Branch { .. }
-                | StatusOutputLineData::StagedChanges { .. }
-                | StatusOutputLineData::UnstagedChanges { .. }
-        )
+    is_selectable_in_mode(line, mode) && is_section_header(line)
 }
 
 pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> bool {
@@ -192,87 +213,5 @@ pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> boo
         }
         // its not possible to move the cursor in these modes
         Mode::InlineReword { .. } => false,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use super::Cursor;
-    use crate::{
-        CliId,
-        command::legacy::status::{
-            output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
-            tui::Mode,
-        },
-    };
-
-    fn line(data: StatusOutputLineData) -> StatusOutputLine {
-        StatusOutputLine {
-            connector: None,
-            content: StatusOutputContent::Plain(Vec::new()),
-            data,
-        }
-    }
-
-    #[test]
-    fn move_previous_section_skips_current_section_when_cursor_is_inside_it() {
-        let lines = vec![
-            line(StatusOutputLineData::UnstagedChanges {
-                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
-            }),
-            line(StatusOutputLineData::UnstagedFile {
-                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
-            }),
-            line(StatusOutputLineData::StagedChanges {
-                cli_id: Arc::new(CliId::Unassigned { id: "s0".into() }),
-            }),
-            line(StatusOutputLineData::StagedFile {
-                cli_id: Arc::new(CliId::Unassigned { id: "s1".into() }),
-            }),
-        ];
-
-        let mut cursor = Cursor(3);
-        cursor.move_previous_section(&lines, &Mode::Normal);
-
-        assert_eq!(cursor, Cursor(0));
-    }
-
-    #[test]
-    fn move_previous_section_moves_to_immediate_previous_when_already_on_section_header() {
-        let lines = vec![
-            line(StatusOutputLineData::UnstagedChanges {
-                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
-            }),
-            line(StatusOutputLineData::UnstagedFile {
-                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
-            }),
-            line(StatusOutputLineData::StagedChanges {
-                cli_id: Arc::new(CliId::Unassigned { id: "s0".into() }),
-            }),
-        ];
-
-        let mut cursor = Cursor(2);
-        cursor.move_previous_section(&lines, &Mode::Normal);
-
-        assert_eq!(cursor, Cursor(0));
-    }
-
-    #[test]
-    fn move_previous_section_does_not_move_when_only_current_section_exists_above_cursor() {
-        let lines = vec![
-            line(StatusOutputLineData::UnstagedChanges {
-                cli_id: Arc::new(CliId::Unassigned { id: "u0".into() }),
-            }),
-            line(StatusOutputLineData::UnstagedFile {
-                cli_id: Arc::new(CliId::Unassigned { id: "u1".into() }),
-            }),
-        ];
-
-        let mut cursor = Cursor(1);
-        cursor.move_previous_section(&lines, &Mode::Normal);
-
-        assert_eq!(cursor, Cursor(1));
     }
 }

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -1,0 +1,876 @@
+use std::sync::Arc;
+
+use ratatui_textarea::TextArea;
+
+use super::{Cursor, is_selectable_in_mode};
+use crate::{
+    CliId,
+    command::legacy::status::{
+        output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
+        tui::Mode,
+    },
+};
+
+fn line(data: StatusOutputLineData) -> StatusOutputLine {
+    StatusOutputLine {
+        connector: None,
+        content: StatusOutputContent::Plain(Vec::new()),
+        data,
+    }
+}
+
+fn unassigned(id: &str) -> Arc<CliId> {
+    Arc::new(CliId::Unassigned { id: id.into() })
+}
+
+fn commit_id(hex: &str) -> gix::ObjectId {
+    gix::ObjectId::from_hex(hex.as_bytes()).unwrap()
+}
+
+fn commit_cli_id(hex: &str, id: &str) -> Arc<CliId> {
+    Arc::new(CliId::Commit {
+        commit_id: commit_id(hex),
+        id: id.into(),
+    })
+}
+
+#[test]
+fn new_selects_first_selectable_line() {
+    let lines = vec![
+        line(StatusOutputLineData::Connector),
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    assert_eq!(Cursor::new(&lines), Cursor(2));
+}
+
+#[test]
+fn new_defaults_to_zero_when_no_line_is_selectable() {
+    let lines = vec![
+        line(StatusOutputLineData::Connector),
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::UpdateNotice),
+    ];
+
+    assert_eq!(Cursor::new(&lines), Cursor(0));
+}
+
+#[test]
+fn restore_returns_matching_line_by_cli_id() {
+    let lines = vec![
+        line(StatusOutputLineData::Connector),
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+    ];
+
+    let selected_cli_id = CliId::Branch {
+        name: "any-other-name".into(),
+        id: "b0".into(),
+        stack_id: None,
+    };
+
+    assert_eq!(Cursor::restore(&selected_cli_id, &lines), Some(Cursor(1)));
+}
+
+#[test]
+fn restore_returns_none_when_cli_id_is_not_present() {
+    let lines = vec![line(StatusOutputLineData::UnstagedChanges {
+        cli_id: unassigned("u0"),
+    })];
+
+    assert_eq!(
+        Cursor::restore(
+            &CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            },
+            &lines
+        ),
+        None
+    );
+}
+
+#[test]
+fn restore_selects_first_matching_line_when_cli_id_appears_multiple_times() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor::restore(&CliId::Unassigned { id: "u0".into() }, &lines),
+        Some(Cursor(0))
+    );
+}
+
+#[test]
+fn select_finds_commit_line_by_object_id() {
+    let wanted = "1111111111111111111111111111111111111111";
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id(wanted, "c1"),
+        }),
+    ];
+
+    assert_eq!(Cursor::select(commit_id(wanted), &lines), Some(Cursor(1)));
+}
+
+#[test]
+fn select_returns_none_when_commit_is_missing() {
+    let lines = vec![line(StatusOutputLineData::Commit {
+        cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c1"),
+    })];
+
+    assert_eq!(
+        Cursor::select(
+            commit_id("2222222222222222222222222222222222222222"),
+            &lines
+        ),
+        None
+    );
+}
+
+#[test]
+fn select_uses_first_matching_commit_when_object_id_appears_multiple_times() {
+    let wanted = "1111111111111111111111111111111111111111";
+    let lines = vec![
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id(wanted, "c0"),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id(wanted, "c1"),
+        }),
+    ];
+
+    assert_eq!(Cursor::select(commit_id(wanted), &lines), Some(Cursor(0)));
+}
+
+#[test]
+fn iter_lines_marks_only_the_selected_line() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: unassigned("f0"),
+        }),
+    ];
+
+    let selected: Vec<bool> = Cursor(1)
+        .iter_lines(&lines)
+        .map(|(_, selected)| selected)
+        .collect();
+
+    assert_eq!(selected, vec![false, true, false]);
+}
+
+#[test]
+fn selected_line_returns_none_when_cursor_out_of_bounds() {
+    let lines = vec![line(StatusOutputLineData::UnstagedChanges {
+        cli_id: unassigned("u0"),
+    })];
+
+    assert!(Cursor(99).selected_line(&lines).is_none());
+}
+
+#[test]
+fn selected_line_returns_line_when_cursor_is_in_bounds() {
+    let lines = vec![
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+    ];
+
+    assert!(matches!(
+        Cursor(1).selected_line(&lines).map(|line| &line.data),
+        Some(StatusOutputLineData::UnstagedChanges { .. })
+    ));
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_parent_when_file_is_selected_and_files_are_hidden() {
+    let parent = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::Branch {
+            cli_id: parent.clone(),
+        }),
+        line(StatusOutputLineData::File {
+            cli_id: unassigned("file0"),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor(2).selection_cli_id_for_reload(&lines, false),
+        Some(&parent)
+    );
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_selected_file_when_files_are_shown() {
+    let file_cli = unassigned("file0");
+    let lines = vec![line(StatusOutputLineData::File {
+        cli_id: file_cli.clone(),
+    })];
+
+    assert_eq!(
+        Cursor(0).selection_cli_id_for_reload(&lines, true),
+        Some(&file_cli)
+    );
+}
+
+#[test]
+fn selection_cli_id_for_reload_returns_none_when_file_has_no_parent_section() {
+    let lines = vec![line(StatusOutputLineData::File {
+        cli_id: unassigned("file0"),
+    })];
+
+    assert_eq!(Cursor(0).selection_cli_id_for_reload(&lines, false), None);
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_selected_cli_id_for_non_file_lines() {
+    let selected = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let lines = vec![line(StatusOutputLineData::Branch {
+        cli_id: selected.clone(),
+    })];
+
+    assert_eq!(
+        Cursor(0).selection_cli_id_for_reload(&lines, false),
+        Some(&selected)
+    );
+}
+
+#[test]
+fn selection_cli_id_for_reload_returns_none_when_cursor_is_out_of_bounds() {
+    let lines = vec![line(StatusOutputLineData::Branch {
+        cli_id: Arc::new(CliId::Branch {
+            name: "main".into(),
+            id: "b0".into(),
+            stack_id: None,
+        }),
+    })];
+
+    assert_eq!(Cursor(99).selection_cli_id_for_reload(&lines, false), None);
+}
+
+#[test]
+fn selection_cli_id_for_reload_returns_none_for_non_file_lines_without_cli_id() {
+    let lines = vec![line(StatusOutputLineData::Hint)];
+
+    assert_eq!(Cursor(0).selection_cli_id_for_reload(&lines, false), None);
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_nearest_parent_section_for_file() {
+    let first_parent = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let nearest_parent = unassigned("u0");
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: first_parent,
+        }),
+        line(StatusOutputLineData::File {
+            cli_id: unassigned("file0"),
+        }),
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: nearest_parent.clone(),
+        }),
+        line(StatusOutputLineData::File {
+            cli_id: unassigned("file1"),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor(3).selection_cli_id_for_reload(&lines, false),
+        Some(&nearest_parent)
+    );
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_commit_as_parent_for_hidden_file() {
+    let parent_commit = commit_cli_id("1111111111111111111111111111111111111111", "c0");
+    let lines = vec![
+        line(StatusOutputLineData::Commit {
+            cli_id: parent_commit.clone(),
+        }),
+        line(StatusOutputLineData::File {
+            cli_id: unassigned("file0"),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor(1).selection_cli_id_for_reload(&lines, false),
+        Some(&parent_commit)
+    );
+}
+
+#[test]
+fn selection_cli_id_for_reload_uses_staged_changes_as_parent_for_hidden_file() {
+    let parent_staged = unassigned("s0");
+    let lines = vec![
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: parent_staged.clone(),
+        }),
+        line(StatusOutputLineData::File {
+            cli_id: unassigned("file0"),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor(1).selection_cli_id_for_reload(&lines, false),
+        Some(&parent_staged)
+    );
+}
+
+#[test]
+fn move_up_moves_to_previous_selectable_line() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(2);
+    cursor.move_up(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_up_does_not_move_when_already_at_first_selectable_line() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_up(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_down_moves_to_next_selectable_line() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::Hint),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_down(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn move_down_does_not_move_when_no_selectable_line_below() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::Hint),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_down(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn movement_does_not_panic_or_move_when_cursor_is_out_of_bounds() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(99);
+    cursor.move_up(&lines, &Mode::Normal);
+    cursor.move_down(&lines, &Mode::Normal);
+    cursor.move_next_section(&lines, &Mode::Normal);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(99));
+}
+
+#[test]
+fn move_next_section_moves_to_next_jump_target() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::UnstagedFile {
+            cli_id: unassigned("u1"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_next_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn move_next_section_does_not_move_when_no_jump_target_below() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::UnstagedFile {
+            cli_id: unassigned("u1"),
+        }),
+    ];
+
+    let mut cursor = Cursor(1);
+    cursor.move_next_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn move_previous_section_skips_current_section_when_cursor_is_inside_it() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::UnstagedFile {
+            cli_id: unassigned("u1"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: unassigned("s1"),
+        }),
+    ];
+
+    let mut cursor = Cursor(3);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_previous_section_moves_to_immediate_previous_when_already_on_section_header() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::UnstagedFile {
+            cli_id: unassigned("u1"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(2);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_previous_section_does_not_move_when_only_current_section_exists_above_cursor() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::UnstagedFile {
+            cli_id: unassigned("u1"),
+        }),
+    ];
+
+    let mut cursor = Cursor(1);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn move_previous_section_does_not_move_when_on_first_jump_target() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_up_in_rub_mode_skips_unavailable_targets() {
+    let allowed = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: allowed.clone(),
+        }),
+        line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: allowed.clone(),
+        }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed],
+    };
+
+    let mut cursor = Cursor(2);
+    cursor.move_up(&lines, &mode);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_down_in_rub_mode_skips_unavailable_targets() {
+    let allowed = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: allowed.clone(),
+        }),
+        line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: allowed.clone(),
+        }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed],
+    };
+
+    let mut cursor = Cursor(0);
+    cursor.move_down(&lines, &mode);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn movement_in_rub_mode_handles_starting_on_unavailable_line() {
+    let allowed_a = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let allowed_b = Arc::new(CliId::Branch {
+        name: "release".into(),
+        id: "b2".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: allowed_a.clone(),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: allowed_a.clone(),
+        }),
+        line(StatusOutputLineData::Branch {
+            cli_id: blocked.clone(),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: allowed_b.clone(),
+        }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed_a, allowed_b],
+    };
+
+    let mut cursor = Cursor(2);
+    cursor.move_up(&lines, &mode);
+    assert_eq!(cursor, Cursor(1));
+
+    let mut cursor = Cursor(2);
+    cursor.move_down(&lines, &mode);
+    assert_eq!(cursor, Cursor(3));
+
+    let mut cursor = Cursor(2);
+    cursor.move_next_section(&lines, &mode);
+    assert_eq!(cursor, Cursor(3));
+}
+
+#[test]
+fn move_next_section_skips_non_jump_targets_like_commits() {
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_next_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn move_next_section_in_rub_mode_skips_unavailable_sections() {
+    let allowed = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: blocked.clone(),
+        }),
+        line(StatusOutputLineData::UnstagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: allowed.clone(),
+        }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed],
+    };
+
+    let mut cursor = Cursor(0);
+    cursor.move_next_section(&lines, &mode);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn move_previous_section_in_rub_mode_skips_unavailable_sections() {
+    let allowed = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: allowed.clone(),
+        }),
+        line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: allowed.clone(),
+        }),
+        line(StatusOutputLineData::StagedFile {
+            cli_id: allowed.clone(),
+        }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed],
+    };
+
+    let mut cursor = Cursor(3);
+    cursor.move_previous_section(&lines, &mode);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
+fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_previous_available_section()
+ {
+    let allowed_a = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let allowed_b = Arc::new(CliId::Branch {
+        name: "release".into(),
+        id: "b2".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: allowed_a.clone(),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: allowed_b.clone(),
+        }),
+        line(StatusOutputLineData::UnstagedChanges { cli_id: blocked }),
+    ];
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed_a, allowed_b],
+    };
+
+    let mut cursor = Cursor(2);
+    cursor.move_previous_section(&lines, &mode);
+
+    assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn movement_does_not_change_cursor_in_inline_reword_mode() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("s0"),
+        }),
+    ];
+
+    let mut cursor = Cursor(1);
+    let inline_reword = Mode::InlineReword {
+        commit_id: commit_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        textarea: Box::new(TextArea::default()),
+    };
+
+    cursor.move_up(&lines, &inline_reword);
+    cursor.move_down(&lines, &inline_reword);
+    cursor.move_next_section(&lines, &inline_reword);
+    cursor.move_previous_section(&lines, &inline_reword);
+
+    assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn is_selectable_in_rub_mode_requires_available_target() {
+    let allowed = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let selectable_line = line(StatusOutputLineData::StagedFile {
+        cli_id: allowed.clone(),
+    });
+    let blocked_line = line(StatusOutputLineData::UnstagedFile { cli_id: blocked });
+    let not_selectable_line = line(StatusOutputLineData::Hint);
+
+    let mode = Mode::Rub {
+        source: unassigned("source"),
+        available_targets: vec![allowed],
+    };
+
+    assert!(is_selectable_in_mode(&selectable_line, &mode));
+    assert!(!is_selectable_in_mode(&blocked_line, &mode));
+    assert!(!is_selectable_in_mode(&not_selectable_line, &mode));
+}
+
+#[test]
+fn is_selectable_is_always_false_in_inline_reword_mode() {
+    let selectable_line = line(StatusOutputLineData::StagedChanges {
+        cli_id: unassigned("s0"),
+    });
+
+    let inline_reword = Mode::InlineReword {
+        commit_id: commit_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        textarea: Box::new(TextArea::default()),
+    };
+
+    assert!(!is_selectable_in_mode(&selectable_line, &inline_reword));
+}

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -54,6 +54,30 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
     },
     KeyBind {
         chord: KeyChord {
+            modifiers: KeyModifiers::SHIFT,
+            keys: &[KeyCode::Char('J')],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::MoveCursorNextSection,
+        modes: KeyBindMode::AllExceptInlineReword,
+        short_description: "next section",
+        code_display: "J",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
+            modifiers: KeyModifiers::SHIFT,
+            keys: &[KeyCode::Char('K')],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::MoveCursorPreviousSection,
+        modes: KeyBindMode::AllExceptInlineReword,
+        short_description: "prev section",
+        code_display: "K",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
             modifiers: KeyModifiers::NONE,
             keys: &[KeyCode::Char('r')],
         },

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -173,6 +173,12 @@ impl App {
             Message::Noop => {}
             Message::MoveCursorUp => self.cursor.move_up(&self.status_lines, &self.mode),
             Message::MoveCursorDown => self.cursor.move_down(&self.status_lines, &self.mode),
+            Message::MoveCursorPreviousSection => self
+                .cursor
+                .move_previous_section(&self.status_lines, &self.mode),
+            Message::MoveCursorNextSection => self
+                .cursor
+                .move_next_section(&self.status_lines, &self.mode),
             Message::StartRub => self.handle_start_rub(),
             Message::EnterNormalMode => {
                 self.mode = Mode::Normal;
@@ -807,6 +813,8 @@ enum Message {
     Quit,
     MoveCursorUp,
     MoveCursorDown,
+    MoveCursorPreviousSection,
+    MoveCursorNextSection,
     StartRub,
     EnterNormalMode,
     ConfirmRub,


### PR DESCRIPTION
Pressing shift+j and shift+k now moves the cursor between sections (branches and staging areas). Makes it easier to get to where you want to rub something by skipping over commits.

Also AI generated a bunch of tests for the cursor since its growing now.