### PR TITLE
gitbutler-edit-mode: edit edited commit directly

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -14,7 +14,7 @@ use but_oxidize::{ObjectIdExt as _, OidExt, gix_to_git2_index};
 use but_rebase::graph_rebase::{Editor, Step};
 use git2::build::CheckoutBuilder;
 use gitbutler_cherry_pick::{ConflictedTreeKey, GixRepositoryExt as _, RepositoryExt as _};
-use gitbutler_commit::commit_ext::{CommitExt, CommitMessageBstr as _};
+use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_operating_modes::{
     EDIT_BRANCH_REF, EditModeMetadata, INTEGRATION_BRANCH_REF, OperatingMode, WORKSPACE_BRANCH_REF,
     operating_mode, read_edit_mode_metadata, write_edit_mode_metadata,
@@ -66,63 +66,29 @@ fn get_commit_index(ctx: &Context, commit_id: gix::ObjectId) -> Result<git2::Ind
     }
 }
 
-/// Returns a commit to be the HEAD of `gitbutler/edit`
+/// Returns a commit to be the HEAD of `gitbutler/edit`.
 ///
-/// This should a commit who's tree is what the commit getting edited
-/// (the editee) is based on.
+/// If the edited commit is unconflicted, this is the edited commit itself.
 ///
-/// If the editee is conflicted:
-/// We should checkout `.conflict-side-0`. This is because the resulting merge
-/// is always based on top of `.conflict-side-0`, so this is the preferable
-/// base.
-///
-/// If the parent is conflicted:
-/// We should checkout the parent's `.auto-resolution` because that is what
-/// the editee is based on
-///
-/// Otherwise:
-/// We can simply return the parent commit.
+/// If the edited commit is conflicted, this is the edited commit except that
+/// the root tree is `.conflict-side-0`. This is because the resulting merge is
+/// always based on top of `.conflict-side-0`, so this is the preferable base.
 fn find_or_create_base_commit(
     repo: &gix::Repository,
     commit_id: gix::ObjectId,
 ) -> Result<gix::ObjectId> {
     let commit = repo.find_commit(commit_id)?;
-    let is_conflicted = commit.is_conflicted();
-    let parent = commit
-        .parent_ids()
-        .next()
-        .context("Expected commit to have a single parent")?
-        .object()?
-        .into_commit();
-    let is_parent_conflicted = parent.is_conflicted();
 
-    // If neither is conflicted, we can use the old parent.
-    if !(is_conflicted || is_parent_conflicted) {
-        return Ok(parent.id);
+    if !commit.is_conflicted() {
+        return Ok(commit_id);
     };
 
-    let base_tree = if is_conflicted {
-        repo.find_real_tree(&commit, ConflictedTreeKey::Ours)?
-    } else {
-        repo.find_real_tree(&parent, ConflictedTreeKey::AutoResolution)?
-    };
+    let base_tree = repo.find_real_tree(&commit, ConflictedTreeKey::Ours)?;
 
-    let author = repo
-        .author()
-        .context("author must be configured")??
-        .to_owned()?;
-    let committer = repo
-        .committer()
-        .context("committer must be configured")??
-        .to_owned()?;
     let commit = gix::objs::Commit {
         tree: base_tree.into(),
-        parents: Default::default(),
-        author,
-        committer,
-        encoding: None,
-        message: parent.message_bstr().to_owned(),
         extra_headers: Vec::new(),
+        ..gix::objs::Commit::try_from(commit.decode()?)?
     };
     Ok(repo.write_object(&commit)?.detach())
 }
@@ -173,6 +139,7 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
     git2_repo.checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))?;
 
     // Checkout the commit as unstaged changes
+    // TODO this may not be necessary if the commit is unconflicted
     let mut index = get_commit_index(ctx, commit_id)?;
 
     let their_commit_msg = commit

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -246,15 +246,15 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
         repo.head()?.peel_to_commit()?.summary(),
         @r#"
     Some(
-        "foobar",
+        "Changes to make millions",
     )
     "#
     );
 
     insta::assert_snapshot!(
         std::fs::read_to_string(repo.path().parent().unwrap().join("conflict"))?,
-        @"
-    <<<<<<< New base: foobar
+        @r"
+    <<<<<<< New base: Changes to make millions
     left
     ||||||| Common ancestor
     base

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -271,7 +271,7 @@ baz
 branch1 commit 1
 branch1 commit 2
 <<<<<` +
-			`<< New base: branch1: third commit
+			`<< New base: Conflicting change commit
 branch1 commit 3
 ||||||| Common ancestor
 =======
@@ -437,7 +437,7 @@ test("should be able gracefully handle adding a branch that is behind of our tar
 bar
 baz
 <<<<<` +
-			`<< New base: commit in base
+			`<< New base: branch1: first commit
 Update to main branch
 ||||||| Common ancestor
 =======
@@ -500,7 +500,7 @@ bar
 baz
 Update to main branch
 <<<<<` +
-			`<< New base: branch1: first commit
+			`<< New base: branch1: second commit
 branch1 commit 1
 ||||||| Common ancestor
 =======


### PR DESCRIPTION
When entering edit mode, a temporary commit needs to be created if
either the commit being edited (C) or the parent of the commit being
edited (P) is conflicted, so that (among other things) `git status`
shows something reasonable. Currently, this temporary commit is created
with no parents and P's commit message. This temporary commit becomes
the HEAD.

This is probably less user-friendly than it could be - the lack of
parents means that the user cannot see C's place in the commit graph,
and the duplicated commit message might make the user wonder if P was
also changed. However, either using C's parent or P's parent together
with P's commit message is confusing (if using C's parents, then we
have a commit with inconsistent parent and commit message; if using P's
parent, then we have a commit masquerading as P but is not P itself).

In an earlier version of this commit, I decided to write the commit
not with P's commit message but with a "(temporary commit)" message,
but after some brainstorming, we decided to instead have the HEAD be C
(or something like it) instead of P. In other words, something that is
more like `git rebase -i` -> `git commit -a --amend` instead of `git
reset --soft HEAD^` -> `git commit -a`. Therefore, it is C if it is not
conflicted; otherwise, it is C except that the tree is one of its sides
of the conflict.

Note that this is backwards compatible with exiting edit mode (because
exiting edit mode only uses the current index, not the current HEAD, so
it doesn't matter whether the HEAD is C, P, or in fact anything else).
This means that a user can enter edit mode with an old version of `but`
and exit it with a new version, or enter edit mode with a new and exit
it with an old.

There is also no change to the main UX - the user still enters edit
mode, resolves all conflicts (ideally), and exits it. Only the output of
commands like `git status` and `git log` changes (in my opinion, for the
better, especially for someone who is more used to the amending workflow
instead of the resetting and recommitting workflow).