### PR TITLE
fix(tui): fix cursor section movement not selecting `MergeBase` lines

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -190,6 +190,7 @@ fn is_section_header(line: &StatusOutputLine) -> bool {
         StatusOutputLineData::Branch { .. }
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::UnstagedChanges { .. }
+            | StatusOutputLineData::MergeBase
     )
 }
 

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -704,6 +704,50 @@ fn move_next_section_skips_non_jump_targets_like_commits() {
 }
 
 #[test]
+fn move_next_section_can_jump_to_merge_base_line() {
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c0"),
+        }),
+        line(StatusOutputLineData::MergeBase),
+    ];
+
+    let mut cursor = Cursor(0);
+    cursor.move_next_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(2));
+}
+
+#[test]
+fn move_previous_section_can_jump_from_merge_base_line() {
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c0"),
+        }),
+        line(StatusOutputLineData::MergeBase),
+    ];
+
+    let mut cursor = Cursor(2);
+    cursor.move_previous_section(&lines, &Mode::Normal);
+
+    assert_eq!(cursor, Cursor(0));
+}
+
+#[test]
 fn move_next_section_in_rub_mode_skips_unavailable_sections() {
     let allowed = Arc::new(CliId::Branch {
         name: "main".into(),


### PR DESCRIPTION
Pressing shift+j wouldn't select "MergeBase" lines such as

```
┴ a1fa3cd [gb-local/main] 2026-03-16 nix
```

I think whether such lines even should be selectable in the first place is probably worth figuring out but currently being able to select it with j but not shift+j is a bug.