### PR TITLE
feat(ai): clarify haiku behavior for commit titles

### DIFF
--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -364,7 +364,7 @@ export class AIService {
 			);
 
 			const extraConcisePart = useHaiku
-				? "Compose the commit message in the form of a haiku. A haiku is a three-line poem with a 5-7-5 syllable structure."
+				? "Write the commit body as a haiku (a three-line poem with a 5-7-5 syllable structure). The title should still be a normal short summary of the changes."
 				: useExtraConciseStyle
 					? "Keep the commit message extra concise: output only the title line, no body or description. Keep it as short as possible."
 					: "";


### PR DESCRIPTION
This pull request makes a small but important clarification to the instructions given to the AI for generating commit messages in haiku form. The change ensures that only the commit body is written as a haiku, while the title remains a standard short summary.

- Clarified the haiku commit message instruction so that only the commit body is a haiku, and the title remains a normal summary (`apps/desktop/src/lib/ai/service.ts`).