### PR TITLE
fix(tui): fix inline reword opening editor opening for commits made with `git commit`

### DIFF
--- a/crates/but/src/command/legacy/commit_message_prep.rs
+++ b/crates/but/src/command/legacy/commit_message_prep.rs
@@ -1,0 +1,61 @@
+use anyhow::{Result, bail};
+
+/// Returns the canonical commit message representation used for comparisons and storage.
+///
+/// This currently trims leading and trailing whitespace.
+pub(crate) fn normalize_commit_message(message: &str) -> &str {
+    message.trim()
+}
+
+/// Returns `true` if `current_message` and `new_message` differ after normalization.
+pub(crate) fn should_update_commit_message(current_message: &str, new_message: &str) -> bool {
+    normalize_commit_message(current_message) != normalize_commit_message(new_message)
+}
+
+/// Prepares a commit message provided directly by the user.
+///
+/// The message is normalized and then validated to be non-empty.
+pub(crate) fn prepare_provided_commit_message(message: &str) -> Result<String> {
+    let normalized = normalize_commit_message(message);
+    if normalized.is_empty() {
+        bail!("Aborting due to empty commit message");
+    }
+    Ok(normalized.to_string())
+}
+
+/// Returns `true` if a commit message should be treated as multi-line for inline rewording.
+///
+/// Trailing whitespace and trailing newlines are ignored so that messages like `"subject\n"`
+/// are still treated as single-line.
+pub(crate) fn commit_message_has_multiple_lines(message: &str) -> bool {
+    message.trim_end().split_once('\n').is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_trims_whitespace() {
+        assert_eq!(normalize_commit_message("  hello\n"), "hello");
+    }
+
+    #[test]
+    fn prepare_provided_commit_message_rejects_empty_after_trim() {
+        let err = prepare_provided_commit_message(" \n\t ")
+            .expect_err("whitespace-only messages must fail");
+        assert_eq!(err.to_string(), "Aborting due to empty commit message");
+    }
+
+    #[test]
+    fn should_update_commit_message_uses_normalized_values() {
+        assert!(!should_update_commit_message("subject", "  subject\n"));
+        assert!(should_update_commit_message("subject", "subject\n\nbody"));
+    }
+
+    #[test]
+    fn commit_message_has_multiple_lines_ignores_trailing_newline() {
+        assert!(!commit_message_has_multiple_lines("subject\n"));
+        assert!(commit_message_has_multiple_lines("subject\n\nbody"));
+    }
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -9,6 +9,7 @@ pub mod actions;
 pub mod ai;
 pub mod branch;
 pub mod commit;
+pub mod commit_message_prep;
 pub mod diff;
 pub mod discard;
 pub mod forge;

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -4,7 +4,13 @@ use but_api::diff::ComputeLineStats;
 use but_ctx::Context;
 use gix::prelude::ObjectIdExt;
 
-use super::{ShowDiffInEditor, estimate_diff_blob_size};
+use super::{
+    ShowDiffInEditor,
+    commit_message_prep::{
+        normalize_commit_message, prepare_provided_commit_message, should_update_commit_message,
+    },
+    estimate_diff_blob_size,
+};
 use crate::{CliId, IdMap, tui, utils::OutputChannel};
 
 pub(crate) fn reword_target(
@@ -136,10 +142,10 @@ pub(crate) fn get_commit_message_from_editor(
     let new_message =
         actually_get_commit_message_from_editor(&current_message, &changed_files, diff.as_deref())?;
 
-    if new_message.trim() == current_message.trim() {
-        Ok(None)
+    if should_update_commit_message(&current_message, &new_message) {
+        Ok(Some(normalize_commit_message(&new_message).to_owned()))
     } else {
-        Ok(Some(new_message.trim().to_owned()))
+        Ok(None)
     }
 }
 
@@ -164,8 +170,8 @@ fn edit_commit_message_by_id_and_reword_commit(
         Some(but_action::commit_format::format_commit_message(
             &current_message,
         ))
-    } else if let Some(message) = prepare_provided_message(message, "commit message") {
-        Some(message?)
+    } else if let Some(message) = message {
+        Some(prepare_provided_commit_message(message)?)
     } else {
         get_commit_message_from_editor(
             ctx,
@@ -174,7 +180,7 @@ fn edit_commit_message_by_id_and_reword_commit(
             show_diff_in_editor,
         )?
     }
-    .filter(|new_message| new_message.trim() != current_message.trim());
+    .filter(|new_message| should_update_commit_message(&current_message, new_message));
 
     if let Some(new_message) = new_message {
         let new_commit_oid =

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -27,6 +27,10 @@ use crate::{
     args::OutputFormat,
     command::legacy::{
         ShowDiffInEditor,
+        commit_message_prep::{
+            commit_message_has_multiple_lines, normalize_commit_message,
+            should_update_commit_message,
+        },
         reword::get_commit_message_from_editor,
         rub::{RubOperation, route_operation},
         status::{
@@ -432,7 +436,7 @@ impl App {
             return Ok(());
         };
 
-        if new_message == current_message {
+        if !should_update_commit_message(&current_message, &new_message) {
             return Ok(());
         }
 
@@ -463,7 +467,7 @@ impl App {
         let commit_details = but_api::diff::commit_details(ctx, commit_id, ComputeLineStats::No)?;
         let current_message = commit_details.commit.inner.message.to_string();
 
-        if current_message.split_once('\n').is_some() {
+        if commit_message_has_multiple_lines(&current_message) {
             messages.push(Message::RewordWithEditor);
             return Ok(());
         }
@@ -510,9 +514,9 @@ impl App {
             .first()
             .map(std::string::String::as_str)
             .unwrap_or("");
-        let new_message = new_subject.to_string();
+        let new_message = normalize_commit_message(new_subject).to_string();
 
-        if new_message == current_message {
+        if !should_update_commit_message(&current_message, &new_message) {
             messages.push(Message::EnterNormalMode);
             return Ok(());
         }


### PR DESCRIPTION
Apparently `git commit -m "foo"` inserts a trailing newline which made the TUI think it was multi line commit message.