### PR TITLE
Make TUI cursor methods consistent

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -171,66 +171,63 @@ impl Cursor {
             })
     }
 
+    #[must_use]
     pub(super) fn move_up(
-        &mut self,
+        self,
         lines: &[StatusOutputLine],
         mode: &Mode,
         show_files: FilesStatusFlag,
-    ) {
+    ) -> Option<Self> {
         if self.0 >= lines.len() {
-            return;
+            return None;
         }
 
-        if let Some((idx, _)) = lines
+        let (idx, _) = lines
             .iter()
             .enumerate()
             .rev()
             .skip(lines.len() - self.0)
-            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))
-        {
-            self.0 = idx;
-        }
+            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))?;
+        Some(Self(idx))
     }
 
+    #[must_use]
     pub(super) fn move_down(
-        &mut self,
+        self,
         lines: &[StatusOutputLine],
         mode: &Mode,
         show_files: FilesStatusFlag,
-    ) {
+    ) -> Option<Self> {
         if self.0 >= lines.len() {
-            return;
+            return None;
         }
 
-        if let Some((idx, _)) = lines
+        let (idx, _) = lines
             .iter()
             .enumerate()
             .skip(self.0 + 1)
-            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))
-        {
-            self.0 = idx;
-        }
+            .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))?;
+        Some(Self(idx))
     }
 
     /// Moves the cursor to the next selectable jump-target line after the current cursor position.
+    #[must_use]
     pub(super) fn move_next_section(
-        &mut self,
+        self,
         lines: &[StatusOutputLine],
         mode: &Mode,
         show_files: FilesStatusFlag,
-    ) {
+    ) -> Option<Self> {
         if self.0 >= lines.len() {
-            return;
+            return None;
         }
 
-        if let Some((idx, _)) = lines
+        let (idx, _) = lines
             .iter()
             .enumerate()
             .skip(self.0 + 1)
-            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))
-        {
-            self.0 = idx;
-        }
+            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))?;
+        Some(Self(idx))
     }
 
     /// Moves the cursor to the previous selectable jump-target line.
@@ -238,14 +235,15 @@ impl Cursor {
     /// If the cursor is inside a section (for example, on a file or commit row), this jumps to the
     /// current section header first. If the cursor is already on a section header, this jumps to the
     /// previous section header.
+    #[must_use]
     pub(super) fn move_previous_section(
-        &mut self,
+        self,
         lines: &[StatusOutputLine],
         mode: &Mode,
         show_files: FilesStatusFlag,
-    ) {
+    ) -> Option<Self> {
         if self.0 >= lines.len() {
-            return;
+            return None;
         }
 
         let current_line_is_section_header = lines.get(self.0).is_some_and(is_section_header);
@@ -255,15 +253,13 @@ impl Cursor {
             self.0 + 1
         };
 
-        if let Some((target_idx, _)) = lines
+        let (target_idx, _) = lines
             .iter()
             .enumerate()
             .take(search_end)
             .rev()
-            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))
-        {
-            self.0 = target_idx;
-        }
+            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))?;
+        Some(Self(target_idx))
     }
 
     /// Returns the cursor position for the closest branch based on the currently selected row.

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -611,7 +611,9 @@ fn move_up_moves_to_previous_selectable_line() {
     ];
 
     let mut cursor = Cursor(2);
-    cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -628,7 +630,9 @@ fn move_up_does_not_move_when_already_at_first_selectable_line() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -646,7 +650,9 @@ fn move_down_moves_to_next_selectable_line() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -661,7 +667,9 @@ fn move_down_does_not_move_when_no_selectable_line_below() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -678,10 +686,21 @@ fn movement_does_not_panic_or_move_when_cursor_is_out_of_bounds() {
     ];
 
     let mut cursor = Cursor(99);
-    cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All);
-    cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All);
-    cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) = cursor.move_down(&lines, &Mode::Normal, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor.closest_branch_cursor(&lines), None);
     assert_eq!(cursor, Cursor(99));
@@ -702,7 +721,10 @@ fn move_next_section_moves_to_next_jump_target() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -719,7 +741,10 @@ fn move_next_section_does_not_move_when_no_jump_target_below() {
     ];
 
     let mut cursor = Cursor(1);
-    cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(1));
 }
@@ -742,7 +767,11 @@ fn move_previous_section_moves_to_current_section_header_when_cursor_is_inside_i
     ];
 
     let mut cursor = Cursor(3);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -762,7 +791,11 @@ fn move_previous_section_moves_to_immediate_previous_when_already_on_section_hea
     ];
 
     let mut cursor = Cursor(2);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -779,7 +812,11 @@ fn move_previous_section_moves_to_current_header_when_only_current_section_exist
     ];
 
     let mut cursor = Cursor(1);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -796,7 +833,11 @@ fn move_previous_section_does_not_move_when_on_first_jump_target() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -971,7 +1012,9 @@ fn move_up_in_rub_mode_skips_unavailable_targets() {
     });
 
     let mut cursor = Cursor(2);
-    cursor.move_up(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -1003,7 +1046,9 @@ fn move_down_in_rub_mode_skips_unavailable_targets() {
     });
 
     let mut cursor = Cursor(0);
-    cursor.move_down(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_down(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -1045,15 +1090,21 @@ fn movement_in_rub_mode_handles_starting_on_unavailable_line() {
     });
 
     let mut cursor = Cursor(2);
-    cursor.move_up(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
     assert_eq!(cursor, Cursor(1));
 
     let mut cursor = Cursor(2);
-    cursor.move_down(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_down(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
     assert_eq!(cursor, Cursor(3));
 
     let mut cursor = Cursor(2);
-    cursor.move_next_section(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
     assert_eq!(cursor, Cursor(3));
 }
 
@@ -1078,7 +1129,10 @@ fn move_next_section_skips_non_jump_targets_like_commits() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -1102,7 +1156,10 @@ fn move_next_section_can_jump_to_merge_base_line() {
     ];
 
     let mut cursor = Cursor(0);
-    cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -1126,7 +1183,11 @@ fn move_previous_section_can_jump_from_merge_base_line() {
     ];
 
     let mut cursor = Cursor(2);
-    cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All);
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &Mode::Normal, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }
@@ -1158,7 +1219,9 @@ fn move_next_section_in_rub_mode_skips_unavailable_sections() {
     });
 
     let mut cursor = Cursor(0);
-    cursor.move_next_section(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -1193,7 +1256,9 @@ fn move_previous_section_in_rub_mode_moves_to_current_available_section_header()
     });
 
     let mut cursor = Cursor(3);
-    cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(2));
 }
@@ -1231,7 +1296,9 @@ fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_pre
     });
 
     let mut cursor = Cursor(2);
-    cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(1));
 }
@@ -1255,10 +1322,21 @@ fn movement_methods_can_move_cursor_in_inline_reword_mode() {
 
     // Inline reword keeps lines selectable to avoid dimming the whole UI.
     // Actual user navigation is blocked at the keybinding/event layer, not in these cursor helpers.
-    cursor.move_up(&lines, &inline_reword, FilesStatusFlag::All);
-    cursor.move_down(&lines, &inline_reword, FilesStatusFlag::All);
-    cursor.move_next_section(&lines, &inline_reword, FilesStatusFlag::All);
-    cursor.move_previous_section(&lines, &inline_reword, FilesStatusFlag::All);
+    if let Some(new_cursor) = cursor.move_up(&lines, &inline_reword, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) = cursor.move_down(&lines, &inline_reword, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &inline_reword, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
+    if let Some(new_cursor) =
+        cursor.move_previous_section(&lines, &inline_reword, FilesStatusFlag::All)
+    {
+        cursor = new_cursor;
+    }
 
     assert_eq!(cursor, Cursor(0));
 }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -331,21 +331,38 @@ impl App {
             }
             Message::JustRender => {}
             Message::MoveCursorUp => {
-                self.cursor
-                    .move_up(&self.status_lines, &self.mode, self.flags.show_files)
+                if let Some(new_cursor) =
+                    self.cursor
+                        .move_up(&self.status_lines, &self.mode, self.flags.show_files)
+                {
+                    self.cursor = new_cursor;
+                }
             }
             Message::MoveCursorDown => {
-                self.cursor
-                    .move_down(&self.status_lines, &self.mode, self.flags.show_files)
+                if let Some(new_cursor) =
+                    self.cursor
+                        .move_down(&self.status_lines, &self.mode, self.flags.show_files)
+                {
+                    self.cursor = new_cursor;
+                }
             }
-            Message::MoveCursorPreviousSection => self.cursor.move_previous_section(
-                &self.status_lines,
-                &self.mode,
-                self.flags.show_files,
-            ),
+            Message::MoveCursorPreviousSection => {
+                if let Some(new_cursor) = self.cursor.move_previous_section(
+                    &self.status_lines,
+                    &self.mode,
+                    self.flags.show_files,
+                ) {
+                    self.cursor = new_cursor;
+                }
+            }
             Message::MoveCursorNextSection => {
-                self.cursor
-                    .move_next_section(&self.status_lines, &self.mode, self.flags.show_files)
+                if let Some(new_cursor) = self.cursor.move_next_section(
+                    &self.status_lines,
+                    &self.mode,
+                    self.flags.show_files,
+                ) {
+                    self.cursor = new_cursor;
+                }
             }
             Message::Rub(rub_message) => match rub_message {
                 RubMessage::Start { using_but_api } => {
@@ -498,12 +515,16 @@ impl App {
             return;
         }
 
-        let previous_cursor = self.cursor;
-        self.cursor
-            .move_down(&self.status_lines, &self.mode, self.flags.show_files);
-        if self.cursor == previous_cursor {
+        if let Some(new_cursor) =
             self.cursor
-                .move_up(&self.status_lines, &self.mode, self.flags.show_files);
+                .move_down(&self.status_lines, &self.mode, self.flags.show_files)
+        {
+            self.cursor = new_cursor;
+        } else if let Some(new_cursor) =
+            self.cursor
+                .move_up(&self.status_lines, &self.mode, self.flags.show_files)
+        {
+            self.cursor = new_cursor;
         }
     }
 
@@ -543,12 +564,16 @@ impl App {
             return;
         }
 
-        let previous_cursor = self.cursor;
-        self.cursor
-            .move_down(&self.status_lines, &self.mode, self.flags.show_files);
-        if self.cursor == previous_cursor {
+        if let Some(new_cursor) =
             self.cursor
-                .move_up(&self.status_lines, &self.mode, self.flags.show_files);
+                .move_down(&self.status_lines, &self.mode, self.flags.show_files)
+        {
+            self.cursor = new_cursor;
+        } else if let Some(new_cursor) =
+            self.cursor
+                .move_up(&self.status_lines, &self.mode, self.flags.show_files)
+        {
+            self.cursor = new_cursor;
         }
     }
 


### PR DESCRIPTION
Some would mutate the existing cursor and some would return a new one. This changes that so all the methods return a new cursor.