### PR TITLE
(ui): rename "Edit commit message" to "Reword commit"

### DIFF
--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -197,7 +197,7 @@
 						}}
 					/>
 					<ContextMenuItem
-						label="Edit commit message"
+						label="Reword commit"
 						icon="edit"
 						testId={TestId.CommitRowContextMenu_EditMessageMenuButton}
 						disabled={isReadOnly}

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -204,7 +204,7 @@
 							drawer?.open();
 							setMode("edit");
 						}}
-						tooltip={isReadOnly ? "Read-only mode" : "Edit commit message"}
+						tooltip={isReadOnly ? "Read-only mode" : "Reword commit"}
 						disabled={isReadOnly || isEditingMessage}
 					/>
 				{/if}
@@ -241,7 +241,7 @@
 							action={({ title, description }) => saveCommitMessage(title, description)}
 							actionLabel="Save changes"
 							onCancel={cancelEdit}
-							floatingBoxHeader="Edit commit message"
+							floatingBoxHeader="Reword commit"
 							loading={messageUpdateQuery.current.isLoading}
 							existingCommitId={commit.id}
 							title={parsedMessage?.title || ""}

--- a/apps/lite/ui/src/routes/project-shared.tsx
+++ b/apps/lite/ui/src/routes/project-shared.tsx
@@ -382,7 +382,7 @@ const CommitMenuPopup: FC<{
 	return (
 		<Popup className={styles.menuPopup}>
 			<Item className={styles.menuItem} onClick={onReword}>
-				Edit commit message
+				Reword commit
 			</Item>
 			<SubmenuRoot>
 				<SubmenuTrigger className={styles.menuItem}>Add empty commit</SubmenuTrigger>


### PR DESCRIPTION
Use the standard git terminology "reword" instead of the generic "edit commit message" in the button tooltip, context menu item, and floating box header. This makes the action more precise and consistent with how git itself describes the operation.