### PR TITLE
TUI not committing/amending all hunks

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -998,6 +998,7 @@ impl App {
         };
 
         // create commit
+        let changes_to_commit = but_workspace::flatten_diff_specs(changes_to_commit);
         let commit_create_result = but_api::commit::create::commit_create(
             ctx,
             insert_commit_relative_to,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     ffi::OsString,
     process::Command,
     sync::Arc,
@@ -964,19 +965,19 @@ impl App {
                         Some(changes),
                         context_lines,
                     )?;
-                assignments
-                    .into_iter()
-                    .filter(|assignment| assignment.stack_id.is_none())
-                    .map(DiffSpec::from)
-                    .collect::<Vec<_>>()
+                diff_specs_from_hunk_assignments(
+                    assignments
+                        .into_iter()
+                        .filter(|assignment| assignment.stack_id.is_none()),
+                )
             }
-            CommitSource::Uncommitted(uncommitted_cli_id) => uncommitted_cli_id
-                .hunk_assignments
-                .iter()
-                .filter(|assignment| &assignment.stack_id == scope_to_stack)
-                .cloned()
-                .map(DiffSpec::from)
-                .collect::<Vec<_>>(),
+            CommitSource::Uncommitted(uncommitted_cli_id) => diff_specs_from_hunk_assignments(
+                uncommitted_cli_id
+                    .hunk_assignments
+                    .iter()
+                    .filter(|assignment| &assignment.stack_id == scope_to_stack)
+                    .cloned(),
+            ),
             CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
                 let context_lines = ctx.settings.context_lines;
                 let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
@@ -989,16 +990,15 @@ impl App {
                         Some(changes),
                         context_lines,
                     )?;
-                assignments
-                    .into_iter()
-                    .filter(|assignment| assignment.stack_id.is_some_and(|id| &id == stack_id))
-                    .map(DiffSpec::from)
-                    .collect::<Vec<_>>()
+                diff_specs_from_hunk_assignments(
+                    assignments
+                        .into_iter()
+                        .filter(|assignment| assignment.stack_id.is_some_and(|id| &id == stack_id)),
+                )
             }
         };
 
         // create commit
-        let changes_to_commit = but_workspace::flatten_diff_specs(changes_to_commit);
         let commit_create_result = but_api::commit::create::commit_create(
             ctx,
             insert_commit_relative_to,
@@ -2518,6 +2518,42 @@ fn has_unassigned_changes(ctx: &mut Context) -> anyhow::Result<bool> {
     Ok(assignments
         .into_iter()
         .any(|assignment| assignment.stack_id.is_none()))
+}
+
+/// Builds one diff spec per file path from a sequence of hunk assignments.
+///
+/// Multiple selected hunks in the same file are merged into a single [`DiffSpec`]
+/// containing all selected hunk headers for that file.
+pub(super) fn diff_specs_from_hunk_assignments(
+    assignments: impl IntoIterator<Item = but_hunk_assignment::HunkAssignment>,
+) -> Vec<DiffSpec> {
+    let mut grouped = BTreeMap::<BString, Vec<but_core::HunkHeader>>::new();
+
+    for assignment in assignments {
+        let file_hunks = grouped.entry(assignment.path_bytes).or_default();
+
+        if let Some(hunk_header) = assignment.hunk_header {
+            let hunk_header = but_core::HunkHeader {
+                old_start: hunk_header.old_start,
+                old_lines: hunk_header.old_lines,
+                new_start: hunk_header.new_start,
+                new_lines: hunk_header.new_lines,
+            };
+
+            if !file_hunks.contains(&hunk_header) {
+                file_hunks.push(hunk_header);
+            }
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|(path, hunk_headers)| DiffSpec {
+            previous_path: None,
+            path,
+            hunk_headers,
+        })
+        .collect()
 }
 
 /// Formats an exit status for human-readable error messages.

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -189,14 +189,9 @@ fn execute_uncommitted_to_commit(
     ctx: &mut Context,
     operation: &UncommittedToCommitOperation<'_>,
 ) -> anyhow::Result<CommitCreateResult> {
-    let changes = operation
-        .hunk_assignments
-        .iter()
-        .copied()
-        .cloned()
-        .map(DiffSpec::from)
-        .collect::<Vec<_>>();
-    let changes = but_workspace::flatten_diff_specs(changes);
+    let changes = super::diff_specs_from_hunk_assignments(
+        operation.hunk_assignments.iter().copied().cloned(),
+    );
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 
@@ -256,7 +251,6 @@ fn execute_unassigned_to_commit(
     operation: &UnassignedToCommitOperation,
 ) -> anyhow::Result<CommitCreateResult> {
     let changes = changes_for_stack_assignment(ctx, None)?;
-    let changes = but_workspace::flatten_diff_specs(changes);
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 
@@ -328,7 +322,6 @@ fn execute_branch_to_commit(
 ) -> anyhow::Result<CommitCreateResult> {
     let stack_id = stack_id_for_branch_name(ctx, operation.name)?;
     let changes = changes_for_stack_assignment(ctx, stack_id)?;
-    let changes = but_workspace::flatten_diff_specs(changes);
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 
@@ -423,16 +416,18 @@ fn reassign_all_from_stack_to_stack(
 }
 
 /// Collects worktree diff specs that are currently assigned to `stack_id`.
+///
+/// The returned specs are grouped by file path so each path appears at most once.
 fn changes_for_stack_assignment(
     ctx: &mut Context,
     stack_id: Option<StackId>,
 ) -> anyhow::Result<Vec<DiffSpec>> {
-    Ok(but_api::diff::changes_in_worktree(ctx)?
+    let assignments = but_api::diff::changes_in_worktree(ctx)?
         .assignments
         .into_iter()
-        .filter(|assignment| assignment.stack_id == stack_id)
-        .map(DiffSpec::from)
-        .collect())
+        .filter(|assignment| assignment.stack_id == stack_id);
+
+    Ok(super::diff_specs_from_hunk_assignments(assignments))
 }
 
 /// Resolves a branch name into its workspace stack id, if any.

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -196,6 +196,7 @@ fn execute_uncommitted_to_commit(
         .cloned()
         .map(DiffSpec::from)
         .collect::<Vec<_>>();
+    let changes = but_workspace::flatten_diff_specs(changes);
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 
@@ -255,6 +256,7 @@ fn execute_unassigned_to_commit(
     operation: &UnassignedToCommitOperation,
 ) -> anyhow::Result<CommitCreateResult> {
     let changes = changes_for_stack_assignment(ctx, None)?;
+    let changes = but_workspace::flatten_diff_specs(changes);
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 
@@ -326,6 +328,7 @@ fn execute_branch_to_commit(
 ) -> anyhow::Result<CommitCreateResult> {
     let stack_id = stack_id_for_branch_name(ctx, operation.name)?;
     let changes = changes_for_stack_assignment(ctx, stack_id)?;
+    let changes = but_workspace::flatten_diff_specs(changes);
     but_api::commit::amend::commit_amend(ctx, operation.oid, changes)
 }
 

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -336,3 +336,72 @@ fn staged_source_commit_cannot_be_forced_to_other_stack_target() {
             "snapshots/staged_source_commit_cannot_be_forced_to_other_stack_target_final.txt"
         ]);
 }
+
+#[test]
+fn commit_from_unassigned_multi_hunk_modified_file_commits_all_hunks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file(
+        "editor.sh",
+        format!("printf '{TEST_EDITOR_MESSAGE}\\n' > \"$1\"\n"),
+    );
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let original = (1..=300)
+        .map(|line| format!("line-{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    env.file("multi-hunk.txt", &original);
+
+    let mut tui = test_tui(env);
+
+    // First commit: add the file so subsequent edits are true modifications.
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
+    tui.input_then_render('c')
+        .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< commit to branch >> g0 [A]"]);
+    with_var("GIT_EDITOR", Some(editor_command.clone()), || {
+        tui.input_then_render(KeyCode::Enter)
+            .assert_current_line_eq(str!["┊●   [..] commit from tui test[..]"]);
+    });
+
+    // Turn the committed file into a multi-hunk modification.
+    let modified = (1..=300)
+        .map(|line| match line {
+            1 => "line-1-modified".to_string(),
+            250 => "line-250-modified".to_string(),
+            _ => format!("line-{line}"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    tui.env.file("multi-hunk.txt", &modified);
+
+    // Move cursor back up to the unassigned section.
+    for _ in 0..10 {
+        tui.input_then_render(KeyCode::Up);
+    }
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
+
+    // Second commit: this reproduces the bug for modified multi-hunk files.
+    tui.input_then_render('c')
+        .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< commit to branch >> g0 [A]"]);
+    with_var("GIT_EDITOR", Some(editor_command), || {
+        tui.input_then_render(KeyCode::Enter)
+            .assert_current_line_eq(str!["┊●   [..] commit from tui test[..]"]);
+    });
+
+    let status_after = tui.env.invoke_git("status --porcelain");
+    assert!(
+        !status_after.lines().any(|line| line.ends_with("multi-hunk.txt")),
+        "after commit from unassigned via TUI, multi-hunk modified file should be fully committed\nstatus was:\n{status_after}"
+    );
+}

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -401,7 +401,9 @@ fn commit_from_unassigned_multi_hunk_modified_file_commits_all_hunks() {
 
     let status_after = tui.env.invoke_git("status --porcelain");
     assert!(
-        !status_after.lines().any(|line| line.ends_with("multi-hunk.txt")),
+        !status_after
+            .lines()
+            .any(|line| line.ends_with("multi-hunk.txt")),
         "after commit from unassigned via TUI, multi-hunk modified file should be fully committed\nstatus was:\n{status_after}"
     );
 }

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -679,3 +679,129 @@ fn commit_file_toggle_off_from_commit_row_preserves_commit_selection() {
             "snapshots/commit_file_toggle_off_from_commit_row_preserves_commit_selection_final.txt"
         ]);
 }
+
+#[test]
+fn rub_from_two_hunks_in_same_file_does_not_duplicate_hunks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file(
+        ".git/editor.sh",
+        "printf 'commit multi-hunk from tui\\n' > \"$1\"\n",
+    );
+    let editor_path = env.projects_root().join(".git/editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let mut tui = test_tui(env);
+
+    // First, create a multiline baseline commit through the TUI itself so workspace metadata stays valid.
+    tui.env.invoke_bash(
+        r#"
+cat > A <<'EOF'
+line-01
+line-02
+line-03
+line-04
+line-05
+line-06
+line-07
+line-08
+line-09
+line-10
+line-11
+line-12
+line-13
+line-14
+line-15
+line-16
+line-17
+line-18
+line-19
+line-20
+EOF
+"#,
+    );
+
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
+    tui.input_then_render('c')
+        .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< commit to branch >> g0 [A]"]);
+
+    with_var("GIT_EDITOR", Some(editor_command.as_str()), || {
+        tui.input_then_render(KeyCode::Enter);
+    });
+
+    // Now produce two separate hunks in the same file.
+    tui.env.invoke_bash(
+        r#"
+cat > A <<'EOF'
+line-01
+line-02
+line-03 changed-hunk-one
+line-04
+line-05
+line-06
+line-07
+line-08
+line-09
+line-10
+line-11
+line-12
+line-13
+line-14
+line-15
+line-16
+line-17
+line-18 changed-hunk-two
+line-19
+line-20
+EOF
+"#,
+    );
+
+    // Move back to unassigned changes and rub those two hunks into the existing commit.
+    tui.input_then_render([KeyCode::Up, KeyCode::Up, KeyCode::Up, KeyCode::Up, KeyCode::Up]);
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< assign hunks >> g0 [A]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   << amend commit >> [..] commit multi-hunk from tui"]);
+    tui.input_then_render(KeyCode::Enter);
+
+    let mut commits_with_marker = Vec::new();
+    for oid in tui.env.invoke_git("rev-list --all").lines() {
+        let has_a = tui
+            .env
+            .invoke_git(&format!("ls-tree -r --name-only {oid}"))
+            .lines()
+            .any(|name| name == "A");
+        if !has_a {
+            continue;
+        }
+        let content = tui.env.invoke_git(&format!("show --format= {oid}:A"));
+        if content.contains("changed-hunk-one") || content.contains("changed-hunk-two") {
+            commits_with_marker.push((oid.to_string(), content));
+        }
+    }
+
+    let first_hunk_total_occurrences = commits_with_marker
+        .iter()
+        .map(|(_, content)| content.matches("changed-hunk-one").count())
+        .sum::<usize>();
+    let second_hunk_total_occurrences = commits_with_marker
+        .iter()
+        .map(|(_, content)| content.matches("changed-hunk-two").count())
+        .sum::<usize>();
+
+    assert_eq!(
+        first_hunk_total_occurrences, 1,
+        "first hunk should exist exactly once across reachable commits after a single rub operation; duplicates indicate the same hunk was applied multiple times"
+    );
+    assert_eq!(
+        second_hunk_total_occurrences, 1,
+        "second hunk should exist exactly once across reachable commits after a single rub operation; duplicates indicate the same hunk was applied multiple times"
+    );
+}

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -1,6 +1,7 @@
 use but_testsupport::Sandbox;
 use crossterm::event::*;
 use snapbox::{file, str};
+use temp_env::with_var;
 
 use crate::command::legacy::status::tui::tests::utils::test_tui;
 
@@ -579,4 +580,200 @@ fn rub_api_stack_to_stack_operation() {
 
     tui.input_then_render([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊  ╭┄<< reassign hunks >> [..] [staged to A]"]);
+}
+
+#[test]
+fn rub_api_unassigned_to_commit_multi_hunk_modified_file_commits_all_hunks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file(
+        "editor.sh",
+        "printf 'commit from tui test\n' > \"$1\"\n".to_string(),
+    );
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let original = (1..=300)
+        .map(|line| format!("line-{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    env.file("multi-hunk.txt", &original);
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render('c');
+    tui.input_then_render(KeyCode::Down);
+    with_var("GIT_EDITOR", Some(editor_command), || {
+        tui.input_then_render(KeyCode::Enter);
+    });
+
+    let modified = (1..=300)
+        .map(|line| match line {
+            1 => "line-1-modified".to_string(),
+            250 => "line-250-modified".to_string(),
+            _ => format!("line-{line}"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    tui.env.file("multi-hunk.txt", &modified);
+
+    for _ in 0..10 {
+        tui.input_then_render(KeyCode::Up);
+    }
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   [..] multi-hunk.txt"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+        .assert_current_line_eq(str!["┊   << source >> << noop >> [..] multi-hunk.txt"]);
+    tui.input_then_render([KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊●   << amend >> [..]"]);
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..]"]);
+
+    let status_after = tui.env.invoke_git("status --porcelain");
+    assert!(
+        !status_after
+            .lines()
+            .any(|line| line.ends_with("multi-hunk.txt")),
+        "after Shift+R unassigned->commit amend, multi-hunk modified file should be fully committed\nstatus was:\n{status_after}"
+    );
+}
+
+#[test]
+fn rub_api_uncommitted_to_commit_multi_hunk_modified_file_commits_all_hunks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file(
+        "editor.sh",
+        "printf 'commit from tui test\n' > \"$1\"\n".to_string(),
+    );
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let original = (1..=300)
+        .map(|line| format!("line-{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    env.file("multi-hunk.txt", &original);
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render('c');
+    tui.input_then_render(KeyCode::Down);
+    with_var("GIT_EDITOR", Some(editor_command), || {
+        tui.input_then_render(KeyCode::Enter);
+    });
+
+    let modified = (1..=300)
+        .map(|line| match line {
+            1 => "line-1-modified".to_string(),
+            250 => "line-250-modified".to_string(),
+            _ => format!("line-{line}"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    tui.env.file("multi-hunk.txt", &modified);
+
+    for _ in 0..10 {
+        tui.input_then_render(KeyCode::Up);
+    }
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   [..] multi-hunk.txt"]);
+
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["┊   << source >> << noop >> [..] multi-hunk.txt"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< assign hunks >> g0 [A]"]);
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render(KeyCode::Up)
+        .assert_current_line_eq(str!["┊  │ [..] multi-hunk.txt"]);
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+        .assert_current_line_eq(str!["┊  │ << source >> << noop >> [..] multi-hunk.txt"]);
+    tui.input_then_render([KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊●   << amend >> [..]"]);
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..]"]);
+
+    let status_after = tui.env.invoke_git("status --porcelain");
+    assert!(
+        !status_after
+            .lines()
+            .any(|line| line.ends_with("multi-hunk.txt")),
+        "after Shift+R uncommitted->commit amend, multi-hunk modified file should be fully committed\nstatus was:\n{status_after}"
+    );
+}
+
+#[test]
+fn rub_api_branch_to_commit_multi_hunk_modified_file_commits_all_hunks() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    env.file(
+        "editor.sh",
+        "printf 'commit from tui test\n' > \"$1\"\n".to_string(),
+    );
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let original = (1..=300)
+        .map(|line| format!("line-{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    env.file("multi-hunk.txt", &original);
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render('c');
+    tui.input_then_render(KeyCode::Down);
+    with_var("GIT_EDITOR", Some(editor_command), || {
+        tui.input_then_render(KeyCode::Enter);
+    });
+
+    let modified = (1..=300)
+        .map(|line| match line {
+            1 => "line-1-modified".to_string(),
+            250 => "line-250-modified".to_string(),
+            _ => format!("line-{line}"),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    tui.env.file("multi-hunk.txt", &modified);
+
+    for _ in 0..10 {
+        tui.input_then_render(KeyCode::Up);
+    }
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   [..] multi-hunk.txt"]);
+
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["┊   << source >> << noop >> [..] multi-hunk.txt"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄<< assign hunks >> g0 [A]"]);
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+        .assert_current_line_eq(str!["┊╭┄<< source >> << noop >> g0 [A]"]);
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   << amend >> [..]"]);
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..]"]);
+
+    let status_after = tui.env.invoke_git("status --porcelain");
+    assert!(
+        !status_after
+            .lines()
+            .any(|line| line.ends_with("multi-hunk.txt")),
+        "after Shift+R branch->commit amend, multi-hunk modified file should be fully committed\nstatus was:\n{status_after}"
+    );
 }


### PR DESCRIPTION
I noticed that if you used the TUI to

- Create a new commit from the unassigned changes
- or amend an existing commit using the but-api based rub (shift+r)

then sometimes not all hunks would get committed and some would be left unassigned.

This PR contains an attempt at fixing it but doesn't feel like its the right fix. It feels too local and I'm wondering if there is something wrong in but-api or perhaps there is some shared APIs thats missing.

For context [here](https://github.com/gitbutlerapp/gitbutler/blob/master/crates/but/src/command/legacy/status/tui/mod.rs#L955-L972) is how the TUI is finding the unassigned stuff to commit.