### PR TITLE
gitbutler-commit: update CommitExt trait documentation

### DIFF
--- a/crates/gitbutler-commit/src/commit_ext.rs
+++ b/crates/gitbutler-commit/src/commit_ext.rs
@@ -1,7 +1,7 @@
 use bstr::{BStr, ByteSlice};
 use but_core::{ChangeId, commit::Headers};
 
-/// Extension trait for `git2::Commit`.
+/// Extension trait for `gix::Commit`.
 ///
 /// For now, it collects useful methods from `gitbutler-core::git::Commit`
 pub trait CommitExt {


### PR DESCRIPTION
## 🧢 Changes

gitbutler-commit: update CommitExt trait documentation

## ☕️ Reasoning

After #5722 it was used for both `git2::Commit` and `gix::Commit`, since #11788 it has only been used for `gix::Commit`.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
