### PR TITLE
fix: refresh gitbutler/workspace HEAD after amend and absorb

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 estib <stron@me.com> Jose Vega <stron@me.com>
 estib <stron@me.com> Esteban Vega <35891811+estib-vega@users.noreply.github.com>
-Codex <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com> chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>
+Codex <codex@openai.com> chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com> 
+Codex <codex@openai.com> GPT 5.4 <codex@openai.com>
 Byron <sebastian.thiel@icloud.com> Sebastian Thiel <sebastian.thiel@icloud.com> <63622+Byron@users.noreply.github.com>
 Copilot <198982749+Copilot@users.noreply.github.com> copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use bstr::BString;
-use but_core::sync::RepoExclusiveGuard;
+use but_core::sync::RepoExclusive;
 use but_ctx::ProjectHandleOrLegacyProjectId;
 use but_hunk_assignment::{CommitMap, convert_assignments_to_diff_specs};
 use but_workspace::commit_engine;
@@ -68,7 +68,7 @@ pub(crate) fn auto_commit(
     llm: Option<&but_llm::LLMProvider>,
     emitter: impl Fn(&str, serde_json::Value) + Send + Sync + 'static,
     absorption_plan: Vec<but_hunk_assignment::CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<usize> {
     let commit_map = CommitMap::default();
 
@@ -88,7 +88,7 @@ pub(crate) fn auto_commit(
         context_lines,
         llm,
         absorption_plan,
-        guard,
+        perm,
         commit_map,
         Some(emitter.clone()),
     ) {
@@ -118,7 +118,7 @@ pub(crate) fn auto_commit_simple(
     context_lines: u32,
     llm: Option<&but_llm::LLMProvider>,
     absorption_plan: Vec<but_hunk_assignment::CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<usize> {
     let commit_map = CommitMap::default();
 
@@ -129,7 +129,7 @@ pub(crate) fn auto_commit_simple(
         context_lines,
         llm,
         absorption_plan,
-        guard,
+        perm,
         commit_map,
         None,
     )
@@ -143,7 +143,7 @@ fn apply_commit_changes(
     context_lines: u32,
     llm: Option<&but_llm::LLMProvider>,
     absorption_plan: Vec<but_hunk_assignment::CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
     mut commit_map: CommitMap,
     emitter: Option<std::sync::Arc<AutoCommitEmitter>>,
 ) -> anyhow::Result<usize> {
@@ -178,7 +178,7 @@ fn apply_commit_changes(
                 },
                 diff_specs,
                 context_lines,
-                guard.write_permission(),
+                perm,
             )?;
 
         if let Some(new_commit_id) = outcome.new_commit

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -6,8 +6,8 @@ use std::{
     str::FromStr,
 };
 
-use but_core::{TreeChange, sync::RepoExclusiveGuard};
-use but_ctx::{Context, ProjectHandleOrLegacyProjectId, access::RepoExclusive};
+use but_core::{TreeChange, sync::RepoExclusive};
+use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 use but_hunk_assignment::CommitAbsorption;
 use but_workspace::legacy::ui::StackEntry;
 use gitbutler_branch::BranchCreateRequest;
@@ -48,7 +48,7 @@ pub fn auto_commit(
     llm: Option<&but_llm::LLMProvider>,
     emitter: impl Fn(&str, serde_json::Value) + Send + Sync + 'static,
     absorption_plan: Vec<CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<usize> {
     auto_commit::auto_commit(
         project_id,
@@ -58,7 +58,7 @@ pub fn auto_commit(
         llm,
         emitter,
         absorption_plan,
-        guard,
+        perm,
     )
 }
 
@@ -68,7 +68,7 @@ pub fn auto_commit_simple(
     context_lines: u32,
     llm: Option<&but_llm::LLMProvider>,
     absorption_plan: Vec<CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<usize> {
     auto_commit::auto_commit_simple(
         repo,
@@ -76,7 +76,7 @@ pub fn auto_commit_simple(
         context_lines,
         llm,
         absorption_plan,
-        guard,
+        perm,
     )
 }
 

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -5,7 +5,7 @@ use std::{
 
 use bstr::ByteSlice;
 use but_api_macros::but_api;
-use but_core::sync::{RepoExclusive, RepoExclusiveGuard};
+use but_core::sync::RepoExclusive;
 use but_ctx::Context;
 use but_hunk_assignment::{
     AbsorptionReason, AbsorptionTarget, CommitAbsorption, CommitMap, FileAbsorption,
@@ -43,7 +43,7 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
         )
         .ok(); // Ignore errors for snapshot creation
 
-    let total_rejected = absorb_impl(absorption_plan, &mut guard, &repo, &data_dir)?;
+    let total_rejected = absorb_impl(absorption_plan, guard.write_permission(), &repo, &data_dir)?;
 
     // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
     // with the rewritten branch commits. Without this, tools that inspect HEAD
@@ -55,7 +55,7 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
 
 pub fn absorb_impl(
     absorption_plan: Vec<CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
     repo: &gix::Repository,
     data_dir: &Path,
 ) -> anyhow::Result<usize> {
@@ -76,7 +76,7 @@ pub fn absorb_impl(
             absorption.stack_id,
             commit_id,
             diff_specs,
-            guard,
+            perm,
             repo,
             data_dir,
         )?;

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -43,7 +43,14 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
         )
         .ok(); // Ignore errors for snapshot creation
 
-    absorb_impl(absorption_plan, &mut guard, &repo, &data_dir)
+    let total_rejected = absorb_impl(absorption_plan, &mut guard, &repo, &data_dir)?;
+
+    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
+    // with the rewritten branch commits. Without this, tools that inspect HEAD
+    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
+    gitbutler_branch_actions::update_workspace_commit(ctx, false)?;
+
+    Ok(total_rejected)
 }
 
 pub fn absorb_impl(
@@ -83,7 +90,7 @@ pub fn absorb_impl(
     Ok(total_rejected)
 }
 
-/// Generate an absorption plan based on the provided target, based on hunk dependencies, assingments and other heuristics
+/// Generate an absorption plan based on the provided target, based on hunk dependencies, assignments and other heuristics
 #[but_api]
 #[instrument(err(Debug))]
 pub fn absorption_plan(

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, str::FromStr};
 
 use anyhow::{Context as _, Result};
 use but_api_macros::but_api;
-use but_core::{RepositoryExt, sync::RepoExclusiveGuard};
+use but_core::{RepositoryExt, sync::RepoExclusive};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignmentRequest;
 use but_settings::AppSettings;
@@ -351,7 +351,7 @@ pub fn amend_commit_from_worktree_changes(
         stack_id,
         commit_id,
         worktree_changes,
-        &mut guard,
+        guard.write_permission(),
         &repo,
         &data_dir,
     )?;
@@ -369,7 +369,7 @@ pub fn amend_commit_and_count_failures(
     stack_id: StackId,
     commit_id: gix::ObjectId,
     worktree_changes: Vec<but_core::DiffSpec>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
     repo: &gix::Repository,
     data_dir: &std::path::Path,
 ) -> anyhow::Result<commit_engine::CreateCommitOutcome> {
@@ -385,7 +385,7 @@ pub fn amend_commit_and_count_failures(
         },
         worktree_changes,
         app_settings.context_lines,
-        guard.write_permission(),
+        perm,
     )?;
     if !outcome.rejected_specs.is_empty() {
         tracing::warn!(?outcome.rejected_specs, "Failed to commit at least one hunk");

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -347,14 +347,21 @@ pub fn amend_commit_from_worktree_changes(
     let mut guard = ctx.exclusive_worktree_access();
     let repo = ctx.repo.get()?;
     let data_dir = ctx.project_data_dir();
-    amend_commit_and_count_failures(
+    let outcome = amend_commit_and_count_failures(
         stack_id,
         commit_id,
         worktree_changes,
         &mut guard,
         &repo,
         &data_dir,
-    )
+    )?;
+
+    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
+    // with the rewritten branch commits. Without this, tools that inspect HEAD
+    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
+    update_workspace_commit(ctx, false)?;
+
+    Ok(outcome)
 }
 
 /// Amend a commit with the given changes and return the number of rejected files

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -74,6 +74,10 @@ pub fn try_exclusive_inter_process_access(
 /// blocking while waiting for someone else to release it, or for all readers to disappear.
 /// Locking is fair.
 ///
+/// Use this only at the boundary where the lock is acquired. Keep the returned [`RepoExclusiveGuard`]
+/// alive in the caller that owns the lock, and pass [`RepoExclusive`] further down instead via
+/// [`RepoExclusiveGuard::write_permission()`].
+///
 /// Note that this **in-process** locking works only under the assumption that no two instances of
 /// GitButler are able to read or write the same repository.
 pub fn exclusive_repo_access(git_dir: impl Into<PathBuf>) -> RepoExclusiveGuard {
@@ -89,13 +93,24 @@ pub fn exclusive_repo_access(git_dir: impl Into<PathBuf>) -> RepoExclusiveGuard 
 /// and block while waiting for writers to disappear.
 /// There can be multiple readers, but only a single writer. Waiting writers will be handled with priority,
 /// thus block readers to prevent writer starvation.
+///
+/// Use this only at the boundary where the lock is acquired. Keep the returned [`RepoSharedGuard`]
+/// alive in the caller that owns the lock, and pass [`RepoShared`] further down instead via
+/// [`RepoSharedGuard::read_permission()`].
 pub fn shared_repo_access(git_dir: impl Into<PathBuf>) -> RepoSharedGuard {
     let mut map = WORKTREE_LOCKS.lock();
     let git_dir = git_dir.into();
     RepoSharedGuard(Some(map.entry(git_dir).or_default().read_arc()))
 }
 
-/// A utility that drops an exclusive lock on drop.
+/// Owns an *exclusive* in-process repository lock and releases it on drop.
+///
+/// This type is for lock acquisition and lock lifetime management only.
+/// Keep it in the top-level caller that actually acquires the lock.
+///
+/// Do not pass this type through application APIs unless the API itself is responsible for lock
+/// ownership. Instead, derive a [`RepoExclusive`] with [`Self::write_permission()`] and pass that
+/// permission token to lower-level functions while keeping the guard alive in the caller.
 #[must_use]
 pub struct RepoExclusiveGuard {
     inner: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
@@ -123,43 +138,64 @@ impl Drop for RepoSharedGuard {
 }
 
 impl RepoExclusiveGuard {
-    /// Signal that a write-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
+    /// Borrow the exclusive permission token tied to this guard.
+    ///
+    /// Pass the returned [`RepoExclusive`] to callees that require proof that the caller already
+    /// holds the exclusive lock.
     pub fn write_permission(&mut self) -> &mut RepoExclusive {
         &mut self.perm
     }
 
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
+    /// Borrow the shared read permission implied by exclusive access.
+    ///
+    /// This is useful for APIs that only need read access but still participate in the permission
+    /// system to prevent concurrent writes.
     pub fn read_permission(&self) -> &RepoShared {
         self.perm.read_permission()
     }
 }
 
-/// A utility that drops a shared lock on drop.
+/// Owns a *shared* in-process repository lock and releases it on drop.
+///
+/// This type is for lock acquisition and lock lifetime management only.
+/// Keep it in the top-level caller that actually acquires the lock.
+///
+/// Do not pass this type through application APIs unless the API itself is responsible for lock
+/// ownership. Instead, derive a [`RepoShared`] with [`Self::read_permission()`] and pass that
+/// permission token to lower-level functions while keeping the guard alive in the caller.
 #[must_use]
 pub struct RepoSharedGuard(Option<ArcRwLockReadGuard<RawRwLock, ()>>);
 
 impl RepoSharedGuard {
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
+    /// Borrow the shared read permission token tied to this guard.
+    ///
+    /// Pass the returned [`RepoShared`] to callees that require proof that the caller already
+    /// holds shared or exclusive read access.
     pub fn read_permission(&self) -> &RepoShared {
         static READ: RepoShared = RepoShared(());
         &READ
     }
 }
 
-/// A token to indicate read-only access was granted to the repository, assuring there are no writers
-/// *within this process*.
+/// A permission token proving read-only repository access was granted within this process.
+///
+/// Use this as a function parameter when a callee only needs proof that no writer is active.
+/// It does not acquire or release locks by itself; that remains the job of [`RepoSharedGuard`] or
+/// [`RepoExclusiveGuard`] in the caller.
 pub struct RepoShared(());
 
-/// A token to indicate exclusive access was granted to the repository, assuring there are no readers or other writers
-/// *within this process*.
+/// A permission token proving exclusive repository access was granted within this process.
+///
+/// Use this as a function parameter when a callee needs proof that no other reader or writer is
+/// active.
+/// It does not acquire or release locks by itself; that remains the job of [`RepoExclusiveGuard`] in the caller.
 pub struct RepoExclusive(());
 
 impl RepoExclusive {
-    /// Signal that a read-permission is available - useful as API-marker to assure these
-    /// can only be called when the respective protection/permission is present.
+    /// Borrow the read permission implied by exclusive access.
+    ///
+    /// This allows code that only needs read access to accept [`RepoShared`] even when the caller
+    /// holds exclusive access.
     pub fn read_permission(&self) -> &RepoShared {
         static READ: RepoShared = RepoShared(());
         &READ

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -109,6 +109,7 @@ pub(crate) fn handle(
         .create_snapshot(SnapshotDetails::new(operation), guard.write_permission())
         .ok(); // Ignore errors for snapshot creation
     absorb_assignments(
+        ctx,
         absorption_plan,
         &mut guard,
         &repo,
@@ -118,12 +119,6 @@ pub(crate) fn handle(
         new,
         plan_json,
     )?;
-    drop(guard);
-
-    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
-    // with the rewritten branch commits. Without this, tools that inspect HEAD
-    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
-    update_workspace_commit(ctx, false)?;
 
     Ok(())
 }
@@ -131,6 +126,7 @@ pub(crate) fn handle(
 /// Absorb a single file into the appropriate commit
 #[expect(clippy::too_many_arguments)]
 fn absorb_assignments(
+    ctx: &Context,
     absorption_plan: Vec<CommitAbsorption>,
     guard: &mut RepoExclusiveGuard,
     repo: &gix::Repository,
@@ -145,6 +141,11 @@ fn absorb_assignments(
     } else {
         but_api::legacy::absorb::absorb_impl(absorption_plan, guard, repo, data_dir)?
     };
+
+    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
+    // with the rewritten branch commits. Without this, tools that inspect HEAD
+    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
+    update_workspace_commit(ctx, false)?;
 
     // Display completion message
     if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -7,6 +7,7 @@ use but_hunk_assignment::{
     JsonFileAbsorption,
 };
 use colored::Colorize;
+use gitbutler_branch_actions::update_workspace_commit;
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -117,6 +118,12 @@ pub(crate) fn handle(
         new,
         plan_json,
     )?;
+    drop(guard);
+
+    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
+    // with the rewritten branch commits. Without this, tools that inspect HEAD
+    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
+    update_workspace_commit(ctx, false)?;
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use but_core::{RepositoryExt, sync::RepoExclusiveGuard};
+use but_core::{RepositoryExt, sync::RepoExclusive};
 use but_ctx::Context;
 use but_hunk_assignment::{
     AbsorptionTarget, CommitAbsorption, HunkAssignment, JsonAbsorbOutput, JsonCommitAbsorption,
@@ -111,7 +111,7 @@ pub(crate) fn handle(
     absorb_assignments(
         ctx,
         absorption_plan,
-        &mut guard,
+        guard.write_permission(),
         &repo,
         &data_dir,
         out,
@@ -128,7 +128,7 @@ pub(crate) fn handle(
 fn absorb_assignments(
     ctx: &Context,
     absorption_plan: Vec<CommitAbsorption>,
-    guard: &mut RepoExclusiveGuard,
+    perm: &mut RepoExclusive,
     repo: &gix::Repository,
     data_dir: &Path,
     out: &mut OutputChannel,
@@ -137,9 +137,9 @@ fn absorb_assignments(
     plan_json: Option<JsonAbsorbOutput>,
 ) -> anyhow::Result<()> {
     let total_rejected = if new {
-        but_action::auto_commit_simple(repo, data_dir, context_lines, None, absorption_plan, guard)?
+        but_action::auto_commit_simple(repo, data_dir, context_lines, None, absorption_plan, perm)?
     } else {
-        but_api::legacy::absorb::absorb_impl(absorption_plan, guard, repo, data_dir)?
+        but_api::legacy::absorb::absorb_impl(absorption_plan, perm, repo, data_dir)?
     };
 
     // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -3,6 +3,7 @@ use but_ctx::{Context, access::RepoExclusive};
 use but_hunk_assignment::HunkAssignment;
 use but_workspace::commit_engine::{self, CreateCommitOutcome};
 use colored::Colorize;
+use gitbutler_branch_actions::update_workspace_commit;
 use gix::ObjectId;
 use nonempty::NonEmpty;
 
@@ -28,6 +29,7 @@ pub(crate) fn uncommitted_to_commit(
         let mut guard = ctx.exclusive_worktree_access();
         amend_diff_specs(ctx, diff_specs, stack_id, oid, guard.write_permission())?
     };
+    update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let new_commit = outcome
@@ -63,6 +65,7 @@ pub(crate) fn assignments_to_commit(
     let mut guard = ctx.exclusive_worktree_access();
     let outcome = amend_diff_specs(ctx, diff_specs, stack_id, oid, guard.write_permission())?;
     drop(guard);
+    update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let new_commit = outcome

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -726,6 +726,17 @@ Dry run complete. No changes were made.
         "Status should be unchanged after dry-run"
     );
 
+    // Also verify the workspace commit did NOT change during dry-run
+    let repo = env.open_repo()?;
+    let ws_id = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
+    drop(repo);
+    // Re-run dry-run and confirm workspace is still the same
+    env.but("absorb i0 --dry-run").assert().success();
+    let repo = env.open_repo()?;
+    let ws_id_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
+    assert_eq!(ws_id, ws_id_after, "dry-run must not touch workspace HEAD");
+    drop(repo);
+
     // Verify the file content wasn't actually changed
     let repo = env.open_repo()?;
     let blob = repo.rev_parse_single(b"A:a.txt")?.object()?;
@@ -759,6 +770,36 @@ Dry run complete. No changes were made.
 ...
 
 "#]]);
+
+    Ok(())
+}
+
+/// Regression test for https://github.com/gitbutlerapp/gitbutler/issues/12750
+/// After absorb, the `gitbutler/workspace` HEAD must be refreshed so that
+/// tools inspecting HEAD (e.g. pre-push hooks that stash against it) see
+/// an up-to-date synthetic commit rather than a stale one.
+#[test]
+fn workspace_head_is_refreshed_after_absorb() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    // Record the workspace commit *before* absorb.
+    let repo = env.open_repo()?;
+    let ws_before = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
+    drop(repo);
+
+    env.but("absorb i0").assert().success().stderr_eq(str![""]);
+
+    // After absorb the workspace commit must have changed.
+    let repo = env.open_repo()?;
+    let ws_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
+
+    assert_ne!(
+        ws_before, ws_after,
+        "gitbutler/workspace HEAD should be refreshed after absorb"
+    );
 
     Ok(())
 }

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -729,13 +729,10 @@ Dry run complete. No changes were made.
     // Also verify the workspace commit did NOT change during dry-run
     let repo = env.open_repo()?;
     let ws_id = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
-    drop(repo);
     // Re-run dry-run and confirm workspace is still the same
     env.but("absorb i0 --dry-run").assert().success();
-    let repo = env.open_repo()?;
     let ws_id_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
     assert_eq!(ws_id, ws_id_after, "dry-run must not touch workspace HEAD");
-    drop(repo);
 
     // Verify the file content wasn't actually changed
     let repo = env.open_repo()?;
@@ -788,12 +785,10 @@ fn workspace_head_is_refreshed_after_absorb() -> anyhow::Result<()> {
     // Record the workspace commit *before* absorb.
     let repo = env.open_repo()?;
     let ws_before = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
-    drop(repo);
 
     env.but("absorb i0").assert().success().stderr_eq(str![""]);
 
     // After absorb the workspace commit must have changed.
-    let repo = env.open_repo()?;
     let ws_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
 
     assert_ne!(

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -98,7 +98,7 @@ pub fn auto_commit(
         llm.as_ref(),
         emitter,
         absorption_plan,
-        &mut guard,
+        guard.write_permission(),
     )
     .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
     Ok(())


### PR DESCRIPTION
## Problem

After `but amend` or `but absorb` operations, the `gitbutler/workspace` synthetic commit was not being updated. This caused tools that inspect HEAD (e.g. pre-push hooks that stash against it) to see a stale commit whose tree no longer matched the actual branch state.

## Solution

Add `update_workspace_commit()` calls to both layers:

**API layer** (used by the Tauri desktop app):
- `amend_commit_from_worktree_changes` in `crates/but-api/src/legacy/workspace.rs`
- `absorb` in `crates/but-api/src/legacy/absorb.rs`

**CLI layer** (used by `but amend` / `but absorb`):
- `uncommitted_to_commit` and `assignments_to_commit` in `crates/but/src/command/legacy/rub/amend.rs`
- `absorb` command handler in `crates/but/src/command/legacy/absorb.rs`

This matches the pattern already used by `move_changes_between_commits`, `split_branch`, `uncommit_changes`, and `stash_into_branch`.

## Testing

- Added regression test `workspace_head_is_refreshed_after_absorb` that verifies the workspace commit ID changes after absorb
- Extended `dry_run_shows_plan_without_changes` test to verify workspace HEAD does *not* change during dry-run
- All 221 existing `but` CLI tests pass
- `cargo fmt --check --all` passes

Closes #12750