### PR TITLE
feat(desktop): show a working indicator

### DIFF
--- a/apps/desktop/src/components/WorkingIndicator.svelte
+++ b/apps/desktop/src/components/WorkingIndicator.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { ActiveOperationIndicator } from "$lib/activeOperations.svelte";
+	import { onDestroy } from "svelte";
+
+	const indicator = new ActiveOperationIndicator();
+	onDestroy(() => indicator.destroy());
+</script>
+
+{#if indicator.visible}
+	<div class="working-indicator" role="status" aria-label="Operation in progress">
+		<div class="working-indicator__dot"></div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	.working-indicator {
+		z-index: var(--z-floating);
+		position: fixed;
+		bottom: 8px;
+		right: 8px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		pointer-events: none;
+	}
+
+	.working-indicator__dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background-color: var(--clr-theme-pop-element);
+		animation: pulse 1s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.4;
+			transform: scale(0.75);
+		}
+	}
+</style>

--- a/apps/desktop/src/lib/activeOperations.svelte.ts
+++ b/apps/desktop/src/lib/activeOperations.svelte.ts
@@ -1,0 +1,84 @@
+/**
+ * Tracks the number of currently in-flight backend operations.
+ * Uses a plain counter (not $state) to avoid interfering with
+ * Svelte's reactive effect scheduling when called from tauriInvoke.
+ */
+
+let activeCount = 0;
+let flushScheduled = false;
+let listeners: Array<(count: number) => void> = [];
+
+/**
+ * Schedule a deferred flush so $state mutations never happen
+ * synchronously inside the tauriInvoke call stack.
+ */
+function scheduleFlush() {
+	if (!flushScheduled) {
+		flushScheduled = true;
+		queueMicrotask(() => {
+			flushScheduled = false;
+			for (const listener of listeners) {
+				listener(activeCount);
+			}
+		});
+	}
+}
+
+export function trackOperation<T>(promise: Promise<T>): Promise<T> {
+	activeCount++;
+	scheduleFlush();
+	return promise.finally(() => {
+		activeCount--;
+		scheduleFlush();
+	});
+}
+
+/**
+ * Reactive indicator that subscribes to operation count changes.
+ * Uses a minimum visible duration so fast operations are still noticeable.
+ */
+export class ActiveOperationIndicator {
+	visible = $state(false);
+	private hideTimeout: ReturnType<typeof setTimeout> | undefined;
+	private readonly minVisibleMs: number;
+	private visibleSince: number | undefined;
+	private unsubscribe: (() => void) | undefined;
+
+	constructor(minVisibleMs = 150) {
+		this.minVisibleMs = minVisibleMs;
+		const onCountChange = (count: number) => {
+			if (count > 0) {
+				clearTimeout(this.hideTimeout);
+				if (!this.visible) {
+					this.visibleSince = performance.now();
+				}
+				this.visible = true;
+			} else if (this.visible) {
+				const elapsed = performance.now() - (this.visibleSince ?? 0);
+				const remaining = Math.max(0, this.minVisibleMs - elapsed);
+				if (remaining === 0) {
+					this.visible = false;
+					this.visibleSince = undefined;
+				} else {
+					this.hideTimeout = setTimeout(() => {
+						this.visible = false;
+						this.visibleSince = undefined;
+					}, remaining);
+				}
+			}
+		};
+		listeners.push(onCountChange);
+		this.unsubscribe = () => {
+			listeners = listeners.filter((l) => l !== onCountChange);
+		};
+		if (activeCount > 0) {
+			this.visibleSince = performance.now();
+			this.visible = true;
+		}
+	}
+
+	destroy() {
+		this.unsubscribe?.();
+		clearTimeout(this.hideTimeout);
+	}
+}

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1,3 +1,4 @@
+import { trackOperation } from "$lib/activeOperations.svelte";
 import { isReduxError } from "$lib/state/reduxError";
 import { getName, getVersion, getVersion as tauriGetVersion } from "@tauri-apps/api/app";
 import { invoke as invokeTauri } from "@tauri-apps/api/core";
@@ -285,14 +286,14 @@ async function tauriInvoke<T>(command: string, params: Record<string, unknown> =
 	// 	throw userError;
 	// });
 
-	try {
-		return await invokeTauri<T>(command, params);
-	} catch (error: unknown) {
-		if (isReduxError(error)) {
-			console.error(`ipc->${command}: ${JSON.stringify(params)}`, error);
-		}
-		throw error;
-	}
+	return trackOperation(
+		invokeTauri<T>(command, params).catch((error: unknown) => {
+			if (isReduxError(error)) {
+				console.error(`ipc->${command}: ${JSON.stringify(params)}`, error);
+			}
+			throw error;
+		}),
+	);
 }
 
 function tauriListen<T>(event: EventName, handle: EventCallback<T>) {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { afterNavigate, beforeNavigate } from "$app/navigation";
 	import { page } from "$app/state";
 	import AppUpdater from "$components/AppUpdater.svelte";
+	import WorkingIndicator from "$components/WorkingIndicator.svelte";
 	import FocusCursor from "$components/FocusCursor.svelte";
 	import GlobalModal from "$components/GlobalModal.svelte";
 	import GlobalSettingsMenuAction from "$components/GlobalSettingsMenuAction.svelte";
@@ -172,6 +173,7 @@
 <div class="app-root" role="application" oncontextmenu={(e) => !dev && e.preventDefault()}>
 	{@render children()}
 </div>
+<WorkingIndicator />
 <ShareIssueModal />
 <ToastController />
 <ChipToastContainer />


### PR DESCRIPTION
## 🧢 Changes

this PR is a small UX improvement that i found myself wishing for constantly: show a small visual indicator whenever *any* operation is happening, somewhere that is readily visible.

## ☕️ Reasoning

while a lot of operations come with a dedicated loading state (like showing a spinner on a button), a lot of operations dont have any kind of interaction/loading indicator. which has lead to a number of times where i thought i clicked an item in a dropdown (like squash all commits) only to sit there staring waiting for it to finish... to then realize i didnt actually click it lmao

so by putting a persistent and consistent visual indicator that the app is working on something, it helps address confusion for interactions where its difficult to provide a good loading state.

## 📌 Todos

the only things i'm not 100% are:
- the positioning of the indicator in the bottom right is not my favorite thing. maybe it belongs in the header? it can sorta clash with toasts rn (it shows above the very bottom right corner of the toast)
- the way we're wrapping `invokeTauri` in `trackOperation` feels a little gross to me since it requires you to use promise methods instead of try/catch w/ async/await buuuut at the same time wrapping the entire async block in `trackOperation` would nest the code a lot more. eh /shrug

## 🎮 Demo

(pay attention to the bottom right corner of the window)

https://github.com/user-attachments/assets/f0d080c3-64f4-4c1e-ab3d-929142099d5b