### PR TITLE
Add general toast in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +760,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 name = "but"
 version = "0.0.0"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "arboard",
  "boolean-enums",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -141,6 +141,7 @@ self_cell.workspace = true
 rand.workspace = true
 ratatui-textarea = "0.8.0"
 arboard = { version = "3.6.1", default-features = false }
+ansi-to-tui = "8.0.1"
 
 [dev-dependencies]
 but-graph.workspace = true

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,10 +1,4 @@
-use std::{
-    borrow::Cow,
-    ffi::OsString,
-    process::Command,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{borrow::Cow, ffi::OsString, process::Command, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use but_ctx::Context;
@@ -16,7 +10,7 @@ use itertools::Either;
 use ratatui::{
     Frame,
     prelude::*,
-    widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap},
+    widgets::{List, ListItem},
 };
 use ratatui_textarea::{CursorMove, TextArea};
 
@@ -33,6 +27,7 @@ use crate::{
                 graph_extension::{ExtensionDirection, extend_connector_spans},
                 highlight::{Highlights, with_highlight},
                 key_bind::{KeyBinds, default_key_binds},
+                toast::{ToastKind, Toasts},
             },
         },
     },
@@ -52,6 +47,7 @@ mod highlight;
 mod key_bind;
 mod operations;
 mod rub_api;
+mod toast;
 
 #[cfg(test)]
 mod tests;
@@ -187,11 +183,7 @@ where
         std::mem::swap(messages, other_messages);
     }
 
-    // dismiss errors
-    let now = Instant::now();
-    let errors_before = app.errors.len();
-    app.errors.retain(|err| err.dismiss_at > now);
-    if app.errors.len() != errors_before {
+    if app.toasts.update() {
         app.should_render = true;
     }
 
@@ -228,7 +220,7 @@ struct App {
     mode: Mode,
     key_binds: KeyBinds,
     debug_enabled: bool,
-    errors: Vec<AppError>,
+    toasts: Toasts,
     renders: u64,
     highlight: Highlights,
 }
@@ -247,7 +239,7 @@ impl App {
             mode: Mode::default(),
             key_binds: default_key_binds(),
             debug_enabled: debug,
-            errors: Vec::new(),
+            toasts: Default::default(),
             renders: 0,
             highlight: Default::default(),
         }
@@ -764,10 +756,11 @@ impl App {
 
     /// Handles showing a transient UI error.
     fn handle_show_error(&mut self, err: Arc<anyhow::Error>, messages: &mut Vec<Message>) {
-        self.errors.push(AppError {
-            inner: err,
-            dismiss_at: Instant::now() + Duration::from_secs(5),
-        });
+        self.toasts.insert(
+            ToastKind::Error,
+            format_error_for_tui(&err),
+            Duration::from_secs(5),
+        );
 
         // ensure we always enter normal mode when something does wrong
         // so we don't get stuck in whatever mode we were in previously
@@ -1416,12 +1409,13 @@ impl App {
         Ok(())
     }
 
-    /// Adds a transient error popup message that auto-dismisses after a short duration.
+    /// Adds a transient error toast message that auto-dismisses after a short duration.
     fn push_transient_error(&mut self, err: anyhow::Error) {
-        self.errors.push(AppError {
-            inner: Arc::new(err),
-            dismiss_at: Instant::now() + Duration::from_secs(5),
-        });
+        self.toasts.insert(
+            ToastKind::Error,
+            format_error_for_tui(&err),
+            Duration::from_secs(5),
+        );
     }
 
     /// Returns the currently selected commit id when the selected line is a commit.
@@ -1473,7 +1467,7 @@ impl App {
 
         self.render_inline_reword(content_area, frame);
 
-        self.render_errors(content_area, frame);
+        self.render_toasts(content_area, frame);
 
         if let Some(debug_area) = debug_area {
             self.render_debug(debug_area, frame);
@@ -1909,19 +1903,9 @@ impl App {
         }
     }
 
-    fn render_errors(&self, area: Rect, frame: &mut Frame) {
-        for (idx, err) in self.errors.iter().rev().enumerate() {
-            let formatted_err = format_error_for_tui(&err.inner);
-            render_error_popup(
-                frame,
-                area,
-                PopupMargin {
-                    right: 1 + idx as u16,
-                    bottom: idx as _,
-                },
-                &formatted_err,
-            );
-        }
+    /// Renders transient toasts stacked in the content area.
+    fn render_toasts(&self, area: Rect, frame: &mut Frame) {
+        toast::render_toasts(frame, area, &self.toasts);
     }
 
     fn render_inline_reword(&self, area: Rect, frame: &mut Frame) {
@@ -2312,11 +2296,6 @@ enum SelectAfterReload {
     Unassigned,
 }
 
-struct PopupMargin {
-    right: u16,
-    bottom: u16,
-}
-
 /// Formats an error for display in the terminal UI without including backtraces.
 ///
 /// The output always starts with the top-level error message and, when available,
@@ -2346,84 +2325,6 @@ fn format_error_for_tui(err: &anyhow::Error) -> String {
     output
 }
 
-fn render_error_popup(frame: &mut Frame, area: Rect, margin: PopupMargin, text: &str) {
-    use unicode_width::UnicodeWidthStr;
-
-    let horizontal_padding: u16 = 1;
-    let vertical_padding: u16 = 0;
-    let border_width: u16 = 2;
-    let border_height: u16 = 2;
-
-    let PopupMargin {
-        right: right_margin,
-        bottom: bottom_margin,
-    } = margin;
-
-    let max_popup_width = area.width.saturating_sub(right_margin).max(1);
-    let max_popup_height = area.height.saturating_sub(bottom_margin).max(1);
-
-    let max_line_width = text
-        .lines()
-        .map(|line| line.width())
-        .max()
-        .unwrap_or_default() as u16;
-
-    let desired_width = max_line_width
-        .saturating_add(border_width)
-        .saturating_add(horizontal_padding * 2);
-    let width = desired_width.clamp(1, max_popup_width);
-
-    let inner_width = width
-        .saturating_sub(border_width)
-        .saturating_sub(horizontal_padding * 2)
-        .max(1) as usize;
-
-    let wrapped_line_count: u16 = text
-        .lines()
-        .map(|line| {
-            let line_width = line.width();
-            let wrapped = line_width.div_ceil(inner_width);
-            wrapped.max(1) as u16
-        })
-        .sum();
-
-    let desired_height = wrapped_line_count
-        .saturating_add(border_height)
-        .saturating_add(vertical_padding * 2);
-    let height = desired_height.clamp(1, max_popup_height);
-
-    let x = area.x.saturating_add(
-        area.width
-            .saturating_sub(right_margin)
-            .saturating_sub(width),
-    );
-    let y = area.y.saturating_add(
-        area.height
-            .saturating_sub(bottom_margin)
-            .saturating_sub(height),
-    );
-
-    let popup_area = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, popup_area);
-
-    let widget = Paragraph::new(text)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().red())
-                .padding(Padding::new(
-                    horizontal_padding,
-                    horizontal_padding,
-                    vertical_padding,
-                    vertical_padding,
-                )),
-        )
-        .wrap(Wrap { trim: false });
-
-    frame.render_widget(widget, popup_area);
-}
-
 fn with_noop_output<F, T>(f: F) -> T
 where
     F: FnOnce(&mut OutputChannel<'_>) -> T,
@@ -2439,12 +2340,6 @@ fn format_exit_status(status: std::process::ExitStatus) -> String {
     } else {
         status.to_string()
     }
-}
-
-#[derive(Debug)]
-pub(super) struct AppError {
-    pub(super) inner: Arc<anyhow::Error>,
-    pub(super) dismiss_at: Instant,
 }
 
 fn rub_operation_display_legacy(source: &CliId, target: &CliId) -> Option<&'static str> {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -462,6 +462,9 @@ impl App {
             Message::CopySelection => {
                 self.handle_copy_selection()?;
             }
+            Message::ShowToast { kind, text } => {
+                self.toasts.insert(kind, text);
+            }
         }
 
         self.ensure_cursor_visible(visible_height);
@@ -664,7 +667,9 @@ impl App {
                 {
                     let source = cli_id_target(source);
                     let target = cli_id_target(target);
-                    with_noop_output(|out| operations::rub_legacy(ctx, out, source, target))?;
+                    with_toast_output(messages, |out| {
+                        operations::rub_legacy(ctx, out, source, target)
+                    })?;
                 }
                 None
             }
@@ -757,11 +762,8 @@ impl App {
 
     /// Handles showing a transient UI error.
     fn handle_show_error(&mut self, err: Arc<anyhow::Error>, messages: &mut Vec<Message>) {
-        self.toasts.insert(
-            ToastKind::Error,
-            format_error_for_tui(&err),
-            Duration::from_secs(5),
-        );
+        self.toasts
+            .insert(ToastKind::Error, format_error_for_tui(&err));
 
         // ensure we always enter normal mode when something does wrong
         // so we don't get stuck in whatever mode we were in previously
@@ -1412,11 +1414,8 @@ impl App {
 
     /// Adds a transient error toast message that auto-dismisses after a short duration.
     fn push_transient_error(&mut self, err: anyhow::Error) {
-        self.toasts.insert(
-            ToastKind::Error,
-            format_error_for_tui(&err),
-            Duration::from_secs(5),
-        );
+        self.toasts
+            .insert(ToastKind::Error, format_error_for_tui(&err));
     }
 
     /// Returns the currently selected commit id when the selected line is a commit.
@@ -2025,6 +2024,7 @@ enum Message {
     EnterNormalMode,
     Reload(Option<SelectAfterReload>),
     ShowError(Arc<anyhow::Error>),
+    ShowToast { kind: ToastKind, text: String },
 
     // Cursor movement
     MoveCursorUp,
@@ -2326,12 +2326,23 @@ fn format_error_for_tui(err: &anyhow::Error) -> String {
     output
 }
 
-fn with_noop_output<F, T>(f: F) -> T
+fn with_toast_output<F, T>(messages: &mut Vec<Message>, f: F) -> anyhow::Result<T>
 where
-    F: FnOnce(&mut OutputChannel<'_>) -> T,
+    F: FnOnce(&mut OutputChannel<'_>) -> anyhow::Result<T>,
 {
-    let mut noop_out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
-    f(&mut noop_out)
+    let mut buf = Vec::new();
+    let mut out = OutputChannel::in_memory(&mut buf, OutputFormat::Human);
+    let t = f(&mut out)?;
+    drop(out);
+
+    if let Ok(text) = String::from_utf8(buf) {
+        messages.push(Message::ShowToast {
+            kind: ToastKind::Info,
+            text,
+        });
+    }
+
+    Ok(t)
 }
 
 /// Formats an exit status for human-readable error messages.

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -661,9 +661,10 @@ impl App {
             }) => {
                 if let Some(selected_line) = self.cursor.selected_line(&self.status_lines)
                     && let Some(target) = selected_line.data.cli_id()
-                    && let Some(operation) = route_operation(source, target)
                 {
-                    with_noop_output(|out| operations::rub_legacy(ctx, out, operation))?;
+                    let source = cli_id_target(source);
+                    let target = cli_id_target(target);
+                    with_noop_output(|out| operations::rub_legacy(ctx, out, source, target))?;
                 }
                 None
             }
@@ -2329,7 +2330,7 @@ fn with_noop_output<F, T>(f: F) -> T
 where
     F: FnOnce(&mut OutputChannel<'_>) -> T,
 {
-    let mut noop_out = OutputChannel::new_without_pager_non_json(OutputFormat::None);
+    let mut noop_out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
     f(&mut noop_out)
 }
 
@@ -2540,4 +2541,16 @@ enum MoveTarget<'a> {
     Branch { name: &'a str },
     Commit { commit_id: gix::ObjectId },
     MergeBase,
+}
+
+fn cli_id_target(id: &CliId) -> &str {
+    match id {
+        CliId::Uncommitted(uncommitted_cli_id) => &uncommitted_cli_id.id,
+        CliId::PathPrefix { id, .. }
+        | CliId::CommittedFile { id, .. }
+        | CliId::Branch { name: id, .. }
+        | CliId::Commit { id, .. }
+        | CliId::Unassigned { id }
+        | CliId::Stack { id, .. } => id,
+    }
 }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -180,9 +180,10 @@ pub(super) fn create_commit_legacy(
 pub(super) fn rub_legacy(
     ctx: &mut Context,
     out: &mut OutputChannel<'_>,
-    operation: RubOperation<'_>,
+    source: &str,
+    target: &str,
 ) -> anyhow::Result<()> {
-    operation.execute(ctx, out)
+    crate::command::legacy::rub::handle(ctx, out, source, target)
 }
 
 pub(super) fn rub_using_but_api(

--- a/crates/but/src/command/legacy/status/tui/toast.rs
+++ b/crates/but/src/command/legacy/status/tui/toast.rs
@@ -1,0 +1,152 @@
+use std::time::{Duration, Instant};
+
+use ratatui::{
+    Frame,
+    prelude::*,
+    widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToastKind {
+    Error,
+    #[expect(
+        dead_code,
+        reason = "info toasts are part of the public TUI API but not emitted yet"
+    )]
+    Info,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct Toasts {
+    toasts: Vec<Toast>,
+}
+
+#[derive(Debug)]
+pub(super) struct Toast {
+    kind: ToastKind,
+    text: String,
+    dismiss_at: Instant,
+}
+
+impl Toasts {
+    pub(super) fn insert(&mut self, kind: ToastKind, text: String, dismiss_after: Duration) {
+        if text.trim().is_empty() {
+            return;
+        }
+        self.toasts.push(Toast {
+            kind,
+            text,
+            dismiss_at: Instant::now() + dismiss_after,
+        });
+    }
+
+    pub(super) fn update(&mut self) -> bool {
+        let now = Instant::now();
+        let len_before = self.toasts.len();
+        self.toasts.retain(|toast| toast.dismiss_at > now);
+        len_before != self.toasts.len()
+    }
+}
+
+pub(super) fn render_toasts(frame: &mut Frame, area: Rect, toasts: &Toasts) {
+    for (idx, toast) in toasts.toasts.iter().rev().enumerate() {
+        render_toast(
+            frame,
+            area,
+            ToastMargin {
+                right: 1 + idx as u16,
+                bottom: idx as u16,
+            },
+            toast,
+        );
+    }
+}
+
+struct ToastMargin {
+    right: u16,
+    bottom: u16,
+}
+
+fn render_toast(frame: &mut Frame, area: Rect, margin: ToastMargin, toast: &Toast) {
+    use unicode_width::UnicodeWidthStr;
+
+    let horizontal_padding: u16 = 1;
+    let vertical_padding: u16 = 0;
+    let border_width: u16 = 2;
+    let border_height: u16 = 2;
+
+    let ToastMargin {
+        right: right_margin,
+        bottom: bottom_margin,
+    } = margin;
+
+    let max_toast_width = area.width.saturating_sub(right_margin).max(1);
+    let max_toast_height = area.height.saturating_sub(bottom_margin).max(1);
+
+    let max_line_width = toast
+        .text
+        .lines()
+        .map(|line| line.width())
+        .max()
+        .unwrap_or_default() as u16;
+
+    let desired_width = max_line_width
+        .saturating_add(border_width)
+        .saturating_add(horizontal_padding * 2);
+    let width = desired_width.clamp(1, max_toast_width);
+
+    let inner_width = width
+        .saturating_sub(border_width)
+        .saturating_sub(horizontal_padding * 2)
+        .max(1) as usize;
+
+    let wrapped_line_count: u16 = toast
+        .text
+        .lines()
+        .map(|line| {
+            let line_width = line.width();
+            let wrapped = line_width.div_ceil(inner_width);
+            wrapped.max(1) as u16
+        })
+        .sum();
+
+    let desired_height = wrapped_line_count
+        .saturating_add(border_height)
+        .saturating_add(vertical_padding * 2);
+    let height = desired_height.clamp(1, max_toast_height);
+
+    let x = area.x.saturating_add(
+        area.width
+            .saturating_sub(right_margin)
+            .saturating_sub(width),
+    );
+    let y = area.y.saturating_add(
+        area.height
+            .saturating_sub(bottom_margin)
+            .saturating_sub(height),
+    );
+
+    let toast_area = Rect::new(x, y, width, height);
+    frame.render_widget(Clear, toast_area);
+
+    let border_style = match toast.kind {
+        ToastKind::Error => Style::default().red(),
+        ToastKind::Info => Style::default().green(),
+    };
+
+    let widget = Paragraph::new(&*toast.text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .padding(Padding::new(
+                    horizontal_padding,
+                    horizontal_padding,
+                    vertical_padding,
+                    vertical_padding,
+                )),
+        )
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(widget, toast_area);
+}

--- a/crates/but/src/command/legacy/status/tui/toast.rs
+++ b/crates/but/src/command/legacy/status/tui/toast.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use ansi_to_tui::IntoText;
 use ratatui::{
     Frame,
     prelude::*,
@@ -9,10 +10,6 @@ use ratatui::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToastKind {
     Error,
-    #[expect(
-        dead_code,
-        reason = "info toasts are part of the public TUI API but not emitted yet"
-    )]
     Info,
 }
 
@@ -29,14 +26,14 @@ pub(super) struct Toast {
 }
 
 impl Toasts {
-    pub(super) fn insert(&mut self, kind: ToastKind, text: String, dismiss_after: Duration) {
+    pub(super) fn insert(&mut self, kind: ToastKind, text: String) {
         if text.trim().is_empty() {
             return;
         }
         self.toasts.push(Toast {
             kind,
             text,
-            dismiss_at: Instant::now() + dismiss_after,
+            dismiss_at: Instant::now() + Duration::from_secs(5),
         });
     }
 
@@ -49,7 +46,7 @@ impl Toasts {
 }
 
 pub(super) fn render_toasts(frame: &mut Frame, area: Rect, toasts: &Toasts) {
-    for (idx, toast) in toasts.toasts.iter().rev().enumerate() {
+    for (idx, toast) in toasts.toasts.iter().enumerate() {
         render_toast(
             frame,
             area,
@@ -68,8 +65,6 @@ struct ToastMargin {
 }
 
 fn render_toast(frame: &mut Frame, area: Rect, margin: ToastMargin, toast: &Toast) {
-    use unicode_width::UnicodeWidthStr;
-
     let horizontal_padding: u16 = 1;
     let vertical_padding: u16 = 0;
     let border_width: u16 = 2;
@@ -80,13 +75,18 @@ fn render_toast(frame: &mut Frame, area: Rect, margin: ToastMargin, toast: &Toas
         bottom: bottom_margin,
     } = margin;
 
+    let toast_text = toast
+        .text
+        .into_text()
+        .unwrap_or_else(|_| Text::raw(toast.text.clone()));
+
     let max_toast_width = area.width.saturating_sub(right_margin).max(1);
     let max_toast_height = area.height.saturating_sub(bottom_margin).max(1);
 
-    let max_line_width = toast
-        .text
-        .lines()
-        .map(|line| line.width())
+    let max_line_width = toast_text
+        .lines
+        .iter()
+        .map(Line::width)
         .max()
         .unwrap_or_default() as u16;
 
@@ -100,9 +100,9 @@ fn render_toast(frame: &mut Frame, area: Rect, margin: ToastMargin, toast: &Toas
         .saturating_sub(horizontal_padding * 2)
         .max(1) as usize;
 
-    let wrapped_line_count: u16 = toast
-        .text
-        .lines()
+    let wrapped_line_count: u16 = toast_text
+        .lines
+        .iter()
         .map(|line| {
             let line_width = line.width();
             let wrapped = line_width.div_ceil(inner_width);
@@ -134,7 +134,7 @@ fn render_toast(frame: &mut Frame, area: Rect, margin: ToastMargin, toast: &Toas
         ToastKind::Info => Style::default().green(),
     };
 
-    let widget = Paragraph::new(&*toast.text)
+    let widget = Paragraph::new(toast_text)
         .block(
             Block::default()
                 .borders(Borders::ALL)

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -641,7 +641,6 @@ impl OutputChannel<'static> {
 }
 
 impl<'a> OutputChannel<'a> {
-    #[expect(dead_code)]
     pub fn in_memory(buf: &'a mut Vec<u8>, format: OutputFormat) -> Self {
         OutputChannel {
             format,
@@ -683,7 +682,6 @@ enum OutputChannelOutput<'a> {
     /// Write to stdout.
     Stdout(std::io::Stdout),
     /// Write to an in-memory buffer.
-    #[expect(dead_code)]
     InMemory(&'a mut Vec<u8>),
 }
 


### PR DESCRIPTION
Refactors the error messages we had to general toasts that can show both errors and info messages.

This'll be used to show result of performing operations like committing, rubbing, etc.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12983 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12981
<!-- GitButler Footer Boundary Bottom -->