### PR TITLE
Remove `VirtualBranchesHandle` from `gitbutler-edit-mode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,7 +3971,6 @@ dependencies = [
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-repo",
- "gitbutler-stack",
  "gitbutler-workspace",
  "gix",
  "insta",

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -14,7 +14,7 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 use gitbutler_reference::{LocalRefname, Refname};
-use gitbutler_stack::{StackId, VirtualBranchesHandle};
+use gitbutler_stack::StackId;
 use tracing::instrument;
 
 use crate::json::HexHash;
@@ -440,8 +440,7 @@ pub fn move_changes_between_commits(
     )?;
 
     // TODO(ctx): remove this, with the rebase engine this is done above - needs at least manual testing to be sure
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     Ok(result)
 }
@@ -471,8 +470,7 @@ pub fn split_branch(
     )?;
 
     // TODO(ctx): remove this, it's done above
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     let refname = Refname::Local(LocalRefname::new(&new_branch_name, None));
     let branch_manager = ctx.branch_manager();
@@ -516,8 +514,7 @@ pub fn split_branch_into_dependent_branch(
         guard.write_permission(),
     )?;
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     Ok(move_changes_result)
 }
@@ -574,8 +571,7 @@ pub fn uncommit_changes(
         guard.write_permission(),
     )?;
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     if let (Some(before_assignments), Some(stack_id)) = (before_assignments, assign_to) {
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
@@ -664,8 +660,7 @@ pub fn stash_into_branch(
         perm,
     );
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    gitbutler_branch_actions::update_workspace_commit(&vb_state, ctx, false)
+    gitbutler_branch_actions::update_workspace_commit(ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     branch_manager.unapply(

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -147,7 +147,7 @@ pub fn cherry_apply(
         update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
     }
 
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     Ok(())
 }

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -31,7 +31,7 @@ use but_ctx::{
 use but_meta::VirtualBranchesTomlMetadata;
 use but_rebase::Rebase;
 use but_workspace::legacy::{StacksFilter, stack_ext::StackExt, stacks_v3};
-use gitbutler_branch_actions::update_workspace_commit;
+use gitbutler_branch_actions::update_workspace_commit_with_vb_state;
 use gitbutler_stack::VirtualBranchesHandle;
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes};
 use gix::{ObjectId, Repository};
@@ -147,7 +147,7 @@ pub fn cherry_apply(
         update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
     }
 
-    update_workspace_commit(ctx, false)?;
+    update_workspace_commit_with_vb_state(&vb_state, ctx, false)?;
 
     Ok(())
 }

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -702,8 +702,7 @@ fn move_file_changes(
     )?;
 
     // TODO(ctx): remove this, with the rebase engine this is done above
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    gitbutler_branch_actions::update_workspace_commit(&vb_state, ctx, false)?;
+    gitbutler_branch_actions::update_workspace_commit(ctx, false)?;
 
     // Update the commit mapping with the new commit ids.
     for (old_commit_id, new_commit_id) in result.replaced_commits.clone().iter() {
@@ -1113,7 +1112,6 @@ pub fn split_branch(
     commit_mapping: &mut HashMap<gix::ObjectId, gix::ObjectId>,
 ) -> Result<StackId, anyhow::Error> {
     let mut guard = ctx.exclusive_worktree_access();
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
 
     let stacks = stacks(ctx)?;
     let source_stack_id = stacks
@@ -1141,7 +1139,7 @@ pub fn split_branch(
         guard.write_permission(),
     )?;
 
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     let refname = Refname::Local(LocalRefname::new(&params.new_branch_name, None));
     let branch_manager = ctx.branch_manager();

--- a/crates/but-worktrees/src/integrate.rs
+++ b/crates/but-worktrees/src/integrate.rs
@@ -77,8 +77,7 @@ pub fn worktree_integrate(
         .set_heads_from_rebase_output(ctx, status.rebase_output.references)?;
     let after = WorkspaceState::create(ctx, perm.read_permission())?;
     update_uncommitted_changes(ctx, before, after, perm)?;
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     git_worktree_remove(ctx.repo.get()?.common_dir(), id, true)?;
 

--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -3,7 +3,6 @@ use bstr::BStr;
 use but_core::{DiffSpec, diff::tree_changes};
 use but_ctx::Context;
 use gitbutler_branch_actions::update_workspace_commit;
-use gitbutler_stack::VirtualBranchesHandle;
 
 use crate::utils::OutputChannel;
 
@@ -29,8 +28,7 @@ pub fn commited_file_to_another_commit(
 
     but_api::commit::commit_move_changes_between_only(ctx, source_id, target_id, relevant_changes)?;
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Moved files between commits!")?;
@@ -67,8 +65,7 @@ pub fn uncommit_file(
 
     but_api::commit::commit_uncommit_changes_only(ctx, source_id, relevant_changes, assign_to)?;
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Uncommitted changes")?;

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -145,8 +145,7 @@ fn go_back_to_integration(ctx: &Context, default_target: &Target) -> Result<Base
     }
 
     let base = target_to_base_branch(ctx, default_target)?;
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
     Ok(base)
 }
 
@@ -263,7 +262,7 @@ pub(crate) fn set_base_branch(
 
     set_exclude_decoration(ctx)?;
 
-    update_workspace_commit(&vb_state, ctx, true)?;
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, true)?;
 
     let base = target_to_base_branch(ctx, &target)?;
     Ok(base)

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -23,7 +23,7 @@ use serde::Serialize;
 use tracing::instrument;
 
 use super::BranchManager;
-use crate::{VirtualBranchesExt, integration::update_workspace_commit};
+use crate::VirtualBranchesExt;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -91,7 +91,7 @@ impl BranchManager<'_> {
         vb_state.set_stack(branch.clone())?;
         self.ctx.add_branch_reference(&branch)?;
 
-        update_workspace_commit(&vb_state, self.ctx, false)?;
+        crate::integration::update_workspace_commit_with_vb_state(&vb_state, self.ctx, false)?;
 
         Ok(branch)
     }
@@ -374,7 +374,7 @@ impl BranchManager<'_> {
         }
         res?;
 
-        update_workspace_commit(&vb_state, self.ctx, false)?;
+        crate::integration::update_workspace_commit_with_vb_state(&vb_state, self.ctx, false)?;
 
         Ok((stack.name(), unapplied_stacks))
     }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -117,7 +117,7 @@ impl BranchManager<'_> {
 
         vb_state.update_ordering()?;
 
-        crate::integration::update_workspace_commit(&vb_state, self.ctx, false)
+        crate::integration::update_workspace_commit_with_vb_state(&vb_state, self.ctx, false)
             .context("failed to update gitbutler workspace")?;
 
         Ok(stack

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -169,7 +169,7 @@ pub fn integrate_branch_with_steps(
     update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
     source_stack.set_heads_from_rebase_output(ctx, result.references)?;
 
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)?;
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)?;
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -46,8 +46,31 @@ fn write_workspace_file(head_target: gix::ObjectId, path: PathBuf) -> Result<()>
     std::fs::write(path, format!(":{sha}"))?;
     Ok(())
 }
-#[instrument(level = "debug", skip(vb_state, ctx), err(Debug))]
+
+/// Update `gitbutler/workspace` using the current virtual branch state from `ctx`.
+///
+/// Prefer this helper unless the caller is already carrying a `VirtualBranchesHandle` through a
+/// stack/target mutation flow. In those cases use [`update_workspace_commit_with_vb_state()`] so
+/// the dependency on that handle stays explicit at the call-site.
 pub fn update_workspace_commit(
+    ctx: &Context,
+    checkout_new_worktree: bool,
+) -> Result<gix::ObjectId> {
+    update_workspace_commit_with_vb_state(&ctx.virtual_branches(), ctx, checkout_new_worktree)
+}
+
+/// Update `gitbutler/workspace` using the caller-provided virtual branch state handle.
+///
+/// This variant exists for flows that have just mutated stacks or the default target through an
+/// already-existing `VirtualBranchesHandle`. Passing that handle keeps it obvious that the
+/// workspace commit must be rebuilt from the same state mutation sequence instead of implicitly
+/// reacquiring a fresh handle from `ctx`.
+///
+/// Most callers should use [`update_workspace_commit()`]. Reach for this helper only when the
+/// handle is already part of the operation itself, such as branch creation, base-branch changes,
+/// or rebases that update stack metadata before refreshing the workspace commit.
+#[instrument(level = "debug", skip(vb_state, ctx), err(Debug))]
+pub fn update_workspace_commit_with_vb_state(
     vb_state: &VirtualBranchesHandle,
     ctx: &Context,
     checkout_new_worktree: bool,
@@ -78,8 +101,6 @@ pub fn update_workspace_commit(
         });
     }
     let prev_head_id = head_ref.target();
-
-    let vb_state = ctx.virtual_branches();
 
     // get all virtual branches, we need to try to update them all
     let virtual_branches: Vec<Stack> = vb_state

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -27,7 +27,10 @@ pub use base::BaseBranch;
 pub mod upstream_integration;
 
 mod integration;
-pub use integration::{GITBUTLER_WORKSPACE_COMMIT_TITLE, update_workspace_commit};
+pub use integration::{
+    GITBUTLER_WORKSPACE_COMMIT_TITLE, update_workspace_commit,
+    update_workspace_commit_with_vb_state,
+};
 
 mod remote;
 

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -70,7 +70,7 @@ pub(crate) fn move_branch(
 
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     let _ = update_uncommitted_changes(ctx, old_workspace, new_workspace, perm);
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     Ok(MoveBranchResult {
@@ -126,7 +126,7 @@ pub(crate) fn tear_off_branch(
 
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     let _ = update_uncommitted_changes(ctx, old_workspace, new_workspace, perm);
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     let branch_manager = ctx.branch_manager();

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -48,7 +48,7 @@ pub(crate) fn move_commit(
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     // Even if this fails, it's not actionable
     let _ = update_uncommitted_changes(ctx, old_workspace, new_workspace, perm);
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     Ok(None)

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -69,7 +69,7 @@ pub fn reorder_stack(
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     // Even if this fails, it's not actionable
     let _ = update_uncommitted_changes(ctx, old_workspace, new_workspace, perm);
-    crate::integration::update_workspace_commit(&state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     Ok(output)

--- a/crates/gitbutler-branch-actions/src/squash.rs
+++ b/crates/gitbutler-branch-actions/src/squash.rs
@@ -268,7 +268,7 @@ fn do_squash_commits(
 
         let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
         update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
-        crate::integration::update_workspace_commit(&vb_state, ctx, false)
+        crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
             .context("failed to update gitbutler workspace")?;
         stack.set_heads_from_rebase_output(ctx, output.references)?;
         new_commit_oid.to_gix()

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -54,7 +54,7 @@ pub(crate) fn undo_commit(
 
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     Ok(stack)

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -620,7 +620,11 @@ pub(crate) fn integrate_upstream(
             update_uncommitted_changes(ctx, old_workspace, new_workspace, permission)?;
         }
 
-        crate::integration::update_workspace_commit(&virtual_branches_state, ctx, false)?;
+        crate::integration::update_workspace_commit_with_vb_state(
+            &virtual_branches_state,
+            ctx,
+            false,
+        )?;
     }
 
     deleted_branches.sort();

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -211,7 +211,7 @@ pub(crate) fn update_commit_message(
     stack.set_stack_head(&vb_state, &repo, output.top_commit)?;
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 
-    crate::integration::update_workspace_commit(&vb_state, ctx, false)
+    crate::integration::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
         .context("failed to update gitbutler workspace")?;
 
     output

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/workspace_migration.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/workspace_migration.rs
@@ -2,7 +2,6 @@ use gitbutler_branch_actions::update_workspace_commit;
 use gitbutler_operating_modes::{
     INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF, ensure_open_workspace_mode,
 };
-use gitbutler_stack::VirtualBranchesHandle;
 
 /// Tests that "verify branch" won't complain if we are on the old integration
 /// branch, and that `update_workspace_commit` will put us back on the a branch
@@ -24,11 +23,7 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
     assert!(result.is_ok());
 
     // Updating workspace commit should put us on the workspace branch.
-    update_workspace_commit(
-        &VirtualBranchesHandle::new(ctx.project_data_dir()),
-        &ctx,
-        false,
-    )?;
+    update_workspace_commit(&ctx, false)?;
     assert_eq!(
         ctx.git2_repo.get()?.head()?.name(),
         Some(WORKSPACE_BRANCH_REF)

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -21,7 +21,6 @@ gitbutler-repo.workspace = true
 gitbutler-operating-modes.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-oplog.workspace = true
-gitbutler-stack.workspace = true
 gitbutler-cherry-pick.workspace = true
 gitbutler-workspace.workspace = true
 

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -18,7 +18,6 @@ use gitbutler_operating_modes::{
     read_edit_mode_metadata, write_edit_mode_metadata,
 };
 use gitbutler_repo::{RepositoryExt as _, SignaturePurpose, signature};
-use gitbutler_stack::VirtualBranchesHandle;
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree};
 use serde::Serialize;
 
@@ -198,6 +197,24 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
     Ok(())
 }
 
+fn workspace_from_workspace_ref(ctx: &Context) -> Result<but_graph::projection::Workspace> {
+    let repo = ctx.repo.get()?;
+    let meta = ctx.meta()?;
+    let mut workspace_ref = repo.find_reference(WORKSPACE_BRANCH_REF)?;
+    let graph = but_graph::Graph::from_commit_traversal(
+        workspace_ref.peel_to_id()?,
+        Some(gix::refs::FullName::try_from(WORKSPACE_BRANCH_REF)?),
+        &meta,
+        but_graph::init::Options::limited(),
+    )?;
+    graph.into_workspace()
+}
+
+fn ensure_stack_in_workspace(ctx: &Context, stack_id: StackId) -> Result<()> {
+    workspace_from_workspace_ref(ctx)?.try_find_stack_by_id(stack_id)?;
+    Ok(())
+}
+
 pub(crate) fn enter_edit_mode(
     ctx: &Context,
     commit_oid: gix::ObjectId,
@@ -209,9 +226,7 @@ pub(crate) fn enter_edit_mode(
         stack_id,
     };
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    // Validate the stack_id
-    vb_state.get_stack_in_workspace(stack_id)?;
+    ensure_stack_in_workspace(ctx, stack_id)?;
 
     commit_uncommited_changes(ctx)?;
     write_edit_mode_metadata(ctx, &edit_mode_metadata).context("Failed to persist metadata")?;
@@ -252,7 +267,6 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
     let edit_mode_metadata = read_edit_mode_metadata(ctx).context("Failed to read metadata")?;
     let git2_repo = &*ctx.git2_repo.get()?;
     let repo = &*ctx.repo.get()?;
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
 
     let old_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
 
@@ -317,7 +331,7 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
         .context("Failed to set head reference")?;
     git2_repo.checkout_head(Some(CheckoutBuilder::new().force()))?;
 
-    update_workspace_commit(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     let uncommtied_changes = get_uncommited_changes(ctx)?;

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -14,8 +14,8 @@ use gitbutler_branch_actions::update_workspace_commit;
 use gitbutler_cherry_pick::{ConflictedTreeKey, RepositoryExt as _};
 use gitbutler_commit::commit_ext::{CommitExt, CommitMessageBstr as _};
 use gitbutler_operating_modes::{
-    EDIT_BRANCH_REF, EditModeMetadata, OperatingMode, WORKSPACE_BRANCH_REF, operating_mode,
-    read_edit_mode_metadata, write_edit_mode_metadata,
+    EDIT_BRANCH_REF, EditModeMetadata, OPEN_WORKSPACE_REFS, OperatingMode, WORKSPACE_BRANCH_REF,
+    operating_mode, read_edit_mode_metadata, write_edit_mode_metadata,
 };
 use gitbutler_repo::{RepositoryExt as _, SignaturePurpose, signature};
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes_with_tree};
@@ -197,13 +197,25 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
     Ok(())
 }
 
+fn open_workspace_ref<'repo>(repo: &'repo gix::Repository) -> Result<gix::Reference<'repo>> {
+    OPEN_WORKSPACE_REFS
+        .iter()
+        .find_map(|&name| repo.find_reference(name).ok())
+        .with_context(|| {
+            format!(
+                "expected one of the open workspace refs to exist: {}",
+                OPEN_WORKSPACE_REFS.join(", ")
+            )
+        })
+}
+
 fn workspace_from_workspace_ref(ctx: &Context) -> Result<but_graph::projection::Workspace> {
     let repo = ctx.repo.get()?;
     let meta = ctx.meta()?;
-    let mut workspace_ref = repo.find_reference(WORKSPACE_BRANCH_REF)?;
+    let mut workspace_ref = open_workspace_ref(&repo)?;
     let graph = but_graph::Graph::from_commit_traversal(
         workspace_ref.peel_to_id()?,
-        Some(gix::refs::FullName::try_from(WORKSPACE_BRANCH_REF)?),
+        Some(workspace_ref.inner.name.clone()),
         &meta,
         but_graph::init::Options::limited(),
     )?;

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -5,17 +5,14 @@ use but_core::{
     ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
 };
 use but_ctx::Context;
-use but_meta::{
-    VirtualBranchesTomlMetadata,
-    legacy_storage::{read_synced_virtual_branches, write_virtual_branches_and_sync},
-    virtual_branches_legacy_types::Target,
-};
+use but_meta::{VirtualBranchesTomlMetadata, virtual_branches_legacy_types::Target};
 use but_oxidize::OidExt as _;
 use but_testsupport::{gix_testtools, open_repo};
 use git2::build::CheckoutBuilder;
 use gitbutler_edit_mode::commands::{
     abort_and_return_to_workspace, enter_edit_mode, save_and_return_to_workspace,
 };
+use gitbutler_operating_modes::INTEGRATION_BRANCH_REF;
 use tempfile::TempDir;
 
 fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
@@ -53,20 +50,16 @@ fn seed_metadata(repo: &gix::Repository) -> Result<()> {
         }],
         workspacecommit_relation: WorkspaceCommitRelation::Merged,
     });
-    meta.set_workspace(&ws)?;
-    meta.set_changed_to_necessitate_write();
-    meta.write_unreconciled()?;
-
     let target = Target {
         branch: "refs/remotes/origin/main".parse()?,
         remote_url: ".".to_owned(),
         sha: repo.rev_parse_single("refs/remotes/origin/main")?.detach(),
         push_remote_name: Some("origin".to_owned()),
     };
-    let state_path = repo.gitbutler_storage_path()?.join("virtual_branches.toml");
-    let mut vb = read_synced_virtual_branches(&state_path)?;
-    vb.default_target = Some(target);
-    write_virtual_branches_and_sync(&state_path, &vb)?;
+    meta.set_workspace(&ws)?;
+    meta.data_mut().default_target = Some(target);
+    meta.set_changed_to_necessitate_write();
+    meta.write_unreconciled()?;
     Ok(())
 }
 
@@ -278,6 +271,36 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
         @r#"
     Some(
         "refs/heads/gitbutler/workspace",
+    )
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn enter_edit_mode_works_with_only_integration_ref_present() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;
+    let foobar = {
+        let repo = ctx.git2_repo.get()?;
+        let workspace_head = repo.head()?.peel_to_commit()?;
+        let foobar = workspace_head.parent(0)?.id();
+        repo.reference(INTEGRATION_BRANCH_REF, workspace_head.id(), true, "")?;
+        repo.set_head(INTEGRATION_BRANCH_REF)?;
+        repo.find_reference("refs/heads/gitbutler/workspace")?
+            .delete()
+            .context("expected workspace ref to exist")?;
+        foobar
+    };
+
+    let stack_id = stack_id(&ctx)?;
+    enter_edit_mode(&mut ctx, foobar.to_gix(), stack_id)?;
+
+    insta::assert_debug_snapshot!(
+        ctx.git2_repo.get()?.head()?.name(),
+        @r#"
+    Some(
+        "refs/heads/gitbutler/edit",
     )
     "#
     );

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -1,18 +1,21 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use bstr::ByteSlice as _;
 use but_core::{
     RefMetadata, RepositoryExt,
     ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
 };
 use but_ctx::Context;
-use but_meta::VirtualBranchesTomlMetadata;
+use but_meta::{
+    VirtualBranchesTomlMetadata,
+    legacy_storage::{read_synced_virtual_branches, write_virtual_branches_and_sync},
+    virtual_branches_legacy_types::Target,
+};
 use but_oxidize::OidExt as _;
 use but_testsupport::{gix_testtools, open_repo};
 use git2::build::CheckoutBuilder;
 use gitbutler_edit_mode::commands::{
     abort_and_return_to_workspace, enter_edit_mode, save_and_return_to_workspace,
 };
-use gitbutler_stack::{Target, VirtualBranchesHandle};
 use tempfile::TempDir;
 
 fn command_ctx(folder: &str) -> Result<(Context, TempDir)> {
@@ -60,8 +63,21 @@ fn seed_metadata(repo: &gix::Repository) -> Result<()> {
         sha: repo.rev_parse_single("refs/remotes/origin/main")?.detach(),
         push_remote_name: Some("origin".to_owned()),
     };
-    VirtualBranchesHandle::new(repo.gitbutler_storage_path()?).set_default_target(target)?;
+    let state_path = repo.gitbutler_storage_path()?.join("virtual_branches.toml");
+    let mut vb = read_synced_virtual_branches(&state_path)?;
+    vb.default_target = Some(target);
+    write_virtual_branches_and_sync(&state_path, &vb)?;
     Ok(())
+}
+
+fn stack_id(ctx: &Context) -> Result<StackId> {
+    let guard = ctx.shared_worktree_access();
+    let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+    ws.stacks
+        .first()
+        .context("expected workspace stack")?
+        .id
+        .context("expected workspace stack id")
 }
 
 #[test]
@@ -71,12 +87,10 @@ fn basic_leaving_edit_mode() -> Result<()> {
 
     let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let stacks = vb_state.list_stacks_in_workspace()?;
-    let stack = stacks.first().unwrap();
     let worktree_dir = repo.path().parent().unwrap().to_path_buf();
     drop(repo);
-    enter_edit_mode(&mut ctx, foobar.to_gix(), stack.id)?;
+    let stack_id = stack_id(&ctx)?;
+    enter_edit_mode(&mut ctx, foobar.to_gix(), stack_id)?;
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
     std::fs::write(worktree_dir.join("newfile"), "created during edit mode\n")?;
@@ -108,11 +122,9 @@ fn conficted_entries_get_written_when_leaving_edit_mode() -> Result<()> {
 
     let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let stacks = vb_state.list_stacks_in_workspace()?;
-    let stack = stacks.first().unwrap();
     drop(repo);
-    enter_edit_mode(&mut ctx, foobar.to_gix(), stack.id)?;
+    let stack_id = stack_id(&ctx)?;
+    enter_edit_mode(&mut ctx, foobar.to_gix(), stack_id)?;
 
     let repo = ctx.git2_repo.get()?;
     let init = repo.find_reference("refs/heads/main")?.peel_to_commit()?;
@@ -161,12 +173,10 @@ fn abort_requires_force_when_changes_were_made() -> Result<()> {
     let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;
     let repo = ctx.git2_repo.get()?;
     let foobar = repo.head()?.peel_to_commit()?.parent(0)?.id();
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let stacks = vb_state.list_stacks_in_workspace()?;
-    let stack = stacks.first().unwrap();
     drop(repo);
 
-    enter_edit_mode(&mut ctx, foobar.to_gix(), stack.id)?;
+    let stack_id = stack_id(&ctx)?;
+    enter_edit_mode(&mut ctx, foobar.to_gix(), stack_id)?;
 
     let repo = ctx.git2_repo.get()?;
     insta::assert_debug_snapshot!(
@@ -225,12 +235,10 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
         .peel_to_commit()?
         .id();
 
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let stacks = vb_state.list_stacks_in_workspace()?;
-    let stack = stacks.first().unwrap();
     drop(repo);
 
-    enter_edit_mode(&mut ctx, conflicted_commit.to_gix(), stack.id)?;
+    let stack_id = stack_id(&ctx)?;
+    enter_edit_mode(&mut ctx, conflicted_commit.to_gix(), stack_id)?;
 
     let repo = ctx.git2_repo.get()?;
     insta::assert_debug_snapshot!(

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -18,7 +18,7 @@ pub const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
 /// name we need some transition period during which both are accepted.
 /// The new branch will be checked out as soon as any modification is made
 /// that triggers `update_workspace_commit`.
-pub const OPEN_WORKSPACE_REFS: [&str; 2] = [INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF];
+pub const OPEN_WORKSPACE_REFS: [&str; 2] = [WORKSPACE_BRANCH_REF, INTEGRATION_BRANCH_REF];
 
 /// The reference the app will checkout when in edit mode
 pub const EDIT_BRANCH_REF: &str = "refs/heads/gitbutler/edit";

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -52,7 +52,7 @@ pub mod virtual_branches {
             })
             .expect("failed to write target");
 
-        gitbutler_branch_actions::update_workspace_commit(&vb_state, ctx, false)
+        gitbutler_branch_actions::update_workspace_commit_with_vb_state(&vb_state, ctx, false)
             .expect("failed to update workspace");
 
         Ok(())

--- a/etc/plans/consistent-data.md
+++ b/etc/plans/consistent-data.md
@@ -56,9 +56,18 @@ The `but_ctx::Context` is the solution to this problem, and is passed around as 
 
 - [ ] [in progress](https://github.com/gitbutlerapp/gitbutler/issues/12075)
 
-### 2. Port consumers of `gitbutler_stack::VirtualBranchesHandle` to `ctx.ws`
+### 2. Port legacy virtual-branches consumers to `ctx.ws`
 
-Crates with references to `VirtualBranchesHandle`: 15
+Track all remaining access paths to `.git/gitbutler/virtual-branches.toml`, including:
+
+- `gitbutler_stack::VirtualBranchesHandle`
+- `ctx.virtual_branches()`
+- `but_meta::legacy_storage::read_synced_virtual_branches()`
+- `but_meta::legacy_storage::write_virtual_branches_and_sync()`
+
+The crate list below started from direct `VirtualBranchesHandle` references and should also cover
+callers that only touch the same legacy state via `ctx.virtual_branches()` or the legacy
+read/write helpers.
 
 #### but-api (1)
 
@@ -72,17 +81,28 @@ Crates with references to `VirtualBranchesHandle`: 15
 
 - [ ] `crates/but-tools/src/workspace.rs`
 
-#### gitbutler-cli (1)
+#### but (10)
 
-- [ ] `crates/gitbutler-cli/src/command/vbranch.rs`
+- [ ] `crates/but/src/command/legacy/branch/list.rs`
+- [ ] `crates/but/src/command/legacy/branch/show.rs`
+- [ ] `crates/but/src/command/legacy/mcp_internal/commit.rs`
+- [ ] `crates/but/src/command/legacy/mcp_internal/stack.rs`
+- [ ] `crates/but/src/command/legacy/pick.rs`
+- [ ] `crates/but/src/command/legacy/push.rs`
+- [ ] `crates/but/src/command/legacy/rub/commits.rs`
+- [ ] `crates/but/src/command/legacy/rub/move.rs`
+- [ ] `crates/but/src/command/legacy/rub/move_commit.rs`
+- [ ] `crates/but/src/command/legacy/status/mod.rs`
 
-#### gitbutler-operating-modes (1)
+#### but-workspace (7)
 
-- [ ] `crates/gitbutler-operating-modes/src/lib.rs`
-
-#### gitbutler-testsupport (1)
-
-- [ ] `crates/gitbutler-testsupport/src/lib.rs`
+- [ ] `crates/but-workspace/src/legacy/commit_engine/mod.rs`
+- [ ] `crates/but-workspace/src/legacy/head.rs`
+- [ ] `crates/but-workspace/src/legacy/mod.rs`
+- [ ] `crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs`
+- [ ] `crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs`
+- [ ] `crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs`
+- [ ] `crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs`
 
 #### but-action (2)
 
@@ -99,10 +119,45 @@ Crates with references to `VirtualBranchesHandle`: 15
 - [ ] `crates/but-worktrees/src/integrate.rs`
 - [ ] `crates/but-worktrees/tests/worktree/main.rs`
 
+#### Reconciliation for workspace-commit refresh
+
+`VirtualBranchesHandle` is only a concurrency-safe handle to `virtual_branches.toml`, not an
+in-memory snapshot of workspace state. The same applies to `ctx.virtual_branches()`, which merely
+creates another handle to the same file. Passing a `VBH` around explicitly should therefore not be
+treated as its own consistency boundary.
+
+The special case in this migration is `gitbutler-branch-actions::update_workspace_commit()`.
+Today it still reads applied stacks from `VirtualBranchesHandle` and delegates the actual merge
+shape to `but_workspace::legacy::remerged_workspace_commit_v2()`. That means the relevant VBH
+work is not "port this function to `ctx.ws` line-by-line", but rather:
+
+- [ ] make `update_workspace_commit()` build the workspace commit via
+      `WorkspaceCommit::from_new_merge_with_tips()`
+- [ ] treat `crates/gitbutler-branch-actions/src/integration.rs` and
+      `crates/but-workspace/src/legacy/head.rs` as one migration cluster
+- [ ] only after that, remove leftover explicit `VirtualBranchesHandle` threading that existed
+      solely to support workspace-commit refresh
+
+Until that refactor lands, the `gitbutler-branch-actions` items below should be read as
+"remaining legacy virtual-branches consumers", including `ctx.virtual_branches()` call sites,
+not as independent stateful-handle flows.
+
+#### gitbutler-cli (1)
+
+- [ ] `crates/gitbutler-cli/src/command/vbranch.rs`
+
+#### gitbutler-operating-modes (1)
+
+- [ ] `crates/gitbutler-operating-modes/src/lib.rs`
+
+#### gitbutler-testsupport (1)
+
+- [ ] `crates/gitbutler-testsupport/src/lib.rs`
+
 #### gitbutler-edit-mode (2)
 
-- [ ] `crates/gitbutler-edit-mode/src/lib.rs`
-- [ ] `crates/gitbutler-edit-mode/tests/edit_mode.rs`
+- [x] `crates/gitbutler-edit-mode/src/lib.rs`
+- [x] `crates/gitbutler-edit-mode/tests/edit_mode.rs`
 
 #### gitbutler-oplog (2)
 
@@ -121,29 +176,6 @@ Crates with references to `VirtualBranchesHandle`: 15
 - [ ] `crates/gitbutler-stack/src/stack_branch.rs`
 - [ ] `crates/gitbutler-stack/src/state.rs`
 - [ ] `crates/gitbutler-stack/tests/mod.rs`
-
-#### but-workspace (7)
-
-- [ ] `crates/but-workspace/src/legacy/commit_engine/mod.rs`
-- [ ] `crates/but-workspace/src/legacy/head.rs`
-- [ ] `crates/but-workspace/src/legacy/mod.rs`
-- [ ] `crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs`
-- [ ] `crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs`
-- [ ] `crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs`
-- [ ] `crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs`
-
-#### but (10)
-
-- [ ] `crates/but/src/command/legacy/branch/list.rs`
-- [ ] `crates/but/src/command/legacy/branch/show.rs`
-- [ ] `crates/but/src/command/legacy/mcp_internal/commit.rs`
-- [ ] `crates/but/src/command/legacy/mcp_internal/stack.rs`
-- [ ] `crates/but/src/command/legacy/pick.rs`
-- [ ] `crates/but/src/command/legacy/push.rs`
-- [ ] `crates/but/src/command/legacy/rub/commits.rs`
-- [ ] `crates/but/src/command/legacy/rub/move.rs`
-- [ ] `crates/but/src/command/legacy/rub/move_commit.rs`
-- [ ] `crates/but/src/command/legacy/status/mod.rs`
 
 #### gitbutler-branch-actions (11)
 


### PR DESCRIPTION
This is a tiny step on the way to getting rid of all vb.toml consumers to be able to remove it.  It's motivated by the recent work `gitbutler-edit-mode` was seeing to hopefully help with modernisation efforts.

Future iterations can probably focus on code around `update_workspace_commit()` is clearly a critical function to replace, but that's better done in a follow-up.

The PR is part of the data-consistency plan, and follow-up of #12753.

### Tasks

* [x] refaciew
