### PR TITLE
Expose `RejectedChange` in `but-sdk`

### DIFF
--- a/crates/but-api/src/commit.rs
+++ b/crates/but-api/src/commit.rs
@@ -54,6 +54,7 @@ pub mod json {
     use serde::Serialize;
 
     use crate::{commit::CommitMoveResult, json::HexHash};
+    use but_core::tree::create_tree::RejectionReason;
 
     use super::{
         CommitCreateResult, CommitInsertBlankResult, CommitRewordResult, MoveChangesResult,
@@ -88,6 +89,19 @@ pub mod json {
         }
     }
 
+    /// A rejected change reported back to the UI as `[reason, path]`.
+    #[derive(Debug, Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+    pub struct RejectedChange(
+        pub RejectionReason,
+        #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+        pub  but_serde::BStringForFrontend,
+    );
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(RejectedChange);
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(RejectionReason);
+
     /// UI type for creating a commit in the rebase graph.
     #[derive(Debug, Serialize)]
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -97,11 +111,7 @@ pub mod json {
         #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
         pub new_commit: Option<HexHash>,
         /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
-        #[cfg_attr(feature = "export-schema", schemars(with = "Vec<(String, String)>"))]
-        pub paths_to_rejected_changes: Vec<(
-            but_core::tree::create_tree::RejectionReason,
-            but_serde::BStringForFrontend,
-        )>,
+        pub paths_to_rejected_changes: Vec<RejectedChange>,
         /// Commits that have been replaced as a side-effect of the create/amend.
         /// Maps `oldId → newId`.
         #[cfg_attr(
@@ -125,7 +135,7 @@ pub mod json {
                 new_commit: new_commit.map(Into::into),
                 paths_to_rejected_changes: rejected_specs
                     .into_iter()
-                    .map(|(reason, diff)| (reason, diff.path.into()))
+                    .map(|(reason, diff)| RejectedChange(reason, diff.path.into()))
                     .collect(),
                 replaced_commits: replaced_commits
                     .into_iter()

--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -11,6 +11,7 @@ pub mod create_tree {
 
     /// Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit.
     #[derive(Default, Debug, Copy, Clone, PartialEq, serde::Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
     pub enum RejectionReason {
         /// All changes were applied, but they didn't end up effectively change the tree to something differing from the target tree.

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -718,6 +718,12 @@ export type RefInfo = {
   isEntrypoint: boolean;
 };
 
+/** A rejected change reported back to the UI as `[reason, path]`. */
+export type RejectedChange = [RejectionReason, string];
+
+/** Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit. */
+export type RejectionReason = "noEffectiveChanges" | "cherryPickMergeConflict" | "workspaceMergeConflict" | "workspaceMergeConflictOfUnrelatedFile" | "worktreeFileMissingForObjectConversion" | "fileToLargeOrBinary" | "pathNotFoundInBaseTree" | "unsupportedDirectoryEntry" | "unsupportedTreeEntry" | "missingDiffSpecAssociation";
+
 /**
  * Specifies a location, usually used to either have something inserted
  * relative to it, or for the selected object to actually be replaced.
@@ -924,7 +930,7 @@ export type UICommitCreateResult = {
   /** The new commit if one was created. */
   newCommit?: string | null;
   /** Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics. */
-  pathsToRejectedChanges: Array<[string, string]>;
+  pathsToRejectedChanges: Array<RejectedChange>;
   /**
    * Commits that have been replaced as a side-effect of the create/amend.
    * Maps `oldId → newId`.


### PR DESCRIPTION
This type would be useful for the front-end.

I used AI to generate this and I have no idea if it's correct. If it looks wrong, would someone else be able to pick this up? 🙏

Closes GB-1168