### PR TITLE
Detect adjacency-based hunk locks with content-aware filtering

### DIFF
--- a/crates/but-hunk-dependency/src/ranges/hunk.rs
+++ b/crates/but-hunk-dependency/src/ranges/hunk.rs
@@ -177,4 +177,66 @@ impl HunkRange {
 
         Ok(self.start <= incoming_last_line && last_line >= start)
     }
+
+    /// Like [`intersects`], but also returns `true` when the two ranges are *adjacent* —
+    /// i.e. one ends on the line immediately before the other starts.
+    ///
+    /// This is used when querying which commits a worktree hunk should be locked to, because
+    /// a reorder or restructuring can create an LCS insertion point right at the boundary
+    /// between two hunks, which would produce a cherry-pick conflict even though the line
+    /// ranges do not technically overlap.
+    pub(crate) fn intersects_or_adjacent(&self, start: u32, lines: u32) -> Result<bool> {
+        if lines == 0 {
+            // Incoming hunk is a pure insertion at position `start`. Check whether
+            // the tracked range is at or adjacent to that position.
+            if self.change_type == TreeStatusKind::Deletion {
+                return Ok(true);
+            }
+            if self.lines == 0 {
+                // Both are points — adjacent if within 1 position of each other.
+                return Ok(
+                    self.start <= start.saturating_add(1) && self.start.saturating_add(1) >= start
+                );
+            }
+            let last_line = (self.start + self.lines).sub_or_err(1)?;
+            return Ok(
+                self.start <= start.saturating_add(1) && last_line.saturating_add(1) >= start
+            );
+        }
+
+        if self.change_type == TreeStatusKind::Deletion {
+            return Ok(true);
+        }
+
+        if self.lines == 0 {
+            // The tracked range is a deletion point (lines == 0). Apply the adjacency
+            // margin to the effective range, otherwise a deletion at position N would
+            // not be considered adjacent to a worktree hunk ending at N-1.
+            let incoming_last_line = (start + lines).sub_or_err(1)?;
+            if self.line_shift < 0 {
+                // Deletion spans multiple lines: effective range from self.start
+                // to self.start + |line_shift| - 1.
+                let lines_removed = 0 - self.line_shift;
+                let this_start = i32::try_from(self.start)?;
+                let last_line = (this_start + lines_removed) - 1;
+                let incoming_start = i32::try_from(start)?;
+                let incoming_last_line = i32::try_from(incoming_last_line)?;
+                return Ok(this_start <= incoming_last_line + 1 && last_line + 1 >= incoming_start);
+            }
+            // Single deletion point: adjacent if within 1 line of the incoming range.
+            return Ok(self.start <= incoming_last_line.saturating_add(1)
+                && self.start.saturating_add(1) >= start);
+        }
+
+        let last_line = (self.start + self.lines)
+            .sub_or_err(1)
+            .context("While calculating the last line")?;
+        let incoming_last_line = (start + lines)
+            .sub_or_err(1)
+            .context("While calculating the last line of the incoming hunk")?;
+
+        // Allow a 1-line gap so that adjacent hunks are treated as intersecting.
+        Ok(self.start <= incoming_last_line.saturating_add(1)
+            && last_line.saturating_add(1) >= start)
+    }
 }

--- a/crates/but-hunk-dependency/src/ranges/mod.rs
+++ b/crates/but-hunk-dependency/src/ranges/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
 use but_core::TreeStatusKind;
-use gix::bstr::BString;
+use gix::bstr::{BString, ByteSlice};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::{InputCommit, InputDiffHunk, InputStack, ui::HunkLockTarget};
+use but_core::unified_diff::DiffHunk;
 
 mod hunk;
 pub use hunk::HunkRange;
@@ -139,8 +140,62 @@ impl WorkspaceRanges {
         })
     }
 
-    /// Finds commits that intersect with a given path and range combination.
-    pub fn intersection(&self, path: &BString, start: u32, lines: u32) -> Option<Vec<&HunkRange>> {
+    /// Finds commits that intersect with a given path and hunk.
+    ///
+    /// For `Modification`-type commit ranges that only *touch* (are adjacent to, but don't
+    /// overlap) the worktree hunk, the adjacency is only counted as an intersection when the
+    /// hunk's diff content suggests the change is a reorder or block-move — the class of
+    /// edits that can produce an LCS insertion point right at the boundary and thereby cause
+    /// a cherry-pick conflict even with no overlapping lines.  Plain substitutions (where
+    /// none of the old lines appear in the new lines) are not flagged.
+    pub fn intersection(&self, path: &BString, hunk: &DiffHunk) -> Option<Vec<&HunkRange>> {
+        let start = hunk.old_start;
+        let lines = hunk.old_lines;
+        if let Some(hunk_range) = self.paths.get(path) {
+            let intersection = hunk_range
+                .iter()
+                .filter(|hr| {
+                    if hr.change_type == TreeStatusKind::Modification {
+                        if hr.intersects(start, lines).unwrap_or(false) {
+                            return true;
+                        }
+                        // Extend to adjacent ranges when:
+                        // - the worktree hunk is a pure insertion (old_lines == 0)
+                        //   AND the commit range is a deletion point (hr.lines == 0):
+                        //   a deletion removes the anchor that the merge algorithm
+                        //   uses to place the insertion, so this can conflict.
+                        //   Insertions adjacent to normal modification spans are safe
+                        //   because `intersects()` already catches insertions *inside*
+                        //   the span, and the merge algorithm can anchor outside it.
+                        // - the hunk content signals a reorder/move (not a plain
+                        //   substitution) via `hunk_suggests_boundary_insertion`.
+                        hr.intersects_or_adjacent(start, lines).unwrap_or(false)
+                            && ((lines == 0 && hr.lines == 0)
+                                || (lines > 0 && hunk_suggests_boundary_insertion(&hunk.diff)))
+                    } else {
+                        // For additions and deletions, we consider the hunk to always intersect.
+                        true
+                    }
+                })
+                .collect_vec();
+            if !intersection.is_empty() {
+                return Some(intersection);
+            }
+        }
+        None
+    }
+
+    /// Like [`intersection`], but takes raw coordinates instead of a [`DiffHunk`].
+    /// The adjacency check is not applied — only strict range overlap is tested.
+    /// Prefer [`intersection`] in production code; this exists for unit tests that
+    /// construct ranges without real diff content.
+    #[cfg(test)]
+    pub(crate) fn intersection_at(
+        &self,
+        path: &BString,
+        start: u32,
+        lines: u32,
+    ) -> Option<Vec<&HunkRange>> {
         if let Some(hunk_range) = self.paths.get(path) {
             let intersection = hunk_range
                 .iter()
@@ -148,7 +203,6 @@ impl WorkspaceRanges {
                     if hunk.change_type == TreeStatusKind::Modification {
                         hunk.intersects(start, lines).unwrap_or(false)
                     } else {
-                        // For additions and deletions, we consider the hunk to always intersect.
                         true
                     }
                 })
@@ -164,6 +218,44 @@ impl WorkspaceRanges {
     pub fn ranges_by_path_map(&self) -> &HashMap<BString, Vec<HunkRange>> {
         &self.paths
     }
+}
+
+/// Returns `true` when the hunk diff content suggests that applying this change may create
+/// an LCS insertion point at the trailing boundary — the condition that causes a cherry-pick
+/// conflict with an adjacent commit even when the line ranges don't strictly overlap.
+///
+/// The signal is a *reorder or block-move*: at least one line appears in both the old (`-`)
+/// and new (`+`) sides, **and** the last new line differs from the last old line (meaning the
+/// LCS is unlikely to terminate with a matched anchor at the end, leaving an unmatched
+/// insertion at the boundary).
+///
+/// Plain substitutions (e.g. `- "2"\n+ "two"`) return `false` because no line is shared
+/// between old and new, so the LCS cannot produce a boundary collision.
+fn hunk_suggests_boundary_insertion(diff: &gix::bstr::BString) -> bool {
+    let content = diff.to_str_lossy();
+    // DiffHunk.diff starts with an @@ header line, never ---/+++ file headers,
+    // so we skip lines starting with @@ and collect all -/+ prefixed lines.
+    let old_lines: Vec<&str> = content
+        .lines()
+        .filter(|l: &&str| l.starts_with('-'))
+        .map(|l| &l[1..])
+        .collect();
+    let new_lines: Vec<&str> = content
+        .lines()
+        .filter(|l: &&str| l.starts_with('+'))
+        .map(|l| &l[1..])
+        .collect();
+
+    if old_lines.is_empty() || new_lines.is_empty() {
+        return false;
+    }
+    // At least one line must appear in both sides (movement/reorder signal).
+    let has_moved_line = old_lines.iter().any(|o| new_lines.iter().any(|n| o == n));
+    if !has_moved_line {
+        return false;
+    }
+    // The last new line must differ from the last old line (trailing insertion signal).
+    old_lines.last() != new_lines.last()
 }
 
 /// Combines ranges from multiple branches/stacks into a single vector

--- a/crates/but-hunk-dependency/src/ranges/tests/workspace.rs
+++ b/crates/but-hunk-dependency/src/ranges/tests/workspace.rs
@@ -1,4 +1,4 @@
-use but_core::{TreeStatusKind, ref_metadata::StackId};
+use but_core::{TreeStatusKind, ref_metadata::StackId, unified_diff::DiffHunk};
 use gix::bstr::BString;
 
 use crate::{
@@ -76,17 +76,17 @@ fn workspace_simple() -> anyhow::Result<()> {
         },
     ])?;
 
-    let dependencies_1 = workspace_ranges.intersection(&path, 2, 1).unwrap();
+    let dependencies_1 = workspace_ranges.intersection_at(&path, 2, 1).unwrap();
     assert_eq!(dependencies_1.len(), 1);
     assert_eq!(dependencies_1[0].commit_id, commit1_id);
     assert_eq!(dependencies_1[0].target, stack1_id);
 
-    let dependencies_2 = workspace_ranges.intersection(&path, 9, 1).unwrap();
+    let dependencies_2 = workspace_ranges.intersection_at(&path, 9, 1).unwrap();
     assert_eq!(dependencies_2.len(), 1);
     assert_eq!(dependencies_2[0].commit_id, commit2_id);
     assert_eq!(dependencies_2[0].target, stack2_id);
 
-    let dependencies_3 = workspace_ranges.intersection(&path, 15, 1).unwrap();
+    let dependencies_3 = workspace_ranges.intersection_at(&path, 15, 1).unwrap();
     assert_eq!(dependencies_3.len(), 1);
     assert_eq!(dependencies_3[0].commit_id, commit2_id);
     assert_eq!(dependencies_3[0].target, stack2_id);
@@ -175,7 +175,7 @@ P5
     {
         // According to stack2, R1 is on line 6. Then, stack1 added 6 lines
         // before that, so R1 should now be on line 12.
-        let dependencies = workspace_ranges.intersection(&path, 12, 1).unwrap();
+        let dependencies = workspace_ranges.intersection_at(&path, 12, 1).unwrap();
         assert_eq!(dependencies.len(), 1);
         assert_eq!(dependencies[0].commit_id, commit3_id);
         assert_eq!(dependencies[0].target, stack2_id);
@@ -209,13 +209,13 @@ fn intersection_with_addition_change_type() -> anyhow::Result<()> {
     }])?;
 
     // For additions, any intersection query should return the hunk
-    let dependencies = workspace_ranges.intersection(&path, 1, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 1, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit1_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Addition);
 
     // Query outside the hunk range should still return it for additions
-    let dependencies = workspace_ranges.intersection(&path, 10, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 10, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit1_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Addition);
@@ -248,13 +248,13 @@ fn intersection_with_deletion_change_type() -> anyhow::Result<()> {
     }])?;
 
     // For deletions, any intersection query should return the hunk
-    let dependencies = workspace_ranges.intersection(&path, 1, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 1, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit1_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Deletion);
 
     // Query outside the hunk range should still return it for deletions
-    let dependencies = workspace_ranges.intersection(&path, 100, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 100, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit1_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Deletion);
@@ -287,15 +287,15 @@ fn intersection_with_modification_respects_range() -> anyhow::Result<()> {
     }])?;
 
     // Query inside the modification range should return it
-    let dependencies = workspace_ranges.intersection(&path, 5, 2).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 5, 2).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit1_id);
 
     // Query outside the modification range should return None
-    let dependencies = workspace_ranges.intersection(&path, 1, 1);
+    let dependencies = workspace_ranges.intersection_at(&path, 1, 1);
     assert!(dependencies.is_none());
 
-    let dependencies = workspace_ranges.intersection(&path, 10, 1);
+    let dependencies = workspace_ranges.intersection_at(&path, 10, 1);
     assert!(dependencies.is_none());
 
     Ok(())
@@ -347,16 +347,448 @@ fn intersection_mixed_change_types() -> anyhow::Result<()> {
     ])?;
 
     // Query at any line should return the addition (since additions always intersect)
-    let dependencies = workspace_ranges.intersection(&path, 1, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 1, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit2_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Addition);
 
     // Query at a different line should still return the addition
-    let dependencies = workspace_ranges.intersection(&path, 100, 1).unwrap();
+    let dependencies = workspace_ranges.intersection_at(&path, 100, 1).unwrap();
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].commit_id, commit2_id);
     assert_eq!(dependencies[0].change_type, TreeStatusKind::Addition);
+
+    Ok(())
+}
+
+/// A worktree hunk that is adjacent to (but not overlapping) a commit's changed lines should
+/// be locked when the diff content signals a reorder/block-move (shared lines, different last
+/// line) — but NOT when it is a plain substitution (no shared lines).
+///
+/// Real-world scenario: commit A creates a file; commit B modifies lines 4-6.
+/// A worktree change reorders lines 1-3.  B's hunk range starts at line 4 — immediately
+/// after the worktree hunk ends at line 3.
+///
+/// `WorkspaceRanges::intersection()` uses `intersects_or_adjacent()` for Modification-type
+/// hunks, but only when `hunk_suggests_boundary_insertion()` returns true for the diff.
+#[test]
+fn adjacent_reorder_is_locked_but_substitution_is_not() -> anyhow::Result<()> {
+    let path = BString::from("file.txt");
+    let stack_id = HunkLockTarget::Stack(StackId::generate());
+    let commit_a = id_from_hex_char('a');
+    let commit_b = id_from_hex_char('b');
+
+    let workspace_ranges = WorkspaceRanges::try_from_stacks(vec![InputStack {
+        target: stack_id,
+        commits_from_base_to_tip: vec![
+            // Commit A: creates the file (6 lines).
+            InputCommit {
+                commit_id: commit_a,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Addition,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 0,
+                        old_lines: 0,
+                        new_start: 1,
+                        new_lines: 6,
+                    }],
+                }],
+            },
+            // Commit B: modifies lines 4-6. Range ends up starting at line 4 after
+            // PathRanges processes the Addition above.
+            InputCommit {
+                commit_id: commit_b,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Modification,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 4,
+                        old_lines: 3,
+                        new_start: 4,
+                        new_lines: 3,
+                    }],
+                }],
+            },
+        ],
+    }])?;
+
+    // Reorder hunk at lines 1-3: shared lines, different last line → signals boundary insertion.
+    // Adjacent to commit B at line 4, so B should be locked.
+    let reorder_hunk = DiffHunk {
+        old_start: 1,
+        old_lines: 3,
+        new_start: 1,
+        new_lines: 3,
+        diff: "@@ -1,3 +1,3 @@\n-line_a\n-line_b\n-line_c\n+line_c\n+line_b\n+line_a\n".into(),
+    };
+    let locks = workspace_ranges
+        .intersection(&path, &reorder_hunk)
+        .unwrap_or_default();
+    let lock_commits: Vec<_> = locks.iter().map(|h| h.commit_id).collect();
+    assert!(
+        lock_commits.contains(&commit_b),
+        "reorder hunk at lines 1-3 should lock to commit B (adjacent at line 4), got: {lock_commits:?}"
+    );
+
+    // Substitution hunk at lines 1-3: no shared lines → no boundary-insertion signal.
+    // Adjacent to commit B but should NOT be locked.
+    let substitution_hunk = DiffHunk {
+        old_start: 1,
+        old_lines: 3,
+        new_start: 1,
+        new_lines: 3,
+        diff: "@@ -1,3 +1,3 @@\n-x\n-y\n-z\n+a\n+b\n+c\n".into(),
+    };
+    let locks = workspace_ranges
+        .intersection(&path, &substitution_hunk)
+        .unwrap_or_default();
+    let lock_commits: Vec<_> = locks.iter().map(|h| h.commit_id).collect();
+    assert!(
+        !lock_commits.contains(&commit_b),
+        "substitution hunk at lines 1-3 should NOT lock to commit B (no shared lines), got: {lock_commits:?}"
+    );
+
+    Ok(())
+}
+
+/// Mimics the real StackCodegen.svelte scenario:
+/// - Commit A creates a file with 20 lines
+/// - Commit B deletes line 14 (context_lines=0 → old_start=14, old_lines=1, new_lines=0)
+/// - Worktree reorders lines 11-13
+///
+/// After PathRanges processes B's deletion, B owns a point at position 14 with lines=0.
+/// The worktree hunk at 11-13 ends at line 13, which is adjacent to position 14.
+#[test]
+fn adjacent_deletion_point_locked_for_reorder() -> anyhow::Result<()> {
+    let path = BString::from("file.txt");
+    let stack_id = HunkLockTarget::Stack(StackId::generate());
+    let commit_a = id_from_hex_char('a');
+    let commit_b = id_from_hex_char('b');
+
+    let workspace_ranges = WorkspaceRanges::try_from_stacks(vec![InputStack {
+        target: stack_id,
+        commits_from_base_to_tip: vec![
+            InputCommit {
+                commit_id: commit_a,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Addition,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 0,
+                        old_lines: 0,
+                        new_start: 1,
+                        new_lines: 20,
+                    }],
+                }],
+            },
+            // Commit B: deletes a single line at position 14 (like removing an import).
+            InputCommit {
+                commit_id: commit_b,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Modification,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 14,
+                        old_lines: 1,
+                        new_start: 14,
+                        new_lines: 0,
+                    }],
+                }],
+            },
+        ],
+    }])?;
+
+    // Reorder hunk at lines 11-13 (adjacent to B's deletion point at 14).
+    let reorder_hunk = DiffHunk {
+        old_start: 11,
+        old_lines: 3,
+        new_start: 11,
+        new_lines: 3,
+        diff: "@@ -11,3 +11,3 @@\n-line_a\n-line_b\n-line_c\n+line_c\n+line_b\n+line_a\n".into(),
+    };
+    let locks = workspace_ranges
+        .intersection(&path, &reorder_hunk)
+        .unwrap_or_default();
+    let lock_commits: Vec<_> = locks.iter().map(|h| h.commit_id).collect();
+    assert!(
+        lock_commits.contains(&commit_b),
+        "reorder hunk at lines 11-13 should lock to commit B (deletion point at 14), got: {lock_commits:?}"
+    );
+
+    Ok(())
+}
+
+/// Faithfully reproduces the StackCodegen.svelte scenario from the workspace.
+///
+/// Three commits in the stack (refactor/filelist-controller):
+/// - Commit A (741cd057d): creates StackCodegen.svelte with 164 lines
+/// - Commit B (846d4c4ab): heavy refactor — deletes imports, state, actions (164→71 lines)
+///   With context_lines=0, this produces many small hunks (deletion at line 14, etc.)
+/// - Commit C (f7e70bef9): adds UI_STATE import (insertion after line 15)
+///
+/// The uncommitted worktree change reorders three imports at lines 11-13.
+/// With context_lines=0, this is TWO hunks (not one):
+///   1. @@ -11,2 +10,0 @$ — delete CodegenMessages + CodegenMcpConfigModal
+///   2. @@ -13,0 +12,2 $$ — insert them back after ReduxResult
+///
+/// When `context_lines=0`, a line reorder (delete + re-insert in different order)
+/// is split into two separate hunks by the diff algorithm: a deletion hunk and an
+/// insertion hunk. The insertion lands adjacent to a tracked deletion point from
+/// an earlier commit.
+///
+/// The dependency on commit B should be detected because B's deletion at old
+/// line 14 creates a tracked point at position 14 in the final file, and the
+/// worktree insertion after position 13 is adjacent to it.
+#[test]
+fn split_reorder_adjacent_to_scattered_deletions() -> anyhow::Result<()> {
+    let path = BString::from("file.txt");
+    let stack_id = HunkLockTarget::Stack(StackId::generate());
+    let commit_a = id_from_hex_char('a');
+    let commit_b = id_from_hex_char('b');
+    let commit_c = id_from_hex_char('c');
+
+    let workspace_ranges = WorkspaceRanges::try_from_stacks(vec![InputStack {
+        target: stack_id,
+        commits_from_base_to_tip: vec![
+            // Commit A: creates the file (164 lines).
+            InputCommit {
+                commit_id: commit_a,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Addition,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 0,
+                        old_lines: 0,
+                        new_start: 1,
+                        new_lines: 164,
+                    }],
+                }],
+            },
+            // Commit B: heavy refactor with many scattered deletions (context_lines=0).
+            // Crucially, the deletion at old line 14 creates a tracked point that
+            // the worktree reorder will land adjacent to.
+            InputCommit {
+                commit_id: commit_b,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Modification,
+                    hunks: vec![
+                        InputDiffHunk {
+                            old_start: 2,
+                            old_lines: 1,
+                            new_start: 2,
+                            new_lines: 1,
+                        },
+                        InputDiffHunk {
+                            old_start: 14,
+                            old_lines: 1,
+                            new_start: 13,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 16,
+                            old_lines: 2,
+                            new_start: 14,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 20,
+                            old_lines: 1,
+                            new_start: 16,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 26,
+                            old_lines: 1,
+                            new_start: 21,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 30,
+                            old_lines: 1,
+                            new_start: 25,
+                            new_lines: 1,
+                        },
+                        InputDiffHunk {
+                            old_start: 33,
+                            old_lines: 2,
+                            new_start: 27,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 36,
+                            old_lines: 65,
+                            new_start: 28,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 110,
+                            old_lines: 4,
+                            new_start: 37,
+                            new_lines: 0,
+                        },
+                        InputDiffHunk {
+                            old_start: 115,
+                            old_lines: 11,
+                            new_start: 39,
+                            new_lines: 1,
+                        },
+                        InputDiffHunk {
+                            old_start: 128,
+                            old_lines: 7,
+                            new_start: 41,
+                            new_lines: 0,
+                        },
+                    ],
+                }],
+            },
+            // Commit C: a few small additions and edits.
+            InputCommit {
+                commit_id: commit_c,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Modification,
+                    hunks: vec![
+                        InputDiffHunk {
+                            old_start: 15,
+                            old_lines: 0,
+                            new_start: 16,
+                            new_lines: 1,
+                        },
+                        InputDiffHunk {
+                            old_start: 27,
+                            old_lines: 0,
+                            new_start: 29,
+                            new_lines: 1,
+                        },
+                        InputDiffHunk {
+                            old_start: 52,
+                            old_lines: 3,
+                            new_start: 54,
+                            new_lines: 1,
+                        },
+                    ],
+                }],
+            },
+        ],
+    }])?;
+
+    // Worktree hunk 1: deletion of two lines at position 11-12.
+    // With context_lines=0, a line reorder is split into a deletion and insertion.
+    let deletion_hunk = DiffHunk {
+        old_start: 11,
+        old_lines: 2,
+        new_start: 10,
+        new_lines: 0,
+        diff: "@@ -11,2 +10,0 @@\n-line_11\n-line_12\n".into(),
+    };
+
+    // Worktree hunk 2: re-insertion of the same two lines (reordered) after line 13.
+    // This is a pure insertion (old_lines=0) adjacent to commit B's deletion point.
+    let insertion_hunk = DiffHunk {
+        old_start: 13,
+        old_lines: 0,
+        new_start: 12,
+        new_lines: 2,
+        diff: "@@ -13,0 +12,2 @@\n+line_12\n+line_11\n".into(),
+    };
+
+    // At least one of the two worktree hunks should lock to commit B.
+    let deletion_locks = workspace_ranges
+        .intersection(&path, &deletion_hunk)
+        .unwrap_or_default();
+    let insertion_locks = workspace_ranges
+        .intersection(&path, &insertion_hunk)
+        .unwrap_or_default();
+
+    let all_lock_commits: Vec<_> = deletion_locks
+        .iter()
+        .chain(insertion_locks.iter())
+        .map(|h| h.commit_id)
+        .collect();
+
+    assert!(
+        all_lock_commits.contains(&commit_b),
+        "reorder adjacent to commit B's deletion should lock to B, got: {all_lock_commits:?}"
+    );
+
+    Ok(())
+}
+
+/// A pure insertion of completely new content adjacent to a commit's modification range.
+/// In a real 3-way merge, git would cleanly insert these new lines — there's no content
+/// overlap or reorder, just fresh lines added right after the commit's changed region.
+///
+/// Adjacency is only extended for pure insertions when the commit range is also a
+/// deletion point (lines == 0), because that's when the merge algorithm loses its
+/// anchor. Normal modification spans have clear boundaries, so insertions outside
+/// them apply cleanly.
+#[test]
+fn pure_insertion_of_new_content_adjacent_to_modification_is_not_locked() -> anyhow::Result<()> {
+    let path = BString::from("file.txt");
+    let stack_id = HunkLockTarget::Stack(StackId::generate());
+    let commit_a = id_from_hex_char('a');
+    let commit_b = id_from_hex_char('b');
+
+    let workspace_ranges = WorkspaceRanges::try_from_stacks(vec![InputStack {
+        target: stack_id,
+        commits_from_base_to_tip: vec![
+            // Commit A: creates a 20-line file.
+            InputCommit {
+                commit_id: commit_a,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Addition,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 0,
+                        old_lines: 0,
+                        new_start: 1,
+                        new_lines: 20,
+                    }],
+                }],
+            },
+            // Commit B: modifies lines 10-12 (e.g. a substitution).
+            InputCommit {
+                commit_id: commit_b,
+                files: vec![InputFile {
+                    path: path.clone(),
+                    change_type: TreeStatusKind::Modification,
+                    hunks: vec![InputDiffHunk {
+                        old_start: 10,
+                        old_lines: 3,
+                        new_start: 10,
+                        new_lines: 3,
+                    }],
+                }],
+            },
+        ],
+    }])?;
+
+    // Worktree: insert two completely new lines right after commit B's range (after line 13).
+    // old_start=13 means "insert after line 13" — one past commit B's last line (12).
+    // This is a pure insertion (old_lines=0) with content that has nothing to do with
+    // commit B's changes. A 3-way merge would apply this cleanly.
+    let insertion_hunk = DiffHunk {
+        old_start: 13,
+        old_lines: 0,
+        new_start: 14,
+        new_lines: 2,
+        diff: "@@ -13,0 +14,2 @@\n+completely_new_line_1\n+completely_new_line_2\n".into(),
+    };
+
+    let locks = workspace_ranges
+        .intersection(&path, &insertion_hunk)
+        .unwrap_or_default();
+    let lock_commits: Vec<_> = locks.iter().map(|h| h.commit_id).collect();
+
+    // Commit A (file creation) will match because the insertion is inside its range.
+    // But commit B should NOT match — it's a normal modification span (lines > 0),
+    // and the insertion is adjacent, not overlapping. A 3-way merge handles this cleanly.
+    assert!(
+        !lock_commits.contains(&commit_b),
+        "Pure insertion of new content adjacent to a modification span should NOT lock to B, got: {lock_commits:?}"
+    );
 
     Ok(())
 }

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -59,9 +59,7 @@ impl HunkDependencies {
                 continue;
             };
             for hunk in hunks {
-                if let Some(intersections) =
-                    ranges.intersection(&change.path, hunk.old_start, hunk.old_lines)
-                {
+                if let Some(intersections) = ranges.intersection(&change.path, &hunk) {
                     let locks: Vec<_> = intersections
                         .into_iter()
                         .map(|dependency| HunkLock {

--- a/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
@@ -19,9 +19,7 @@ fn intersect_workspace_ranges(
         };
         let mut intersections = Vec::new();
         for hunk in hunks {
-            if let Some(hunk_ranges) =
-                ranges.intersection(&change.path, hunk.old_start, hunk.old_lines)
-            {
+            if let Some(hunk_ranges) = ranges.intersection(&change.path, &hunk) {
                 let hunk_ranges: Vec<_> =
                     hunk_ranges.into_iter().cloned().map(Into::into).collect();
                 intersections.push(HunkIntersection {

--- a/crates/but-testing/src/command/diff.rs
+++ b/crates/but-testing/src/command/diff.rs
@@ -137,9 +137,7 @@ fn intersect_workspace_ranges(
         };
         let mut intersections = Vec::new();
         for hunk in hunks {
-            if let Some(hunk_ranges) =
-                ranges.intersection(&change.path, hunk.old_start, hunk.old_lines)
-            {
+            if let Some(hunk_ranges) = ranges.intersection(&change.path, &hunk) {
                 intersections.push(HunkIntersection {
                     hunk,
                     commit_intersections: hunk_ranges.into_iter().cloned().collect(),


### PR DESCRIPTION
With context_lines=0 (how GitButler generates diffs), the diff algorithm
can split a line reorder into two separate hunks: a deletion and an
insertion. The insertion lands adjacent to a commit's tracked range but
doesn't overlap it, so the existing strict-overlap check misses the
dependency. Cherry-picking that commit then fails because the merge
algorithm's LCS produces an insertion point right at the boundary.

Fix this by adding `intersects_or_adjacent()` to `HunkRange`, which
extends the overlap check with a 1-line adjacency margin. To avoid
false positives, adjacency locks are gated on two conditions:

- For non-empty worktree hunks (old_lines > 0): only lock when
  `hunk_suggests_boundary_insertion()` detects a reorder (shared lines
  between old/new sides with a different trailing line). Plain
  substitutions are not flagged.

- For pure insertions (old_lines == 0): only lock when the commit
  range is itself a deletion point (lines == 0), since that's when
  the merge algorithm loses its anchor. Insertions adjacent to normal
  modification spans are safe — `intersects()` already catches
  insertions inside the span, and the merge algorithm can anchor
  outside it.

Change `WorkspaceRanges::intersection()` to accept `&DiffHunk` instead
of raw start/lines so it has access to diff content for the filtering.
The old coordinate-only API is preserved as `intersection_at()` for
unit tests.

Tests added:
- adjacent_reorder_is_locked_but_substitution_is_not
- adjacent_deletion_point_locked_for_reorder
- split_reorder_adjacent_to_scattered_deletions (full 3-commit scenario
  with scattered deletions and a split worktree reorder)
- pure_insertion_of_new_content_adjacent_to_modification_is_not_locked