### PR TITLE
properly isolate the last remaining tests

### DIFF
--- a/crates/but-oxidize/src/lib.rs
+++ b/crates/but-oxidize/src/lib.rs
@@ -54,12 +54,25 @@ impl ObjectIdExt for gix::Id<'_> {
 }
 
 pub trait RepoExt {
+    /// Reopen a `git2` repository as a `gix` repository with the normal Git configuration chain.
+    ///
+    /// Use this for helpers that inspect worktree state or run filters and therefore must see
+    /// global ignores, `core.autocrlf`, and globally configured filters like Git LFS.
     fn to_gix_repo(&self) -> anyhow::Result<gix::Repository>;
+
+    /// Reopen a `git2` repository as an isolated `gix` repository for helpers that only need
+    /// object access and repository-local configuration.
+    fn to_isolated_gix_repo(&self) -> anyhow::Result<gix::Repository>;
 }
 
 impl RepoExt for &git2::Repository {
     fn to_gix_repo(&self) -> anyhow::Result<gix::Repository> {
         let repo = gix::open(self.path())?;
+        Ok(repo)
+    }
+
+    fn to_isolated_gix_repo(&self) -> anyhow::Result<gix::Repository> {
+        let repo = gix::open_opts(self.path(), gix::open::Options::isolated())?;
         Ok(repo)
     }
 }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -241,7 +241,7 @@ impl BranchManager<'_> {
         }
         branch.set_stack_head(
             &vb_state,
-            &(&*git2_repo).to_gix_repo()?,
+            &(&*git2_repo).to_isolated_gix_repo()?,
             head_commit.id().to_gix(),
         )?;
         self.ctx.add_branch_reference(&branch)?;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_core::{
-    RefMetadata, RepositoryExt,
+    GitConfigSettings, RefMetadata, RepositoryExt,
     ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
 };
 use but_ctx::Context;
@@ -29,7 +29,7 @@ pub fn writable_context(script_name: &str, repo_name: &str) -> Result<(Context, 
         } else {
             gix_testtools::Creation::CopyFromReadOnly
         },
-        3,
+        4,
         move |fixture| {
             if fixture.is_uninitialized() {
                 let repo = open_repo(&fixture.path().join(&repo_name_for_post))?;
@@ -50,7 +50,7 @@ pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> 
     let script_name_for_post = script_name.clone();
     let (root, _) = gix_testtools::scripted_fixture_read_only_with_post(
         script_name.clone(),
-        3,
+        4,
         move |fixture| {
             if fixture.is_uninitialized() {
                 if script_name_for_post == "for-listing.sh" {
@@ -75,6 +75,8 @@ pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> 
 }
 
 fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> Result<()> {
+    disable_gitbutler_commit_signing(repo)?;
+
     let stacks = match (script_name, repo_name) {
         ("reorder.sh", "multiple-commits") => vec![
             StackSpec {
@@ -154,6 +156,13 @@ fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> R
 
     write_workspace_metadata(repo, &stacks)?;
     Ok(())
+}
+
+fn disable_gitbutler_commit_signing(repo: &gix::Repository) -> Result<()> {
+    repo.set_git_settings(&GitConfigSettings {
+        gitbutler_sign_commits: Some(false),
+        ..Default::default()
+    })
 }
 
 fn write_workspace_metadata(repo: &gix::Repository, stacks: &[StackSpec<'_>]) -> Result<()> {

--- a/crates/gitbutler-cherry-pick/src/lib.rs
+++ b/crates/gitbutler-cherry-pick/src/lib.rs
@@ -68,7 +68,7 @@ impl RepositoryExt for git2::Repository {
         commit: &git2::Commit,
         side: ConflictedTreeKey,
     ) -> Result<git2::Tree<'_>> {
-        let gix_repo = self.to_gix_repo()?;
+        let gix_repo = self.to_isolated_gix_repo()?;
         let gix_commit = gix_repo.find_commit(commit.id().to_gix())?;
         let tree_id = gix_repo.find_real_tree(&gix_commit, side)?.to_git2();
         Ok(self.find_tree(tree_id)?)


### PR DESCRIPTION
This way `make nextest` runs through without problems, even if signatures don't work.
This also makes tests faster as they won't try to sign things (which might actually work).
Obviously they aren't testing exact hashes or they'd fail.

### Tasks

* [x] fix isolation properly after [something](https://github.com/gitbutlerapp/gitbutler/pull/12929#discussion_r2959070161) cam up in review
