### PR TITLE
Fix getting stuck in file list mode after rubbing

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -632,6 +632,8 @@ impl App {
             | Mode::Move(..) => None,
         };
 
+        self.flags.show_files = FilesStatusFlag::None;
+
         messages.extend([
             Message::EnterNormalMode,
             reload_message.unwrap_or(Message::Reload(None)),

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -594,6 +594,29 @@ fn commit_file_list_rub_can_escape_scope_and_esc_reenters_file_list() {
 }
 
 #[test]
+fn confirm_rub_closes_commit_file_list() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render([KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊●   [..] add A"]);
+
+    tui.input_then_render('f')
+        .assert_current_line_eq(str!["┊│     [..] A A"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+        .assert_current_line_eq(str!["┊│     << source >> << noop >> [..] A A"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..] add A"]);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄h0 [B]"]);
+}
+
+#[test]
 fn esc_in_normal_mode_closes_global_file_list() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
     env.setup_metadata(&["A", "B"]).unwrap();


### PR DESCRIPTION
We didn't properly close the commit file list after confirming a rub. This fixes that and adds a regression test.