### PR TITLE
Decompose StackView and FileList into compound components

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -168,7 +168,7 @@
 >
 	{#if args.type === "stack-branch"}
 		{@const moveHandler = args.stackId
-			? new MoveCommitDzHandler(stackService, args.stackId, projectId)
+			? new MoveCommitDzHandler(args.stackId, projectId)
 			: undefined}
 		{#if !args.prNumber && args.stackId}
 			<PrNumberUpdater {projectId} stackId={args.stackId} {branchName} />

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -168,7 +168,7 @@
 >
 	{#if args.type === "stack-branch"}
 		{@const moveHandler = args.stackId
-			? new MoveCommitDzHandler(stackService, args.stackId, projectId, uiState)
+			? new MoveCommitDzHandler(stackService, args.stackId, projectId)
 			: undefined}
 		{#if !args.prNumber && args.stackId}
 			<PrNumberUpdater {projectId} stackId={args.stackId} {branchName} />

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -306,8 +306,6 @@
 						{@const { amendHandler, squashHandler, hunkHandler } = createCommitDropHandlers({
 							projectId,
 							stackId,
-							stackService,
-							hooksService,
 							commit: dzCommit,
 							runHooks: $runHooks,
 							okWithForce: true,

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -34,6 +34,7 @@
 	import { createCommitSelection } from "$lib/selection/key";
 	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+
 	import { combineResults } from "$lib/state/helpers";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
@@ -307,7 +308,6 @@
 							stackId,
 							stackService,
 							hooksService,
-							uiState: controller.uiState,
 							commit: dzCommit,
 							runHooks: $runHooks,
 							okWithForce: true,

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -32,9 +32,10 @@
 	import { HOOKS_SERVICE } from "$lib/hooks/hooksService";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { createCommitSelection } from "$lib/selection/key";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
 	import { persisted } from "@gitbutler/shared/persisted";
 	import { Button, Modal, RadioButton, TestId } from "@gitbutler/ui";
@@ -45,61 +46,35 @@
 	import type { BranchDetails } from "$lib/stacks/stack";
 
 	interface Props {
-		projectId: string;
-		stackId?: string;
-		laneId: string;
 		branchName: string;
 		lastBranch: boolean;
 		branchDetails: BranchDetails;
 		stackingReorderDropzoneManager: ReorderCommitDzFactory;
 		roundedTop?: boolean;
-		active?: boolean;
-		visibleRange?: { start: number; end: number };
-
-		handleUncommit: (commitId: string, branchName: string) => Promise<void>;
-		startEditingCommitMessage: (branchName: string, commitId: string) => void;
-		onclick?: () => void;
-		onFileClick?: (index: number) => void;
 	}
 
-	let {
-		projectId,
-		stackId,
-		laneId,
-		branchName,
-		branchDetails,
-		lastBranch,
-		stackingReorderDropzoneManager,
-		roundedTop,
-		active,
-		visibleRange,
-		handleUncommit,
-		startEditingCommitMessage,
-		onclick,
-		onFileClick,
-	}: Props = $props();
+	let { branchName, branchDetails, lastBranch, stackingReorderDropzoneManager, roundedTop }: Props =
+		$props();
 
+	const controller = getStackContext();
 	const stackService = inject(STACK_SERVICE);
-	const uiState = inject(UI_STATE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const hooksService = inject(HOOKS_SERVICE);
 	const ircApiService = inject(IRC_API_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
 
+	const projectId = $derived(controller.projectId);
+	const stackId = $derived(controller.stackId);
+
 	const commitReactionsQuery = $derived(ircApiService.commitReactions());
 	const commitReactions = $derived(commitReactionsQuery?.response ?? {});
 
 	const [integrateUpstreamCommits, integrating] = stackService.integrateUpstreamCommits;
 
-	const projectState = $derived(uiState.project(projectId));
-	const exclusiveAction = $derived(projectState.exclusiveAction.current);
+	const exclusiveAction = $derived(controller.exclusiveAction);
 	const commitAction = $derived(exclusiveAction?.type === "commit" ? exclusiveAction : undefined);
-	const isCommitting = $derived(
-		exclusiveAction?.type === "commit" && exclusiveAction.stackId === stackId,
-	);
-	const laneState = $derived(uiState.lane(laneId));
-	const selection = $derived(laneState.selection);
+	const selection = $derived(controller.selection);
 	const runHooks = $derived(projectRunCommitHooks(projectId));
 
 	const selectedBranchName = $derived(selection.current?.branchName);
@@ -113,14 +88,33 @@
 	let integrationModal = $state<Modal>();
 
 	async function handleCommitClick(commitId: string, upstream: boolean) {
-		const currentSelection = laneState.selection.current;
+		const currentSelection = controller.selection.current;
 		// Toggle: if this exact commit is already selected, clear the selection
 		if (currentSelection?.commitId === commitId && currentSelection?.branchName === branchName) {
-			laneState.selection.set(undefined);
+			controller.selection.set(undefined);
 		} else {
-			laneState.selection.set({ branchName, commitId, upstream, previewOpen: true });
+			controller.selection.set({ branchName, commitId, upstream, previewOpen: true });
 		}
-		onclick?.();
+		controller.clearWorktreeSelection();
+	}
+
+	async function handleUncommit(commitId: string) {
+		await stackService.uncommit({
+			projectId,
+			stackId: ensureValue(stackId),
+			branchName,
+			commitId,
+		});
+	}
+
+	function startEditingCommitMessage(commitId: string) {
+		controller.selection.set({ branchName, commitId, previewOpen: true });
+		controller.projectState.exclusiveAction.set({
+			type: "edit-commit-message",
+			stackId,
+			branchName,
+			commitId,
+		});
 	}
 
 	function kickOffIntegration() {
@@ -215,7 +209,7 @@
 {/snippet}
 
 {#snippet commitReorderDz(dropzone: ReorderCommitDzHandler)}
-	{#if !isCommitting}
+	{#if !controller.isCommitting}
 		<Dropzone handlers={[dropzone]}>
 			{#snippet overlay({ hovered, activated })}
 				<CommitLineOverlay {hovered} {activated} />
@@ -247,7 +241,7 @@
 						{@const lastCommit = i === upstreamOnlyCommits.length - 1}
 						{@const selected = commit.id === selectedCommitId && branchName === selectedBranchName}
 						{@const commitId = commit.id}
-						{#if !isCommitting}
+						{#if !controller.isCommitting}
 							<CommitRow
 								type="Remote"
 								{stackId}
@@ -259,7 +253,7 @@
 								{first}
 								{lastCommit}
 								{selected}
-								{active}
+								active={controller.active}
 								reactions={commitReactions[commit.id]}
 								onclick={() => handleCommitClick(commit.id, true)}
 								disableCommitActions={false}
@@ -283,7 +277,7 @@
 					{#snippet template(commit, { first, last })}
 						{@const commitId = commit.id}
 						{@const selected = commit.id === selectedCommitId && branchName === selectedBranchName}
-						{#if isCommitting}
+						{#if controller.isCommitting}
 							<!-- Only commits to the base can be `last`, see next `CommitGoesHere`. -->
 							<CommitGoesHere
 								{commitId}
@@ -293,7 +287,7 @@
 								{first}
 								last={false}
 								onclick={() => {
-									projectState.exclusiveAction.set({
+									controller.projectState.exclusiveAction.set({
 										type: "commit",
 										stackId,
 										branchName,
@@ -313,15 +307,15 @@
 							stackId,
 							stackService,
 							hooksService,
-							uiState,
+							uiState: controller.uiState,
 							commit: dzCommit,
 							runHooks: $runHooks,
 							okWithForce: true,
 							onCommitIdChange: (newId) => {
-								const wasSelected = laneState.selection.current?.commitId === commitId;
+								const wasSelected = controller.selection.current?.commitId === commitId;
 								if (stackId && wasSelected) {
 									const previewOpen = selection.current?.previewOpen ?? false;
-									uiState.lane(stackId).selection.set({ branchName, commitId: newId, previewOpen });
+									controller.laneState.selection.set({ branchName, commitId: newId, previewOpen });
 								}
 							},
 						})}
@@ -378,7 +372,7 @@
 									{lastBranch}
 									{selected}
 									{tooltip}
-									{active}
+									active={controller.active}
 									reactions={commitReactions[commit.id]}
 									onclick={() => handleCommitClick(commit.id, false)}
 									disableCommitActions={false}
@@ -391,8 +385,8 @@
 											commitMessage: commit.message,
 											commitStatus: commit.state.type,
 											commitUrl: forge.current.commitUrl(commitId),
-											onUncommitClick: () => handleUncommit(commit.id, branchName),
-											onEditMessageClick: () => startEditingCommitMessage(branchName, commit.id),
+											onUncommitClick: () => handleUncommit(commit.id),
+											onEditMessageClick: () => startEditingCommitMessage(commit.id),
 										}}
 										<CommitContextMenu
 											showOnHover
@@ -417,7 +411,7 @@
 													title="Changed files"
 													{projectId}
 													{stackId}
-													{visibleRange}
+													visibleRange={controller.visibleRange}
 													draggableFiles
 													selectionId={createCommitSelection({ commitId: commitId, stackId })}
 													persistId={`commit-${commitId}`}
@@ -432,19 +426,19 @@
 													allowUnselect={false}
 													onFileClick={(index) => {
 														// Ensure the commit is selected so the preview shows it
-														const currentSelection = laneState.selection.current;
+														const currentSelection = controller.selection.current;
 														if (
 															currentSelection?.commitId !== commitId ||
 															currentSelection?.branchName !== branchName
 														) {
-															laneState.selection.set({
+															controller.selection.set({
 																branchName,
 																commitId,
 																upstream: false,
 																previewOpen: true,
 															});
 														}
-														onFileClick?.(index);
+														controller.jumpToIndex(index);
 													}}
 												/>
 											{/snippet}
@@ -456,7 +450,7 @@
 						{@render commitReorderDz(
 							stackingReorderDropzoneManager.belowCommit(branchName, commit.id),
 						)}
-						{#if isCommitting && last}
+						{#if controller.isCommitting && last}
 							<CommitGoesHere
 								commitId={branchDetails.baseCommit}
 								{first}
@@ -465,7 +459,7 @@
 									exclusiveAction.parentCommitId === branchDetails.baseCommit &&
 									commitAction?.branchName === branchName}
 								onclick={() => {
-									projectState.exclusiveAction.set({
+									controller.projectState.exclusiveAction.set({
 										type: "commit",
 										stackId,
 										branchName,

--- a/apps/desktop/src/components/BranchInsertion.svelte
+++ b/apps/desktop/src/components/BranchInsertion.svelte
@@ -4,7 +4,6 @@
 	import Dropzone from "$components/Dropzone.svelte";
 	import { MoveBranchDzHandler } from "$lib/branches/dropHandler";
 	import type { ForgePrService } from "$lib/forge/interface/forgePrService";
-	import type { StackService } from "$lib/stacks/stackService.svelte";
 
 	interface Props {
 		projectId: string;
@@ -13,7 +12,6 @@
 		lineColor: string;
 		isCommitting: boolean;
 		baseBranchName: string | undefined;
-		stackService: StackService;
 		prService: ForgePrService | undefined;
 		isFirst?: boolean;
 	}
@@ -25,7 +23,6 @@
 		lineColor,
 		isCommitting,
 		baseBranchName,
-		stackService,
 		prService,
 		isFirst = false,
 	}: Props = $props();
@@ -33,7 +30,6 @@
 
 {#if !isCommitting && baseBranchName}
 	{@const moveBranchHandler = new MoveBranchDzHandler(
-		stackService,
 		prService,
 		projectId,
 		stackId,

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -145,7 +145,6 @@
 						{lineColor}
 						isCommitting={controller.isCommitting}
 						{baseBranchName}
-						{stackService}
 						prService={forge.current.prService}
 						isFirst={firstBranch}
 					/>

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -20,12 +20,10 @@
 	import { REORDER_DROPZONE_FACTORY } from "$lib/dragging/stackingReorderDropzoneManager";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { createBranchSelection } from "$lib/selection/key";
-	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
 	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { type BranchDetails } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { URL_SERVICE } from "$lib/utils/url";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
@@ -40,15 +38,11 @@
 	const { branches }: Props = $props();
 
 	const controller = getStackContext();
-	const uiState = inject(UI_STATE);
 	const stackService = inject(STACK_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const urlService = inject(URL_SERVICE);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
-	const uncommittedService = inject(UNCOMMITTED_SERVICE);
-
-	// Reactive aliases for template readability (passed to leaf components)
 	const projectId = $derived(controller.projectId);
 	const stackId = $derived(controller.stackId);
 	const laneId = $derived(controller.laneId);
@@ -142,13 +136,7 @@
 				{@const codegenQuery = stackId
 					? claudeCodeService.messages({ projectId, stackId })
 					: undefined}
-				{@const startCommittingDz = new StartCommitDzHandler(
-					uiState,
-					uncommittedService,
-					projectId,
-					stackId,
-					branchName,
-				)}
+				{@const startCommittingDz = new StartCommitDzHandler(projectId, stackId, branchName)}
 				{#if stackId}
 					<BranchInsertion
 						{projectId}

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -7,7 +7,6 @@
 	import BranchHeaderContextMenu from "$components/BranchHeaderContextMenu.svelte";
 	import BranchInsertion from "$components/BranchInsertion.svelte";
 	import CodegenRow from "$components/CodegenRow.svelte";
-	import ConflictResolutionConfirmModal from "$components/ConflictResolutionConfirmModal.svelte";
 	import NestedChangedFiles from "$components/NestedChangedFiles.svelte";
 	import PushButton from "$components/PushButton.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
@@ -19,109 +18,45 @@
 	import { currentStatus } from "$lib/codegen/messages";
 	import { projectDisableCodegen } from "$lib/config/config";
 	import { REORDER_DROPZONE_FACTORY } from "$lib/dragging/stackingReorderDropzoneManager";
-	import { editPatch } from "$lib/editMode/editPatchUtils";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
-	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { createBranchSelection } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { type BranchDetails } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { URL_SERVICE } from "$lib/utils/url";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
-	import { Button, Modal, TestId } from "@gitbutler/ui";
+	import { Button, TestId } from "@gitbutler/ui";
 	import { QueryStatus } from "@reduxjs/toolkit/query";
 	import { tick } from "svelte";
-	import type { CommitStatusType } from "$lib/commits/commit";
 
 	type Props = {
-		projectId: string;
-		stackId?: string;
-		laneId: string;
 		branches: BranchDetails[];
-		active: boolean;
-		onclick?: () => void;
-		onFileClick?: (index: number) => void;
-		visibleRange?: { start: number; end: number };
 	};
 
-	const {
-		projectId,
-		branches,
-		stackId,
-		laneId,
-		active,
-		visibleRange,
-		onclick,
-		onFileClick,
-	}: Props = $props();
+	const { branches }: Props = $props();
+
+	const controller = getStackContext();
 	const stackService = inject(STACK_SERVICE);
-	const uiState = inject(UI_STATE);
-	const modeService = inject(MODE_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const urlService = inject(URL_SERVICE);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 
-	// Component is read-only when stackId is undefined
-	const isReadOnly = $derived(!stackId);
+	// Reactive aliases for template readability (passed to leaf components)
+	const projectId = $derived(controller.projectId);
+	const stackId = $derived(controller.stackId);
+	const laneId = $derived(controller.laneId);
 
 	let addDependentBranchModalContext = $state<AddDependentBranchModalProps>();
 	let addDependentBranchModal = $state<AddDependentBranchModal>();
 
-	const projectState = $derived(uiState.project(projectId));
-	const exclusiveAction = $derived(projectState.exclusiveAction.current);
-	const isCommitting = $derived(
-		exclusiveAction?.type === "commit" && exclusiveAction?.stackId === stackId,
-	);
-	const laneState = $derived(uiState.lane(laneId));
-	const selection = $derived(laneState.selection);
-	const selectedCommitId = $derived(selection.current?.commitId);
+	const selection = $derived(controller.selection);
+	const selectedCommitId = $derived(controller.commitId);
 	const codegenDisabled = $derived(projectDisableCodegen(projectId));
-
-	let conflictResolutionConfirmationModal =
-		$state<ReturnType<typeof ConflictResolutionConfirmModal>>();
-
-	async function handleUncommit(commitId: string, branchName: string) {
-		await stackService.uncommit({
-			projectId,
-			stackId: ensureValue(stackId),
-			branchName,
-			commitId: commitId,
-		});
-	}
-
-	function startEditingCommitMessage(branchName: string, commitId: string) {
-		laneState.selection.set({ branchName, commitId, previewOpen: true });
-		projectState.exclusiveAction.set({
-			type: "edit-commit-message",
-			stackId,
-			branchName,
-			commitId,
-		});
-	}
-
-	async function handleEditPatch(args: {
-		commitId: string;
-		type: CommitStatusType;
-		hasConflicts: boolean;
-		isAncestorMostConflicted: boolean;
-	}) {
-		if (isReadOnly) return;
-		if (args.type === "LocalAndRemote" && args.hasConflicts && !args.isAncestorMostConflicted) {
-			conflictResolutionConfirmationModal?.show();
-			return;
-		}
-		await editPatch({
-			modeService,
-			commitId: args.commitId,
-			stackId: ensureValue(stackId),
-			projectId,
-		});
-	}
 
 	const selectedCommit = $derived(
 		selectedCommitId ? stackService.commitDetails(projectId, selectedCommitId) : undefined,
@@ -206,7 +141,7 @@
 					? claudeCodeService.messages({ projectId, stackId })
 					: undefined}
 				{@const startCommittingDz = new StartCommitDzHandler(
-					uiState,
+					controller.uiState,
 					uncommittedService,
 					projectId,
 					stackId,
@@ -218,7 +153,7 @@
 						{stackId}
 						{branchName}
 						{lineColor}
-						{isCommitting}
+						isCommitting={controller.isCommitting}
 						{baseBranchName}
 						{stackService}
 						prService={forge.current.prService}
@@ -233,7 +168,7 @@
 					{branchName}
 					{lineColor}
 					{first}
-					{isCommitting}
+					isCommitting={controller.isCommitting}
 					{iconName}
 					{selected}
 					{isNewBranch}
@@ -254,18 +189,18 @@
 					trackingBranch={branch.remoteTrackingBranch ?? undefined}
 					readonly={!!branch.remoteTrackingBranch}
 					onclick={() => {
-						const currentSelection = uiState.lane(laneId).selection.current;
+						const currentSelection = controller.selection.current;
 						// Toggle: if this branch is already selected, clear the selection
 						if (
 							currentSelection?.branchName === branchName &&
 							!currentSelection.codegen &&
 							!currentSelection?.commitId
 						) {
-							uiState.lane(laneId).selection.set(undefined);
+							controller.selection.set(undefined);
 						} else {
-							uiState.lane(laneId).selection.set({ branchName, previewOpen: true });
+							controller.selection.set({ branchName, previewOpen: true });
 						}
-						onclick?.();
+						controller.clearWorktreeSelection();
 					}}
 				>
 					{#snippet buttons()}
@@ -274,7 +209,7 @@
 								icon="stack-plus"
 								size="tag"
 								kind="outline"
-								tooltip={isReadOnly ? "Read-only mode" : "Create new branch"}
+								tooltip={controller.isReadOnly ? "Read-only mode" : "Create new branch"}
 								onclick={async () => {
 									addDependentBranchModalContext = {
 										projectId,
@@ -284,7 +219,7 @@
 									await tick();
 									addDependentBranchModal?.show();
 								}}
-								disabled={isReadOnly}
+								disabled={controller.isReadOnly}
 							/>
 						{/if}
 
@@ -296,14 +231,14 @@
 									shrinkable
 									onclick={(e) => {
 										e.stopPropagation();
-										projectState.exclusiveAction.set({
+										controller.projectState.exclusiveAction.set({
 											type: "create-pr",
 											stackId,
 											branchName,
 										});
 									}}
 									testId={TestId.CreateReviewButton}
-									disabled={!!projectState.exclusiveAction.current}
+									disabled={!!controller.exclusiveAction}
 									icon="pr-plus"
 								>
 									{`Create ${forge.current.name === "gitlab" ? "MR" : "PR"}`}
@@ -342,7 +277,7 @@
 								tooltip="New Codegen Session"
 								onclick={async () => {
 									if (!stackId) return;
-									laneState?.selection.set({ branchName, codegen: true, previewOpen: true });
+									controller.selection.set({ branchName, codegen: true, previewOpen: true });
 									focusClaudeInput(stackId);
 								}}
 							/>
@@ -379,7 +314,7 @@
 									{stackId}
 									{status}
 									selected={codegenSelected}
-									{onclick}
+									onclick={() => controller.clearWorktreeSelection()}
 								/>
 							{/if}
 						{/if}
@@ -416,17 +351,17 @@
 										changes={result.changes}
 										stats={result.stats}
 										allowUnselect={false}
-										{visibleRange}
+										visibleRange={controller.visibleRange}
 										onFileClick={(index) => {
 											// Ensure the branch is selected so the preview shows it
-											const currentSelection = laneState.selection.current;
+											const currentSelection = controller.selection.current;
 											if (
 												currentSelection?.branchName !== branchName ||
 												currentSelection?.commitId !== undefined
 											) {
-												laneState.selection.set({ branchName, previewOpen: true });
+												controller.selection.set({ branchName, previewOpen: true });
 											}
-											onFileClick?.(index);
+											controller.jumpToIndex(index);
 										}}
 									/>
 								{/snippet}
@@ -437,9 +372,6 @@
 					{#snippet branchContent()}
 						<BranchCommitList
 							{lastBranch}
-							{projectId}
-							{stackId}
-							{laneId}
 							{branchName}
 							{branchDetails}
 							{stackingReorderDropzoneManager}
@@ -447,12 +379,6 @@
 								stackId !== undefined &&
 								codegenQuery?.response &&
 								codegenQuery.response.length > 0}
-							{active}
-							{visibleRange}
-							{handleUncommit}
-							{startEditingCommitMessage}
-							{onclick}
-							{onFileClick}
 						/>
 					{/snippet}
 				</BranchCard>
@@ -460,33 +386,6 @@
 		</ReduxResult>
 	{/each}
 </div>
-
-<Modal
-	bind:this={conflictResolutionConfirmationModal}
-	width="small"
-	defaultItem={{} as {
-		type: CommitStatusType;
-		commitId: string;
-		stackId: string;
-		hasConflicts: boolean;
-		isAncestorMostConflicted: boolean;
-		close: () => void;
-	}}
-	onSubmit={async (close, item) => {
-		await handleEditPatch(item);
-		close();
-	}}
->
-	<div>
-		<p>It's generally better to start resolving conflicts from the bottom up.</p>
-		<br />
-		<p>Are you sure you want to resolve conflicts for this commit?</p>
-	</div>
-	{#snippet controls(close)}
-		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
-		<Button style="pop" type="submit">Yes</Button>
-	{/snippet}
-</Modal>
 
 {#if addDependentBranchModalContext}
 	<AddDependentBranchModal

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -25,6 +25,7 @@
 	import { type BranchDetails } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
+	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { URL_SERVICE } from "$lib/utils/url";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
@@ -39,6 +40,7 @@
 	const { branches }: Props = $props();
 
 	const controller = getStackContext();
+	const uiState = inject(UI_STATE);
 	const stackService = inject(STACK_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const urlService = inject(URL_SERVICE);
@@ -141,7 +143,7 @@
 					? claudeCodeService.messages({ projectId, stackId })
 					: undefined}
 				{@const startCommittingDz = new StartCommitDzHandler(
-					controller.uiState,
+					uiState,
 					uncommittedService,
 					projectId,
 					stackId,

--- a/apps/desktop/src/components/FileListConflicts.svelte
+++ b/apps/desktop/src/components/FileListConflicts.svelte
@@ -1,0 +1,144 @@
+<!--
+	Compound component that renders unrepresented conflict entries
+	and the "Resolve conflicts" action. Must be a child of <FileListProvider>.
+
+	Only renders if there are conflict entries not already represented
+	in the file list changes.
+
+	Usage:
+	```svelte
+	<FileListProvider {changes} {selectionId}>
+		<FileListConflicts {conflictEntries} {ancestorMostConflictedCommitId} {projectId} />
+		<FileListItems mode="list" />
+	</FileListProvider>
+	```
+-->
+<script lang="ts">
+	import EditPatchConfirmModal from "$components/EditPatchConfirmModal.svelte";
+	import { conflictEntryHint } from "$lib/conflictEntryPresence";
+	import { editPatch } from "$lib/editMode/editPatchUtils";
+	import { MODE_SERVICE } from "$lib/mode/modeService";
+	import { getFileListContext } from "$lib/selection/fileListController.svelte";
+	import { SETTINGS } from "$lib/settings/userSettings";
+	import { injectOptional, inject } from "@gitbutler/core/context";
+	import { AsyncButton, FileListItem, TestId } from "@gitbutler/ui";
+	import type { ConflictEntriesObj } from "$lib/files/conflicts";
+
+	type Props = {
+		projectId: string;
+		stackId?: string;
+		conflictEntries?: ConflictEntriesObj;
+		ancestorMostConflictedCommitId?: string;
+		draggable?: boolean;
+	};
+
+	const { projectId, stackId, conflictEntries, ancestorMostConflictedCommitId, draggable }: Props =
+		$props();
+
+	const controller = getFileListContext();
+	const modeService = injectOptional(MODE_SERVICE, undefined);
+	const userSettings = inject(SETTINGS);
+
+	let editPatchModal: EditPatchConfirmModal | undefined = $state();
+	let selectedFilePath = $state("");
+
+	const unrepresentedConflictedEntries = $derived.by(() => {
+		if (!conflictEntries?.entries) return {};
+
+		const changes = controller.changes;
+		return Object.fromEntries(
+			Object.entries(conflictEntries.entries).filter(([key, _value]) =>
+				changes.every((change) => change.path !== key),
+			),
+		);
+	});
+
+	function showEditPatchConfirmation(filePath: string) {
+		selectedFilePath = filePath;
+		editPatchModal?.show();
+	}
+
+	function handleConfirmEditPatch() {
+		editPatchModal?.hide();
+		editPatch({
+			modeService,
+			commitId: ancestorMostConflictedCommitId!,
+			stackId: stackId!,
+			projectId,
+		});
+	}
+
+	function handleCancelEditPatch() {
+		editPatchModal?.hide();
+		selectedFilePath = "";
+	}
+</script>
+
+{#if Object.keys(unrepresentedConflictedEntries).length > 0}
+	{@const entries = Object.entries(unrepresentedConflictedEntries)}
+	<div class="conflicted-entries">
+		{#each entries as [path, kind], i}
+			<FileListItem
+				{draggable}
+				filePath={path}
+				pathFirst={$userSettings.pathFirst}
+				active={controller.active}
+				conflicted
+				conflictHint={conflictEntryHint(kind)}
+				listMode="list"
+				isLast={!ancestorMostConflictedCommitId && i === entries.length - 1}
+				onclick={(e) => {
+					e.stopPropagation();
+					showEditPatchConfirmation(path);
+				}}
+			/>
+		{/each}
+
+		{#if ancestorMostConflictedCommitId}
+			<div class="conflicted-entries__action">
+				<p class="text-12 text-body clr-text-2">
+					If the branch has multiple conflicted commits, GitButler opens the earliest one first,
+					since later commits depend on it.
+				</p>
+				<AsyncButton
+					testId={TestId.CommitDrawerResolveConflictsButton}
+					kind="solid"
+					style="danger"
+					wide
+					action={() =>
+						editPatch({
+							modeService,
+							commitId: ancestorMostConflictedCommitId!,
+							stackId: stackId!,
+							projectId,
+						})}
+				>
+					Resolve conflicts
+				</AsyncButton>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<EditPatchConfirmModal
+	bind:this={editPatchModal}
+	fileName={selectedFilePath}
+	onConfirm={handleConfirmEditPatch}
+	onCancel={handleCancelEditPatch}
+/>
+
+<style lang="postcss">
+	.conflicted-entries {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.conflicted-entries__action {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: 12px;
+		gap: 12px;
+		border-bottom: 1px solid var(--clr-border-2);
+	}
+</style>

--- a/apps/desktop/src/components/FileListItems.svelte
+++ b/apps/desktop/src/components/FileListItems.svelte
@@ -1,0 +1,205 @@
+<!--
+	Compound component that renders the file list (list or tree mode).
+	Must be a child of <FileListProvider>.
+
+	Usage:
+	```svelte
+	<FileListProvider {changes} {selectionId}>
+		<FileListItems mode="list" draggable />
+	</FileListProvider>
+	```
+-->
+<script lang="ts">
+	import FileListItemWrapper from "$components/FileListItemWrapper.svelte";
+	import FileTreeNode from "$components/FileTreeNode.svelte";
+	import LazyList from "$components/LazyList.svelte";
+	import {
+		getLockedCommitIds,
+		getLockedTargets,
+		isFileLocked,
+	} from "$lib/dependencies/dependencies";
+	import { DEPENDENCY_SERVICE } from "$lib/dependencies/dependencyService.svelte";
+	import { abbreviateFolders, changesToFileTree } from "$lib/files/filetreeV3";
+	import { isExecutableStatus } from "$lib/hunks/change";
+	import {
+		getFileListContext,
+		type FileListKeyHandler,
+	} from "$lib/selection/fileListController.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import type { ConflictEntriesObj } from "$lib/files/conflicts";
+	import type { TreeChange } from "$lib/hunks/change";
+
+	type Props = {
+		projectId: string;
+		stackId?: string;
+		mode: "list" | "tree";
+		showCheckboxes?: boolean;
+		draggable?: boolean;
+		showLockedIndicator?: boolean;
+		visibleRange?: { start: number; end: number };
+		/** nick → file paths mapping from IRC working files broadcast */
+		ircWorkingFiles?: Record<string, string[]>;
+		/** Per-file conflict hints (rendered inline on each item) */
+		conflictEntries?: ConflictEntriesObj;
+		dataTestId?: string;
+		/** Called when a file is selected (click, Enter/Space/l, or arrow navigation). */
+		onselect?: (change: TreeChange, index: number) => void;
+		/** Extra keyboard handlers injected by the consumer (e.g. AI shortcuts). */
+		extraKeyHandlers?: FileListKeyHandler[];
+	};
+
+	const {
+		projectId,
+		stackId,
+		mode,
+		showCheckboxes,
+		draggable,
+		showLockedIndicator = false,
+		visibleRange,
+		ircWorkingFiles,
+		conflictEntries,
+		dataTestId,
+		onselect,
+		extraKeyHandlers,
+	}: Props = $props();
+
+	const controller = getFileListContext();
+	const dependencyService = inject(DEPENDENCY_SERVICE);
+
+	/** Invert nick→paths map to path→nicks for per-file lookup. */
+	const ircWorkingUsersByPath = $derived.by(() => {
+		if (!ircWorkingFiles) return undefined;
+		const map = new Map<string, string[]>();
+		for (const [nick, paths] of Object.entries(ircWorkingFiles)) {
+			for (const p of paths) {
+				const nicks = map.get(p);
+				if (nicks) {
+					nicks.push(nick);
+				} else {
+					map.set(p, [nick]);
+				}
+			}
+		}
+		return map;
+	});
+
+	const filePaths = $derived(controller.changes.map((change) => change.path));
+	const fileDependenciesQuery = $derived(
+		showLockedIndicator ? dependencyService.filesDependencies(projectId, filePaths) : null,
+	);
+	const fileDependencies = $derived(fileDependenciesQuery?.result.data || []);
+</script>
+
+{#snippet fileTemplate(change: TreeChange, idx: number, depth: number = 0, isLast: boolean = false)}
+	{@const isExecutable = isExecutableStatus(change.status)}
+	{@const selected = controller.isSelected(change.path)}
+	{@const locked = showLockedIndicator && isFileLocked(change.path, fileDependencies)}
+	{@const lockedCommitIds = showLockedIndicator
+		? getLockedCommitIds(change.path, fileDependencies)
+		: []}
+	{@const lockedTargets = showLockedIndicator
+		? getLockedTargets(change.path, fileDependencies)
+		: []}
+	<FileListItemWrapper
+		selectionId={controller.selectionId}
+		{change}
+		{projectId}
+		{stackId}
+		{selected}
+		listMode={mode}
+		{depth}
+		active={controller.active}
+		{locked}
+		{lockedCommitIds}
+		{lockedTargets}
+		{isLast}
+		notched={controller.hasSelectionInList &&
+			visibleRange !== undefined &&
+			idx >= visibleRange.start &&
+			idx < visibleRange.end}
+		{draggable}
+		executable={isExecutable}
+		showCheckbox={showCheckboxes}
+		ircWorkingUsers={ircWorkingUsersByPath?.get(change.path)}
+		focusableOpts={{
+			onKeydown: (e) => {
+				// 1. Activation keys (Enter/Space/l)
+				if (controller.handleActivation(change, idx, e)) {
+					onselect?.(change, idx);
+					return;
+				}
+				// 2. Extra handlers (e.g. AI shortcuts)
+				if (extraKeyHandlers) {
+					for (const handler of extraKeyHandlers) {
+						if (handler(change, idx, e)) return;
+					}
+				}
+				// 3. Arrow/vim navigation
+				const navigatedIndex = controller.handleNavigation(e);
+				if (navigatedIndex !== undefined) {
+					const navigatedChange = controller.changes[navigatedIndex];
+					if (navigatedChange) onselect?.(navigatedChange, navigatedIndex);
+				}
+			},
+			focusable: true,
+		}}
+		onclick={(e) => {
+			e.stopPropagation();
+			controller.select(e, change, idx);
+			onselect?.(change, idx);
+		}}
+		{conflictEntries}
+	/>
+{/snippet}
+
+<div
+	data-testid={dataTestId}
+	class="file-list"
+	use:focusable={{
+		vertical: true,
+		onActive: (value) => (controller.active = value),
+	}}
+>
+	{#if controller.changes.length > 0}
+		{#if mode === "tree"}
+			{@const node = abbreviateFolders(changesToFileTree(controller.changes))}
+			<FileTreeNode
+				isRoot
+				{projectId}
+				selectionId={controller.selectionId}
+				{stackId}
+				{node}
+				{showCheckboxes}
+				draggableFiles={draggable}
+				changes={controller.changes}
+				{fileTemplate}
+			/>
+		{:else}
+			<LazyList items={controller.changes} chunkSize={100}>
+				{#snippet template(change, context)}
+					<!--
+						There is a bug here related to the reactivity of `idSelection.has`,
+						affecting somehow the first item in the list of files.. but only where
+						used for the "assigned files" of the workspace.
+
+						This unused variable is a workaround, while present the reactivity
+						works as expected.
+
+						TODO: Bisect this issue, it was introduced between nightly version
+						0.5.1705 and 0.5.1783.
+						-->
+					{@const _selected = controller.isSelected(change.path)}
+					{@render fileTemplate(change, context.index, 0, context.last)}
+				{/snippet}
+			</LazyList>
+		{/if}
+	{/if}
+</div>
+
+<style lang="postcss">
+	.file-list {
+		display: flex;
+		flex-direction: column;
+	}
+</style>

--- a/apps/desktop/src/components/FileListItems.svelte
+++ b/apps/desktop/src/components/FileListItems.svelte
@@ -127,19 +127,22 @@
 				// 1. Activation keys (Enter/Space/l)
 				if (controller.handleActivation(change, idx, e)) {
 					onselect?.(change, idx);
-					return;
+					return true;
 				}
 				// 2. Extra handlers (e.g. AI shortcuts)
 				if (extraKeyHandlers) {
 					for (const handler of extraKeyHandlers) {
-						if (handler(change, idx, e)) return;
+						if (handler(change, idx, e)) return true;
 					}
 				}
-				// 3. Arrow/vim navigation
+				// 3. Arrow/vim navigation — only claim the event if we moved
 				const navigatedIndex = controller.handleNavigation(e);
-				if (navigatedIndex !== undefined) {
+				if (navigatedIndex !== undefined && navigatedIndex !== idx) {
 					const navigatedChange = controller.changes[navigatedIndex];
-					if (navigatedChange) onselect?.(navigatedChange, navigatedIndex);
+					if (navigatedChange) {
+						onselect?.(navigatedChange, navigatedIndex);
+					}
+					return true;
 				}
 			},
 			focusable: true,
@@ -147,7 +150,9 @@
 		onclick={(e) => {
 			e.stopPropagation();
 			controller.select(e, change, idx);
-			onselect?.(change, idx);
+			if (controller.isSelected(change.path)) {
+				onselect?.(change, idx);
+			}
 		}}
 		{conflictEntries}
 	/>

--- a/apps/desktop/src/components/FileListProvider.svelte
+++ b/apps/desktop/src/components/FileListProvider.svelte
@@ -1,0 +1,39 @@
+<!--
+	Context provider for file list compound components.
+
+	Creates a FileListController and sets it into Svelte context so that
+	children like <FileListItems> and <FileListConflicts> can access
+	shared selection state, keyboard handling, and focus management.
+
+	Usage:
+	```svelte
+	<FileListProvider {changes} {selectionId}>
+		<FileListItems mode="list" />
+	</FileListProvider>
+	```
+-->
+<script lang="ts">
+	import { FileListController, setFileListContext } from "$lib/selection/fileListController.svelte";
+	import type { TreeChange } from "$lib/hunks/change";
+	import type { SelectionId } from "$lib/selection/key";
+	import type { Snippet } from "svelte";
+
+	type Props = {
+		changes: TreeChange[];
+		selectionId: SelectionId;
+		allowUnselect?: boolean;
+		children: Snippet;
+	};
+
+	const { changes, selectionId, allowUnselect = true, children }: Props = $props();
+
+	const controller = new FileListController({
+		changes: () => changes,
+		selectionId: () => selectionId,
+		allowUnselect: () => allowUnselect,
+	});
+
+	setFileListContext(controller);
+</script>
+
+{@render children()}

--- a/apps/desktop/src/components/IrcCommit.svelte
+++ b/apps/desktop/src/components/IrcCommit.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ConfigurableScrollableContainer from "$components/ConfigurableScrollableContainer.svelte";
-	import FileList from "$components/FileList.svelte";
+	import FileListItems from "$components/FileListItems.svelte";
+	import FileListProvider from "$components/FileListProvider.svelte";
 	import UnifiedDiffView from "$components/UnifiedDiffView.svelte";
 	import { createCommitSelection } from "$lib/selection/key";
 	import type { UnifiedDiff } from "$lib/hunks/diff";
@@ -41,15 +42,15 @@
 	</div>
 	<div class="irc-commit-body">
 		<div class="irc-commit-files">
-			<ConfigurableScrollableContainer>
-				<FileList
-					{projectId}
-					{changes}
-					listMode="list"
-					{selectionId}
-					onFileClick={(index) => (selectedIndex = index)}
-				/>
-			</ConfigurableScrollableContainer>
+			<FileListProvider {changes} {selectionId}>
+				<ConfigurableScrollableContainer>
+					<FileListItems
+						{projectId}
+						mode="list"
+						onselect={(_change, index) => (selectedIndex = index)}
+					/>
+				</ConfigurableScrollableContainer>
+			</FileListProvider>
 		</div>
 		{#if selectedChange && selectedDiff}
 			<div class="irc-commit-diff">

--- a/apps/desktop/src/components/NestedChangedFiles.svelte
+++ b/apps/desktop/src/components/NestedChangedFiles.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import ChangedFileStats from "$components/ChangedFileStats.svelte";
-	import FileList from "$components/FileList.svelte";
+	import FileListConflicts from "$components/FileListConflicts.svelte";
+	import FileListItems from "$components/FileListItems.svelte";
+	import FileListProvider from "$components/FileListProvider.svelte";
 	import emptyFolderSvg from "$lib/assets/empty-state/empty-folder.svg?raw";
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { readStableSelectionKey, stableSelectionKey, type SelectionId } from "$lib/selection/key";
@@ -116,19 +118,24 @@
 					{/snippet}
 				</EmptyStatePlaceholder>
 			{:else}
-				<FileList
-					{selectionId}
-					{projectId}
-					{stackId}
-					{changes}
-					{listMode}
-					{conflictEntries}
-					{draggableFiles}
-					{ancestorMostConflictedCommitId}
-					{allowUnselect}
-					{visibleRange}
-					{onFileClick}
-				/>
+				<FileListProvider {changes} {selectionId} {allowUnselect}>
+					<FileListConflicts
+						{projectId}
+						{stackId}
+						{conflictEntries}
+						{ancestorMostConflictedCommitId}
+						draggable={draggableFiles}
+					/>
+					<FileListItems
+						{projectId}
+						{stackId}
+						mode={listMode}
+						draggable={draggableFiles}
+						{conflictEntries}
+						{visibleRange}
+						onselect={onFileClick && ((_change, index) => onFileClick(index))}
+					/>
+				</FileListProvider>
 			{/if}
 		{/if}
 	</div>

--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import FileList from "$components/FileList.svelte";
+	import FileListItems from "$components/FileListItems.svelte";
+	import FileListProvider from "$components/FileListProvider.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import SnapshotAttachment from "$components/SnapshotAttachment.svelte";
 	import { createdOnDay, HISTORY_SERVICE } from "$lib/history/history";
@@ -227,28 +228,25 @@
 		<ReduxResult result={snapshotDiff.result} {projectId}>
 			{#snippet children(files)}
 				{#if files.length > 0 && !isRestoreSnapshot}
-					<SnapshotAttachment
-						foldable={files.length > 2}
-						foldedAmount={files.length}
-						foldedHeight="7rem"
+					<FileListProvider
+						changes={files}
+						selectionId={{ type: "snapshot", snapshotId: entry.id }}
+						allowUnselect={false}
 					>
-						<ScrollableContainer>
-							<FileList
-								selectionId={{ type: "snapshot", snapshotId: entry.id }}
-								{projectId}
-								stackId={undefined}
-								changes={files}
-								listMode="list"
-								onFileClick={(index) => {
-									const change = files[index];
-									if (change) {
-										onDiffClick(change.path);
-									}
-								}}
-								allowUnselect={false}
-							/>
-						</ScrollableContainer>
-					</SnapshotAttachment>
+						<SnapshotAttachment
+							foldable={files.length > 2}
+							foldedAmount={files.length}
+							foldedHeight="7rem"
+						>
+							<ScrollableContainer>
+								<FileListItems
+									{projectId}
+									mode="list"
+									onselect={(change) => onDiffClick(change.path)}
+								/>
+							</ScrollableContainer>
+						</SnapshotAttachment>
+					</FileListProvider>
 				{/if}
 			{/snippet}
 		</ReduxResult>

--- a/apps/desktop/src/components/StackCodegen.svelte
+++ b/apps/desktop/src/components/StackCodegen.svelte
@@ -1,5 +1,5 @@
 <!--
-	Compound child that owns all codegen state and rendering for the stack details panel.
+	Compound child that owns MCP config and renders CodegenMessages for the stack details panel.
 	Reads shared state from StackController via context.
 
 	Usage:
@@ -8,96 +8,24 @@
 	```
 -->
 <script lang="ts">
-	import CodegenMessages from "$components/codegen/CodegenMessages.svelte";
-	import CodegenMcpConfigModal from "$components/codegen/CodegenMcpConfigModal.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
-	import { ATTACHMENT_SERVICE } from "$lib/codegen/attachmentService.svelte";
+	import CodegenMcpConfigModal from "$components/codegen/CodegenMcpConfigModal.svelte";
+	import CodegenMessages from "$components/codegen/CodegenMessages.svelte";
 	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
-	import { MessageSender } from "$lib/codegen/messageQueue.svelte";
-	import { RULES_SERVICE } from "$lib/rules/rulesService.svelte";
 	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { inject } from "@gitbutler/core/context";
-	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 	import type { ClaudeConfig } from "$lib/codegen/types";
 
 	type Props = {
 		hasRulesToClear: boolean;
 		claudeConfig: ClaudeConfig;
-		branchName: string;
 		onclose: () => void;
 	};
 
-	const { hasRulesToClear, claudeConfig, branchName, onclose }: Props = $props();
+	const { hasRulesToClear, claudeConfig, onclose }: Props = $props();
 
 	const controller = getStackContext();
-
-	// ── Injected services ────────────────────────────────────────────
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
-	const rulesService = inject(RULES_SERVICE);
-	const attachmentService = inject(ATTACHMENT_SERVICE);
-
-	// ── Codegen state ────────────────────────────────────────────────
-	const isStackActiveQuery = $derived(
-		claudeCodeService.isStackActive(controller.projectId, controller.stackId),
-	);
-	const isStackActive = $derived(isStackActiveQuery?.response || false);
-	const events = $derived(
-		claudeCodeService.messages({
-			projectId: controller.projectId,
-			stackId: controller.stackId,
-		}),
-	);
-	const sessionIdQuery = $derived(
-		rulesService.aiSessionId(controller.projectId, controller.stackId),
-	);
-	const permissionRequests = $derived(
-		claudeCodeService.permissionRequests({ projectId: controller.projectId }),
-	);
-	const attachments = $derived(attachmentService.getByBranch(controller.branchName));
-
-	const selectedThinkingLevel = $derived(controller.projectState.thinkingLevel.current);
-	const selectedModel = $derived(controller.projectState.selectedModel.current);
-	const selectedPermissionMode = $derived(controller.laneState.permissionMode.current);
-
-	const messageSender = $derived(
-		controller.stackId && controller.branchName
-			? new MessageSender({
-					projectId: reactive(() => controller.projectId),
-					selectedBranch: reactive(() => ({
-						stackId: controller.stackId!,
-						head: controller.branchName!,
-					})),
-					thinkingLevel: reactive(() => selectedThinkingLevel),
-					model: reactive(() => selectedModel),
-					permissionMode: reactive(() => selectedPermissionMode),
-				})
-			: undefined,
-	);
-	const initialPrompt = $derived(messageSender?.prompt);
-
-	// ── Actions ──────────────────────────────────────────────────────
-	async function onAbort() {
-		if (controller.stackId) {
-			await claudeCodeService.cancelSession({
-				projectId: controller.projectId,
-				stackId: controller.stackId,
-			});
-		}
-	}
-
-	async function sendMessage(prompt: string) {
-		await messageSender?.sendMessage(prompt, attachments);
-		attachmentService.clearByBranch(controller.branchName);
-	}
-
-	async function handleAnswerQuestion(answers: Record<string, string>) {
-		if (!controller.stackId) return;
-		await claudeCodeService.answerAskUserQuestion({
-			projectId: controller.projectId,
-			stackId: controller.stackId,
-			answers,
-		});
-	}
 
 	let mcpConfigModal = $state<CodegenMcpConfigModal>();
 	const mcpClaudeConfigQuery = $derived(
@@ -106,31 +34,10 @@
 </script>
 
 <CodegenMessages
-	projectId={controller.projectId}
-	stackId={controller.stackId}
-	laneId={controller.laneId}
-	{branchName}
 	{onclose}
-	onMcpSettings={() => {
-		mcpConfigModal?.open();
-	}}
-	{onAbort}
-	{initialPrompt}
-	events={events.response || []}
-	permissionRequests={permissionRequests.response || []}
-	onSubmit={sendMessage}
-	onChange={(prompt) => messageSender?.setPrompt(prompt)}
-	sessionId={sessionIdQuery.response}
-	{isStackActive}
+	onMcpSettings={() => mcpConfigModal?.open()}
 	{hasRulesToClear}
 	projectRegistered={claudeConfig.projectRegistered}
-	onRetryConfig={async () => {
-		await claudeCodeService.fetchClaudeConfig(
-			{ projectId: controller.projectId },
-			{ forceRefetch: true },
-		);
-	}}
-	onAnswerQuestion={handleAnswerQuestion}
 />
 
 <!-- MCP CONFIG MODAL -->

--- a/apps/desktop/src/components/StackCodegen.svelte
+++ b/apps/desktop/src/components/StackCodegen.svelte
@@ -1,0 +1,163 @@
+<!--
+	Compound child that owns all codegen state and rendering for the stack details panel.
+	Reads shared state from StackController via context.
+
+	Usage:
+	```svelte
+	<StackCodegen {hasRulesToClear} {claudeConfig} onclose={() => controller.closePreview()} />
+	```
+-->
+<script lang="ts">
+	import CodegenMessages from "$components/codegen/CodegenMessages.svelte";
+	import CodegenMcpConfigModal from "$components/codegen/CodegenMcpConfigModal.svelte";
+	import ReduxResult from "$components/ReduxResult.svelte";
+	import { ATTACHMENT_SERVICE } from "$lib/codegen/attachmentService.svelte";
+	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
+	import { MessageSender } from "$lib/codegen/messageQueue.svelte";
+	import { RULES_SERVICE } from "$lib/rules/rulesService.svelte";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
+	import type { ClaudeConfig } from "$lib/codegen/types";
+
+	type Props = {
+		hasRulesToClear: boolean;
+		claudeConfig: ClaudeConfig;
+		branchName: string;
+		onclose: () => void;
+	};
+
+	const { hasRulesToClear, claudeConfig, branchName, onclose }: Props = $props();
+
+	const controller = getStackContext();
+
+	// ── Injected services ────────────────────────────────────────────
+	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
+	const rulesService = inject(RULES_SERVICE);
+	const attachmentService = inject(ATTACHMENT_SERVICE);
+
+	// ── Codegen state ────────────────────────────────────────────────
+	const isStackActiveQuery = $derived(
+		claudeCodeService.isStackActive(controller.projectId, controller.stackId),
+	);
+	const isStackActive = $derived(isStackActiveQuery?.response || false);
+	const events = $derived(
+		claudeCodeService.messages({
+			projectId: controller.projectId,
+			stackId: controller.stackId,
+		}),
+	);
+	const sessionIdQuery = $derived(
+		rulesService.aiSessionId(controller.projectId, controller.stackId),
+	);
+	const permissionRequests = $derived(
+		claudeCodeService.permissionRequests({ projectId: controller.projectId }),
+	);
+	const attachments = $derived(attachmentService.getByBranch(controller.branchName));
+
+	const selectedThinkingLevel = $derived(controller.projectState.thinkingLevel.current);
+	const selectedModel = $derived(controller.projectState.selectedModel.current);
+	const selectedPermissionMode = $derived(controller.laneState.permissionMode.current);
+
+	const messageSender = $derived(
+		controller.stackId && controller.branchName
+			? new MessageSender({
+					projectId: reactive(() => controller.projectId),
+					selectedBranch: reactive(() => ({
+						stackId: controller.stackId!,
+						head: controller.branchName!,
+					})),
+					thinkingLevel: reactive(() => selectedThinkingLevel),
+					model: reactive(() => selectedModel),
+					permissionMode: reactive(() => selectedPermissionMode),
+				})
+			: undefined,
+	);
+	const initialPrompt = $derived(messageSender?.prompt);
+
+	// ── Actions ──────────────────────────────────────────────────────
+	async function onAbort() {
+		if (controller.stackId) {
+			await claudeCodeService.cancelSession({
+				projectId: controller.projectId,
+				stackId: controller.stackId,
+			});
+		}
+	}
+
+	async function sendMessage(prompt: string) {
+		await messageSender?.sendMessage(prompt, attachments);
+		attachmentService.clearByBranch(controller.branchName);
+	}
+
+	async function handleAnswerQuestion(answers: Record<string, string>) {
+		if (!controller.stackId) return;
+		await claudeCodeService.answerAskUserQuestion({
+			projectId: controller.projectId,
+			stackId: controller.stackId,
+			answers,
+		});
+	}
+
+	let mcpConfigModal = $state<CodegenMcpConfigModal>();
+	const mcpClaudeConfigQuery = $derived(
+		claudeCodeService.claudeConfig({ projectId: controller.projectId }),
+	);
+</script>
+
+<CodegenMessages
+	projectId={controller.projectId}
+	stackId={controller.stackId}
+	laneId={controller.laneId}
+	{branchName}
+	{onclose}
+	onMcpSettings={() => {
+		mcpConfigModal?.open();
+	}}
+	{onAbort}
+	{initialPrompt}
+	events={events.response || []}
+	permissionRequests={permissionRequests.response || []}
+	onSubmit={sendMessage}
+	onChange={(prompt) => messageSender?.setPrompt(prompt)}
+	sessionId={sessionIdQuery.response}
+	{isStackActive}
+	{hasRulesToClear}
+	projectRegistered={claudeConfig.projectRegistered}
+	onRetryConfig={async () => {
+		await claudeCodeService.fetchClaudeConfig(
+			{ projectId: controller.projectId },
+			{ forceRefetch: true },
+		);
+	}}
+	onAnswerQuestion={handleAnswerQuestion}
+/>
+
+<!-- MCP CONFIG MODAL -->
+<ReduxResult
+	result={mcpClaudeConfigQuery.result}
+	projectId={controller.projectId}
+	stackId={controller.stackId}
+	hideError
+>
+	{#snippet children(config, { stackId: resolvedStackId })}
+		{@const resolvedLaneState = resolvedStackId
+			? controller.uiState.lane(resolvedStackId)
+			: undefined}
+		<CodegenMcpConfigModal
+			disabledServers={resolvedLaneState?.disabledMcpServers.current || []}
+			bind:this={mcpConfigModal}
+			claudeConfig={config}
+			toggleServer={(server) => {
+				const disabledServers = resolvedLaneState?.disabledMcpServers.current;
+				if (disabledServers) {
+					if (disabledServers.includes(server)) {
+						resolvedLaneState?.disabledMcpServers.set(disabledServers.filter((s) => s !== server));
+					} else {
+						resolvedLaneState?.disabledMcpServers.set([...disabledServers, server]);
+					}
+				}
+			}}
+		/>
+	{/snippet}
+</ReduxResult>

--- a/apps/desktop/src/components/StackCodegen.svelte
+++ b/apps/desktop/src/components/StackCodegen.svelte
@@ -13,6 +13,7 @@
 	import CodegenMessages from "$components/codegen/CodegenMessages.svelte";
 	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
 	import { getStackContext } from "$lib/stack/stackController.svelte";
+	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import type { ClaudeConfig } from "$lib/codegen/types";
 
@@ -25,6 +26,7 @@
 	const { hasRulesToClear, claudeConfig, onclose }: Props = $props();
 
 	const controller = getStackContext();
+	const uiState = inject(UI_STATE);
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
 
 	let mcpConfigModal = $state<CodegenMcpConfigModal>();
@@ -48,9 +50,7 @@
 	hideError
 >
 	{#snippet children(config, { stackId: resolvedStackId })}
-		{@const resolvedLaneState = resolvedStackId
-			? controller.uiState.lane(resolvedStackId)
-			: undefined}
+		{@const resolvedLaneState = resolvedStackId ? uiState.lane(resolvedStackId) : undefined}
 		<CodegenMcpConfigModal
 			disabledServers={resolvedLaneState?.disabledMcpServers.current || []}
 			bind:this={mcpConfigModal}

--- a/apps/desktop/src/components/StackDetails.svelte
+++ b/apps/desktop/src/components/StackDetails.svelte
@@ -131,12 +131,7 @@
 	{#if stackId && selection?.irc && ircChannel}
 		<IrcChannel projectId={controller.projectId} type="group" channel={ircChannel} autojoin />
 	{:else if stackId && selection?.branchName && selection?.codegen}
-		<StackCodegen
-			branchName={selection.branchName}
-			{hasRulesToClear}
-			{claudeConfig}
-			onclose={() => controller.closePreview()}
-		/>
+		<StackCodegen {hasRulesToClear} {claudeConfig} onclose={() => controller.closePreview()} />
 	{:else}
 		{@const commit = commitQuery?.response}
 		{@const dzCommit: DzCommitData | undefined = commit

--- a/apps/desktop/src/components/StackDetails.svelte
+++ b/apps/desktop/src/components/StackDetails.svelte
@@ -114,7 +114,7 @@
 	const branchName = $derived(controller.branchName);
 	const commitId = $derived(controller.commitId);
 	const upstream = $derived(controller.upstream);
-	const activeLastAdded = $derived(controller.activeLastAdded);
+	const focusedFileStore = $derived(controller.focusedFileStore);
 	const selection = $derived(controller.laneState.selection.current);
 </script>
 
@@ -210,7 +210,7 @@
 										changes={commit.changes}
 										draggable={true}
 										selectable={false}
-										startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+										startIndex={focusedFileStore ? get(focusedFileStore)?.index : undefined}
 										{onVisibleChange}
 									/>
 								{/snippet}
@@ -251,13 +251,13 @@
 							{projectId}
 							draggable={true}
 							selectable={false}
-							startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+							startIndex={focusedFileStore ? get(focusedFileStore)?.index : undefined}
 							{onVisibleChange}
 						/>
 					{/snippet}
 				</ReduxResult>
 			</div>
-		{:else if activeLastAdded}
+		{:else if focusedFileStore}
 			<MultiDiffView
 				{stackId}
 				selectionId={{ type: "worktree", stackId }}
@@ -267,7 +267,7 @@
 				draggable={true}
 				selectable={controller.isCommitting}
 				onclose={() => controller.closePreview()}
-				startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+				startIndex={focusedFileStore ? get(focusedFileStore)?.index : undefined}
 				{onVisibleChange}
 			/>
 		{/if}

--- a/apps/desktop/src/components/StackDetails.svelte
+++ b/apps/desktop/src/components/StackDetails.svelte
@@ -1,0 +1,325 @@
+<!--
+	Compound child that renders the stack details/preview panel (right side).
+	Reads shared state from StackController via context.
+
+	Handles: commit view, branch view, worktree multi-diff,
+	codegen messages, IRC channel.
+
+	Usage:
+	```svelte
+	<StackDetails
+		{hasRulesToClear}
+		{claudeConfig}
+		{ircChannel}
+		onWidthChange={(w) => ...}
+	/>
+	```
+-->
+<script lang="ts">
+	import BranchView from "$components/BranchView.svelte";
+	import CardOverlay from "$components/CardOverlay.svelte";
+	import CommitView from "$components/CommitView.svelte";
+	import Dropzone from "$components/Dropzone.svelte";
+	import IrcChannel from "$components/IrcChannel.svelte";
+	import MultiDiffView from "$components/MultiDiffView.svelte";
+	import ReduxResult from "$components/ReduxResult.svelte";
+	import Resizer from "$components/Resizer.svelte";
+	import StackCodegen from "$components/StackCodegen.svelte";
+	import { isLocalAndRemoteCommit, isUpstreamCommit } from "$components/lib";
+	import {
+		AmendCommitWithChangeDzHandler,
+		AmendCommitWithHunkDzHandler,
+		createCommitDropHandlers,
+		type DzCommitData,
+	} from "$lib/commits/dropHandler";
+	import { projectRunCommitHooks } from "$lib/config/config";
+	import { isParsedError } from "$lib/error/parser";
+	import { HOOKS_SERVICE } from "$lib/hooks/hooksService";
+	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { TestId } from "@gitbutler/ui";
+	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import { isDefined } from "@gitbutler/ui/utils/typeguards";
+	import { get } from "svelte/store";
+	import { fly } from "svelte/transition";
+	import type { ClaudeConfig } from "$lib/codegen/types";
+
+	type Props = {
+		hasRulesToClear: boolean;
+		claudeConfig: ClaudeConfig;
+		ircChannel?: string;
+		onWidthChange: (width: number) => void;
+	};
+
+	const { hasRulesToClear, claudeConfig, ircChannel, onWidthChange }: Props = $props();
+
+	const controller = getStackContext();
+
+	const stackService = inject(STACK_SERVICE);
+	const hooksService = inject(HOOKS_SERVICE);
+	const uncommittedService = inject(UNCOMMITTED_SERVICE);
+
+	const RESIZER_CONFIG = {
+		minWidth: 20,
+		maxWidth: 64,
+		defaultValue: 37,
+	};
+	const DETAILS_RIGHT_PADDING_REM = 1.125;
+
+	const commitQuery = $derived(
+		controller.commitId
+			? stackService.commitById(controller.projectId, controller.stackId, controller.commitId)
+			: undefined,
+	);
+	const runHooks = $derived(projectRunCommitHooks(controller.projectId));
+	const commitFiles = $derived(
+		controller.commitId
+			? stackService.commitChanges(controller.projectId, controller.commitId)
+			: undefined,
+	);
+	const assignedFiles = $derived(
+		uncommittedService.getChangesByStackId(controller.stackId || null),
+	);
+
+	function onerror(err: unknown) {
+		if (isParsedError(err) && err.code === "errors.branch.notfound") {
+			controller.selection.set(undefined);
+			console.warn("Workspace selection cleared");
+		}
+	}
+
+	let multiDiffView = $state<MultiDiffView>();
+
+	$effect(() => {
+		if (multiDiffView) {
+			controller.registerDiffView({
+				jump: (index) => multiDiffView?.jumpToIndex(index),
+				popout: () => multiDiffView?.openFloatingDiff(),
+			});
+		}
+		return () => controller.unregisterDiffView();
+	});
+
+	function onVisibleChange(change: { start: number; end: number } | undefined) {
+		controller.setVisibleRange(change);
+	}
+
+	let detailsEl = $state<HTMLDivElement>();
+
+	const projectId = $derived(controller.projectId);
+	const stackId = $derived(controller.stackId);
+	const laneId = $derived(controller.laneId);
+	const branchName = $derived(controller.branchName);
+	const commitId = $derived(controller.commitId);
+	const upstream = $derived(controller.upstream);
+	const activeLastAdded = $derived(controller.activeLastAdded);
+	const selection = $derived(controller.laneState.selection.current);
+</script>
+
+<div
+	in:fly={{ y: 20, duration: 200 }}
+	class="details-view"
+	class:codegen-view={selection?.codegen || selection?.irc}
+	bind:this={detailsEl}
+	data-details={stackId}
+	style:right="{DETAILS_RIGHT_PADDING_REM}rem"
+	use:focusable={{ vertical: true }}
+	data-testid={TestId.StackPreview}
+>
+	{#if stackId && selection?.irc && ircChannel}
+		<IrcChannel projectId={controller.projectId} type="group" channel={ircChannel} autojoin />
+	{:else if stackId && selection?.branchName && selection?.codegen}
+		<StackCodegen
+			branchName={selection.branchName}
+			{hasRulesToClear}
+			{claudeConfig}
+			onclose={() => controller.closePreview()}
+		/>
+	{:else}
+		{@const commit = commitQuery?.response}
+		{@const dzCommit: DzCommitData | undefined = commit
+			? {
+					id: commit.id,
+					isRemote: isUpstreamCommit(commit),
+					isIntegrated:
+						isLocalAndRemoteCommit(commit) && commit.state.type === "Integrated",
+					hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts,
+				}
+			: undefined}
+		{@const { amendHandler, squashHandler, hunkHandler } =
+			controller.isCommitView && dzCommit
+				? createCommitDropHandlers({
+						projectId: controller.projectId,
+						stackId: controller.stackId,
+						stackService,
+						hooksService,
+						uiState: controller.uiState,
+						commit: dzCommit,
+						runHooks: $runHooks,
+						okWithForce: true,
+						onCommitIdChange: (newId) => {
+							if (stackId && branchName && selection) {
+								const previewOpen = selection.previewOpen ?? true;
+								controller.laneState.selection.set({
+									branchName,
+									commitId: newId,
+									previewOpen,
+								});
+							}
+						},
+					})
+				: { amendHandler: undefined, squashHandler: undefined, hunkHandler: undefined }}
+		{#if branchName && commitId}
+			<Dropzone
+				handlers={[amendHandler, squashHandler, hunkHandler].filter(isDefined)}
+				fillHeight
+				overflow
+			>
+				{#snippet overlay({ hovered, activated, handler })}
+					{@const label =
+						handler instanceof AmendCommitWithChangeDzHandler ||
+						handler instanceof AmendCommitWithHunkDzHandler
+							? "Amend"
+							: "Squash"}
+					<CardOverlay {hovered} {activated} {label} />
+				{/snippet}
+				<div class="details-view__inner">
+					<CommitView
+						{projectId}
+						{stackId}
+						{laneId}
+						commitKey={{
+							stackId,
+							branchName,
+							commitId,
+							upstream: !!upstream,
+						}}
+						draggableFiles
+						rounded
+						{onerror}
+						onclose={() => controller.closePreview()}
+						onpopout={() => controller.openFloatingDiff()}
+					/>
+					{#if commitFiles}
+						{@const commitResult = commitFiles?.result}
+						{#if commitResult}
+							<ReduxResult {projectId} {stackId} result={commitResult}>
+								{#snippet children(commit)}
+									<MultiDiffView
+										{stackId}
+										selectionId={{ type: "commit", commitId, stackId }}
+										bind:this={multiDiffView}
+										{projectId}
+										changes={commit.changes}
+										draggable={true}
+										selectable={false}
+										startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+										{onVisibleChange}
+									/>
+								{/snippet}
+							</ReduxResult>
+						{/if}
+					{/if}
+				</div>
+			</Dropzone>
+		{:else if branchName}
+			{@const changesQuery = stackService.branchChanges({
+				projectId: controller.projectId,
+				stackId: controller.stackId,
+				branch: branchName,
+			})}
+			<div class="details-view__inner">
+				<BranchView
+					{stackId}
+					{laneId}
+					{projectId}
+					{branchName}
+					{onerror}
+					onclose={() => controller.closePreview()}
+					rounded
+					onpopout={() => controller.openFloatingDiff()}
+				/>
+				<ReduxResult {projectId} {stackId} result={changesQuery.result}>
+					{#snippet children(result)}
+						<MultiDiffView
+							{stackId}
+							selectionId={{
+								type: "branch",
+								branchName,
+								remote: undefined,
+								stackId,
+							}}
+							changes={result.changes}
+							bind:this={multiDiffView}
+							{projectId}
+							draggable={true}
+							selectable={false}
+							startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+							{onVisibleChange}
+						/>
+					{/snippet}
+				</ReduxResult>
+			</div>
+		{:else if activeLastAdded}
+			<MultiDiffView
+				{stackId}
+				selectionId={{ type: "worktree", stackId }}
+				changes={assignedFiles}
+				bind:this={multiDiffView}
+				{projectId}
+				draggable={true}
+				selectable={controller.isCommitting}
+				onclose={() => controller.closePreview()}
+				startIndex={activeLastAdded ? get(activeLastAdded)?.index : undefined}
+				{onVisibleChange}
+			/>
+		{/if}
+	{/if}
+</div>
+
+<!-- DETAILS VIEW WIDTH RESIZER -->
+{#if detailsEl}
+	<Resizer
+		viewport={detailsEl}
+		persistId="resizer-panel2-${stackId}"
+		direction="right"
+		showBorder
+		minWidth={RESIZER_CONFIG.minWidth}
+		maxWidth={RESIZER_CONFIG.maxWidth}
+		defaultValue={RESIZER_CONFIG.defaultValue}
+		syncName="panel2"
+		onWidth={onWidthChange}
+	/>
+{/if}
+
+<style lang="postcss">
+	.details-view {
+		display: flex;
+		z-index: var(--z-ground);
+		position: absolute;
+		top: 12px;
+		flex-shrink: 0;
+		flex-direction: column;
+		height: 100%;
+		max-height: calc(100% - 24px);
+		margin-right: 2px;
+	}
+
+	.codegen-view {
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-1);
+	}
+
+	:global(.details-view__inner) {
+		display: flex;
+		position: relative;
+		flex: 1;
+		flex-direction: column;
+		height: 100%;
+		gap: 8px;
+	}
+</style>

--- a/apps/desktop/src/components/StackDetails.svelte
+++ b/apps/desktop/src/components/StackDetails.svelte
@@ -150,7 +150,6 @@
 						stackId: controller.stackId,
 						stackService,
 						hooksService,
-						uiState: controller.uiState,
 						commit: dzCommit,
 						runHooks: $runHooks,
 						okWithForce: true,

--- a/apps/desktop/src/components/StackDetails.svelte
+++ b/apps/desktop/src/components/StackDetails.svelte
@@ -148,8 +148,6 @@
 				? createCommitDropHandlers({
 						projectId: controller.projectId,
 						stackId: controller.stackId,
-						stackService,
-						hooksService,
 						commit: dzCommit,
 						runHooks: $runHooks,
 						okWithForce: true,

--- a/apps/desktop/src/components/StackPanel.svelte
+++ b/apps/desktop/src/components/StackPanel.svelte
@@ -204,20 +204,7 @@
 		<IrcRow stackId={controller.stackId} channel={ircChannel} selected={controller.ircPanelOpen} />
 	{/if}
 
-	<BranchList
-		projectId={controller.projectId}
-		{branches}
-		laneId={controller.laneId}
-		stackId={controller.stackId}
-		active={controller.active}
-		onclick={() => {
-			controller.clearWorktreeSelection();
-		}}
-		onFileClick={(index) => {
-			controller.jumpToIndex(index);
-		}}
-		visibleRange={controller.visibleRange}
-	/>
+	<BranchList {branches} />
 </div>
 
 <style lang="postcss">

--- a/apps/desktop/src/components/StackPanel.svelte
+++ b/apps/desktop/src/components/StackPanel.svelte
@@ -1,0 +1,295 @@
+<!--
+	Compound child that renders the left panel of a stack view.
+	Contains: worktree changes, start commit button, IRC row, and branch list.
+	Reads shared state from StackController via context.
+
+	Usage:
+	```svelte
+	<StackPanel {branches} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
+	```
+-->
+<script lang="ts">
+	import BranchList from "$components/BranchList.svelte";
+	import IrcRow from "$components/IrcRow.svelte";
+	import NewCommitView from "$components/NewCommitView.svelte";
+	import StackDragHandle from "$components/StackDragHandle.svelte";
+	import WorktreeChanges from "$components/WorktreeChanges.svelte";
+	import { stagingBehaviorFeature } from "$lib/config/uiFeatureFlags";
+	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
+	import { createWorktreeSelection, type SelectionId } from "$lib/selection/key";
+	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { Button, TestId } from "@gitbutler/ui";
+	import type { BranchDetails } from "$lib/stacks/stack";
+
+	type Props = {
+		branches: BranchDetails[];
+		topBranchName?: string;
+		onFoldStack?: () => void;
+		ircEnabled: boolean;
+		ircChannel?: string;
+	};
+
+	const { branches, topBranchName, onFoldStack, ircEnabled, ircChannel }: Props = $props();
+
+	const controller = getStackContext();
+	const stackService = inject(STACK_SERVICE);
+	const uncommittedService = inject(UNCOMMITTED_SERVICE);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
+
+	const changes = $derived(uncommittedService.changesByStackId(controller.stackId || null));
+	const startCommitVisible = $derived(uncommittedService.startCommitVisible(controller.stackId));
+	const defaultBranchQuery = $derived(
+		stackService.defaultBranch(controller.projectId, controller.stackId),
+	);
+	const defaultBranch = $derived(defaultBranchQuery?.response);
+
+	let dropzoneActivated = $state(false);
+	let dropzoneHovered = $state(false);
+
+	function selectedPathsForSelection(selectionId: SelectionId): string[] {
+		return idSelection.values(selectionId).map((entry) => entry.path);
+	}
+
+	function checkSelectedFilesForCommit() {
+		const stackAssignments = controller.stackId
+			? uncommittedService.getAssignmentsByStackId(controller.stackId)
+			: [];
+		if (controller.stackId && stackAssignments.length > 0) {
+			const selectionId = createWorktreeSelection({ stackId: controller.stackId });
+			const selectedPaths = selectedPathsForSelection(selectionId);
+
+			if (selectedPaths.length > 0) {
+				uncommittedService.checkFiles(controller.stackId, selectedPaths);
+			} else {
+				uncommittedService.checkAll(controller.stackId);
+			}
+			uncommittedService.uncheckAll(null);
+			return;
+		}
+
+		const selectionId = createWorktreeSelection({});
+		const selectedPaths = selectedPathsForSelection(selectionId);
+
+		if (selectedPaths.length > 0) {
+			uncommittedService.checkFiles(null, selectedPaths);
+		} else {
+			uncommittedService.checkAll(null);
+		}
+	}
+
+	function uncheckAll() {
+		if (controller.stackId) {
+			uncommittedService.uncheckAll(controller.stackId);
+		}
+		uncommittedService.uncheckAll(null);
+	}
+
+	function checkAllFiles() {
+		const stackAssignments = controller.stackId
+			? uncommittedService.getAssignmentsByStackId(controller.stackId)
+			: [];
+		if (controller.stackId && stackAssignments.length > 0) {
+			uncommittedService.checkAll(controller.stackId);
+			uncommittedService.uncheckAll(null);
+			return;
+		}
+
+		uncommittedService.checkAll(null);
+	}
+
+	function checkFilesForCommit(): true {
+		switch ($stagingBehaviorFeature) {
+			case "all":
+				checkAllFiles();
+				return true;
+			case "selection":
+				checkSelectedFilesForCommit();
+				return true;
+			case "none":
+				uncheckAll();
+				return true;
+		}
+	}
+
+	function startCommit(branchName: string) {
+		controller.projectState.exclusiveAction.set({
+			type: "commit",
+			branchName,
+			stackId: controller.stackId,
+		});
+
+		checkFilesForCommit();
+	}
+</script>
+
+<div class="stack-v stack-view__inner">
+	<StackDragHandle
+		stackId={controller.stackId}
+		projectId={controller.projectId}
+		disabled={controller.isCommitting}
+		onFold={onFoldStack}
+		branchName={topBranchName}
+	/>
+
+	<div
+		class="assignments-wrap"
+		class:assignments__empty={changes.current.length === 0 && !controller.isCommitting}
+	>
+		<div
+			class="worktree-wrap"
+			class:remove-border-bottom={(controller.isCommitting && changes.current.length === 0) ||
+				!startCommitVisible.current}
+			class:dropzone-activated={dropzoneActivated && changes.current.length === 0}
+			class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
+		>
+			<WorktreeChanges
+				title="Staged"
+				projectId={controller.projectId}
+				stackId={controller.stackId}
+				mode="assigned"
+				visibleRange={controller.visibleRange}
+				onDropzoneActivated={(activated) => {
+					dropzoneActivated = activated;
+				}}
+				onDropzoneHovered={(hovered) => {
+					dropzoneHovered = hovered;
+				}}
+				onFileClick={(index) => {
+					controller.selection.set(undefined);
+					controller.jumpToIndex(index);
+				}}
+			>
+				{#snippet emptyPlaceholder()}
+					{#if !controller.isCommitting}
+						<div class="assigned-changes-empty">
+							<p class="text-12 text-body assigned-changes-empty__text">
+								Drop files to stage or commit directly
+							</p>
+						</div>
+					{/if}
+				{/snippet}
+			</WorktreeChanges>
+		</div>
+
+		{#if startCommitVisible.current || controller.isCommitting}
+			{#if !controller.isCommitting}
+				<div class="start-commit">
+					<Button
+						testId={TestId.StartCommitButton}
+						kind={changes.current.length > 0 ? "solid" : "outline"}
+						style={changes.current.length > 0 ? "pop" : "gray"}
+						type="button"
+						wide
+						disabled={controller.isReadOnly ||
+							defaultBranch === null ||
+							!!controller.exclusiveAction}
+						tooltip={controller.isReadOnly ? "Read-only mode" : undefined}
+						onclick={() => {
+							if (defaultBranch) startCommit(defaultBranch);
+						}}
+					>
+						Start a commit…
+					</Button>
+				</div>
+			{:else if controller.isCommitting}
+				<NewCommitView projectId={controller.projectId} stackId={controller.stackId} />
+			{/if}
+		{/if}
+	</div>
+
+	{#if ircEnabled && topBranchName}
+		<IrcRow stackId={controller.stackId} channel={ircChannel} selected={controller.ircPanelOpen} />
+	{/if}
+
+	<BranchList
+		projectId={controller.projectId}
+		{branches}
+		laneId={controller.laneId}
+		stackId={controller.stackId}
+		active={controller.active}
+		onclick={() => {
+			controller.clearWorktreeSelection();
+		}}
+		onFileClick={(index) => {
+			controller.jumpToIndex(index);
+		}}
+		visibleRange={controller.visibleRange}
+	/>
+</div>
+
+<style lang="postcss">
+	.stack-view__inner {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.assignments-wrap {
+		display: flex;
+		flex-shrink: 0;
+		flex-direction: column;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+	}
+
+	.worktree-wrap {
+		display: flex;
+		flex-direction: column;
+		border-bottom: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml) var(--radius-ml) 0 0;
+
+		&.remove-border-bottom {
+			border-bottom: none;
+		}
+
+		&.dropzone-activated {
+			& .assigned-changes-empty {
+				padding: 20px 8px 20px;
+				background-color: var(--clr-bg-1);
+				transition:
+					background-color var(--transition-fast),
+					padding var(--transition-fast);
+			}
+
+			& .assigned-changes-empty__text {
+				color: var(--clr-theme-pop-on-soft);
+			}
+		}
+
+		&.dropzone-hovered {
+			& .assigned-changes-empty__text {
+				opacity: 1;
+			}
+		}
+	}
+
+	.start-commit {
+		padding: 12px;
+		background-color: var(--clr-bg-1);
+	}
+
+	/* EMPTY ASSIGN AREA */
+	:global(.assigned-changes-empty) {
+		display: flex;
+		position: relative;
+		padding: 10px 8px;
+		overflow: hidden;
+		gap: 12px;
+		background-color: var(--clr-bg-2);
+		transition: background-color var(--transition-fast);
+	}
+
+	:global(.assigned-changes-empty__text) {
+		width: 100%;
+		color: var(--clr-text-2);
+		text-align: center;
+		opacity: 0.7;
+		transition:
+			color var(--transition-fast),
+			opacity var(--transition-fast);
+	}
+</style>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -1,63 +1,25 @@
 <script lang="ts">
-	import BranchList from "$components/BranchList.svelte";
-	import BranchView from "$components/BranchView.svelte";
-	import CardOverlay from "$components/CardOverlay.svelte";
-	import CommitView from "$components/CommitView.svelte";
 	import ConfigurableScrollableContainer from "$components/ConfigurableScrollableContainer.svelte";
-	import Dropzone from "$components/Dropzone.svelte";
 	import FullviewLoading from "$components/FullviewLoading.svelte";
-	import IrcChannel from "$components/IrcChannel.svelte";
-	import IrcRow from "$components/IrcRow.svelte";
-	import MultiDiffView from "$components/MultiDiffView.svelte";
-	import NewCommitView from "$components/NewCommitView.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import Resizer from "$components/Resizer.svelte";
-	import StackDragHandle from "$components/StackDragHandle.svelte";
-	import WorktreeChanges from "$components/WorktreeChanges.svelte";
-	import CodegenMcpConfigModal from "$components/codegen/CodegenMcpConfigModal.svelte";
-	import CodegenMessages from "$components/codegen/CodegenMessages.svelte";
-	import { isLocalAndRemoteCommit, isUpstreamCommit } from "$components/lib";
-	import { ATTACHMENT_SERVICE } from "$lib/codegen/attachmentService.svelte";
+	import StackDetails from "$components/StackDetails.svelte";
+	import StackPanel from "$components/StackPanel.svelte";
 	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
-	import { MessageSender } from "$lib/codegen/messageQueue.svelte";
-	import {
-		AmendCommitWithChangeDzHandler,
-		AmendCommitWithHunkDzHandler,
-		createCommitDropHandlers,
-		type DzCommitData,
-	} from "$lib/commits/dropHandler";
 	import { SETTINGS_SERVICE } from "$lib/config/appSettingsV2";
-	import { projectRunCommitHooks } from "$lib/config/config";
-	import { stagingBehaviorFeature } from "$lib/config/uiFeatureFlags";
-	import { isParsedError } from "$lib/error/parser";
-	import { HOOKS_SERVICE } from "$lib/hooks/hooksService";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { sessionChannel } from "$lib/irc/protocol";
 	import { IRC_SESSION_BRIDGE } from "$lib/irc/sessionBridge.svelte";
 	import { RULES_SERVICE } from "$lib/rules/rulesService.svelte";
-	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
-	import {
-		createBranchSelection,
-		createCommitSelection,
-		createWorktreeSelection,
-		readKey,
-		type SelectionId,
-	} from "$lib/selection/key";
-	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { StackController, setStackContext } from "$lib/stack/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { combineResults } from "$lib/state/helpers";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
-
 	import { inject } from "@gitbutler/core/context";
 	import { persistWithExpiration } from "@gitbutler/shared/persisted";
-
-	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
-	import { Button, TestId } from "@gitbutler/ui";
+	import { TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { intersectionObserver } from "@gitbutler/ui/utils/intersectionObserver";
-	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { untrack } from "svelte";
-	import { fly } from "svelte/transition";
 
 	type Props = {
 		projectId: string;
@@ -81,244 +43,69 @@
 		onVisible,
 	}: Props = $props();
 
-	const stableStackId = $derived(stackId);
-	const stableProjectId = $derived(projectId);
-	let lanesScrollableEl = $state<HTMLDivElement>();
+	// ── Controller (shared state for compound children) ───────────────
+	const controller = new StackController({
+		projectId: () => projectId,
+		stackId: () => stackId,
+		laneId: () => laneId,
+	});
+	setStackContext(controller);
 
-	let dropzoneActivated = $state(false);
-	let dropzoneHovered = $state(false);
-
+	// ── Services (only those needed at the composition root level) ────
 	const stackService = inject(STACK_SERVICE);
-	const uncommittedService = inject(UNCOMMITTED_SERVICE);
-	const uiState = inject(UI_STATE);
-	const hooksService = inject(HOOKS_SERVICE);
-	const idSelection = inject(FILE_SELECTION_MANAGER);
+	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
+	const rulesService = inject(RULES_SERVICE);
+	const settingsService = inject(SETTINGS_SERVICE);
+	const ircApiService = inject(IRC_API_SERVICE);
+	const ircSessionBridge = inject(IRC_SESSION_BRIDGE);
 
-	// Component is read-only when stackId is undefined
-	const isReadOnly = $derived(!stableStackId);
+	// ── Data queries for ReduxResult ──────────────────────────────────
+	const branchesQuery = $derived(stackService.branches(controller.projectId, controller.stackId));
+	const hasRulesToClear = $derived(
+		rulesService.hasRulesToClear(controller.projectId, controller.stackId),
+	);
+	const claudeConfigQuery = $derived(
+		claudeCodeService.claudeConfig({ projectId: controller.projectId }),
+	);
 
-	const projectState = $derived(uiState.project(stableProjectId));
-
-	const action = $derived(projectState.exclusiveAction.current);
-	const isCommitting = $derived(action?.type === "commit" && action.stackId === stableStackId);
-
-	// If the user is making a commit to a different lane we dim this one.
-	const dimmed = $derived(action?.type === "commit" && action?.stackId !== stableStackId);
-
-	// Resizer configuration for stack panels and details view
-	const RESIZER_CONFIG: {
-		panel1: { minWidth: number; maxWidth: number; defaultValue: number };
-		panel2: { minWidth: number; maxWidth: number; defaultValue: number };
-	} = {
-		panel1: {
-			minWidth: 20,
-			maxWidth: 64,
-			defaultValue: 23,
-		},
-		panel2: {
-			minWidth: 20,
-			maxWidth: 64,
-			defaultValue: 37,
-		},
+	// ── Resizer config ────────────────────────────────────────────────
+	const PANEL1_RESIZER = {
+		minWidth: 20,
+		maxWidth: 64,
+		defaultValue: 23,
 	};
+	const DETAILS_DEFAULT_WIDTH = 37;
 
 	const persistedStackWidth = $derived(
 		persistWithExpiration(
-			RESIZER_CONFIG.panel1.defaultValue,
-			`ui-stack-width-${stableStackId}`,
+			PANEL1_RESIZER.defaultValue,
+			`ui-stack-width-${controller.stackId}`,
 			1440,
 		),
 	);
 
-	const branchesQuery = $derived(stackService.branches(stableProjectId, stableStackId));
-
-	let active = $state(false);
-
-	const laneState = $derived(uiState.lane(laneId));
-	const selection = $derived(laneState.selection);
-	const assignedSelection = $derived(
-		idSelection.getById(createWorktreeSelection({ stackId: stableStackId })),
-	);
-	const lastAddedAssigned = $derived(assignedSelection.lastAdded);
-	const assignedKey = $derived(
-		$lastAddedAssigned?.key ? readKey($lastAddedAssigned.key) : undefined,
-	);
-
-	const commitId = $derived(selection.current?.commitId);
-	const branchName = $derived(selection.current?.branchName);
-	const upstream = $derived(selection.current?.upstream);
-	const previewOpen = $derived(selection.current?.previewOpen);
-
-	// Get commit data for drop handlers when viewing a commit
-	const commitQuery = $derived(
-		commitId ? stackService.commitById(stableProjectId, stableStackId, commitId) : undefined,
-	);
-	const runHooks = $derived(projectRunCommitHooks(stableProjectId));
-	const isCommitView = $derived(!!(branchName && commitId));
-
-	const activeSelectionId: SelectionId | undefined = $derived.by(() => {
-		if (commitId) {
-			return createCommitSelection({ commitId, stackId: stableStackId });
-		} else if (branchName) {
-			return createBranchSelection({ stackId: stableStackId, branchName, remote: undefined });
-		}
-		return createWorktreeSelection({ stackId });
-	});
-
-	const activeLastAdded = $derived.by(() => {
-		if (activeSelectionId) {
-			return idSelection.getById(activeSelectionId).lastAdded;
-		}
-	});
-
-	const selectedFile = $derived($activeLastAdded?.key ? readKey($activeLastAdded.key) : undefined);
-	const changes = $derived(uncommittedService.changesByStackId(stableStackId || null));
-
 	let stackViewEl = $state<HTMLDivElement>();
-	let compactDiv = $state<HTMLDivElement>();
 
-	const defaultBranchQuery = $derived(stackService.defaultBranch(stableProjectId, stableStackId));
-	const defaultBranch = $derived(defaultBranchQuery?.response);
-
-	function selectedPathsForSelection(selectionId: SelectionId): string[] {
-		return idSelection.values(selectionId).map((entry) => entry.path);
-	}
-
-	function checkSelectedFilesForCommit() {
-		const stackAssignments = stableStackId
-			? uncommittedService.getAssignmentsByStackId(stableStackId)
-			: [];
-		if (stableStackId && stackAssignments.length > 0) {
-			// If there are assignments for this stack, we check those.
-			const selectionId = createWorktreeSelection({ stackId: stableStackId });
-			const selectedPaths = selectedPathsForSelection(selectionId);
-
-			// If there are selected paths, we check those.
-			if (selectedPaths.length > 0) {
-				uncommittedService.checkFiles(stableStackId, selectedPaths);
-			} else {
-				uncommittedService.checkAll(stableStackId);
-			}
-			// Uncheck the unassigned files.
-			uncommittedService.uncheckAll(null);
-			return;
-		}
-
-		const selectionId = createWorktreeSelection({});
-		const selectedPaths = selectedPathsForSelection(selectionId);
-
-		// If there are selected paths in the unassigned selection, we check those.
-		if (selectedPaths.length > 0) {
-			uncommittedService.checkFiles(null, selectedPaths);
-		} else {
-			uncommittedService.checkAll(null);
-		}
-	}
-
-	function uncheckAll() {
-		if (stableStackId) {
-			uncommittedService.uncheckAll(stableStackId);
-		}
-		uncommittedService.uncheckAll(null);
-	}
-
-	function checkAllFiles() {
-		const stackAssignments = stableStackId
-			? uncommittedService.getAssignmentsByStackId(stableStackId)
-			: [];
-		if (stableStackId && stackAssignments.length > 0) {
-			// If there are assignments for this stack, we check those.
-			uncommittedService.checkAll(stableStackId);
-			// Uncheck the unassigned files.
-			uncommittedService.uncheckAll(null);
-			return;
-		}
-
-		uncommittedService.checkAll(null);
-	}
-
-	function checkFilesForCommit(): true {
-		switch ($stagingBehaviorFeature) {
-			case "all":
-				checkAllFiles();
-				return true;
-			case "selection":
-				// We only check the selected files.
-				checkSelectedFilesForCommit();
-				return true;
-			case "none":
-				uncheckAll();
-				return true;
-		}
-	}
-
-	function startCommit(branchName: string) {
-		projectState.exclusiveAction.set({
-			type: "commit",
-			branchName,
-			stackId: stableStackId,
-		});
-
-		checkFilesForCommit();
-	}
-
-	function onclosePreview() {
-		// Clear file selections for the active branch or commit
-		if (activeSelectionId) {
-			idSelection.clear(activeSelectionId);
-		}
-		// Clear the lane selection (branch/commit)
-		selection.set(undefined);
-	}
-
-	const startCommitVisible = $derived(uncommittedService.startCommitVisible(stableStackId));
-
-	function onerror(err: unknown) {
-		// Clear selection if branch not found.
-		if (isParsedError(err) && err.code === "errors.branch.notfound") {
-			selection?.set(undefined);
-			console.warn("Workspace selection cleared");
-		}
-	}
-
-	// Details view can be opened in two ways:
-	// 1. User selects a branch/commit/file and opens preview
-	// 2. Files are assigned to this stack (assignedKey exists)
-	const hasActiveSelection = $derived(!!(branchName || commitId || selectedFile));
-	const isPreviewOpenForSelection = $derived(hasActiveSelection && previewOpen);
-	const hasAssignedFiles = $derived(!!assignedKey);
-	const ircPanelOpen = $derived(selection.current?.irc === true);
-
-	let isDetailsViewOpen = $derived(isPreviewOpenForSelection || hasAssignedFiles || ircPanelOpen);
-
-	const DETAILS_RIGHT_PADDING_REM = 1.125;
-
-	// Function to update CSS custom property for details view width
+	// ── Details view width CSS custom property ────────────────────────
 	function updateDetailsViewWidth(width: number) {
 		if (stackViewEl) {
 			stackViewEl.style.setProperty("--details-view-width", `${width}rem`);
 		}
 	}
 
-	// Set initial CSS custom properties when details view opens/closes
 	$effect(() => {
 		const element = stackViewEl;
 		if (element) {
-			if (isDetailsViewOpen) {
-				// Set default width if not already set or is zero
+			if (controller.isDetailsViewOpen) {
 				const currentWidth = element.style.getPropertyValue("--details-view-width");
 				if (!currentWidth || currentWidth === "0rem") {
-					element.style.setProperty(
-						"--details-view-width",
-						`${RESIZER_CONFIG.panel2.defaultValue}rem`,
-					);
+					element.style.setProperty("--details-view-width", `${DETAILS_DEFAULT_WIDTH}rem`);
 				}
 			} else {
 				element.style.setProperty("--details-view-width", "0rem");
 			}
 		}
 
-		// Cleanup function to reset the property when the effect reruns or component unmounts
 		return () => {
 			if (element) {
 				element.style.removeProperty("--details-view-width");
@@ -326,64 +113,23 @@
 		};
 	});
 
-	// Codegen related services and state
-	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
-	const rulesService = inject(RULES_SERVICE);
-	const attachmentService = inject(ATTACHMENT_SERVICE);
-	const settingsService = inject(SETTINGS_SERVICE);
+	// ── IRC bridge lifecycle (needs to run at stack level) ────────────
 	const settingsStore = settingsService.appSettings;
 	const ircSettings = $derived($settingsStore?.irc);
 	const ircEnabled = $derived(
 		($settingsStore?.featureFlags?.irc && $settingsStore?.irc?.connection?.enabled) ?? false,
 	);
 
-	const claudeConfigQuery = $derived(claudeCodeService.claudeConfig({ projectId }));
-	const isStackActiveQuery = $derived(claudeCodeService.isStackActive(projectId, stackId));
-	const isStackActive = $derived(isStackActiveQuery?.response || false);
-	const events = $derived(claudeCodeService.messages({ projectId, stackId }));
-	const sessionIdQuery = $derived(rulesService.aiSessionId(projectId, stackId));
-	const sessionId = $derived(sessionIdQuery.response);
-	const hasRulesToClear = $derived(rulesService.hasRulesToClear(projectId, stackId));
-	const permissionRequests = $derived(claudeCodeService.permissionRequests({ projectId }));
-	const attachments = $derived(attachmentService.getByBranch(branchName));
-
-	const selectedThinkingLevel = $derived(projectState.thinkingLevel.current);
-	const selectedModel = $derived(projectState.selectedModel.current);
-	const selectedPermissionMode = $derived(uiState.lane(laneId).permissionMode.current);
-
-	const messageSender = $derived(
-		stackId && branchName
-			? new MessageSender({
-					projectId: reactive(() => projectId),
-					selectedBranch: reactive(() => ({ stackId, head: branchName })),
-					thinkingLevel: reactive(() => selectedThinkingLevel),
-					model: reactive(() => selectedModel),
-					permissionMode: reactive(() => selectedPermissionMode),
-				})
-			: undefined,
-	);
-	const initialPrompt = $derived(messageSender?.prompt);
-
-	const assignedFiles = $derived(uncommittedService.getChangesByStackId(stackId || null));
-	const commitFiles = $derived(
-		commitId ? stackService.commitChanges(projectId, commitId) : undefined,
-	);
-
-	let mcpConfigModal = $state<CodegenMcpConfigModal>();
-	let multiDiffView = $state<MultiDiffView>();
-	let visibleRange = $state<{ start: number; end: number } | undefined>();
-
-	// IRC Session Bridge
-	const ircSessionBridge = inject(IRC_SESSION_BRIDGE);
-
-	// IRC Channel panel
-	const ircApiService = inject(IRC_API_SERVICE);
 	const ircNickQuery = $derived(ircApiService.nick());
 	const ircNick = $derived(ircNickQuery?.response);
 	const ircChannel = $derived(
 		ircNick && topBranchName ? sessionChannel(ircNick, topBranchName) : undefined,
 	);
 
+	const sessionIdQuery = $derived(
+		rulesService.aiSessionId(controller.projectId, controller.stackId),
+	);
+	const sessionId = $derived(sessionIdQuery.response);
 	const isManuallyBridged = $derived(ircSessionBridge.isManuallyBridged(stackId));
 	const readyToBridge = $derived(
 		sessionId &&
@@ -393,11 +139,9 @@
 			(ircSettings?.autoShare || isManuallyBridged.current),
 	);
 
-	// Reactive connection state — drives bridge connect/disconnect.
 	const connectionStateQuery = $derived(ircEnabled ? ircApiService.connectionState() : undefined);
 	const connectionReady = $derived(connectionStateQuery?.response?.ready ?? false);
 
-	// Register/unregister the bridge when auto-share conditions are met.
 	$effect(() => {
 		if (!readyToBridge) return;
 		if (!stackId || !topBranchName) return;
@@ -415,35 +159,10 @@
 		};
 	});
 
-	// React to connection readiness changes.
 	$effect(() => {
 		if (!stackId) return;
 		ircSessionBridge.setBotReady(stackId, connectionReady);
 	});
-
-	async function onAbort() {
-		if (stackId) {
-			await claudeCodeService.cancelSession({ projectId, stackId });
-		}
-	}
-
-	async function sendMessage(prompt: string) {
-		await messageSender?.sendMessage(prompt, attachments);
-		attachmentService.clearByBranch(branchName);
-	}
-
-	async function handleAnswerQuestion(answers: Record<string, string>) {
-		if (!stackId) return;
-		await claudeCodeService.answerAskUserQuestion({
-			projectId,
-			stackId,
-			answers,
-		});
-	}
-
-	function onVisibleChange(change: { start: number; end: number } | undefined) {
-		visibleRange = change;
-	}
 </script>
 
 <div
@@ -452,11 +171,11 @@
 	data-scrollable-for-dragging
 	class="stack-view-wrapper"
 	role="presentation"
-	class:dimmed
+	class:dimmed={controller.dimmed}
 	tabindex="-1"
-	data-id={stableStackId}
+	data-id={controller.stackId}
 	data-testid={TestId.Stack}
-	data-testid-stackid={stableStackId}
+	data-testid-stackid={controller.stackId}
 	data-testid-stack={topBranchName}
 	use:intersectionObserver={{
 		callback: (entry) => {
@@ -464,13 +183,12 @@
 		},
 		options: {
 			threshold: 0.5,
-			root: lanesScrollableEl,
 		},
 	}}
 	use:focusable={{
 		onKeydown: (event) => {
-			if (event.key === "Escape" && isDetailsViewOpen) {
-				onclosePreview();
+			if (event.key === "Escape" && controller.isDetailsViewOpen) {
+				controller.closePreview();
 				event.preventDefault();
 				event.stopPropagation();
 				return true;
@@ -479,7 +197,7 @@
 	}}
 >
 	<ReduxResult
-		projectId={stableProjectId}
+		projectId={controller.projectId}
 		result={combineResults(branchesQuery.result, hasRulesToClear.result, claudeConfigQuery.result)}
 	>
 		{#snippet loading()}
@@ -491,124 +209,30 @@
 			<ConfigurableScrollableContainer childrenWrapHeight="100%" enableDragScroll>
 				<div
 					class="stack-view"
-					class:details-open={isDetailsViewOpen}
+					class:details-open={controller.isDetailsViewOpen}
 					style:width="{$persistedStackWidth}rem"
 					data-fade-on-reorder
-					use:focusable={{ vertical: true, onActive: (value) => (active = value) }}
+					use:focusable={{
+						vertical: true,
+						onActive: (value) => (controller.active = value),
+					}}
 					bind:this={stackViewEl}
 				>
-					<div class="stack-v stack-view__inner">
-						<!-- If we are currently committing, we should keep this open so users can actually stop committing again :wink: -->
-						<StackDragHandle
-							stackId={stableStackId}
-							{projectId}
-							disabled={isCommitting}
-							onFold={onFoldStack}
-							branchName={topBranchName}
-						/>
-
-						<div
-							class="assignments-wrap"
-							class:assignments__empty={changes.current.length === 0 && !isCommitting}
-						>
-							<div
-								class="worktree-wrap"
-								class:remove-border-bottom={(isCommitting && changes.current.length === 0) ||
-									!startCommitVisible.current}
-								class:dropzone-activated={dropzoneActivated && changes.current.length === 0}
-								class:dropzone-hovered={dropzoneHovered && changes.current.length === 0}
-							>
-								<WorktreeChanges
-									title="Staged"
-									projectId={stableProjectId}
-									stackId={stableStackId}
-									mode="assigned"
-									{visibleRange}
-									onDropzoneActivated={(activated) => {
-										dropzoneActivated = activated;
-									}}
-									onDropzoneHovered={(hovered) => {
-										dropzoneHovered = hovered;
-									}}
-									onFileClick={(index) => {
-										// Clear one selection when you modify the other.
-										laneState?.selection.set(undefined);
-										multiDiffView?.jumpToIndex(index);
-									}}
-								>
-									{#snippet emptyPlaceholder()}
-										{#if !isCommitting}
-											<div class="assigned-changes-empty">
-												<p class="text-12 text-body assigned-changes-empty__text">
-													Drop files to stage or commit directly
-												</p>
-											</div>
-										{/if}
-									{/snippet}
-								</WorktreeChanges>
-							</div>
-
-							{#if startCommitVisible.current || isCommitting}
-								{#if !isCommitting}
-									<div class="start-commit">
-										<Button
-											testId={TestId.StartCommitButton}
-											kind={changes.current.length > 0 ? "solid" : "outline"}
-											style={changes.current.length > 0 ? "pop" : "gray"}
-											type="button"
-											wide
-											disabled={isReadOnly ||
-												defaultBranch === null ||
-												!!projectState.exclusiveAction.current}
-											tooltip={isReadOnly ? "Read-only mode" : undefined}
-											onclick={() => {
-												if (defaultBranch) startCommit(defaultBranch);
-											}}
-										>
-											Start a commit…
-										</Button>
-									</div>
-								{:else if isCommitting}
-									<NewCommitView projectId={stableProjectId} stackId={stableStackId} />
-								{/if}
-							{/if}
-						</div>
-
-						{#if ircEnabled && topBranchName}
-							<IrcRow stackId={stableStackId} channel={ircChannel} selected={ircPanelOpen} />
-						{/if}
-
-						<BranchList
-							projectId={stableProjectId}
-							{branches}
-							{laneId}
-							stackId={stableStackId}
-							{active}
-							onclick={() => {
-								// Clear one selection when you modify the other.
-								idSelection.clear({ type: "worktree", stackId: stableStackId });
-							}}
-							onFileClick={(index) => {
-								multiDiffView?.jumpToIndex(index);
-							}}
-							{visibleRange}
-						/>
-					</div>
+					<StackPanel {branches} {topBranchName} {onFoldStack} {ircEnabled} {ircChannel} />
 
 					<!-- RESIZE PANEL 1 -->
 					{#if stackViewEl}
 						<Resizer
-							persistId="ui-stack-width-${stableStackId}"
+							persistId="ui-stack-width-${controller.stackId}"
 							viewport={stackViewEl}
 							zIndex="var(--z-lifted)"
 							direction="right"
-							showBorder={!isDetailsViewOpen}
-							minWidth={RESIZER_CONFIG.panel1.minWidth}
-							maxWidth={RESIZER_CONFIG.panel1.maxWidth}
-							defaultValue={$persistedStackWidth ?? RESIZER_CONFIG.panel1.defaultValue}
+							showBorder={!controller.isDetailsViewOpen}
+							minWidth={PANEL1_RESIZER.minWidth}
+							maxWidth={PANEL1_RESIZER.maxWidth}
+							defaultValue={$persistedStackWidth ?? PANEL1_RESIZER.defaultValue}
 							syncName="panel1"
 							onWidth={(newWidth) => {
-								// Update the persisted stack width when panel1 resizer changes
 								persistedStackWidth.set(newWidth);
 							}}
 						/>
@@ -616,226 +240,18 @@
 				</div>
 			</ConfigurableScrollableContainer>
 
-			<!-- PREVIEW -->
-			{#if isDetailsViewOpen}
-				{@const selection = laneState.selection.current}
-				<div
-					in:fly={{ y: 20, duration: 200 }}
-					class="details-view"
-					class:codegen-view={selection?.codegen || selection?.irc}
-					bind:this={compactDiv}
-					data-details={stableStackId}
-					style:right="{DETAILS_RIGHT_PADDING_REM}rem"
-					use:focusable={{ vertical: true }}
-					data-testid={TestId.StackPreview}
-				>
-					{#if stableStackId && selection?.irc && ircChannel}
-						<IrcChannel projectId={stableProjectId} type="group" channel={ircChannel} autojoin />
-					{:else if stableStackId && selection?.branchName && selection?.codegen}
-						<CodegenMessages
-							projectId={stableProjectId}
-							stackId={stableStackId}
-							{laneId}
-							branchName={selection.branchName}
-							onclose={onclosePreview}
-							onMcpSettings={() => {
-								mcpConfigModal?.open();
-							}}
-							{onAbort}
-							{initialPrompt}
-							events={events.response || []}
-							permissionRequests={permissionRequests.response || []}
-							onSubmit={sendMessage}
-							onChange={(prompt) => messageSender?.setPrompt(prompt)}
-							sessionId={sessionIdQuery.response}
-							{isStackActive}
-							{hasRulesToClear}
-							projectRegistered={claudeConfig.projectRegistered}
-							onRetryConfig={async () => {
-								await claudeCodeService.fetchClaudeConfig({ projectId }, { forceRefetch: true });
-							}}
-							onAnswerQuestion={handleAnswerQuestion}
-						/>
-					{:else}
-						{@const commit = commitQuery?.response}
-						{@const dzCommit: DzCommitData | undefined = commit
-							? {
-									id: commit.id,
-									isRemote: isUpstreamCommit(commit),
-									isIntegrated:
-										isLocalAndRemoteCommit(commit) && commit.state.type === 'Integrated',
-									hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts
-								}
-							: undefined}
-						{@const { amendHandler, squashHandler, hunkHandler } =
-							isCommitView && dzCommit
-								? createCommitDropHandlers({
-										projectId: stableProjectId,
-										stackId: stableStackId,
-										stackService,
-										hooksService,
-										uiState,
-										commit: dzCommit,
-										runHooks: $runHooks,
-										okWithForce: true,
-										onCommitIdChange: (newId) => {
-											if (stableStackId && branchName && selection) {
-												const previewOpen = selection.previewOpen ?? true;
-												uiState
-													.lane(stableStackId)
-													.selection.set({ branchName, commitId: newId, previewOpen });
-											}
-										},
-									})
-								: { amendHandler: undefined, squashHandler: undefined, hunkHandler: undefined }}
-						{#if branchName && commitId}
-							<Dropzone
-								handlers={[amendHandler, squashHandler, hunkHandler].filter(isDefined)}
-								fillHeight
-								overflow
-							>
-								{#snippet overlay({ hovered, activated, handler })}
-									{@const label =
-										handler instanceof AmendCommitWithChangeDzHandler ||
-										handler instanceof AmendCommitWithHunkDzHandler
-											? "Amend"
-											: "Squash"}
-									<CardOverlay {hovered} {activated} {label} />
-								{/snippet}
-								<div class="details-view__inner">
-									<CommitView
-										projectId={stableProjectId}
-										stackId={stableStackId}
-										{laneId}
-										commitKey={{
-											stackId: stableStackId,
-											branchName,
-											commitId,
-											upstream: !!upstream,
-										}}
-										draggableFiles
-										rounded
-										{onerror}
-										onclose={onclosePreview}
-										onpopout={() => multiDiffView?.openFloatingDiff()}
-									/>
-									{#if commitFiles}
-										{@const commitResult = commitFiles?.result}
-										{#if commitResult}
-											<ReduxResult {projectId} {stackId} result={commitResult}>
-												{#snippet children(commit)}
-													<MultiDiffView
-														{stackId}
-														selectionId={{ type: "commit", commitId, stackId: stableStackId }}
-														bind:this={multiDiffView}
-														projectId={stableProjectId}
-														changes={commit.changes}
-														draggable={true}
-														selectable={false}
-														startIndex={$activeLastAdded?.index}
-														{onVisibleChange}
-													/>
-												{/snippet}
-											</ReduxResult>
-										{/if}
-									{/if}
-								</div>
-							</Dropzone>
-						{:else if branchName}
-							{@const changesQuery = stackService.branchChanges({
-								projectId: stableProjectId,
-								stackId: stableStackId,
-								branch: branchName,
-							})}
-							<div class="details-view__inner">
-								<!-- TOP SECTION: Branch/Commit Details (no resizer) -->
-								<BranchView
-									stackId={stableStackId}
-									{laneId}
-									projectId={stableProjectId}
-									{branchName}
-									{onerror}
-									onclose={onclosePreview}
-									rounded
-									onpopout={() => multiDiffView?.openFloatingDiff()}
-								/>
-								<ReduxResult {projectId} {stackId} result={changesQuery.result}>
-									{#snippet children(result)}
-										<MultiDiffView
-											{stackId}
-											selectionId={{
-												type: "branch",
-												branchName,
-												remote: undefined,
-												stackId: stableStackId,
-											}}
-											changes={result.changes}
-											bind:this={multiDiffView}
-											projectId={stableProjectId}
-											draggable={true}
-											selectable={false}
-											startIndex={$activeLastAdded?.index}
-											{onVisibleChange}
-										/>
-									{/snippet}
-								</ReduxResult>
-							</div>
-						{:else if $activeLastAdded}
-							<MultiDiffView
-								{stackId}
-								selectionId={{ type: "worktree", stackId }}
-								changes={assignedFiles}
-								bind:this={multiDiffView}
-								projectId={stableProjectId}
-								draggable={true}
-								selectable={isCommitting}
-								onclose={onclosePreview}
-								startIndex={$activeLastAdded.index}
-								{onVisibleChange}
-							/>
-						{/if}
-					{/if}
-				</div>
-
-				<!-- DETAILS VIEW WIDTH RESIZER - Only show when details view is open -->
-				{#if compactDiv}
-					<Resizer
-						viewport={compactDiv}
-						persistId="resizer-panel2-${stableStackId}"
-						direction="right"
-						showBorder
-						minWidth={RESIZER_CONFIG.panel2.minWidth}
-						maxWidth={RESIZER_CONFIG.panel2.maxWidth}
-						defaultValue={RESIZER_CONFIG.panel2.defaultValue}
-						syncName="panel2"
-						onWidth={updateDetailsViewWidth}
-					/>
-				{/if}
+			<!-- DETAILS PANEL -->
+			{#if controller.isDetailsViewOpen}
+				<StackDetails
+					{hasRulesToClear}
+					{claudeConfig}
+					{ircChannel}
+					onWidthChange={updateDetailsViewWidth}
+				/>
 			{/if}
 		{/snippet}
 	</ReduxResult>
 </div>
-
-<ReduxResult result={claudeConfigQuery.result} {projectId} {stackId} hideError>
-	{#snippet children(claudeConfig, { stackId })}
-		{@const laneState = stackId ? uiState.lane(stackId) : undefined}
-		<CodegenMcpConfigModal
-			disabledServers={laneState?.disabledMcpServers.current || []}
-			bind:this={mcpConfigModal}
-			{claudeConfig}
-			toggleServer={(server) => {
-				const disabledServers = laneState?.disabledMcpServers.current;
-				if (disabledServers) {
-					if (disabledServers.includes(server)) {
-						laneState?.disabledMcpServers.set(disabledServers.filter((s) => s !== server));
-					} else {
-						laneState?.disabledMcpServers.set([...disabledServers, server]);
-					}
-				}
-			}}
-		/>
-	{/snippet}
-</ReduxResult>
 
 <style lang="postcss">
 	.stack-view-wrapper {
@@ -862,113 +278,20 @@
 		flex-direction: column;
 		min-height: 100%;
 		padding: 0 12px;
-		/* Use CSS custom properties for details view width to avoid ResizeObserver errors */
 		--details-view-width: 0rem;
-	}
-
-	.stack-view__inner {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
 	}
 
 	.stack-view.details-open {
 		margin-right: calc(var(--details-view-width) + 1.125rem);
 	}
+
 	.dimmed .stack-view {
 		pointer-events: none;
 	}
 
-	.assigned-changes-empty__text {
-		width: 100%;
-		color: var(--clr-text-2);
-		text-align: center;
-		opacity: 0.7;
-		transition:
-			color var(--transition-fast),
-			opacity var(--transition-fast);
-	}
-
-	.assignments-wrap {
+	.lane-skeleton {
 		display: flex;
-		flex-shrink: 0;
-		flex-direction: column;
-		overflow: hidden;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml);
-	}
-
-	.worktree-wrap {
-		display: flex;
-		flex-direction: column;
-		border-bottom: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml) var(--radius-ml) 0 0;
-
-		&.remove-border-bottom {
-			border-bottom: none;
-		}
-
-		&.dropzone-activated {
-			& .assigned-changes-empty {
-				padding: 20px 8px 20px;
-				background-color: var(--clr-bg-1);
-				transition:
-					background-color var(--transition-fast),
-					padding var(--transition-fast);
-			}
-
-			& .assigned-changes-empty__text {
-				color: var(--clr-theme-pop-on-soft);
-			}
-		}
-
-		&.dropzone-hovered {
-			& .assigned-changes-empty__text {
-				opacity: 1;
-			}
-		}
-	}
-
-	.details-view {
-		display: flex;
-		z-index: var(--z-ground);
-		position: absolute;
-		top: 12px;
-		flex-shrink: 0;
 		flex-direction: column;
 		height: 100%;
-		max-height: calc(100% - 24px);
-		margin-right: 2px;
-	}
-	.codegen-view {
-		overflow: hidden;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml);
-		background-color: var(--clr-bg-1);
-	}
-
-	.details-view__inner {
-		display: flex;
-		position: relative;
-		flex: 1;
-		flex-direction: column;
-		height: 100%;
-		gap: 8px;
-	}
-
-	.start-commit {
-		padding: 12px;
-		background-color: var(--clr-bg-1);
-	}
-
-	/* EMPTY ASSIGN AREA */
-	.assigned-changes-empty {
-		display: flex;
-		position: relative;
-		padding: 10px 8px;
-		overflow: hidden;
-		gap: 12px;
-		background-color: var(--clr-bg-2);
-		transition: background-color var(--transition-fast);
 	}
 </style>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -43,7 +43,6 @@
 		onVisible,
 	}: Props = $props();
 
-	// ── Controller (shared state for compound children) ───────────────
 	const controller = new StackController({
 		projectId: () => projectId,
 		stackId: () => stackId,
@@ -51,7 +50,6 @@
 	});
 	setStackContext(controller);
 
-	// ── Services (only those needed at the composition root level) ────
 	const stackService = inject(STACK_SERVICE);
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
 	const rulesService = inject(RULES_SERVICE);
@@ -59,7 +57,6 @@
 	const ircApiService = inject(IRC_API_SERVICE);
 	const ircSessionBridge = inject(IRC_SESSION_BRIDGE);
 
-	// ── Data queries for ReduxResult ──────────────────────────────────
 	const branchesQuery = $derived(stackService.branches(controller.projectId, controller.stackId));
 	const hasRulesToClear = $derived(
 		rulesService.hasRulesToClear(controller.projectId, controller.stackId),
@@ -68,7 +65,6 @@
 		claudeCodeService.claudeConfig({ projectId: controller.projectId }),
 	);
 
-	// ── Resizer config ────────────────────────────────────────────────
 	const PANEL1_RESIZER = {
 		minWidth: 20,
 		maxWidth: 64,
@@ -86,7 +82,8 @@
 
 	let stackViewEl = $state<HTMLDivElement>();
 
-	// ── Details view width CSS custom property ────────────────────────
+	const isDetailsOpen = $derived(controller.isDetailsViewOpen);
+
 	function updateDetailsViewWidth(width: number) {
 		if (stackViewEl) {
 			stackViewEl.style.setProperty("--details-view-width", `${width}rem`);
@@ -96,7 +93,7 @@
 	$effect(() => {
 		const element = stackViewEl;
 		if (element) {
-			if (controller.isDetailsViewOpen) {
+			if (isDetailsOpen) {
 				const currentWidth = element.style.getPropertyValue("--details-view-width");
 				if (!currentWidth || currentWidth === "0rem") {
 					element.style.setProperty("--details-view-width", `${DETAILS_DEFAULT_WIDTH}rem`);
@@ -113,7 +110,6 @@
 		};
 	});
 
-	// ── IRC bridge lifecycle (needs to run at stack level) ────────────
 	const settingsStore = settingsService.appSettings;
 	const ircSettings = $derived($settingsStore?.irc);
 	const ircEnabled = $derived(
@@ -187,7 +183,7 @@
 	}}
 	use:focusable={{
 		onKeydown: (event) => {
-			if (event.key === "Escape" && controller.isDetailsViewOpen) {
+			if (event.key === "Escape" && isDetailsOpen) {
 				controller.closePreview();
 				event.preventDefault();
 				event.stopPropagation();
@@ -209,7 +205,7 @@
 			<ConfigurableScrollableContainer childrenWrapHeight="100%" enableDragScroll>
 				<div
 					class="stack-view"
-					class:details-open={controller.isDetailsViewOpen}
+					class:details-open={isDetailsOpen}
 					style:width="{$persistedStackWidth}rem"
 					data-fade-on-reorder
 					use:focusable={{
@@ -227,7 +223,7 @@
 							viewport={stackViewEl}
 							zIndex="var(--z-lifted)"
 							direction="right"
-							showBorder={!controller.isDetailsViewOpen}
+							showBorder={!isDetailsOpen}
 							minWidth={PANEL1_RESIZER.minWidth}
 							maxWidth={PANEL1_RESIZER.maxWidth}
 							defaultValue={$persistedStackWidth ?? PANEL1_RESIZER.defaultValue}
@@ -241,7 +237,7 @@
 			</ConfigurableScrollableContainer>
 
 			<!-- DETAILS PANEL -->
-			{#if controller.isDetailsViewOpen}
+			{#if isDetailsOpen}
 				<StackDetails
 					{hasRulesToClear}
 					{claudeConfig}

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -18,7 +18,6 @@
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { createWorktreeSelection } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject, injectOptional } from "@gitbutler/core/context";
 
@@ -61,7 +60,6 @@
 	// Create a unique persist ID based on stackId and mode (both are static props)
 	const persistId = stackId ? `worktree-${mode}-${stackId}` : `worktree-${mode}`;
 
-	const stackService = inject(STACK_SERVICE);
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const uiState = inject(UI_STATE);
@@ -80,7 +78,7 @@
 	// Create selectionId for this worktree lane
 	const selectionId = $derived(createWorktreeSelection({ stackId }));
 
-	const uncommitDzHandler = $derived(new UncommitDzHandler(projectId, stackService, stackId));
+	const uncommitDzHandler = $derived(new UncommitDzHandler(projectId, stackId));
 
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -80,9 +80,7 @@
 	// Create selectionId for this worktree lane
 	const selectionId = $derived(createWorktreeSelection({ stackId }));
 
-	const uncommitDzHandler = $derived(
-		new UncommitDzHandler(projectId, stackService, uiState, stackId),
-	);
+	const uncommitDzHandler = $derived(new UncommitDzHandler(projectId, stackService, stackId));
 
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -2,14 +2,19 @@
 	import CardOverlay from "$components/CardOverlay.svelte";
 	import ScrollableContainer from "$components/ConfigurableScrollableContainer.svelte";
 	import Dropzone from "$components/Dropzone.svelte";
-	import FileList from "$components/FileList.svelte";
+	import FileListItems from "$components/FileListItems.svelte";
 	import FileListMode from "$components/FileListMode.svelte";
+	import FileListProvider from "$components/FileListProvider.svelte";
 	import WorktreeChangesSelectAll from "$components/WorktreeChangesSelectAll.svelte";
+	import { ACTION_SERVICE } from "$lib/actions/actionService.svelte";
+	import { AI_SERVICE } from "$lib/ai/service";
 	import { UncommitDzHandler } from "$lib/commits/dropHandler";
+	import { projectAiGenEnabled } from "$lib/config/config";
 	import { DIFF_SERVICE } from "$lib/hunks/diffService.svelte";
 	import { AssignmentDropHandler } from "$lib/hunks/dropHandler";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { WORKING_FILES_BROADCAST } from "$lib/irc/workingFilesBroadcast.svelte";
+	import { showToast } from "$lib/notifications/toasts";
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { createWorktreeSelection } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
@@ -22,6 +27,8 @@
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { type Snippet } from "svelte";
 	import type { DropzoneHandler } from "$lib/dragging/handler";
+	import type { TreeChange } from "$lib/hunks/change";
+	import type { FileListKeyHandler } from "$lib/selection/fileListController.svelte";
 
 	type Props = {
 		projectId: string;
@@ -94,6 +101,93 @@
 		new AssignmentDropHandler(projectId, diffService, uncommittedService, stackId, idSelection),
 	);
 
+	const DEFAULT_MODEL = "gpt-4.1";
+	const aiService = inject(AI_SERVICE);
+	const actionService = inject(ACTION_SERVICE);
+	const [autoCommit] = actionService.autoCommit;
+	const [branchChanges] = actionService.branchChanges;
+
+	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
+	let aiConfigurationValid = $state(false);
+	const canUseGBAI = $derived($aiGenEnabled && aiConfigurationValid);
+
+	$effect(() => {
+		aiService.validateGitButlerAPIConfiguration().then((value) => {
+			aiConfigurationValid = value;
+		});
+	});
+
+	function getSelectedTreeChanges(): TreeChange[] | undefined {
+		const selectedFiles = idSelection.values(selectionId);
+		if (selectedFiles.length === 0) return;
+		const paths = new Set(selectedFiles.map((file) => file.path));
+		return changes.current.filter((change) => paths.has(change.path));
+	}
+
+	/**
+	 * Create a branch and commit from the selected changes.
+	 *
+	 * _Branch [/bræntʃ/]_ is a verb that means to create a new branch and commit from the current changes.
+	 *
+	 * _According to who? Me._
+	 *
+	 * - Anonymous
+	 */
+	async function branchSelection() {
+		const treeChanges = getSelectedTreeChanges();
+		if (!treeChanges || !canUseGBAI) return;
+
+		showToast({
+			style: "info",
+			title: "Creating a branch and committing the changes",
+			message: "This may take a few seconds.",
+		});
+
+		await branchChanges({
+			projectId,
+			changes: treeChanges,
+			model: DEFAULT_MODEL,
+		});
+
+		showToast({
+			style: "success",
+			title: "And... done!",
+			message: `Now, you're free to continue`,
+		});
+	}
+
+	async function autoCommitSelection() {
+		const treeChanges = getSelectedTreeChanges();
+		if (!treeChanges) return;
+
+		await autoCommit({
+			projectId,
+			target: {
+				type: "treeChanges",
+				subject: {
+					changes: treeChanges,
+					assigned_stack_id: stackId ?? null,
+				},
+			},
+			useAi: $aiGenEnabled,
+		});
+	}
+
+	const aiKeyHandlers: FileListKeyHandler[] = [
+		(_change, _idx, e) => {
+			if (e.code === "KeyB" && (e.ctrlKey || e.metaKey) && e.altKey) {
+				branchSelection();
+				e.preventDefault();
+				return true;
+			}
+			if (e.code === "KeyC" && (e.ctrlKey || e.metaKey) && e.altKey) {
+				autoCommitSelection();
+				e.preventDefault();
+				return true;
+			}
+		},
+	];
+
 	function getDropzoneLabel(handler: DropzoneHandler | undefined): string {
 		if (handler instanceof UncommitDzHandler) {
 			return "Uncommit";
@@ -106,20 +200,21 @@
 </script>
 
 {#snippet fileList()}
-	<FileList
-		dataTestId={TestId.UncommittedChanges_FileList}
-		draggableFiles
-		{selectionId}
-		showCheckboxes={isCommitting}
-		changes={changes.current}
-		{projectId}
-		{listMode}
-		{stackId}
-		{onFileClick}
-		{visibleRange}
-		showLockedIndicator
-		{ircWorkingFiles}
-	/>
+	<FileListProvider changes={changes.current} {selectionId}>
+		<FileListItems
+			{projectId}
+			{stackId}
+			mode={listMode}
+			showCheckboxes={isCommitting}
+			draggable
+			showLockedIndicator
+			{visibleRange}
+			{ircWorkingFiles}
+			dataTestId={TestId.UncommittedChanges_FileList}
+			onselect={onFileClick && ((_change, index) => onFileClick(index))}
+			extraKeyHandlers={aiKeyHandlers}
+		/>
+	</FileListProvider>
 {/snippet}
 
 <Dropzone

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -16,7 +16,9 @@
 	import CodegenTodoAccordion from "$components/codegen/CodegenTodoAccordion.svelte";
 	import noClaudeCodeSvg from "$lib/assets/empty-state/claude-disconected.svg?raw";
 	import laneNewSvg from "$lib/assets/empty-state/lane-new.svg?raw";
+	import { ATTACHMENT_SERVICE } from "$lib/codegen/attachmentService.svelte";
 	import { CLAUDE_CODE_SERVICE } from "$lib/codegen/claude";
+	import { MessageSender } from "$lib/codegen/messageQueue.svelte";
 	import {
 		currentStatus,
 		thinkingOrCompactingStartedAt,
@@ -31,10 +33,11 @@
 	import { SETTINGS_SERVICE } from "$lib/config/appSettingsV2";
 	import { RULES_SERVICE } from "$lib/rules/rulesService.svelte";
 	import { SETTINGS } from "$lib/settings/userSettings";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { getStackContext } from "$lib/stack/stackController.svelte";
 	import { formatCompactNumber } from "$lib/utils/number";
 	import { getEditorUri, URL_SERVICE } from "$lib/utils/url";
 	import { inject } from "@gitbutler/core/context";
+	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 	import {
 		Button,
 		ContextMenu,
@@ -51,67 +54,45 @@
 	import VirtualList from "@gitbutler/ui/components/VirtualList.svelte";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import type {
-		ClaudeMessage,
 		ThinkingLevel,
 		ModelType,
 		PermissionMode,
 		PermissionDecision,
-		ClaudePermissionRequest,
 	} from "$lib/codegen/types";
 
 	type Props = {
-		projectId: string;
-		branchName: string;
-		stackId?: string;
-		laneId: string;
-		initialPrompt?: string;
-		isStackActive?: boolean;
-		projectRegistered?: boolean;
-		events: ClaudeMessage[];
-		permissionRequests: ClaudePermissionRequest[];
-		sessionId?: string;
 		hasRulesToClear?: boolean;
-		onMcpSettings?: () => void;
+		projectRegistered?: boolean;
 		onclose?: () => void;
-		onChange: (value: string) => void;
-		onAbort?: () => Promise<void>;
-		onSubmit?: (prompt: string) => Promise<void>;
-		onAnswerQuestion?: (answers: Record<string, string>) => Promise<void>;
-		onRetryConfig?: () => Promise<void>;
+		onMcpSettings?: () => void;
 	};
-	const {
-		projectId,
-		stackId,
-		laneId,
-		branchName,
-		initialPrompt,
-		isStackActive,
-		projectRegistered,
-		events,
-		permissionRequests,
-		sessionId,
-		hasRulesToClear,
-		onclose,
-		onChange,
-		onAbort,
-		onSubmit,
-		onMcpSettings,
-		onAnswerQuestion,
-		onRetryConfig,
-	}: Props = $props();
+	const { hasRulesToClear, projectRegistered, onclose, onMcpSettings }: Props = $props();
 
-	const stableBranchName = $derived(branchName);
+	const controller = getStackContext();
+	const projectId = $derived(controller.projectId);
+	const stackId = $derived(controller.stackId);
+	const laneId = $derived(controller.laneId);
+	const branchName = $derived(controller.branchName ?? "");
 
 	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
 	const rulesService = inject(RULES_SERVICE);
-	const uiState = inject(UI_STATE);
 	const urlService = inject(URL_SERVICE);
 	const userSettings = inject(SETTINGS);
 	const settingsService = inject(SETTINGS_SERVICE);
+	const attachmentService = inject(ATTACHMENT_SERVICE);
 	const claudeSettings = $derived($settingsService?.claude);
 
+	const isStackActiveQuery = $derived(claudeCodeService.isStackActive(projectId, stackId));
+	const isStackActive = $derived(isStackActiveQuery?.response || false);
+	const eventsQuery = $derived(claudeCodeService.messages({ projectId, stackId }));
+	const events = $derived(eventsQuery.response || []);
+	const sessionIdQuery = $derived(rulesService.aiSessionId(projectId, stackId));
+	const sessionId = $derived(sessionIdQuery.response);
+	const permissionRequestsQuery = $derived(claudeCodeService.permissionRequests({ projectId }));
+	const permissionRequests = $derived(permissionRequestsQuery.response || []);
+	const attachments = $derived(attachmentService.getByBranch(branchName));
+
 	const claudeAvailable = $derived(claudeCodeService.checkAvailable(undefined));
-	// const canEnterChat = $derived(claudeAvailable.status === "available" && !!projectRegistered);
 	const canEnterChat = $derived(!!projectRegistered);
 
 	let clearContextModal = $state<Modal>();
@@ -176,10 +157,25 @@
 		urlService.openExternalUrl(editorUri);
 	}
 
-	const projectState = uiState.project(projectId);
-	const selectedThinkingLevel = $derived(projectState.thinkingLevel.current);
-	const selectedModel = $derived(projectState.selectedModel.current);
-	const selectedPermissionMode = $derived(uiState.lane(laneId).permissionMode.current);
+	const selectedThinkingLevel = $derived(controller.projectState.thinkingLevel.current);
+	const selectedModel = $derived(controller.projectState.selectedModel.current);
+	const selectedPermissionMode = $derived(controller.laneState.permissionMode.current);
+
+	const messageSender = $derived(
+		stackId && branchName
+			? new MessageSender({
+					projectId: reactive(() => projectId),
+					selectedBranch: reactive(() => ({
+						stackId: stackId!,
+						head: branchName!,
+					})),
+					thinkingLevel: reactive(() => selectedThinkingLevel),
+					model: reactive(() => selectedModel),
+					permissionMode: reactive(() => selectedPermissionMode),
+				})
+			: undefined,
+	);
+	const initialPrompt = $derived(messageSender?.prompt);
 
 	async function onPermissionDecision(
 		id: string,
@@ -195,17 +191,17 @@
 	}
 
 	function selectModel(model: ModelType) {
-		projectState.selectedModel.set(model);
+		controller.projectState.selectedModel.set(model);
 		modelContextMenu?.close();
 	}
 
 	function selectThinkingLevel(level: ThinkingLevel) {
-		projectState.thinkingLevel.set(level);
+		controller.projectState.thinkingLevel.set(level);
 		thinkingModeContextMenu?.close();
 	}
 
 	function selectPermissionMode(mode: PermissionMode) {
-		uiState.lane(laneId).permissionMode.set(mode);
+		controller.laneState.permissionMode.set(mode);
 		permissionModeContextMenu?.close();
 	}
 
@@ -233,17 +229,30 @@
 	async function insertTemplate(templateContent: string) {
 		const currentPrompt = await inputRef?.getText();
 		const newPrompt = currentPrompt + (currentPrompt ? "\n\n" : "") + templateContent;
-		onChange?.(newPrompt);
+		messageSender?.setPrompt(newPrompt);
 		inputRef?.setText(newPrompt);
 		templateContextMenu?.close();
 	}
 
-	// function getCurrentSessionId(events: ClaudeMessage[]): string | undefined {
-	// 	// Get the most recent session ID from the messages
-	// 	if (events.length === 0) return undefined;
-	// 	const lastEvent = events[events.length - 1];
-	// 	return lastEvent?.sessionId;
-	// }
+	async function onAbort() {
+		if (stackId) {
+			await claudeCodeService.cancelSession({ projectId, stackId });
+		}
+	}
+
+	async function sendMessage(prompt: string) {
+		await messageSender?.sendMessage(prompt, attachments);
+		attachmentService.clearByBranch(branchName);
+	}
+
+	async function handleAnswerQuestion(answers: Record<string, string>) {
+		if (!stackId) return;
+		await claudeCodeService.answerAskUserQuestion({ projectId, stackId, answers });
+	}
+
+	async function retryConfig() {
+		await claudeCodeService.fetchClaudeConfig({ projectId }, { forceRefetch: true });
+	}
 
 	function clearContextAndRules() {
 		clearContextModal?.show();
@@ -555,22 +564,17 @@
 					{#if formattedMessages.length > 0}
 						<CodegenChatClaudeNotAvaliableBanner
 							onSettingsBtnClick={() => {
-								uiState.global.modal.set({
-									type: "project-settings",
-									projectId,
-									selectedId: "agent",
-								});
+								controller.openProjectSettingsModal("agent");
 							}}
 						/>
 					{/if}
 				{:else if !projectRegistered}
 					{#if formattedMessages.length > 0}
-						<CodegenChatClaudeNotRegistered {onRetryConfig} />
+						<CodegenChatClaudeNotRegistered onRetryConfig={retryConfig} />
 					{/if}
 				{:else}
 					{@const status = currentStatus(events, isStackActive)}
-					{@const laneState = uiState.lane(laneId)}
-					{@const addedDirs = laneState.addedDirs.current}
+					{@const addedDirs = controller.laneState.addedDirs.current}
 
 					<div class="dialog-wrapper">
 						{#if pendingAskUserQuestion}
@@ -578,21 +582,21 @@
 								questions={pendingAskUserQuestion.questions}
 								answered={pendingAskUserQuestion.answered}
 								onSubmitAnswers={async (answers) => {
-									await onAnswerQuestion?.(answers);
+									await handleAnswerQuestion(answers);
 								}}
 								onCancel={async () => {
 									dismissedAskUserQuestions = {
 										...dismissedAskUserQuestions,
 										[pendingAskUserQuestion.toolUseId]: true,
 									};
-									await onAbort?.();
+									await onAbort();
 								}}
 							/>
 						{:else}
 							<AddedDirectories
 								{addedDirs}
 								onRemoveDir={(dir) => {
-									laneState.addedDirs.remove(dir);
+									controller.laneState.addedDirs.remove(dir);
 								}}
 							/>
 
@@ -600,13 +604,13 @@
 								bind:this={inputRef}
 								{projectId}
 								{stackId}
-								branchName={stableBranchName}
+								{branchName}
 								value={initialPrompt || ""}
 								loading={["running", "compacting"].includes(status)}
 								compacting={status === "compacting"}
-								{onChange}
+								onChange={(prompt) => messageSender?.setPrompt(prompt)}
 								onSubmit={async (prompt) => {
-									await onSubmit?.(prompt);
+									await sendMessage(prompt);
 									setTimeout(() => {
 										virtualList?.scrollToBottom();
 									}, 100);

--- a/apps/desktop/src/lib/branches/dropHandler.ts
+++ b/apps/desktop/src/lib/branches/dropHandler.ts
@@ -1,11 +1,11 @@
 import { FileChangeDropData, FolderChangeDropData, HunkDropDataV3 } from "$lib/dragging/draggables";
 import { updateStackPrs } from "$lib/forge/shared/prFooter";
 import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 import { UI_STATE } from "$lib/state/uiState.svelte";
 import { inject } from "@gitbutler/core/context";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { ForgePrService } from "$lib/forge/interface/forgePrService";
-import type { StackService } from "$lib/stacks/stackService.svelte";
 
 export class BranchDropData {
 	constructor(
@@ -24,8 +24,9 @@ export class BranchDropData {
 }
 
 export class MoveBranchDzHandler implements DropzoneHandler {
+	private readonly stackService = inject(STACK_SERVICE);
+
 	constructor(
-		private readonly stackService: StackService,
 		private readonly prService: ForgePrService | undefined,
 		private readonly projectId: string,
 		private readonly stackId: string,

--- a/apps/desktop/src/lib/branches/dropHandler.ts
+++ b/apps/desktop/src/lib/branches/dropHandler.ts
@@ -1,10 +1,11 @@
 import { FileChangeDropData, FolderChangeDropData, HunkDropDataV3 } from "$lib/dragging/draggables";
 import { updateStackPrs } from "$lib/forge/shared/prFooter";
+import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+import { UI_STATE } from "$lib/state/uiState.svelte";
+import { inject } from "@gitbutler/core/context";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { ForgePrService } from "$lib/forge/interface/forgePrService";
-import type { UncommittedService } from "$lib/selection/uncommittedService.svelte";
 import type { StackService } from "$lib/stacks/stackService.svelte";
-import type { UiState } from "$lib/state/uiState.svelte";
 
 export class BranchDropData {
 	constructor(
@@ -67,9 +68,10 @@ export class MoveBranchDzHandler implements DropzoneHandler {
 }
 
 export class StartCommitDzHandler implements DropzoneHandler {
+	private readonly uiState = inject(UI_STATE);
+	private readonly uncommittedService = inject(UNCOMMITTED_SERVICE);
+
 	constructor(
-		private readonly uiState: UiState,
-		private readonly uncommittedService: UncommittedService,
 		private readonly projectId: string,
 		private readonly stackId: string | undefined,
 		private readonly branchName: string,

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -9,12 +9,13 @@ import {
 	HunkDropDataV3,
 	type ChangeDropData,
 } from "$lib/dragging/draggables";
-import { type HooksService } from "$lib/hooks/hooksService";
+import { HOOKS_SERVICE } from "$lib/hooks/hooksService";
 import { showToast } from "$lib/notifications/toasts";
+import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+import { UI_STATE, type UiState } from "$lib/state/uiState.svelte";
+import { inject } from "@gitbutler/core/context";
 import { untrack } from "svelte";
 import type { DropzoneHandler } from "$lib/dragging/handler";
-import type { StackService } from "$lib/stacks/stackService.svelte";
-import type { UiState } from "$lib/state/uiState.svelte";
 
 /** Details about a commit belonging to a drop zone. */
 export type DzCommitData = {
@@ -37,9 +38,9 @@ export class CommitDropData {
 /** Handler that can move commits between stacks. */
 export class MoveCommitDzHandler implements DropzoneHandler {
 	private readonly uiState = inject(UI_STATE);
+	private readonly stackService = inject(STACK_SERVICE);
 
 	constructor(
-		private stackService: StackService,
 		private stackId: string,
 		private projectId: string,
 	) {}
@@ -83,15 +84,16 @@ export class MoveCommitDzHandler implements DropzoneHandler {
  * Handler that will be able to amend a commit using `TreeChange`.
  */
 export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
+	private readonly uiState = inject(UI_STATE);
+	private readonly stackService = inject(STACK_SERVICE);
+	private readonly hooksService = inject(HOOKS_SERVICE);
+
 	constructor(
 		private projectId: string,
-		private readonly stackService: StackService,
-		private readonly hooksService: HooksService,
 		private stackId: string,
 		private runHooks: boolean,
 		private commit: DzCommitData,
 		private onresult: (result: string) => void,
-		private readonly uiState: UiState,
 	) {}
 	accepts(data: unknown): boolean {
 		if (!(data instanceof FileChangeDropData || data instanceof FolderChangeDropData)) return false;
@@ -156,10 +158,10 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 
 export class UncommitDzHandler implements DropzoneHandler {
 	private readonly uiState = inject(UI_STATE);
+	private readonly stackService = inject(STACK_SERVICE);
 
 	constructor(
 		private projectId: string,
-		private readonly stackService: StackService,
 		private readonly assignTo?: string,
 	) {}
 
@@ -250,11 +252,11 @@ export class UncommitDzHandler implements DropzoneHandler {
  */
 export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 	private readonly uiState = inject(UI_STATE);
+	private readonly stackService = inject(STACK_SERVICE);
+	private readonly hooksService = inject(HOOKS_SERVICE);
 
 	constructor(
 		private args: {
-			stackService: StackService;
-			hooksService: HooksService;
 			okWithForce: boolean;
 			projectId: string;
 			stackId: string;
@@ -276,7 +278,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: HunkDropDataV3): Promise<void> {
-		const { stackService, projectId, stackId, commit, okWithForce, runHooks } = this.args;
+		const { projectId, stackId, commit, okWithForce, runHooks } = this.args;
 		if (!okWithForce && commit.isRemote) return;
 
 		if (data instanceof HunkDropDataV3) {
@@ -288,7 +290,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 					throw new Error("Can't receive a change without it's source or commit");
 				}
 
-				const { replacedCommits } = await stackService.moveChangesBetweenCommits({
+				const { replacedCommits } = await this.stackService.moveChangesBetweenCommits({
 					projectId,
 					destinationStackId: stackId,
 					destinationCommitId: commit.id,
@@ -334,12 +336,12 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 
 			if (runHooks) {
 				try {
-					await this.args.hooksService.runPreCommitHooks(projectId, worktreeChanges);
+					await this.hooksService.runPreCommitHooks(projectId, worktreeChanges);
 				} catch {
 					return;
 				}
 			}
-			stackService.amendCommitMutation({
+			this.stackService.amendCommitMutation({
 				projectId,
 				stackId,
 				commitId: commit.id,
@@ -347,7 +349,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			});
 			if (runHooks) {
 				try {
-					await this.args.hooksService.runPostCommitHooks(projectId);
+					await this.hooksService.runPostCommitHooks(projectId);
 				} catch {
 					return;
 				}
@@ -360,9 +362,10 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
  * Handler that is able to squash two commits using `DzCommitData`.
  */
 export class SquashCommitDzHandler implements DropzoneHandler {
+	private readonly stackService = inject(STACK_SERVICE);
+
 	constructor(
 		private args: {
-			stackService: StackService;
 			projectId: string;
 			stackId: string;
 			commit: DzCommitData;
@@ -381,9 +384,9 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: unknown) {
-		const { stackService, projectId, stackId, commit } = this.args;
+		const { projectId, stackId, commit } = this.args;
 		if (data instanceof CommitDropData) {
-			await stackService.squashCommits({
+			await this.stackService.squashCommits({
 				projectId,
 				stackId,
 				sourceCommitIds: [data.commit.id],
@@ -413,8 +416,6 @@ function updateUiState(
 export function createCommitDropHandlers(args: {
 	projectId: string;
 	stackId: string | undefined;
-	stackService: StackService;
-	hooksService: HooksService;
 	commit: DzCommitData;
 	runHooks: boolean;
 	onCommitIdChange?: (newCommitId: string) => void;
@@ -436,27 +437,21 @@ export function createCommitDropHandlers(args: {
 
 	const amendHandler = new AmendCommitWithChangeDzHandler(
 		args.projectId,
-		args.stackService,
-		args.hooksService,
 		stackId,
 		args.runHooks,
 		commit,
 		(newId) => {
 			onCommitIdChange?.(newId);
 		},
-		args.uiState,
 	);
 
 	const squashHandler = new SquashCommitDzHandler({
-		stackService: args.stackService,
 		projectId: args.projectId,
 		stackId,
 		commit,
 	});
 
 	const hunkHandler = new AmendCommitWithHunkDzHandler({
-		stackService: args.stackService,
-		hooksService: args.hooksService,
 		projectId: args.projectId,
 		stackId,
 		commit,

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -36,11 +36,12 @@ export class CommitDropData {
 
 /** Handler that can move commits between stacks. */
 export class MoveCommitDzHandler implements DropzoneHandler {
+	private readonly uiState = inject(UI_STATE);
+
 	constructor(
 		private stackService: StackService,
 		private stackId: string,
 		private projectId: string,
-		private uiState?: UiState,
 	) {}
 
 	accepts(data: unknown): boolean {
@@ -62,11 +63,9 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 
 	ondrop(data: CommitDropData): void {
 		// Clear the selection from the source lane if this commit was selected
-		if (this.uiState) {
-			const sourceSelection = untrack(() => this.uiState!.lane(data.stackId).selection.current);
-			if (sourceSelection?.commitId === data.commit.id) {
-				this.uiState.lane(data.stackId).selection.set(undefined);
-			}
+		const sourceSelection = untrack(() => this.uiState.lane(data.stackId).selection.current);
+		if (sourceSelection?.commitId === data.commit.id) {
+			this.uiState.lane(data.stackId).selection.set(undefined);
 		}
 
 		this.stackService
@@ -156,10 +155,11 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 }
 
 export class UncommitDzHandler implements DropzoneHandler {
+	private readonly uiState = inject(UI_STATE);
+
 	constructor(
 		private projectId: string,
 		private readonly stackService: StackService,
-		private readonly uiState: UiState,
 		private readonly assignTo?: string,
 	) {}
 
@@ -249,6 +249,8 @@ export class UncommitDzHandler implements DropzoneHandler {
  * Handler that is able to amend a commit using `Hunk`.
  */
 export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
+	private readonly uiState = inject(UI_STATE);
+
 	constructor(
 		private args: {
 			stackService: StackService;
@@ -257,7 +259,6 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			projectId: string;
 			stackId: string;
 			commit: DzCommitData;
-			uiState: UiState;
 			runHooks: boolean;
 		},
 	) {}
@@ -275,7 +276,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: HunkDropDataV3): Promise<void> {
-		const { stackService, projectId, stackId, commit, okWithForce, uiState, runHooks } = this.args;
+		const { stackService, projectId, stackId, commit, okWithForce, runHooks } = this.args;
 		if (!okWithForce && commit.isRemote) return;
 
 		if (data instanceof HunkDropDataV3) {
@@ -310,8 +311,8 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 				});
 
 				// Update the project state to point to the new commit if needed.
-				updateUiState(uiState, data.stackId, data.commitId, replacedCommits);
-				updateUiState(uiState, stackId, commit.id, replacedCommits);
+				updateUiState(this.uiState, data.stackId, data.commitId, replacedCommits);
+				updateUiState(this.uiState, stackId, commit.id, replacedCommits);
 
 				return;
 			}
@@ -414,7 +415,6 @@ export function createCommitDropHandlers(args: {
 	stackId: string | undefined;
 	stackService: StackService;
 	hooksService: HooksService;
-	uiState: UiState;
 	commit: DzCommitData;
 	runHooks: boolean;
 	onCommitIdChange?: (newCommitId: string) => void;
@@ -461,7 +461,6 @@ export function createCommitDropHandlers(args: {
 		stackId,
 		commit,
 		okWithForce,
-		uiState: args.uiState,
 		runHooks: args.runHooks,
 	});
 

--- a/apps/desktop/src/lib/selection/fileListController.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileListController.svelte.ts
@@ -1,0 +1,161 @@
+/**
+ * Reactive controller that owns file list selection, keyboard navigation,
+ * and focus management.
+ *
+ * Instantiate in a component's `<script>` block so that `inject()` and
+ * `$effect()` bind to the component lifecycle.
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   const controller = new FileListController({ ... });
+ * </script>
+ * ```
+ */
+import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
+import { selectFilesInList, updateSelection } from "$lib/selection/fileSelectionUtils";
+import { type SelectionId } from "$lib/selection/key";
+import { inject } from "@gitbutler/core/context";
+import { FOCUS_MANAGER } from "@gitbutler/ui/focus/focusManager";
+import { getContext, setContext, untrack } from "svelte";
+import { get } from "svelte/store";
+import type { TreeChange } from "$lib/hunks/change";
+import type { FileSelectionManager } from "$lib/selection/fileSelectionManager.svelte";
+import type { SelectedFile } from "$lib/selection/key";
+
+const FILE_LIST_CTX = Symbol("FileListController");
+
+/** Set the controller into Svelte component context. Called by FileListProvider. */
+export function setFileListContext(controller: FileListController): void {
+	setContext(FILE_LIST_CTX, controller);
+}
+
+/** Read the controller from Svelte component context. Called by compound children. */
+export function getFileListContext(): FileListController {
+	const ctx = getContext<FileListController>(FILE_LIST_CTX);
+	if (!ctx) {
+		throw new Error("FileListController not found — wrap your component in <FileListProvider>");
+	}
+	return ctx;
+}
+
+/**
+ * Extra keyboard handler that callers can inject to extend file list
+ * keyboard behavior (e.g. AI shortcuts in the worktree context).
+ *
+ * Return `true` to indicate the event was handled.
+ */
+export type FileListKeyHandler = (
+	change: TreeChange,
+	idx: number,
+	e: KeyboardEvent,
+) => boolean | void;
+
+export class FileListController {
+	private idSelection: FileSelectionManager;
+	private focusManager;
+	private getChanges: () => TreeChange[];
+	private getSelectionId: () => SelectionId;
+	private getAllowUnselect: () => boolean;
+
+	active = $state(false);
+
+	constructor(params: {
+		changes: () => TreeChange[];
+		selectionId: () => SelectionId;
+		allowUnselect?: () => boolean;
+	}) {
+		this.idSelection = inject(FILE_SELECTION_MANAGER);
+		this.focusManager = inject(FOCUS_MANAGER);
+		this.getChanges = params.changes;
+		this.getSelectionId = params.selectionId;
+		this.getAllowUnselect = params.allowUnselect ?? (() => true);
+
+		const currentSelection = $derived(this.idSelection.getById(this.getSelectionId()));
+		const lastAdded = $derived(currentSelection.lastAdded);
+		const lastAddedIndex = $derived(get(lastAdded)?.index);
+
+		$effect(() => {
+			if (lastAddedIndex !== undefined) {
+				untrack(() => {
+					if (this.active) {
+						this.focusManager.focusNthSibling(lastAddedIndex);
+					}
+				});
+			}
+		});
+	}
+
+	get selection(): FileSelectionManager {
+		return this.idSelection;
+	}
+
+	get selectionId(): SelectionId {
+		return this.getSelectionId();
+	}
+
+	get changes(): TreeChange[] {
+		return this.getChanges();
+	}
+
+	get selectedFileIds(): SelectedFile[] {
+		return this.idSelection.values(this.selectionId);
+	}
+
+	get selectedPaths(): Set<string> {
+		return new Set(this.selectedFileIds.map((f) => f.path));
+	}
+
+	get hasSelectionInList(): boolean {
+		return this.changes.some((change) => this.selectedPaths.has(change.path));
+	}
+
+	isSelected(path: string): boolean {
+		return this.idSelection.has(path, this.selectionId);
+	}
+
+	select(e: MouseEvent | KeyboardEvent, change: TreeChange, index: number): void {
+		selectFilesInList(
+			e,
+			change,
+			this.changes,
+			this.idSelection,
+			true,
+			index,
+			this.selectionId,
+			this.getAllowUnselect(),
+		);
+	}
+
+	/** Returns true if the key was an activation key (Enter/Space/l) and select was called. */
+	handleActivation(change: TreeChange, idx: number, e: KeyboardEvent): boolean {
+		if (e.key === "Enter" || e.key === " " || e.key === "l") {
+			e.stopPropagation();
+			this.select(e, change, idx);
+			return true;
+		}
+		return false;
+	}
+
+	/** Handles arrow/vim navigation. Returns the index of the newly focused item, or undefined. */
+	handleNavigation(e: KeyboardEvent): number | undefined {
+		if (
+			updateSelection({
+				allowMultiple: true,
+				ctrlKey: e.ctrlKey,
+				metaKey: e.metaKey,
+				shiftKey: e.shiftKey,
+				key: e.key,
+				targetElement: e.currentTarget as HTMLElement,
+				files: this.changes,
+				selectedFileIds: this.selectedFileIds,
+				fileIdSelection: this.idSelection,
+				selectionId: this.selectionId,
+				preventDefault: () => e.preventDefault(),
+			})
+		) {
+			const lastAdded = get(this.idSelection.getById(this.selectionId).lastAdded);
+			return lastAdded?.index;
+		}
+		return undefined;
+	}
+}

--- a/apps/desktop/src/lib/selection/fileListController.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileListController.svelte.ts
@@ -58,6 +58,10 @@ export class FileListController {
 	private getAllowUnselect: () => boolean;
 
 	active = $state(false);
+	readonly selectedPaths = $derived(new Set(this.selectedFileIds.map((f) => f.path)));
+	readonly hasSelectionInList = $derived(
+		this.changes.some((change) => this.selectedPaths.has(change.path)),
+	);
 
 	constructor(params: {
 		changes: () => TreeChange[];
@@ -70,18 +74,17 @@ export class FileListController {
 		this.getSelectionId = params.selectionId;
 		this.getAllowUnselect = params.allowUnselect ?? (() => true);
 
-		const currentSelection = $derived(this.idSelection.getById(this.getSelectionId()));
-		const lastAdded = $derived(currentSelection.lastAdded);
-		const lastAddedIndex = $derived(get(lastAdded)?.index);
-
 		$effect(() => {
-			if (lastAddedIndex !== undefined) {
-				untrack(() => {
-					if (this.active) {
-						this.focusManager.focusNthSibling(lastAddedIndex);
-					}
-				});
-			}
+			const store = this.idSelection.getById(this.getSelectionId()).lastAdded;
+			return store.subscribe((value) => {
+				if (value?.index !== undefined) {
+					untrack(() => {
+						if (this.active) {
+							this.focusManager.focusNthSibling(value.index);
+						}
+					});
+				}
+			});
 		});
 	}
 
@@ -99,14 +102,6 @@ export class FileListController {
 
 	get selectedFileIds(): SelectedFile[] {
 		return this.idSelection.values(this.selectionId);
-	}
-
-	get selectedPaths(): Set<string> {
-		return new Set(this.selectedFileIds.map((f) => f.path));
-	}
-
-	get hasSelectionInList(): boolean {
-		return this.changes.some((change) => this.selectedPaths.has(change.path));
 	}
 
 	isSelected(path: string): boolean {

--- a/apps/desktop/src/lib/stack/stackController.svelte.ts
+++ b/apps/desktop/src/lib/stack/stackController.svelte.ts
@@ -7,17 +7,18 @@
  * Instantiate during component init so that `inject()` and `$effect()` bind
  * to the component lifecycle.
  */
+import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 import {
 	createBranchSelection,
 	createCommitSelection,
 	createWorktreeSelection,
 	readKey,
 	type SelectionId,
+	type SelectedFile,
 } from "$lib/selection/key";
 import { UI_STATE } from "$lib/state/uiState.svelte";
 import { inject } from "@gitbutler/core/context";
 import { getContext, setContext } from "svelte";
-import { get } from "svelte/store";
 import type { FileSelectionManager } from "$lib/selection/fileSelectionManager.svelte";
 import type { ProjectSettingsPageId } from "$lib/settings/projectSettingsPages";
 
@@ -38,8 +39,7 @@ export function getStackContext(): StackController {
 }
 
 export class StackController {
-	/** Exposed for compound children that need direct uiState access (e.g. drop handlers). */
-	uiState;
+	private uiState;
 	private idSelection: FileSelectionManager;
 	private getProjectId: () => string;
 	private getStackId: () => string | undefined;
@@ -55,6 +55,14 @@ export class StackController {
 	private diffJumpHandler?: (index: number) => void;
 	private diffPopoutHandler?: () => void;
 
+	/**
+	 * Reactively-tracked file selection values.
+	 * Updated via $effect subscriptions to the underlying Writable stores,
+	 * so that consumers reading these in $derived/templates get proper updates.
+	 */
+	private _selectedFile = $state<SelectedFile | undefined>();
+	private _assignedKey = $state<SelectedFile | undefined>();
+
 	constructor(params: {
 		projectId: () => string;
 		stackId: () => string | undefined;
@@ -65,9 +73,32 @@ export class StackController {
 		this.getProjectId = params.projectId;
 		this.getStackId = params.stackId;
 		this.getLaneId = params.laneId;
-	}
 
-	// ── Identity ──────────────────────────────────────────────────────
+		// Subscribe to the active selection's lastAdded store so that
+		// selectedFile is properly reactive (not a snapshot via get()).
+		$effect(() => {
+			const store = this.activeLastAdded;
+			if (!store) {
+				this._selectedFile = undefined;
+				return;
+			}
+			return store.subscribe((value) => {
+				this._selectedFile = value?.key ? readKey(value.key) : undefined;
+			});
+		});
+
+		// Same for the worktree-assigned selection.
+		$effect(() => {
+			const store = this.lastAddedAssigned;
+			if (!store) {
+				this._assignedKey = undefined;
+				return;
+			}
+			return store.subscribe((value) => {
+				this._assignedKey = value?.key ? readKey(value.key) : undefined;
+			});
+		});
+	}
 
 	get projectId(): string {
 		return this.getProjectId();
@@ -154,10 +185,7 @@ export class StackController {
 	}
 
 	get selectedFile() {
-		const lastAdded = this.activeLastAdded;
-		if (!lastAdded) return undefined;
-		const value = get(lastAdded);
-		return value?.key ? readKey(value.key) : undefined;
+		return this._selectedFile;
 	}
 
 	private get assignedSelection() {
@@ -169,8 +197,7 @@ export class StackController {
 	}
 
 	get assignedKey() {
-		const value = get(this.lastAddedAssigned);
-		return value?.key ? readKey(value.key) : undefined;
+		return this._assignedKey;
 	}
 
 	get hasActiveSelection(): boolean {
@@ -202,6 +229,14 @@ export class StackController {
 
 	clearWorktreeSelection(): void {
 		this.idSelection.clear({ type: "worktree", stackId: this.stackId });
+	}
+
+	openProjectSettingsModal(selectedId?: ProjectSettingsPageId): void {
+		this.uiState.global.modal.set({
+			type: "project-settings",
+			projectId: this.projectId,
+			selectedId,
+		});
 	}
 
 	// ── Cross-panel diff coordination ─────────────────────────────────

--- a/apps/desktop/src/lib/stack/stackController.svelte.ts
+++ b/apps/desktop/src/lib/stack/stackController.svelte.ts
@@ -1,0 +1,230 @@
+/**
+ * Reactive controller that owns shared state for the StackView compound component.
+ *
+ * Manages selection coordination, preview state, and cross-panel communication
+ * (e.g. left panel file click → right panel diff jump).
+ *
+ * Instantiate during component init so that `inject()` and `$effect()` bind
+ * to the component lifecycle.
+ */
+import {
+	createBranchSelection,
+	createCommitSelection,
+	createWorktreeSelection,
+	readKey,
+	type SelectionId,
+} from "$lib/selection/key";
+import { UI_STATE } from "$lib/state/uiState.svelte";
+import { inject } from "@gitbutler/core/context";
+import { getContext, setContext } from "svelte";
+import { get } from "svelte/store";
+import type { FileSelectionManager } from "$lib/selection/fileSelectionManager.svelte";
+import type { ProjectSettingsPageId } from "$lib/settings/projectSettingsPages";
+
+const STACK_CTX = Symbol("StackController");
+
+/** Set the controller into Svelte component context. */
+export function setStackContext(controller: StackController): void {
+	setContext(STACK_CTX, controller);
+}
+
+/** Read the controller from Svelte component context. */
+export function getStackContext(): StackController {
+	const ctx = getContext<StackController>(STACK_CTX);
+	if (!ctx) {
+		throw new Error("StackController not found — wrap your component in a StackView");
+	}
+	return ctx;
+}
+
+export class StackController {
+	/** Exposed for compound children that need direct uiState access (e.g. drop handlers). */
+	uiState;
+	private idSelection: FileSelectionManager;
+	private getProjectId: () => string;
+	private getStackId: () => string | undefined;
+	private getLaneId: () => string;
+
+	/** Whether this stack's focusable region is active. */
+	active = $state(false);
+
+	/** Visible range from MultiDiffView, consumed by WorktreeChanges for notching. */
+	visibleRange = $state<{ start: number; end: number } | undefined>();
+
+	/** Cross-panel diff view coordination. */
+	private diffJumpHandler?: (index: number) => void;
+	private diffPopoutHandler?: () => void;
+
+	constructor(params: {
+		projectId: () => string;
+		stackId: () => string | undefined;
+		laneId: () => string;
+	}) {
+		this.uiState = inject(UI_STATE);
+		this.idSelection = inject(FILE_SELECTION_MANAGER);
+		this.getProjectId = params.projectId;
+		this.getStackId = params.stackId;
+		this.getLaneId = params.laneId;
+	}
+
+	// ── Identity ──────────────────────────────────────────────────────
+
+	get projectId(): string {
+		return this.getProjectId();
+	}
+
+	get stackId(): string | undefined {
+		return this.getStackId();
+	}
+
+	get laneId(): string {
+		return this.getLaneId();
+	}
+
+	get isReadOnly(): boolean {
+		return !this.stackId;
+	}
+
+	get laneState() {
+		return this.uiState.lane(this.laneId);
+	}
+
+	get selection() {
+		return this.laneState.selection;
+	}
+
+	get commitId(): string | undefined {
+		return this.selection.current?.commitId;
+	}
+
+	get branchName(): string | undefined {
+		return this.selection.current?.branchName;
+	}
+
+	get upstream(): boolean | undefined {
+		return this.selection.current?.upstream;
+	}
+
+	get previewOpen(): boolean | undefined {
+		return this.selection.current?.previewOpen;
+	}
+
+	get isCommitView(): boolean {
+		return !!(this.branchName && this.commitId);
+	}
+
+	get projectState() {
+		return this.uiState.project(this.projectId);
+	}
+
+	get exclusiveAction() {
+		return this.projectState.exclusiveAction.current;
+	}
+
+	get isCommitting(): boolean {
+		return this.exclusiveAction?.type === "commit" && this.exclusiveAction.stackId === this.stackId;
+	}
+
+	get dimmed(): boolean {
+		return (
+			this.exclusiveAction?.type === "commit" && this.exclusiveAction?.stackId !== this.stackId
+		);
+	}
+
+	// ── Active selection ID (for file selection tracking) ─────────────
+
+	get activeSelectionId(): SelectionId | undefined {
+		if (this.commitId) {
+			return createCommitSelection({ commitId: this.commitId, stackId: this.stackId });
+		} else if (this.branchName) {
+			return createBranchSelection({
+				stackId: this.stackId,
+				branchName: this.branchName,
+				remote: undefined,
+			});
+		}
+		return createWorktreeSelection({ stackId: this.stackId });
+	}
+
+	get activeLastAdded() {
+		if (this.activeSelectionId) {
+			return this.idSelection.getById(this.activeSelectionId).lastAdded;
+		}
+		return undefined;
+	}
+
+	get selectedFile() {
+		const lastAdded = this.activeLastAdded;
+		if (!lastAdded) return undefined;
+		const value = get(lastAdded);
+		return value?.key ? readKey(value.key) : undefined;
+	}
+
+	private get assignedSelection() {
+		return this.idSelection.getById(createWorktreeSelection({ stackId: this.stackId }));
+	}
+
+	get lastAddedAssigned() {
+		return this.assignedSelection.lastAdded;
+	}
+
+	get assignedKey() {
+		const value = get(this.lastAddedAssigned);
+		return value?.key ? readKey(value.key) : undefined;
+	}
+
+	get hasActiveSelection(): boolean {
+		return !!(this.branchName || this.commitId || this.selectedFile);
+	}
+
+	get isPreviewOpenForSelection(): boolean {
+		return this.hasActiveSelection && !!this.previewOpen;
+	}
+
+	get hasAssignedFiles(): boolean {
+		return !!this.assignedKey;
+	}
+
+	get ircPanelOpen(): boolean {
+		return this.selection.current?.irc === true;
+	}
+
+	get isDetailsViewOpen(): boolean {
+		return this.isPreviewOpenForSelection || this.hasAssignedFiles || this.ircPanelOpen;
+	}
+
+	closePreview(): void {
+		if (this.activeSelectionId) {
+			this.idSelection.clear(this.activeSelectionId);
+		}
+		this.selection.set(undefined);
+	}
+
+	clearWorktreeSelection(): void {
+		this.idSelection.clear({ type: "worktree", stackId: this.stackId });
+	}
+
+	// ── Cross-panel diff coordination ─────────────────────────────────
+
+	registerDiffView(handlers: { jump: (index: number) => void; popout: () => void }): void {
+		this.diffJumpHandler = handlers.jump;
+		this.diffPopoutHandler = handlers.popout;
+	}
+
+	unregisterDiffView(): void {
+		this.diffJumpHandler = undefined;
+		this.diffPopoutHandler = undefined;
+	}
+
+	jumpToIndex(index: number): void {
+		this.diffJumpHandler?.(index);
+	}
+
+	openFloatingDiff(): void {
+		this.diffPopoutHandler?.();
+	}
+
+	setVisibleRange(range: { start: number; end: number } | undefined): void {
+		this.visibleRange = range;
+	}
+}

--- a/apps/desktop/src/lib/stack/stackController.svelte.ts
+++ b/apps/desktop/src/lib/stack/stackController.svelte.ts
@@ -40,28 +40,19 @@ export function getStackContext(): StackController {
 
 export class StackController {
 	private uiState;
-	private idSelection: FileSelectionManager;
+	private fileSelection: FileSelectionManager;
 	private getProjectId: () => string;
 	private getStackId: () => string | undefined;
 	private getLaneId: () => string;
 
-	/** Whether this stack's focusable region is active. */
 	active = $state(false);
-
-	/** Visible range from MultiDiffView, consumed by WorktreeChanges for notching. */
 	visibleRange = $state<{ start: number; end: number } | undefined>();
 
-	/** Cross-panel diff view coordination. */
 	private diffJumpHandler?: (index: number) => void;
 	private diffPopoutHandler?: () => void;
 
-	/**
-	 * Reactively-tracked file selection values.
-	 * Updated via $effect subscriptions to the underlying Writable stores,
-	 * so that consumers reading these in $derived/templates get proper updates.
-	 */
-	private _selectedFile = $state<SelectedFile | undefined>();
-	private _assignedKey = $state<SelectedFile | undefined>();
+	private _focusedFile = $state<SelectedFile | undefined>();
+	private _stagedFocusedFile = $state<SelectedFile | undefined>();
 
 	constructor(params: {
 		projectId: () => string;
@@ -69,33 +60,30 @@ export class StackController {
 		laneId: () => string;
 	}) {
 		this.uiState = inject(UI_STATE);
-		this.idSelection = inject(FILE_SELECTION_MANAGER);
+		this.fileSelection = inject(FILE_SELECTION_MANAGER);
 		this.getProjectId = params.projectId;
 		this.getStackId = params.stackId;
 		this.getLaneId = params.laneId;
 
-		// Subscribe to the active selection's lastAdded store so that
-		// selectedFile is properly reactive (not a snapshot via get()).
 		$effect(() => {
-			const store = this.activeLastAdded;
+			const store = this.focusedFileStore;
 			if (!store) {
-				this._selectedFile = undefined;
+				this._focusedFile = undefined;
 				return;
 			}
 			return store.subscribe((value) => {
-				this._selectedFile = value?.key ? readKey(value.key) : undefined;
+				this._focusedFile = value?.key ? readKey(value.key) : undefined;
 			});
 		});
 
-		// Same for the worktree-assigned selection.
 		$effect(() => {
-			const store = this.lastAddedAssigned;
+			const store = this.stagedFocusedFileStore;
 			if (!store) {
-				this._assignedKey = undefined;
+				this._stagedFocusedFile = undefined;
 				return;
 			}
 			return store.subscribe((value) => {
-				this._assignedKey = value?.key ? readKey(value.key) : undefined;
+				this._stagedFocusedFile = value?.key ? readKey(value.key) : undefined;
 			});
 		});
 	}
@@ -162,8 +150,6 @@ export class StackController {
 		);
 	}
 
-	// ── Active selection ID (for file selection tracking) ─────────────
-
 	get activeSelectionId(): SelectionId | undefined {
 		if (this.commitId) {
 			return createCommitSelection({ commitId: this.commitId, stackId: this.stackId });
@@ -177,39 +163,39 @@ export class StackController {
 		return createWorktreeSelection({ stackId: this.stackId });
 	}
 
-	get activeLastAdded() {
+	get focusedFileStore() {
 		if (this.activeSelectionId) {
-			return this.idSelection.getById(this.activeSelectionId).lastAdded;
+			return this.fileSelection.getById(this.activeSelectionId).lastAdded;
 		}
 		return undefined;
 	}
 
-	get selectedFile() {
-		return this._selectedFile;
+	get focusedFile() {
+		return this._focusedFile;
 	}
 
-	private get assignedSelection() {
-		return this.idSelection.getById(createWorktreeSelection({ stackId: this.stackId }));
+	private get stagedFileGroup() {
+		return this.fileSelection.getById(createWorktreeSelection({ stackId: this.stackId }));
 	}
 
-	get lastAddedAssigned() {
-		return this.assignedSelection.lastAdded;
+	get stagedFocusedFileStore() {
+		return this.stagedFileGroup.lastAdded;
 	}
 
-	get assignedKey() {
-		return this._assignedKey;
+	get stagedFocusedFile() {
+		return this._stagedFocusedFile;
 	}
 
-	get hasActiveSelection(): boolean {
-		return !!(this.branchName || this.commitId || this.selectedFile);
+	get hasPreviewTarget(): boolean {
+		return !!(this.branchName || this.commitId || this.focusedFile);
 	}
 
-	get isPreviewOpenForSelection(): boolean {
-		return this.hasActiveSelection && !!this.previewOpen;
+	get isSelectionPreviewOpen(): boolean {
+		return this.hasPreviewTarget && !!this.previewOpen;
 	}
 
-	get hasAssignedFiles(): boolean {
-		return !!this.assignedKey;
+	get hasStagedFileFocused(): boolean {
+		return !!this.stagedFocusedFile;
 	}
 
 	get ircPanelOpen(): boolean {
@@ -217,18 +203,18 @@ export class StackController {
 	}
 
 	get isDetailsViewOpen(): boolean {
-		return this.isPreviewOpenForSelection || this.hasAssignedFiles || this.ircPanelOpen;
+		return this.isSelectionPreviewOpen || this.hasStagedFileFocused || this.ircPanelOpen;
 	}
 
 	closePreview(): void {
 		if (this.activeSelectionId) {
-			this.idSelection.clear(this.activeSelectionId);
+			this.fileSelection.clear(this.activeSelectionId);
 		}
 		this.selection.set(undefined);
 	}
 
 	clearWorktreeSelection(): void {
-		this.idSelection.clear({ type: "worktree", stackId: this.stackId });
+		this.fileSelection.clear({ type: "worktree", stackId: this.stackId });
 	}
 
 	openProjectSettingsModal(selectedId?: ProjectSettingsPageId): void {
@@ -238,8 +224,6 @@ export class StackController {
 			selectedId,
 		});
 	}
-
-	// ── Cross-panel diff coordination ─────────────────────────────────
 
 	registerDiffView(handlers: { jump: (index: number) => void; popout: () => void }): void {
 		this.diffJumpHandler = handlers.jump;


### PR DESCRIPTION
- Extract the monolithic StackView.svelte (~800 lines) into compound components: StackPanel , StackDetails , and StackCodegen , coordinated by a StackController reactive class
- Extract FileList.svelte into compound components: FileListProvider , FileListItems , and FileListConflicts , coordinated by a FileListController reactive class
- Replace prop drilling of identity and UI state in BranchList and BranchCommitList with getStackContext()
- Move codegen data queries and message sending from StackCodegen into CodegenMessages , making StackCodegen a thin wrapper
- Fix a reactivity bug where switching commits caused the details panel CSS to flash by memoizing isDetailsViewOpen with $derived
- Rename file selection tracking APIs for clarity ( activeLastAdded → focusedFileStore , assignedKey → stagedFocusedFile , etc.)
