### PR TITLE
fix: make installer shell detection prefer the reported shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
  "curl",
  "dirs 6.0.0",
  "flate2",
+ "insta",
  "minisign-verify",
  "owo-colors",
  "serde",

--- a/crates/but-installer/Cargo.toml
+++ b/crates/but-installer/Cargo.toml
@@ -45,5 +45,8 @@ xattr = "1.6.1"
 # I couldn't make it work without the ssl feature enabled, it doesn't dynamically link to libssl without it so https just doesn't work
 curl = { version = "0.4.49", default-features = false, features = ["ssl"] }
 
+[dev-dependencies]
+insta.workspace = true
+
 [lints]
 workspace = true

--- a/crates/but-installer/src/shell.rs
+++ b/crates/but-installer/src/shell.rs
@@ -149,18 +149,12 @@ fn preferred_shell_config_path(
     fish_config: &Path,
     zshrc: &Path,
     bash_profile: &Path,
-    bashrc: &Path,
+    _bashrc: &Path,
 ) -> PathBuf {
     match shell_type {
         ShellType::Fish => fish_config.to_path_buf(),
         ShellType::Zsh => zshrc.to_path_buf(),
-        ShellType::Bash => {
-            if bash_profile.exists() {
-                bash_profile.to_path_buf()
-            } else {
-                bashrc.to_path_buf()
-            }
-        }
+        ShellType::Bash => bash_profile.to_path_buf(),
     }
 }
 
@@ -271,6 +265,8 @@ fn setup_posix_shell_config(
     let path_cmd = format!("export PATH=\"{}:$PATH\"", bin_dir.display());
     let completion_cmd = shell_type.completion_command();
 
+    prepare_posix_shell_config(shell_config, shell_type)?;
+
     let contents = fs::read_to_string(shell_config).unwrap_or_default();
 
     // Check for PATH setup with more robust detection
@@ -376,6 +372,44 @@ fn setup_posix_shell_config(
     Ok(())
 }
 
+/// On macOS, Bash typically reads `~/.bash_profile` for login shells instead of
+/// `~/.bashrc`. If we are about to update a missing `.bash_profile` and a
+/// `.bashrc` already exists, create `.bash_profile` first and source `.bashrc`
+/// from it so existing user configuration continues to apply.
+#[cfg(target_os = "macos")]
+fn prepare_posix_shell_config(shell_config: &Path, shell_type: ShellType) -> Result<()> {
+    if shell_type != ShellType::Bash || shell_config.exists() {
+        return Ok(());
+    }
+
+    let Some(file_name) = shell_config.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    if file_name != ".bash_profile" {
+        return Ok(());
+    }
+
+    let bashrc = shell_config.with_file_name(".bashrc");
+    if !bashrc.exists() {
+        return Ok(());
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(shell_config)?;
+    writeln!(file, "if [ -f \"$HOME/.bashrc\" ]; then")?;
+    writeln!(file, "  . \"$HOME/.bashrc\"")?;
+    writeln!(file, "fi")?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn prepare_posix_shell_config(_shell_config: &Path, _shell_type: ShellType) -> Result<()> {
+    Ok(())
+}
+
 fn print_manual_setup_instructions(bin_dir: &Path, already_in_path: bool) {
     ui::println_empty();
     warn("Could not detect your shell configuration file");
@@ -452,6 +486,49 @@ mod tests {
         assert_eq!(detected, Some((zshrc, ShellType::Zsh)));
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_detect_shell_config_prefers_bash_profile_when_bash_has_no_existing_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path();
+        let fish_config = home_dir.join(".config/fish/config.fish");
+        let zshrc = home_dir.join(".zshrc");
+        let bash_profile = home_dir.join(".bash_profile");
+        let bashrc = home_dir.join(".bashrc");
+
+        let detected = detect_shell_config_with_preference(
+            Some(ShellType::Bash),
+            &fish_config,
+            &zshrc,
+            &bash_profile,
+            &bashrc,
+        );
+
+        assert_eq!(detected, Some((bash_profile, ShellType::Bash)));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_detect_shell_config_prefers_bash_profile_when_only_bashrc_exists() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path();
+        let fish_config = home_dir.join(".config/fish/config.fish");
+        let zshrc = home_dir.join(".zshrc");
+        let bash_profile = home_dir.join(".bash_profile");
+        let bashrc = home_dir.join(".bashrc");
+        std::fs::write(&bashrc, "# existing bashrc").unwrap();
+
+        let detected = detect_shell_config_with_preference(
+            Some(ShellType::Bash),
+            &fish_config,
+            &zshrc,
+            &bash_profile,
+            &bashrc,
+        );
+
+        assert_eq!(detected, Some((bash_profile, ShellType::Bash)));
+    }
+
     #[test]
     fn test_setup_posix_shell_config_creates_missing_config() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -469,6 +546,32 @@ mod tests {
         # Added by GitButler installer
         export PATH="$BIN_DIR:$PATH"
         eval "$(but completions zsh)"
+        "#);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_setup_posix_shell_config_creates_bash_profile_that_sources_bashrc() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path();
+        let bin_dir = home_dir.join(".local/bin");
+        let bash_profile = home_dir.join(".bash_profile");
+        let bashrc = home_dir.join(".bashrc");
+        std::fs::write(&bashrc, "# existing bashrc").unwrap();
+
+        setup_posix_shell_config(&bash_profile, ShellType::Bash, &bin_dir, false).unwrap();
+
+        let content = std::fs::read_to_string(&bash_profile)
+            .unwrap()
+            .replace(&bin_dir.display().to_string(), "$BIN_DIR");
+        insta::assert_snapshot!(content, @r#"
+        if [ -f "$HOME/.bashrc" ]; then
+          . "$HOME/.bashrc"
+        fi
+
+        # Added by GitButler installer
+        export PATH="$BIN_DIR:$PATH"
+        eval "$(but completions bash)"
         "#);
     }
 

--- a/crates/but-installer/src/shell.rs
+++ b/crates/but-installer/src/shell.rs
@@ -35,6 +35,15 @@ impl ShellType {
             ShellType::Fish => "fish",
         }
     }
+
+    fn from_process_name(name: &str) -> Option<Self> {
+        match name.trim_start_matches('-') {
+            "zsh" => Some(ShellType::Zsh),
+            "bash" => Some(ShellType::Bash),
+            "fish" => Some(ShellType::Fish),
+            _ => None,
+        }
+    }
 }
 
 pub(crate) fn setup_path(home_dir: &Path) -> Result<()> {
@@ -73,18 +82,19 @@ pub(crate) fn setup_path(home_dir: &Path) -> Result<()> {
         success(&format!("{} is already in your PATH", bin_dir.display()));
     }
 
-    // Detect shell config file
     let fish_config = home_dir.join(".config/fish/config.fish");
     let zshrc = home_dir.join(".zshrc");
     let bash_profile = home_dir.join(".bash_profile");
     let bashrc = home_dir.join(".bashrc");
 
-    if fish_config.exists() {
-        setup_fish_config(&fish_config, &bin_dir, already_in_path)?;
-    } else if let Some((shell_config, shell_type)) =
-        detect_shell_config(&zshrc, &bash_profile, &bashrc)
+    if let Some((shell_config, shell_type)) =
+        detect_shell_config(&fish_config, &zshrc, &bash_profile, &bashrc)
     {
-        setup_posix_shell_config(&shell_config, shell_type, &bin_dir, already_in_path)?;
+        if shell_type == ShellType::Fish {
+            setup_fish_config(&shell_config, &bin_dir, already_in_path)?;
+        } else {
+            setup_posix_shell_config(&shell_config, shell_type, &bin_dir, already_in_path)?;
+        }
     } else {
         print_manual_setup_instructions(&bin_dir, already_in_path);
     }
@@ -92,13 +102,93 @@ pub(crate) fn setup_path(home_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+fn detect_shell_from_env() -> Option<ShellType> {
+    let shell = env::var_os("SHELL")?;
+    let shell_name = Path::new(&shell)
+        .file_name()
+        .and_then(|name| name.to_str())?;
+
+    ShellType::from_process_name(shell_name)
+}
+
 fn detect_shell_config(
+    fish_config: &Path,
     zshrc: &Path,
     bash_profile: &Path,
     bashrc: &Path,
 ) -> Option<(PathBuf, ShellType)> {
-    if zshrc.exists() {
+    detect_shell_config_with_preference(
+        detect_shell_from_env(),
+        fish_config,
+        zshrc,
+        bash_profile,
+        bashrc,
+    )
+}
+
+fn detect_shell_config_with_preference(
+    preferred_shell: Option<ShellType>,
+    fish_config: &Path,
+    zshrc: &Path,
+    bash_profile: &Path,
+    bashrc: &Path,
+) -> Option<(PathBuf, ShellType)> {
+    if let Some(shell_type) = preferred_shell {
+        return Some((
+            preferred_shell_config_path(shell_type, fish_config, zshrc, bash_profile, bashrc),
+            shell_type,
+        ));
+    }
+
+    detect_shell_config_from_existing_files(fish_config, zshrc, bash_profile, bashrc)
+}
+
+#[cfg(target_os = "macos")]
+fn preferred_shell_config_path(
+    shell_type: ShellType,
+    fish_config: &Path,
+    zshrc: &Path,
+    bash_profile: &Path,
+    bashrc: &Path,
+) -> PathBuf {
+    match shell_type {
+        ShellType::Fish => fish_config.to_path_buf(),
+        ShellType::Zsh => zshrc.to_path_buf(),
+        ShellType::Bash => {
+            if bash_profile.exists() {
+                bash_profile.to_path_buf()
+            } else {
+                bashrc.to_path_buf()
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn preferred_shell_config_path(
+    shell_type: ShellType,
+    fish_config: &Path,
+    zshrc: &Path,
+    _bash_profile: &Path,
+    bashrc: &Path,
+) -> PathBuf {
+    match shell_type {
+        ShellType::Fish => fish_config.to_path_buf(),
+        ShellType::Zsh => zshrc.to_path_buf(),
+        ShellType::Bash => bashrc.to_path_buf(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_shell_config_from_existing_files(
+    fish_config: &Path,
+    zshrc: &Path,
+    bash_profile: &Path,
+    bashrc: &Path,
+) -> Option<(PathBuf, ShellType)> {
+    if fish_config.exists() {
+        Some((fish_config.to_path_buf(), ShellType::Fish))
+    } else if zshrc.exists() {
         Some((zshrc.to_path_buf(), ShellType::Zsh))
     } else if bash_profile.exists() {
         Some((bash_profile.to_path_buf(), ShellType::Bash))
@@ -110,14 +200,17 @@ fn detect_shell_config(
 }
 
 #[cfg(target_os = "linux")]
-fn detect_shell_config(
+fn detect_shell_config_from_existing_files(
+    fish_config: &Path,
     zshrc: &Path,
     // bash_profile is only sourced when executing a login shell, which is rarely how shells are
     // invoked on Linux distros. Therefore, we ignore it when detecting shell config on Linux.
     _bash_profile: &Path,
     bashrc: &Path,
 ) -> Option<(PathBuf, ShellType)> {
-    if zshrc.exists() {
+    if fish_config.exists() {
+        Some((fish_config.to_path_buf(), ShellType::Fish))
+    } else if zshrc.exists() {
         Some((zshrc.to_path_buf(), ShellType::Zsh))
     } else if bashrc.exists() {
         Some((bashrc.to_path_buf(), ShellType::Bash))
@@ -216,7 +309,11 @@ fn setup_posix_shell_config(
     }
 
     // Try to add to config file
-    match OpenOptions::new().append(true).open(shell_config) {
+    match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(shell_config)
+    {
         Ok(mut file) => {
             writeln!(file)?;
             writeln!(file, "# Added by GitButler installer")?;
@@ -322,6 +419,57 @@ mod tests {
         assert_eq!(ShellType::Zsh.name(), "zsh");
         assert_eq!(ShellType::Bash.name(), "bash");
         assert_eq!(ShellType::Fish.name(), "fish");
+    }
+
+    #[test]
+    fn test_shell_type_from_process_name() {
+        assert_eq!(ShellType::from_process_name("zsh"), Some(ShellType::Zsh));
+        assert_eq!(ShellType::from_process_name("-bash"), Some(ShellType::Bash));
+        assert_eq!(ShellType::from_process_name("fish"), Some(ShellType::Fish));
+        assert_eq!(ShellType::from_process_name("sh"), None);
+    }
+
+    #[test]
+    fn test_detect_shell_config_prefers_reported_shell_over_existing_fish_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path();
+        let fish_config = home_dir.join(".config/fish/config.fish");
+        let zshrc = home_dir.join(".zshrc");
+        let bash_profile = home_dir.join(".bash_profile");
+        let bashrc = home_dir.join(".bashrc");
+
+        std::fs::create_dir_all(fish_config.parent().unwrap()).unwrap();
+        std::fs::write(&fish_config, "but completions fish | source").unwrap();
+
+        let detected = detect_shell_config_with_preference(
+            Some(ShellType::Zsh),
+            &fish_config,
+            &zshrc,
+            &bash_profile,
+            &bashrc,
+        );
+
+        assert_eq!(detected, Some((zshrc, ShellType::Zsh)));
+    }
+
+    #[test]
+    fn test_setup_posix_shell_config_creates_missing_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path();
+        let bin_dir = home_dir.join(".local/bin");
+        let zshrc = home_dir.join(".zshrc");
+
+        setup_posix_shell_config(&zshrc, ShellType::Zsh, &bin_dir, false).unwrap();
+
+        let content = std::fs::read_to_string(&zshrc)
+            .unwrap()
+            .replace(&bin_dir.display().to_string(), "$BIN_DIR");
+        insta::assert_snapshot!(content, @r#"
+
+        # Added by GitButler installer
+        export PATH="$BIN_DIR:$PATH"
+        eval "$(but completions zsh)"
+        "#);
     }
 
     #[test]


### PR DESCRIPTION
## Tasks

* [x] refackiew


## Question for the reviewer

Is there a good reason to *not* use `$SHELL`? For all I know, it's only set by the login shell and future sub-shells inherit it.

----

## 🧢 Changes
- prefer the shell reported by `$SHELL` before falling back to config-file heuristics
- stop a stray fish config from overriding zsh/bash setup during installation
- create the selected POSIX shell config file when it does not exist yet, and add regression tests for the selection logic

## ☕️ Reasoning
The installer was picking fish whenever `~/.config/fish/config.fish` existed, even for users running the install from a zsh environment via `curl ... | sh`. Using the reported shell first matches the user's configured terminal shell and fixes the incorrect completion instructions from #12931.

## 🎫 Affected issues
Closes #12931

## ✅ Verification
- `cargo test -p but-installer`
