### PR TITLE
Silence output when starting background sync before running TUI

### DIFF
--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -338,7 +338,7 @@ async fn match_subcommand(
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
-                            background_sync: BackgroundSync::Enabled,
+                            background_sync: BackgroundSync::Enabled { silent: false },
                             ..Default::default()
                         },
                         out,
@@ -359,7 +359,7 @@ async fn match_subcommand(
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
-                            background_sync: BackgroundSync::Enabled,
+                            background_sync: BackgroundSync::Enabled { silent: false },
                             ..Default::default()
                         },
                         out,
@@ -380,7 +380,7 @@ async fn match_subcommand(
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
-                            background_sync: BackgroundSync::Enabled,
+                            background_sync: BackgroundSync::Enabled { silent: false },
                             ..Default::default()
                         },
                         out,
@@ -397,7 +397,7 @@ async fn match_subcommand(
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
-                            background_sync: BackgroundSync::Enabled,
+                            background_sync: BackgroundSync::Enabled { silent: false },
                             ..Default::default()
                         },
                         out,
@@ -409,7 +409,7 @@ async fn match_subcommand(
                     let mut ctx = setup::init_ctx(
                         &args,
                         InitCtxOptions {
-                            background_sync: BackgroundSync::Enabled,
+                            background_sync: BackgroundSync::Enabled { silent: false },
                             ..Default::default()
                         },
                         out,
@@ -577,7 +577,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -610,7 +610,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: true },
                     ..Default::default()
                 },
                 out,
@@ -630,7 +630,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -651,7 +651,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -689,7 +689,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -703,7 +703,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -718,7 +718,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -734,7 +734,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -912,7 +912,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -972,7 +972,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -989,7 +989,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1039,7 +1039,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1163,7 +1163,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1179,7 +1179,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1197,7 +1197,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1219,7 +1219,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1256,7 +1256,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1277,7 +1277,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1328,7 +1328,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1343,7 +1343,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,
@@ -1358,7 +1358,7 @@ async fn match_subcommand(
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
-                    background_sync: BackgroundSync::Enabled,
+                    background_sync: BackgroundSync::Enabled { silent: false },
                     ..Default::default()
                 },
                 out,

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -12,7 +12,10 @@ use crate::{
 
 #[derive(Default)]
 pub(crate) enum BackgroundSync {
-    Enabled,
+    Enabled {
+        /// If true nothing will be printed when spawning background sync.
+        silent: bool,
+    },
     #[default]
     Disabled,
 }
@@ -201,7 +204,7 @@ pub fn init_ctx(
         BackgroundSync::Disabled => {
             return Ok(ctx);
         }
-        BackgroundSync::Enabled => {
+        BackgroundSync::Enabled { silent } => {
             // Check if background tasks are disabled via environment variable
             if std::env::var("NO_BG_TASKS").is_ok() {
                 return Ok(ctx);
@@ -218,7 +221,7 @@ pub fn init_ctx(
 
             // Spawn background sync if there's anything to do
             if sync_operations.has_work() {
-                spawn_background_sync(args, out, last_fetch, sync_operations);
+                spawn_background_sync(args, out, last_fetch, sync_operations, silent);
             }
         }
     }
@@ -318,6 +321,7 @@ fn spawn_background_sync(
     out: &mut OutputChannel,
     last_fetch: Option<std::time::SystemTime>,
     operations: SyncOperations,
+    silent: bool,
 ) {
     let binary_path = std::env::current_exe().unwrap_or_default();
     let mut cmd = tokio::process::Command::new(binary_path);
@@ -343,7 +347,7 @@ fn spawn_background_sync(
         .group()
         .kill_on_drop(false);
 
-    if cmd.spawn().is_ok() {
+    if cmd.spawn().is_ok() && !silent {
         // Show user feedback about what's happening
         // Only show "last fetch" message if we're actually fetching
         let msg = if operations.fetch {


### PR DESCRIPTION
I don't think we should be printing anything to stdout before starting the tui. The user wont see it until the TUI quits.

The TUI could manage its own background process but I'm not sure thats right either since I doubt people keep the TUI open for long. At least thats not how I use it. I guess a proper fix would be a daemon, which is something we've talked about

So this just simply silences the "Initiated a background sync..." when running the TUI.