### PR TITLE
Fix entering branch mode without branches

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -293,7 +293,7 @@ impl Cursor {
             _ => first_branch_index(lines),
         };
 
-        target_idx.map(Self)
+        target_idx.or_else(|| merge_base_index(lines)).map(Self)
     }
 }
 
@@ -305,6 +305,13 @@ fn first_branch_index(lines: &[StatusOutputLine]) -> Option<usize> {
             Some(CliId::Branch { .. })
         )
     })
+}
+
+/// Returns the index of the merge-base line, if any.
+fn merge_base_index(lines: &[StatusOutputLine]) -> Option<usize> {
+    lines
+        .iter()
+        .position(|line| matches!(line.data, StatusOutputLineData::MergeBase))
 }
 
 /// Returns the index of the nearest preceding branch line before or at `from_idx`.

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -975,6 +975,20 @@ fn closest_branch_cursor_from_merge_base_is_noop() {
 }
 
 #[test]
+fn closest_branch_cursor_falls_back_to_merge_base_when_no_branch_exists() {
+    let lines = vec![
+        line(StatusOutputLineData::UnstagedChanges {
+            cli_id: unassigned("u0"),
+        }),
+        line(StatusOutputLineData::MergeBase),
+    ];
+
+    let cursor = Cursor(0);
+
+    assert_eq!(cursor.closest_branch_cursor(&lines), Some(Cursor(1)));
+}
+
+#[test]
 fn closest_branch_cursor_is_none_when_no_branch_exists() {
     let lines = vec![line(StatusOutputLineData::UnstagedChanges {
         cli_id: unassigned("u0"),


### PR DESCRIPTION
If you didn't have any branches, pressing `b` to enter branch mode did nothing. This fixes that!