### PR TITLE
feat(tui): press shift+c to copy the selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,7 @@ name = "but"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "boolean-enums",
  "bstr",
  "but-action",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -140,6 +140,7 @@ itertools.workspace = true
 self_cell.workspace = true
 rand.workspace = true
 ratatui-textarea = "0.8.0"
+arboard = { version = "3.6.1", default-features = false }
 
 [dev-dependencies]
 but-graph.workspace = true

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     CLI_DATE, CliId, IdMap,
     command::legacy::{
         forge::review,
-        status::output::{CommitLineContent, StatusOutput, StatusOutputLine},
+        status::output::{BranchLineContent, CommitLineContent, StatusOutput, StatusOutputLine},
     },
     id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
@@ -913,30 +913,36 @@ fn print_group(
                 |id| matches!(id, CliId::Branch { .. }),
                 "branch",
             )?;
-            let mut branch_line = Vec::from([
-                Span::styled(segment.short_id.clone(), Style::default().blue().bold()),
-                Span::raw(" ["),
-                Span::styled(branch, Style::default().green().bold()),
-                Span::raw(workspace),
-                Span::raw("]"),
-            ]);
-            branch_line.extend(ci_spans);
+            let mut branch_suffix = Vec::new();
+            branch_suffix.extend(ci_spans);
             if !merge_status.content.is_empty() {
-                branch_line.push(merge_status);
+                branch_suffix.push(merge_status);
             }
-            branch_line.extend(review_spans);
+            branch_suffix.extend(review_spans);
             if !no_commits.is_empty() {
-                branch_line.push(Span::raw(" "));
-                branch_line.push(Span::styled(no_commits, Style::default().dim().italic()));
+                branch_suffix.push(Span::raw(" "));
+                branch_suffix.push(Span::styled(no_commits, Style::default().dim().italic()));
             }
             if let Some(stack_mark) = stack_mark.as_ref().cloned() {
-                branch_line.push(Span::raw(" "));
-                branch_line.push(stack_mark);
+                branch_suffix.push(Span::raw(" "));
+                branch_suffix.push(stack_mark);
             }
 
             output.branch(
                 Vec::from([Span::raw(format!("┊{notch}┄"))]),
-                branch_line,
+                BranchLineContent {
+                    id: Vec::from([Span::styled(
+                        segment.short_id.clone(),
+                        Style::default().blue().bold(),
+                    )]),
+                    decoration_start: Vec::from([Span::raw(" [")]),
+                    branch_name: Vec::from([
+                        Span::styled(branch, Style::default().green().bold()),
+                        Span::raw(workspace),
+                    ]),
+                    decoration_end: Vec::from([Span::raw("]")]),
+                    suffix: branch_suffix,
+                },
                 branch_cli_id,
             )?;
 

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -124,12 +124,12 @@ impl StatusOutput<'_> {
     pub(super) fn branch(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: Vec<Span<'static>>,
+        line: BranchLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            StatusOutputContent::Plain(line),
+            StatusOutputContent::Branch(line),
             StatusOutputLineData::Branch {
                 cli_id: Arc::new(id),
             },
@@ -252,8 +252,10 @@ impl StatusOutput<'_> {
 pub(super) enum StatusOutputContent {
     /// Generic status content represented as one flat list of spans.
     Plain(Vec<Span<'static>>),
-    /// Structured content for commit rows where SHA and message are split.
+    /// Structured content for commit rows.
     Commit(CommitLineContent),
+    /// Structured content for branch rows.
+    Branch(BranchLineContent),
 }
 
 /// Structured content for a commit row in status output.
@@ -262,6 +264,24 @@ pub(super) struct CommitLineContent {
     pub(super) sha: Vec<Span<'static>>,
     pub(super) author: Vec<Span<'static>>,
     pub(super) message: Vec<Span<'static>>,
+    pub(super) suffix: Vec<Span<'static>>,
+}
+
+/// Structured content for a branch row in status output.
+///
+/// Consdering the example "dp [dp-branch-1] (no commits)" see the field docs for what exactly they
+/// correspond to.
+#[derive(Debug, Default, Clone)]
+pub(super) struct BranchLineContent {
+    /// "dp" in the example
+    pub(super) id: Vec<Span<'static>>,
+    /// " [" in the example
+    pub(super) decoration_start: Vec<Span<'static>>,
+    /// "dp-branch-1" in the example
+    pub(super) branch_name: Vec<Span<'static>>,
+    /// "] " in the example
+    pub(super) decoration_end: Vec<Span<'static>>,
+    /// "(no commits)" in the example
     pub(super) suffix: Vec<Span<'static>>,
 }
 

--- a/crates/but/src/command/legacy/status/render_oneshot.rs
+++ b/crates/but/src/command/legacy/status/render_oneshot.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style};
 use crate::{
     command::legacy::status::{
         StatusOutputLine,
-        output::{CommitLineContent, StatusOutputContent},
+        output::{BranchLineContent, CommitLineContent, StatusOutputContent},
     },
     utils::WriteWithUtils,
 };
@@ -41,6 +41,19 @@ pub(super) fn render_oneshot(
             spans.append(&mut sha);
             spans.append(&mut author);
             spans.append(&mut message);
+            spans.append(&mut suffix);
+        }
+        StatusOutputContent::Branch(BranchLineContent {
+            mut id,
+            mut decoration_start,
+            mut branch_name,
+            mut decoration_end,
+            mut suffix,
+        }) => {
+            spans.append(&mut id);
+            spans.append(&mut decoration_start);
+            spans.append(&mut branch_name);
+            spans.append(&mut decoration_end);
             spans.append(&mut suffix);
         }
     }

--- a/crates/but/src/command/legacy/status/tui/highlight.rs
+++ b/crates/but/src/command/legacy/status/tui/highlight.rs
@@ -1,0 +1,47 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use ratatui::{style::Stylize as _, text::Span};
+
+use crate::CliId;
+
+#[derive(Debug, Default)]
+pub(super) struct Highlights {
+    ids: Vec<HighlightedCliId>,
+}
+
+#[derive(Debug)]
+struct HighlightedCliId {
+    id: Arc<CliId>,
+    expire_at: Instant,
+}
+
+impl Highlights {
+    pub(super) fn insert(&mut self, id: Arc<CliId>) {
+        if self.contains(&id) {
+            return;
+        }
+        self.ids.push(HighlightedCliId {
+            id,
+            expire_at: Instant::now() + Duration::from_secs_f32(0.15),
+        });
+    }
+
+    pub(super) fn contains(&self, id: &CliId) -> bool {
+        self.ids.iter().any(|h| &*h.id == id)
+    }
+
+    pub(super) fn update(&mut self) -> bool {
+        let now = Instant::now();
+        let len_before = self.ids.len();
+        self.ids.retain(|id| id.expire_at > now);
+        let len_after = self.ids.len();
+        len_before != len_after
+    }
+}
+
+pub(super) fn with_highlight(span: Span<'static>) -> Span<'static> {
+    span.black().on_white().not_dim()
+}

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -231,6 +231,15 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
     });
 
     key_binds.register(StaticKeyBind {
+        short_description: "copy",
+        chord_display: "shift+c",
+        key_matcher: press().shift().code(KeyCode::Char('C')),
+        modes: Vec::from([ModeDiscriminant::Normal]),
+        message: Message::CopySelection,
+        hide_from_hotbar: true,
+    });
+
+    key_binds.register(StaticKeyBind {
         short_description: "back",
         chord_display: "esc",
         key_matcher: press().code(KeyCode::Esc),

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,10 +1,12 @@
 use std::{
+    borrow::Cow,
     ffi::OsString,
     process::Command,
     sync::Arc,
     time::{Duration, Instant},
 };
 
+use anyhow::Context as _;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use crossterm::event::{self, Event};
@@ -24,10 +26,12 @@ use crate::{
     command::legacy::{
         rub::{RubOperation, route_operation},
         status::{
-            StatusFlags, StatusOutputLine,
+            CommitLineContent, StatusFlags, StatusOutputLine,
+            output::BranchLineContent,
             tui::{
                 cursor::{Cursor, is_selectable_in_mode},
                 graph_extension::{ExtensionDirection, extend_connector_spans},
+                highlight::{Highlights, with_highlight},
                 key_bind::{KeyBinds, default_key_binds},
             },
         },
@@ -44,6 +48,7 @@ use super::{
 
 mod cursor;
 mod graph_extension;
+mod highlight;
 mod key_bind;
 mod operations;
 mod rub_api;
@@ -134,6 +139,37 @@ where
     anyhow::Error: From<<T::Backend as Backend>::Error>,
     E: EventPolling,
 {
+    update(
+        app,
+        terminal_guard,
+        event_polling,
+        messages,
+        other_messages,
+        ctx,
+        out,
+        mode,
+    )
+    .await?;
+    render(app, terminal_guard)?;
+    Ok(())
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn update<T, E>(
+    app: &mut App,
+    terminal_guard: &mut T,
+    event_polling: E,
+    messages: &mut Vec<Message>,
+    other_messages: &mut Vec<Message>,
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    mode: &OperatingMode,
+) -> anyhow::Result<()>
+where
+    T: TerminalGuard,
+    anyhow::Error: From<<T::Backend as Backend>::Error>,
+    E: EventPolling,
+{
     // poll events
     for event in event_polling.poll()? {
         event_to_messages(event, &app.key_binds, &app.mode, messages);
@@ -159,7 +195,18 @@ where
         app.should_render = true;
     }
 
-    // render
+    if app.highlight.update() {
+        app.should_render = true;
+    }
+
+    Ok(())
+}
+
+fn render<T>(app: &mut App, terminal_guard: &mut T) -> anyhow::Result<()>
+where
+    T: TerminalGuard,
+    anyhow::Error: From<<T::Backend as Backend>::Error>,
+{
     if std::mem::take(&mut app.should_render) {
         terminal_guard.terminal_mut().draw(|frame| {
             app.renders += 1;
@@ -183,6 +230,7 @@ struct App {
     debug_enabled: bool,
     errors: Vec<AppError>,
     renders: u64,
+    highlight: Highlights,
 }
 
 impl App {
@@ -201,6 +249,7 @@ impl App {
             debug_enabled: debug,
             errors: Vec::new(),
             renders: 0,
+            highlight: Default::default(),
         }
     }
 
@@ -418,6 +467,9 @@ impl App {
                     self.handle_create_new_branch(ctx, messages)?;
                 }
             },
+            Message::CopySelection => {
+                self.handle_copy_selection()?;
+            }
         }
 
         self.ensure_cursor_visible(visible_height);
@@ -1159,6 +1211,33 @@ impl App {
         Ok(())
     }
 
+    fn handle_copy_selection(&mut self) -> anyhow::Result<()> {
+        let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+            return Ok(());
+        };
+        let Some(cli_id) = selection.data.cli_id() else {
+            return Ok(());
+        };
+
+        let what_to_copy = match &**cli_id {
+            CliId::Branch { name, .. } => Cow::Borrowed(&**name),
+            CliId::Commit { commit_id, .. } => Cow::Owned(commit_id.to_hex_with_len(7).to_string()),
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Unassigned { .. }
+            | CliId::Stack { .. }
+            | CliId::Uncommitted(_) => return Ok(()),
+        };
+
+        arboard::Clipboard::new()
+            .and_then(|mut clipboard| clipboard.set_text(what_to_copy))
+            .context("failed to copy to system clipboard")?;
+
+        self.highlight.insert(Arc::clone(cli_id));
+
+        Ok(())
+    }
+
     /// Handles opening the full-screen commit reword editor for the selected commit.
     fn handle_reword_with_editor<T>(
         &mut self,
@@ -1499,17 +1578,47 @@ impl App {
 
         let content_spans = match content {
             StatusOutputContent::Plain(spans) => spans.clone(),
-            StatusOutputContent::Commit(commit_content) => {
+            StatusOutputContent::Commit(CommitLineContent {
+                sha,
+                author,
+                message,
+                suffix,
+            }) => {
+                let mut spans =
+                    Vec::with_capacity(sha.len() + author.len() + message.len() + suffix.len());
+                if data.cli_id().is_some_and(|id| self.highlight.contains(id)) {
+                    spans.extend(sha.iter().cloned().map(with_highlight));
+                } else {
+                    spans.extend(sha.iter().cloned());
+                }
+                spans.extend(author.iter().cloned());
+                spans.extend(message.iter().cloned());
+                spans.extend(suffix.iter().cloned());
+                spans
+            }
+            StatusOutputContent::Branch(BranchLineContent {
+                id,
+                decoration_start,
+                branch_name,
+                decoration_end,
+                suffix,
+            }) => {
                 let mut spans = Vec::with_capacity(
-                    commit_content.sha.len()
-                        + commit_content.author.len()
-                        + commit_content.message.len()
-                        + commit_content.suffix.len(),
+                    id.len()
+                        + decoration_start.len()
+                        + branch_name.len()
+                        + decoration_end.len()
+                        + suffix.len(),
                 );
-                spans.extend(commit_content.sha.iter().cloned());
-                spans.extend(commit_content.author.iter().cloned());
-                spans.extend(commit_content.message.iter().cloned());
-                spans.extend(commit_content.suffix.iter().cloned());
+                spans.extend(id.iter().cloned());
+                spans.extend(decoration_start.iter().cloned());
+                if data.cli_id().is_some_and(|id| self.highlight.contains(id)) {
+                    spans.extend(branch_name.iter().cloned().map(with_highlight));
+                } else {
+                    spans.extend(branch_name.iter().cloned());
+                }
+                spans.extend(decoration_end.iter().cloned());
+                spans.extend(suffix.iter().cloned());
                 spans
             }
         };
@@ -1949,6 +2058,9 @@ enum Message {
     Files(FilesMessage),
     Move(MoveMessage),
     Branch(BranchMessage),
+
+    // Utilities
+    CopySelection,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Pressing shift+c now copies the branch or commit on the current line.

I find that very useful for sending things to other commands, such as `but pr new <branch>` or telling an agent to `review <commit>`.