### PR TITLE
Allow submodules to be added as projects

### DIFF
--- a/crates/but-project-handle/src/project_handle.rs
+++ b/crates/but-project-handle/src/project_handle.rs
@@ -29,8 +29,8 @@ pub enum ProjectHandleOrLegacyProjectId {
 /// Lifecycle
 impl ProjectHandle {
     /// Create a project handle from `path`.
-    /// Note that this *should* be the git-dir as it's the most stable, and also allows to quickly check
-    /// for duplication if this convention is followed.
+    /// Note that this *should* be the git-dir as it's the most stable, and also
+    /// allows to quickly check for duplication if this convention is followed.
     /// This is also needed to support bare repositories properly.
     pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = gix::path::realpath(path)?;

--- a/crates/but-project-handle/src/project_handle.rs
+++ b/crates/but-project-handle/src/project_handle.rs
@@ -29,6 +29,9 @@ pub enum ProjectHandleOrLegacyProjectId {
 /// Lifecycle
 impl ProjectHandle {
     /// Create a project handle from `path`.
+    /// Note that this *should* be the git-dir as it's the most stable, and also allows to quickly check
+    /// for duplication if this convention is followed.
+    /// This is also needed to support bare repositories properly.
     pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = gix::path::realpath(path)?;
         path_to_string(&path).map(Self)

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use but_error::Code;
@@ -10,6 +10,71 @@ use crate::{AuthKey, ProjectHandle, ProjectHandleOrLegacyProjectId, project::Add
 pub(crate) struct Controller {
     local_data_dir: PathBuf,
     projects_storage: storage::Storage,
+}
+
+struct ResolvedProjectRepo {
+    repo: gix::Repository,
+    worktree_dir: PathBuf,
+}
+
+#[expect(clippy::result_large_err)]
+fn normalize_project_repo(
+    repo: gix::Repository,
+) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
+    if repo.is_bare() {
+        return Err(AddProjectOutcome::BareRepository);
+    }
+    // Submodules also use a `.git` file in the worktree, so the repository identity must come
+    // from the resolved gitdir instead of the worktree-local `.git` entry.
+    if repo.worktree().is_some_and(|wt| !wt.is_main()) {
+        return Err(AddProjectOutcome::NonMainWorktree);
+    }
+
+    let Some(worktree_dir) = repo.workdir().map(ToOwned::to_owned) else {
+        return Err(AddProjectOutcome::NoWorkdir);
+    };
+
+    Ok(ResolvedProjectRepo { repo, worktree_dir })
+}
+
+#[expect(clippy::result_large_err)]
+fn resolve_project_repo_exact(
+    path: &Path,
+) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
+    let repo = match gix::open_opts(path, gix::open::Options::isolated()) {
+        Ok(repo) => repo,
+        Err(err) => return Err(AddProjectOutcome::NotAGitRepository(err.to_string())),
+    };
+
+    normalize_project_repo(repo)
+}
+
+#[expect(clippy::result_large_err)]
+fn resolve_project_repo_by_discovery(
+    path: &Path,
+) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
+    let repo = match gix::discover(path) {
+        Ok(repo) => repo,
+        Err(err) => return Err(AddProjectOutcome::NotAGitRepository(err.to_string())),
+    };
+
+    normalize_project_repo(repo)
+}
+
+fn find_existing_project_by_git_dir(
+    all_projects: &[Project],
+    git_dir: &Path,
+) -> Result<Option<Project>> {
+    for project in all_projects {
+        let project = project
+            .clone()
+            .migrated()
+            .unwrap_or_else(|_| project.clone());
+        if project.git_dir_opt() == Some(git_dir) {
+            return Ok(Some(project));
+        }
+    }
+    Ok(None)
 }
 
 impl Controller {
@@ -65,97 +130,68 @@ impl Controller {
         worktree_dir: P,
     ) -> Result<AddProjectOutcome> {
         let worktree_dir = worktree_dir.as_ref();
+        if !worktree_dir.exists() {
+            return Ok(AddProjectOutcome::PathNotFound);
+        }
+        if !worktree_dir.is_dir() {
+            return Ok(AddProjectOutcome::NotADirectory);
+        }
 
         let all_projects = self
             .projects_storage
             .list()
             .context("failed to list projects from storage")?;
-
         let resolved_path = gix::path::realpath(worktree_dir)?;
-        // Check if any existing project contains the given path
-        if let Some(existing_project) = all_projects.iter().find(|project| {
-            resolved_path.starts_with(project.worktree_dir_but_should_use_git_dir())
-        }) {
-            return Ok(AddProjectOutcome::AlreadyExists(
-                existing_project.clone().migrated()?,
-            ));
+        let resolved_repo = match resolve_project_repo_by_discovery(&resolved_path) {
+            Ok(repo) => repo,
+            Err(outcome) => return Ok(outcome),
+        };
+
+        if let Some(existing_project) =
+            find_existing_project_by_git_dir(&all_projects, resolved_repo.repo.git_dir())?
+        {
+            return Ok(AddProjectOutcome::AlreadyExists(existing_project));
         }
 
-        self.add(worktree_dir)
+        self.add(resolved_repo.worktree_dir)
     }
 
     pub(crate) fn add(&self, worktree_dir: impl AsRef<Path>) -> Result<AddProjectOutcome> {
         let worktree_dir = worktree_dir.as_ref();
+        if !worktree_dir.exists() {
+            return Ok(AddProjectOutcome::PathNotFound);
+        }
+        if !worktree_dir.is_dir() {
+            return Ok(AddProjectOutcome::NotADirectory);
+        }
         let resolved_path = gix::path::realpath(worktree_dir)?;
+        let resolved_repo = match resolve_project_repo_exact(&resolved_path) {
+            Ok(repo) => repo,
+            Err(outcome) => return Ok(outcome),
+        };
         let all_projects = self
             .projects_storage
             .list()
             .context("failed to list projects from storage")?;
-        if let Some(existing_project) = all_projects
-            .iter()
-            .find(|project| project.worktree_dir_but_should_use_git_dir() == resolved_path)
+        if let Some(existing_project) =
+            find_existing_project_by_git_dir(&all_projects, resolved_repo.repo.git_dir())?
         {
-            return Ok(AddProjectOutcome::AlreadyExists(
-                existing_project.clone().migrated()?,
-            ));
+            return Ok(AddProjectOutcome::AlreadyExists(existing_project));
         }
-        if !resolved_path.exists() {
-            return Ok(AddProjectOutcome::PathNotFound);
-        }
-        if !resolved_path.is_dir() {
-            return Ok(AddProjectOutcome::NotADirectory);
-        }
-        // Make sure the repo is opened from the resolved path - it must be absolute for persistence.
-        let repo = match gix::open_opts(&resolved_path, gix::open::Options::isolated()) {
-            Ok(repo) if repo.is_bare() => {
-                return Ok(AddProjectOutcome::BareRepository);
-            }
-            Ok(repo) if repo.worktree().is_some_and(|wt| !wt.is_main()) => {
-                if worktree_dir.join(".git").is_file() {
-                    return Ok(AddProjectOutcome::NonMainWorktree);
-                };
-                repo
-            }
-            Ok(repo) => match repo.workdir() {
-                None => {
-                    return Ok(AddProjectOutcome::NoWorkdir);
-                }
-                Some(wd) => {
-                    if !wd.join(".git").is_dir() {
-                        return Ok(AddProjectOutcome::NoDotGitDirectory);
-                    }
-                    repo
-                }
-            },
-            Err(err) => {
-                return Ok(AddProjectOutcome::NotAGitRepository(err.to_string()));
-            }
-        };
-
+        let repo = resolved_repo.repo;
         let id = ProjectHandleOrLegacyProjectId::ProjectHandle(ProjectHandle::from_path(
             repo.git_dir(),
         )?);
 
-        // Resolve the path first to get the actual directory name
-        let title_is_not_normal_component = worktree_dir
-            .components()
-            .next_back()
-            .is_none_or(|c| !matches!(c, Component::Normal(_)));
-        let path_for_title = if title_is_not_normal_component {
-            &resolved_path
-        } else {
-            worktree_dir
-        };
-
-        let title = path_for_title.file_name().map_or_else(
-            || resolved_path.display().to_string(),
+        let title = resolved_repo.worktree_dir.file_name().map_or_else(
+            || resolved_repo.worktree_dir.display().to_string(),
             |name| name.to_string_lossy().into_owned(),
         );
 
         let project = Project {
             title,
             // TODO(1.0): make this always `None`, until the field can be removed for good.
-            worktree_dir: resolved_path,
+            worktree_dir: resolved_repo.worktree_dir,
             api: None,
             git_dir: repo.git_dir().to_owned(),
             ..Project::default_with_id(id)

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -77,6 +77,37 @@ fn find_existing_project_by_git_dir(
     Ok(None)
 }
 
+fn find_existing_project_containing_path(
+    all_projects: &[Project],
+    path: &Path,
+) -> Result<Option<Project>> {
+    let mut best_match: Option<(usize, Project)> = None;
+
+    for project in all_projects {
+        let project = project
+            .clone()
+            .migrated()
+            .unwrap_or_else(|_| project.clone());
+        let Ok(project_worktree_dir) = gix::path::realpath(&project.worktree_dir) else {
+            continue;
+        };
+
+        if !path.starts_with(&project_worktree_dir) {
+            continue;
+        }
+
+        let candidate_len = project_worktree_dir.as_os_str().len();
+        if best_match
+            .as_ref()
+            .is_none_or(|(best_len, _)| candidate_len > *best_len)
+        {
+            best_match = Some((candidate_len, project));
+        }
+    }
+
+    Ok(best_match.map(|(_, project)| project))
+}
+
 impl Controller {
     /// Assure we can list projects, and if not possibly existing projects files will be renamed, and an error is produced early.
     pub(crate) fn assure_app_can_startup_or_fix_it(
@@ -133,15 +164,20 @@ impl Controller {
         if !worktree_dir.exists() {
             return Ok(AddProjectOutcome::PathNotFound);
         }
-        if !worktree_dir.is_dir() {
-            return Ok(AddProjectOutcome::NotADirectory);
-        }
 
         let all_projects = self
             .projects_storage
             .list()
             .context("failed to list projects from storage")?;
         let resolved_path = gix::path::realpath(worktree_dir)?;
+        if !resolved_path.is_dir() {
+            if let Some(existing_project) =
+                find_existing_project_containing_path(&all_projects, &resolved_path)?
+            {
+                return Ok(AddProjectOutcome::AlreadyExists(existing_project));
+            }
+            return Ok(AddProjectOutcome::NotADirectory);
+        }
         let resolved_repo = match resolve_project_repo_by_discovery(&resolved_path) {
             Ok(repo) => repo,
             Err(outcome) => return Ok(outcome),

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -70,13 +70,15 @@ pub fn add<P: AsRef<Path>>(path: P) -> anyhow::Result<AddProjectOutcome> {
     add_at_app_data_dir(but_path::app_data_dir()?, path)
 }
 
+/// This is very much like [`gix::discover()`] compared to [`gix::open()`] in [`add()`].
 pub fn add_with_best_effort<P: AsRef<Path>>(path: P) -> anyhow::Result<AddProjectOutcome> {
     let controller = Controller::from_path(but_path::app_data_dir()?);
     controller.add_with_best_effort(path)
 }
 
-/// Like [`Controller::add_with_best_effort()`], but it allows to obtain a controller from `app_data_dir` directly,
+/// Like [`add_with_best_effort()`], but it allows to obtain a controller from `app_data_dir` directly,
 /// without relying on globals. This helps with isolation, particularly in tests.
+/// This is very much like [`gix::discover()`]
 pub fn add_with_best_effort_at_app_data_dir(
     app_data_dir: impl AsRef<Path>,
     path: impl AsRef<Path>,

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -75,6 +75,16 @@ pub fn add_with_best_effort<P: AsRef<Path>>(path: P) -> anyhow::Result<AddProjec
     controller.add_with_best_effort(path)
 }
 
+/// Like [`Controller::add_with_best_effort()`], but it allows to obtain a controller from `app_data_dir` directly,
+/// without relying on globals. This helps with isolation, particularly in tests.
+pub fn add_with_best_effort_at_app_data_dir(
+    app_data_dir: impl AsRef<Path>,
+    path: impl AsRef<Path>,
+) -> anyhow::Result<AddProjectOutcome> {
+    let controller = Controller::from_path(app_data_dir.as_ref());
+    controller.add_with_best_effort(path)
+}
+
 /// Control the `app_data_dir` at which the project is supposed to be added.
 ///
 /// Useful mostly for testing, and a reminder that we want to keep project metadata with the project,

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -254,22 +254,20 @@ impl Project {
             .to_owned();
         Ok(true)
     }
-
-    pub(crate) fn worktree_dir_but_should_use_git_dir(&self) -> &Path {
-        &self.worktree_dir
-    }
 }
 
 /// Instantiation
 impl Project {
     /// Search upwards from `path` to discover a Git worktree.
     pub fn from_path(path: &Path) -> anyhow::Result<Project> {
-        let worktree_dir = gix::discover(path)?
+        let repo = gix::discover(path)?;
+        let worktree_dir = repo
             .workdir()
             .context("Bare repositories aren't supported")?
             .to_owned();
-        let project_id =
-            ProjectHandleOrLegacyProjectId::ProjectHandle(ProjectHandle::from_path(&worktree_dir)?);
+        let project_id = ProjectHandleOrLegacyProjectId::ProjectHandle(ProjectHandle::from_path(
+            repo.git_dir(),
+        )?);
         Project {
             worktree_dir,
             ..Project::default_with_id(project_id)
@@ -339,7 +337,10 @@ impl Project {
     /// Set the worktree directory to `repo_path`, the worktree or git dir.
     pub fn set_worktree_dir(&mut self, repo_path: PathBuf) -> anyhow::Result<()> {
         let repo = gix::open_opts(&repo_path, gix::open::Options::isolated())?;
-        self.worktree_dir = repo_path;
+        self.worktree_dir = repo
+            .workdir()
+            .context("BUG: we currently only support non-bare repos, yet this one didn't have a worktree dir")?
+            .to_owned();
         self.git_dir = repo.git_dir().to_owned();
         Ok(())
     }
@@ -351,6 +352,10 @@ impl Project {
             "BUG: must call `project.migrated()` before using the git_dir to have it initialised."
         );
         &self.git_dir
+    }
+
+    pub(crate) fn git_dir_opt(&self) -> Option<&Path> {
+        (!self.git_dir.as_os_str().is_empty()).then_some(&self.git_dir)
     }
 
     /// Returns the path to the directory containing the `GitButler` state for this project.

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -92,7 +92,7 @@ mod add {
         assert_eq!(
             serde_json::to_value(&project)?["path"],
             serde_json::Value::String(submodule.display().to_string()),
-            "path is thw worktree directory (and deprecated, hence the access workaround)"
+            "path is the worktree directory (and deprecated, hence the access workaround)"
         );
         assert_eq!(
             project.open_isolated_repo()?.gitbutler_storage_path()?,
@@ -154,6 +154,32 @@ mod add {
         Ok(())
     }
 
+    /// Used in deep-links for instance
+    #[test]
+    fn best_effort_finds_existing_project_from_file_path() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), repo.path())?.unwrap_project();
+        let file_path = repo.path().join("nested/inside/file.txt");
+        std::fs::create_dir_all(file_path.parent().expect("file has parent"))?;
+        std::fs::write(&file_path, "hello world")?;
+
+        let outcome =
+            gitbutler_project::add_with_best_effort_at_app_data_dir(data_dir.path(), &file_path)?;
+        let existing_project = match outcome {
+            gitbutler_project::AddProjectOutcome::AlreadyExists(project) => project,
+            other => panic!("expected existing project to be found, got {other:?}"),
+        };
+
+        assert_eq!(
+            existing_project.id, project.id,
+            "it finds the containing project even if a filepath is given"
+        );
+        assert_eq!(existing_project.git_dir(), project.git_dir());
+        Ok(())
+    }
+
     mod error {
         use gitbutler_project::AddProjectOutcome;
 
@@ -198,15 +224,32 @@ mod add {
         }
 
         #[test]
-        fn nested_directory_inside_repo_is_not_added_by_exact_path() {
+        fn nested_directory_inside_repo_is_not_added_by_exact_path_but_is_by_best_effort() {
             let data_dir = paths::data_dir();
             let repo = gitbutler_testsupport::TestProject::default();
             let nested_dir = repo.path().join("nested/inside");
             std::fs::create_dir_all(&nested_dir).unwrap();
+            let project = gitbutler_project::add_at_app_data_dir(data_dir.path(), repo.path())
+                .unwrap()
+                .unwrap_project();
 
             let outcome =
                 gitbutler_project::add_at_app_data_dir(data_dir.path(), &nested_dir).unwrap();
             assert!(matches!(outcome, AddProjectOutcome::NotAGitRepository(_)));
+
+            let outcome = gitbutler_project::add_with_best_effort_at_app_data_dir(
+                data_dir.path(),
+                &nested_dir,
+            )
+            .unwrap();
+            let existing_project = match outcome {
+                AddProjectOutcome::AlreadyExists(project) => project,
+                other => panic!("expected owning project to be found, got {other:?}"),
+            };
+            assert_eq!(
+                existing_project.id, project.id,
+                "With best effort, we find the surrounding project, it's like discover"
+            );
         }
 
         #[test]

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use but_core::RepositoryExt;
 use gitbutler_testsupport::{self, paths};
 use tempfile::TempDir;
@@ -8,6 +10,17 @@ pub fn new() -> TempDir {
 
 fn storage_key() -> String {
     but_project_handle::storage_path_config_key().to_owned()
+}
+
+fn repo_path_at(name: &str) -> PathBuf {
+    gitbutler_testsupport::gix_testtools::scripted_fixture_read_only("various-repositories.sh")
+        .unwrap()
+        .join(name)
+}
+
+fn writable_fixture() -> TempDir {
+    gitbutler_testsupport::gix_testtools::scripted_fixture_writable("various-repositories.sh")
+        .unwrap()
 }
 
 mod add {
@@ -64,9 +77,84 @@ mod add {
         Ok(())
     }
 
-    mod error {
-        use std::path::PathBuf;
+    #[test]
+    fn submodule_is_added_as_project() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let fixture = writable_fixture();
+        let superproject = fixture.path().join("with-submodule").canonicalize()?;
+        let submodule = superproject.join("submodule");
+        let expected_git_dir = superproject.join(".git/modules/submodule").canonicalize()?;
 
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), &submodule)?.unwrap_project();
+
+        assert_eq!(project.git_dir(), expected_git_dir.as_path());
+        assert_eq!(
+            serde_json::to_value(&project)?["path"],
+            serde_json::Value::String(submodule.display().to_string()),
+            "path is thw worktree directory (and deprecated, hence the access workaround)"
+        );
+        assert_eq!(
+            project.open_isolated_repo()?.gitbutler_storage_path()?,
+            expected_git_dir.join("gitbutler")
+        );
+
+        let loaded = gitbutler_project::get_with_path(data_dir.path(), project.id)?;
+        assert_eq!(loaded.git_dir(), expected_git_dir.as_path());
+        Ok(())
+    }
+
+    #[test]
+    fn best_effort_adds_submodule_even_if_superproject_exists() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let fixture = writable_fixture();
+        let superproject = fixture.path().join("with-submodule").canonicalize()?;
+        let submodule = superproject.join("submodule");
+        let expected_submodule_git_dir =
+            superproject.join(".git/modules/submodule").canonicalize()?;
+        let parent = gitbutler_project::add_at_app_data_dir(data_dir.path(), &superproject)?
+            .unwrap_project();
+
+        let outcome =
+            gitbutler_project::add_with_best_effort_at_app_data_dir(data_dir.path(), &submodule)?;
+        let project = match outcome {
+            gitbutler_project::AddProjectOutcome::Added(project) => project,
+            other => panic!("expected submodule to be added, got {other:?}"),
+        };
+
+        assert_ne!(
+            project.id, parent.id,
+            "parent and super projects are distinct"
+        );
+        assert_eq!(project.git_dir(), expected_submodule_git_dir.as_path());
+        Ok(())
+    }
+
+    #[test]
+    fn best_effort_adds_parent_repo_from_nested_directory() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let repo = gitbutler_testsupport::TestProject::default();
+        let nested_dir = repo.path().join("nested/inside");
+        let expected_worktree_dir = repo.path().canonicalize()?;
+        let expected_git_dir = git2::Repository::open(repo.path())?.path().canonicalize()?;
+        std::fs::create_dir_all(&nested_dir)?;
+
+        let outcome =
+            gitbutler_project::add_with_best_effort_at_app_data_dir(data_dir.path(), &nested_dir)?;
+        let project = match outcome {
+            gitbutler_project::AddProjectOutcome::Added(project) => project,
+            other => panic!("expected parent repo to be added, got {other:?}"),
+        };
+
+        assert_eq!(project.git_dir(), expected_git_dir.as_path());
+        assert_eq!(
+            serde_json::to_value(&project)?["path"],
+            serde_json::Value::String(expected_worktree_dir.display().to_string())
+        );
+        Ok(())
+    }
+
+    mod error {
         use gitbutler_project::AddProjectOutcome;
 
         use super::*;
@@ -78,15 +166,6 @@ mod add {
             let outcome =
                 gitbutler_project::add_at_app_data_dir(tmp.path(), root.as_path()).unwrap();
             assert!(matches!(outcome, AddProjectOutcome::NoWorkdir));
-        }
-
-        #[test]
-        fn submodule() {
-            let tmp = paths::data_dir();
-            let root = repo_path_at("with-submodule").join("submodule");
-            let outcome =
-                gitbutler_project::add_at_app_data_dir(tmp.path(), root.as_path()).unwrap();
-            assert!(matches!(outcome, AddProjectOutcome::NoDotGitDirectory));
         }
 
         #[test]
@@ -115,6 +194,18 @@ mod add {
             let tmp = tempfile::tempdir().unwrap();
             let outcome =
                 gitbutler_project::add_at_app_data_dir(data_dir.path(), tmp.path()).unwrap();
+            assert!(matches!(outcome, AddProjectOutcome::NotAGitRepository(_)));
+        }
+
+        #[test]
+        fn nested_directory_inside_repo_is_not_added_by_exact_path() {
+            let data_dir = paths::data_dir();
+            let repo = gitbutler_testsupport::TestProject::default();
+            let nested_dir = repo.path().join("nested/inside");
+            std::fs::create_dir_all(&nested_dir).unwrap();
+
+            let outcome =
+                gitbutler_project::add_at_app_data_dir(data_dir.path(), &nested_dir).unwrap();
             assert!(matches!(outcome, AddProjectOutcome::NotAGitRepository(_)));
         }
 
@@ -176,14 +267,6 @@ mod add {
             )
             .unwrap()
         }
-
-        fn repo_path_at(name: &str) -> PathBuf {
-            gitbutler_testsupport::gix_testtools::scripted_fixture_read_only(
-                "various-repositories.sh",
-            )
-            .unwrap()
-            .join(name)
-        }
     }
 }
 
@@ -210,6 +293,28 @@ mod delete {
                 .unwrap()
                 .exists()
         );
+    }
+
+    #[test]
+    fn submodule_success_without_accidentally_removing_submodule() -> anyhow::Result<()> {
+        let data_dir = paths::data_dir();
+        let fixture = writable_fixture();
+        let submodule = fixture
+            .path()
+            .join("with-submodule")
+            .join("submodule")
+            .canonicalize()?;
+        let project =
+            gitbutler_project::add_at_app_data_dir(data_dir.path(), &submodule)?.unwrap_project();
+        let project_id = project.id.clone();
+        let gb_dir = project.open_isolated_repo()?.gitbutler_storage_path()?;
+
+        assert_eq!(gb_dir, project.git_dir().join("gitbutler"));
+        gitbutler_project::delete_with_path(data_dir.path(), project_id.clone())?;
+        assert!(submodule.exists());
+        assert!(!gb_dir.exists());
+        assert!(gitbutler_project::get_with_path(data_dir.path(), project_id).is_err());
+        Ok(())
     }
 
     #[test]

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -38,7 +38,7 @@ export declare function commitCreate(projectId: string, relativeTo: RelativeTo, 
 export declare function commitDetailsWithLineStats(projectId: string, commitId: string): Promise<CommitDetails>
 
 /**
- * Inserts a blank commit relative to either a commit or a reference, with oplog support
+ * Inserts a blank commit relative to either a commit or a reference, with oplog support.
  *
  * Returns the result including the new commit ID and any replaced commits.
  */
@@ -52,7 +52,7 @@ export declare function commitInsertBlank(projectId: string, relativeTo: Relativ
 export declare function commitMove(projectId: string, subjectCommitId: string, relativeTo: RelativeTo, side: InsertSide): Promise<UICommitMoveResult>
 
 /**
- * Moves changes between two commits
+ * Moves changes between two commits.
  *
  * Returns where the source and destination commits were mapped to.
  */
@@ -66,7 +66,7 @@ export declare function commitMoveChangesBetween(projectId: string, sourceCommit
 export declare function commitReword(projectId: string, commitId: string, message: string): Promise<UICommitRewordResult>
 
 /**
- * Uncommits changes from a commit, with oplog and optional assign_to support
+ * Uncommits changes from a commit, with oplog and optional assign_to support.
  *
  * If `assign_to` is provided, the newly uncommitted changes will be assigned
  * to the specified stack.
@@ -924,7 +924,7 @@ export type UICommitCreateResult = {
   pathsToRejectedChanges: Array<[string, string]>;
   /**
    * Commits that have been replaced as a side-effect of the create/amend.
-   * Maps `oldId → newId`.
+   * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
 };
@@ -935,7 +935,7 @@ export type UICommitInsertBlankResult = {
   newCommit: string;
   /**
    * Commits that have been replaced as a side-effect of the insertion.
-   * Maps `oldId → newId`.
+   * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
 };
@@ -944,7 +944,7 @@ export type UICommitInsertBlankResult = {
 export type UICommitMoveResult = {
   /**
    * Commits that have been replaced as a side-effect of the move.
-   * Maps `oldId → newId`.
+   * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
 };
@@ -955,7 +955,7 @@ export type UICommitRewordResult = {
   newCommit: string;
   /**
    * Commits that have been replaced as a side-effect of the reword.
-   * Maps `oldId → newId`.
+   * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
 };
@@ -973,7 +973,7 @@ export type UIMoveBranchResult = {
 export type UIMoveChangesResult = {
   /**
    * Commits that have been mapped from one thing to another.
-   * Maps `oldId → newId`.
+   * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
 };


### PR DESCRIPTION
## Tasks

* [x] refackiew
* [x] GUI testing


https://github.com/user-attachments/assets/1c7de03c-85de-4095-aeb2-986fbb1f5c96

----

## Summary
- allow project add/open to accept submodules by resolving repo identity from the discovered gitdir
- fix best-effort project detection so nested submodules can coexist with an added superproject
- add regression coverage for direct add, best-effort add, and delete behavior for submodule projects

## Testing
- cargo test -p gitbutler-project

## Risks
- this only fixes add/open identity and storage-path handling for submodules
- broader submodule workflow limitations after open, like base-branch-less inspection flows, are still unchanged

Related to #10720