### PR TITLE
Export the move_branch and tear_off_branch APIs to the sdk

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1695,7 +1695,7 @@ function injectEndpoints(api: BackendApi, uiState: UiState) {
 				}
 			>({
 				extraOptions: {
-					command: "tear_off_branch",
+					command: "tear_off_branch_legacy",
 					actionName: "Tear Off Branch",
 				},
 				query: (args) => args,

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -150,7 +150,7 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
 }
 
 /// Move a branch on top of another
-#[but_api(json::UIMoveBranchResult)]
+#[but_api(napi, json::UIMoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn move_branch(
     ctx: &mut but_ctx::Context,
@@ -172,6 +172,10 @@ pub fn move_branch(
 }
 
 /// Move the branch, updating the workspace and the metadata.
+///
+/// `subject_branch` - The branch to move.
+///
+/// `target_branch` - The branch to move `subject_branch` on top of.
 fn move_branch_impl(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
@@ -182,6 +186,53 @@ fn move_branch_impl(
     let editor = workspace.graph.to_editor(&repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(editor, &workspace, subject_branch, target_branch)?;
+
+    let materialization = rebase.materialize()?;
+    if let Some((ws_meta, ref_name)) = ws_meta.zip(workspace.ref_name()) {
+        let mut md = meta.workspace(ref_name)?;
+        *md = ws_meta;
+        meta.set_workspace(&md)?;
+    }
+    workspace.refresh_from_head(&repo, &meta)?;
+
+    Ok(MoveBranchResult {
+        replaced_commits: materialization.history.commit_mappings(),
+    })
+}
+
+/// Take a branch out of a stack
+///
+/// `subject_branch` - The branch to take out of its stack, and create a new one out of.
+#[but_api(napi, json::UIMoveBranchResult)]
+#[instrument(err(Debug))]
+pub fn tear_off_branch(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+) -> anyhow::Result<MoveBranchResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+        ctx,
+        SnapshotDetails::new(OperationKind::TearOffBranch),
+    )
+    .ok();
+
+    let move_branch_result = tear_off_branch_impl(ctx, subject_branch);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| move_branch_result.is_ok()) {
+        let mut guard = ctx.exclusive_worktree_access();
+        snapshot.commit(ctx, guard.write_permission()).ok();
+    }
+    move_branch_result
+}
+
+/// Move the branch, updating the workspace and the metadata.
+fn tear_off_branch_impl(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+) -> anyhow::Result<MoveBranchResult> {
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, mut workspace, _) = ctx.workspace_mut_and_db()?;
+    let editor = workspace.graph.to_editor(&repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::tear_off_branch(editor, &workspace, subject_branch, None)?;
 
     let materialization = rebase.materialize()?;
     if let Some((ws_meta, ref_name)) = ws_meta.zip(workspace.ref_name()) {

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -401,7 +401,7 @@ pub fn move_branch_legacy(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn tear_off_branch(
+pub fn tear_off_branch_legacy(
     ctx: &mut but_ctx::Context,
     source_stack_id: StackId,
     subject_branch_name: String,

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -379,8 +379,8 @@ pub async fn run() {
             but_post(legacy::virtual_branches::move_branch_legacy_cmd),
         )
         .route(
-            "/tear_off_branch",
-            but_post(legacy::virtual_branches::tear_off_branch_cmd),
+            "/tear_off_branch_legacy",
+            but_post(legacy::virtual_branches::tear_off_branch_legacy_cmd),
         )
         .route(
             "/update_commit_message",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -299,7 +299,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::virtual_branches::tauri_fetch_from_remotes::fetch_from_remotes,
                 legacy::virtual_branches::tauri_move_commit::move_commit,
                 legacy::virtual_branches::tauri_move_branch_legacy::move_branch_legacy,
-                legacy::virtual_branches::tauri_tear_off_branch::tear_off_branch,
+                legacy::virtual_branches::tauri_tear_off_branch_legacy::tear_off_branch_legacy,
                 legacy::virtual_branches::tauri_normalize_branch_name::normalize_branch_name,
                 legacy::virtual_branches::tauri_upstream_integration_statuses::upstream_integration_statuses,
                 legacy::virtual_branches::tauri_integrate_upstream::integrate_upstream,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -81,6 +81,16 @@ export declare function listBranches(projectId: string, filter: BranchListingFil
 
 export declare function listProjectsStateless(): Promise<Array<ProjectForFrontend>>
 
+/** Move a branch on top of another */
+export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string): Promise<UIMoveBranchResult>
+
+/**
+ * Take a branch out of a stack
+ *
+ * `subject_branch` - The branch to take out of its stack, and create a new one out of.
+ */
+export declare function tearOffBranch(projectId: string, subjectBranch: string): Promise<UIMoveBranchResult>
+
 /**
  * Provide a unified diff for `change`, but fail if `change` is a [type-change](but_core::ModeFlags::TypeChange)
  * or if it involves a change to a [submodule](gix::object::Kind::Commit).

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { apply, assignHunk, branchDetails, branchDiff, changesInWorktree, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitMoveToBranch, commitReword, commitUncommitChanges, headInfo, listBranches, listProjectsStateless, treeChangeDiffs, unapplyStack, WatcherHandle, watcherStart } = nativeBinding
+const { apply, assignHunk, branchDetails, branchDiff, changesInWorktree, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitMoveToBranch, commitReword, commitUncommitChanges, headInfo, listBranches, listProjectsStateless, moveBranch, tearOffBranch, treeChangeDiffs, unapplyStack, WatcherHandle, watcherStart } = nativeBinding
 export { apply }
 export { assignHunk }
 export { branchDetails }
@@ -597,6 +597,8 @@ export { commitUncommitChanges }
 export { headInfo }
 export { listBranches }
 export { listProjectsStateless }
+export { moveBranch }
+export { tearOffBranch }
 export { treeChangeDiffs }
 export { unapplyStack }
 export { WatcherHandle }


### PR DESCRIPTION
Export the move branch and branch tear off APIs as but APIs and as napi bindings.

Mark the previous tear off branch API as legacy.