### PR TITLE
feat(tui): try rebuilding rub from but-api primitives

### DIFF
--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -26,7 +26,7 @@ type Description = String;
 
 /// Represents the operation to perform for a given source and target combination.
 /// This enum serves as the single source of truth for valid rub operations.
-#[derive(Debug)]
+#[derive(Debug, strum::EnumDiscriminants)]
 pub(crate) enum RubOperation<'a> {
     UnassignUncommitted(
         NonEmpty<&'a but_hunk_assignment::HunkAssignment>,

--- a/crates/but/src/command/legacy/status/tui/cursor.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor.rs
@@ -44,7 +44,10 @@ impl Cursor {
         Some(Self(idx))
     }
 
-    pub(super) fn select(object_id: gix::ObjectId, lines: &[StatusOutputLine]) -> Option<Self> {
+    pub(super) fn select_commit(
+        object_id: gix::ObjectId,
+        lines: &[StatusOutputLine],
+    ) -> Option<Self> {
         let idx = lines.iter().position(|line| {
             if let Some(CliId::Commit { commit_id, .. }) = line.data.cli_id().map(|id| &**id)
                 && *commit_id == object_id
@@ -53,6 +56,31 @@ impl Cursor {
             } else {
                 false
             }
+        })?;
+        Some(Self(idx))
+    }
+
+    /// Select the first line that points to the given branch name.
+    pub(super) fn select_branch(branch_name: String, lines: &[StatusOutputLine]) -> Option<Self> {
+        let idx = lines.iter().position(|line| {
+            if let Some(CliId::Branch { name, .. }) = line.data.cli_id().map(|id| &**id)
+                && *name == branch_name
+            {
+                true
+            } else {
+                false
+            }
+        })?;
+        Some(Self(idx))
+    }
+
+    /// Select the first line that points to the unassigned section.
+    pub(super) fn select_unassigned(lines: &[StatusOutputLine]) -> Option<Self> {
+        let idx = lines.iter().position(|line| {
+            matches!(
+                line.data.cli_id().map(|id| &**id),
+                Some(CliId::Unassigned { .. })
+            )
         })?;
         Some(Self(idx))
     }
@@ -208,6 +236,10 @@ pub(super) fn is_selectable_in_mode(line: &StatusOutputLine, mode: &Mode) -> boo
     match mode {
         Mode::Normal => line.is_selectable(),
         Mode::Rub {
+            source: _,
+            available_targets,
+        }
+        | Mode::RubButApi {
             source: _,
             available_targets,
         } => {

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -138,7 +138,10 @@ fn select_finds_commit_line_by_object_id() {
         }),
     ];
 
-    assert_eq!(Cursor::select(commit_id(wanted), &lines), Some(Cursor(1)));
+    assert_eq!(
+        Cursor::select_commit(commit_id(wanted), &lines),
+        Some(Cursor(1))
+    );
 }
 
 #[test]
@@ -148,7 +151,7 @@ fn select_returns_none_when_commit_is_missing() {
     })];
 
     assert_eq!(
-        Cursor::select(
+        Cursor::select_commit(
             commit_id("2222222222222222222222222222222222222222"),
             &lines
         ),
@@ -168,7 +171,114 @@ fn select_uses_first_matching_commit_when_object_id_appears_multiple_times() {
         }),
     ];
 
-    assert_eq!(Cursor::select(commit_id(wanted), &lines), Some(Cursor(0)));
+    assert_eq!(
+        Cursor::select_commit(commit_id(wanted), &lines),
+        Some(Cursor(0))
+    );
+}
+
+#[test]
+fn select_branch_finds_branch_line_by_name() {
+    let lines = vec![
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c0"),
+        }),
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor::select_branch("main".into(), &lines),
+        Some(Cursor(1))
+    );
+}
+
+#[test]
+fn select_branch_returns_none_when_branch_is_missing() {
+    let lines = vec![line(StatusOutputLineData::Branch {
+        cli_id: Arc::new(CliId::Branch {
+            name: "main".into(),
+            id: "b0".into(),
+            stack_id: None,
+        }),
+    })];
+
+    assert_eq!(Cursor::select_branch("feature".into(), &lines), None);
+}
+
+#[test]
+fn select_branch_uses_first_matching_line_when_branch_appears_multiple_times() {
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+    ];
+
+    assert_eq!(
+        Cursor::select_branch("main".into(), &lines),
+        Some(Cursor(0))
+    );
+}
+
+#[test]
+fn select_unassigned_finds_unassigned_line() {
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: Arc::new(CliId::Branch {
+                name: "main".into(),
+                id: "b0".into(),
+                stack_id: None,
+            }),
+        }),
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+    ];
+
+    assert_eq!(Cursor::select_unassigned(&lines), Some(Cursor(1)));
+}
+
+#[test]
+fn select_unassigned_uses_first_matching_line() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::StagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+    ];
+
+    assert_eq!(Cursor::select_unassigned(&lines), Some(Cursor(0)));
+}
+
+#[test]
+fn select_unassigned_returns_none_when_missing() {
+    let lines = vec![line(StatusOutputLineData::Branch {
+        cli_id: Arc::new(CliId::Branch {
+            name: "main".into(),
+            id: "b0".into(),
+            stack_id: None,
+        }),
+    })];
+
+    assert_eq!(Cursor::select_unassigned(&lines), None);
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -18,6 +18,9 @@ pub(super) fn default_key_binds() -> KeyBinds {
             ModeDiscriminant::Rub => {
                 register_rub_mode_key_binds(&mut key_binds);
             }
+            ModeDiscriminant::RubButApi => {
+                register_rub_but_api_mode_key_binds(&mut key_binds);
+            }
             ModeDiscriminant::InlineReword => {
                 register_inline_reword_mode_key_binds(&mut key_binds);
             }
@@ -33,7 +36,7 @@ pub(super) fn default_key_binds() -> KeyBinds {
 fn register_global_key_binds(key_binds: &mut KeyBinds) {
     let all_except_text_input_modes = ModeDiscriminant::iter()
         .filter(|mode| match mode {
-            ModeDiscriminant::Normal | ModeDiscriminant::Rub => true,
+            ModeDiscriminant::Normal | ModeDiscriminant::Rub | ModeDiscriminant::RubButApi => true,
             ModeDiscriminant::InlineReword | ModeDiscriminant::Command => false,
         })
         .collect::<Vec<_>>();
@@ -93,7 +96,19 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
         chord_display: "r",
         key_matcher: press().code(KeyCode::Char('r')),
         modes: Vec::from([ModeDiscriminant::Normal]),
-        message: Message::StartRub,
+        message: Message::StartRub {
+            using_but_api: false,
+        },
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "rub (but-api)",
+        chord_display: "shift+r",
+        key_matcher: press().shift().code(KeyCode::Char('R')),
+        modes: Vec::from([ModeDiscriminant::Normal]),
+        message: Message::StartRub {
+            using_but_api: true,
+        },
     });
 
     key_binds.register(StaticKeyBind {
@@ -151,6 +166,24 @@ fn register_rub_mode_key_binds(key_binds: &mut KeyBinds) {
         chord_display: "esc",
         key_matcher: press().code(KeyCode::Esc),
         modes: Vec::from([ModeDiscriminant::Rub]),
+        message: Message::EnterNormalMode,
+    });
+}
+
+fn register_rub_but_api_mode_key_binds(key_binds: &mut KeyBinds) {
+    key_binds.register(StaticKeyBind {
+        short_description: "confirm",
+        chord_display: "enter",
+        key_matcher: press().code(KeyCode::Enter),
+        modes: Vec::from([ModeDiscriminant::RubButApi]),
+        message: Message::ConfirmRub,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "back",
+        chord_display: "esc",
+        key_matcher: press().code(KeyCode::Esc),
+        modes: Vec::from([ModeDiscriminant::RubButApi]),
         message: Message::EnterNormalMode,
     });
 }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -49,6 +49,7 @@ use super::output::{StatusOutputContent, StatusOutputLineData};
 
 mod cursor;
 mod key_bind;
+mod rub_api;
 
 #[cfg(test)]
 mod tests;
@@ -250,7 +251,13 @@ impl App {
             Message::MoveCursorNextSection => self
                 .cursor
                 .move_next_section(&self.status_lines, &self.mode),
-            Message::StartRub => self.handle_start_rub(),
+            Message::StartRub { using_but_api } => {
+                if using_but_api {
+                    self.handle_start_rub_using_but_api()
+                } else {
+                    self.handle_start_rub()
+                }
+            }
             Message::EnterNormalMode => {
                 self.mode = Mode::Normal;
             }
@@ -318,6 +325,47 @@ impl App {
         }
     }
 
+    fn handle_start_rub_using_but_api(&mut self) {
+        if !matches!(self.mode, Mode::Normal) {
+            return;
+        }
+
+        let Some(selected_line) = self.cursor.selected_line(&self.status_lines) else {
+            return;
+        };
+
+        let Some(cli_id) = selected_line.data.cli_id() else {
+            return;
+        };
+
+        let available_targets = self
+            .status_lines
+            .iter()
+            .filter_map(|line| line.data.cli_id())
+            .filter(|target| *target == cli_id || route_operation(cli_id, target).is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        self.mode = Mode::RubButApi {
+            source: Arc::clone(cli_id),
+            available_targets,
+        };
+
+        if self
+            .cursor
+            .selected_line(&self.status_lines)
+            .is_some_and(|line| cursor::is_selectable_in_mode(line, &self.mode))
+        {
+            return;
+        }
+
+        let previous_cursor = self.cursor;
+        self.cursor.move_down(&self.status_lines, &self.mode);
+        if self.cursor == previous_cursor {
+            self.cursor.move_up(&self.status_lines, &self.mode);
+        }
+    }
+
     /// Handles toggling file visibility and requests a status reload.
     fn handle_toggle_files(&mut self, messages: &mut Vec<Message>) {
         self.flags.show_files = !self.flags.show_files;
@@ -330,15 +378,47 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
-        if let Mode::Rub { source, .. } = &self.mode
-            && let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
-            && let Some(target) = selected_line.data.cli_id()
-            && let Some(operation) = route_operation(source, target)
-        {
-            with_noop_output(|out| operation.execute(ctx, out))?;
-        }
+        let reload_message = match &self.mode {
+            Mode::Rub {
+                source,
+                available_targets: _,
+            } => {
+                if let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
+                    && let Some(target) = selected_line.data.cli_id()
+                    && let Some(operation) = route_operation(source, target)
+                {
+                    with_noop_output(|out| operation.execute(ctx, out))?;
+                }
+                None
+            }
+            Mode::RubButApi {
+                source,
+                available_targets: _,
+            } => {
+                if let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
+                    && let Some(target) = selected_line.data.cli_id()
+                    && let Some(operation) = route_operation(source, target)
+                {
+                    if let Some(what_to_select) = rub_api::perform_operation(ctx, &operation)? {
+                        Some(Message::Reload(Some(what_to_select)))
+                    } else {
+                        messages.push(Message::ShowError(Arc::new(anyhow::Error::from(
+                            rub_api::OperationNotSupported::new(&operation),
+                        ))));
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            Mode::Normal | Mode::InlineReword { .. } | Mode::Command { .. } => None,
+        };
 
-        messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
+        messages.extend([
+            Message::EnterNormalMode,
+            reload_message.unwrap_or(Message::Reload(None)),
+        ]);
+
         Ok(())
     }
 
@@ -380,7 +460,11 @@ impl App {
 
         self.cursor = if let Some(select_after_reload) = select_after_reload {
             match select_after_reload {
-                SelectAfterReload::Commit(commit_id) => Cursor::select(commit_id, &new_lines),
+                SelectAfterReload::Commit(commit_id) => {
+                    Cursor::select_commit(commit_id, &new_lines)
+                }
+                SelectAfterReload::Branch(branch) => Cursor::select_branch(branch, &new_lines),
+                SelectAfterReload::Unassigned => Cursor::select_unassigned(&new_lines),
             }
         } else {
             self.cursor
@@ -746,7 +830,7 @@ impl App {
                         }
 
                         let rub_operation_display =
-                            rub_operation_display(source, target).unwrap_or("invalid");
+                            rub_operation_display_legacy(source, target).unwrap_or("invalid");
                         line.extend([
                             Span::raw("<< ").black().on_blue(),
                             Span::raw(rub_operation_display).black().on_blue(),
@@ -755,11 +839,49 @@ impl App {
                         ]);
                     }
                 }
+                Mode::RubButApi {
+                    source,
+                    available_targets: _,
+                } => {
+                    if let Some(target) = data.cli_id() {
+                        if target == source {
+                            line.extend([
+                                Span::raw("<< source >>").black().on_green(),
+                                Span::raw(" "),
+                            ]);
+                        }
+
+                        match rub_api::rub_operation_display(source, target)
+                            .unwrap_or(rub_api::RubOperationDisplay::Supported("invalid"))
+                        {
+                            rub_api::RubOperationDisplay::Supported(display) => {
+                                line.extend([
+                                    Span::raw("<< ").black().on_blue(),
+                                    Span::raw(display).black().on_blue(),
+                                    Span::raw(" >>").black().on_blue(),
+                                    Span::raw(" "),
+                                ]);
+                            }
+                            rub_api::RubOperationDisplay::NotSupported(_, discriminant) => {
+                                line.extend([
+                                    Span::raw("<< ").black().on_red(),
+                                    Span::raw(format!("{discriminant:?}")).black().on_red(),
+                                    Span::raw(" is not supported >>").black().on_red(),
+                                    Span::raw(" "),
+                                ]);
+                            }
+                        }
+                    }
+                }
             }
         } else {
             match &self.mode {
                 Mode::Normal | Mode::InlineReword { .. } | Mode::Command { .. } => {}
                 Mode::Rub {
+                    source,
+                    available_targets: _,
+                }
+                | Mode::RubButApi {
                     source,
                     available_targets: _,
                 } => {
@@ -800,6 +922,10 @@ impl App {
             Mode::Rub {
                 source: _,
                 available_targets,
+            }
+            | Mode::RubButApi {
+                source: _,
+                available_targets,
             } => {
                 let can_rub_here = if let Some(cli_id) = data.cli_id() {
                     available_targets.contains(cli_id)
@@ -829,6 +955,9 @@ impl App {
         let mode_span = match self.mode {
             Mode::Normal => Span::styled("  normal  ", Style::default().black().on_green()),
             Mode::Rub { .. } => Span::styled("  rub  ", Style::default().black().on_magenta()),
+            Mode::RubButApi { .. } => {
+                Span::styled("  rub (api)  ", Style::default().black().on_magenta())
+            }
             Mode::InlineReword { .. } => {
                 Span::styled("  reword  ", Style::default().black().on_blue())
             }
@@ -849,7 +978,10 @@ impl App {
         frame.render_widget(" ", layout[1]);
 
         match &self.mode {
-            Mode::Normal | Mode::Rub { .. } | Mode::InlineReword { .. } => {
+            Mode::Normal
+            | Mode::Rub { .. }
+            | Mode::RubButApi { .. }
+            | Mode::InlineReword { .. } => {
                 let mut line = Line::default();
                 let mut key_binds_iter = self
                     .key_binds
@@ -963,7 +1095,7 @@ fn event_to_messages(ev: Event, key_binds: &KeyBinds, mode: &Mode, messages: &mu
                     Mode::Command { .. } => {
                         messages.push(Message::CommandInput(ev));
                     }
-                    Mode::Normal | Mode::Rub { .. } => {}
+                    Mode::Normal | Mode::Rub { .. } | Mode::RubButApi { .. } => {}
                 }
             }
         }
@@ -977,7 +1109,7 @@ fn event_to_messages(ev: Event, key_binds: &KeyBinds, mode: &Mode, messages: &mu
             Mode::Command { .. } => {
                 messages.push(Message::CommandInput(ev));
             }
-            Mode::Normal | Mode::Rub { .. } => {
+            Mode::Normal | Mode::Rub { .. } | Mode::RubButApi { .. } => {
                 messages.push(Message::Noop);
             }
         },
@@ -996,7 +1128,7 @@ enum Message {
     MoveCursorDown,
     MoveCursorPreviousSection,
     MoveCursorNextSection,
-    StartRub,
+    StartRub { using_but_api: bool },
     EnterNormalMode,
     ConfirmRub,
     Reload(Option<SelectAfterReload>),
@@ -1022,6 +1154,10 @@ enum Mode {
         source: Arc<CliId>,
         available_targets: Vec<Arc<CliId>>,
     },
+    RubButApi {
+        source: Arc<CliId>,
+        available_targets: Vec<Arc<CliId>>,
+    },
     InlineReword {
         commit_id: gix::ObjectId,
         textarea: Box<TextArea<'static>>,
@@ -1032,39 +1168,11 @@ enum Mode {
 }
 
 /// What to select after reloading
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum SelectAfterReload {
-    /// Select a specific commit
     Commit(gix::ObjectId),
-}
-
-fn rub_operation_display(source: &CliId, target: &CliId) -> Option<&'static str> {
-    if source == target {
-        return Some("no operation");
-    }
-
-    Some(match route_operation(source, target)? {
-        RubOperation::UnassignUncommitted(..) => "unassign hunks",
-        RubOperation::UncommittedToCommit(..) => "amend commit",
-        RubOperation::UncommittedToBranch(..) => "assign hunks",
-        RubOperation::UncommittedToStack(..) => "assign hunks",
-        RubOperation::StackToUnassigned(..) => "unassign hunks",
-        RubOperation::StackToStack { .. } => "reassign hunks",
-        RubOperation::StackToBranch { .. } => "reassign hunks",
-        RubOperation::UnassignedToCommit(..) => "amend commit",
-        RubOperation::UnassignedToBranch(..) => "assign hunks",
-        RubOperation::UnassignedToStack(..) => "assign hunks",
-        RubOperation::UndoCommit(..) => "undo commit",
-        RubOperation::SquashCommits { .. } => "squash commits",
-        RubOperation::MoveCommitToBranch(..) => "move commit",
-        RubOperation::BranchToUnassigned(..) => "unassign hunks",
-        RubOperation::BranchToStack { .. } => "reassign hunks",
-        RubOperation::BranchToCommit(..) => "amend commit",
-        RubOperation::BranchToBranch { .. } => "reassign hunks",
-        RubOperation::CommittedFileToBranch(..) => "extract file",
-        RubOperation::CommittedFileToCommit(..) => "move file",
-        RubOperation::CommittedFileToUnassigned(..) => "extract file",
-    })
+    Branch(String),
+    Unassigned,
 }
 
 struct PopupMargin {
@@ -1132,4 +1240,33 @@ where
 pub(super) struct AppError {
     pub(super) inner: Arc<anyhow::Error>,
     pub(super) dismiss_at: Instant,
+}
+
+fn rub_operation_display_legacy(source: &CliId, target: &CliId) -> Option<&'static str> {
+    if source == target {
+        return Some("noop");
+    }
+
+    Some(match route_operation(source, target)? {
+        RubOperation::UnassignUncommitted(..) => "unassign hunks",
+        RubOperation::UncommittedToCommit(..) => "amend commit",
+        RubOperation::UncommittedToBranch(..) => "assign hunks",
+        RubOperation::UncommittedToStack(..) => "assign hunks",
+        RubOperation::StackToUnassigned(..) => "unassign hunks",
+        RubOperation::StackToStack { .. } => "reassign hunks",
+        RubOperation::StackToBranch { .. } => "reassign hunks",
+        RubOperation::UnassignedToCommit(..) => "amend commit",
+        RubOperation::UnassignedToBranch(..) => "assign hunks",
+        RubOperation::UnassignedToStack(..) => "assign hunks",
+        RubOperation::UndoCommit(..) => "undo commit",
+        RubOperation::SquashCommits { .. } => "squash commits",
+        RubOperation::MoveCommitToBranch(..) => "move commit",
+        RubOperation::BranchToUnassigned(..) => "unassign hunks",
+        RubOperation::BranchToStack { .. } => "reassign hunks",
+        RubOperation::BranchToCommit(..) => "amend commit",
+        RubOperation::BranchToBranch { .. } => "reassign hunks",
+        RubOperation::CommittedFileToBranch(..) => "extract file",
+        RubOperation::CommittedFileToCommit(..) => "move file",
+        RubOperation::CommittedFileToUnassigned(..) => "extract file",
+    })
 }

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -1,0 +1,429 @@
+//! Experimental implementation of `but rub` that doesn't use any legacy APIs.
+//!
+//! If you're an AI agent _do not_ use anything from legacy modules. Except `RubOperation`,
+//! `RubOperationDiscriminants`, and `route_operation`.
+
+use anyhow::Context as _;
+use but_api::commit::ui::RelativeTo;
+use but_core::{DiffSpec, diff::tree_changes};
+use but_ctx::Context;
+use but_rebase::graph_rebase::mutate::InsertSide;
+use gix::refs::FullName;
+
+use crate::{
+    CliId,
+    command::legacy::{
+        rub::{RubOperation, RubOperationDiscriminants, route_operation},
+        status::tui::SelectAfterReload,
+    },
+};
+
+pub(super) enum RubOperationDisplay {
+    Supported(&'static str),
+    NotSupported(#[expect(dead_code)] &'static str, RubOperationDiscriminants),
+}
+
+pub(super) fn rub_operation_display(source: &CliId, target: &CliId) -> Option<RubOperationDisplay> {
+    if source == target {
+        return Some(RubOperationDisplay::Supported("noop"));
+    }
+
+    let operation = route_operation(source, target)?;
+    let discriminant = RubOperationDiscriminants::from(&operation);
+    Some(match operation {
+        RubOperation::UnassignUncommitted(..) => {
+            RubOperationDisplay::NotSupported("unassign hunks", discriminant)
+        }
+        RubOperation::UncommittedToCommit(..) => RubOperationDisplay::Supported("amend"),
+        RubOperation::UncommittedToBranch(..) => {
+            RubOperationDisplay::NotSupported("assign hunks", discriminant)
+        }
+        RubOperation::UncommittedToStack(..) => {
+            RubOperationDisplay::NotSupported("assign hunks", discriminant)
+        }
+        RubOperation::StackToUnassigned(..) => {
+            RubOperationDisplay::NotSupported("unassign hunks", discriminant)
+        }
+        RubOperation::StackToStack { .. } => {
+            RubOperationDisplay::NotSupported("reassign hunks", discriminant)
+        }
+        RubOperation::StackToBranch { .. } => {
+            RubOperationDisplay::NotSupported("reassign hunks", discriminant)
+        }
+        RubOperation::UnassignedToCommit(..) => RubOperationDisplay::Supported("amend"),
+        RubOperation::UnassignedToBranch(..) => {
+            RubOperationDisplay::NotSupported("assign hunks", discriminant)
+        }
+        RubOperation::UnassignedToStack(..) => {
+            RubOperationDisplay::NotSupported("assign hunks", discriminant)
+        }
+        RubOperation::UndoCommit(..) => {
+            RubOperationDisplay::NotSupported("undo commit", discriminant)
+        }
+        RubOperation::SquashCommits { .. } => {
+            RubOperationDisplay::NotSupported("squash", discriminant)
+        }
+        RubOperation::MoveCommitToBranch(..) => RubOperationDisplay::Supported("move commit"),
+        RubOperation::BranchToUnassigned(..) => {
+            RubOperationDisplay::NotSupported("unassign hunks", discriminant)
+        }
+        RubOperation::BranchToStack { .. } => {
+            RubOperationDisplay::NotSupported("reassign hunks", discriminant)
+        }
+        RubOperation::BranchToCommit(..) => {
+            let source_stack_id = match source {
+                CliId::Branch { stack_id, .. } => stack_id,
+                _ => unreachable!("BranchToCommit operation requires branch source"),
+            };
+
+            if source_stack_id.is_none() {
+                RubOperationDisplay::NotSupported("amend", discriminant)
+            } else {
+                RubOperationDisplay::Supported("amend")
+            }
+        }
+        RubOperation::BranchToBranch { .. } => {
+            RubOperationDisplay::NotSupported("reassign hunks", discriminant)
+        }
+        RubOperation::CommittedFileToBranch(..) => {
+            let target_stack_id = match target {
+                CliId::Branch { stack_id, .. } => stack_id,
+                _ => unreachable!("CommittedFileToBranch operation requires branch target"),
+            };
+
+            if target_stack_id.is_none() {
+                RubOperationDisplay::NotSupported("uncommit file", discriminant)
+            } else {
+                RubOperationDisplay::Supported("uncommit file")
+            }
+        }
+        RubOperation::CommittedFileToCommit(..) => RubOperationDisplay::Supported("move file"),
+        RubOperation::CommittedFileToUnassigned(..) => {
+            RubOperationDisplay::Supported("uncommit file")
+        }
+    })
+}
+
+#[expect(unused_variables)]
+pub(super) fn perform_operation(
+    ctx: &mut Context,
+    operation: &RubOperation<'_>,
+) -> anyhow::Result<Option<SelectAfterReload>> {
+    match operation {
+        RubOperation::UnassignUncommitted(hunk_assignments, _) => {
+            // unassign selected hunks.
+            Ok(None)
+        }
+        RubOperation::UncommittedToCommit(hunk_assignments, _, oid) => {
+            // Amend selected uncommitted hunks into the target commit.
+            let changes = hunk_assignments
+                .iter()
+                .copied()
+                .cloned()
+                .map(DiffSpec::from)
+                .collect::<Vec<_>>();
+            let results = but_api::commit::commit_amend(ctx, *oid, changes)?;
+
+            Ok(Some(
+                results
+                    .new_commit
+                    .map(SelectAfterReload::Commit)
+                    .unwrap_or(SelectAfterReload::Unassigned),
+            ))
+        }
+        RubOperation::UncommittedToBranch(non_empty, _, _) => {
+            // assign selected hunks to branch.
+            Ok(None)
+        }
+        RubOperation::UncommittedToStack(non_empty, _, id) => {
+            // assign selected hunks to stack.
+            Ok(None)
+        }
+        RubOperation::StackToUnassigned(id) => {
+            // move all assignments from stack to unassigned.
+            Ok(None)
+        }
+        RubOperation::StackToStack { from, to } => {
+            // move all assignments between stacks.
+            Ok(None)
+        }
+        RubOperation::StackToBranch { from, to } => {
+            // move all assignments from stack to branch.
+            Ok(None)
+        }
+        RubOperation::UnassignedToCommit(oid) => {
+            // Amend all currently unassigned hunks into the target commit.
+            let changes = {
+                let context_lines = ctx.settings.context_lines;
+                let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+                let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
+                let (assignments, _assignments_error) =
+                    but_hunk_assignment::assignments_with_fallback(
+                        db.hunk_assignments_mut()?,
+                        &repo,
+                        &ws,
+                        false,
+                        Some(changes),
+                        None,
+                        context_lines,
+                    )?;
+
+                assignments
+                    .into_iter()
+                    .filter(|assignment| assignment.stack_id.is_none())
+                    .map(DiffSpec::from)
+                    .collect::<Vec<_>>()
+            };
+
+            let results = but_api::commit::commit_amend(ctx, *oid, changes)?;
+
+            Ok(Some(
+                results
+                    .new_commit
+                    .map(SelectAfterReload::Commit)
+                    .unwrap_or(SelectAfterReload::Unassigned),
+            ))
+        }
+        RubOperation::UnassignedToBranch(_) => {
+            // assign unassigned changes to branch.
+            Ok(None)
+        }
+        RubOperation::UnassignedToStack(id) => {
+            // assign unassigned changes to stack.
+            Ok(None)
+        }
+        RubOperation::UndoCommit(oid) => {
+            // undo commit.
+            Ok(None)
+        }
+        RubOperation::SquashCommits {
+            source,
+            destination,
+        } => {
+            // squash source into destination.
+            Ok(None)
+        }
+        RubOperation::MoveCommitToBranch(oid, branch_name) => {
+            // Move the selected commit to become the first commit on the target branch.
+            let target_full_name = FullName::try_from(format!("refs/heads/{branch_name}"))?;
+            but_api::commit::commit_move(
+                ctx,
+                *oid,
+                RelativeTo::Reference(target_full_name),
+                InsertSide::Below,
+            )?;
+
+            Ok(Some(SelectAfterReload::Branch(branch_name.to_string())))
+        }
+        RubOperation::BranchToUnassigned(_) => {
+            // move all assignments from branch to unassigned.
+            Ok(None)
+        }
+        RubOperation::BranchToStack { from, to } => {
+            // move all assignments from branch to stack.
+            Ok(None)
+        }
+        RubOperation::BranchToCommit(branch_name, oid) => {
+            // Amend hunks assigned to the given branch into the target commit.
+            let changes = {
+                let context_lines = ctx.settings.context_lines;
+                let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+                let target_branch_full_name =
+                    FullName::try_from(format!("refs/heads/{branch_name}"))?;
+                let stack_id = ws
+                    .find_segment_and_stack_by_refname(target_branch_full_name.as_ref())
+                    .and_then(|(stack, _segment)| stack.id);
+                let Some(stack_id) = stack_id else {
+                    return Ok(None);
+                };
+
+                let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
+                let (assignments, _assignments_error) =
+                    but_hunk_assignment::assignments_with_fallback(
+                        db.hunk_assignments_mut()?,
+                        &repo,
+                        &ws,
+                        false,
+                        Some(changes),
+                        None,
+                        context_lines,
+                    )?;
+
+                assignments
+                    .into_iter()
+                    .filter(|assignment| assignment.stack_id.as_ref() == Some(&stack_id))
+                    .map(DiffSpec::from)
+                    .collect::<Vec<_>>()
+            };
+
+            let results = but_api::commit::commit_amend(ctx, *oid, changes)?;
+
+            Ok(Some(
+                results
+                    .new_commit
+                    .map(SelectAfterReload::Commit)
+                    .unwrap_or(SelectAfterReload::Branch(branch_name.to_string())),
+            ))
+        }
+        RubOperation::BranchToBranch { from, to } => {
+            // move all assignments between branches.
+            Ok(None)
+        }
+        RubOperation::CommittedFileToBranch(path, commit, branch_name) => {
+            // Uncommit file changes from a commit and assign them to the target branch.
+            let (relevant_changes, stack_id) = {
+                let repo = ctx.repo.get()?;
+                let (_guard, _repo, ws, _) = ctx.workspace_and_db()?;
+                let target_branch_full_name =
+                    FullName::try_from(format!("refs/heads/{branch_name}"))?;
+                let stack_id = ws
+                    .find_segment_and_stack_by_refname(target_branch_full_name.as_ref())
+                    .and_then(|(stack, _segment)| stack.id);
+                let Some(stack_id) = stack_id else {
+                    return Ok(None);
+                };
+
+                let source_commit = repo.find_commit(*commit)?;
+                let source_commit_parent_id =
+                    source_commit.parent_ids().next().context("no parents")?;
+
+                let tree_changes =
+                    tree_changes(&repo, Some(source_commit_parent_id.detach()), *commit)?;
+                let relevant_changes = tree_changes
+                    .into_iter()
+                    .filter(|tc| tc.path == *path)
+                    .map(DiffSpec::from)
+                    .collect::<Vec<_>>();
+
+                (relevant_changes, stack_id)
+            };
+
+            but_api::commit::commit_uncommit_changes(
+                ctx,
+                *commit,
+                relevant_changes,
+                Some(stack_id),
+            )?;
+
+            Ok(Some(SelectAfterReload::Branch(branch_name.to_string())))
+        }
+        RubOperation::CommittedFileToCommit(path, source_commit, destination_commit) => {
+            // Move file changes from one commit into another commit.
+            let relevant_changes = {
+                let repo = ctx.repo.get()?;
+                let source = repo.find_commit(*source_commit)?;
+                let source_parent_id = source.parent_ids().next().context("no parents")?;
+
+                let tree_changes =
+                    tree_changes(&repo, Some(source_parent_id.detach()), *source_commit)?;
+                tree_changes
+                    .into_iter()
+                    .filter(|tc| tc.path == *path)
+                    .map(DiffSpec::from)
+                    .collect::<Vec<_>>()
+            };
+
+            let result = but_api::commit::commit_move_changes_between(
+                ctx,
+                *source_commit,
+                *destination_commit,
+                relevant_changes,
+            )?;
+            let destination_to_select = result
+                .replaced_commits
+                .get(destination_commit)
+                .copied()
+                .unwrap_or(*destination_commit);
+
+            Ok(Some(SelectAfterReload::Commit(destination_to_select)))
+        }
+        RubOperation::CommittedFileToUnassigned(path, oid) => {
+            // Uncommit file changes from a commit into the unassigned area.
+            let relevant_changes = {
+                let repo = ctx.repo.get()?;
+                let source_commit = repo.find_commit(*oid)?;
+                let source_commit_parent_id =
+                    source_commit.parent_ids().next().context("no parents")?;
+
+                let tree_changes =
+                    tree_changes(&repo, Some(source_commit_parent_id.detach()), *oid)?;
+                tree_changes
+                    .into_iter()
+                    .filter(|tc| tc.path == *path)
+                    .map(DiffSpec::from)
+                    .collect::<Vec<_>>()
+            };
+
+            but_api::commit::commit_uncommit_changes(ctx, *oid, relevant_changes, None)?;
+
+            Ok(Some(SelectAfterReload::Unassigned))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct OperationNotSupported(RubOperationDiscriminants);
+
+impl OperationNotSupported {
+    pub(super) fn new(operation: &RubOperation<'_>) -> Self {
+        OperationNotSupported(RubOperationDiscriminants::from(operation))
+    }
+}
+
+impl std::fmt::Display for OperationNotSupported {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?} is not supported", self.0)
+    }
+}
+
+impl std::error::Error for OperationNotSupported {}
+
+#[cfg(test)]
+mod tests {
+    use bstr::BString;
+
+    use super::{RubOperationDisplay, rub_operation_display};
+    use crate::CliId;
+
+    /// Converts a hex object id into `gix::ObjectId` for test setup.
+    fn commit_id(hex: &str) -> gix::ObjectId {
+        gix::ObjectId::from_hex(hex.as_bytes()).unwrap()
+    }
+
+    #[test]
+    fn branch_to_commit_is_not_supported_when_source_branch_has_no_stack() {
+        let source = CliId::Branch {
+            name: "main".into(),
+            id: "b0".into(),
+            stack_id: None,
+        };
+        let target = CliId::Commit {
+            commit_id: commit_id("1111111111111111111111111111111111111111"),
+            id: "c0".into(),
+        };
+
+        assert!(matches!(
+            rub_operation_display(&source, &target),
+            Some(RubOperationDisplay::NotSupported(_, _))
+        ));
+    }
+
+    #[test]
+    fn committed_file_to_branch_is_not_supported_when_target_branch_has_no_stack() {
+        let source = CliId::CommittedFile {
+            commit_id: commit_id("1111111111111111111111111111111111111111"),
+            path: BString::from("file.txt"),
+            id: "f0".into(),
+        };
+        let target = CliId::Branch {
+            name: "main".into(),
+            id: "b0".into(),
+            stack_id: None,
+        };
+
+        assert!(matches!(
+            rub_operation_display(&source, &target),
+            Some(RubOperationDisplay::NotSupported(_, _))
+        ));
+    }
+}

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -164,7 +164,7 @@ fn esc_leaves_rub_mode() {
         .assert_current_line_eq(str!["┊   vo A test.txt"]);
 
     tui.input_then_render('r')
-        .assert_current_line_eq(str!["┊   << source >> << no operation >> vo A test.txt"]);
+        .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
 
     tui.input_then_render(KeyCode::Esc)
         .assert_current_line_eq(str!["┊   vo A test.txt"]);
@@ -200,7 +200,7 @@ fn rubbing() {
         .assert_current_line_eq(str!["┊   vo A test.txt"]);
 
     tui.input_then_render('r')
-        .assert_current_line_eq(str!["┊   << source >> << no operation >> vo A test.txt"]);
+        .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
 
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄<< assign hunks >> g0 [A]"]);


### PR DESCRIPTION
Adds an experimental re-implementation of rub, for the TUI only, based on but-api primitives.

Pressing shift+r uses this alternate rub implementation.

---

These are the operations currently supported:

- `RubOperation::UncommittedToCommit` — amend selected uncommitted hunks into the target commit
- `RubOperation::UnassignedToCommit` — amend all currently unassigned hunks into the target commit
- `RubOperation::MoveCommitToBranch` — move the selected commit to become the first commit on the target branch
- `RubOperation::BranchToCommit` — amend hunks assigned to the given branch into the target commit
- `RubOperation::CommittedFileToBranch` — uncommit file changes from a commit and assign them to the target branch
- `RubOperation::CommittedFileToCommit` — move file changes from one commit into another commit
- `RubOperation::CommittedFileToUnassigned` — uncommit file changes from a commit into the unassigned area

These are the operations that don’t seem to be supported yet:

1. Hunk assignment / reassignment operations
  - `RubOperation::UnassignUncommitted` — unassign selected hunks
  - `RubOperation::UncommittedToBranch` — assign selected hunks to branch
  - `RubOperation::UncommittedToStack` — assign selected hunks to stack
  - `RubOperation::StackToUnassigned` — move all assignments from stack to unassigned
  - `RubOperation::StackToStack` — move all assignments between stacks
  - `RubOperation::StackToBranch` — move all assignments from stack to branch
  - `RubOperation::UnassignedToBranch` — assign unassigned changes to branch
  - `RubOperation::UnassignedToStack` — assign unassigned changes to stack
  - `RubOperation::BranchToUnassigned` — move all assignments from branch to unassigned
  - `RubOperation::BranchToStack` — move all assignments from branch to stack
  - `RubOperation::BranchToBranch` — move all assignments between branches
2. Commit-history operations
  - `RubOperation::UndoCommit` — remove all changes introduced by the selected commit from that commit, turning them back into worktree changes (i.e. “uncommit” it).
  - `RubOperation::SquashCommits` — take all changes from the source commit and fold them into the destination commit, effectively combining them into one logical commit.



<!-- jj-sync-prs: e39f85cc-4589-41f7-9bae-d491c1ee2eda -->
---
> [!NOTE]
> This pull request is part of a stack:
> - [feat(tui): try rebuilding rub from but-api primitives](https://github.com/gitbutlerapp/gitbutler/pull/12871) 👈 you are here
>   - [test(tui): tests for rubbing with but-api](https://github.com/gitbutlerapp/gitbutler/pull/12894)
>     - [chore(tui): clean up large Message type](https://github.com/gitbutlerapp/gitbutler/pull/12903)
>       - [fix(tui): trim key binds in hot bar](https://github.com/gitbutlerapp/gitbutler/pull/12904)
>         - [feat(tui): committing](https://github.com/gitbutlerapp/gitbutler/pull/12905)
>
>
