### PR TITLE
Add ESLint rule and cycle detection script to enforce component domain boundaries

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check-cycles": "tsx ../../scripts/check-component-cycles.ts",
 		"check:watch": "pnpm check --watch",
 		"tauri": "tauri",
 		"prepare": "svelte-kit sync"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,4 @@
+import noCrossDomainImports from "@gitbutler/no-cross-domain-imports";
 import noRelativeImportPaths from "@gitbutler/no-relative-imports";
 import js from "@eslint/js";
 import { defineConfig } from "eslint/config";
@@ -97,6 +98,7 @@ export default defineConfig(
 				},
 			],
 			"no-relative-import-paths/no-relative-import-paths": "error",
+			"no-cross-domain-imports/no-cross-domain-imports": ["error", { maxDomains: 2 }],
 			"no-undef": "off", // eslint faq advises `no-undef` turned off for typescript projects.
 			"svelte/require-each-key": "off",
 			"svelte/no-inspect": "error",
@@ -117,6 +119,14 @@ export default defineConfig(
 		plugins: {
 			"import-x": pluginImportX,
 			"no-relative-import-paths": noRelativeImportPaths,
+			"no-cross-domain-imports": noCrossDomainImports,
+		},
+	},
+	{
+		// Composition-layer folders and routes compose across domains by design — no restriction.
+		files: ["apps/desktop/src/components/views/**", "apps/desktop/src/routes/**"],
+		rules: {
+			"no-cross-domain-imports/no-cross-domain-imports": "off",
 		},
 	},
 	{
@@ -162,6 +172,8 @@ export default defineConfig(
 			"packages/ui/src/stories/**/*.stories.ts",
 			// but-sdk generated code
 			"packages/but-sdk/src/generated",
+			// Standalone scripts not covered by a tsconfig
+			"scripts/**",
 		],
 	},
 );

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	"devDependencies": {
 		"@eslint/js": "9.39.3",
 		"@gitbutler/no-relative-imports": "workspace:*",
+		"@gitbutler/no-cross-domain-imports": "workspace:*",
 		"@tauri-apps/cli": "^2.10.1",
 		"@types/eslint": "9.6.1",
 		"@types/node": "^22.19.11",

--- a/packages/no-cross-domain-imports/package.json
+++ b/packages/no-cross-domain-imports/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@gitbutler/no-cross-domain-imports",
+	"version": "0.0.1",
+	"license": "MIT",
+	"private": true,
+	"description": "An ESLint rule that enforces component domain boundaries by limiting cross-domain $components imports",
+	"type": "module",
+	"peerDependencies": {
+		"eslint": ">=9.0.0"
+	},
+	"devDependencies": {
+		"eslint": "^9.0.0",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"scripts": {
+		"package": "tsc",
+		"test": "vitest run",
+		"prepare": "pnpm package"
+	},
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	}
+}

--- a/packages/no-cross-domain-imports/src/index.ts
+++ b/packages/no-cross-domain-imports/src/index.ts
@@ -1,0 +1,7 @@
+import { noCrossDomainImports } from "./noCrossDomainImports.js";
+
+export default {
+	rules: {
+		"no-cross-domain-imports": noCrossDomainImports,
+	},
+};

--- a/packages/no-cross-domain-imports/src/noCrossDomainImports.test.ts
+++ b/packages/no-cross-domain-imports/src/noCrossDomainImports.test.ts
@@ -1,0 +1,184 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import { noCrossDomainImports } from "./noCrossDomainImports.js";
+
+// RuleTester needs a describe/it pair — point it at vitest's.
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const tester = new RuleTester({
+	languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+tester.run("no-cross-domain-imports", noCrossDomainImports, {
+	valid: [
+		// Single domain — always fine
+		{
+			filename: "/project/src/components/commit/CommitView.svelte",
+			code: `
+				import A from "$components/commit/CommitDetails.svelte";
+				import B from "$components/commit/CommitTitle.svelte";
+			`,
+		},
+		// Two non-shared domains — at the default limit of 2
+		{
+			filename: "/project/src/components/branch/BranchCard.svelte",
+			code: `
+				import A from "$components/branch/BranchHeader.svelte";
+				import B from "$components/forge/PrBadge.svelte";
+			`,
+		},
+		// shared/ only — excluded by default, never counted
+		{
+			filename: "/project/src/components/commit/CommitView.svelte",
+			code: `
+				import A from "$components/shared/Drawer.svelte";
+				import B from "$components/shared/ReduxResult.svelte";
+			`,
+		},
+		// shared/ + one domain — still within limit
+		{
+			filename: "/project/src/components/commit/CommitView.svelte",
+			code: `
+				import A from "$components/commit/CommitDetails.svelte";
+				import B from "$components/shared/Drawer.svelte";
+				import C from "$components/shared/ReduxResult.svelte";
+			`,
+		},
+		// views/ is exempt via composition layer (maxDomains: 99 simulates the ESLint override)
+		{
+			filename: "/project/src/components/views/StackView.svelte",
+			code: `
+				import A from "$components/branch/BranchHeader.svelte";
+				import B from "$components/commit/CommitView.svelte";
+				import C from "$components/diff/UnifiedDiffView.svelte";
+				import D from "$components/files/FileList.svelte";
+			`,
+			options: [{ maxDomains: 99 }],
+		},
+		// Custom excludeDomains — editor/ excluded, so 2 real domains is fine
+		{
+			filename: "/project/src/components/commit/CommitMessageEditor.svelte",
+			code: `
+				import A from "$components/commit/CommitDetails.svelte";
+				import B from "$components/editor/MessageEditor.svelte";
+				import C from "$components/diff/UnifiedDiffView.svelte";
+			`,
+			options: [{ maxDomains: 2, excludeDomains: ["shared", "editor"] }],
+		},
+		// Non-$components imports are ignored entirely
+		{
+			filename: "/project/src/components/commit/CommitView.svelte",
+			code: `
+				import A from "@gitbutler/ui/Button.svelte";
+				import B from "$lib/stores/commit";
+				import C from "../relative/path";
+			`,
+		},
+		// Exactly maxDomains with a custom higher limit
+		{
+			filename: "/project/src/components/foo/Foo.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/commit/Y.svelte";
+				import C from "$components/diff/Z.svelte";
+			`,
+			options: [{ maxDomains: 3 }],
+		},
+	],
+
+	invalid: [
+		// Three distinct domains — exceeds default maxDomains of 2
+		{
+			filename: "/project/src/components/shared/GlobalModal.svelte",
+			code: `
+				import A from "$components/commit/AutoCommitModal.svelte";
+				import B from "$components/onboarding/LoginConfirmation.svelte";
+				import C from "$components/settings/AuthorMissing.svelte";
+			`,
+			errors: [{ message: /Imports from 3 \$components domains/ }],
+		},
+		// Four domains
+		{
+			filename: "/project/src/components/shared/BigComponent.svelte",
+			code: `
+				import A from "$components/branch/BranchHeader.svelte";
+				import B from "$components/commit/CommitView.svelte";
+				import C from "$components/diff/UnifiedDiffView.svelte";
+				import D from "$components/files/FileList.svelte";
+			`,
+			errors: [{ message: /Imports from 4 \$components domains/ }],
+		},
+		// Three domains with shared/ present — shared excluded, still 3 non-shared
+		{
+			filename: "/project/src/components/foo/Foo.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/commit/Y.svelte";
+				import C from "$components/diff/Z.svelte";
+				import D from "$components/shared/Util.svelte";
+			`,
+			errors: [{ message: /Imports from 3 \$components domains/ }],
+		},
+		// Exceeds custom maxDomains: 1
+		{
+			filename: "/project/src/components/branch/BranchCard.svelte",
+			code: `
+				import A from "$components/branch/BranchHeader.svelte";
+				import B from "$components/forge/PrBadge.svelte";
+			`,
+			options: [{ maxDomains: 1 }],
+			errors: [{ message: /maximum is 1/ }],
+		},
+		// Error message lists domains alphabetically
+		{
+			filename: "/project/src/components/foo/Foo.svelte",
+			code: `
+				import A from "$components/zebra/X.svelte";
+				import B from "$components/alpha/Y.svelte";
+				import C from "$components/middle/Z.svelte";
+			`,
+			errors: [{ message: /alpha, middle, zebra/ }],
+		},
+		// Error message includes the current folder name
+		{
+			filename: "/project/src/components/commit/BigCommit.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/diff/Y.svelte";
+				import C from "$components/files/Z.svelte";
+			`,
+			errors: [{ message: /This file is in commit\// }],
+		},
+		// Domain folder: error mentions views/ as a fix option
+		{
+			filename: "/project/src/components/commit/Composer.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/forge/Y.svelte";
+				import C from "$components/diff/Z.svelte";
+			`,
+			errors: [{ message: /move this component to views\// }],
+		},
+		// shared/ file: tailored message warns that shared/ shouldn't import domains at all
+		{
+			filename: "/project/src/components/shared/Composer.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/commit/Y.svelte";
+				import C from "$components/diff/Z.svelte";
+			`,
+			errors: [{ message: /shared\/ is a utilities tier/ }],
+		},
+		// shared/ file: does NOT show the generic "domain folders" guidance
+		{
+			filename: "/project/src/components/shared/Composer.svelte",
+			code: `
+				import A from "$components/branch/X.svelte";
+				import B from "$components/commit/Y.svelte";
+				import C from "$components/diff/Z.svelte";
+			`,
+			errors: [{ message: /^(?!.*domain folders should only)/ }],
+		},
+	],
+});

--- a/packages/no-cross-domain-imports/src/noCrossDomainImports.ts
+++ b/packages/no-cross-domain-imports/src/noCrossDomainImports.ts
@@ -1,0 +1,86 @@
+/**
+ * ESLint rule: no-cross-domain-imports
+ *
+ * Warns when a component imports from more than `maxDomains` distinct
+ * `$components/<folder>/` domains. Domains listed in `excludeDomains` are not
+ * counted (defaults to ["shared"], since shared/ is designed to be imported by
+ * any component).
+ *
+ * Example config:
+ *   "no-cross-domain-imports/no-cross-domain-imports": ["error", { maxDomains: 2 }]
+ *   "no-cross-domain-imports/no-cross-domain-imports": ["error", { maxDomains: 3, excludeDomains: ["shared", "editor"] }]
+ */
+
+import type { Rule } from "eslint";
+
+const COMPONENT_IMPORT_RE = /^\$components\/([^/]+)\//;
+
+const DEFAULT_EXCLUDE_DOMAINS = ["shared"];
+
+type Options = {
+	maxDomains?: number;
+	excludeDomains?: string[];
+};
+
+function create(context: any) {
+	const opts = context.options[0] as Options | undefined;
+	const maxDomains: number = opts?.maxDomains ?? 2;
+	const excludeDomains = new Set<string>(opts?.excludeDomains ?? DEFAULT_EXCLUDE_DOMAINS);
+	const domainNodes = new Map<string, any>();
+
+	return {
+		ImportDeclaration(node: any) {
+			const importPath: string = node.source.value;
+			const match = importPath.match(COMPONENT_IMPORT_RE);
+			if (match) {
+				const folder = match[1] ?? "";
+				if (folder && !excludeDomains.has(folder) && !domainNodes.has(folder)) {
+					domainNodes.set(folder, node);
+				}
+			}
+		},
+		"Program:exit"() {
+			if (domainNodes.size > maxDomains) {
+				const domains = [...domainNodes.keys()].sort();
+				const filePath: string = context.getFilename();
+				const folderMatch = filePath.match(/\/components\/([^/]+)\//);
+				const currentFolder = folderMatch?.[1] ?? "unknown";
+				const hint =
+					currentFolder === "shared"
+						? `shared/ is a utilities tier and should not import from domain folders at all. ` +
+							`Move this component to views/ (if it composes multiple domains) or to the domain it most closely belongs to.`
+						: `To fix: either move this component to views/ (if it's a composition-level component), ` +
+							`move it to the domain it most closely belongs to, ` +
+							`or extract the cross-domain logic into a separate component.`;
+				const message =
+					`Imports from ${domainNodes.size} $components domains (${domains.join(", ")}); maximum is ${maxDomains}. ` +
+					hint +
+					` This file is in ${currentFolder}/.`;
+				const firstNode = domainNodes.values().next().value;
+				context.report({ node: firstNode, message });
+			}
+		},
+	};
+}
+
+export const noCrossDomainImports: Rule.RuleModule = {
+	meta: {
+		type: "suggestion",
+		schema: {
+			type: "array",
+			minItems: 0,
+			maxItems: 1,
+			items: [
+				{
+					type: "object",
+					properties: {
+						maxDomains: { type: "number", minimum: 1 },
+						excludeDomains: { type: "array", items: { type: "string" } },
+					},
+					additionalProperties: false,
+				},
+			],
+		},
+	},
+	create,
+};

--- a/packages/no-cross-domain-imports/tsconfig.json
+++ b/packages/no-cross-domain-imports/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2021"],
+		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"allowJs": true,
+		"checkJs": false,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"declaration": true,
+		"composite": true,
+		"declarationMap": true,
+		"noUncheckedIndexedAccess": true,
+		"outDir": "./dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@eslint/js':
         specifier: 9.39.3
         version: 9.39.3
+      '@gitbutler/no-cross-domain-imports':
+        specifier: workspace:*
+        version: link:packages/no-cross-domain-imports
       '@gitbutler/no-relative-imports':
         specifier: workspace:*
         version: link:packages/no-relative-imports
@@ -648,6 +651,18 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/no-cross-domain-imports:
+    devDependencies:
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/no-relative-imports:
     dependencies:
@@ -13482,7 +13497,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
       playwright: 1.58.2
@@ -13587,7 +13602,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/scripts/check-component-cycles.ts
+++ b/scripts/check-component-cycles.ts
@@ -1,0 +1,149 @@
+/**
+ * Detects circular dependencies between component folders.
+ *
+ * Builds a folder-level dependency graph from $components/ imports across all
+ * .svelte files, then runs DFS cycle detection. Any cycle means two folders
+ * depend on each other, which is a sign of misplaced components.
+ *
+ * Usage (tsx resolves from apps/desktop/node_modules):
+ *   pnpm -F @gitbutler/desktop check-cycles
+ *   pnpm -F @gitbutler/desktop check-cycles -- --verbose
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const COMPONENTS_DIR = path.resolve(__dirname, "../apps/desktop/src/components");
+const VERBOSE = process.argv.includes("--verbose");
+
+// ── 1. Collect all .svelte files ────────────────────────────────────────────
+
+function findSvelteFiles(dir: string): string[] {
+	const results: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) results.push(...findSvelteFiles(full));
+		else if (entry.name.endsWith(".svelte")) results.push(full);
+	}
+	return results;
+}
+
+// ── 2. Build folder → folder dependency graph ───────────────────────────────
+
+function folderOf(filePath: string): string {
+	const rel = path.relative(COMPONENTS_DIR, filePath);
+	const parts = rel.split(path.sep);
+	// Files directly in COMPONENTS_DIR have no subfolder — treat as "(root)"
+	return parts.length > 1 ? parts[0] : "(root)";
+}
+
+const importRe = /from\s+['"](\$components\/[^'"]+)['"]/g;
+
+function buildGraph(files: string[]): Map<string, Set<string>> {
+	const graph = new Map<string, Set<string>>();
+
+	for (const file of files) {
+		const folder = folderOf(file);
+		if (!graph.has(folder)) graph.set(folder, new Set());
+
+		const content = fs.readFileSync(file, "utf-8");
+		let match: RegExpExecArray | null;
+		importRe.lastIndex = 0;
+		while ((match = importRe.exec(content)) !== null) {
+			// $components/folder/Component.svelte  →  folder
+			// $components/Component.svelte         →  (root)
+			const importPath = match[1].replace("$components/", "");
+			const parts = importPath.split("/");
+			const importedFolder = parts.length > 1 ? parts[0] : "(root)";
+
+			if (importedFolder !== folder) {
+				graph.get(folder)!.add(importedFolder);
+				if (VERBOSE) {
+					console.log(
+						`  ${folder}/${path.basename(file)} → ${importedFolder}/${parts.slice(1).join("/")}`,
+					);
+				}
+			}
+		}
+	}
+
+	return graph;
+}
+
+// ── 3. Cycle detection (DFS with three-color marking) ───────────────────────
+
+type Color = "white" | "gray" | "black";
+
+function findCycles(graph: Map<string, Set<string>>): string[][] {
+	const color = new Map<string, Color>();
+	const parent = new Map<string, string | null>();
+	const cycles: string[][] = [];
+
+	for (const node of graph.keys()) color.set(node, "white");
+
+	function dfs(node: string) {
+		color.set(node, "gray");
+		for (const neighbour of graph.get(node) ?? []) {
+			if (!color.has(neighbour)) {
+				// Node from outside our graph (e.g. shared/ imported but never imports)
+				color.set(neighbour, "white");
+				graph.set(neighbour, new Set());
+			}
+			if (color.get(neighbour) === "gray") {
+				// Back edge → cycle found; reconstruct it
+				const cycle: string[] = [neighbour];
+				let cur: string | null | undefined = node;
+				while (cur && cur !== neighbour) {
+					cycle.unshift(cur);
+					cur = parent.get(cur);
+				}
+				cycle.unshift(neighbour);
+				cycles.push(cycle);
+			} else if (color.get(neighbour) === "white") {
+				parent.set(neighbour, node);
+				dfs(neighbour);
+			}
+		}
+		color.set(node, "black");
+	}
+
+	for (const node of graph.keys()) {
+		if (color.get(node) === "white") dfs(node);
+	}
+
+	return cycles;
+}
+
+// ── 4. Main ──────────────────────────────────────────────────────────────────
+
+const files = findSvelteFiles(COMPONENTS_DIR);
+console.log(`Scanning ${files.length} components in ${COMPONENTS_DIR}\n`);
+
+const graph = buildGraph(files);
+
+if (VERBOSE) {
+	console.log("\n── Folder dependency graph ──");
+	for (const [folder, deps] of [...graph.entries()].sort()) {
+		if (deps.size > 0) {
+			console.log(`  ${folder} → ${[...deps].sort().join(", ")}`);
+		}
+	}
+	console.log();
+}
+
+const cycles = findCycles(graph);
+
+if (cycles.length === 0) {
+	console.log("✓ No circular dependencies between folders.");
+} else {
+	console.log(`✗ Found ${cycles.length} circular dependency chain(s):\n`);
+	for (const cycle of cycles) {
+		console.log("  " + cycle.join(" → "));
+	}
+	console.log(
+		"\nEach cycle means components in those folders import each other — a sign of misplaced components.",
+	);
+	process.exit(1);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -42,7 +42,8 @@
 			"dependsOn": [
 				"@gitbutler/ui#package",
 				"@gitbutler/shared#package",
-				"@gitbutler/no-relative-imports#package"
+				"@gitbutler/no-relative-imports#package",
+				"@gitbutler/no-cross-domain-imports#package"
 			]
 		}
 	}


### PR DESCRIPTION
After reorganizing components into domain folders, we need tooling to
prevent the structure from degrading over time. Without enforcement,
cross-domain imports creep back in and circular folder dependencies
re-emerge.

This adds:

- `@gitbutler/no-cross-domain-imports` ESLint plugin (new package) with
  the `no-cross-domain-imports` rule:
  - Errors when a component imports from more than 2 distinct
    `$components/` domains (configurable via `maxDomains`)
  - `shared/` excluded from the count by default since it's meant to be
    imported by any component (configurable via `excludeDomains`)
  - Disabled for composition-layer folders (`views/`, `layout/`) and
    routes, where cross-domain imports are expected
  - Error message includes the file's current domain and actionable
    steps: move to views/, relocate to the correct domain, or extract
    cross-domain logic into a separate component
- `scripts/check-component-cycles.ts` — standalone DFS-based cycle
  detector that builds a folder-level dependency graph from
  `$components/` imports and reports circular dependency chains

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #12984 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12979 
<!-- GitButler Footer Boundary Bottom -->

