### PR TITLE
Hunk assignments no longer affected file/hunk locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,6 @@ dependencies = [
  "but-db",
  "but-graph",
  "but-hunk-assignment",
- "but-hunk-dependency",
  "but-workspace",
  "chrono",
  "gix",

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -101,7 +101,6 @@ fn handle_changes_simple_inner(
         &ws,
         true,
         None::<Vec<but_core::TreeChange>>,
-        None,
         context_lines,
     )
     .map_err(|err| serde_error::Error::new(&*err))?;

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -92,14 +92,12 @@ fn handle_changes_simple_inner(
         }
     }
 
-    // Get any assignments that may have been made, which also includes any hunk locks. Assignments should be updated according to locks where applicable.
     let context_lines = ctx.settings.context_lines;
     let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        true,
         None::<Vec<but_core::TreeChange>>,
         context_lines,
     )

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -728,7 +728,6 @@ pub fn commit_uncommit_changes_only(
             &ws,
             false,
             None::<Vec<but_core::TreeChange>>,
-            None,
             context_lines,
         )?;
         Some(assignments)
@@ -750,7 +749,6 @@ pub fn commit_uncommit_changes_only(
             &ws,
             false,
             None::<Vec<but_core::TreeChange>>,
-            None,
             context_lines,
         )?;
 

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -774,7 +774,6 @@ pub fn commit_uncommit_changes_only(
             &repo,
             &ws,
             to_assign,
-            None,
             context_lines,
         )?;
     }

--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -726,7 +726,6 @@ pub fn commit_uncommit_changes_only(
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;
@@ -747,7 +746,6 @@ pub fn commit_uncommit_changes_only(
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;

--- a/crates/but-api/src/legacy/diff.rs
+++ b/crates/but-api/src/legacy/diff.rs
@@ -42,14 +42,11 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
     );
     let mut trans = db.immediate_transaction()?;
 
-    // If the dependencies calculation failed, we still want to try to get assignments
-    // so we pass an empty HunkDependencies in that case.
     let (assignments, assignments_error) = {
         but_hunk_assignment::assignments_with_fallback(
             trans.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             Some(changes.changes.clone()),
             context_lines,
         )?

--- a/crates/but-api/src/legacy/diff.rs
+++ b/crates/but-api/src/legacy/diff.rs
@@ -69,13 +69,7 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
 
     trans.commit()?;
     drop((repo, ws, db));
-    but_rules::handler::process_workspace_rules(
-        ctx,
-        &assignments,
-        &dependencies.as_ref().ok().cloned(),
-        guard.write_permission(),
-    )
-    .ok();
+    but_rules::handler::process_workspace_rules(ctx, &assignments, guard.write_permission()).ok();
 
     Ok(WorktreeChanges {
         worktree_changes: changes.into(),
@@ -102,7 +96,6 @@ pub fn assign_hunk(
         &repo,
         &ws,
         assignments,
-        None,
         context_lines,
     )?;
     Ok(rejections)

--- a/crates/but-api/src/legacy/diff.rs
+++ b/crates/but-api/src/legacy/diff.rs
@@ -3,9 +3,7 @@ use but_api_macros::but_api;
 use but_core::ui::TreeChange;
 use but_ctx::Context;
 use but_hunk_assignment::{AssignmentRejection, HunkAssignmentRequest, WorktreeChanges};
-use but_hunk_dependency::ui::{
-    HunkDependencies, hunk_dependencies_for_workspace_changes_by_worktree_dir,
-};
+use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
 use tracing::instrument;
 
 /// Provide a unified diff for `change`, but fail if `change` is a [type-change](but_core::ModeFlags::TypeChange)
@@ -46,25 +44,15 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
 
     // If the dependencies calculation failed, we still want to try to get assignments
     // so we pass an empty HunkDependencies in that case.
-    let (assignments, assignments_error) = match &dependencies {
-        Ok(dependencies) => but_hunk_assignment::assignments_with_fallback(
+    let (assignments, assignments_error) = {
+        but_hunk_assignment::assignments_with_fallback(
             trans.hunk_assignments_mut()?,
             &repo,
             &ws,
             false,
             Some(changes.changes.clone()),
-            Some(dependencies),
             context_lines,
-        )?,
-        Err(_) => but_hunk_assignment::assignments_with_fallback(
-            trans.hunk_assignments_mut()?,
-            &repo,
-            &ws,
-            false,
-            Some(changes.changes.clone()),
-            Some(&HunkDependencies::default()), // empty dependencies on error
-            context_lines,
-        )?,
+        )?
     };
 
     trans.commit()?;

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -258,7 +258,6 @@ pub fn unapply_stack(ctx: &mut Context, stack_id: StackId) -> Result<()> {
         &ws,
         false,
         Some(but_core::diff::ui::worktree_changes(&repo)?.changes),
-        None,
         context_lines,
     )?;
     let assigned_diffspec = but_workspace::flatten_diff_specs(

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -256,7 +256,6 @@ pub fn unapply_stack(ctx: &mut Context, stack_id: StackId) -> Result<()> {
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         Some(but_core::diff::ui::worktree_changes(&repo)?.changes),
         context_lines,
     )?;

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -616,7 +616,6 @@ pub fn uncommit_changes(
             &repo,
             &ws,
             to_assign,
-            None,
             context_lines,
         )?;
     }

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -564,7 +564,6 @@ pub fn uncommit_changes(
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;
@@ -589,7 +588,6 @@ pub fn uncommit_changes(
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -566,7 +566,6 @@ pub fn uncommit_changes(
             &ws,
             false,
             None::<Vec<but_core::TreeChange>>,
-            None,
             context_lines,
         )?;
         Some(changes.0)
@@ -592,7 +591,6 @@ pub fn uncommit_changes(
             &ws,
             false,
             None::<Vec<but_core::TreeChange>>,
-            None,
             context_lines,
         )?;
 

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -448,7 +448,6 @@ pub fn assign_hunks_post_tool_call(
         &ws,
         true,
         Some(changes.clone()),
-        None,
         context_lines,
     )?;
 

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -486,7 +486,6 @@ pub fn assign_hunks_post_tool_call(
         &repo,
         &ws,
         assignment_reqs,
-        None,
         context_lines,
     )?;
 

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -446,7 +446,6 @@ pub fn assign_hunks_post_tool_call(
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        true,
         Some(changes.clone()),
         context_lines,
     )?;

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -1000,7 +1000,6 @@ fn append_assigned_files_info(
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         None::<Vec<but_core::TreeChange>>,
         context_lines,
     ) {

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -1002,7 +1002,6 @@ fn append_assigned_files_info(
         &ws,
         false,
         None::<Vec<but_core::TreeChange>>,
-        None,
         context_lines,
     ) {
         Ok((assignments, _error)) => assignments,

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -173,7 +173,6 @@ pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<Curso
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        true,
         Some(changes.clone()),
         context_lines,
     )?;

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -210,7 +210,6 @@ pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<Curso
         &repo,
         &ws,
         assignment_reqs,
-        None,
         context_lines,
     )?;
 

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -175,7 +175,6 @@ pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<Curso
         &ws,
         true,
         Some(changes.clone()),
-        None,
         context_lines,
     )?;
 

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -402,7 +402,6 @@ pub fn assign(
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
     requests: Vec<HunkAssignmentRequest>,
-    deps: Option<&HunkDependencies>,
     context_lines: u32,
 ) -> Result<Vec<AssignmentRejection>> {
     let identifiable_stacks = workspace
@@ -411,14 +410,6 @@ pub fn assign(
         .filter_map(|s| s.id)
         .collect::<Vec<_>>();
 
-    let owned_deps;
-    let deps = if let Some(deps) = deps {
-        deps
-    } else {
-        owned_deps =
-            hunk_dependencies_for_workspace_changes_by_worktree_dir(repo, workspace, None)?;
-        &owned_deps
-    };
     let worktree_changes: Vec<but_core::TreeChange> =
         but_core::diff::worktree_changes(repo)?.changes;
     let mut worktree_assignments = vec![];
@@ -449,23 +440,13 @@ pub fn assign(
         true,
     );
 
-    // Reconcile with hunk locks
-    let lock_assignments = hunk_dependency_assignments(deps);
-    let with_locks = reconcile::assignments(
-        &with_requests,
-        &lock_assignments,
-        &identifiable_stacks,
-        MultipleOverlapping::SetNone,
-        false,
-    );
-
-    state::set_assignments(db, with_locks.clone())?;
+    state::set_assignments(db, with_requests.clone())?;
 
     // Request where the stack_id is different from the outcome are considered rejections - this is due to locking
     // Collect all the rejected requests together with the locks that caused the rejection
     let mut rejections = vec![];
     for req in requests {
-        let locks = with_locks
+        let locks = with_requests
             .iter()
             .filter(|assignment| {
                 req.matches_assignment(assignment) && req.stack_id != assignment.stack_id

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -476,11 +476,7 @@ fn reconcile_worktree_changes_with_worktree(
             diff.ok().flatten(),
         ));
     }
-    let reconciled = reconcile_with_worktree(
-        db.to_ref(),
-        workspace,
-        &worktree_assignments,
-    )?;
+    let reconciled = reconcile_with_worktree(db.to_ref(), workspace, &worktree_assignments)?;
 
     state::set_assignments(db, reconciled.clone())?;
     Ok(reconciled)

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -18,9 +18,7 @@ use anyhow::Result;
 use bstr::{BString, ByteSlice};
 use but_core::{DiffSpec, HunkHeader, TreeChange, UnifiedPatch, ref_metadata::StackId};
 use but_db::{HunkAssignmentsHandle, HunkAssignmentsHandleMut};
-use but_hunk_dependency::ui::{
-    HunkDependencies, HunkLock, hunk_dependencies_for_workspace_changes_by_worktree_dir,
-};
+use but_hunk_dependency::ui::{HunkDependencies, HunkLock};
 use gix::ObjectId;
 use itertools::Itertools;
 use reconcile::MultipleOverlapping;
@@ -471,45 +469,30 @@ pub fn assignments_with_fallback(
     workspace: &but_graph::projection::Workspace,
     set_assignment_from_locks: bool,
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
-    deps: Option<&HunkDependencies>,
     context_lines: u32,
 ) -> Result<(Vec<HunkAssignment>, Option<anyhow::Error>)> {
-    let hunk_assignments = reconcile_worktree_changes_with_worktree_and_locks(
+    let hunk_assignments = reconcile_worktree_changes_with_worktree(
         db,
         repo,
         workspace,
         set_assignment_from_locks,
         worktree_changes,
-        deps,
         context_lines,
     )?;
     Ok((hunk_assignments, None))
 }
 
-fn reconcile_worktree_changes_with_worktree_and_locks(
+fn reconcile_worktree_changes_with_worktree(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
     set_assignment_from_locks: bool,
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
-    deps: Option<&HunkDependencies>,
     context_lines: u32,
 ) -> Result<Vec<HunkAssignment>> {
     let worktree_changes: Vec<but_core::TreeChange> = match worktree_changes {
         Some(wtc) => wtc.into_iter().map(Into::into).collect(),
         None => but_core::diff::worktree_changes(repo)?.changes,
-    };
-
-    let owned_deps;
-    let deps = if let Some(deps) = deps {
-        deps
-    } else {
-        owned_deps = hunk_dependencies_for_workspace_changes_by_worktree_dir(
-            repo,
-            workspace,
-            Some(worktree_changes.clone()),
-        )?;
-        &owned_deps
     };
 
     if worktree_changes.is_empty() {
@@ -523,12 +506,11 @@ fn reconcile_worktree_changes_with_worktree_and_locks(
             diff.ok().flatten(),
         ));
     }
-    let reconciled = reconcile_with_worktree_and_locks(
+    let reconciled = reconcile_with_worktree(
         db.to_ref(),
         workspace,
         set_assignment_from_locks,
         &worktree_assignments,
-        deps,
         context_lines,
     )?;
 
@@ -558,13 +540,12 @@ fn reconcile_worktree_changes_with_worktree_and_locks(
 ///
 /// `context_lines` determines the amount of context lines in diffs, and it should match the UI.
 // TODO: Isn't it usually better to have no context, and look at hunks themselves?
-#[instrument(skip(db, workspace, worktree_assignments, deps), err(Debug))]
-fn reconcile_with_worktree_and_locks(
+#[instrument(skip(db, workspace, worktree_assignments), err(Debug))]
+fn reconcile_with_worktree(
     db: HunkAssignmentsHandle,
     workspace: &but_graph::projection::Workspace,
     set_assignment_from_locks: bool,
     worktree_assignments: &[HunkAssignment],
-    deps: &HunkDependencies,
     context_lines: u32,
 ) -> Result<Vec<HunkAssignment>> {
     let identifiable_stacks = workspace
@@ -582,46 +563,7 @@ fn reconcile_with_worktree_and_locks(
         true,
     );
 
-    let lock_assignments = hunk_dependency_assignments(deps);
-    let with_locks = reconcile::assignments(
-        &with_worktree,
-        &lock_assignments,
-        &identifiable_stacks,
-        MultipleOverlapping::SetNone,
-        set_assignment_from_locks,
-    );
-
-    Ok(with_locks)
-}
-
-fn hunk_dependency_assignments(deps: &HunkDependencies) -> Vec<HunkAssignment> {
-    let mut assignments = vec![];
-    for (path, hunk, locks) in &deps.diffs {
-        // If there are locks towards more than one stack, this means double locking and the assignment None - the user can resolve this by partial committing.
-        let locked_to_stack_ids_count = locks
-            .iter()
-            .map(|lock| lock.target)
-            .collect::<std::collections::HashSet<_>>()
-            .len();
-        let stack_id: Option<StackId> = if locked_to_stack_ids_count == 1 {
-            locks[0].target.into()
-        } else {
-            None
-        };
-        let assignment = HunkAssignment {
-            id: None,
-            hunk_header: Some(hunk.into()),
-            path: path.clone(),
-            path_bytes: path.clone().into(),
-            stack_id,
-            hunk_locks: Some(locks.clone()),
-            line_nums_added: None,   // derived data (not persisted)
-            line_nums_removed: None, // derived data (not persisted)
-            diff: None,              // derived data (not persisted)
-        };
-        assignments.push(assignment);
-    }
-    assignments
+    Ok(with_worktree)
 }
 
 /// This also generates a UUID for the assignment

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -20,7 +20,6 @@ use but_core::{DiffSpec, HunkHeader, TreeChange, UnifiedPatch, ref_metadata::Sta
 use but_db::{HunkAssignmentsHandle, HunkAssignmentsHandleMut};
 use but_hunk_dependency::ui::{HunkDependencies, HunkLock};
 use gix::ObjectId;
-use itertools::Itertools;
 use reconcile::MultipleOverlapping;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -386,13 +385,7 @@ impl HunkAssignment {
 }
 
 /// Sets the assignment for a hunk. It must be already present in the current assignments, errors out if it isn't.
-/// If the stack is not in the list of applied stacks, it errors out.
 /// Returns the updated assignments list.
-///
-/// Optionally takes pre-computed hunk dependencies. If not provided, they will
-/// be computed using the provided `repo` and `workspace`.
-///
-/// The provided hunk dependencies should be computed for all workspace changes.
 ///
 /// `context_lines` determines the amount of context lines in diffs, and it should match the UI.
 pub fn assign(
@@ -432,42 +425,21 @@ pub fn assign(
     // Reconcile with the requested changes
     let with_requests = reconcile::assignments(
         &with_worktree,
-        &requests_to_assignments(requests.clone()),
+        &requests_to_assignments(requests),
         &identifiable_stacks,
         MultipleOverlapping::SetMostLines,
         true,
     );
 
-    state::set_assignments(db, with_requests.clone())?;
+    state::set_assignments(db, with_requests)?;
 
-    // Request where the stack_id is different from the outcome are considered rejections - this is due to locking
-    // Collect all the rejected requests together with the locks that caused the rejection
-    let mut rejections = vec![];
-    for req in requests {
-        let locks = with_requests
-            .iter()
-            .filter(|assignment| {
-                req.matches_assignment(assignment) && req.stack_id != assignment.stack_id
-            })
-            .flat_map(|assignment| assignment.hunk_locks.clone().unwrap_or_default())
-            .collect_vec();
-        if !locks.is_empty() {
-            rejections.push(AssignmentRejection {
-                request: req.clone(),
-                locks,
-            });
-        }
-    }
-    Ok(rejections)
+    Ok(vec![])
 }
 
-/// Similar to the `reconcile_with_worktree_and_locks` function.
-/// TODO: figure out a better name for this function
 pub fn assignments_with_fallback(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
-    set_assignment_from_locks: bool,
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
     context_lines: u32,
 ) -> Result<(Vec<HunkAssignment>, Option<anyhow::Error>)> {
@@ -475,7 +447,6 @@ pub fn assignments_with_fallback(
         db,
         repo,
         workspace,
-        set_assignment_from_locks,
         worktree_changes,
         context_lines,
     )?;
@@ -486,7 +457,6 @@ fn reconcile_worktree_changes_with_worktree(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
-    set_assignment_from_locks: bool,
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
     context_lines: u32,
 ) -> Result<Vec<HunkAssignment>> {
@@ -509,9 +479,7 @@ fn reconcile_worktree_changes_with_worktree(
     let reconciled = reconcile_with_worktree(
         db.to_ref(),
         workspace,
-        set_assignment_from_locks,
         &worktree_assignments,
-        context_lines,
     )?;
 
     state::set_assignments(db, reconciled.clone())?;
@@ -531,22 +499,12 @@ fn reconcile_worktree_changes_with_worktree(
 ///
 /// If a stack is no longer present in the workspace (either unapplied or deleted), any assignments to it are removed.
 ///
-/// If a hunk has a dependency on a particular stack and it has been previously assigned to another stack, the assignment is updated to reflect that dependency.
-/// If a hunk has a dependency but it has not been previously assigned to any stack, it is left unassigned (stack_id is None). This is so that the hunk assignment workflow can remain optional.
-///
 /// This needs to be ran only after the worktree has changed.
-///
-/// If `worktree_changes` is `None`, they will be fetched automatically.
-///
-/// `context_lines` determines the amount of context lines in diffs, and it should match the UI.
-// TODO: Isn't it usually better to have no context, and look at hunks themselves?
 #[instrument(skip(db, workspace, worktree_assignments), err(Debug))]
 fn reconcile_with_worktree(
     db: HunkAssignmentsHandle,
     workspace: &but_graph::projection::Workspace,
-    set_assignment_from_locks: bool,
     worktree_assignments: &[HunkAssignment],
-    context_lines: u32,
 ) -> Result<Vec<HunkAssignment>> {
     let identifiable_stacks = workspace
         .stacks

--- a/crates/but-rules/Cargo.toml
+++ b/crates/but-rules/Cargo.toml
@@ -21,7 +21,6 @@ but-core.workspace = true
 but-hunk-assignment.workspace = true
 but-graph.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
-but-hunk-dependency.workspace = true
 but-ctx.workspace = true
 
 anyhow.workspace = true

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -5,7 +5,6 @@ use but_core::{ChangeId, DiffSpec, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_db::HunkAssignmentsHandleMut;
 use but_hunk_assignment::HunkAssignment;
-use but_hunk_dependency::ui::HunkDependencies;
 use but_workspace::legacy::commit_engine;
 use itertools::Itertools;
 
@@ -14,7 +13,6 @@ use crate::{Filter, StackTarget};
 pub fn process_workspace_rules(
     ctx: &mut Context,
     assignments: &[HunkAssignment],
-    dependencies: &Option<HunkDependencies>,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<usize> {
     let mut updates = 0;
@@ -75,7 +73,6 @@ pub fn process_workspace_rules(
                         &repo,
                         new_ws.as_ref().unwrap_or(&ws),
                         assignments,
-                        dependencies.as_ref(),
                         context_lines,
                     )
                     .unwrap_or_default();
@@ -216,7 +213,6 @@ fn handle_assign(
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
     assignments: Vec<HunkAssignment>,
-    deps: Option<&HunkDependencies>,
     context_lines: u32,
 ) -> anyhow::Result<usize> {
     let len = assignments.len();
@@ -225,7 +221,6 @@ fn handle_assign(
         repo,
         workspace,
         but_hunk_assignment::assignments_to_requests(assignments),
-        deps,
         context_lines,
     )
     .map(|_| len)

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -312,7 +312,6 @@ pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Res
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             Some(wt_changes.changes),
             context_lines,
         )

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -304,7 +304,7 @@ pub fn list_rules(ctx: &Context) -> anyhow::Result<Vec<WorkspaceRule>> {
 
 /// NOTE: may create an empty branch!
 pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Result<()> {
-    let (assignments, dependencies) = {
+    let assignments = {
         let context_lines = ctx.settings.context_lines;
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
         let wt_changes = but_core::diff::worktree_changes(&repo)?;
@@ -325,9 +325,9 @@ pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Res
             context_lines,
         )
         .map_err(|e| anyhow::anyhow!("Failed to get assignments: {e}"))?;
-        (assignments, dependencies)
+        assignments
     };
 
-    handler::process_workspace_rules(ctx, &assignments, &Some(dependencies), perm)?;
+    handler::process_workspace_rules(ctx, &assignments, perm)?;
     Ok(())
 }

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -1,6 +1,5 @@
 use but_core::{ChangeId, sync::RepoExclusive};
 use but_ctx::Context;
-use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
 use serde::{Deserialize, Serialize};
 
 pub mod db;
@@ -309,19 +308,12 @@ pub fn process_rules(ctx: &mut Context, perm: &mut RepoExclusive) -> anyhow::Res
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
         let wt_changes = but_core::diff::worktree_changes(&repo)?;
 
-        let dependencies = hunk_dependencies_for_workspace_changes_by_worktree_dir(
-            &repo,
-            &ws,
-            Some(wt_changes.changes.clone()),
-        )?;
-
         let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
             false,
             Some(wt_changes.changes),
-            Some(&dependencies),
             context_lines,
         )
         .map_err(|e| anyhow::anyhow!("Failed to get assignments: {e}"))?;

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -63,7 +63,6 @@ pub mod assignment {
             &ws,
             false,
             None::<Vec<but_core::TreeChange>>,
-            None,
             context_lines,
         )?;
         if use_json {

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -61,7 +61,6 @@ pub mod assignment {
             db.hunk_assignments_mut()?,
             &repo,
             &ws,
-            false,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -88,7 +88,6 @@ pub mod assignment {
             &repo,
             &ws,
             vec![assignment],
-            None,
             context_lines,
         )?;
         if use_json {

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1515,7 +1515,6 @@ pub fn get_filtered_changes(
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         None::<Vec<but_core::TreeChange>>,
         context_lines,
     )

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1517,7 +1517,6 @@ pub fn get_filtered_changes(
         &ws,
         false,
         None::<Vec<but_core::TreeChange>>,
-        None,
         context_lines,
     )
     .map_err(|err| serde_error::Error::new(&*err))?;

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -103,7 +103,6 @@ fn wt_assignments(ctx: &mut Context) -> anyhow::Result<Vec<HunkAssignment>> {
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         Some(changes.clone()),
         context_lines,
     )?;

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -105,7 +105,6 @@ fn wt_assignments(ctx: &mut Context) -> anyhow::Result<Vec<HunkAssignment>> {
         &ws,
         false,
         Some(changes.clone()),
-        None,
         context_lines,
     )?;
     Ok(assignments)

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -151,7 +151,6 @@ fn assign_all_inner(
         &ws,
         false,
         Some(changes),
-        None,
         context_lines,
     )?;
 

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -201,14 +201,8 @@ pub(crate) fn do_assignments(
 ) -> anyhow::Result<()> {
     let context_lines = ctx.settings.context_lines;
     let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
-    let rejections = but_hunk_assignment::assign(
-        db.hunk_assignments_mut()?,
-        &repo,
-        &ws,
-        reqs,
-        None,
-        context_lines,
-    )?;
+    let rejections =
+        but_hunk_assignment::assign(db.hunk_assignments_mut()?, &repo, &ws, reqs, context_lines)?;
     if !rejections.is_empty()
         && let Some(out) = out.for_human()
     {

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -149,7 +149,6 @@ fn assign_all_inner(
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         Some(changes),
         context_lines,
     )?;

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -162,9 +162,7 @@ pub(super) fn perform_operation(
                         db.hunk_assignments_mut()?,
                         &repo,
                         &ws,
-                        false,
                         Some(changes),
-                        None,
                         context_lines,
                     )?;
 
@@ -243,9 +241,7 @@ pub(super) fn perform_operation(
                         db.hunk_assignments_mut()?,
                         &repo,
                         &ws,
-                        false,
                         Some(changes),
-                        None,
                         context_lines,
                     )?;
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -562,7 +562,6 @@ impl IdMap {
                     db.hunk_assignments_mut()?,
                     &repo,
                     &ws,
-                    false,
                     Some(changes),
                     context_lines,
                 )?;

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -564,7 +564,6 @@ impl IdMap {
                     &ws,
                     false,
                     Some(changes),
-                    None,
                     context_lines,
                 )?;
                 assignments

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -37,7 +37,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
 Found 1 changed file to absorb:
 
 Absorbed to commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
 
@@ -116,7 +116,7 @@ k0 a.txt│
 Found 1 changed file to absorb:
 
 Absorbed to commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
 
 
@@ -291,7 +291,7 @@ k0 a.txt│
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ╭┄zz [unstaged changes]
-┊   nk M a.txt 🔒 889385c, a7aa4ef, f4ea7f8
+┊   nk M a.txt
 ┊
 ┊╭┄g0 [A]
 ┊●   a7aa4ef partial change to a.txt 3
@@ -323,12 +323,9 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 889385c partial change to a.txt 2
-  (files locked to commit due to hunk range overlap)
-    a.txt @1,4 +1,4
-
 Absorbed to commit: a7aa4ef partial change to a.txt 3
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
+    a.txt @1,4 +1,4
     a.txt @6,4 +6,4
 
 
@@ -346,10 +343,10 @@ Hint: you can run `but undo` to undo these changes
 ┊     no changes
 ┊
 ┊╭┄g0 [A]
-┊●   4822140 partial change to a.txt 3
-┊│     48:nk M a.txt
-┊●   4593422 partial change to a.txt 2
-┊│     45:nk M a.txt
+┊●   a309adb partial change to a.txt 3
+┊│     a3:nk M a.txt
+┊●   889385c partial change to a.txt 2
+┊│     88:nk M a.txt
 ┊●   8dc39e0 partial change to a.txt 1
 ┊│     8d:nk M a.txt
 ┊●   f4ea7f8 a.txt
@@ -418,7 +415,7 @@ fn uncommitted_file_new() -> anyhow::Result<()> {
 Found 1 changed file to absorb:
 
 Created on top of commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
 
@@ -536,7 +533,7 @@ k0 a.txt│
 Found 1 changed file to absorb:
 
 Created on top of commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
 
 
@@ -581,7 +578,7 @@ Hint: you can run `but undo` to undo these changes
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
 ╭┄zz [unstaged changes]
-┊   nk M a.txt 🔒 f4ea7f8
+┊   nk M a.txt
 ┊
 ┊╭┄g0 [A]
 ┊●   5a72bff [AUTO-COMMIT] Generated commit message
@@ -639,7 +636,7 @@ fn dry_run_new_shows_plan_without_changes() -> anyhow::Result<()> {
 Found 1 changed file to absorb:
 
 Created on top of commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
 
@@ -710,7 +707,7 @@ fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
 Found 1 changed file to absorb:
 
 Absorbed to commit: f4ea7f8 a.txt
-  (files locked to commit due to hunk range overlap)
+  (last commit in the primary lane)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
@@ -39,7 +39,6 @@ fn unapply_with_data() -> anyhow::Result<()> {
         &ws,
         false,
         Some(changes.clone()),
-        None,
         context_lines,
     )
     .unwrap();
@@ -62,7 +61,6 @@ fn unapply_with_data() -> anyhow::Result<()> {
         &ws,
         false,
         Some(changes.clone()),
-        None,
         context_lines,
     )
     .unwrap();

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
@@ -37,7 +37,6 @@ fn unapply_with_data() -> anyhow::Result<()> {
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         Some(changes.clone()),
         context_lines,
     )
@@ -59,7 +58,6 @@ fn unapply_with_data() -> anyhow::Result<()> {
         db.hunk_assignments_mut()?,
         &repo,
         &ws,
-        false,
         Some(changes.clone()),
         context_lines,
     )

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/save_and_unapply_virtual_branch.rs
@@ -53,7 +53,6 @@ fn unapply_with_data() -> anyhow::Result<()> {
         &repo,
         &ws,
         vec![req],
-        None,
         context_lines,
     )
     .unwrap();

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -125,12 +125,9 @@ impl Handler {
                 .map(|err| serde_error::Error::new(&**err)),
         };
         drop((repo, ws, db));
-        if let Ok(update_count) = but_rules::handler::process_workspace_rules(
-            ctx,
-            &assignments,
-            &dependencies.as_ref().ok().cloned(),
-            perm,
-        ) && update_count > 0
+        if let Ok(update_count) =
+            but_rules::handler::process_workspace_rules(ctx, &assignments, perm)
+            && update_count > 0
         {
             let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
             // Getting these again since they were updated

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -110,7 +110,6 @@ impl Handler {
             &repo,
             &ws,
             wt_changes.changes.clone(),
-            &dependencies,
             context_lines,
         )?;
 
@@ -136,7 +135,6 @@ impl Handler {
                 &repo,
                 &ws,
                 wt_changes.changes.clone(),
-                &dependencies,
                 context_lines,
             )?;
             changes = but_hunk_assignment::WorktreeChanges {
@@ -224,23 +222,17 @@ fn assignments_and_errors(
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,
     tree_changes: Vec<TreeChange>,
-    dependencies: &Result<but_hunk_dependency::ui::HunkDependencies>,
     context_lines: u32,
 ) -> Result<(Vec<HunkAssignment>, Option<serde_error::Error>)> {
-    let (assignments, assignments_error) = match &dependencies {
-        Ok(dependencies) => but_hunk_assignment::assignments_with_fallback(
+    let (assignments, assignments_error) = {
+        but_hunk_assignment::assignments_with_fallback(
             db,
             repo,
             workspace,
             false,
             Some(tree_changes),
-            Some(dependencies),
             context_lines,
-        )?,
-        Err(e) => (
-            vec![],
-            Some(anyhow::anyhow!("failed to get hunk dependencies: {e}")),
-        ),
+        )?
     };
     Ok((
         assignments,

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -229,7 +229,6 @@ fn assignments_and_errors(
             db,
             repo,
             workspace,
-            false,
             Some(tree_changes),
             context_lines,
         )?


### PR DESCRIPTION
Hunk dependencies and locks will instead surface at the time of comitting.

Assigning of hunks or files to lanes is no longer constrained by dependencies (locks) towards lanes - the user can assign (stage) to whatever lane they want.
Of course at the time of committing, if there is a dependency towards another lane, the dependent part will not be part of the commit 