### PR TITLE
Refactor frontend components: extract modals, and utilities

### DIFF
--- a/apps/desktop/src/components/AbsorbPlanModal.svelte
+++ b/apps/desktop/src/components/AbsorbPlanModal.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
+	import { type TreeChange } from "$lib/hunks/change";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import {
+		Button,
+		CopyButton,
+		FileListItem,
+		Icon,
+		Modal,
+		ModalHeader,
+		ScrollableContainer,
+		TestId,
+		chipToasts,
+	} from "@gitbutler/ui";
+	import { tick } from "svelte";
+	import type { HunkAssignment } from "@gitbutler/core/api";
+
+	type Props = {
+		projectId: string;
+		stackId: string | undefined;
+	};
+
+	const { projectId, stackId }: Props = $props();
+
+	const stackService = inject(STACK_SERVICE);
+	const clipboardService = inject(CLIPBOARD_SERVICE);
+	const [absorb, absorbingChanges] = stackService.absorb;
+
+	let modal = $state<ReturnType<typeof Modal> | undefined>();
+	let absorbPlan = $state<HunkAssignment.CommitAbsorption[]>([]);
+	let isScrollVisible = $state(true);
+
+	export async function show(changes: TreeChange[]) {
+		const changesToAbsorb = $state.snapshot(changes);
+		const plan = await stackService.fetchAbsorbPlan(projectId, {
+			type: "treeChanges",
+			subject: {
+				changes: changesToAbsorb,
+				assigned_stack_id: stackId ?? null,
+			},
+		});
+		if (!plan || plan.length === 0) {
+			chipToasts.error("No suitable commits found to absorb changes into.");
+			return;
+		}
+		absorbPlan = plan;
+		await tick();
+		modal?.show(null);
+	}
+
+	function uniquePaths(files: HunkAssignment.FileAbsorption[]): string[] {
+		const pathSet = new Set<string>();
+		for (const file of files) {
+			pathSet.add(file.path);
+		}
+		return Array.from(pathSet);
+	}
+</script>
+
+<Modal
+	width={500}
+	noPadding
+	bind:this={modal}
+	testId={TestId.AbsobModal}
+	onSubmit={async () => {
+		try {
+			await chipToasts.promise(absorb({ projectId, absorptionPlan: absorbPlan }), {
+				loading: "Absorbing changes",
+				success: "Changes absorbed successfully",
+				error: "Failed to absorb changes",
+			});
+			modal?.close();
+		} catch (error) {
+			console.error("Failed to absorb changes:", error);
+		}
+	}}
+>
+	<ModalHeader sticky={!isScrollVisible}>Absorb Changes into Commits</ModalHeader>
+	<ScrollableContainer onscrollTop={(visible) => (isScrollVisible = visible)}>
+		<div class="absorb-plan-content">
+			<p class="text-13 text-body clr-text-2">
+				The following changes will be absorbed into their respective commits:
+			</p>
+			<div class="commit-absorptions">
+				{#each absorbPlan as commitAbsorption}
+					{@const uniqueFilePaths = uniquePaths(commitAbsorption.files)}
+					<div class="commit-absorption" data-testid={TestId.AbsorbModal_CommitAbsorption}>
+						{#if commitAbsorption.reason !== "default_stack"}
+							<div class="absorption__reason text-12 text-body clr-text-2">
+								{#if commitAbsorption.reason === "hunk_dependency"}
+									📍 Files depend on the commit due to overlapping hunks
+								{:else if commitAbsorption.reason === "stack_assignment"}
+									🔖 Files assigned to this stack
+								{/if}
+							</div>
+						{/if}
+
+						<div class="absorption__content">
+							<div class="commit-header">
+								<Icon name="commit" />
+
+								<div class="flex gap-8 overflow-hidden align-center full-width">
+									<p class="text-13 text-semibold truncate flex-1">
+										{commitAbsorption.commitSummary.split("\n")[0]}
+									</p>
+									<CopyButton
+										class="text-12 clr-text-2"
+										text={commitAbsorption.commitId}
+										onclick={() => {
+											clipboardService.write(commitAbsorption.commitId, {
+												message: "Commit ID copied",
+											});
+										}}
+									/>
+								</div>
+							</div>
+
+							<ul class="file-list">
+								{#each uniqueFilePaths as filePath (filePath)}
+									<FileListItem
+										{filePath}
+										clickable={false}
+										listMode="list"
+										isLast={uniqueFilePaths.indexOf(filePath) === uniqueFilePaths.length - 1}
+									/>
+								{/each}
+							</ul>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</ScrollableContainer>
+
+	{#snippet controls(close)}
+		<Button kind="outline" onclick={close}>Cancel</Button>
+		<Button
+			style="pop"
+			type="submit"
+			loading={absorbingChanges.current.isLoading}
+			disabled={absorbPlan.length === 0 || absorbingChanges.current.isLoading}
+			testId={TestId.AbsorbModal_ActionButton}
+		>
+			Absorb changes
+		</Button>
+	{/snippet}
+</Modal>
+
+<style lang="postcss">
+	.absorb-plan-content {
+		display: flex;
+		flex-direction: column;
+		padding: 16px;
+		padding-top: 0;
+		gap: 12px;
+	}
+	.commit-absorptions {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.commit-absorption {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-1);
+	}
+	.absorption__reason {
+		display: flex;
+		padding: 8px;
+		border-bottom: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-2);
+	}
+	.absorption__content {
+		display: flex;
+		flex-direction: column;
+		padding: 12px;
+	}
+	.commit-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.file-list {
+		display: flex;
+		flex-direction: column;
+		margin-top: 12px;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		background-color: var(--clr-bg-1);
+	}
+</style>

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import BranchIntegrationModal from "$components/BranchIntegrationModal.svelte";
 	import CardOverlay from "$components/CardOverlay.svelte";
 	import CommitContextMenu from "$components/CommitContextMenu.svelte";
 	import CommitGoesHere from "$components/CommitGoesHere.svelte";
@@ -10,6 +9,7 @@
 	import NestedChangedFiles from "$components/NestedChangedFiles.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import UpstreamCommitsAction from "$components/UpstreamCommitsAction.svelte";
+	import UpstreamIntegrationActions from "$components/UpstreamIntegrationActions.svelte";
 	import { isLocalAndRemoteCommit, isUpstreamCommit } from "$components/lib";
 	import { commitCreatedAt } from "$lib/branches/v3";
 	import { commitStatusLabel } from "$lib/commits/commit";
@@ -29,7 +29,6 @@
 		ReorderCommitDzHandler,
 	} from "$lib/dragging/stackingReorderDropzoneManager";
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
-	import { HOOKS_SERVICE } from "$lib/hooks/hooksService";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { createCommitSelection } from "$lib/selection/key";
 	import { getStackContext } from "$lib/stack/stackController.svelte";
@@ -38,8 +37,7 @@
 	import { combineResults } from "$lib/state/helpers";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
-	import { persisted } from "@gitbutler/shared/persisted";
-	import { Button, Modal, RadioButton, TestId } from "@gitbutler/ui";
+	import { TestId } from "@gitbutler/ui";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
@@ -60,7 +58,6 @@
 	const controller = getStackContext();
 	const stackService = inject(STACK_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
-	const hooksService = inject(HOOKS_SERVICE);
 	const ircApiService = inject(IRC_API_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
@@ -70,8 +67,6 @@
 
 	const commitReactionsQuery = $derived(ircApiService.commitReactions());
 	const commitReactions = $derived(commitReactionsQuery?.response ?? {});
-
-	const [integrateUpstreamCommits, integrating] = stackService.integrateUpstreamCommits;
 
 	const exclusiveAction = $derived(controller.exclusiveAction);
 	const commitAction = $derived(exclusiveAction?.type === "commit" ? exclusiveAction : undefined);
@@ -85,8 +80,6 @@
 	const upstreamOnlyCommits = $derived(
 		stackService.upstreamCommits(projectId, stackId, branchName),
 	);
-
-	let integrationModal = $state<Modal>();
 
 	async function handleCommitClick(commitId: string, upstream: boolean) {
 		const currentSelection = controller.selection.current;
@@ -117,97 +110,7 @@
 			commitId,
 		});
 	}
-
-	function kickOffIntegration() {
-		integrationModal?.show();
-	}
-
-	function handleRebaseIntegration() {
-		if (!stackId) return;
-		integrateUpstreamCommits({
-			projectId,
-			stackId,
-			seriesName: branchName,
-			integrationStrategy: { type: "rebase" },
-		});
-	}
-
-	type IntegrationMode = "rebase" | "interactive";
-
-	const integrationMode = persisted<IntegrationMode>("rebase", "branchUpstreamIntegrationMode");
-
-	function integrate(mode: IntegrationMode) {
-		switch (mode) {
-			case "rebase":
-				handleRebaseIntegration();
-				break;
-			case "interactive":
-				kickOffIntegration();
-				break;
-		}
-	}
-
-	function getLabelForIntegrationMode(mode: IntegrationMode): string {
-		switch (mode) {
-			case "rebase":
-				return "Rebase";
-			case "interactive":
-				return "Configure integration…";
-		}
-	}
 </script>
-
-<BranchIntegrationModal bind:modalRef={integrationModal} {projectId} {stackId} {branchName} />
-
-{#snippet integrateUpstreamAction()}
-	<form
-		class="uppstream-integration-actions"
-		onsubmit={() => {
-			integrate($integrationMode);
-		}}
-	>
-		<div class="uppstream-integration-actions__radio-container">
-			{@render integrationRadioOption(
-				"rebase",
-				"Rebase upstream changes",
-				"Place local-only changes on top, then the upstream changes. Similar to git pull --rebase.",
-			)}
-			{@render integrationRadioOption(
-				"interactive",
-				"Interactive integration",
-				"Review and resolve any conflicts before completing the integration.",
-			)}
-		</div>
-
-		<Button
-			type="submit"
-			style="warning"
-			disabled={integrating.current.isLoading}
-			testId={TestId.UpstreamCommitsIntegrateButton}
-		>
-			{getLabelForIntegrationMode($integrationMode)}
-		</Button>
-	</form>
-{/snippet}
-
-<!-- Integration radio option snippet -->
-{#snippet integrationRadioOption(mode: IntegrationMode, title: string, description: string)}
-	<label class="integration-radio-option" class:selected={$integrationMode === mode}>
-		<div class="integration-radio-content">
-			<h4 class="text-13 text-semibold">{title}</h4>
-			<p class="text-11 text-body clr-text-2">
-				{description}
-			</p>
-		</div>
-		<RadioButton
-			class="integration-radio-option__radio"
-			name="integrationMode"
-			value={mode}
-			checked={$integrationMode === mode}
-			onchange={() => integrationMode.set(mode)}
-		/>
-	</label>
-{/snippet}
 
 {#snippet commitReorderDz(dropzone: ReorderCommitDzHandler)}
 	{#if !controller.isCommitting}
@@ -267,7 +170,7 @@
 						{#snippet action()}
 							<h3 class="text-13 text-semibold m-b-4">Upstream has new commits</h3>
 							<p class="text-12 text-body clr-text-2 m-b-14">Update your branch to stay current.</p>
-							{@render integrateUpstreamAction()}
+							<UpstreamIntegrationActions {projectId} {stackId} {branchName} />
 						{/snippet}
 					</UpstreamCommitsAction>
 				{/if}
@@ -486,58 +389,5 @@
 		&.rounded {
 			border-radius: var(--radius-ml);
 		}
-	}
-
-	.uppstream-integration-actions {
-		display: flex;
-		flex-direction: column;
-		gap: 14px;
-	}
-
-	.uppstream-integration-actions__radio-container {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.integration-radio-option {
-		display: flex;
-		z-index: 0;
-		position: relative;
-		padding: 14px;
-		gap: 20px;
-		border: 1px solid var(--clr-border-2);
-		background: var(--clr-bg-1);
-		cursor: pointer;
-
-		&:not(.selected):hover {
-			background: var(--hover-bg-1);
-		}
-
-		&:first-child {
-			border-top-right-radius: var(--radius-m);
-			border-top-left-radius: var(--radius-m);
-		}
-		&:last-child {
-			margin-top: -1px;
-			border-bottom-right-radius: var(--radius-m);
-			border-bottom-left-radius: var(--radius-m);
-		}
-
-		&.selected {
-			z-index: 1;
-			border-color: var(--clr-theme-pop-element);
-			background: var(--clr-theme-pop-bg);
-		}
-	}
-
-	:global(.integration-radio-option__radio) {
-		flex-shrink: 0;
-	}
-
-	.integration-radio-content {
-		display: flex;
-		flex: 1;
-		flex-direction: column;
-		gap: 6px;
 	}
 </style>

--- a/apps/desktop/src/components/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/BranchIntegrationModal.svelte
@@ -9,6 +9,18 @@
 		type Commit,
 		type UpstreamCommit,
 	} from "$lib/branches/v3";
+	import {
+		canShiftStepDown,
+		canShiftStepUp,
+		getStepCommitInfo,
+		pickLocalStep,
+		pickUpstreamStep,
+		shiftStepDown,
+		shiftStepUp,
+		splitStepAtCommit,
+		squashStepInto,
+		updateStepType,
+	} from "$lib/stacks/integrationStepUtils";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Modal, ModalFooter, Button, ScrollableContainer, SimpleCommitRow } from "@gitbutler/ui";
@@ -28,7 +40,6 @@
 		modalRef?.close();
 	}
 
-	// --- Begin InteractiveBranchIntegration logic ---
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 	const stackService = inject(STACK_SERVICE);
 	const [integrate, integrating] = stackService.integrateBranchWithSteps;
@@ -40,180 +51,52 @@
 
 	let editableSteps = $derived(initialIntegrationSteps.response ?? []);
 
-	// Constants
 	const FLIP_ANIMATION_DURATION = 150;
 	const MAX_SCROLL_HEIGHT = "50vh";
 
-	// Helper functions for step manipulation
-	function updateStepType(stepId: string, commitId: string, newType: "pick" | "skip") {
-		editableSteps = editableSteps.map((step) => {
-			if (step.subject.id === stepId) {
-				return { type: newType, subject: { id: stepId, commitId } };
-			}
-			return step;
-		});
-	}
-
-	function pickUpstreamFromStep(stepId: string, commitId: string, upstreamCommitId: string) {
-		editableSteps = editableSteps.map((step) => {
-			if (step.subject.id === stepId) {
-				return {
-					type: "pickUpstream",
-					subject: { id: stepId, commitId, upstreamCommitId },
-				};
-			}
-			return step;
-		});
-	}
-
-	function pickLocalFromStep(stepId: string, commitId: string) {
-		editableSteps = editableSteps.map((step) => {
-			if (step.subject.id === stepId) {
-				return { type: "pick", subject: { id: stepId, commitId } };
-			}
-			return step;
-		});
-	}
-
 	function skipStepById(stepId: string, commitId: string) {
-		updateStepType(stepId, commitId, "skip");
+		editableSteps = updateStepType(editableSteps, stepId, commitId, "skip");
 	}
 	function pickStepById(stepId: string, commitId: string) {
-		updateStepType(stepId, commitId, "pick");
+		editableSteps = updateStepType(editableSteps, stepId, commitId, "pick");
 	}
+	function pickUpstreamFromStep(stepId: string, commitId: string, upstreamCommitId: string) {
+		editableSteps = pickUpstreamStep(editableSteps, stepId, commitId, upstreamCommitId);
+	}
+	function pickLocalFromStep(stepId: string, commitId: string) {
+		editableSteps = pickLocalStep(editableSteps, stepId, commitId);
+	}
+
 	async function getCommitMessage(commitIds: string[]): Promise<string> {
 		if (stackId === undefined) return "";
 		const commitDetails = await stackService.fetchCommitsByIds(projectId, stackId, commitIds);
 		return commitDetails.map((c) => c.message).join("\n\n");
 	}
-	function getStepCommitInfo(step: InteractiveIntegrationStep): {
-		id: string;
-		commitIds: string[];
-	} {
-		const id = step.subject.id;
-		switch (step.type) {
-			case "pickUpstream":
-				return { id, commitIds: [step.subject.upstreamCommitId] };
-			case "pick":
-			case "skip":
-				return { id, commitIds: [step.subject.commitId] };
-			case "squash":
-				return { id, commitIds: step.subject.commits };
-		}
-	}
 	async function squashStepById(stepId: string, commitIds: string[]) {
-		const stepIndex = editableSteps.findIndex((step) => step.subject.id === stepId);
-		const isValidSquashOperation = stepIndex !== -1 && stepIndex < editableSteps.length - 1;
-		if (!isValidSquashOperation) {
-			return;
-		}
-		const newSteps = structuredClone(editableSteps);
-		const stepToSquash = newSteps[stepIndex];
-		const stepToBeSquashedInto = newSteps[stepIndex + 1];
-		if (!stepToSquash || !stepToBeSquashedInto) {
-			return;
-		}
-		const targetStepInfo = getStepCommitInfo(stepToBeSquashedInto);
+		const stepIndex = editableSteps.findIndex((s) => s.subject.id === stepId);
+		if (stepIndex === -1 || stepIndex >= editableSteps.length - 1) return;
+		const targetStepInfo = getStepCommitInfo(editableSteps[stepIndex + 1]!);
 		const combinedCommits = [...commitIds, ...targetStepInfo.commitIds];
 		const squashMessage = await getCommitMessage(combinedCommits);
-		newSteps.splice(stepIndex, 2, {
-			type: "squash",
-			subject: {
-				id: targetStepInfo.id,
-				commits: combinedCommits,
-				message: squashMessage,
-			},
-		});
-		editableSteps = newSteps;
+		editableSteps = squashStepInto(editableSteps, stepId, commitIds, squashMessage);
 	}
 	async function splitOffCommitFromStep(stepId: string, commitId: string) {
-		const stepIndex = editableSteps.findIndex((step) => step.subject.id === stepId);
-		if (stepIndex === -1) return;
-		const newSteps = structuredClone(editableSteps);
-		const stepToSplit = newSteps[stepIndex];
-		if (!stepToSplit || stepToSplit.type !== "squash") {
-			return;
-		}
-		const { commits } = stepToSplit.subject;
-		const canSplitCommits = commits.length > 1 && commits.includes(commitId);
-		if (!canSplitCommits) return;
+		const step = editableSteps.find((s) => s.subject.id === stepId);
+		if (!step || step.type !== "squash") return;
+		const { commits } = step.subject;
 		const commitIndex = commits.indexOf(commitId);
-		if (commitIndex === -1) return;
+		if (commitIndex <= 0 || !commits.includes(commitId)) return;
 		const firstGroup = commits.slice(0, commitIndex);
 		const secondGroup = commits.slice(commitIndex);
-		if (firstGroup.length === 0) return;
-		if (firstGroup.length === 1) {
-			newSteps[stepIndex] = {
-				type: "pick",
-				subject: { id: stepId, commitId: firstGroup[0]! },
-			};
-		} else {
-			const firstGroupMessage = await getCommitMessage(firstGroup);
-			newSteps[stepIndex] = {
-				type: "squash",
-				subject: {
-					id: stepId,
-					commits: firstGroup,
-					message: firstGroupMessage,
-				},
-			};
-		}
-		if (secondGroup.length === 1) {
-			const newPickStep = {
-				type: "pick" as const,
-				subject: {
-					id: crypto.randomUUID(),
-					commitId: secondGroup[0]!,
-				},
-			};
-			newSteps.splice(stepIndex + 1, 0, newPickStep);
-		} else {
-			const secondGroupMessage = await getCommitMessage(secondGroup);
-			const newSquashStep = {
-				type: "squash" as const,
-				subject: {
-					id: crypto.randomUUID(),
-					commits: secondGroup,
-					message: secondGroupMessage,
-				},
-			};
-			newSteps.splice(stepIndex + 1, 0, newSquashStep);
-		}
-		editableSteps = newSteps;
-	}
-	function getStepIndex(stepId: string): number {
-		return editableSteps.findIndex((step) => step.subject.id === stepId);
-	}
-	function canShiftStepUp(stepId: string): boolean {
-		const index = getStepIndex(stepId);
-		return index > 0;
-	}
-	function canShiftStepDown(stepId: string): boolean {
-		const index = getStepIndex(stepId);
-		return index !== -1 && index < editableSteps.length - 1;
-	}
-	function swapSteps(indexA: number, indexB: number) {
-		const newSteps = structuredClone(editableSteps);
-		const stepA = newSteps[indexA];
-		const stepB = newSteps[indexB];
-		if (!stepA || !stepB) return;
-		newSteps[indexA] = stepB;
-		newSteps[indexB] = stepA;
-		editableSteps = newSteps;
-	}
-	function shiftStepDown(stepId: string) {
-		const currentIndex = getStepIndex(stepId);
-		const isValidShift = currentIndex !== -1 && currentIndex < editableSteps.length - 1;
-		if (isValidShift) {
-			swapSteps(currentIndex, currentIndex + 1);
-		}
-	}
-	function shiftStepUp(stepId: string) {
-		const currentIndex = getStepIndex(stepId);
-		const isValidShift = currentIndex > 0;
-		if (isValidShift) {
-			swapSteps(currentIndex, currentIndex - 1);
-		}
+		const firstGroupMessage = firstGroup.length > 1 ? await getCommitMessage(firstGroup) : "";
+		const secondGroupMessage = secondGroup.length > 1 ? await getCommitMessage(secondGroup) : "";
+		editableSteps = splitStepAtCommit(
+			editableSteps,
+			stepId,
+			commitId,
+			firstGroupMessage,
+			secondGroupMessage,
+		);
 	}
 	async function handleIntegrate() {
 		if (stackId === undefined) {
@@ -227,7 +110,6 @@
 		});
 		closeModal();
 	}
-	// --- End InteractiveBranchIntegration logic ---
 </script>
 
 <Modal bind:this={modalRef} title="Integrate the upstream changes" noPadding width={500}>
@@ -480,8 +362,8 @@
 			class="branch-integration__move-buttons__up"
 			size="tag"
 			icon="arrow-up"
-			disabled={!canShiftStepUp(stepId) || disabled}
-			onclick={() => shiftStepUp(stepId)}
+			disabled={!canShiftStepUp(editableSteps, stepId) || disabled}
+			onclick={() => (editableSteps = shiftStepUp(editableSteps, stepId))}
 		/>
 		<Button
 			kind="outline"
@@ -489,8 +371,8 @@
 			class="branch-integration__move-buttons__down"
 			size="tag"
 			icon="arrow-down"
-			disabled={!canShiftStepDown(stepId) || disabled}
-			onclick={() => shiftStepDown(stepId)}
+			disabled={!canShiftStepDown(editableSteps, stepId) || disabled}
+			onclick={() => (editableSteps = shiftStepDown(editableSteps, stepId))}
 		/>
 	</div>
 {/snippet}

--- a/apps/desktop/src/components/ChangedFilesContextMenu.svelte
+++ b/apps/desktop/src/components/ChangedFilesContextMenu.svelte
@@ -1,14 +1,15 @@
 <!-- This is a V3 replacement for `FileContextMenu.svelte` -->
 <script lang="ts">
-	import BranchNameTextbox from "$components/BranchNameTextbox.svelte";
+	import AbsorbPlanModal from "$components/AbsorbPlanModal.svelte";
+	import DiscardChangesModal from "$components/DiscardChangesModal.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
+	import StashIntoBranchModal from "$components/StashIntoBranchModal.svelte";
 	import { ACTION_SERVICE } from "$lib/actions/actionService.svelte";
 	import { AI_SERVICE } from "$lib/ai/service";
 	import { BACKEND } from "$lib/backend";
 	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
 	import { changesToDiffSpec } from "$lib/commits/utils";
 	import { projectAiExperimentalFeaturesEnabled, projectAiGenEnabled } from "$lib/config/config";
-	import { autoSelectBranchCreationFeature } from "$lib/config/uiFeatureFlags";
 	import { FILE_SERVICE } from "$lib/files/fileService";
 	import { isTreeChange, type TreeChange } from "$lib/hunks/change";
 	import { vscodePath } from "$lib/project/project";
@@ -17,28 +18,17 @@
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
-	import { computeChangeStatus } from "$lib/utils/fileStatus";
 	import { getEditorUri, URL_SERVICE } from "$lib/utils/url";
 	import { inject } from "@gitbutler/core/context";
 	import {
-		AsyncButton,
-		Button,
 		ContextMenu,
 		ContextMenuItem,
 		ContextMenuItemSubmenu,
 		ContextMenuSection,
-		CopyButton,
-		FileListItem,
-		Modal,
-		ModalHeader,
-		ScrollableContainer,
 		chipToasts,
-		Icon,
 		TestId,
 	} from "@gitbutler/ui";
-	import { tick } from "svelte";
 	import type { SelectionId } from "$lib/selection/key";
-	import type { HunkAssignment } from "@gitbutler/core/api";
 
 	const DEFAULT_MODEL = "gpt-4";
 
@@ -98,9 +88,9 @@
 	const backend = inject(BACKEND);
 	const [autoCommit, autoCommitting] = actionService.autoCommit;
 	const [branchChanges, branchingChanges] = actionService.branchChanges;
+	const [, absorbingChanges] = stackService.absorb;
 	const [splitOffChanges] = stackService.splitBranch;
 	const [splitBranchIntoDependentBranch] = stackService.splitBrancIntoDependentBranch;
-	const [absorb, absorbingChanges] = stackService.absorb;
 
 	const projectService = inject(PROJECTS_SERVICE);
 
@@ -123,10 +113,10 @@
 		}
 	})();
 
-	let confirmationModal: ReturnType<typeof Modal> | undefined;
-	let stashConfirmationModal: ReturnType<typeof Modal> | undefined;
-	let absorbPlanModal = $state<ReturnType<typeof Modal> | undefined>();
 	let contextMenu: ReturnType<typeof ContextMenu>;
+	let discardModal: ReturnType<typeof DiscardChangesModal>;
+	let stashModal: ReturnType<typeof StashIntoBranchModal>;
+	let absorbModal: ReturnType<typeof AbsorbPlanModal>;
 	let aiConfigurationValid = $state(false);
 
 	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
@@ -153,47 +143,6 @@
 			return item.changes[0]!.path;
 		}
 		return null;
-	}
-
-	async function confirmDiscard(item: ChangedFilesItem) {
-		await stackService.discardChanges({
-			projectId,
-			worktreeChanges: changesToDiffSpec(item.changes),
-		});
-
-		const selectedFiles = item.changes.map((change) => ({ ...selectionId, path: change.path }));
-
-		// Unselect the discarded files
-		idSelection.removeMany(selectedFiles);
-
-		confirmationModal?.close();
-	}
-
-	let stashBranchName = $state<string>();
-	let slugifiedRefName: string | undefined = $state();
-	let stashBranchNameInput = $state<ReturnType<typeof BranchNameTextbox>>();
-	let absorbPlan = $state<HunkAssignment.CommitAbsorption[]>([]);
-
-	function uniquePaths(files: HunkAssignment.FileAbsorption[]): string[] {
-		const pathSet = new Set<string>();
-		for (const file of files) {
-			pathSet.add(file.path);
-		}
-		return Array.from(pathSet);
-	}
-
-	async function confirmStashIntoBranch(item: ChangedFilesItem, branchName: string | undefined) {
-		if (!branchName) {
-			return;
-		}
-
-		await stackService.stashIntoBranch({
-			projectId,
-			branchName,
-			worktreeChanges: changesToDiffSpec(item.changes),
-		});
-
-		stashConfirmationModal?.close();
 	}
 
 	export function open(e: MouseEvent | HTMLElement, item: ChangedFilesItem) {
@@ -264,24 +213,6 @@
 		} catch (error) {
 			console.error("Branching changes failed:", error);
 		}
-	}
-
-	async function triggerAbsorbChanges(changes: TreeChange[]) {
-		const changesToAbsorb = $state.snapshot(changes);
-		const plan = await stackService.fetchAbsorbPlan(projectId, {
-			type: "treeChanges",
-			subject: {
-				changes: changesToAbsorb,
-				assigned_stack_id: stackId ?? null,
-			},
-		});
-		if (!plan || plan.length === 0) {
-			chipToasts.error("No suitable commits found to absorb changes into.");
-			return;
-		}
-		absorbPlan = plan;
-		await tick();
-		absorbPlanModal?.show(null);
 	}
 
 	async function split(changes: TreeChange[]) {
@@ -368,8 +299,6 @@
 			console.error("Failed to split into dependent branch:", error);
 		}
 	}
-
-	let isAbsorbModalScrollVisible = $state(true);
 </script>
 
 <ContextMenu
@@ -394,20 +323,15 @@
 							testId={TestId.FileListItemContextMenu_DiscardChanges}
 							icon="bin"
 							onclick={() => {
-								confirmationModal?.show(item);
+								discardModal.show(item);
 								contextMenu.close();
 							}}
 						/>
 						<ContextMenuItem
 							label="Stash into branch…"
 							icon="branch-bottom-up-arrow"
-							onclick={async () => {
-								stashConfirmationModal?.show(item);
-								stashBranchName = await stackService.fetchNewBranchName(projectId);
-								// Select text after async value is loaded and DOM is updated
-								if ($autoSelectBranchCreationFeature) {
-									await stashBranchNameInput?.selectAll();
-								}
+							onclick={() => {
+								stashModal.show(item);
 								contextMenu.close();
 							}}
 						/>
@@ -416,7 +340,7 @@
 							icon="commit-absorb"
 							testId={TestId.FileListItemContextMenu_Absorb}
 							onclick={() => {
-								triggerAbsorbChanges(item.changes);
+								absorbModal.show(item.changes);
 								contextMenu.close();
 							}}
 							disabled={absorbingChanges.current.isLoading}
@@ -582,258 +506,6 @@
 	{/snippet}
 </ContextMenu>
 
-<Modal
-	width="small"
-	type="warning"
-	title="Discard changes"
-	testId={TestId.DiscardFileChangesConfirmationModal}
-	bind:this={confirmationModal}
-	onSubmit={(_, item) => isChangedFilesItem(item) && confirmDiscard(item)}
->
-	{#snippet children(item)}
-		{#if isChangedFilesItem(item)}
-			{#if isChangedFolderItem(item)}
-				<p class="discard-caption">
-					Are you sure you want to discard all changes in
-					<span class="text-bold">{item.path}</span>?
-				</p>
-			{:else}
-				{@const changes = item.changes}
-				{#if changes.length < 10}
-					<p class="discard-caption">
-						Are you sure you want to discard the changes<br />to the following files:
-					</p>
-					<ul class="file-list">
-						{#each changes as change}
-							<FileListItem
-								filePath={change.path}
-								fileStatus={computeChangeStatus(change)}
-								clickable={false}
-								listMode="list"
-							/>
-						{/each}
-					</ul>
-				{:else}
-					<p>
-						Discard the changes to all <span class="text-bold">
-							{changes.length} files
-						</span>?
-					</p>
-				{/if}
-			{/if}
-		{:else}
-			<p class="text-13">Woops! Malformed data :(</p>
-		{/if}
-	{/snippet}
-	{#snippet controls(close, item)}
-		<Button
-			testId={TestId.DiscardFileChangesConfirmationModal_Cancel}
-			kind="outline"
-			onclick={close}>Cancel</Button
-		>
-		<AsyncButton
-			testId={TestId.DiscardFileChangesConfirmationModal_Discard}
-			style="danger"
-			type="submit"
-			action={async () => await confirmDiscard(item)}
-		>
-			Confirm
-		</AsyncButton>
-	{/snippet}
-</Modal>
-
-<Modal
-	width={434}
-	type="info"
-	title="Stash changes into a new branch"
-	bind:this={stashConfirmationModal}
-	onSubmit={(_, item) => isChangedFilesItem(item) && confirmStashIntoBranch(item, slugifiedRefName)}
->
-	{#snippet children(item)}
-		<div class="content-wrap">
-			<BranchNameTextbox
-				bind:this={stashBranchNameInput}
-				id="stashBranchName"
-				placeholder="Enter your branch name..."
-				bind:value={stashBranchName}
-				autofocus
-				onslugifiedvalue={(value) => (slugifiedRefName = value)}
-			/>
-			<div class="explanation">
-				<p class="primary-text">
-					{#if isChangedFolderItem(item)}
-						All changes in this folder
-					{:else}
-						Your selected changes
-					{/if}
-					will be moved to a new branch and removed from your current workspace. To get these changes
-					back later, switch to the new branch and uncommit the stash.
-				</p>
-			</div>
-
-			<div class="technical-note">
-				<p class="text-12 text-body clr-text-2">
-					💡 This creates a new branch, commits your changes, then unapplies the branch. Future
-					versions will have simpler stash management.
-				</p>
-			</div>
-		</div>
-	{/snippet}
-	{#snippet controls(close, item)}
-		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
-		<AsyncButton
-			style="pop"
-			disabled={!slugifiedRefName}
-			type="submit"
-			action={async () => await confirmStashIntoBranch(item, slugifiedRefName)}
-		>
-			Stash into branch
-		</AsyncButton>
-	{/snippet}
-</Modal>
-
-<Modal
-	width={500}
-	noPadding
-	bind:this={absorbPlanModal}
-	testId={TestId.AbsobModal}
-	onSubmit={async () => {
-		try {
-			await chipToasts.promise(absorb({ projectId, absorptionPlan: absorbPlan }), {
-				loading: "Absorbing changes",
-				success: "Changes absorbed successfully",
-				error: "Failed to absorb changes",
-			});
-			absorbPlanModal?.close();
-		} catch (error) {
-			console.error("Failed to absorb changes:", error);
-		}
-	}}
->
-	<ModalHeader sticky={!isAbsorbModalScrollVisible}>Absorb Changes into Commits</ModalHeader>
-	<ScrollableContainer onscrollTop={(visible) => (isAbsorbModalScrollVisible = visible)}>
-		<div class="absorb-plan-content">
-			<p class="text-13 text-body clr-text-2">
-				The following changes will be absorbed into their respective commits:
-			</p>
-			<div class="commit-absorptions">
-				{#each absorbPlan as commitAbsorption}
-					{@const uniqueFilePaths = uniquePaths(commitAbsorption.files)}
-					<div class="commit-absorption" data-testid={TestId.AbsorbModal_CommitAbsorption}>
-						{#if commitAbsorption.reason !== "default_stack"}
-							<div class="absorption__reason text-12 text-body clr-text-2">
-								{#if commitAbsorption.reason === "hunk_dependency"}
-									📍 Files depend on the commit due to overlapping hunks
-								{:else if commitAbsorption.reason === "stack_assignment"}
-									🔖 Files assigned to this stack
-								{/if}
-							</div>
-						{/if}
-
-						<div class="absorption__content">
-							<div class="commit-header">
-								<Icon name="commit" />
-
-								<div class="flex gap-8 overflow-hidden align-center full-width">
-									<p class="text-13 text-semibold truncate flex-1">
-										{commitAbsorption.commitSummary.split("\n")[0]}
-									</p>
-									<CopyButton
-										class="text-12 clr-text-2"
-										text={commitAbsorption.commitId}
-										onclick={() => {
-											clipboardService.write(commitAbsorption.commitId, {
-												message: "Commit ID copied",
-											});
-										}}
-									/>
-								</div>
-							</div>
-
-							<ul class="file-list">
-								{#each uniqueFilePaths as filePath (filePath)}
-									<FileListItem
-										{filePath}
-										clickable={false}
-										listMode="list"
-										isLast={uniqueFilePaths.indexOf(filePath) === uniqueFilePaths.length - 1}
-									/>
-								{/each}
-							</ul>
-						</div>
-					</div>
-				{/each}
-			</div>
-		</div>
-	</ScrollableContainer>
-
-	{#snippet controls(close)}
-		<Button kind="outline" onclick={close}>Cancel</Button>
-		<Button
-			style="pop"
-			type="submit"
-			loading={absorbingChanges.current.isLoading}
-			disabled={absorbPlan.length === 0 || absorbingChanges.current.isLoading}
-			testId={TestId.AbsorbModal_ActionButton}
-		>
-			Absorb changes
-		</Button>
-	{/snippet}
-</Modal>
-
-<style lang="postcss">
-	.discard-caption {
-		color: var(--clr-text-2);
-	}
-	.file-list {
-		display: flex;
-		flex-direction: column;
-		margin-top: 12px;
-		overflow: hidden;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-1);
-	}
-	/* MODAL WINDOW */
-	.content-wrap {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-	.absorb-plan-content {
-		display: flex;
-		flex-direction: column;
-		padding: 16px;
-		padding-top: 0;
-		gap: 12px;
-	}
-	.commit-absorptions {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-	.commit-absorption {
-		display: flex;
-		flex-direction: column;
-		overflow: hidden;
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml);
-		background-color: var(--clr-bg-1);
-	}
-	.absorption__reason {
-		display: flex;
-		padding: 8px;
-		border-bottom: 1px solid var(--clr-border-2);
-		background-color: var(--clr-bg-2);
-	}
-	.absorption__content {
-		display: flex;
-		flex-direction: column;
-		padding: 12px;
-	}
-	.commit-header {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-	}
-</style>
+<DiscardChangesModal bind:this={discardModal} {projectId} {selectionId} />
+<StashIntoBranchModal bind:this={stashModal} {projectId} />
+<AbsorbPlanModal bind:this={absorbModal} {projectId} {stackId} />

--- a/apps/desktop/src/components/DiscardChangesModal.svelte
+++ b/apps/desktop/src/components/DiscardChangesModal.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { changesToDiffSpec } from "$lib/commits/utils";
+	import { isTreeChange, type TreeChange } from "$lib/hunks/change";
+	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { computeChangeStatus } from "$lib/utils/fileStatus";
+	import { inject } from "@gitbutler/core/context";
+	import { AsyncButton, Button, FileListItem, Modal, TestId } from "@gitbutler/ui";
+	import type { SelectionId } from "$lib/selection/key";
+
+	type ChangedFilesItem = {
+		changes: TreeChange[];
+	};
+
+	function isChangedFilesItem(item: unknown): item is ChangedFilesItem {
+		return (
+			typeof item === "object" &&
+			item !== null &&
+			"changes" in item &&
+			Array.isArray(item.changes) &&
+			item.changes.every(isTreeChange)
+		);
+	}
+
+	type ChangedFolderItem = ChangedFilesItem & { path: string };
+
+	function isChangedFolderItem(item: ChangedFilesItem): item is ChangedFolderItem {
+		return "path" in item && typeof item.path === "string";
+	}
+
+	type Props = {
+		projectId: string;
+		selectionId: SelectionId;
+	};
+
+	const { projectId, selectionId }: Props = $props();
+
+	const stackService = inject(STACK_SERVICE);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
+
+	let modal: ReturnType<typeof Modal> | undefined;
+
+	export function show(item: ChangedFilesItem) {
+		modal?.show(item);
+	}
+
+	async function confirmDiscard(item: ChangedFilesItem) {
+		await stackService.discardChanges({
+			projectId,
+			worktreeChanges: changesToDiffSpec(item.changes),
+		});
+
+		const selectedFiles = item.changes.map((change) => ({ ...selectionId, path: change.path }));
+		idSelection.removeMany(selectedFiles);
+
+		modal?.close();
+	}
+</script>
+
+<Modal
+	width="small"
+	type="warning"
+	title="Discard changes"
+	testId={TestId.DiscardFileChangesConfirmationModal}
+	bind:this={modal}
+>
+	{#snippet children(item)}
+		{#if isChangedFilesItem(item)}
+			{#if isChangedFolderItem(item)}
+				<p class="discard-caption">
+					Are you sure you want to discard all changes in
+					<span class="text-bold">{item.path}</span>?
+				</p>
+			{:else}
+				{@const changes = item.changes}
+				{#if changes.length < 10}
+					<p class="discard-caption">
+						Are you sure you want to discard the changes<br />to the following files:
+					</p>
+					<ul class="file-list">
+						{#each changes as change}
+							<FileListItem
+								filePath={change.path}
+								fileStatus={computeChangeStatus(change)}
+								clickable={false}
+								listMode="list"
+							/>
+						{/each}
+					</ul>
+				{:else}
+					<p>
+						Discard the changes to all <span class="text-bold">
+							{changes.length} files
+						</span>?
+					</p>
+				{/if}
+			{/if}
+		{:else}
+			<p class="text-13">Woops! Malformed data :(</p>
+		{/if}
+	{/snippet}
+	{#snippet controls(close, item)}
+		<Button
+			testId={TestId.DiscardFileChangesConfirmationModal_Cancel}
+			kind="outline"
+			onclick={close}>Cancel</Button
+		>
+		<AsyncButton
+			testId={TestId.DiscardFileChangesConfirmationModal_Discard}
+			style="danger"
+			type="submit"
+			action={async () => {
+				if (isChangedFilesItem(item)) await confirmDiscard(item);
+			}}
+		>
+			Confirm
+		</AsyncButton>
+	{/snippet}
+</Modal>
+
+<style lang="postcss">
+	.discard-caption {
+		color: var(--clr-text-2);
+	}
+	.file-list {
+		display: flex;
+		flex-direction: column;
+		margin-top: 12px;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		background-color: var(--clr-bg-1);
+	}
+</style>

--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -34,6 +34,7 @@
 		ScrollableContainer,
 		type BranchShouldBeDeletedMap,
 		TestId,
+		AsyncButton,
 	} from "@gitbutler/ui";
 	import { tick } from "svelte";
 	import { SvelteMap } from "svelte/reactivity";
@@ -441,18 +442,18 @@
 	{#snippet controls()}
 		<div class="controls">
 			<Button onclick={() => modal?.close()} kind="outline">Cancel</Button>
-			<Button
+			<AsyncButton
 				testId={TestId.IntegrateUpstreamActionButton}
 				wide
 				style="pop"
 				disabled={isDivergedResolved || !branchStatuses}
 				loading={integratingUpstream === "loading" || !branchStatuses}
-				onclick={async () => {
+				action={async () => {
 					await integrate();
 				}}
 			>
 				Update workspace
-			</Button>
+			</AsyncButton>
 		</div>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/components/RuleEditor.svelte
+++ b/apps/desktop/src/components/RuleEditor.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import NewRuleMenu from "$components/NewRuleMenu.svelte";
+	import ReduxResult from "$components/ReduxResult.svelte";
+	import RuleFiltersEditor from "$components/RuleFiltersEditor.svelte";
+	import {
+		type WorkspaceRuleId,
+		type RuleFilterMap,
+		type RuleFilterType,
+		type StackTarget,
+		encodeStackTarget,
+		decodeStackTarget,
+		compareStackTarget,
+	} from "$lib/rules/rule";
+	import { RULES_SERVICE } from "$lib/rules/rulesService.svelte";
+	import { getStackName } from "$lib/stacks/stack";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { typedKeys } from "$lib/utils/object";
+	import { inject } from "@gitbutler/core/context";
+	import { Button, chipToasts, Icon, Select, SelectItem, Spacer } from "@gitbutler/ui";
+	import { isDefined } from "@gitbutler/ui/utils/typeguards";
+
+	type Props = {
+		projectId: string;
+		ruleId?: WorkspaceRuleId;
+		initialStackTarget?: StackTarget;
+		initialFilterValues?: Partial<RuleFilterMap>;
+		onsave: () => void;
+		oncancel: () => void;
+	};
+
+	const {
+		projectId,
+		ruleId,
+		initialStackTarget,
+		initialFilterValues = {},
+		onsave,
+		oncancel,
+	}: Props = $props();
+
+	const rulesService = inject(RULES_SERVICE);
+	const stackService = inject(STACK_SERVICE);
+
+	const [create, creatingRule] = rulesService.createWorkspaceRule;
+	const [update, updatingRule] = rulesService.updateWorkspaceRule;
+
+	let stackTargetSelected = $state<StackTarget | undefined>(initialStackTarget);
+	let draftRuleFilterInitialValues = $state<Partial<RuleFilterMap>>(initialFilterValues);
+	const ruleFilterTypes = $derived(typedKeys(draftRuleFilterInitialValues));
+	const encodedStackTarget = $derived(
+		stackTargetSelected && encodeStackTarget(stackTargetSelected),
+	);
+
+	let ruleFiltersEditor = $state<RuleFiltersEditor>();
+	let addFilterButton = $state<HTMLDivElement>();
+	let newFilterContextMenu = $state<NewRuleMenu>();
+
+	const validFilters = $derived(!ruleFiltersEditor || ruleFiltersEditor.imports.filtersValid);
+	const canSaveRule = $derived(stackTargetSelected !== undefined && validFilters);
+
+	const stackEntries = $derived(stackService.stacks(projectId));
+
+	function openAddFilterContextMenu(e: MouseEvent) {
+		e.stopPropagation();
+		newFilterContextMenu?.toggle(e);
+	}
+
+	function addDraftRuleFilter(type: RuleFilterType) {
+		const ruleTypes = typedKeys(draftRuleFilterInitialValues);
+		if (!ruleTypes.includes(type)) {
+			draftRuleFilterInitialValues[type] = null;
+		}
+	}
+
+	function removeDraftRuleFilter(type: RuleFilterType) {
+		draftRuleFilterInitialValues[type] = undefined;
+		delete draftRuleFilterInitialValues[type];
+	}
+
+	async function saveRule() {
+		const ruleFilters = ruleFiltersEditor ? ruleFiltersEditor.getRuleFilters() : [];
+
+		if (ruleFilters === undefined) {
+			chipToasts.error("Invalid rule filters");
+			return;
+		}
+
+		if (!stackTargetSelected) {
+			chipToasts.error("Please select a branch to assign the rule");
+			return;
+		}
+
+		if (ruleId) {
+			await update({
+				projectId,
+				request: {
+					id: ruleId,
+					enabled: null,
+					action: {
+						type: "explicit",
+						subject: {
+							type: "assign",
+							subject: { target: stackTargetSelected },
+						},
+					},
+					filters: ruleFilters,
+					trigger: null,
+				},
+			});
+		} else {
+			await create({
+				projectId,
+				request: {
+					action: {
+						type: "explicit",
+						subject: {
+							type: "assign",
+							subject: { target: stackTargetSelected },
+						},
+					},
+					filters: ruleFilters,
+					trigger: "fileSytemChange",
+				},
+			});
+		}
+
+		onsave();
+	}
+</script>
+
+<div class="rule-editor">
+	<div class="rule-editor__action">
+		<h3 class="text-13 text-semibold">Assign to branch</h3>
+		<ReduxResult {projectId} result={stackEntries.result}>
+			{#snippet children(stacks)}
+				{@const stackOptions = [
+					...stacks
+						.map((stack) =>
+							stack.id
+								? {
+										label: getStackName(stack),
+										value: encodeStackTarget({ type: "stackId", subject: stack.id }),
+									}
+								: undefined,
+						)
+						.filter(isDefined),
+					{ separator: true } as const,
+					{
+						label: "Leftmost lane",
+						value: encodeStackTarget({ type: "leftmost" }),
+					},
+					{
+						label: "Rightmost lane",
+						value: encodeStackTarget({ type: "rightmost" }),
+					},
+				]}
+
+				<Select
+					value={encodedStackTarget}
+					options={stackOptions}
+					minHeight={200}
+					flex="1"
+					searchable
+					onselect={(selectedStackTarget) => {
+						stackTargetSelected = decodeStackTarget(selectedStackTarget);
+					}}
+					icon={stackTargetSelected
+						? stackTargetSelected.type === "leftmost"
+							? "leftmost-lane"
+							: stackTargetSelected.type === "rightmost"
+								? "rightmost-lane"
+								: "branch"
+						: "branch"}
+				>
+					{#snippet itemSnippet({ item, highlighted })}
+						<SelectItem
+							selected={item.value ? compareStackTarget(item.value, stackTargetSelected) : false}
+							{highlighted}
+						>
+							{item.label || ""}
+							{#snippet iconSnippet()}
+								{#if item.value}
+									{@const target = decodeStackTarget(item.value)}
+									{#if target.type === "leftmost"}
+										<Icon name="leftmost-lane" />
+									{:else if target.type === "rightmost"}
+										<Icon name="rightmost-lane" />
+									{:else}
+										<Icon name="branch" />
+									{/if}
+								{/if}
+							{/snippet}
+						</SelectItem>
+					{/snippet}
+				</Select>
+			{/snippet}
+		</ReduxResult>
+	</div>
+
+	{#if typedKeys(draftRuleFilterInitialValues).length > 0}
+		<div class="rule-editor__filters">
+			<RuleFiltersEditor
+				bind:this={ruleFiltersEditor}
+				{projectId}
+				initialFilterValues={draftRuleFilterInitialValues}
+				addFilter={addDraftRuleFilter}
+				deleteFilter={removeDraftRuleFilter}
+			/>
+		</div>
+	{:else}
+		<div class="rule-editor__matches-all">
+			<p class="text-13">Matches all changes</p>
+			<div bind:this={addFilterButton} class="rule-editor__add-filter-button text-12">
+				<button type="button" onclick={openAddFilterContextMenu}>
+					<span class="clr-text-1 underline-dotted"> Add filter +</span>
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	<Spacer margin={2} dotted />
+
+	<div class="rule-editor__buttons">
+		<Button onclick={oncancel} kind="outline">Cancel</Button>
+		<Button
+			onclick={saveRule}
+			kind="solid"
+			wide
+			style="gray"
+			disabled={!canSaveRule}
+			loading={stackEntries.result.isLoading ||
+				creatingRule.current.isLoading ||
+				updatingRule.current.isLoading}
+		>
+			Save rule
+		</Button>
+	</div>
+</div>
+
+<NewRuleMenu
+	bind:this={newFilterContextMenu}
+	addedFilterTypes={ruleFilterTypes}
+	trigger={addFilterButton}
+	addFromFilter={(type) => {
+		addDraftRuleFilter(type);
+	}}
+/>
+
+<style lang="postcss">
+	.rule-editor {
+		display: flex;
+		flex-direction: column;
+		padding: 12px;
+		padding-bottom: 16px;
+		gap: 16px;
+		border-bottom: 1px solid var(--clr-border-2);
+	}
+
+	.rule-editor__action {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.rule-editor__filters {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.rule-editor__matches-all {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 12px;
+		gap: 8px;
+		border-radius: var(--radius-m);
+		background-color: var(--clr-bg-2);
+
+		& p {
+			color: var(--clr-text-2);
+			text-align: center;
+		}
+	}
+
+	.rule-editor__add-filter-button {
+		color: var(--clr-text-2);
+	}
+
+	.rule-editor__buttons {
+		display: flex;
+		justify-content: flex-end;
+		gap: 6px;
+	}
+</style>

--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -1,38 +1,19 @@
 <script lang="ts">
 	import Drawer from "$components/Drawer.svelte";
-	import NewRuleMenu from "$components/NewRuleMenu.svelte";
 	import ReduxResult from "$components/ReduxResult.svelte";
 	import Rule from "$components/Rule.svelte";
-	import RuleFiltersEditor from "$components/RuleFiltersEditor.svelte";
+	import RuleEditor from "$components/RuleEditor.svelte";
 	import {
 		type WorkspaceRuleId,
 		type RuleFilterMap,
-		type RuleFilterType,
-		type WorkspaceRule,
 		type StackTarget,
-		encodeStackTarget,
-		decodeStackTarget,
-		compareStackTarget,
+		type WorkspaceRule,
 		type RuleFilter,
 	} from "$lib/rules/rule";
 	import { RULES_SERVICE, workspaceRulesSelectors } from "$lib/rules/rulesService.svelte";
-	import { getStackName } from "$lib/stacks/stack";
-	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { typedKeys } from "$lib/utils/object";
 	import { inject } from "@gitbutler/core/context";
-	import {
-		Button,
-		chipToasts,
-		Select,
-		SelectItem,
-		Icon,
-		Badge,
-		Spacer,
-		SkeletonBone,
-		Link,
-	} from "@gitbutler/ui";
+	import { Badge, Button, chipToasts, Link, SkeletonBone } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
-	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { slide } from "svelte/transition";
 
 	type Props = {
@@ -42,53 +23,20 @@
 	const { projectId }: Props = $props();
 
 	const rulesService = inject(RULES_SERVICE);
-	const stackService = inject(STACK_SERVICE);
-
-	const [create, creatingRule] = rulesService.createWorkspaceRule;
-	const [update, updatingRule] = rulesService.updateWorkspaceRule;
-
-	let selectedRuleId = $state<WorkspaceRuleId>();
-	let stackTargetSelected = $state<StackTarget>();
-	const encodedStackTarget = $derived(
-		stackTargetSelected && encodeStackTarget(stackTargetSelected),
-	);
-
-	let draftRuleFilterInitialValues = $state<Partial<RuleFilterMap>>({});
-	const ruleFilterTypes = $derived(typedKeys(draftRuleFilterInitialValues));
-
-	// Component references
-	let ruleFiltersEditor = $state<RuleFiltersEditor>();
-
-	let addFilterButton = $state<HTMLDivElement>();
-	let newFilterContextMenu = $state<NewRuleMenu>();
 
 	// Visual state
 	let mode = $state<"list" | "edit" | "add">("list");
 	let editingRuleId = $state<WorkspaceRuleId | null>(null);
 
+	// Initial values passed to RuleEditor when opening edit mode
+	let editorInitialStackTarget = $state<StackTarget | undefined>(undefined);
+	let editorInitialFilterValues = $state<Partial<RuleFilterMap>>({});
+
 	// Read initial collapsed state from persisted storage, default to false (open) if not found
 	const drawerPersistId = `rules-drawer-${projectId}`;
 	let drawer = $state<Drawer>();
 
-	const validFilters = $derived(!ruleFiltersEditor || ruleFiltersEditor.imports.filtersValid);
-	const canSaveRule = $derived(stackTargetSelected !== undefined && validFilters);
-
-	function openAddFilterContextMenu(e: MouseEvent) {
-		e.stopPropagation();
-		newFilterContextMenu?.toggle(e);
-	}
-
-	function addDraftRuleFilter(type: RuleFilterType) {
-		const ruleTypes = typedKeys(draftRuleFilterInitialValues);
-		if (!ruleTypes.includes(type)) {
-			draftRuleFilterInitialValues[type] = null;
-		}
-	}
-
-	function removeDraftRuleFilter(type: RuleFilterType) {
-		draftRuleFilterInitialValues[type] = undefined;
-		delete draftRuleFilterInitialValues[type];
-	}
+	const rules = $derived(rulesService.workspaceRules(projectId));
 
 	function openRuleEditor() {
 		if (editingRuleId !== null) {
@@ -104,13 +52,12 @@
 	}
 
 	function resetEditor() {
-		stackTargetSelected = undefined;
-		draftRuleFilterInitialValues = {};
-		selectedRuleId = undefined;
+		editorInitialStackTarget = undefined;
+		editorInitialFilterValues = {};
 		editingRuleId = null;
 	}
 
-	function cancelRuleEdition() {
+	function closeEditor() {
 		mode = "list";
 		resetEditor();
 	}
@@ -151,75 +98,17 @@
 			return;
 		}
 
-		selectedRuleId = rule.id;
 		editingRuleId = rule.id;
-		stackTargetSelected = rule.action.subject.subject.target;
-		const initialValues: Partial<RuleFilterMap> = {};
+		editorInitialStackTarget = rule.action.subject.subject.target;
 
+		const initialValues: Partial<RuleFilterMap> = {};
 		for (const filter of rule.filters) {
 			updateInitialValues(filter, initialValues);
 		}
-
-		draftRuleFilterInitialValues = initialValues;
+		editorInitialFilterValues = initialValues;
 
 		mode = "edit";
 	}
-
-	async function saveRule() {
-		// Logic to save the rule
-		// This needs to be writtent like this.
-		// If there's no rule filters editor, it means that the match is all files
-		const ruleFilters = ruleFiltersEditor ? ruleFiltersEditor.getRuleFilters() : [];
-
-		if (ruleFilters === undefined) {
-			chipToasts.error("Invalid rule filters");
-			return;
-		}
-
-		if (!stackTargetSelected) {
-			chipToasts.error("Please select a branch to assign the rule");
-			return;
-		}
-
-		if (selectedRuleId) {
-			await update({
-				projectId,
-				request: {
-					id: selectedRuleId,
-					enabled: null,
-					action: {
-						type: "explicit",
-						subject: {
-							type: "assign",
-							subject: { target: stackTargetSelected },
-						},
-					},
-					filters: ruleFilters,
-					trigger: null,
-				},
-			});
-		} else {
-			await create({
-				projectId,
-				request: {
-					action: {
-						type: "explicit",
-						subject: {
-							type: "assign",
-							subject: { target: stackTargetSelected },
-						},
-					},
-					filters: ruleFilters,
-					trigger: "fileSytemChange",
-				},
-			});
-		}
-
-		mode = "list";
-		resetEditor();
-	}
-
-	const rules = $derived(rulesService.workspaceRules(projectId));
 
 	function separateRules(allRules: WorkspaceRule[]) {
 		const regularRules: WorkspaceRule[] = [];
@@ -294,7 +183,7 @@
 			{#if totalRules > 0}
 				{#if mode === "add"}
 					<div in:slide={{ duration: 150 }}>
-						{@render ruleEditor()}
+						<RuleEditor {projectId} onsave={closeEditor} oncancel={closeEditor} />
 					</div>
 				{/if}
 
@@ -303,7 +192,14 @@
 						{#each regularRules.slice().reverse() as rule (rule.id)}
 							{#if editingRuleId === rule.id}
 								<div in:slide={{ duration: 150 }}>
-									{@render ruleEditor()}
+									<RuleEditor
+										{projectId}
+										ruleId={rule.id}
+										initialStackTarget={editorInitialStackTarget}
+										initialFilterValues={editorInitialFilterValues}
+										onsave={closeEditor}
+										oncancel={closeEditor}
+									/>
 								</div>
 							{:else}
 								<Rule {projectId} {rule} editRule={() => editExistingRule(rule)} />
@@ -316,7 +212,14 @@
 							{#each aiRules.slice().reverse() as rule (rule.id)}
 								{#if editingRuleId === rule.id}
 									<div in:slide={{ duration: 150 }}>
-										{@render ruleEditor()}
+										<RuleEditor
+											{projectId}
+											ruleId={rule.id}
+											initialStackTarget={editorInitialStackTarget}
+											initialFilterValues={editorInitialFilterValues}
+											onsave={closeEditor}
+											oncancel={closeEditor}
+										/>
 									</div>
 								{:else}
 									<Rule {projectId} {rule} editRule={() => editExistingRule(rule)} />
@@ -327,7 +230,7 @@
 				</div>
 			{:else if mode === "add"}
 				<div in:slide={{ duration: 170 }}>
-					{@render ruleEditor()}
+					<RuleEditor {projectId} onsave={closeEditor} oncancel={closeEditor} />
 				</div>
 			{:else}
 				<div class="rules-placeholder">
@@ -347,125 +250,6 @@
 			{/if}
 		{/snippet}
 	</ReduxResult>
-{/snippet}
-
-{#snippet ruleEditor()}
-	{@const stackEntries = stackService.stacks(projectId)}
-	<div class="rules-list__editor-content">
-		<div class="rules-list__action">
-			<h3 class="text-13 text-semibold">Assign to branch</h3>
-			<ReduxResult {projectId} result={stackEntries.result}>
-				{#snippet children(stacks)}
-					{@const stackOptions = [
-						...stacks
-							.map((stack) =>
-								stack.id
-									? {
-											label: getStackName(stack),
-											value: encodeStackTarget({ type: "stackId", subject: stack.id }),
-										}
-									: undefined,
-							)
-							.filter(isDefined),
-						{ separator: true } as const,
-						{
-							label: "Leftmost lane",
-							value: encodeStackTarget({ type: "leftmost" }),
-						},
-						{
-							label: "Rightmost lane",
-							value: encodeStackTarget({ type: "rightmost" }),
-						},
-					]}
-
-					<Select
-						value={encodedStackTarget}
-						options={stackOptions}
-						minHeight={200}
-						flex="1"
-						searchable
-						onselect={(selectedStackTarget) => {
-							stackTargetSelected = decodeStackTarget(selectedStackTarget);
-						}}
-						icon={stackTargetSelected
-							? stackTargetSelected.type === "leftmost"
-								? "leftmost-lane"
-								: stackTargetSelected.type === "rightmost"
-									? "rightmost-lane"
-									: "branch"
-							: "branch"}
-					>
-						{#snippet itemSnippet({ item, highlighted })}
-							<SelectItem
-								selected={item.value ? compareStackTarget(item.value, stackTargetSelected) : false}
-								{highlighted}
-							>
-								{item.label || ""}
-								{#snippet iconSnippet()}
-									{#if item.value}
-										{@const target = decodeStackTarget(item.value)}
-										{#if target.type === "leftmost"}
-											<Icon name="leftmost-lane" />
-										{:else if target.type === "rightmost"}
-											<Icon name="rightmost-lane" />
-										{:else}
-											<Icon name="branch" />
-										{/if}
-									{/if}
-								{/snippet}
-							</SelectItem>
-						{/snippet}
-					</Select>
-				{/snippet}
-			</ReduxResult>
-		</div>
-
-		{#if typedKeys(draftRuleFilterInitialValues).length > 0}
-			<div class="rules-list__filters">
-				<RuleFiltersEditor
-					bind:this={ruleFiltersEditor}
-					{projectId}
-					initialFilterValues={draftRuleFilterInitialValues}
-					addFilter={addDraftRuleFilter}
-					deleteFilter={removeDraftRuleFilter}
-				/>
-			</div>
-		{:else}
-			<div class="rules-list__matches-all">
-				<p class="text-13">Matches all changes</p>
-				<div bind:this={addFilterButton} class="rules-list__add-filter-button text-12">
-					<button type="button" onclick={openAddFilterContextMenu}>
-						<span class="clr-text-1 underline-dotted"> Add filter +</span>
-					</button>
-				</div>
-			</div>
-		{/if}
-
-		<Spacer margin={2} dotted />
-
-		<div class="rules-list__editor-buttons">
-			<Button onclick={cancelRuleEdition} kind="outline">Cancel</Button>
-			<Button
-				onclick={saveRule}
-				kind="solid"
-				wide
-				style="gray"
-				disabled={!canSaveRule}
-				loading={stackEntries.result.isLoading ||
-					creatingRule.current.isLoading ||
-					updatingRule.current.isLoading}>Save rule</Button
-			>
-		</div>
-	</div>
-
-	<NewRuleMenu
-		bind:this={newFilterContextMenu}
-		addedFilterTypes={ruleFilterTypes}
-		trigger={addFilterButton}
-		addFromFilter={(type) => {
-			addDraftRuleFilter(type);
-		}}
-	/>
 {/snippet}
 
 <style lang="postcss">
@@ -498,51 +282,6 @@
 	.rules-section {
 		display: flex;
 		flex-direction: column;
-	}
-
-	.rules-list__editor-content {
-		display: flex;
-		flex-direction: column;
-		padding: 12px;
-		padding-bottom: 16px;
-		gap: 16px;
-		border-bottom: 1px solid var(--clr-border-2);
-	}
-
-	.rules-list__filters {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.rules-list__matches-all {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 12px;
-		gap: 8px;
-		border-radius: var(--radius-m);
-		background-color: var(--clr-bg-2);
-
-		& p {
-			color: var(--clr-text-2);
-			text-align: center;
-		}
-	}
-
-	.rules-list__action {
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-	}
-
-	.rules-list__add-filter-button {
-		color: var(--clr-text-2);
-	}
-
-	.rules-list__editor-buttons {
-		display: flex;
-		justify-content: flex-end;
-		gap: 6px;
 	}
 
 	.rule-skeleton {

--- a/apps/desktop/src/components/StashIntoBranchModal.svelte
+++ b/apps/desktop/src/components/StashIntoBranchModal.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import BranchNameTextbox from "$components/BranchNameTextbox.svelte";
+	import { changesToDiffSpec } from "$lib/commits/utils";
+	import { autoSelectBranchCreationFeature } from "$lib/config/uiFeatureFlags";
+	import { isTreeChange, type TreeChange } from "$lib/hunks/change";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { AsyncButton, Button, Modal } from "@gitbutler/ui";
+
+	type ChangedFilesItem = {
+		changes: TreeChange[];
+	};
+
+	function isChangedFilesItem(item: unknown): item is ChangedFilesItem {
+		return (
+			typeof item === "object" &&
+			item !== null &&
+			"changes" in item &&
+			Array.isArray(item.changes) &&
+			item.changes.every(isTreeChange)
+		);
+	}
+
+	type ChangedFolderItem = ChangedFilesItem & { path: string };
+
+	function isChangedFolderItem(item: ChangedFilesItem): item is ChangedFolderItem {
+		return "path" in item && typeof item.path === "string";
+	}
+
+	type Props = {
+		projectId: string;
+	};
+
+	const { projectId }: Props = $props();
+
+	const stackService = inject(STACK_SERVICE);
+
+	let modal: ReturnType<typeof Modal> | undefined;
+	let stashBranchName = $state<string>();
+	let slugifiedRefName: string | undefined = $state();
+	let stashBranchNameInput = $state<ReturnType<typeof BranchNameTextbox>>();
+
+	export async function show(item: ChangedFilesItem) {
+		slugifiedRefName = undefined;
+		modal?.show(item);
+		stashBranchName = await stackService.fetchNewBranchName(projectId);
+		if ($autoSelectBranchCreationFeature) {
+			await stashBranchNameInput?.selectAll();
+		}
+	}
+
+	async function confirmStashIntoBranch(item: ChangedFilesItem, branchName: string | undefined) {
+		if (!branchName) return;
+
+		await stackService.stashIntoBranch({
+			projectId,
+			branchName,
+			worktreeChanges: changesToDiffSpec(item.changes),
+		});
+
+		modal?.close();
+	}
+</script>
+
+<Modal width={434} type="info" title="Stash changes into a new branch" bind:this={modal}>
+	{#snippet children(item)}
+		<div class="content-wrap">
+			<BranchNameTextbox
+				bind:this={stashBranchNameInput}
+				id="stashBranchName"
+				placeholder="Enter your branch name..."
+				bind:value={stashBranchName}
+				autofocus
+				onslugifiedvalue={(value) => (slugifiedRefName = value)}
+			/>
+			<div class="explanation">
+				<p class="primary-text">
+					{#if isChangedFilesItem(item) && isChangedFolderItem(item)}
+						All changes in this folder
+					{:else}
+						Your selected changes
+					{/if}
+					will be moved to a new branch and removed from your current workspace. To get these changes
+					back later, switch to the new branch and uncommit the stash.
+				</p>
+			</div>
+
+			<div class="technical-note">
+				<p class="text-12 text-body clr-text-2">
+					💡 This creates a new branch, commits your changes, then unapplies the branch. Future
+					versions will have simpler stash management.
+				</p>
+			</div>
+		</div>
+	{/snippet}
+	{#snippet controls(close, item)}
+		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
+		<AsyncButton
+			style="pop"
+			disabled={!slugifiedRefName}
+			type="submit"
+			action={async () => {
+				if (isChangedFilesItem(item)) await confirmStashIntoBranch(item, slugifiedRefName);
+			}}
+		>
+			Stash into branch
+		</AsyncButton>
+	{/snippet}
+</Modal>
+
+<style lang="postcss">
+	.content-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+</style>

--- a/apps/desktop/src/components/UpstreamIntegrationActions.svelte
+++ b/apps/desktop/src/components/UpstreamIntegrationActions.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import BranchIntegrationModal from "$components/BranchIntegrationModal.svelte";
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { persisted } from "@gitbutler/shared/persisted";
+	import { Button, Modal, RadioButton, TestId } from "@gitbutler/ui";
+
+	type IntegrationMode = "rebase" | "interactive";
+
+	type Props = {
+		projectId: string;
+		stackId: string | undefined;
+		branchName: string;
+	};
+
+	const { projectId, stackId, branchName }: Props = $props();
+
+	const stackService = inject(STACK_SERVICE);
+	const [integrateUpstreamCommits, integrating] = stackService.integrateUpstreamCommits;
+
+	const integrationMode = persisted<IntegrationMode>("rebase", "branchUpstreamIntegrationMode");
+
+	let integrationModal = $state<Modal>();
+
+	function kickOffIntegration() {
+		integrationModal?.show();
+	}
+
+	function handleRebaseIntegration() {
+		if (!stackId) return;
+		integrateUpstreamCommits({
+			projectId,
+			stackId,
+			seriesName: branchName,
+			integrationStrategy: { type: "rebase" },
+		});
+	}
+
+	function integrate(mode: IntegrationMode) {
+		switch (mode) {
+			case "rebase":
+				handleRebaseIntegration();
+				break;
+			case "interactive":
+				kickOffIntegration();
+				break;
+		}
+	}
+
+	function getLabelForIntegrationMode(mode: IntegrationMode): string {
+		switch (mode) {
+			case "rebase":
+				return "Rebase";
+			case "interactive":
+				return "Configure integration…";
+		}
+	}
+</script>
+
+<BranchIntegrationModal bind:modalRef={integrationModal} {projectId} {stackId} {branchName} />
+
+{#snippet integrationRadioOption(mode: IntegrationMode, title: string, description: string)}
+	<label class="integration-radio-option" class:selected={$integrationMode === mode}>
+		<div class="integration-radio-content">
+			<h4 class="text-13 text-semibold">{title}</h4>
+			<p class="text-11 text-body clr-text-2">
+				{description}
+			</p>
+		</div>
+		<RadioButton
+			class="integration-radio-option__radio"
+			name="integrationMode"
+			value={mode}
+			checked={$integrationMode === mode}
+			onchange={() => integrationMode.set(mode)}
+		/>
+	</label>
+{/snippet}
+
+<form
+	class="upstream-integration-actions"
+	onsubmit={(e) => {
+		e.preventDefault();
+		integrate($integrationMode);
+	}}
+>
+	<div class="upstream-integration-actions__radio-container">
+		{@render integrationRadioOption(
+			"rebase",
+			"Rebase upstream changes",
+			"Place local-only changes on top, then the upstream changes. Similar to git pull --rebase.",
+		)}
+		{@render integrationRadioOption(
+			"interactive",
+			"Interactive integration",
+			"Review and resolve any conflicts before completing the integration.",
+		)}
+	</div>
+
+	<Button
+		type="submit"
+		style="warning"
+		disabled={integrating.current.isLoading}
+		testId={TestId.UpstreamCommitsIntegrateButton}
+	>
+		{getLabelForIntegrationMode($integrationMode)}
+	</Button>
+</form>
+
+<style lang="postcss">
+	.upstream-integration-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+	}
+
+	.upstream-integration-actions__radio-container {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.integration-radio-option {
+		display: flex;
+		z-index: 0;
+		position: relative;
+		padding: 14px;
+		gap: 20px;
+		border: 1px solid var(--clr-border-2);
+		background: var(--clr-bg-1);
+		cursor: pointer;
+
+		&:not(.selected):hover {
+			background: var(--hover-bg-1);
+		}
+
+		&:first-child {
+			border-top-right-radius: var(--radius-m);
+			border-top-left-radius: var(--radius-m);
+		}
+		&:last-child {
+			margin-top: -1px;
+			border-bottom-right-radius: var(--radius-m);
+			border-bottom-left-radius: var(--radius-m);
+		}
+
+		&.selected {
+			z-index: 1;
+			border-color: var(--clr-theme-pop-element);
+			background: var(--clr-theme-pop-bg);
+		}
+	}
+
+	:global(.integration-radio-option__radio) {
+		flex-shrink: 0;
+	}
+
+	.integration-radio-content {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		gap: 6px;
+	}
+</style>

--- a/apps/desktop/src/lib/stacks/integrationStepUtils.ts
+++ b/apps/desktop/src/lib/stacks/integrationStepUtils.ts
@@ -1,0 +1,205 @@
+import type { InteractiveIntegrationStep } from "$lib/stacks/stack";
+
+export function getStepIndex(steps: InteractiveIntegrationStep[], stepId: string): number {
+	return steps.findIndex((step) => step.subject.id === stepId);
+}
+
+export function canShiftStepUp(steps: InteractiveIntegrationStep[], stepId: string): boolean {
+	return getStepIndex(steps, stepId) > 0;
+}
+
+export function canShiftStepDown(steps: InteractiveIntegrationStep[], stepId: string): boolean {
+	const index = getStepIndex(steps, stepId);
+	return index !== -1 && index < steps.length - 1;
+}
+
+export function swapSteps(
+	steps: InteractiveIntegrationStep[],
+	indexA: number,
+	indexB: number,
+): InteractiveIntegrationStep[] {
+	const newSteps = structuredClone(steps);
+	const stepA = newSteps[indexA];
+	const stepB = newSteps[indexB];
+	if (!stepA || !stepB) return steps;
+	newSteps[indexA] = stepB;
+	newSteps[indexB] = stepA;
+	return newSteps;
+}
+
+export function shiftStepUp(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+): InteractiveIntegrationStep[] {
+	const currentIndex = getStepIndex(steps, stepId);
+	if (currentIndex > 0) {
+		return swapSteps(steps, currentIndex, currentIndex - 1);
+	}
+	return steps;
+}
+
+export function shiftStepDown(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+): InteractiveIntegrationStep[] {
+	const currentIndex = getStepIndex(steps, stepId);
+	if (currentIndex !== -1 && currentIndex < steps.length - 1) {
+		return swapSteps(steps, currentIndex, currentIndex + 1);
+	}
+	return steps;
+}
+
+export function updateStepType(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+	commitId: string,
+	newType: "pick" | "skip",
+): InteractiveIntegrationStep[] {
+	return steps.map((step) => {
+		if (step.subject.id === stepId) {
+			return { type: newType, subject: { id: stepId, commitId } };
+		}
+		return step;
+	});
+}
+
+export function pickUpstreamStep(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+	commitId: string,
+	upstreamCommitId: string,
+): InteractiveIntegrationStep[] {
+	return steps.map((step) => {
+		if (step.subject.id === stepId) {
+			return {
+				type: "pickUpstream",
+				subject: { id: stepId, commitId, upstreamCommitId },
+			};
+		}
+		return step;
+	});
+}
+
+export function pickLocalStep(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+	commitId: string,
+): InteractiveIntegrationStep[] {
+	return steps.map((step) => {
+		if (step.subject.id === stepId) {
+			return { type: "pick", subject: { id: stepId, commitId } };
+		}
+		return step;
+	});
+}
+
+export function getStepCommitInfo(step: InteractiveIntegrationStep): {
+	id: string;
+	commitIds: string[];
+} {
+	const id = step.subject.id;
+	switch (step.type) {
+		case "pickUpstream":
+			return { id, commitIds: [step.subject.upstreamCommitId] };
+		case "pick":
+		case "skip":
+			return { id, commitIds: [step.subject.commitId] };
+		case "squash":
+			return { id, commitIds: step.subject.commits };
+	}
+}
+
+/**
+ * Squash a step into the one below it. The caller must pre-fetch the squash message.
+ */
+export function squashStepInto(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+	commitIds: string[],
+	squashMessage: string,
+): InteractiveIntegrationStep[] {
+	const stepIndex = steps.findIndex((step) => step.subject.id === stepId);
+	const isValidSquashOperation = stepIndex !== -1 && stepIndex < steps.length - 1;
+	if (!isValidSquashOperation) return steps;
+
+	const newSteps = structuredClone(steps);
+	const stepToBeSquashedInto = newSteps[stepIndex + 1];
+	if (!stepToBeSquashedInto) return steps;
+
+	const targetStepInfo = getStepCommitInfo(stepToBeSquashedInto);
+	const combinedCommits = [...commitIds, ...targetStepInfo.commitIds];
+
+	newSteps.splice(stepIndex, 2, {
+		type: "squash",
+		subject: {
+			id: targetStepInfo.id,
+			commits: combinedCommits,
+			message: squashMessage,
+		},
+	});
+	return newSteps;
+}
+
+/**
+ * Split a squash step at a commit boundary. The caller must pre-fetch group messages
+ * for groups with more than one commit.
+ */
+export function splitStepAtCommit(
+	steps: InteractiveIntegrationStep[],
+	stepId: string,
+	commitId: string,
+	firstGroupMessage: string,
+	secondGroupMessage: string,
+): InteractiveIntegrationStep[] {
+	const stepIndex = steps.findIndex((step) => step.subject.id === stepId);
+	if (stepIndex === -1) return steps;
+
+	const newSteps = structuredClone(steps);
+	const stepToSplit = newSteps[stepIndex];
+	if (!stepToSplit || stepToSplit.type !== "squash") return steps;
+
+	const { commits } = stepToSplit.subject;
+	const commitIndex = commits.indexOf(commitId);
+	if (commits.length <= 1 || !commits.includes(commitId) || commitIndex === -1) return steps;
+
+	const firstGroup = commits.slice(0, commitIndex);
+	const secondGroup = commits.slice(commitIndex);
+	if (firstGroup.length === 0) return steps;
+
+	if (firstGroup.length === 1) {
+		newSteps[stepIndex] = {
+			type: "pick",
+			subject: { id: stepId, commitId: firstGroup[0]! },
+		};
+	} else {
+		newSteps[stepIndex] = {
+			type: "squash",
+			subject: {
+				id: stepId,
+				commits: firstGroup,
+				message: firstGroupMessage,
+			},
+		};
+	}
+
+	if (secondGroup.length === 1) {
+		newSteps.splice(stepIndex + 1, 0, {
+			type: "pick" as const,
+			subject: {
+				id: crypto.randomUUID(),
+				commitId: secondGroup[0]!,
+			},
+		});
+	} else {
+		newSteps.splice(stepIndex + 1, 0, {
+			type: "squash" as const,
+			subject: {
+				id: crypto.randomUUID(),
+				commits: secondGroup,
+				message: secondGroupMessage,
+			},
+		});
+	}
+
+	return newSteps;
+}

--- a/packages/ui/src/lib/components/Modal.svelte
+++ b/packages/ui/src/lib/components/Modal.svelte
@@ -61,10 +61,29 @@
 	let item = $state<T>(defaultItem as any);
 	let isClosing = $state(false);
 	let closingPromise: Promise<void> | undefined = undefined;
+	let formEl: HTMLFormElement | undefined = $state();
 
 	function handleKeyDown(event: KeyboardEvent) {
 		if (event.key === "Escape") {
 			close();
+		}
+		if (event.key === "Enter") {
+			const target = event.target;
+			const isNativeSubmitElement =
+				target instanceof HTMLInputElement ||
+				target instanceof HTMLTextAreaElement ||
+				target instanceof HTMLButtonElement ||
+				(target instanceof HTMLElement && target.isContentEditable);
+			if (!isNativeSubmitElement) {
+				event.preventDefault();
+				// Click the submit button if one exists (triggers AsyncButton loading state).
+				const submitBtn = formEl?.querySelector<HTMLButtonElement>('button[type="submit"]');
+				if (submitBtn) {
+					submitBtn.click();
+				} else {
+					onSubmit?.(close, item);
+				}
+			}
 		}
 	}
 
@@ -83,6 +102,8 @@
 	export function close(): Promise<void> {
 		if (!open) return Promise.resolve();
 		if (isClosing && closingPromise) return closingPromise;
+
+		window.removeEventListener("keydown", handleKeyDown);
 
 		isClosing = true;
 		closingPromise = new Promise((resolve) => {
@@ -126,6 +147,7 @@
 		onkeydown={onKeyDown}
 	>
 		<form
+			bind:this={formEl}
 			class="modal-form"
 			class:medium={width === "medium"}
 			class:large={width === "large"}


### PR DESCRIPTION
## What

Reduces complexity in several large Svelte components by extracting self-contained pieces into focused files. Also adds an architecture guide to document the patterns used.

---

## Component extractions

### `ChangedFilesContextMenu` — ~840 → ~510 lines

Three modals extracted, each owning its own state, service injections, and logic, exposed via a single `show()` method:

- `DiscardChangesModal.svelte`
- `StashIntoBranchModal.svelte`
- `AbsorbPlanModal.svelte`

### `RulesList` — ~558 → ~308 lines

- `RuleEditor.svelte` — extracted a 250-line snippet that was inlined across 4 render sites

### `BranchCommitList` — ~544 → ~398 lines

- `UpstreamIntegrationActions.svelte` — upstream integration UI with mode picker and modal

### `BranchIntegrationModal` — ~593 → ~475 lines

- `$lib/stacks/integrationStepUtils.ts` — 13 pure step manipulation functions (pick, skip, squash, split, shift) made immutable (accept array → return new array)

---

## Test plan

- `pnpm check` — 0 errors
- Manual smoke test recommended for each affected flow: discard changes, stash into branch, absorb changes, upstream integration