### PR TITLE
CLI: add `but pr open` to open review URL in browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "machine-uid",
  "minus",
  "nonempty",
+ "open",
  "posthog-rs",
  "rand 0.9.2",
  "ratatui",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -115,6 +115,7 @@ rmcp.workspace = true
 command-group = { version = "5.0.1", features = ["with-tokio"] }
 gix = { workspace = true, features = ["tracing", "tracing-detail"] }
 colored = "3.0.0"
+open.workspace = true
 serde_json.workspace = true
 boolean-enums.workspace = true
 terminal_size = "0.4.3"

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -437,6 +437,8 @@ but pr new <branch-id> -m "Title..."        # Inline message: first line is titl
 but pr new <branch-id> -t     # Use default content (commit message), skip prompts
 but pr                        # Create PR (prompts for branch)
 but pr template               # Configure PR description template
+but pr open                   # Open review URL in browser (prompts for selection)
+but pr open <selector>        # Open review URL for specific branch/PR
 ```
 
 **Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks (`--run-hooks`) are enabled by default.

--- a/crates/but/src/args/forge.rs
+++ b/crates/but/src/args/forge.rs
@@ -87,6 +87,19 @@ pub mod pr {
             /// Path to the review template file within the repository.
             template_path: Option<String>,
         },
+        /// Open the review URL in the default web browser.
+        /// If no review is specified, you will be prompted to select one from the
+        /// reviews associated with branches in your workspace.
+        Open {
+            /// The target of this operation.
+            /// This can be one or multiple (comma-separated):
+            /// - Branch names,
+            /// - Branch IDs,
+            /// - Stack IDs (in which case, all the reviews associated with the stacked branches are selected),
+            /// - Associated review IDs (i.e. PR numeric IDs or MR numeric IDs, without the symbol).
+            #[clap(value_name = "SELECTOR")]
+            selector: Option<String>,
+        },
     }
 }
 

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -44,6 +44,7 @@ pub enum CommandName {
     ForgeListUsers,
     ForgeForget,
     PrNew,
+    PrOpen,
     PrTemplate,
     DisableAutoMerge,
     EnableAutoMerge,

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -274,6 +274,54 @@ pub fn set_review_template(
     Ok(())
 }
 
+/// Open the review URL(s) in the default web browser.
+/// If no selector is given, prompts the user to choose from reviews in the workspace.
+pub async fn open_review(
+    ctx: &mut Context,
+    selector: Option<String>,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let review_ids = resolve_review_selection(ctx, selector)?;
+
+    if review_ids.is_empty() {
+        if let Some(out) = out.for_human() {
+            writeln!(out, "No reviews selected")?;
+        }
+        return Ok(());
+    }
+
+    for review_id in review_ids {
+        let review = but_api::legacy::forge::get_review(ctx, review_id)
+            .with_context(|| format!("Failed to get review {review_id}"))?;
+        open::that(&review.html_url)
+            .with_context(|| format!("Failed to open URL: {}", review.html_url))?;
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "{} {} {}{}",
+                "→".cyan(),
+                "Opened".green(),
+                review.unit_symbol.cyan(),
+                review.number.to_string().cyan().bold()
+            )?;
+            writeln!(
+                out,
+                "  {} {}",
+                "URL:".dimmed(),
+                review.html_url.underline().blue()
+            )?;
+        }
+        if let Some(out) = out.for_json() {
+            out.write_value(serde_json::json!({
+                "url": review.html_url,
+                "number": review.number,
+            }))?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Create a new forge review for a branch.
 /// If no branch is specified, prompts the user to select one.
 /// If there is only one branch without a an acco, asks for confirmation.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1125,6 +1125,12 @@ async fn match_subcommand(
                         .context("Failed to set reviews as ready-for-review.")
                         .emit_metrics(metrics_ctx)
                 }
+                Some(forge::pr::Subcommands::Open { selector }) => {
+                    command::legacy::forge::review::open_review(&mut ctx, selector, out)
+                        .await
+                        .context("Failed to open review in browser.")
+                        .emit_metrics(metrics_ctx)
+                }
                 None => {
                     // Default to `pr new` when no subcommand is provided
                     command::legacy::forge::review::create_review(

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -162,6 +162,7 @@ impl Subcommands {
                 }
                 Some(forge::pr::Subcommands::SetDraft { .. }) => SetReviewDraft,
                 Some(forge::pr::Subcommands::SetReady { .. }) => SetReviewReady,
+                Some(forge::pr::Subcommands::Open { .. }) => PrOpen,
             },
             #[cfg(feature = "legacy")]
             Subcommands::Actions(_)


### PR DESCRIPTION
## Summary
- Adds `but pr open` subcommand that opens the review URL in the default web browser
- Supports the same selector syntax as other PR subcommands (branch names, branch IDs, stack IDs, review numbers)
- When no selector is provided, prompts the user to choose from reviews in the workspace
- Includes human-readable output with colored URL and review number, plus JSON output for scripting

Closes #12340

## Test plan
- [x] `cargo build -p but` passes
- [x] `cargo clippy -p but --all-targets` passes with no warnings
- [x] `cargo fmt --check -p but` passes
- [x] `cargo test -p but` passes (one pre-existing failure in `reword` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)