### PR TITLE
skill: replace --json with human-readable output for bench experiment

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -12,9 +12,9 @@ Use GitButler CLI (`but`) as the default version-control interface.
 ## Non-Negotiable Rules
 
 1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that.
-2. Always add `--json --status-after` to mutation commands.
-3. Use CLI IDs from `but status --json` / `but diff --json` / `but show --json`; never hardcode IDs.
-4. Start with `but status --json` before mutations so IDs and stack state are current.
+2. Always add `--status-after` to mutation commands.
+3. Use CLI IDs from `but status -fv` / `but diff` / `but show`; never hardcode IDs.
+4. Start with `but status -fv` before mutations so IDs and stack state are current.
 5. Create a branch for new work with `but branch new <name>` when needed.
 
 ## Core Flow
@@ -23,7 +23,7 @@ Use GitButler CLI (`but`) as the default version-control interface.
 
 ```bash
 # 1. Inspect state and gather IDs
-but status --json
+but status -fv
 
 # 2. If new branch needed:
 but branch new <name>
@@ -31,45 +31,45 @@ but branch new <name>
 # 3. Edit files (Edit/Write tools)
 
 # 4. Refresh IDs if needed
-but status --json
+but status -fv
 
 # 5. Perform mutation with IDs from status/diff/show
-but <mutation> ... --json --status-after
+but <mutation> ... --status-after
 ```
 
 ## Command Patterns
 
-- Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --json --status-after`
-- Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --json --status-after`
-- Amend: `but amend <file-id> <commit-id> --json --status-after`
-- Reorder commits: `but move <source-commit-id> <target-commit-id> --json --status-after` (**commit IDs**, not branch names)
+- Commit: `but commit <branch> -m "<msg>" --changes <id>,<id> --status-after`
+- Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --status-after`
+- Amend: `but amend <file-id> <commit-id> --status-after`
+- Reorder commits: `but move <source-commit-id> <target-commit-id> --status-after` (**commit IDs**, not branch names)
 - Stack branches: `but branch move <branch-name> <target-branch-name>` (**branch names**, not IDs — e.g. `but branch move feature/frontend feature/backend`)
 - Push: `but push` or `but push <branch-id>`
-- Pull: `but pull --check --json` then `but pull --json --status-after`
+- Pull: `but pull --check` then `but pull --status-after`
 
 ## Task Recipes
 
 ### Commit files
 
-1. `but status --json`
-2. Find the `cliId` for each file you want to commit.
-3. `but commit <branch> -m "<msg>" --changes <id1>,<id2> --json --status-after`
+1. `but status -fv`
+2. Find the CLI ID for each file you want to commit.
+3. `but commit <branch> -m "<msg>" --changes <id1>,<id2> --status-after`
    Use `-c` to create the branch if it doesn't exist. Omit IDs you don't want committed.
-4. **Check the `--status-after` output** for remaining uncommitted changes. If the file still appears in `unassignedChanges` or `assignedChanges` after commit, it may be dependency-locked to another branch. See "Stacked dependency / commit-lock recovery" below.
+4. **Check the `--status-after` output** for remaining uncommitted changes. If the file still appears as unassigned or assigned to another branch after commit, it may be dependency-locked. See "Stacked dependency / commit-lock recovery" below.
 
 ### Amend into existing commit
 
-1. `but status --json` (or `but show <branch-id> --json`)
+1. `but status -fv` (or `but show <branch-id>`)
 2. Locate file ID and target commit ID.
-3. `but amend <file-id> <commit-id> --json --status-after`
+3. `but amend <file-id> <commit-id> --status-after`
 
 ### Reorder commits (not branches)
 
 **`but move` reorders commits within a branch. To stack branches, use `but branch move` instead.**
 
-1. `but status --json`
-2. `but move <commit-a> <commit-b> --json --status-after` — uses commit IDs like `c3`, `c5`
-3. Refresh IDs from the returned status, then run the inverse: `but move <commit-b> <commit-a> --json --status-after`
+1. `but status -fv`
+2. `but move <commit-a> <commit-b> --status-after` — uses commit IDs like `c3`, `c5`
+3. Refresh IDs from the returned status, then run the inverse: `but move <commit-b> <commit-a> --status-after`
 
 ### Stack existing branches
 
@@ -101,20 +101,20 @@ A **dependency lock** occurs when a file was originally committed on branch A, b
 
 **Recovery:** Stack your branch on the dependency branch, then commit:
 
-1. `but status --json` — identify which branch originally owns the file (check commit history).
+1. `but status -fv` — identify which branch originally owns the file (check commit history).
 2. `but branch move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
-3. `but status --json` — the file should now be assignable. Commit it.
-4. `but commit <branch> -m "<msg>" --changes <id> --json --status-after`
+3. `but status -fv` — the file should now be assignable. Commit it.
+4. `but commit <branch> -m "<msg>" --changes <id> --status-after`
 
-**If `but branch move` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status --json` to confirm both branches still exist and are applied, then retry `but branch move` with exact branch names from the status output.
+**If `but branch move` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry `but branch move` with exact branch names from the status output.
 
 ### Resolve conflicts after reorder/move
 
 **NEVER use `git add`, `git commit`, `git checkout --theirs`, `git checkout --ours`, or any git write commands during resolution.** Only use `but resolve` commands and edit files directly with the Edit tool.
 
-If `but move` causes conflicts (`"conflicted": true` in status):
+If `but move` causes conflicts (conflicted commits in status):
 
-1. `but status --json` — find commits with `"conflicted": true`.
+1. `but status -fv` — find commits marked as conflicted.
 2. `but resolve <commit-id>` — enter resolution mode. This puts conflict markers in the files.
 3. **Read the conflicted files** to see the `<<<<<<<` / `=======` / `>>>>>>>` markers.
 4. **Edit the files** to resolve conflicts by choosing the correct content and removing markers.
@@ -127,7 +127,7 @@ If `but move` causes conflicts (`"conflicted": true` in status):
 
 | git | but |
 |---|---|
-| `git status` | `but status --json` |
+| `git status` | `but status -fv` |
 | `git add` + `git commit` | `but commit ... --changes ...` |
 | `git checkout -b` | `but branch new <name>` |
 | `git push` | `but push` |
@@ -140,9 +140,9 @@ If `but move` causes conflicts (`"conflicted": true` in status):
 - Prefer explicit IDs over file paths for mutations.
 - `--changes` accepts comma-separated values (`--changes a1,b2`) or repeated flags (`--changes a1 --changes b2`), not space-separated.
 - Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
-- After a successful `--status-after`, don't run a redundant `but status` unless you need new IDs.
-- Use `but show <branch-id> --json` to see commit details for a branch, including per-commit file changes and line counts.
-- **Per-commit file counts**: `but status --json` does NOT include per-commit file counts. Use `but show <branch-id> --json` or `git show --stat <commit-hash>` to get them.
+- After a successful `--status-after`, don't run a redundant `but status -fv` unless you need new IDs.
+- Use `but show <branch-id>` to see commit details for a branch, including per-commit file changes and line counts.
+- **Per-commit file counts**: `but status` does NOT include per-commit file counts. Use `but show <branch-id>` or `git show --stat <commit-hash>` to get them.
 - Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a failed attempt.
 - Run `but skill check` only when command behavior diverges from this skill, not as routine preflight.
 - For command syntax and flags: `references/reference.md`

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -43,7 +43,7 @@ workspace (gitbutler/workspace)
 
 ## CLI IDs: Short Identifiers
 
-Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status --json`.
+Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status`.
 
 ```
 Commits:    1b, 8f, c2     (short hex prefixes of the SHA, long enough to be unique)
@@ -345,7 +345,7 @@ Git commands that don't modify state are safe to use:
 **Safe (read-only):**
 
 - `git log` - View history
-- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs and `--json`)
+- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs)
 - `git show` - View commits
 - `git blame` - See line history
 - `git reflog` - View reference log

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -2,7 +2,7 @@
 
 Real-world examples of common workflows.
 
-**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `c3`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status --json`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs use short hex prefixes (e.g., `1b`, `8f`), and file/hunk/stack IDs are auto-generated (e.g., `g0`, `h0`). All IDs are unique across entity types.
+**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `c3`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status -fv`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs use short hex prefixes (e.g., `1b`, `8f`), and file/hunk/stack IDs are auto-generated (e.g., `g0`, `h0`). All IDs are unique across entity types.
 
 ## Example 1: Starting Independent Parallel Work
 
@@ -10,7 +10,7 @@ Real-world examples of common workflows.
 
 ```bash
 # 1. Check current state
-but status --json
+but status -fv
 
 # 2. Create two independent (parallel) branches
 but branch new api-endpoint
@@ -20,26 +20,26 @@ but branch new ui-styling
 # (edit api/users.js and components/Button.svelte)
 
 # 4. Check what's unstaged
-but status --json
+but status -fv
 
 # 5. Commit specific files directly using --changes (recommended for agents)
-# Use cliId values from but status --json output (e.g., branch IDs and file IDs)
+# Use CLI ID values from but status -fv output (e.g., branch IDs and file IDs)
 # For multiple IDs, use one comma-separated argument or repeat --changes.
-but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --json --status-after
-but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --json --status-after
+but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --status-after
+but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --status-after
 
 # Alternative: stage first, then commit with --only
 # but stage <api-file-id> <api-branch-id> && but stage <ui-file-id> <ui-branch-id>
-# but commit <api-branch-id> --only -m "Add user details endpoint" --json --status-after
-# but commit <ui-branch-id> --only -m "Update button hover styles" --json --status-after
+# but commit <api-branch-id> --only -m "Add user details endpoint" --status-after
+# but commit <ui-branch-id> --only -m "Update button hover styles" --status-after
 
 # 6. Push branches independently (optional, can skip if using pr new)
-but push <api-branch-id> --json
-but push <ui-branch-id> --json
+but push <api-branch-id>
+but push <ui-branch-id>
 
 # 7. Create pull requests (auto-pushes if not already pushed)
-but pr new <api-branch-id> --json
-but pr new <ui-branch-id> --json
+but pr new <api-branch-id>
+but pr new <ui-branch-id>
 ```
 
 **Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
@@ -50,29 +50,29 @@ but pr new <ui-branch-id> --json
 
 ```bash
 # 1. Check current state and update
-but pull --json
-but status --json
+but pull
+but status -fv
 
 # 2. Create base branch for authentication
 but branch new add-authentication
 
 # 3. Implement auth and commit
 # (edit auth/login.js, auth/middleware.js)
-but status --json
-but stage <file-ids> bu --json --status-after  # Stage changes to auth branch
-but commit bu --only -m "Add JWT authentication" --json --status-after
+but status -fv
+but stage <file-ids> bu --status-after  # Stage changes to auth branch
+but commit bu --only -m "Add JWT authentication" --status-after
 
 # 4. Create stacked branch anchored on authentication
 but branch new user-profile -a bu
 
 # 5. Implement profile page (depends on auth)
 # (edit pages/profile.js)
-but status --json
-but stage <file-ids> bv --json --status-after  # Stage changes to profile branch
-but commit bv --only -m "Add user profile page" --json --status-after
+but status -fv
+but stage <file-ids> bv --status-after  # Stage changes to profile branch
+but commit bv --only -m "Add user profile page" --status-after
 
 # 6. Push both branches (maintains stack relationship)
-but push --json
+but push
 ```
 
 **Result:** Two PRs where user-profile PR depends on authentication PR. GitHub/GitLab shows the dependency.
@@ -83,7 +83,7 @@ but push --json
 
 ```bash
 # 1. Check current commits and unstaged changes
-but status --json
+but status -fv
 
 # Output shows:
 # Branch: feature-x (bu)
@@ -94,10 +94,10 @@ but status --json
 #   a1: fix-typo.js (staged to bu)
 
 # 2. Preview what absorb would do (recommended first step)
-but absorb a1 --dry-run --json    # Shows where a1 would be absorbed
+but absorb a1 --dry-run    # Shows where a1 would be absorbed
 
 # 3. Absorb the specific file into appropriate commit
-but absorb a1 --json --status-after    # Absorb just this file + get updated status
+but absorb a1 --status-after    # Absorb just this file + get updated status
 
 # GitButler analyzes the change and amends it into c3
 # (because the typo is in code from c3)
@@ -106,9 +106,9 @@ but absorb a1 --json --status-after    # Absorb just this file + get updated sta
 **Targeted vs blanket absorb:**
 
 ```bash
-but absorb a1 --json --status-after    # Absorb specific file (recommended)
-but absorb bu --json --status-after    # Absorb all changes staged to branch bu
-but absorb --json --status-after       # Absorb ALL uncommitted changes (use with caution)
+but absorb a1 --status-after    # Absorb specific file (recommended)
+but absorb bu --status-after    # Absorb all changes staged to branch bu
+but absorb --status-after       # Absorb ALL uncommitted changes (use with caution)
 ```
 
 **Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
@@ -128,13 +128,13 @@ but absorb --json --status-after       # Absorb ALL uncommitted changes (use wit
 # c1: Initial implementation
 
 # Squash all commits in branch
-but squash bu --json --status-after
+but squash bu --status-after
 
 # Or squash specific range
-but squash c2..c5 --json --status-after    # Squashes c2, c3, c4, c5 into one
+but squash c2..c5 --status-after    # Squashes c2, c3, c4, c5 into one
 
 # Or squash specific commits
-but squash c2 c3 c4 --json --status-after    # Squashes these three
+but squash c2 c3 c4 --status-after    # Squashes these three
 ```
 
 ### Scenario B: Moving Files Between Commits
@@ -143,14 +143,14 @@ but squash c2 c3 c4 --json --status-after    # Squashes these three
 
 ```bash
 # 1. See which files are in which commits
-but status --json -f
+but status -fv
 
 # Output shows:
 # c3: api.js, utils.js
 # c2: config.js
 
 # 2. Move utils.js from c3 to c2
-but rub a2 c2 --json --status-after    # File a2 (utils.js) → commit c2 + get updated status
+but rub a2 c2 --status-after    # File a2 (utils.js) → commit c2 + get updated status
 ```
 
 ### Scenario C: Moving Commit to Different Branch
@@ -159,7 +159,7 @@ but rub a2 c2 --json --status-after    # File a2 (utils.js) → commit c2 + get 
 
 ```bash
 # 1. Check current state
-but status --json
+but status -fv
 
 # Output:
 # Branch: feature-a (bu)
@@ -170,7 +170,7 @@ but status --json
 but branch new feature-b    # Creates branch bv
 
 # 3. Move the commit
-but move c3 bv --json --status-after    # Move c3 to top of branch bv
+but move c3 bv --status-after    # Move c3 to top of branch bv
 ```
 
 ## Example 5: Stacking Existing Branches
@@ -179,7 +179,7 @@ but move c3 bv --json --status-after    # Move c3 to top of branch bv
 
 ```bash
 # 1. Check current state — two independent branches in separate stacks
-but status --json
+but status -fv
 
 # Output:
 # Stack 1: feature/backend (bu) — 2 commits
@@ -193,9 +193,9 @@ but branch move feature/frontend feature/backend
 # Stack 1: feature/backend → feature/frontend (stacked)
 
 # 3. Continue working — commits go to the right branch
-but status --json
-but commit bu -m "Add caching layer" --changes <id> --json --status-after   # To backend
-but commit bv -m "Add dialog component" --changes <id> --json --status-after # To frontend
+but status -fv
+but commit bu -m "Add caching layer" --changes <id> --status-after   # To backend
+but commit bv -m "Add dialog component" --changes <id> --status-after # To frontend
 ```
 
 **Key point:** `but branch move` takes full branch **names** (like `feature/frontend`), NOT CLI IDs (like `bv`). This is different from `but move` which takes commit IDs.
@@ -215,10 +215,10 @@ but mark bu    # Branch bu (refactor) is now marked
 # (edit 20 different files)
 
 # 4. All changes automatically staged to refactor branch
-but status --json  # Shows all changes staged to bu
+but status -fv  # Shows all changes staged to bu
 
 # 5. Commit the staged changes
-but commit bu --only -m "Refactor error handling across app" --json --status-after
+but commit bu --only -m "Refactor error handling across app" --status-after
 
 # 6. Remove mark
 but unmark
@@ -237,7 +237,7 @@ but mark c5    # Commit c5 is now marked
 # (edit files)
 
 # 4. Check result
-but show c5 --json    # Shows accumulated changes
+but show c5    # Shows accumulated changes
 
 # 5. Remove mark when done
 but unmark
@@ -249,13 +249,13 @@ but unmark
 
 ```bash
 # 1. Pull updates
-but pull --json
+but pull
 
 # Output:
 # Conflict in commit c3 on branch feature-x
 
 # 2. Check status
-but status --json
+but status -fv
 
 # Output:
 # Branch: feature-x (bu)
@@ -296,7 +296,7 @@ but resolve finish
 
 ```bash
 # 1. Update to latest
-but pull --json
+but pull
 
 # 2. Create branch for feature
 but branch new user-dashboard
@@ -305,37 +305,37 @@ but branch new user-dashboard
 # (create dashboard.js, add routes)
 
 # 4. Check and stage
-but status --json
-but stage <file-ids> bu --json --status-after  # Stage changes to dashboard branch
+but status -fv
+but stage <file-ids> bu --status-after  # Stage changes to dashboard branch
 
 # 5. First commit
-but commit bu --only -m "Add dashboard route and basic layout" --json --status-after
+but commit bu --only -m "Add dashboard route and basic layout" --status-after
 
 # 6. Continue iterating
 # (add widgets, styling)
-but stage <file-ids> bu --json --status-after
-but commit bu --only -m "Add dashboard widgets" --json --status-after
-but stage <file-ids> bu --json --status-after
-but commit bu --only -m "Style dashboard components" --json --status-after
+but stage <file-ids> bu --status-after
+but commit bu --only -m "Add dashboard widgets" --status-after
+but stage <file-ids> bu --status-after
+but commit bu --only -m "Style dashboard components" --status-after
 
 # 7. Make small fix
 # (fix typo in widget)
-but absorb a1 --json --status-after    # Absorb specific file into appropriate commit
+but absorb a1 --status-after    # Absorb specific file into appropriate commit
 
 # 8. Clean up if needed
-but squash bu --json --status-after    # Combine all commits (optional)
+but squash bu --status-after    # Combine all commits (optional)
 
 # 9. Push to remote (can also skip - pr new auto-pushes)
-but push bu --json
+but push bu
 
 # 10. Create pull request
-but pr new bu --json
+but pr new bu
 
 # Output:
 # Created PR #123: https://github.com/org/repo/pull/123
 
 # 11. After PR is merged, update
-but pull --json
+but pull
 ```
 
 ## Example 9: Working with Applied/Unapplied Branches
@@ -344,7 +344,7 @@ but pull --json
 
 ```bash
 # 1. Check active branches
-but status --json
+but status -fv
 
 # Output:
 # Applied branches:
@@ -359,11 +359,11 @@ but unapply bw
 
 # 3. Focus on feature-a
 # (make changes, stage, commit)
-but stage <file-ids> bu --json --status-after
-but commit bu --only -m "Complete feature-a" --json --status-after
+but stage <file-ids> bu --status-after
+but commit bu --only -m "Complete feature-a" --status-after
 
 # 4. Create PR for feature-a (auto-pushes)
-but pr new bu --json
+but pr new bu
 
 # 5. Reapply other branches
 but apply bv
@@ -379,7 +379,7 @@ but resolve ...
 
 ```bash
 # 1. Current state
-but status --json
+but status -fv
 
 # Output:
 # Branch: feature-x (bu)
@@ -395,10 +395,10 @@ but reword c3 -m "Fix edge case in parser"
 but reword c2 -m "Update error messages"
 
 # 3. Move c5 to be earlier
-but move c5 c3 --json --status-after    # Move c5 before c3
+but move c5 c3 --status-after    # Move c5 before c3
 
 # 4. Squash similar commits
-but squash c2 c3 --json --status-after    # Combine error handling commits
+but squash c2 c3 --status-after    # Combine error handling commits
 
 # Output:
 # Branch: feature-x (bu)
@@ -408,7 +408,7 @@ but squash c2 c3 --json --status-after    # Combine error handling commits
 #   c1: Initial
 
 # 5. Push clean history
-but push bu --json
+but push bu
 ```
 
 ## Example 11: Daily Development Workflow
@@ -417,44 +417,44 @@ but push bu --json
 
 ```bash
 # Morning: Start day
-but pull --json                   # Get latest from team
+but pull                   # Get latest from team
 
 # Start new task
 but branch new fix-auth-bug       # Create branch for today's work
 
 # Work and commit iteratively
 # (make changes)
-but status --json                 # Check changes
-but stage <file-ids> bu --json --status-after    # Stage to branch
-but commit bu --only -m "Identify auth bug source" --json --status-after
+but status -fv              # Check changes
+but stage <file-ids> bu --status-after    # Stage to branch
+but commit bu --only -m "Identify auth bug source" --status-after
 # (make more changes)
-but stage <file-ids> bu --json --status-after    # Stage to branch
-but commit bu --only -m "Fix token expiration handling" --json --status-after
+but stage <file-ids> bu --status-after    # Stage to branch
+but commit bu --only -m "Fix token expiration handling" --status-after
 # (small fix to existing code)
-but absorb a1 --json --status-after              # Absorb specific fix into appropriate commit
+but absorb a1 --status-after              # Absorb specific fix into appropriate commit
 
 # Mid-day: Start urgent fix on different branch
 but branch new hotfix-login       # Parallel branch for urgent work
 # (make fix)
-but stage <file-ids> bv --json --status-after    # Stage to hotfix branch
-but commit bv --only -m "Fix login redirect loop" --json --status-after
-but pr new bv --json              # Push and create PR immediately
+but stage <file-ids> bv --status-after    # Stage to hotfix branch
+but commit bv --only -m "Fix login redirect loop" --status-after
+but pr new bv              # Push and create PR immediately
 
 # Back to original work
 # (continue working on bu, auth bug fix)
-but stage <file-ids> bu --json --status-after    # Stage to auth branch
-but commit bu --only -m "Add tests for token handling" --json --status-after
+but stage <file-ids> bu --status-after    # Stage to auth branch
+but commit bu --only -m "Add tests for token handling" --status-after
 
 # End of day: Clean up and create PR
-but squash bu --json --status-after    # Combine into clean history
-but pr new bu --json              # Push and create PR
+but squash bu --status-after    # Combine into clean history
+but pr new bu              # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)
-but absorb <file-id> --json --status-after    # Absorb specific changes into commits
+but absorb <file-id> --status-after    # Absorb specific changes into commits
 # Or absorb all changes for this branch:
-but absorb bu --json --status-after          # Absorb all changes staged to bu
-but push bu --with-force --json   # Force push updated history
+but absorb bu --status-after          # Absorb all changes staged to bu
+but push bu --with-force   # Force push updated history
 ```
 
 ## Example 12: Recovering from Mistakes
@@ -475,7 +475,7 @@ but undo         # Reverts the squash
 
 ```bash
 # View operation history
-but oplog --json
+but oplog
 
 # Output:
 # s5: squash branch bu
@@ -492,7 +492,7 @@ but oplog restore s4
 
 ```bash
 # Changed a file but want to discard
-but status --json
+but status -fv
 
 # Output:
 # Unstaged:
@@ -507,21 +507,16 @@ but discard a1
 ### Quick Status Check
 
 ```bash
-but status --json -f    # File-centric view for quick overview
+but status -fv    # File-centric view for quick overview
 ```
 
 ### Preview Before Doing
 
 ```bash
-but absorb <file-id> --dry-run --json  # See where specific file would be absorbed
-but push --dry-run --json              # See what would be pushed
+but absorb <file-id> --dry-run  # See where specific file would be absorbed
+but push --dry-run              # See what would be pushed
 ```
 
-### JSON for Scripting
-
-```bash
-but status --json | jq '.branches[] | .name'    # List branch names
-```
 
 ### Auto-completion
 
@@ -533,6 +528,6 @@ eval "$(but completions bash)"    # Add to ~/.bashrc
 ### Viewing History
 
 ```bash
-but show bu --json       # Show all commits in branch
+but show bu       # Show all commits in branch
 git log bu               # Traditional git log (read-only, still works)
 ```

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -24,8 +24,7 @@ Overview of workspace state - this is your entry point.
 
 ```bash
 but status              # Human-readable view
-but status -f           # File-centric view (shows which files in which commits)
-but status --json       # Structured output for parsing
+but status -fv          # File-centric view with full commit details (recommended)
 but status --verbose    # Detailed information
 but status --upstream   # Show upstream relationship
 ```
@@ -43,8 +42,7 @@ Details about a commit or branch.
 
 ```bash
 but show <id>           # Show details
-but show <id> --verbose # More detailed information
-but show <id> --json    # Structured output
+but show <id> --verbose # Show with full messages and file details
 ```
 
 ### `but diff [target]`
@@ -56,10 +54,9 @@ but diff <file-id>      # Diff for specific file
 but diff <branch-id>    # Diff for all changes in branch
 but diff <commit-id>    # Diff for specific commit
 but diff                # Diff for entire workspace
-but diff --json         # JSON output with hunk IDs for `but commit --changes`
 ```
 
-**Hunk IDs in JSON output:** For uncommitted changes, `but diff --json` returns each hunk as a separate entry in `changes[]` with an `id` field (e.g., `e8`, `j0`). Pass these IDs to `but commit --changes` for fine-grained, hunk-level commits. For commit/branch diffs, `id` is absent — entries are per-file with hunks nested under `diff.hunks`.
+**Hunk IDs:** For uncommitted changes, `but diff` shows each hunk with an ID (e.g., `e8`, `j0`). Pass these IDs to `but commit --changes` for fine-grained, hunk-level commits.
 
 ## Branching
 
@@ -69,7 +66,6 @@ List all branches (default when no subcommand).
 
 ```bash
 but branch              # List branches
-but branch --json       # JSON output
 but branch list [filter]  # Filter branches by name (case-insensitive substring)
 but branch list --no-ahead  # Skip commits-ahead calculation (faster)
 but branch list --no-check  # Skip clean-merge check (faster)
@@ -208,8 +204,8 @@ but commit empty --after <target>        # Insert empty commit after target
 **Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
 
 **Committing specific files or hunks:** Use `--changes` (or `-p`) with comma-separated CLI IDs to commit only those files or hunks:
-- **File IDs** from `but status --json`: commits entire files
-- **Hunk IDs** from `but diff --json`: commits individual hunks
+- **File IDs** from `but status`: commits entire files
+- **Hunk IDs** from `but diff`: commits individual hunks
 - `--changes` takes one argument per flag. Use `--changes a1,b2` or `--changes a1 --changes b2`, not `--changes a1 b2`.
 
 **Note:** `--changes` and `--only` are mutually exclusive.
@@ -220,7 +216,7 @@ but commit empty --after <target>        # Insert empty commit after target
 
 Example: `but commit my-branch -m "Fix bug" --changes ab,cd` commits files/hunks `ab` and `cd`.
 
-To commit specific hunks from a file with multiple changes, use `but diff --json` to see hunk IDs, then specify them individually.
+To commit specific hunks from a file with multiple changes, use `but diff` to see hunk IDs, then specify them individually.
 
 If only one branch is applied, you can omit the branch ID.
 
@@ -355,7 +351,7 @@ but discard <hunk-id>         # Discard hunk changes
 
 ## Conflict Resolution
 
-When commits have conflicts (shown in `but status` — look for `conflicted: true`):
+When commits have conflicts (shown in `but status` — look for commits marked as conflicted):
 
 ### `but resolve <commit>`
 
@@ -391,7 +387,7 @@ but resolve cancel
 
 **Workflow:**
 
-1. `but status --json` — identify conflicted commits (look for `conflicted: true`)
+1. `but status` — identify conflicted commits (marked as conflicted in the output)
 2. `but resolve <commit-id>` — enter resolution mode for the conflicted commit
 3. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content
 4. `but resolve status` — verify no conflicts remain
@@ -497,7 +493,6 @@ View operation history.
 
 ```bash
 but oplog
-but oplog --json
 ```
 
 Shows all operations with snapshot IDs.
@@ -567,8 +562,7 @@ but alias
 
 Available on most commands:
 
-- `-j, --json` - Output in JSON format for parsing
-- `--status-after` - After a mutation command, also output workspace status. In human mode, prints status after the command output. In JSON mode, wraps both in `{"result": ..., "status": ...}` on success, or `{"result": ..., "status_error": "..."}` if the status query fails. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
+- `--status-after` - After a mutation command, also output workspace status. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
 - `-C, --current-dir <PATH>` - Run as if started in different directory
 - `-h, --help` - Show help for command
 


### PR DESCRIPTION
Remove all --json flag references from skill files. Mutation commands now use only --status-after (no --json). Inspection commands use 'but status -fv' for file-centric human-readable output instead of 'but status --json'.

Impact on but-bench

Claude: +2.5% pass rate, speed neutral. Big win on dependency-lock-recovery (20% → 100%).

Codex: +15% pass rate, 40% faster. Wins across the board.

Both: No regressions caused by dropping --json.

Claude Code (sonnet-4-6)

| Scenario                   | Baseline (--json) | No-JSON (-fv) | Δ pass  | VC wall baseline | VC wall no-json | Δ wall |
| -------------------------- | ----------------- | ------------- | ------- | ---------------- | --------------- | ------ |
| absorb-changes             | 5/5               | 5/5           | =       | 36s              | 26s             | -28%   |
| amend-into-commit          | 5/5               | 5/5           | =       | 14s              | 15s             | +9%    |
| commit-to-stacks           | 5/5               | 5/5           | =       | 188s             | 225s            | +19%   |
| dependency-lock-recovery   | 1/5               | 5/5           | 🟢 +80% | 148s             | 192s            | +29%   |
| move-across-stacks         | 5/5               | 5/5           | =       | 24s              | 35s             | +42%   |
| move-branch-between-stacks | 5/5               | 5/5           | =       | 157s             | 98s             | -37%   |
| move-file-between-commits  | 5/5               | 5/5           | =       | 138s             | 199s            | +44%   |
| reorder-in-stack           | 5/5               | 5/5           | =       | 125s             | 254s            | +103%  |
| reorder-with-conflict      | 5/5               | 5/5           | =       | 45s              | 41s             | -7%    |
| resolve-conflict           | 4/5               | 3/5           | 🔴 -20% | 122s             | 75s             | -38%   |
| reword-commit              | 5/5               | 5/5           | =       | 13s              | 11s             | -13%   |
| selective-commit           | 5/5               | 5/5           | =       | 118s             | 502s            | +325%  |
| split-commit               | 5/5               | 4/5           | 🔴 -20% | 35s              | 44s             | +26%   |
| squash-commits             | 5/5               | 5/5           | =       | 21s              | 16s             | -27%   |
| stacked-branch-commit      | 0/5               | 0/5           | =       | 52s              | 104s            | +99%   |
| status-comprehension       | 4/5               | 4/5           | =       | 45s              | 57s             | +25%   |
| TOTAL                      | 69/80 (86%)       | 71/80 (89%)   | +2.5%   | 80s avg          | 118s avg        | —      |

Codex (gpt-5.4)

| Scenario                   | Baseline (--json) | No-JSON (-fv) | Δ pass  | VC wall baseline | VC wall no-json | Δ wall |
| -------------------------- | ----------------- | ------------- | ------- | ---------------- | --------------- | ------ |
| absorb-changes             | 3/3               | 5/5           | =       | 72s              | 50s             | -31%   |
| amend-into-commit          | 3/3               | 5/5           | =       | 11s              | 4s              | -66%   |
| commit-to-stacks           | 3/3               | 5/5           | =       | 1024s            | 348s            | -66%   |
| dependency-lock-recovery   | 1/3               | 5/5           | 🟢 +67% | 573s             | 241s            | -58%   |
| move-across-stacks         | 3/3               | 5/5           | =       | 32s              | 10s             | -69%   |
| move-branch-between-stacks | 1/3               | 5/5           | 🟢 +67% | 779s             | 154s            | -80%   |
| move-file-between-commits  | 3/3               | 5/5           | =       | 415s             | 309s            | -26%   |
| reorder-in-stack           | 3/3               | 5/5           | =       | 182s             | 231s            | +27%   |
| reorder-with-conflict      | 3/3               | 5/5           | =       | 87s              | 54s             | -37%   |
| resolve-conflict           | 3/3               | 3/5           | 🔴 -40% | 170s             | 65s             | -61%   |
| reword-commit              | 3/3               | 5/5           | =       | 13s              | 15s             | +14%   |
| selective-commit           | 0/3               | 2/5           | 🟢 +40% | 154s             | 665s            | +332%  |
| split-commit               | 0/3               | 4/5           | 🟢 +80% | 129s             | 46s             | -65%   |
| squash-commits             | 3/3               | 5/5           | =       | 29s              | 19s             | -34%   |
| stacked-branch-commit      | 0/3               | 0/5           | =       | 237s             | 134s            | -44%   |
| status-comprehension       | 0/3               | 1/5           | 🟢 +20% | 187s             | 114s            | -39%   |
| TOTAL                      | 32/48 (67%)       | 65/80 (81%)   | +14.6%  | 256s avg         | 154s avg        | -40%   |

Note: baseline was k=3, current run k=5. Codex VC wall time down 40% across the board.

