### PR TITLE
Add Windows support for CLI updates via npm

### DIFF
--- a/crates/but/src/args/update.rs
+++ b/crates/but/src/args/update.rs
@@ -19,7 +19,7 @@ pub enum Subcommands {
         days: u32,
     },
 
-    /// Install or update the GitButler desktop application.
+    /// Install or update the GitButler CLI.
     ///
     /// By default, auto-detects your current channel (release/nightly) and installs the latest
     /// version for that channel.
@@ -29,8 +29,10 @@ pub enum Subcommands {
     ///
     /// Linux: Installs and updates only the CLI itself.
     ///
+    /// Windows: If installed via npm, performs the update through npm. Otherwise, provides
+    /// download instructions.
+    ///
     /// Note: For other platforms and install forms, see <https://gitbutler.com/downloads>
-    #[cfg(unix)]
     Install {
         /// What to install: "nightly", "release", or a version like "0.18.7"
         ///

--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -15,7 +15,6 @@ pub fn handle(
     match cmd {
         update::Subcommands::Check => check_for_updates(out, app_settings),
         update::Subcommands::Suppress { days } => suppress_updates(out, days),
-        #[cfg(unix)]
         update::Subcommands::Install { target } => install(out, target),
     }
 }
@@ -109,7 +108,6 @@ fn suppress_updates(out: &mut OutputChannel, days: u32) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
     // Installation requires interactive output and cannot be used with JSON mode
     // because the installer writes directly to stdout/stderr
@@ -122,6 +120,23 @@ fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
         );
     }
 
+    #[cfg(unix)]
+    {
+        install_unix(out, target)
+    }
+    #[cfg(windows)]
+    {
+        install_windows(out, target)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (out, target);
+        anyhow::bail!("Update installation is not supported on this platform.\nPlease visit https://gitbutler.com/downloads")
+    }
+}
+
+#[cfg(unix)]
+fn install_unix(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
     // Parse target to determine what to install
     let version_request = match target.as_deref() {
         Some("nightly") => VersionRequest::Nightly,
@@ -161,6 +176,186 @@ fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
         writeln!(writer)?;
     }
 
+    invalidate_update_cache(out);
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn install_windows(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
+    let exe_path = std::env::current_exe()?;
+
+    // Detect if installed via npm by checking if the executable is under a node_modules directory.
+    if let Some(npm_pkg_name) = detect_npm_package(&exe_path) {
+        return install_via_npm(out, &npm_pkg_name, target);
+    }
+
+    // Not an npm installation - provide download instructions
+    if let Some(writer) = out.for_human() {
+        writeln!(
+            writer,
+            "{} Automatic updates are not yet supported for this installation type on Windows.",
+            "→".yellow().bold()
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "Please download the latest version from: {}",
+            "https://gitbutler.com/downloads".cyan()
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Detect if the executable is installed via npm and return the package name.
+///
+/// npm global installations on Windows place executables at paths like:
+///   `C:\Users\<user>\AppData\Roaming\npm\node_modules\<package>\...`
+/// or shims at:
+///   `C:\Users\<user>\AppData\Roaming\npm\<name>.cmd`
+///
+/// We look for `node_modules` in the path to find the package name.
+#[cfg(windows)]
+fn detect_npm_package(exe_path: &std::path::Path) -> Option<String> {
+    let components: Vec<_> = exe_path.components().collect();
+
+    for (i, component) in components.iter().enumerate() {
+        if let std::path::Component::Normal(name) = component {
+            if name.to_string_lossy() == "node_modules" {
+                // The next component should be the package name (or scope)
+                if let Some(std::path::Component::Normal(pkg)) = components.get(i + 1) {
+                    let pkg_name = pkg.to_string_lossy().to_string();
+                    if pkg_name.starts_with('@') {
+                        // Scoped package: @scope/name
+                        if let Some(std::path::Component::Normal(name)) = components.get(i + 2) {
+                            return Some(format!("{}/{}", pkg_name, name.to_string_lossy()));
+                        }
+                    }
+                    return Some(pkg_name);
+                }
+            }
+        }
+    }
+
+    // Also check for npm shim pattern: <npm_dir>/<name>.cmd alongside <npm_dir>/node_modules/<name>
+    if let Some(parent) = exe_path.parent() {
+        let node_modules = parent.join("node_modules");
+        if node_modules.is_dir() {
+            // Check if we look like an npm shim (e.g., but.cmd, but.exe next to node_modules/)
+            if let Some(stem) = exe_path.file_stem() {
+                let candidate = node_modules.join(stem.to_string_lossy().as_ref());
+                if candidate.is_dir() {
+                    return Some(stem.to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    // Check the `npm_package_name` env var as a fallback (set during npm lifecycle scripts)
+    std::env::var("npm_package_name").ok().filter(|s| !s.is_empty())
+}
+
+/// Perform an npm-based update by spawning a detached process.
+///
+/// On Windows, the EBUSY error occurs because npm cannot rename the package directory
+/// while the current process (running from that directory) is still active. The solution
+/// is to spawn a detached updater script and immediately exit, allowing npm to proceed
+/// without file locks.
+#[cfg(windows)]
+fn install_via_npm(
+    out: &mut OutputChannel,
+    npm_pkg_name: &str,
+    target: Option<String>,
+) -> Result<()> {
+    let version_suffix = match target.as_deref() {
+        Some(version) => format!("@{version}"),
+        None => "@latest".to_string(),
+    };
+
+    let install_spec = format!("{npm_pkg_name}{version_suffix}");
+
+    if let Some(writer) = out.for_human() {
+        writeln!(
+            writer,
+            "{} Detected npm installation (package: {})",
+            "→".cyan().bold(),
+            npm_pkg_name.bold()
+        )?;
+        writeln!(
+            writer,
+            "{} Spawning background updater to avoid EBUSY file lock errors...",
+            "→".cyan().bold(),
+        )?;
+    }
+
+    // Create a temporary batch script that:
+    // 1. Waits for this process to exit (via a short delay)
+    // 2. Runs npm install -g <package>
+    // 3. Reports the result
+    let temp_dir = std::env::temp_dir();
+    let script_path = temp_dir.join("but-update.cmd");
+    let log_path = temp_dir.join("but-update.log");
+
+    let script_content = format!(
+        "@echo off\r\n\
+         echo Waiting for the CLI process to exit...\r\n\
+         timeout /t 3 /nobreak >nul 2>&1\r\n\
+         echo Updating {install_spec}...\r\n\
+         npm install -g {install_spec} > \"{log}\" 2>&1\r\n\
+         if %errorlevel% equ 0 (\r\n\
+             echo.\r\n\
+             echo Update completed successfully.\r\n\
+         ) else (\r\n\
+             echo.\r\n\
+             echo Update failed. Check the log at: {log}\r\n\
+             echo You can also try updating manually:\r\n\
+             echo   1. Close all terminals running 'but'\r\n\
+             echo   2. Run: npm install -g {install_spec}\r\n\
+         )\r\n\
+         pause\r\n",
+        log = log_path.display(),
+    );
+
+    std::fs::write(&script_path, &script_content)?;
+
+    // Spawn the script in a new, visible console window so the user can see progress.
+    // The CREATE_NEW_CONSOLE flag ensures the script runs independently.
+    use std::os::windows::process::CommandExt;
+    const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+
+    std::process::Command::new("cmd.exe")
+        .args(["/c", "start", "\"GitButler Update\"", "/wait"])
+        .arg(&script_path)
+        .creation_flags(CREATE_NEW_CONSOLE)
+        .spawn()?;
+
+    if let Some(writer) = out.for_human() {
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{} Update is running in a separate window.",
+            "✓".green().bold()
+        )?;
+        writeln!(
+            writer,
+            "  The update log will be saved to: {}",
+            log_path.display()
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "  If the update fails, close all terminals running 'but' and run:"
+        )?;
+        writeln!(writer, "    npm install -g {install_spec}")?;
+    }
+
+    invalidate_update_cache(out);
+
+    Ok(())
+}
+
+fn invalidate_update_cache(out: &mut OutputChannel) {
     let mut cache = but_ctx::Context::app_cache();
     if let Err(err) = cache.update_check_mut().and_then(|handle| handle.delete()) {
         tracing::warn!(?err, "Failed to invalidate update check cache");
@@ -168,9 +363,8 @@ fn install(out: &mut OutputChannel, target: Option<String>) -> Result<()> {
             writeln!(
                 writer,
                 "Failed to invalidate update check cache - skipping invalidation: {err:?}",
-            )?;
+            )
+            .ok();
         }
     }
-
-    Ok(())
 }


### PR DESCRIPTION
## 🧢 Changes

- Removed `#[cfg(unix)]` guards from the `install` command to enable it on all platforms
- Refactored `install()` function to dispatch to platform-specific implementations:
  - `install_unix()`: Handles Linux/macOS installations (existing logic)
  - `install_windows()`: New Windows-specific handler with npm detection
- Added `detect_npm_package()` to identify npm-based installations on Windows by checking for `node_modules` in the executable path or the `npm_package_name` environment variable
- Added `install_via_npm()` to perform npm updates on Windows by spawning a detached batch script that waits for the current process to exit before running `npm install -g`, avoiding EBUSY file lock errors
- Added `invalidate_update_cache()` helper function to reduce code duplication
- Updated command documentation to reflect Windows npm support and clarify that the command updates the CLI (not the desktop app)

## ☕️ Reasoning

Previously, the `install` command was only available on Unix platforms. This change extends update support to Windows users with npm-based installations.

On Windows, npm cannot rename package directories while the current process (running from that directory) holds file locks. The solution spawns a detached updater script that waits for the CLI process to exit before proceeding with the npm update, eliminating the EBUSY error.

For non-npm Windows installations, the command provides helpful download instructions pointing users to the official downloads page.

The refactoring improves maintainability by separating platform-specific logic into dedicated functions and extracting the cache invalidation logic into a reusable helper.

https://claude.ai/code/session_01TBAMrb7RTK9884TPorXCTP

<!-- gk-ai-analysis-start:c17c7d6960fcf4f3ab6bf5f10fd95a0816f41030 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBjcm9zcy1wbGF0Zm9ybSBDTEkgdXBkYXRlIHN1cHBvcnQgYnkgcmVmYWN0b3JpbmcgdGhlIGluc3RhbGwgY29tbWFuZCBhbmQgaW50cm9kdWNpbmcgYSBXaW5kb3dzLXNwZWNpZmljIGltcGxlbWVudGF0aW9uIHRoYXQgdXBkYXRlcyB2aWEgbnBtIHVzaW5nIGEgZGV0YWNoZWQgc2NyaXB0LiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IkVuYWJsZWQgaW5zdGFsbCBjb21tYW5kIG9uIFdpbmRvd3MiLCJkZXNjcmlwdGlvbiI6IlJlbW92ZWQgdGhlIGAjW2NmZyh1bml4KV1gIGd1YXJkIGZyb20gdGhlIGBJbnN0YWxsYCBzdWJjb21tYW5kIGluIGFyZ3VtZW50IHBhcnNpbmcgdG8gYWxsb3cgQ0xJIHVwZGF0ZXMgdG8gYmUgdHJpZ2dlcmVkIG9uIGFsbCBzdXBwb3J0ZWQgcGxhdGZvcm1zLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJjcmF0ZXMvYnV0L3NyYy9hcmdzL3VwZGF0ZS5ycyIsImxpbmVTdGFydCI6MzJ9LHsidGl0bGUiOiJQbGF0Zm9ybS1zcGVjaWZpYyBkaXNwYXRjaCByZWZhY3RvciIsImRlc2NyaXB0aW9uIjoiVGhlIGBpbnN0YWxsKClgIGNvbW1hbmQgbm93IGFjdHMgYXMgYSBkaXNwYXRjaGVyLCBjYWxsaW5nIGNvbmRpdGlvbmFsbHkgY29tcGlsZWQgYGluc3RhbGxfdW5peCgpYCBvciBgaW5zdGFsbF93aW5kb3dzKClgIGZ1bmN0aW9ucyBkZXBlbmRpbmcgb24gdGhlIHRhcmdldCBPUywgYW5kIHJlamVjdGluZyB1bnN1cHBvcnRlZCBwbGF0Zm9ybXMgZ3JhY2VmdWxseS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiY3JhdGVzL2J1dC9zcmMvY29tbWFuZC91cGRhdGUucnMiLCJsaW5lU3RhcnQiOjEyMH0seyJ0aXRsZSI6IkhldXJpc3RpYyBucG0gZGV0ZWN0aW9uIGZvciBXaW5kb3dzIiwiZGVzY3JpcHRpb24iOiJBZGRlZCBgZGV0ZWN0X25wbV9wYWNrYWdlKClgIHdoaWNoIHBhcnNlcyB0aGUgZXhlY3V0YWJsZSBwYXRoIHRvIGZpbmQgYSBgbm9kZV9tb2R1bGVzYCBjb21wb25lbnQuIElmIGZvdW5kLCBpdCBjb3JyZWN0bHkgaGFuZGxlcyBib3RoIHNjb3BlZCAoZS5nLiwgYEBzY29wZS9uYW1lYCkgYW5kIHVuc2NvcGVkIHBhY2thZ2UgbmFtZXMgdG8gZGV0ZXJtaW5lIGlmIGl0IHdhcyBpbnN0YWxsZWQgZ2xvYmFsbHkgdmlhIG5wbS4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiY3JhdGVzL2J1dC9zcmMvY29tbWFuZC91cGRhdGUucnMiLCJsaW5lU3RhcnQiOjIxNn0seyJ0aXRsZSI6IkdyYWNlZnVsIGZhbGxiYWNrIGZvciBub24tbnBtIFdpbmRvd3MgaW5zdGFsbGF0aW9ucyIsImRlc2NyaXB0aW9uIjoiSWYgYGluc3RhbGxfd2luZG93c2AgY2Fubm90IGRldGVjdCBhbiBucG0gZW52aXJvbm1lbnQsIGl0IGZhbGxzIGJhY2sgdG8gcHJpbnRpbmcgaW50ZXJhY3RpdmUgZG93bmxvYWQgaW5zdHJ1Y3Rpb25zIGZvciB0aGUgdXNlciByYXRoZXIgdGhhbiBmYWlsaW5nIG91dHJpZ2h0LiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJjcmF0ZXMvYnV0L3NyYy9jb21tYW5kL3VwZGF0ZS5ycyIsImxpbmVTdGFydCI6MTkwfSx7InRpdGxlIjoiRXh0cmFjdGVkIGNhY2hlIGludmFsaWRhdGlvbiBsb2dpYyIsImRlc2NyaXB0aW9uIjoiVGhlIHBvc3QtdXBkYXRlIGNhY2hlIGludmFsaWRhdGlvbiBsb2dpYyB3YXMgcmVmYWN0b3JlZCBvdXQgb2YgdGhlIG1haW4gaW5zdGFsbCBmdW5jdGlvbiBhbmQgaW50byBhIHJldXNhYmxlIGBpbnZhbGlkYXRlX3VwZGF0ZV9jYWNoZSgpYCBoZWxwZXIuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6ImNyYXRlcy9idXQvc3JjL2NvbW1hbmQvdXBkYXRlLnJzIiwibGluZVN0YXJ0IjoxNzl9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOlt7InRpdGxlIjoiT3B0aW1pemUgcGF0aCBjb21wb25lbnQgY29tcGFyaXNvbiB1c2luZyBPc1N0ciIsImRlc2NyaXB0aW9uIjoiSW4gYGRldGVjdF9ucG1fcGFja2FnZWAsIGNvbXBhcmluZyB0aGUgcGF0aCBjb21wb25lbnQgd2l0aCBgbmFtZS50b19zdHJpbmdfbG9zc3koKSA9PSBcIm5vZGVfbW9kdWxlc1wiYCBpbmN1cnMgYW4gYWxsb2NhdGlvbiBpZiB0aGUgc3RyaW5nIGNvbnRhaW5zIG5vbi1VVEY4IGNoYXJhY3RlcnMuIEl0IGlzIG1vcmUgZWZmaWNpZW50IHRvIGNvbXBhcmUgZGlyZWN0bHkgdXNpbmcgYG5hbWUgPT0gc3RkOjpmZmk6Ok9zU3RyOjpuZXcoXCJub2RlX21vZHVsZXNcIilgLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJjcmF0ZXMvYnV0L3NyYy9jb21tYW5kL3VwZGF0ZS5ycyIsImxpbmVTdGFydCI6MjIyfV0sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:c17c7d6960fcf4f3ab6bf5f10fd95a0816f41030 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/gitbutlerapp/gitbutler/pull/12877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->