### PR TITLE
feat(tui): enter move mode from branch mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -434,6 +434,15 @@ fn register_branch_mode_key_binds(key_binds: &mut KeyBinds) {
     });
 
     key_binds.register(StaticKeyBind {
+        short_description: "move",
+        chord_display: "m",
+        key_matcher: press().code(KeyCode::Char('m')),
+        modes: Vec::from([ModeDiscriminant::Branch]),
+        message: Message::Move(MoveMessage::Start),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
         short_description: "back",
         chord_display: "b",
         key_matcher: press().code(KeyCode::Char('b')),

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -916,9 +916,6 @@ impl App {
     }
 
     fn handle_move_start_message(&mut self) {
-        if !matches!(self.mode, Mode::Normal) {
-            return;
-        }
         let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
             return;
         };

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_down_moves_from_branch_to_merge_base_target_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_down_moves_from_branch_to_merge_base_target_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_from_commit_jumps_to_nearest_preceding_branch_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_from_commit_jumps_to_nearest_preceding_branch_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_from_unassigned_jumps_to_first_branch_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/branch_mode_from_unassigned_jumps_to_first_branch_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/entering_branch_mode_closes_global_file_list_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/entering_branch_mode_closes_global_file_list_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/focus_reload_in_branch_mode_preserves_branch_selection_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/focus_reload_in_branch_mode_preserves_branch_selection_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/focus_reload_in_branch_mode_preserves_merge_base_selection_final.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/focus_reload_in_branch_mode_preserves_merge_base_selection_final.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mode_toggle_key_b_enters_and_leaves_branch_mode_001.txt
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mode_toggle_key_b_enters_and_leaves_branch_mode_001.txt
@@ -17,4 +17,4 @@
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  branch   ↓/j down • ↑/k up • q quit • n new • esc back                                            "
+"  branch   ↓/j down • ↑/k up • q quit • n new • m move • esc back                                   "


### PR DESCRIPTION
Previously you could press `m` to pick a branch or commit to move. Now you can also press `m` when inside branch mode to move the selected branch. So `b` then `m`. Just a little less rigid.