### PR TITLE
Improve diff rendering performance for large files

### DIFF
--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -27,6 +27,7 @@
 	import { EmptyStatePlaceholder, generateHunkId, HunkDiff, TestId } from "@gitbutler/ui";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { parseHunk } from "@gitbutler/ui/utils/diffParsing";
+	import { untrack } from "svelte";
 	import type { FileDependencies } from "$lib/dependencies/dependencies";
 	import type { TreeChange } from "$lib/hunks/change";
 	import type { UnifiedDiff } from "$lib/hunks/diff";
@@ -34,6 +35,8 @@
 	import type { LineId } from "@gitbutler/ui/utils/diffParsing";
 
 	const LARGE_DIFF_THRESHOLD = 1000;
+	const INITIAL_HUNKS = 5;
+	const HUNKS_PER_FRAME = 10;
 
 	type Props = {
 		projectId: string;
@@ -66,7 +69,6 @@
 	let contextMenu = $state<ReturnType<typeof HunkContextMenu>>();
 	let showAnyways = $state(false);
 	let viewport = $state<HTMLDivElement>();
-
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
 
@@ -127,6 +129,32 @@
 		});
 		return filtered;
 	}
+
+	const filteredHunks = $derived(diff?.type === "Patch" ? filter(diff.subject.hunks) : []);
+	let renderedHunkCount = $state(INITIAL_HUNKS);
+
+	$effect(() => {
+		// Reset and stream hunks progressively whenever file/diff/showAnyways changes.
+		// Avoids blocking the main thread by mounting all hunk components at once.
+		void change.path;
+		void diff;
+		void showAnyways;
+
+		const total = untrack(() => filteredHunks.length);
+		renderedHunkCount = INITIAL_HUNKS;
+
+		if (total <= INITIAL_HUNKS) return;
+
+		let rafId: number;
+		function addMore() {
+			renderedHunkCount = Math.min(renderedHunkCount + HUNKS_PER_FRAME, total);
+			if (renderedHunkCount < total) {
+				rafId = requestAnimationFrame(addMore);
+			}
+		}
+		rafId = requestAnimationFrame(addMore);
+		return () => cancelAnimationFrame(rafId);
+	});
 
 	function linesInclude(
 		newStart: number | undefined,
@@ -222,7 +250,7 @@
 					}}
 				/>
 			{:else}
-				{#each filter(diff.subject.hunks) as hunk, hunkIndex}
+				{#each filteredHunks.slice(0, renderedHunkCount) as hunk, hunkIndex}
 					{@const selection = uncommittedService.hunkCheckStatus(stackId, change.path, hunk)}
 					{@const [_, lineLocks] = getLineLocks(hunk, fileDependencies?.dependencies ?? [])}
 					{@const hunkId = generateHunkId(change.path, hunkIndex)}
@@ -333,13 +361,23 @@
 						{/if}
 					</div>
 				{:else}
-					<div class="hunk-placehoder">
-						<EmptyStatePlaceholder image={emptyFileSvg} gap={12} topBottomPadding={34}>
-							{#snippet caption()}
-								It’s empty ¯\_(ツ゚)_/¯
-							{/snippet}
-						</EmptyStatePlaceholder>
-					</div>
+					{#if diff.subject.hunks.length === 0}
+						<div class="hunk-placehoder">
+							<EmptyStatePlaceholder image={emptyFileSvg} gap={12} topBottomPadding={34}>
+								{#snippet caption()}
+									It’s empty ¯\_(ツ゚)_/¯
+								{/snippet}
+							</EmptyStatePlaceholder>
+						</div>
+					{:else}
+						<div class="hunk-placehoder">
+							<EmptyStatePlaceholder gap={12} topBottomPadding={34}>
+								{#snippet caption()}
+									Loading diff…
+								{/snippet}
+							</EmptyStatePlaceholder>
+						</div>
+					{/if}
 				{/each}
 			{/if}
 		{:else if diff.type === "TooLarge"}

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -76,6 +76,27 @@
 	const hunkHasLocks = $derived(lineLocks && lineLocks.length > 0);
 	const colspan = $derived(showingCheckboxes || hunkHasLocks ? 3 : 2);
 	let tableWrapperElem = $state<HTMLElement>();
+	let isVisible = $state(false);
+
+	// Rough line count for height reservation while body is not yet mounted
+	const estimatedBodyHeight = $derived(Math.max(hunkStr.split("\n").length - 1, 1) * 22);
+
+	$effect(() => {
+		if (!tableWrapperElem) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						isVisible = true;
+						observer.disconnect();
+					}
+				}
+			},
+			{ rootMargin: "300px 0px" },
+		);
+		observer.observe(tableWrapperElem);
+		return () => observer.disconnect();
+	});
 
 	function handleHunkContextMenu(e: MouseEvent | KeyboardEvent) {
 		e.preventDefault();
@@ -149,7 +170,7 @@
 				</tr>
 			</thead>
 
-			{#if tableWrapperElem}
+			{#if tableWrapperElem && isVisible}
 				<HunkDiffBody
 					comment={hunk.comment}
 					{filePath}
@@ -168,6 +189,12 @@
 					{handleLineContextMenu}
 					{lockWarning}
 				/>
+			{:else if tableWrapperElem}
+				<tbody>
+					<tr style="height: {estimatedBodyHeight}px">
+						<td colspan="10"></td>
+					</tr>
+				</tbody>
 			{/if}
 		</table>
 	</ScrollableContainer>


### PR DESCRIPTION
Rendering a large diff (e.g. Cargo.lock) previously blocked the main
thread while mounting hundreds of hunk components synchronously before
the first paint.

Three changes address this:

- UnifiedDiffView: stream hunk components progressively via
  requestAnimationFrame — render the first 5 on first paint then add
  10 per frame until all are mounted. Reset the stream whenever the
  file or diff changes.

- HunkDiff: lazy-mount HunkDiffBody with IntersectionObserver so
  off-screen hunk bodies are not created until they scroll into view
  (300px pre-load margin). A height-reserving placeholder prevents
  layout shifts before the body mounts.

- HunkDiffBody: add content-visibility: auto to tbody so the browser
  skips layout and paint for off-screen row groups.

Also shows "Loading diff..." instead of "It's empty" while hunk
assignments are still being populated on first load.