### PR TITLE
Add in-memory `OutputChannel`

### DIFF
--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -24,7 +24,7 @@ use crate::{
 /// Main entry point for config command
 pub async fn exec(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     cmd: Option<Subcommands>,
 ) -> Result<()> {
     match cmd {
@@ -38,7 +38,7 @@ pub async fn exec(
 }
 
 /// Show overview of important settings
-async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
+async fn show_overview(ctx: &mut Context, out: &mut OutputChannel<'_>) -> Result<()> {
     #[derive(Serialize)]
     struct ConfigOverview {
         name: Option<String>,
@@ -175,7 +175,7 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
 
 /// Handle metrics config subcommand (doesn't require repo context)
 pub(crate) async fn metrics_config(
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     status: Option<MetricsStatus>,
 ) -> Result<()> {
     let app_settings_sync = load_app_settings_sync()?;
@@ -324,7 +324,7 @@ fn write_user_config_human(out: &mut dyn std::fmt::Write, info: &UserConfigInfo)
 /// Handle user config subcommand
 async fn user_config(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     cmd: Option<UserSubcommand>,
 ) -> Result<()> {
     let repo = ctx.repo.get()?;
@@ -412,7 +412,7 @@ async fn user_config(
 
 /// Handle forge config subcommand (doesn't require repo context)
 pub(crate) async fn forge_config(
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     cmd: Option<ForgeSubcommand>,
 ) -> Result<()> {
     match cmd {
@@ -424,7 +424,7 @@ pub(crate) async fn forge_config(
 }
 
 /// Show overview of forge configuration (same as list-users)
-async fn forge_show_overview(out: &mut OutputChannel) -> Result<()> {
+async fn forge_show_overview(out: &mut OutputChannel<'_>) -> Result<()> {
     let known_gh_accounts = but_api::github::list_known_github_accounts()?;
     let known_gl_accounts = but_api::gitlab::list_known_gitlab_accounts()?;
 
@@ -552,7 +552,7 @@ fn extract_account_details(
 }
 
 /// Authenticate with a forge provider (GitHub, GitLab, etc)
-async fn forge_auth(out: &mut OutputChannel) -> Result<()> {
+async fn forge_auth(out: &mut OutputChannel<'_>) -> Result<()> {
     use cli_prompts::DisplayPrompt;
 
     #[derive(Debug, Clone)]
@@ -588,7 +588,7 @@ async fn forge_auth(out: &mut OutputChannel) -> Result<()> {
 }
 
 /// Authenticate with GitLab
-async fn gitlab_auth(out: &mut OutputChannel) -> Result<()> {
+async fn gitlab_auth(out: &mut OutputChannel<'_>) -> Result<()> {
     use cli_prompts::DisplayPrompt;
     #[derive(Debug, Clone)]
     enum AuthMethod {
@@ -660,7 +660,7 @@ async fn gitlab_self_hosted(mut inout: InputOutputChannel<'_>) -> Result<()> {
 }
 
 /// Authenticate with GitHub
-async fn github_auth(out: &mut OutputChannel) -> Result<()> {
+async fn github_auth(out: &mut OutputChannel<'_>) -> Result<()> {
     use cli_prompts::DisplayPrompt;
 
     #[derive(Debug, Clone)]
@@ -771,7 +771,7 @@ async fn github_oauth(mut inout: InputOutputChannel<'_>) -> Result<()> {
 
 async fn display_authenticated_github_accounts(
     known_gh_accounts: &Vec<but_github::GithubAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     writeln!(out, "\n{}:", "Authenticated GitHub accounts".bold())?;
     writeln!(out)?;
@@ -804,7 +804,7 @@ async fn display_authenticated_github_accounts(
 
 async fn display_authenticated_gitlab_accounts(
     known_gl_accounts: &Vec<but_gitlab::GitlabAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     if known_gl_accounts.is_empty() {
         return Ok(false);
@@ -866,7 +866,7 @@ fn forget_account(account: &AccountToForget) -> Result<()> {
 }
 
 /// Forget a GitHub account
-async fn forge_forget(username: Option<String>, out: &mut OutputChannel) -> Result<()> {
+async fn forge_forget(username: Option<String>, out: &mut OutputChannel<'_>) -> Result<()> {
     use cli_prompts::DisplayPrompt;
 
     let known_gh_accounts = but_api::github::list_known_github_accounts()?;
@@ -938,7 +938,7 @@ async fn forge_forget(username: Option<String>, out: &mut OutputChannel) -> Resu
 /// Handle target config subcommand
 async fn target_config(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     branch: Option<String>,
 ) -> Result<()> {
     match branch {
@@ -1040,7 +1040,11 @@ async fn target_config(
 }
 
 /// Handle UI config subcommand
-fn ui_config(ctx: &mut Context, out: &mut OutputChannel, cmd: Option<UiSubcommand>) -> Result<()> {
+fn ui_config(
+    ctx: &mut Context,
+    out: &mut OutputChannel<'_>,
+    cmd: Option<UiSubcommand>,
+) -> Result<()> {
     let repo = ctx.repo.get()?;
 
     match cmd {

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -561,7 +561,7 @@ fn print_applied_branches_table(
     ctx: &Context,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 
@@ -672,7 +672,7 @@ fn print_branches_table(
     branch_review_map: &HashMap<String, Vec<but_forge::ForgeReview>>,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -21,7 +21,7 @@ pub async fn enable_auto_merge(
     ctx: &mut Context,
     selector: Option<String>,
     off: bool,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> anyhow::Result<()> {
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
@@ -115,7 +115,7 @@ pub async fn set_draftiness(
     ctx: &mut Context,
     selector: Option<String>,
     draft: bool,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> anyhow::Result<()> {
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
@@ -234,7 +234,7 @@ pub async fn set_draftiness(
 pub fn set_review_template(
     ctx: &mut Context,
     template_path: Option<String>,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> anyhow::Result<()> {
     if let Some(path) = template_path {
         let message = format!("Set review template path to: {}", &path);
@@ -287,7 +287,7 @@ pub async fn create_review(
     default: bool,
     draft: bool,
     message: Option<ForgeReviewMessage>,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> anyhow::Result<()> {
     // Fail fast if no forge user is authenticated, before pushing or prompting.
     ensure_forge_authentication(ctx).await?;
@@ -457,7 +457,7 @@ pub async fn handle_multiple_branches_in_workspace(
     default_message: bool,
     draft: bool,
     message: Option<&ForgeReviewMessage>,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     selected_branches: Option<Vec<String>>,
 ) -> anyhow::Result<()> {
     let mut overall_outcome = PublishReviewsOutcome {
@@ -525,7 +525,7 @@ fn prompt_for_branch_selection(
     ctx: &Context,
     review_map: &std::collections::HashMap<String, Vec<but_forge::ForgeReview>>,
     applied_stacks: &[but_workspace::legacy::ui::StackEntry],
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> anyhow::Result<Vec<String>> {
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
     let base_branch_id = base_branch.current_sha;
@@ -623,7 +623,7 @@ async fn publish_reviews_for_branch_and_dependents(
     default_message: bool,
     draft: bool,
     message: Option<&ForgeReviewMessage>,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) -> Result<PublishReviewsOutcome, anyhow::Error> {
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
     let all_branches_up_to_subject = stack_entry

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub async fn handle(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     branch_id: &str,
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -65,7 +65,7 @@ struct PullSummary {
 
 pub async fn handle(
     ctx: &Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     check_only: bool,
 ) -> anyhow::Result<()> {
     if check_only {
@@ -75,7 +75,7 @@ pub async fn handle(
     }
 }
 
-async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+async fn handle_check(ctx: &Context, out: &mut OutputChannel<'_>) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
 
     writeln!(progress, "Fetching from upstream remotes...")?;
@@ -239,7 +239,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
     Ok(())
 }
 
-async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+async fn handle_pull(ctx: &Context, out: &mut OutputChannel<'_>) -> anyhow::Result<()> {
     let mut pull_result = PullResult {
         status: String::new(),
         upstream_url: None,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -147,14 +147,14 @@ struct StatusContext<'a> {
     mode: &'a gitbutler_operating_modes::OperatingMode,
 }
 
-fn show_edit_mode_status(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+fn show_edit_mode_status(ctx: &mut Context, out: &mut OutputChannel<'_>) -> anyhow::Result<()> {
     // Delegate to the resolve status logic to show actual conflict details
     crate::command::legacy::resolve::show_resolve_status(ctx, out)
 }
 
 pub(crate) async fn worktree(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     flags: StatusFlags,
     render_mode: StatusRenderMode,
 ) -> anyhow::Result<()> {
@@ -210,7 +210,7 @@ pub(crate) async fn worktree(
 
 async fn build_status_context<'a>(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mode: &'a OperatingMode,
     flags: StatusFlags,
     render_mode: StatusRenderMode,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -62,7 +62,7 @@ const CURSOR_CONTEXT_ROWS: usize = 3;
 
 pub(super) async fn render_tui(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mode: &OperatingMode,
     flags: StatusFlags,
     status_lines: Vec<StatusOutputLine>,
@@ -131,7 +131,7 @@ async fn render_loop_once<T, E>(
     messages: &mut Vec<Message>,
     other_messages: &mut Vec<Message>,
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mode: &OperatingMode,
 ) -> anyhow::Result<()>
 where
@@ -162,7 +162,7 @@ async fn update<T, E>(
     messages: &mut Vec<Message>,
     other_messages: &mut Vec<Message>,
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mode: &OperatingMode,
 ) -> anyhow::Result<()>
 where
@@ -328,7 +328,7 @@ impl App {
     async fn handle_message<T>(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut OutputChannel<'_>,
         mode: &OperatingMode,
         terminal_guard: &mut T,
         messages: &mut Vec<Message>,
@@ -348,7 +348,7 @@ impl App {
     async fn try_handle_message<T>(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut OutputChannel<'_>,
         mode: &OperatingMode,
         terminal_guard: &mut T,
         messages: &mut Vec<Message>,
@@ -717,7 +717,7 @@ impl App {
     async fn handle_reload(
         &mut self,
         ctx: &mut Context,
-        out: &mut OutputChannel,
+        out: &mut OutputChannel<'_>,
         mode: &OperatingMode,
         select_after_reload: Option<SelectAfterReload>,
     ) -> anyhow::Result<()> {
@@ -1366,7 +1366,7 @@ impl App {
     fn handle_run_command<T>(
         &mut self,
         terminal_guard: &mut T,
-        out: &mut OutputChannel,
+        out: &mut OutputChannel<'_>,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()>
     where
@@ -1408,7 +1408,7 @@ impl App {
     }
 
     /// Prompts the user to press enter before returning from a command execution.
-    fn prompt_to_continue(&mut self, out: &mut OutputChannel) -> anyhow::Result<()> {
+    fn prompt_to_continue(&mut self, out: &mut OutputChannel<'_>) -> anyhow::Result<()> {
         if let Some(mut input_channel) = out.prepare_for_terminal_input() {
             input_channel.prompt_single_line("\npress enter to continue...")?;
         }
@@ -2426,7 +2426,7 @@ fn render_error_popup(frame: &mut Frame, area: Rect, margin: PopupMargin, text: 
 
 fn with_noop_output<F, T>(f: F) -> T
 where
-    F: FnOnce(&mut OutputChannel) -> T,
+    F: FnOnce(&mut OutputChannel<'_>) -> T,
 {
     let mut noop_out = OutputChannel::new_without_pager_non_json(OutputFormat::None);
     f(&mut noop_out)

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -30,7 +30,7 @@ use crate::{
 
 pub(super) async fn reload_legacy(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mode: &OperatingMode,
     flags: StatusFlags,
     debug_enabled: bool,
@@ -179,7 +179,7 @@ pub(super) fn create_commit_legacy(
 
 pub(super) fn rub_legacy(
     ctx: &mut Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     operation: RubOperation<'_>,
 ) -> anyhow::Result<()> {
     operation.execute(ctx, out)

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -20,7 +20,7 @@ pub(super) struct TestTui {
     terminal: Terminal<TestBackend>,
     terminal_width: u16,
     pub(super) env: Sandbox,
-    out: OutputChannel,
+    out: OutputChannel<'static>,
     mode: OperatingMode,
     async_runtime: tokio::runtime::Runtime,
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -218,7 +218,7 @@ async fn match_subcommand(
     cmd: Subcommands,
     args: Args,
     app_settings: AppSettings,
-    mut output: OutputChannel,
+    mut output: OutputChannel<'_>,
 ) -> Result<()> {
     let out = &mut output;
     let metrics_ctx = cmd.to_metrics_context(&app_settings);
@@ -1397,7 +1397,7 @@ async fn maybe_run_status_after(
     status_after: bool,
     result: &anyhow::Result<()>,
     ctx: &mut but_ctx::Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
 ) {
     if !status_after {
         return;
@@ -1424,7 +1424,7 @@ async fn maybe_run_status_after(
 #[cfg(feature = "legacy")]
 async fn run_status_after(
     ctx: &mut but_ctx::Context,
-    out: &mut OutputChannel,
+    out: &mut OutputChannel<'_>,
     mutation_json: Option<serde_json::Value>,
 ) {
     use crate::command::legacy::status::StatusFlags;

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -34,11 +34,11 @@ pub enum ConfirmOrEmpty {
 }
 
 /// A utility `std::io::Write` implementation that can always be used to generate output for humans or for scripts.
-pub struct OutputChannel {
+pub struct OutputChannel<'a> {
     /// How to print the output, one should match on it. Match on this if you prefer this style.
     format: OutputFormat,
     /// The output to use if there is no pager.
-    stdout: std::io::Stdout,
+    out: OutputChannelOutput<'a>,
     /// Possibly a pager we are using. If `Some`, the pager itself is used for output instead of `stdout`.
     pager: Option<Pager>,
     /// When `Some`, JSON values written via `write_value` are captured here instead of going to stdout.
@@ -58,7 +58,7 @@ pub struct ProgressChannel {
 impl ProgressChannel {
     /// Create a new progress channel that writes to stderr if it's a terminal and `for_humans` is true.
     /// If `for_humans` is false, the channel becomes a no-op.
-    pub fn new(for_humans: bool) -> Self {
+    fn new(for_humans: bool) -> Self {
         ProgressChannel {
             inner: if for_humans {
                 let stderr = std::io::stderr();
@@ -107,7 +107,7 @@ fn ignore_broken_pipe(err: std::io::Error) -> std::io::Result<()> {
 }
 
 /// Access
-impl OutputChannel {
+impl OutputChannel<'_> {
     /// Get the output format setting.
     pub fn format(&self) -> OutputFormat {
         self.format
@@ -115,7 +115,7 @@ impl OutputChannel {
 }
 
 /// An [`std::fmt::Write`] implementation that supports additional utility methods for output formatting.
-pub trait WriteWithUtils: std::fmt::Write + 'static {
+pub trait WriteWithUtils: std::fmt::Write {
     /// Truncate the given text to the specified maximum width, unless the output is passed through a pager.
     ///
     /// Note that while copy-on-write is used internally, the returned value is always owned as it's typically
@@ -128,7 +128,7 @@ pub trait WriteWithUtils: std::fmt::Write + 'static {
     fn is_paged(&self) -> bool;
 }
 
-impl WriteWithUtils for OutputChannel {
+impl WriteWithUtils for OutputChannel<'_> {
     fn truncate_if_unpaged(&self, text: &str, max_width: usize) -> String {
         if self.pager.is_some() {
             text.to_owned()
@@ -143,20 +143,23 @@ impl WriteWithUtils for OutputChannel {
 }
 
 /// Output
-impl OutputChannel {
+impl<'a> OutputChannel<'a> {
     /// Provide a write implementation for humans, if the format setting permits.
-    pub fn for_human(&mut self) -> Option<&mut dyn WriteWithUtils> {
+    pub fn for_human(&mut self) -> Option<&mut (dyn WriteWithUtils + 'a)> {
         matches!(self.format, OutputFormat::Human).then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a write implementation for Shell output, if the format setting permits.
-    pub fn for_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
+    pub fn for_shell(&mut self) -> Option<&mut (dyn WriteWithUtils + 'a)> {
         matches!(self.format, OutputFormat::Shell).then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a write implementation for text output (human or shell), if the format setting permits.
-    pub fn for_human_or_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
+    pub fn for_human_or_shell(&mut self) -> Option<&mut (dyn WriteWithUtils + 'a)> {
         matches!(self.format, OutputFormat::Human | OutputFormat::Shell)
             .then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a handle to receive a serde-serializable value to write to stdout.
     pub fn for_json(&mut self) -> Option<&mut Self> {
         matches!(self.format, OutputFormat::Json).then_some(self)
@@ -165,12 +168,15 @@ impl OutputChannel {
     /// A convenience function to create a progress channel that only writes when the output is for humans.
     /// The progress channel writes to stderr if it's a terminal and the output format is [`OutputFormat::Human`].
     pub fn progress_channel(&self) -> ProgressChannel {
-        ProgressChannel::new(matches!(self.format, OutputFormat::Human))
+        ProgressChannel::new(
+            matches!(self.format, OutputFormat::Human)
+                && matches!(self.out, OutputChannelOutput::Stdout(_)),
+        )
     }
 }
 
 /// User input
-impl OutputChannel {
+impl OutputChannel<'_> {
     /// Return `true` if external prompt support like [`Selection`](cli_prompts::prompts::Selection) can be used,
     /// *and* the output is meant *for humans*.
     ///
@@ -178,7 +184,7 @@ impl OutputChannel {
     pub fn can_prompt(&self) -> bool {
         matches!(self.format, OutputFormat::Human)
             && std::io::stdin().is_terminal()
-            && self.stdout.is_terminal()
+            && self.out.is_terminal()
     }
 
     /// Before performing further output, obtain an input channel which always bypasses the pager when writing,
@@ -188,7 +194,7 @@ impl OutputChannel {
     pub fn prepare_for_terminal_input(&mut self) -> Option<InputOutputChannel<'_>> {
         use std::io::IsTerminal;
         let stdin = std::io::stdin();
-        if !stdin.is_terminal() || !self.stdout.is_terminal() {
+        if !stdin.is_terminal() || !self.out.is_terminal() {
             return None;
         }
         if self.for_human().is_none() {
@@ -197,12 +203,14 @@ impl OutputChannel {
             );
             return None;
         }
-        Some(InputOutputChannel { out: self })
+        Some(InputOutputChannel {
+            out: self.out.as_mut(),
+        })
     }
 }
 
 /// JSON utilities
-impl OutputChannel {
+impl OutputChannel<'_> {
     /// Write `value` as pretty JSON to the output.
     ///
     /// When JSON buffering is active (via [`Self::start_json_buffering`]), the value is captured
@@ -253,7 +261,7 @@ impl OutputChannel {
     }
 }
 
-impl std::fmt::Write for OutputChannel {
+impl std::fmt::Write for OutputChannel<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         use std::io::Write;
         match self.format {
@@ -273,7 +281,7 @@ impl std::fmt::Write for OutputChannel {
                         })
                     }
                     None => {
-                        self.stdout.write_all(s.as_bytes()).or_else(|err| {
+                        self.out.write_all(s.as_bytes()).or_else(|err| {
                             if err.kind() == std::io::ErrorKind::BrokenPipe {
                                 // Ignore broken pipes and keep writing.
                                 // This allows the caller to use `?` without having to think
@@ -297,7 +305,7 @@ impl std::fmt::Write for OutputChannel {
 
 /// A channel to obtain various kinds of user input from a terminal, bypassing the pager.
 pub struct InputOutputChannel<'out> {
-    out: &'out mut OutputChannel,
+    out: OutputChannelOutputMut<'out>,
 }
 
 impl std::fmt::Write for InputOutputChannel<'_> {
@@ -305,7 +313,6 @@ impl std::fmt::Write for InputOutputChannel<'_> {
         use std::io::Write;
         // bypass the pager, fail on broken pipes (we are prompting)
         self.out
-            .stdout
             .write_all(s.as_bytes())
             .map_err(|_| std::fmt::Error)
     }
@@ -314,8 +321,8 @@ impl std::fmt::Write for InputOutputChannel<'_> {
 impl InputOutputChannel<'_> {
     fn readline(&mut self, prompt: &str, echo: InputEcho) -> anyhow::Result<ReadlineInput> {
         const PLACEHOLDER_FOR_SECRET: &str = "•";
-        self.out.stdout.write_all(prompt.as_bytes())?;
-        self.out.stdout.flush()?;
+        self.out.write_all(prompt.as_bytes())?;
+        self.out.flush()?;
 
         let _raw_mode = RawModeGuard::new()?;
         let mut line = String::new();
@@ -327,28 +334,26 @@ impl InputOutputChannel<'_> {
                         line.push(ch);
                         match echo {
                             InputEcho::Visible => {
-                                write!(self.out.stdout, "{ch}")?;
-                                self.out.stdout.flush()?;
+                                write!(self.out, "{ch}")?;
+                                self.out.flush()?;
                             }
                             InputEcho::Hidden => {
-                                self.out
-                                    .stdout
-                                    .write_all(PLACEHOLDER_FOR_SECRET.as_bytes())?;
-                                self.out.stdout.flush()?;
+                                self.out.write_all(PLACEHOLDER_FOR_SECRET.as_bytes())?;
+                                self.out.flush()?;
                             }
                         }
                     }
                     KeyEditAction::Backspace => {
                         if line.pop().is_some() {
                             // Move back, erase one char, then move back again.
-                            self.out.stdout.write_all(b"\x08 \x08")?;
-                            self.out.stdout.flush()?;
+                            self.out.write_all(b"\x08 \x08")?;
+                            self.out.flush()?;
                         }
                     }
                     KeyEditAction::Submit => {
                         // In raw mode, '\n' may not return to column 0, so always emit CRLF.
-                        self.out.stdout.write_all(b"\r\n")?;
-                        self.out.stdout.flush()?;
+                        self.out.write_all(b"\r\n")?;
+                        self.out.flush()?;
                         let trimmed = line.trim().to_owned();
                         return if trimmed.is_empty() {
                             Ok(ReadlineInput::Empty)
@@ -358,8 +363,8 @@ impl InputOutputChannel<'_> {
                     }
                     KeyEditAction::EndOfInput => {
                         // Keep follow-up output aligned even after prompt cancellation.
-                        self.out.stdout.write_all(b"\r\n")?;
-                        self.out.stdout.flush()?;
+                        self.out.write_all(b"\r\n")?;
+                        self.out.flush()?;
                         return Ok(ReadlineInput::EndOfInput);
                     }
                     KeyEditAction::Ignore => {}
@@ -369,14 +374,14 @@ impl InputOutputChannel<'_> {
                         line.push_str(&text);
                         match echo {
                             InputEcho::Visible => {
-                                self.out.stdout.write_all(text.as_bytes())?;
-                                self.out.stdout.flush()?;
+                                self.out.write_all(text.as_bytes())?;
+                                self.out.flush()?;
                             }
                             InputEcho::Hidden => {
                                 let placeholders =
                                     PLACEHOLDER_FOR_SECRET.repeat(text.chars().count());
-                                self.out.stdout.write_all(placeholders.as_bytes())?;
-                                self.out.stdout.flush()?;
+                                self.out.write_all(placeholders.as_bytes())?;
+                                self.out.flush()?;
                             }
                         }
                     }
@@ -589,19 +594,19 @@ impl Drop for RawModeGuard {
 /// Be sure to flush everything written after the prompt as well - the output channel may be buffered.
 impl Drop for InputOutputChannel<'_> {
     fn drop(&mut self) {
-        self.out.stdout.flush().ok();
+        self.out.flush().ok();
     }
 }
 
 /// Lifecycle
-impl OutputChannel {
+impl OutputChannel<'static> {
     /// Create a new instance to output with `format` (advisory), which affects where it prints to.
     /// The `use_pager` parameter controls whether a pager should be created.
     ///
     /// It's configured to print to stdout unless [`OutputFormat::Json`] is used, then it prints everything
     /// to a `/dev/null` equivalent, so callers never have to worry if they interleave JSON with other output.
     pub fn new_with_optional_pager(format: OutputFormat, use_pager: bool) -> Self {
-        let stdout = std::io::stdout();
+        let stdout = OutputChannelOutput::Stdout(std::io::stdout());
         let pager = if !use_pager
             || !matches!(format, OutputFormat::Human)
             || std::env::var_os("NOPAGER").is_some()
@@ -614,7 +619,7 @@ impl OutputChannel {
 
         OutputChannel {
             format,
-            stdout,
+            out: stdout,
             pager,
             json_buffer: None,
         }
@@ -628,14 +633,26 @@ impl OutputChannel {
                 OutputFormat::Human | OutputFormat::Shell | OutputFormat::None => format,
                 OutputFormat::Json => OutputFormat::None,
             },
-            stdout: std::io::stdout(),
+            out: OutputChannelOutput::Stdout(std::io::stdout()),
             pager: None,
             json_buffer: None,
         }
     }
 }
 
-impl Drop for OutputChannel {
+impl<'a> OutputChannel<'a> {
+    #[expect(dead_code)]
+    pub fn in_memory(buf: &'a mut Vec<u8>, format: OutputFormat) -> Self {
+        OutputChannel {
+            format,
+            out: OutputChannelOutput::InMemory(buf),
+            pager: None,
+            json_buffer: None,
+        }
+    }
+}
+
+impl Drop for OutputChannel<'_> {
     fn drop(&mut self) {
         // Flush any buffered JSON that was never consumed — this means
         // the status-after path did not complete, but we should still
@@ -657,6 +674,93 @@ impl Drop for OutputChannel {
                 child.wait().ok();
             }
             None => (),
+        }
+    }
+}
+
+/// The actual output [`OutputChannel`] writes to.
+enum OutputChannelOutput<'a> {
+    /// Write to stdout.
+    Stdout(std::io::Stdout),
+    /// Write to an in-memory buffer.
+    #[expect(dead_code)]
+    InMemory(&'a mut Vec<u8>),
+}
+
+impl OutputChannelOutput<'_> {
+    /// Get an owned [`OutputChannelOutputMut`] for the [`OutputChannelOutput`].
+    ///
+    /// Without this [`InputOutputChannel`] would end up with two lifetimes since `&'a mut` is
+    /// invariant.
+    #[inline]
+    fn as_mut(&mut self) -> OutputChannelOutputMut<'_> {
+        match self {
+            OutputChannelOutput::Stdout(stdout) => OutputChannelOutputMut::Stdout(stdout),
+            OutputChannelOutput::InMemory(buf) => OutputChannelOutputMut::InMemory(buf),
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        match self {
+            OutputChannelOutput::Stdout(stdout) => stdout.is_terminal(),
+            OutputChannelOutput::InMemory(_) => false,
+        }
+    }
+}
+
+impl std::io::Write for OutputChannelOutput<'_> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.as_mut().write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.as_mut().flush()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.as_mut().write_all(buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        self.as_mut().write_vectored(bufs)
+    }
+}
+
+enum OutputChannelOutputMut<'a> {
+    Stdout(&'a mut std::io::Stdout),
+    InMemory(&'a mut Vec<u8>),
+}
+
+impl std::io::Write for OutputChannelOutputMut<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Stdout(stdout) => stdout.write(buf),
+            Self::InMemory(in_memory) => in_memory.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Stdout(stdout) => stdout.flush(),
+            Self::InMemory(_) => Ok(()),
+        }
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Stdout(stdout) => stdout.write_all(buf),
+            Self::InMemory(in_memory) => in_memory.write_all(buf),
+        }
+    }
+
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        match self {
+            Self::Stdout(stdout) => stdout.write_vectored(bufs),
+            Self::InMemory(in_memory) => in_memory.write_vectored(bufs),
         }
     }
 }


### PR DESCRIPTION
I'm working on aligning the operations performed by the CLI and the TUI. So committing with the TUI should call the same handler function that `but commit` does.

All those CLI handler functions require a `&mut OutputChannel` for printing to stdout. If committing from the TUI I think instead we should instead show the output in a toast. This enables that by adding a variant of `OutputChannel` that writes to a buffer. The TUI can then initialize that buffer and render a ratatui toast after calling the handler.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12983
- <kbd>&nbsp;1&nbsp;</kbd> #12981 👈 
<!-- GitButler Footer Boundary Bottom -->