### PR TITLE
Remove frontend-shaped paramters from `but-api` functions

### DIFF
--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -19,6 +19,12 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 ///     - Use it like `but_api(try_from = JSONReturnType)` where `JSONReturnType::try_from(actual_return_type)?` is implemented.
 ///     - Controls how the actual return value is fallibly converted for JSON serialization in `func_json` and `func_cmd`.
 ///
+/// # Parameter Attributes
+///
+/// Function parameters may use `#[but_api(TransportType)]` to keep the implementation
+/// signature on a pure Rust type while generated wrappers accept a transport-oriented serde type.
+/// This is currently limited to owned parameters and requires `impl From<TransportType> for ParamType`.
+///
 /// These can be combined with commas, e.g. `#[but_api(napi, try_from = json::CommitDetails)]`
 /// or `#[but_api(napi, json::CommitDetails)]`.
 ///
@@ -48,6 +54,7 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 #[proc_macro_attribute]
 pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(item as ItemFn);
+    let sanitized_input_fn = strip_param_but_api_attrs(&input_fn);
 
     let vis = &input_fn.vis;
     let sig = &input_fn.sig;
@@ -309,7 +316,7 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         // Original function stays
-        #input_fn
+        #sanitized_input_fn
 
         const _: () = {
             #[expect(dead_code)]
@@ -386,6 +393,12 @@ enum WrapperCallArgKind {
     AsRef,
 }
 
+/// A custom wrapper-surface transport type declared on a function parameter via
+/// `#[but_api(TransportType)]`.
+struct ParamTransportMapping {
+    transport_ty: syn::Type,
+}
+
 fn build_wrapper_params<'a>(
     input: impl IntoIterator<Item = &'a syn::FnArg>,
 ) -> Result<WrapperParamsInfo, syn::Error> {
@@ -410,6 +423,19 @@ fn build_wrapper_params<'a>(
             ));
         };
         let ident = &pat_ident.ident;
+
+        if let Some(custom_transport) = parse_param_transport_mapping(pat_ty)? {
+            let transport_ty = &custom_transport.transport_ty;
+            let binding_ty = &pat_ty.ty;
+            param_field_names.push(ident.clone());
+            struct_fields_with_json_types.push(quote! { pub #ident: #transport_ty });
+            json_fn_input_params.push(syn::parse_quote! { #ident: #transport_ty });
+            param_conversions.push(quote! {
+                let mut #ident: #binding_ty = <#binding_ty>::from(#ident);
+            });
+            call_arg_idents.push(quote! { #ident });
+            continue;
+        }
 
         if let Some(mapping) = build_wrapper_parameter_mapping(&pat_ty.ty)? {
             let json_ident = mapping.json_ident.unwrap_or_else(|| ident.clone());
@@ -459,6 +485,78 @@ fn build_wrapper_params<'a>(
         call_arg_idents,
         requires_legacy,
     })
+}
+
+/// Remove parameter-level `#[but_api(...)]` attributes from the original function item before it
+/// is emitted again, as only the proc-macro implementation should interpret them.
+fn strip_param_but_api_attrs(input_fn: &ItemFn) -> ItemFn {
+    let mut stripped = input_fn.clone();
+    for arg in &mut stripped.sig.inputs {
+        let FnArg::Typed(pat_ty) = arg else {
+            continue;
+        };
+        pat_ty.attrs.retain(|attr| !attr.path().is_ident("but_api"));
+    }
+    stripped
+}
+
+/// Parse an optional parameter-local transport override from `#[but_api(TransportType)]`.
+///
+/// This mirrors the top-level `#[but_api(Type)]` shorthand by treating the provided type as the
+/// wrapper-facing transport type and assuming `impl From<TransportType> for ParamType`.
+/// The override is intentionally limited to owned parameters and cannot overlap with built-in
+/// remappings like `Context` or `gix::ObjectId`.
+fn parse_param_transport_mapping(
+    pat_ty: &syn::PatType,
+) -> Result<Option<ParamTransportMapping>, syn::Error> {
+    let mut transport_ty = None;
+
+    for attr in &pat_ty.attrs {
+        if !attr.path().is_ident("but_api") {
+            continue;
+        }
+
+        let parsed: syn::Type = attr.parse_args_with(|input: syn::parse::ParseStream| {
+            if input.peek(syn::Ident) && input.peek2(syn::Token![=]) {
+                let ident: syn::Ident = input.parse()?;
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "Expected `Type`; use `#[but_api(Type)]` instead of `#[but_api(transport = Type)]` for parameter attributes",
+                ));
+            }
+
+            let ty: syn::Type = input.parse()?;
+            if !input.is_empty() {
+                return Err(input.error("Unexpected tokens after parameter transport type"));
+            }
+            Ok(ty)
+        })?;
+
+        if transport_ty.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "Only one `#[but_api(Type)]` attribute may be specified per parameter",
+            ));
+        }
+
+        if matches!(&*pat_ty.ty, syn::Type::Reference(_)) {
+            return Err(syn::Error::new_spanned(
+                &pat_ty.ty,
+                "`#[but_api(Type)]` only supports owned parameters",
+            ));
+        }
+
+        if build_wrapper_parameter_mapping(&pat_ty.ty)?.is_some() {
+            return Err(syn::Error::new_spanned(
+                &pat_ty.ty,
+                "`#[but_api(Type)]` cannot be combined with built-in parameter remapping",
+            ));
+        }
+
+        transport_ty = Some(parsed);
+    }
+
+    Ok(transport_ty.map(|transport_ty| ParamTransportMapping { transport_ty }))
 }
 
 fn build_wrapper_parameter_mapping(
@@ -894,6 +992,21 @@ fn build_napi_params<'a>(
             ));
         };
         let ident = &pat_ident.ident;
+
+        if let Some(custom_transport) = parse_param_transport_mapping(pat_ty)? {
+            let transport_ty = &custom_transport.transport_ty;
+            let ts_type_str = type_to_ts_name(transport_ty);
+            let transport_ident = format_ident!("__{}_transport", ident);
+            let actual_ty = &pat_ty.ty;
+            params.push(quote! { #[napi(ts_arg_type = #ts_type_str)] #ident: ::serde_json::Value });
+            conversions.push(quote! {
+                let #transport_ident: #transport_ty = ::serde_json::from_value(#ident)
+                    .map_err(|e| napi::Error::new(napi::Status::InvalidArg, format!("{e}")))?;
+                let #ident: #actual_ty = <#actual_ty>::from(#transport_ident);
+            });
+            call_arg_idents.push(quote! { #ident });
+            continue;
+        }
 
         // Check if this parameter has a json type mapping (Context, ObjectId)
         if let Some(mapping) = json_ty_by_name.get(&ident.to_string()) {

--- a/crates/but-api-macros/tests/src/lib.rs
+++ b/crates/but-api-macros/tests/src/lib.rs
@@ -124,6 +124,28 @@ impl From<(usize, isize)> for ComplexResult {
     }
 }
 
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "type", content = "subject")]
+pub enum UiRelativeTo {
+    Commit(String),
+    Reference(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RelativeTo {
+    Commit(String),
+    Reference(String),
+}
+
+impl From<UiRelativeTo> for RelativeTo {
+    fn from(value: UiRelativeTo) -> Self {
+        match value {
+            UiRelativeTo::Commit(commit) => Self::Commit(commit),
+            UiRelativeTo::Reference(reference) => Self::Reference(reference),
+        }
+    }
+}
+
 pub fn oid_from_hex(hex: &str) -> gix::ObjectId {
     gix::ObjectId::from_str(hex).expect("test literal object ids are valid")
 }

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_builtin_conflict.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_builtin_conflict.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiRelativeTo, panic_capture};
+
+#[but_api]
+pub fn invalid_transport_builtin(
+    #[but_api(UiRelativeTo)] commit_id: gix::ObjectId,
+) -> anyhow::Result<()> {
+    let _ = commit_id;
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_builtin_conflict.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_builtin_conflict.stderr
@@ -1,0 +1,5 @@
+error: `#[but_api(Type)]` cannot be combined with built-in parameter remapping
+ --> tests/ui/fail/base_parameter_transport_builtin_conflict.rs:7:41
+  |
+7 |     #[but_api(UiRelativeTo)] commit_id: gix::ObjectId,
+  |                                         ^^^^^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_keyed.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_keyed.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiRelativeTo, panic_capture};
+
+#[but_api]
+pub fn invalid_transport_keyed(
+    #[but_api(transport = UiRelativeTo)] relative_to: String,
+) -> anyhow::Result<()> {
+    let _ = relative_to;
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_keyed.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_keyed.stderr
@@ -1,0 +1,5 @@
+error: Expected `Type`; use `#[but_api(Type)]` instead of `#[but_api(transport = Type)]` for parameter attributes
+ --> tests/ui/fail/base_parameter_transport_keyed.rs:7:15
+  |
+7 |     #[but_api(transport = UiRelativeTo)] relative_to: String,
+  |               ^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_reference.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_reference.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiRelativeTo, panic_capture};
+
+#[but_api]
+pub fn invalid_transport_reference(
+    #[but_api(UiRelativeTo)] relative_to: &str,
+) -> anyhow::Result<()> {
+    let _ = relative_to;
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_reference.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_parameter_transport_reference.stderr
@@ -1,0 +1,5 @@
+error: `#[but_api(Type)]` only supports owned parameters
+ --> tests/ui/fail/base_parameter_transport_reference.rs:7:43
+  |
+7 |     #[but_api(UiRelativeTo)] relative_to: &str,
+  |                                           ^^^^

--- a/crates/but-api-macros/tests/tests/ui/pass/default_parameter_transport.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_parameter_transport.rs
@@ -1,0 +1,31 @@
+// Case: `#[but_api(Type)]` on an owned parameter remaps wrapper transport types
+// while keeping the implementation signature domain-oriented.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{RelativeTo, UiRelativeTo, json, panic_capture};
+
+#[but_api]
+pub fn transport_surface(
+    #[but_api(UiRelativeTo)] relative_to: RelativeTo,
+) -> anyhow::Result<String> {
+    let kind = match relative_to {
+        RelativeTo::Commit(_) => "commit",
+        RelativeTo::Reference(_) => "reference",
+    };
+    Ok(kind.to_owned())
+}
+
+fn main() {
+    let _ = transport_surface_json(UiRelativeTo::Commit("abc".into()));
+
+    #[cfg(feature = "legacy")]
+    {
+        let _ = transport_surface_cmd(serde_json::json!({
+            "relativeTo": {
+                "type": "commit",
+                "subject": "abc"
+            }
+        }));
+    }
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/napi_parameter_transport.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/napi_parameter_transport.rs
@@ -1,0 +1,22 @@
+// Case: `#[but_api(napi)]` parameter transport remap accepts the transport type shape on the
+// generated napi surface while the implementation uses the internal type.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{RelativeTo, UiRelativeTo, json, panic_capture};
+
+#[but_api(napi)]
+pub fn napi_transport_surface(
+    #[but_api(UiRelativeTo)] relative_to: RelativeTo,
+) -> anyhow::Result<String> {
+    let kind = match relative_to {
+        RelativeTo::Commit(_) => "commit",
+        RelativeTo::Reference(_) => "reference",
+    };
+    Ok(kind.to_owned())
+}
+
+fn main() {
+    let _ = napi_transport_surface_napi;
+    let _ = napi_napi_transport_surface::napi_transport_surface;
+}

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -5,10 +5,7 @@ use but_api_macros::but_api;
 use but_core::{DiffSpec, sync::RepoExclusive, tree::create_tree::RejectionReason};
 use but_hunk_assignment::HunkAssignmentRequest;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{
-    GraphExt, LookupStep as _,
-    mutate::{InsertSide, RelativeTo},
-};
+use but_rebase::graph_rebase::{Editor, GraphExt, LookupStep as _, ToSelector, mutate::InsertSide};
 use tracing::instrument;
 
 /// Outcome after creating a commit.
@@ -328,6 +325,38 @@ pub mod ui {
     }
 }
 
+/// Specifies a location relative to which a commit operation should occur.
+/// This is the fully-owned cousin of [but_rebase::graph_rebase::mutate::RelativeTo]
+/// as the [`but_api`] macro doesn't support contained references or referenced parameters
+/// beyond a few well-known ones.
+#[derive(Debug, Clone)]
+pub enum RelativeTo {
+    /// Relative to a commit.
+    Commit(gix::ObjectId),
+    /// Relative to a reference.
+    Reference(gix::refs::FullName),
+}
+
+impl From<ui::RelativeTo> for RelativeTo {
+    fn from(value: ui::RelativeTo) -> Self {
+        match value {
+            ui::RelativeTo::Commit(commit) => Self::Commit(commit),
+            ui::RelativeTo::Reference(reference) | ui::RelativeTo::ReferenceBytes(reference) => {
+                Self::Reference(reference)
+            }
+        }
+    }
+}
+
+impl ToSelector for RelativeTo {
+    fn to_selector(&self, editor: &Editor) -> anyhow::Result<but_rebase::graph_rebase::Selector> {
+        match self {
+            Self::Commit(commit) => editor.select_commit(*commit),
+            Self::Reference(reference) => editor.select_reference(reference.as_ref()),
+        }
+    }
+}
+
 /// Inserts a blank commit relative to either a commit or a reference
 ///
 /// Returns the result including the new commit ID and any replaced commits.
@@ -335,7 +364,7 @@ pub mod ui {
 #[instrument(err(Debug))]
 pub fn commit_insert_blank_only(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    #[but_api(ui::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitInsertBlankResult> {
     let mut guard = ctx.exclusive_worktree_access();
@@ -347,15 +376,13 @@ pub fn commit_insert_blank_only(
 /// Returns the result including the new commit ID and any replaced commits.
 pub(crate) fn commit_insert_blank_only_impl(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    relative_to: RelativeTo,
     side: InsertSide,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitInsertBlankResult> {
     let meta = ctx.meta()?;
     let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = ws.graph.to_editor(&repo)?;
-
-    let relative_to: RelativeTo = (&relative_to).into();
 
     let (outcome, blank_commit_selector) =
         but_workspace::commit::insert_blank_commit(editor, side, relative_to)?;
@@ -380,7 +407,7 @@ pub(crate) fn commit_insert_blank_only_impl(
 #[instrument(err(Debug))]
 pub fn commit_insert_blank(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    #[but_api(ui::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitInsertBlankResult> {
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
@@ -402,7 +429,7 @@ pub fn commit_insert_blank(
 #[instrument(err(Debug))]
 pub fn commit_create_only(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    #[but_api(ui::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
     changes: Vec<DiffSpec>,
     message: String,
@@ -423,7 +450,7 @@ pub fn commit_create_only(
 /// Creates and inserts a commit relative to either a commit or a reference.
 pub(crate) fn commit_create_only_impl(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    relative_to: RelativeTo,
     side: InsertSide,
     changes: Vec<DiffSpec>,
     message: String,
@@ -433,8 +460,6 @@ pub(crate) fn commit_create_only_impl(
     let meta = ctx.meta()?;
     let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = ws.graph.to_editor(&repo)?;
-    let relative_to: RelativeTo = (&relative_to).into();
-
     let but_workspace::commit::CommitCreateOutcome {
         rebase,
         commit_selector,
@@ -472,7 +497,7 @@ pub(crate) fn commit_create_only_impl(
 #[instrument(err(Debug))]
 pub fn commit_create(
     ctx: &mut but_ctx::Context,
-    relative_to: ui::RelativeTo,
+    #[but_api(ui::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
     changes: Vec<DiffSpec>,
     message: String,
@@ -663,7 +688,7 @@ pub fn commit_move_only(
     let meta = ctx.meta()?;
     let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
     let editor = ws.graph.to_editor(&repo)?;
-    let relative_to: RelativeTo = (&relative_to).into();
+    let relative_to: RelativeTo = relative_to.into();
 
     let rebase =
         but_workspace::commit::move_commit(editor, &ws, subject_commit_id, relative_to, side)?;

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -292,7 +292,7 @@ fn determine_target_commit(
             .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?;
         commit_insert_blank_only_impl(
             ctx,
-            crate::commit::ui::RelativeTo::Reference(branch.reference.clone()),
+            crate::commit::RelativeTo::Reference(branch.reference.clone()),
             InsertSide::Below,
             perm,
         )?;
@@ -327,7 +327,7 @@ fn determine_target_commit(
             .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?;
         commit_insert_blank_only_impl(
             ctx,
-            crate::commit::ui::RelativeTo::Reference(branch.reference.clone()),
+            crate::commit::RelativeTo::Reference(branch.reference.clone()),
             InsertSide::Below,
             perm,
         )?;

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::{commit_create, commit_insert_blank},
+    commit::{RelativeTo, commit_create, commit_insert_blank},
     diff,
     legacy::{repo, workspace},
 };
@@ -60,11 +60,7 @@ pub(crate) fn insert_blank_commit(
                 let repo = ctx.repo.get()?;
                 shorten_object_id(&repo, *oid)
             };
-            commit_insert_blank(
-                ctx,
-                but_api::commit::ui::RelativeTo::Commit(*oid),
-                insert_side,
-            )?;
+            commit_insert_blank(ctx, RelativeTo::Commit(*oid), insert_side)?;
             format!("Created blank commit {position_desc} commit {short_oid}")
         }
         CliId::Branch { name, .. } => {
@@ -72,11 +68,7 @@ pub(crate) fn insert_blank_commit(
                 let repo = ctx.repo.get()?;
                 repo.find_reference(name)?.detach()
             };
-            commit_insert_blank(
-                ctx,
-                but_api::commit::ui::RelativeTo::Reference(reference.name),
-                insert_side,
-            )?;
+            commit_insert_blank(ctx, RelativeTo::Reference(reference.name), insert_side)?;
             match insert_side {
                 InsertSide::Above => format!("Created blank commit at the top of stack '{name}'"),
                 InsertSide::Below => {
@@ -464,7 +456,7 @@ pub(crate) fn commit(
     // Insert relative to the branch reference itself so only that branch tip is advanced.
     let outcome = commit_create(
         ctx,
-        but_api::commit::ui::RelativeTo::Reference(target_branch.reference.clone()),
+        RelativeTo::Reference(target_branch.reference.clone()),
         InsertSide::Below,
         diff_specs,
         final_commit_message,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Context as _;
 use bstr::BString;
 use but_api::{
-    commit::{commit_insert_blank, ui::RelativeTo},
+    commit::{RelativeTo, commit_insert_blank},
     diff::ComputeLineStats,
 };
 use but_core::DiffSpec;


### PR DESCRIPTION
A follow-up to #12884.

### Tasks

* [x] refacview

----

This change achieves the goal of removing frontend-oriented parameter types from but-api implementation signatures while preserving the existing transport surface for Tauri/JSON/NAPI callers.

For commit creation and blank-insert APIs, the Rust implementation now takes an internal commit::RelativeTo domain type instead of commit::ui::RelativeTo. The #[but_api] macro gained a narrow parameter transport remap via #[but_api(transport = Type)] so wrappers can still accept the existing UI transport type and convert it into the internal Rust type.

For the legacy settings path, but-api and but-settings no longer take UiUpdate-shaped parameters internally. The Tauri adapter remains the frontend boundary and forwards the frontend payload into a pure Rust Option<bool> update call.

The commit also adds trybuild coverage for the new macro behavior, including default and napi pass cases plus failure cases for unsupported reference parameters and conflicts with built-in remaps.
