### PR TITLE
update Anthropic and OpenAI BYOK models to latest 

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,7 @@
 		"prepare": "svelte-kit sync"
 	},
 	"devDependencies": {
-		"@anthropic-ai/sdk": "^0.78.0",
+		"@anthropic-ai/sdk": "^0.80.0",
 		"@gitbutler/core": "workspace:*",
 		"@gitbutler/design-core": "1.8.3",
 		"@gitbutler/shared": "workspace:*",
@@ -83,7 +83,7 @@
 		"@tauri-apps/plugin-deep-link": "~2.4.7",
 		"dayjs": "^1.11.13",
 		"ollama": "^0.6.3",
-		"openai": "^4.104.0",
+		"openai": "^6.32.0",
 		"reconnecting-websocket": "^4.4.0",
 		"redux-persist": "^6.0.0",
 		"rxjs": "catalog:"

--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -59,7 +59,7 @@
 		modelKind = await aiService.getModelKind();
 
 		openAIKeyOption = await aiService.getOpenAIKeyOption();
-		openAIModelName = await aiService.getOpenAIModleName();
+		openAIModelName = await aiService.getOpenAIModelName();
 		openAIKey = await aiService.getOpenAIKey();
 		openAICustomEndpoint = await aiService.getOpenAICustomEndpoint();
 
@@ -94,55 +94,31 @@
 
 	const openAIModelOptions = [
 		{
-			label: "GPT 5",
-			value: OpenAIModelName.GPT5,
+			label: "GPT 5.4",
+			value: OpenAIModelName.GPT54,
 		},
 		{
-			label: "GPT 5 Mini",
-			value: OpenAIModelName.GPT5Mini,
+			label: "GPT 5.4 Mini",
+			value: OpenAIModelName.GPT54Mini,
 		},
 		{
-			label: "o3 Mini",
-			value: OpenAIModelName.O3mini,
-		},
-		{
-			label: "o1 Mini",
-			value: OpenAIModelName.O1mini,
-		},
-		{
-			label: "GPT 4o mini",
-			value: OpenAIModelName.GPT4oMini,
-		},
-		{
-			label: "GPT 4.1",
-			value: OpenAIModelName.GPT4_1,
-		},
-		{
-			label: "GPT 4.1 mini (recommended)",
-			value: OpenAIModelName.GPT4_1Mini,
+			label: "GPT 5.4 Nano (recommended)",
+			value: OpenAIModelName.GPT54Nano,
 		},
 	];
 
 	const anthropicModelOptions = [
 		{
-			label: "Haiku",
+			label: "Haiku (recommended)",
 			value: AnthropicModelName.Haiku,
 		},
 		{
-			label: "Sonnet 3.5",
-			value: AnthropicModelName.Sonnet35,
+			label: "Sonnet",
+			value: AnthropicModelName.Sonnet,
 		},
 		{
-			label: "Sonnet 3.7 (recommended)",
-			value: AnthropicModelName.Sonnet37,
-		},
-		{
-			label: "Sonnet 4",
-			value: AnthropicModelName.Sonnet4,
-		},
-		{
-			label: "Opus 4",
-			value: AnthropicModelName.Opus4,
+			label: "Opus",
+			value: AnthropicModelName.Opus,
 		},
 	];
 

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -33,7 +33,7 @@ import type { GitConfigSettings } from "@gitbutler/core/api";
 const defaultGitConfig = Object.freeze({
 	[GitAIConfigKey.ModelProvider]: ModelKind.OpenAI,
 	[GitAIConfigKey.OpenAIKeyOption]: KeyOption.ButlerAPI,
-	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT4oMini,
+	[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT54Nano,
 	[GitAIConfigKey.AnthropicKeyOption]: KeyOption.ButlerAPI,
 	[GitAIConfigKey.AnthropicModelName]: AnthropicModelName.Haiku,
 });
@@ -245,6 +245,66 @@ describe("AIService", () => {
 					"When using Anthropic in a bring your own key configuration, you must provide a valid token",
 				),
 			);
+		});
+	});
+
+	describe("#getOpenAIModelName", () => {
+		test("When a valid model is stored, it returns the stored value", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.OpenAIModelName]: OpenAIModelName.GPT54,
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getOpenAIModelName()).toBe(OpenAIModelName.GPT54);
+		});
+
+		test("When a legacy/unknown model is stored, it falls back to the default", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.OpenAIModelName]: "gpt-4-turbo",
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getOpenAIModelName()).toBe(OpenAIModelName.GPT54Nano);
+		});
+	});
+
+	describe("#getAnthropicModelName", () => {
+		test("When a valid model is stored, it returns the stored value", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.AnthropicModelName]: AnthropicModelName.Opus,
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getAnthropicModelName()).toBe(AnthropicModelName.Opus);
+		});
+
+		test("When a legacy/unknown model is stored, it falls back to the default", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.AnthropicModelName]: "claude-3-opus-20240229",
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getAnthropicModelName()).toBe(AnthropicModelName.Haiku);
 		});
 	});
 

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -153,11 +153,16 @@ export class AIService {
 		return await this.secretsService.get(AISecretHandle.OpenAIKey);
 	}
 
-	async getOpenAIModleName() {
-		return await this.gitConfig.getWithDefault<OpenAIModelName>(
+	async getOpenAIModelName() {
+		const defaultModel = OpenAIModelName.GPT54Nano;
+		const storedValue = await this.gitConfig.getWithDefault<string>(
 			GitAIConfigKey.OpenAIModelName,
-			OpenAIModelName.GPT4oMini,
+			defaultModel,
 		);
+		if (Object.values(OpenAIModelName).includes(storedValue as OpenAIModelName)) {
+			return storedValue as OpenAIModelName;
+		}
+		return defaultModel;
 	}
 
 	async getAnthropicKeyOption() {
@@ -172,10 +177,15 @@ export class AIService {
 	}
 
 	async getAnthropicModelName() {
-		return await this.gitConfig.getWithDefault<AnthropicModelName>(
+		const defaultModel = AnthropicModelName.Haiku;
+		const storedValue = await this.gitConfig.getWithDefault<string>(
 			GitAIConfigKey.AnthropicModelName,
-			AnthropicModelName.Haiku,
+			defaultModel,
 		);
+		if (Object.values(AnthropicModelName).includes(storedValue as AnthropicModelName)) {
+			return storedValue as AnthropicModelName;
+		}
+		return defaultModel;
 	}
 
 	async getDiffLengthLimit() {
@@ -308,7 +318,7 @@ export class AIService {
 		}
 
 		if (modelKind === ModelKind.OpenAI) {
-			const openAIModelName = await this.getOpenAIModleName();
+			const openAIModelName = await this.getOpenAIModelName();
 			const openAIKey = await this.getOpenAIKey();
 			const openAICustomEndpoint = await this.getOpenAICustomEndpoint();
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -10,22 +10,16 @@ export enum ModelKind {
 
 // https://platform.openai.com/docs/models
 export enum OpenAIModelName {
-	O3mini = "o3-mini",
-	O1mini = "o1-mini",
-	GPT5 = "gpt-5",
-	GPT5Mini = "gpt-5-mini",
-	GPT4_1 = "gpt-4.1",
-	GPT4_1Mini = "gpt-4.1-mini",
-	GPT4oMini = "gpt-4o-mini",
+	GPT54 = "gpt-5.4",
+	GPT54Mini = "gpt-5.4-mini",
+	GPT54Nano = "gpt-5.4-nano",
 }
 
 // https://docs.anthropic.com/en/docs/about-claude/models/overview
 export enum AnthropicModelName {
-	Haiku = "claude-3-5-haiku-20241022",
-	Sonnet35 = "claude-3-5-sonnet-20241022",
-	Sonnet37 = "claude-3-7-sonnet-20250219",
-	Sonnet4 = "claude-sonnet-4-0",
-	Opus4 = "claude-opus-4-0",
+	Haiku = "claude-haiku-4-5",
+	Sonnet = "claude-sonnet-4-6",
+	Opus = "claude-opus-4-6",
 }
 
 export enum MessageRole {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       openai:
-        specifier: ^4.104.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@4.3.6)
+        specifier: ^6.32.0
+        version: 6.32.0(ws@8.19.0)(zod@4.3.6)
       reconnecting-websocket:
         specifier: ^4.4.0
         version: 4.4.0
@@ -228,8 +228,8 @@ importers:
         version: 7.8.2
     devDependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.78.0
-        version: 0.78.0(zod@4.3.6)
+        specifier: ^0.80.0
+        version: 0.80.0(zod@4.3.6)
       '@gitbutler/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -992,8 +992,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@anthropic-ai/sdk@0.78.0':
-    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -4385,12 +4385,6 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
@@ -4911,10 +4905,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   aggregate-error@4.0.1:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
@@ -6307,9 +6297,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -6318,10 +6305,6 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -6588,9 +6571,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -7443,11 +7423,6 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -7535,12 +7510,12 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+  openai@6.32.0:
+    resolution: {integrity: sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -9147,9 +9122,6 @@ packages:
     resolution: {integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==}
     engines: {node: '>=14'}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -9385,10 +9357,6 @@ packages:
 
   wdio-video-reporter@6.2.0:
     resolution: {integrity: sha512-b/LHQFluxIcP7foWW0gJ/5W6x1NsTVzJ2yiZZ+W4ETtYBUFU0Xfd2fYVC3q3Uxb3He6QkuNT+h0xCefJSZRyVg==}
-
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
 
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
@@ -9655,7 +9623,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -13130,15 +13098,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 22.19.15
-      form-data: 4.0.5
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
@@ -13859,10 +13818,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   aggregate-error@4.0.1:
     dependencies:
@@ -15546,8 +15501,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -15559,11 +15512,6 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   forwarded-parse@2.1.2: {}
 
@@ -15893,10 +15841,6 @@ snapshots:
       - supports-color
 
   human-signals@8.0.1: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   iconv-corefoundation@1.1.7:
     dependencies:
@@ -16925,8 +16869,6 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-domexception@1.0.0: {}
-
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -17020,20 +16962,10 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@4.3.6):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+  openai@6.32.0(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
-    transitivePeerDependencies:
-      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -18734,8 +18666,6 @@ snapshots:
 
   unbash@2.2.0: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
@@ -19153,8 +19083,6 @@ snapshots:
       - allure-playwright
       - expect-webdriverio
       - webdriverio
-
-  web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@5.1.0: {}
 


### PR DESCRIPTION
## 🧢 Changes

Replace the available OpenAI model list with:

 - GPT 5.4
 - GPT 5.4 Mini
 - GPT 5.4 Nano

Change the default OpenAI model from GPT 4o Mini to GPT 5.4 Nano so new and unset configurations use the recommended model.

Replace outdated Claude model identifiers with the latest versions:

 - claude-haiku-4-5
 - claude-sonnet-4-6
 - claude-opus-4-6

Fall back to the current default model when git config contains legacy or unknown values. This prevents outdated model names from being returned after model options change.

Upgraded openai from v4.104.0 to v6.32.0

Upgraded @anthropic-ai/sdk from v0.78.0 to v0.80.0.

Validate stored OpenAI and Anthropic model names before returning them from the AI service.

Add tests that cover both valid stored values and invalid legacy values to ensure the service keeps existing selections when valid and safely defaults when they are not.

<img width="885" height="479" alt="Screenshot 2026-03-23 at 6 22 04 AM" src="https://github.com/user-attachments/assets/de154a44-4e45-45fc-86c2-13e9b237faa8" />

<img width="849" height="479" alt="Screenshot 2026-03-23 at 6 22 35 AM" src="https://github.com/user-attachments/assets/290cfeb6-394d-4308-ab9a-1fb1268ff2ea" />
