### PR TITLE
feat(tui): command mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -212,6 +212,6 @@ pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> boo
                     .is_some_and(|cli_id| available_targets.contains(cli_id))
         }
         // its not possible to move the cursor in these modes
-        Mode::InlineReword { .. } => false,
+        Mode::InlineReword { .. } | Mode::Command { .. } => false,
     }
 }

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -31,11 +31,23 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
     KeyBind {
         chord: KeyChord {
             modifiers: KeyModifiers::NONE,
+            keys: &[KeyCode::Enter],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::RunCommand,
+        modes: KeyBindMode::Only(&[ModeDiscriminants::Command]),
+        short_description: "run",
+        code_display: "enter",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
+            modifiers: KeyModifiers::NONE,
             keys: &[KeyCode::Char('j'), KeyCode::Down],
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorDown,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "down",
         code_display: "↓/j",
         hidden: false,
@@ -47,7 +59,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorUp,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "up",
         code_display: "↑/k",
         hidden: false,
@@ -59,7 +71,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorNextSection,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "next section",
         code_display: "J",
         hidden: false,
@@ -71,7 +83,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::MoveCursorPreviousSection,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "prev section",
         code_display: "K",
         hidden: false,
@@ -131,7 +143,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::ToggleFiles,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "files",
         code_display: "f",
         hidden: false,
@@ -146,6 +158,18 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         modes: KeyBindMode::AllExceptNormal,
         short_description: "back",
         code_display: "esc",
+        hidden: false,
+    },
+    KeyBind {
+        chord: KeyChord {
+            modifiers: KeyModifiers::NONE,
+            keys: &[KeyCode::Char(':')],
+        },
+        kind: KeyEventKind::Press,
+        message: &Message::EnterCommandMode,
+        modes: KeyBindMode::Only(&[ModeDiscriminants::Normal]),
+        short_description: "command",
+        code_display: ":",
         hidden: false,
     },
     KeyBind {
@@ -167,7 +191,7 @@ pub(super) static KEY_BINDS: &[KeyBind] = &[
         },
         kind: KeyEventKind::Press,
         message: &Message::Quit,
-        modes: KeyBindMode::AllExceptInlineReword,
+        modes: KeyBindMode::AllExceptTextInputModes,
         short_description: "quit",
         code_display: "q",
         hidden: false,
@@ -225,7 +249,9 @@ impl KeyBind {
 
     pub(super) fn available_in_mode(self, mode: &Mode) -> bool {
         match self.modes {
-            KeyBindMode::AllExceptInlineReword => !matches!(mode, Mode::InlineReword { .. }),
+            KeyBindMode::AllExceptTextInputModes => {
+                !matches!(mode, Mode::InlineReword { .. } | Mode::Command { .. })
+            }
             KeyBindMode::Only(supported_modes) => supported_modes
                 .iter()
                 .copied()
@@ -244,10 +270,8 @@ pub(super) struct KeyChord {
 /// The modes a key binding is available in.
 #[derive(Debug, Copy, Clone)]
 pub(super) enum KeyBindMode {
-    /// Available in all modes except inline reword.
-    ///
-    /// Inline reword is special since it shows a text area that eats all inputs.
-    AllExceptInlineReword,
+    /// Available in all modes except modes that use text input such as inline reword and command.
+    AllExceptTextInputModes,
     /// Available in all modes except normal mode.
     AllExceptNormal,
     /// Only available in these modes.

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,4 +1,6 @@
 use std::{
+    ffi::OsString,
+    process::Command,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -189,7 +191,7 @@ impl App {
                 self.handle_reload(ctx, out, mode, select_after_reload)
                     .await?
             }
-            Message::ShowError(err) => self.handle_show_error(err),
+            Message::ShowError(err) => self.handle_show_error(err, messages),
             Message::CreateEmptyCommit => self.handle_create_empty_commit(ctx, messages)?,
             Message::RewordWithEditor => {
                 self.handle_reword_with_editor(ctx, guard, messages)?;
@@ -197,6 +199,9 @@ impl App {
             Message::StartRewordInline => self.handle_start_reword_inline(ctx, messages)?,
             Message::RewordInlineInput(ev) => self.handle_reword_inline_input(ev),
             Message::ConfirmInlineReword => self.handle_confirm_inline_reword(ctx, messages)?,
+            Message::EnterCommandMode => self.handle_enter_command_mode(),
+            Message::CommandInput(ev) => self.handle_command_input(ev),
+            Message::RunCommand => self.handle_run_command(guard, out, messages)?,
         }
 
         Ok(())
@@ -322,11 +327,15 @@ impl App {
     }
 
     /// Handles showing a transient UI error.
-    fn handle_show_error(&mut self, err: Arc<anyhow::Error>) {
+    fn handle_show_error(&mut self, err: Arc<anyhow::Error>, messages: &mut Vec<Message>) {
         self.errors.push(AppError {
             inner: err,
             dismiss_at: Instant::now() + Duration::from_secs(5),
         });
+
+        // ensure we always enter normal mode when something does wrong
+        // so we don't get stuck in whatever mode we were in previously
+        messages.push(Message::EnterNormalMode);
     }
 
     /// Handles creating an empty commit relative to the current selection.
@@ -520,6 +529,63 @@ impl App {
         Ok(())
     }
 
+    fn handle_enter_command_mode(&mut self) {
+        if !matches!(self.mode, Mode::Normal) {
+            return;
+        }
+
+        let mut textarea = TextArea::default();
+        textarea.set_cursor_line_style(Style::default());
+        textarea.move_cursor(CursorMove::End);
+
+        self.mode = Mode::Command {
+            textarea: Box::new(textarea),
+        };
+    }
+
+    fn handle_command_input(&mut self, ev: Event) {
+        if let Mode::Command { textarea } = &mut self.mode {
+            textarea.input(ev);
+        }
+    }
+
+    fn handle_run_command(
+        &mut self,
+        guard: &mut TerminalGuard,
+        out: &mut OutputChannel,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
+        let Mode::Command { textarea } = &self.mode else {
+            messages.push(Message::EnterNormalMode);
+            return Ok(());
+        };
+
+        let Some(input) = textarea.lines().first() else {
+            return Ok(());
+        };
+
+        let binary_path = std::env::current_exe().unwrap_or_default();
+        let args = shell_words::split(input)?.into_iter().map(OsString::from);
+
+        let mut cmd = Command::new(binary_path);
+        cmd.args(args);
+
+        let _suspend_guard = guard.suspend()?;
+        cmd.spawn()?.wait()?;
+
+        let mut input_channel = out
+            .prepare_for_terminal_input()
+            .context("failed to prepare input")?;
+
+        input_channel.prompt_single_line("\npress enter to continue...")?;
+
+        drop(_suspend_guard);
+
+        messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
+
+        Ok(())
+    }
+
     /// Returns the currently selected commit id when the selected line is a commit.
     fn selected_commit_id(&self) -> Option<gix::ObjectId> {
         let selection = self.cursor.selected_line(&self.status_lines)?;
@@ -589,7 +655,7 @@ impl App {
 
         if is_selected {
             match &self.mode {
-                Mode::Normal | Mode::InlineReword { .. } => {}
+                Mode::Normal | Mode::InlineReword { .. } | Mode::Command { .. } => {}
                 Mode::Rub {
                     source,
                     available_targets: _,
@@ -615,7 +681,7 @@ impl App {
             }
         } else {
             match &self.mode {
-                Mode::Normal | Mode::InlineReword { .. } => {}
+                Mode::Normal | Mode::InlineReword { .. } | Mode::Command { .. } => {}
                 Mode::Rub {
                     source,
                     available_targets: _,
@@ -642,7 +708,7 @@ impl App {
         };
 
         match &self.mode {
-            Mode::Normal => {
+            Mode::Normal | Mode::Command { .. } => {
                 line.extend(content_spans);
             }
             Mode::InlineReword { .. } => {
@@ -675,7 +741,7 @@ impl App {
             }
         }
 
-        if is_selected {
+        if is_selected && !matches!(self.mode, Mode::Command { .. }) {
             line = line.style(Style::default().bg(CURSOR_BG));
         }
 
@@ -689,32 +755,55 @@ impl App {
             Mode::InlineReword { .. } => {
                 Span::styled("  reword  ", Style::default().black().on_blue())
             }
+            Mode::Command { .. } => {
+                Span::styled("  command  ", Style::default().black().on_yellow())
+            }
         };
 
-        let padding = Span::raw(" ");
+        let layout = Layout::horizontal([
+            Constraint::Length(mode_span.width() as _),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
+        .split(area);
 
-        let mut line = Line::from_iter([mode_span, padding]);
+        frame.render_widget(mode_span, layout[0]);
 
-        let mut key_binds_iter = self
-            .key_binds
-            .iter()
-            .copied()
-            .filter(|key_bind| key_bind.available_in_mode(&self.mode))
-            .filter(|key_bind| !key_bind.hidden)
-            .peekable();
-        while let Some(key_bind) = key_binds_iter.next() {
-            line.extend([
-                Span::styled(key_bind.code_display, Style::default().blue()),
-                Span::raw(" "),
-                Span::styled(key_bind.short_description, Style::default().dim()),
-            ]);
+        frame.render_widget(" ", layout[1]);
 
-            if key_binds_iter.peek().is_some() {
-                line.push_span(Span::styled(" • ", Style::default().dim()));
+        match &self.mode {
+            Mode::Normal | Mode::Rub { .. } | Mode::InlineReword { .. } => {
+                let mut line = Line::default();
+                let mut key_binds_iter = self
+                    .key_binds
+                    .iter()
+                    .copied()
+                    .filter(|key_bind| key_bind.available_in_mode(&self.mode))
+                    .filter(|key_bind| !key_bind.hidden)
+                    .peekable();
+                while let Some(key_bind) = key_binds_iter.next() {
+                    line.extend([
+                        Span::styled(key_bind.code_display, Style::default().blue()),
+                        Span::raw(" "),
+                        Span::styled(key_bind.short_description, Style::default().dim()),
+                    ]);
+
+                    if key_binds_iter.peek().is_some() {
+                        line.push_span(Span::styled(" • ", Style::default().dim()));
+                    }
+                }
+
+                frame.render_widget(line, layout[2]);
+            }
+            Mode::Command { textarea } => {
+                let command_layout =
+                    Layout::horizontal([Constraint::Length(4), Constraint::Min(1)])
+                        .split(layout[2]);
+
+                frame.render_widget("but ", command_layout[0]);
+                frame.render_widget(&**textarea, command_layout[1]);
             }
         }
-
-        frame.render_widget(line, area);
     }
 
     fn render_errors(&self, area: Rect, frame: &mut Frame) {
@@ -796,13 +885,27 @@ fn event_to_messages(ev: Event, key_binds: &[KeyBind], mode: &Mode, messages: &m
                     Mode::InlineReword { .. } => {
                         messages.push(Message::RewordInlineInput(ev));
                     }
+                    Mode::Command { .. } => {
+                        messages.push(Message::CommandInput(ev));
+                    }
                     Mode::Normal | Mode::Rub { .. } => {}
                 }
             }
         }
-        Event::Resize(_, _) | Event::Paste(_) => {
-            messages.push(Message::Noop); // trigger a render
+        Event::Resize(_, _) => {
+            messages.push(Message::Noop);
         }
+        Event::Paste(_) => match mode {
+            Mode::InlineReword { .. } => {
+                messages.push(Message::RewordInlineInput(ev));
+            }
+            Mode::Command { .. } => {
+                messages.push(Message::CommandInput(ev));
+            }
+            Mode::Normal | Mode::Rub { .. } => {
+                messages.push(Message::Noop);
+            }
+        },
         Event::FocusGained => {
             messages.push(Message::Reload(None));
         }
@@ -829,6 +932,9 @@ enum Message {
     StartRewordInline,
     ConfirmInlineReword,
     RewordInlineInput(Event),
+    EnterCommandMode,
+    CommandInput(Event),
+    RunCommand,
 }
 
 #[derive(Debug, Default, strum::EnumDiscriminants)]
@@ -841,6 +947,9 @@ enum Mode {
     },
     InlineReword {
         commit_id: gix::ObjectId,
+        textarea: Box<TextArea<'static>>,
+    },
+    Command {
         textarea: Box<TextArea<'static>>,
     },
 }

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -407,6 +407,19 @@ impl InputOutputChannel<'_> {
         )
     }
 
+    /// Like [`Self::prompt`] but without a newline between the prompt and the input.
+    pub fn prompt_single_line(
+        &mut self,
+        prompt: impl AsRef<str>,
+    ) -> anyhow::Result<Option<String>> {
+        Ok(
+            match self.readline(&format!("{} ", prompt.as_ref()), InputEcho::Visible)? {
+                ReadlineInput::Text(line) => Some(line),
+                ReadlineInput::Empty | ReadlineInput::EndOfInput => None,
+            },
+        )
+    }
+
     /// Prompt for a non-empty secret string from the user, or `None` if the
     /// input was empty.
     ///


### PR DESCRIPTION
Pressing `:` enters command mode where you can run `but` commands without leaving the TUI.