### PR TITLE
Add piped `OutputChannel`

### DIFF
--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -771,7 +771,7 @@ async fn github_oauth(mut inout: InputOutputChannel<'_>) -> Result<()> {
 
 async fn display_authenticated_github_accounts(
     known_gh_accounts: &Vec<but_github::GithubAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     writeln!(out, "\n{}:", "Authenticated GitHub accounts".bold())?;
     writeln!(out)?;
@@ -804,7 +804,7 @@ async fn display_authenticated_github_accounts(
 
 async fn display_authenticated_gitlab_accounts(
     known_gl_accounts: &Vec<but_gitlab::GitlabAccountIdentifier>,
-    out: &mut (dyn Write + 'static),
+    out: &mut dyn Write,
 ) -> Result<bool, anyhow::Error> {
     if known_gl_accounts.is_empty() {
         return Ok(false);

--- a/crates/but/src/command/legacy/ai.rs
+++ b/crates/but/src/command/legacy/ai.rs
@@ -10,7 +10,7 @@ use but_llm::{ChatMessage, LLMProvider};
 use colored::Colorize;
 use schemars::JsonSchema;
 
-use crate::utils::OutputChannel;
+use crate::utils::{OutputChannel, WriteWithUtils as _};
 
 /// Generate a commit message using AI based on the unified diff and optional user summary.
 ///

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -561,7 +561,7 @@ fn print_applied_branches_table(
     ctx: &Context,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 
@@ -672,7 +672,7 @@ fn print_branches_table(
     branch_review_map: &HashMap<String, Vec<but_forge::ForgeReview>>,
     commits_ahead_map: Option<&HashMap<String, usize>>,
     merge_status_map: Option<&HashMap<String, bool>>,
-    out: &mut (dyn std::fmt::Write + 'static),
+    out: &mut dyn std::fmt::Write,
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 
 use crate::{
     CliId, IdMap,
-    utils::{OutputChannel, shorten_object_id},
+    utils::{OutputChannel, WriteWithUtils as _, shorten_object_id},
 };
 
 pub async fn handle(
@@ -14,8 +14,6 @@ pub async fn handle(
     out: &mut OutputChannel,
     branch_id: &str,
 ) -> anyhow::Result<()> {
-    let mut progress = out.progress_channel();
-
     let id_map = IdMap::new_from_context(ctx, None)?;
 
     // Resolve the branch ID
@@ -42,7 +40,7 @@ pub async fn handle(
     // Check if target is gb-local
     if target_remote == "gb-local" {
         writeln!(
-            progress,
+            out.progress_channel(),
             "Merging branch {} into target {}",
             branch_name.bright_cyan(),
             format!("{}/{}", target_remote, base_branch.branch_name).bright_cyan()
@@ -70,7 +68,7 @@ pub async fn handle(
             .into_fully_peeled_id()?;
 
         writeln!(
-            progress,
+            out.progress_channel(),
             "Merging {} ({}) into {} ({})",
             branch_name.bright_cyan(),
             shorten_object_id(&repo, merge_in_branch_head_oid).bright_black(),
@@ -107,7 +105,11 @@ pub async fn handle(
             vec![merge_in_branch_head_oid, local_branch_head_oid],
         )?;
 
-        writeln!(progress, "\nUpdating {}", local_branch_name.blue())?;
+        writeln!(
+            out.progress_channel(),
+            "\nUpdating {}",
+            local_branch_name.blue()
+        )?;
 
         // update the local branch
         let branch_ref_name: gix::refs::FullName =
@@ -122,7 +124,7 @@ pub async fn handle(
         crate::command::legacy::pull::handle(ctx, out, false).await?;
 
         writeln!(
-            progress,
+            out.progress_channel(),
             "\n{}",
             "Merge and update complete!".green().bold()
         )?;

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -14,7 +14,7 @@ use gitbutler_branch_actions::upstream_integration::{
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{OutputChannel, shorten_hex_object_id};
+use crate::utils::{OutputChannel, WriteWithUtils as _, shorten_hex_object_id};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -76,14 +76,12 @@ pub async fn handle(
 }
 
 async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
-    let mut progress = out.progress_channel();
-
-    writeln!(progress, "Fetching from upstream remotes...")?;
+    writeln!(out.progress_channel(), "Fetching from upstream remotes...")?;
 
     let base_branch =
         but_api::legacy::virtual_branches::fetch_from_remotes(ctx, Some("auto".to_string()))?;
 
-    writeln!(progress, "Checking integration statuses...")?;
+    writeln!(out.progress_channel(), "Checking integration statuses...")?;
 
     let status =
         but_api::legacy::virtual_branches::upstream_integration_statuses(ctx.to_sync(), None)
@@ -143,7 +141,11 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
         };
         out.write_value(output)?;
     } else if let Some(out) = out.for_human() {
-        writeln!(progress, "{}", "Checking base branch status...".bold())?;
+        writeln!(
+            out.progress_channel(),
+            "{}",
+            "Checking base branch status...".bold()
+        )?;
         writeln!(
             out,
             "\n{}\t{}",
@@ -257,11 +259,9 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         undo_command: None,
     };
 
-    let mut progress = out.progress_channel();
-
     // Step 1: Check upstream data
     writeln!(
-        progress,
+        out.progress_channel(),
         "{}",
         "Fetching newest data from remotes...".bright_cyan()
     )?;
@@ -288,7 +288,11 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     }
 
     if let Some(out) = out.for_human() {
-        writeln!(progress, "   Checking: {}", upstream_url.bright_cyan())?;
+        writeln!(
+            out.progress_channel(),
+            "   Checking: {}",
+            upstream_url.bright_cyan()
+        )?;
 
         if base_branch.behind > 0 {
             writeln!(
@@ -322,7 +326,10 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
             writeln!(out, "\n{}", "No new upstream commits found".green())?;
         }
 
-        writeln!(progress, "   Checking integration statuses...")?;
+        writeln!(
+            out.progress_channel(),
+            "   Checking integration statuses..."
+        )?;
     }
 
     // Step 2: Check integration status

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -9,8 +9,8 @@ use serde::Serialize;
 
 use crate::{
     CliId, IdMap,
-    args::{push, push::Command},
-    utils::{OutputChannel, shorten_hex_object_id, shorten_object_id},
+    args::push::{self, Command},
+    utils::{OutputChannel, WriteWithUtils as _, shorten_hex_object_id, shorten_object_id},
 };
 
 /// Represents the result of branch selection when no branch is specified
@@ -141,10 +141,8 @@ fn handle_dry_run(
     branch_id: &Option<String>,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let mut progress = out.progress_channel();
-
     // Fetch from remote first to get latest state
-    writeln!(progress, "Fetching from remote...")?;
+    writeln!(out.progress_channel(), "Fetching from remote...")?;
 
     but_api::legacy::virtual_branches::fetch_from_remotes(ctx, Some("dry_run_push".into()))?;
 
@@ -175,7 +173,7 @@ fn handle_dry_run(
         }
 
         writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "No branches have unpushed commits.".dimmed()
         )?;
@@ -323,14 +321,14 @@ fn handle_dry_run(
     }
 
     // Output human-readable format
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "{} {}",
         "Dry run:".bright_blue().bold(),
         "Showing what would be pushed".dimmed()
     )?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
 
     // Group branches by stack
     let mut branches_by_stack: std::collections::HashMap<String, Vec<&DryRunBranchInfo>> =
@@ -351,7 +349,7 @@ fn handle_dry_run(
         // Highlight stacked branches (multiple branches in same stack)
         if branches.len() > 1 {
             writeln!(
-                progress,
+                out.progress_channel(),
                 "{} {} {}",
                 "Stack:".yellow().bold(),
                 stack_name.cyan(),
@@ -384,9 +382,9 @@ fn handle_dry_run(
             let has_next = is_in_stack && !is_last;
 
             if is_in_stack && !is_first {
-                writeln!(progress, "{}", "│".dimmed())?;
+                writeln!(out.progress_channel(), "{}", "│".dimmed())?;
             } else {
-                writeln!(progress)?;
+                writeln!(out.progress_channel())?;
             }
 
             // Determine the gutter character
@@ -405,7 +403,7 @@ fn handle_dry_run(
             // Display branch name with stacking indicator and visual line
             if let Some(stacked_on) = &info.stacked_on {
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{} {} {} {} {}",
                     gutter.dimmed(),
                     "Branch:".bold(),
@@ -415,7 +413,7 @@ fn handle_dry_run(
                 )?;
             } else {
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{} {} {}",
                     gutter.dimmed(),
                     "Branch:".bold(),
@@ -436,7 +434,7 @@ fn handle_dry_run(
             let line_prefix = if has_next { "│ " } else { "  " };
 
             writeln!(
-                progress,
+                out.progress_channel(),
                 "{}  {} {} {}",
                 line_prefix.dimmed(),
                 "→".green(),
@@ -444,7 +442,7 @@ fn handle_dry_run(
                 format!("{}/{}", info.remote, branch_name).yellow()
             )?;
             writeln!(
-                progress,
+                out.progress_channel(),
                 "{}  {} {}",
                 line_prefix.dimmed(),
                 "Commits:".dimmed(),
@@ -458,13 +456,13 @@ fn handle_dry_run(
 
             if !info.commits.is_empty() {
                 if is_in_stack {
-                    writeln!(progress, "{}", line_prefix.dimmed())?;
+                    writeln!(out.progress_channel(), "{}", line_prefix.dimmed())?;
                 } else {
-                    writeln!(progress)?;
+                    writeln!(out.progress_channel())?;
                 }
                 for commit in &info.commits {
                     writeln!(
-                        progress,
+                        out.progress_channel(),
                         "{}    {} {}",
                         line_prefix.dimmed(),
                         commit.sha_short.green(),
@@ -474,7 +472,7 @@ fn handle_dry_run(
 
                 if info.unpushed_commits > info.commits.len() {
                     writeln!(
-                        progress,
+                        out.progress_channel(),
                         "{}    {}",
                         line_prefix.dimmed(),
                         format!(
@@ -488,9 +486,9 @@ fn handle_dry_run(
 
             // Show upstream commits if any
             if !info.upstream_commits.is_empty() {
-                writeln!(progress)?;
+                writeln!(out.progress_channel())?;
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{}  {} {} {}",
                     line_prefix.dimmed(),
                     "⚠".yellow(),
@@ -506,10 +504,10 @@ fn handle_dry_run(
                     )
                     .yellow()
                 )?;
-                writeln!(progress)?;
+                writeln!(out.progress_channel())?;
                 for commit in &info.upstream_commits {
                     writeln!(
-                        progress,
+                        out.progress_channel(),
                         "{}    {} {}",
                         line_prefix.dimmed(),
                         commit.sha_short.red(),
@@ -520,9 +518,9 @@ fn handle_dry_run(
 
             // Show warning if present
             if let Some(warning) = &info.warning {
-                writeln!(progress)?;
+                writeln!(out.progress_channel())?;
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{}  {} {}",
                     line_prefix.dimmed(),
                     "⚠".red().bold(),
@@ -532,9 +530,9 @@ fn handle_dry_run(
 
             // Show force push indicator
             if info.requires_force {
-                writeln!(progress)?;
+                writeln!(out.progress_channel())?;
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{}  {} {}",
                     line_prefix.dimmed(),
                     "⚡".yellow(),
@@ -543,15 +541,15 @@ fn handle_dry_run(
             }
         }
 
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
     }
 
     let total_commits: usize = dry_run_infos.iter().map(|i| i.unpushed_commits).sum();
     let total_branches = dry_run_infos.len();
 
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "{} Would push {} {} across {} {}",
         "Summary:".bright_blue().bold(),
         total_commits.to_string().yellow().bold(),
@@ -567,9 +565,9 @@ fn handle_dry_run(
             "branches"
         }
     )?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "{}",
         "Run without --dry-run to push these changes.".dimmed()
     )?;
@@ -585,19 +583,18 @@ fn push_single_branch(
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let result = push_single_branch_impl(ctx, branch_name, args, gerrit_mode)?;
-    let mut progress = out.progress_channel();
 
     if let Some(out) = out.for_json() {
         out.write_value(&result)?;
     }
 
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "{} Push completed successfully",
         "✓".green().bold()
     )?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     if !result.branch_sha_updates.is_empty() {
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
         for (branch, before_sha, after_sha) in &result.branch_sha_updates {
@@ -612,7 +609,7 @@ fn push_single_branch(
             let remote_ref = format!("{}/{}", result.remote, branch);
 
             writeln!(
-                progress,
+                out.progress_channel(),
                 "  {} -> {} ({} -> {})",
                 branch.cyan(),
                 remote_ref.dimmed(),
@@ -661,7 +658,6 @@ fn push_all_branches(
     gerrit_mode: bool,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let mut progress = out.progress_channel();
     let branches_with_info = get_branches_with_unpushed_info(ctx)?;
 
     // Filter to only branches with unpushed commits
@@ -681,29 +677,38 @@ fn push_all_branches(
         }
 
         writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "No branches have unpushed commits.".dimmed()
         )?;
         return Ok(());
     }
 
-    writeln!(progress)?;
-    writeln!(progress, "{}", "Pushing branches...".bright_blue().bold())?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
+    writeln!(
+        out.progress_channel(),
+        "{}",
+        "Pushing branches...".bright_blue().bold()
+    )?;
+    writeln!(out.progress_channel())?;
 
     let mut total_commits_pushed = 0;
     let mut pushed_results = Vec::new();
     let mut failed_branches = Vec::new();
 
     for (branch_name, unpushed_count, _) in branches_to_push {
-        write!(progress, "  {} {}... ", "→".cyan(), branch_name.bold())?;
+        write!(
+            out.progress_channel(),
+            "  {} {}... ",
+            "→".cyan(),
+            branch_name.bold()
+        )?;
 
         match push_single_branch_impl(ctx, &branch_name, args, gerrit_mode) {
             Ok(result) => {
                 total_commits_pushed += unpushed_count;
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "{} ({} commit{})",
                     "✓".green(),
                     unpushed_count.to_string().yellow(),
@@ -716,7 +721,12 @@ fn push_all_branches(
                     branch_name: branch_name.clone(),
                     error: e.to_string(),
                 });
-                writeln!(progress, "{} {}", "✗".red(), e.to_string().red())?;
+                writeln!(
+                    out.progress_channel(),
+                    "{} {}",
+                    "✗".red(),
+                    e.to_string().red()
+                )?;
             }
         }
     }
@@ -730,11 +740,11 @@ fn push_all_branches(
         out.write_value(&batch_result)?;
     }
 
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
 
     if !pushed_results.is_empty() {
         writeln!(
-            progress,
+            out.progress_channel(),
             "{} {} {} {}",
             "✓".green().bold(),
             "Successfully pushed".green().bold(),
@@ -745,7 +755,7 @@ fn push_all_branches(
                 "commits"
             }
         )?;
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
 
         // Print combined branch, remote, and SHA information for all pushed branches
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
@@ -762,7 +772,7 @@ fn push_all_branches(
                 let remote_ref = format!("{}/{}", result.remote, branch);
 
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "  {} -> {} ({} -> {})",
                     branch.cyan(),
                     remote_ref.dimmed(),
@@ -774,9 +784,9 @@ fn push_all_branches(
     }
 
     if !failed_branches.is_empty() {
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
         writeln!(
-            progress,
+            out.progress_channel(),
             "{} Failed to push {} {}:",
             "✗".red().bold(),
             failed_branches.len().to_string().red().bold(),
@@ -788,7 +798,7 @@ fn push_all_branches(
         )?;
         for failed in &failed_branches {
             writeln!(
-                progress,
+                out.progress_channel(),
                 "    {} - {}",
                 failed.branch_name.red(),
                 failed.error.dimmed()

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -19,7 +19,7 @@ use crate::{
     IdMap,
     args::resolve::Subcommands,
     id::CliId,
-    utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
+    utils::{Confirm, ConfirmDefault, OutputChannel, WriteWithUtils as _, shorten_object_id},
 };
 
 pub(crate) fn handle(
@@ -164,10 +164,8 @@ fn show_status_impl(
         return show_workflow_help(out);
     }
 
-    let mut progress = out.progress_channel();
-
     writeln!(
-        progress,
+        out.progress_channel(),
         "{}\n - resolve all conflicts \n - finalize with {} \n - OR cancel with {}\n",
         "You are currently in conflict resolution mode.".bold(),
         "but resolve finish".green().bold(),
@@ -178,20 +176,20 @@ fn show_status_impl(
 
     // If all conflicts are resolved and we're in human mode, offer to finalize
     if all_resolved && prompt_to_finalize {
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
         writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "All conflicts have been resolved!".green().bold()
         )?;
 
         let should_finalize = if let Some(mut inout) = out.prepare_for_terminal_input() {
             if inout.confirm("Finalize the resolution now?", ConfirmDefault::Yes)? == Confirm::Yes {
-                writeln!(progress)?;
+                writeln!(inout.progress_channel())?;
                 true
             } else {
                 writeln!(
-                    progress,
+                    inout.progress_channel(),
                     "Resolution not finalized. Run {} when ready.",
                     "but resolve finish".green().bold()
                 )?;
@@ -538,20 +536,27 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
         return show_workflow_help(out);
     }
 
-    let mut progress = out.progress_channel();
-
     // We have conflicts - show them grouped by branch
     if out.for_human().is_some() {
-        writeln!(progress, "{}", "Found conflicted commits:".yellow().bold())?;
-        writeln!(progress)?;
+        writeln!(
+            out.progress_channel(),
+            "{}",
+            "Found conflicted commits:".yellow().bold()
+        )?;
+        writeln!(out.progress_channel())?;
 
         let mut all_commits: Vec<&ConflictedCommit> = vec![];
 
         for (branch_name, commits) in &conflicts_by_branch {
-            writeln!(progress, "{} {}", "Branch:".bold(), branch_name.green())?;
+            writeln!(
+                out.progress_channel(),
+                "{} {}",
+                "Branch:".bold(),
+                branch_name.green()
+            )?;
             for commit in commits {
                 writeln!(
-                    progress,
+                    out.progress_channel(),
                     "  {} {} {}",
                     "●".red(),
                     commit.commit_short_id.dimmed(),
@@ -559,12 +564,12 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
                 )?;
                 all_commits.push(commit);
             }
-            writeln!(progress)?;
+            writeln!(out.progress_channel())?;
         }
 
         // Prompt user to select a commit to resolve
         writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "Would you like to start resolving these conflicts?".bold()
         )?;
@@ -589,7 +594,7 @@ fn check_and_prompt_for_conflicts(ctx: &mut Context, out: &mut OutputChannel) ->
 
         if let Some(commit_id_to_resolve) = commit_id_to_resolve {
             // Enter resolution mode for the selected commit
-            writeln!(progress)?;
+            writeln!(out.progress_channel())?;
             return enter_resolution(ctx, out, &commit_id_to_resolve);
         }
     } else if let Some(json_out) = out.for_json() {

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -567,10 +567,9 @@ fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow
 fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result<gix::Repository> {
     use std::fmt::Write as FmtWrite;
 
-    let mut progress = out.progress_channel();
     if let Some(mut inout) = out.prepare_for_terminal_input() {
         writeln!(
-            &mut progress as &mut dyn FmtWrite,
+            inout.progress_channel(),
             "{}",
             "No git repository found.".red()
         )?;
@@ -581,7 +580,7 @@ fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result
         ))?;
         if input.as_deref() == Some("y") {
             writeln!(
-                &mut progress as &mut dyn FmtWrite,
+                inout.progress_channel(),
                 "{}",
                 "Initializing new repository and creating an empty first commit...".dimmed()
             )?;
@@ -590,7 +589,7 @@ fn setup_new_repo(current_dir: &Path, out: &mut OutputChannel) -> anyhow::Result
             create_empty_initial_commit(&repo)?;
 
             writeln!(
-                &mut progress as &mut dyn FmtWrite,
+                inout.progress_channel(),
                 "{}",
                 "Initialized a new repository and created an empty first commit.\n".green()
             )?;

--- a/crates/but/src/command/skill.rs
+++ b/crates/but/src/command/skill.rs
@@ -6,7 +6,10 @@ use cli_prompts::{DisplayPrompt, prompts::AbortReason};
 use colored::Colorize;
 use serde::Serialize;
 
-use crate::{args::skill, utils::OutputChannel};
+use crate::{
+    args::skill,
+    utils::{OutputChannel, WriteWithUtils as _},
+};
 
 /// Error type for user-initiated cancellation
 #[derive(Debug, Clone, Copy)]
@@ -706,7 +709,6 @@ fn prompt_for_install_path(
     ctx: Option<&mut Context>,
     global: bool,
     out: &mut OutputChannel,
-    progress: &mut impl std::io::Write,
 ) -> Result<PathBuf> {
     if out.for_human().is_none() {
         anyhow::bail!(
@@ -732,33 +734,39 @@ fn prompt_for_install_path(
     };
 
     let scope = match determine_install_scope_resolution(global, local_scope_available) {
-        InstallScopeResolution::PromptUser => prompt_for_install_scope(progress)?,
+        InstallScopeResolution::PromptUser => {
+            prompt_for_install_scope(&mut out.progress_channel())?
+        }
         InstallScopeResolution::Fixed(scope) => scope,
     };
 
     if !global && !local_scope_available {
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
         if ctx.is_none() {
             writeln!(
-                progress,
+                out.progress_channel(),
                 "{} Not in a git repository. Installing globally in your home directory.",
                 "ℹ".blue()
             )?;
         } else {
             writeln!(
-                progress,
+                out.progress_channel(),
                 "{} Local installs require a repository workdir. Installing globally in your home directory.",
                 "ℹ".blue()
             )?;
         }
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
     }
 
     let base_dir = get_base_dir(ctx, scope.is_global())?;
 
-    writeln!(progress)?;
-    writeln!(progress, "{}", "Select a skill folder format:".bold())?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
+    writeln!(
+        out.progress_channel(),
+        "{}",
+        "Select a skill folder format:".bold()
+    )?;
+    writeln!(out.progress_channel())?;
 
     let available_formats: Vec<&SkillFormat> = SKILL_FORMATS
         .iter()
@@ -859,8 +867,6 @@ fn install_skill(
         "SkillFormat name and path must not be empty"
     );
 
-    let mut progress = out.progress_channel();
-
     // Validate flags
     if detect && custom_path.is_some() {
         anyhow::bail!("Cannot use both --detect and --path options together");
@@ -885,7 +891,7 @@ fn install_skill(
     } else if detect {
         detect_install_path(ctx, global)?
     } else {
-        prompt_for_install_path(ctx, global, out, &mut progress)?
+        prompt_for_install_path(ctx, global, out)?
     };
 
     // Validate installation path
@@ -899,15 +905,15 @@ fn install_skill(
     // Check if files already exist and warn user
     let skill_md_path = install_path.join("SKILL.md");
     if skill_md_path.exists() {
-        writeln!(progress)?;
+        writeln!(out.progress_channel())?;
         writeln!(
-            progress,
+            out.progress_channel(),
             "{} Skill files already exist at {}",
             "⚠".yellow(),
             install_path.display().to_string().cyan()
         )?;
-        writeln!(progress, "  Overwriting existing files...")?;
-        writeln!(progress)?;
+        writeln!(out.progress_channel(), "  Overwriting existing files...")?;
+        writeln!(out.progress_channel())?;
     }
 
     // Prepare all content before writing (validate UTF-8 and inject version)
@@ -936,24 +942,24 @@ fn install_skill(
     }
 
     // Output success message
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "{} GitButler skill installed successfully!",
         "✓".green().bold()
     )?;
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
     writeln!(
-        progress,
+        out.progress_channel(),
         "  Location: {}",
         install_path.display().to_string().cyan()
     )?;
-    writeln!(progress)?;
-    writeln!(progress, "  Files installed:")?;
+    writeln!(out.progress_channel())?;
+    writeln!(out.progress_channel(), "  Files installed:")?;
     for file in SKILL_FILES {
-        writeln!(progress, "    • {}", file.path)?;
+        writeln!(out.progress_channel(), "    • {}", file.path)?;
     }
-    writeln!(progress)?;
+    writeln!(out.progress_channel())?;
 
     if let Some(out) = out.for_json() {
         let file_paths: Vec<&str> = SKILL_FILES.iter().map(|f| f.path).collect();

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -543,7 +543,9 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Fetch => {
+            use crate::utils::WriteWithUtils as _;
             use std::fmt::Write;
+
             let mut progress = out.progress_channel();
             writeln!(
                 progress,

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -7,7 +7,7 @@ use command_group::AsyncCommandGroup;
 
 use crate::{
     args::Args,
-    utils::{Confirm, ConfirmDefault, OutputChannel},
+    utils::{Confirm, ConfirmDefault, OutputChannel, WriteWithUtils as _},
 };
 
 #[derive(Default)]
@@ -393,21 +393,20 @@ enum SetupPromptResult {
 
 fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult {
     use std::fmt::Write;
-    let mut progress = out.progress_channel();
 
     // Progress channel only writes when output is for humans, so we can write unconditionally
     _ = writeln!(
-        progress,
+        out.progress_channel(),
         "The current project is not configured to be managed by GitButler.\n"
     );
-    writeln!(progress, "{}\n", message.red()).ok();
+    writeln!(out.progress_channel(), "{}\n", message.red()).ok();
 
     // Check if we have an interactive terminal and prompt the user
     let user_declined_in_interactive_mode = if let Some(mut inout) =
         out.prepare_for_terminal_input()
     {
         _ = writeln!(
-            progress,
+            inout.progress_channel(),
             "In order to manage projects with GitButler, we need to do some changes:\n\n - Switch you to a special `gitbutler/workspace` branch to enable parallel branches\n - Install Git hooks to help manage the tooling\n\nYou can go back to normal git workflows at any time by either:\n\n - Running `but teardown`\n - Manually checking out a normal branch with `git checkout <branch>`\n",
         );
 
@@ -426,7 +425,7 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
     if user_declined_in_interactive_mode {
         // User declined in interactive mode
         _ = writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "Please run `but setup` to switch to GitButler management.\n".yellow()
         );
@@ -441,7 +440,7 @@ fn prompt_for_setup(out: &mut OutputChannel, message: &str) -> SetupPromptResult
     } else if out.for_human().is_some() && !user_declined_in_interactive_mode {
         // Non-interactive terminal, just show the hint
         _ = writeln!(
-            progress,
+            out.progress_channel(),
             "{}",
             "Please run `but setup` to switch to GitButler management.\n".yellow()
         );

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -63,6 +63,7 @@ where
 }
 
 fn json_pretty_to_stdout(value: &impl serde::Serialize) -> std::io::Result<()> {
+    // TODO: make this use OutputChannel
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
     let value = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal, Write};
+use std::io::Write;
 
 use but_secret::Sensitive;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -37,8 +37,11 @@ pub enum ConfirmOrEmpty {
 pub struct OutputChannel {
     /// How to print the output, one should match on it. Match on this if you prefer this style.
     format: OutputFormat,
-    /// The output to use if there is no pager.
-    stdout: std::io::Stdout,
+    /// The stdout output to use if there is no pager.
+    stdout: Box<dyn WritePlusIsTerminal>,
+    /// The stderr output to use.
+    stderr: Box<dyn WritePlusIsTerminal>,
+    stderr_is_terminal: bool,
     /// Possibly a pager we are using. If `Some`, the pager itself is used for output instead of `stdout`.
     pager: Option<Pager>,
     /// When `Some`, JSON values written via `write_value` are captured here instead of going to stdout.
@@ -50,19 +53,20 @@ pub struct OutputChannel {
 /// if the error channel is connected to a terminal and the output format is for humans,
 /// for providing progress or error information.
 /// Broken pipes will also be ignored, thus the output written to this channel should be considered optional.
-pub struct ProgressChannel {
+pub struct ProgressChannel<'out> {
     /// The channel writes will go to, if we are connected to a terminal and output is for humans.
-    inner: Option<std::io::Stderr>,
+    inner: Option<&'out mut OutputChannel>,
 }
 
-impl ProgressChannel {
-    /// Create a new progress channel that writes to stderr if it's a terminal and `for_humans` is true.
-    /// If `for_humans` is false, the channel becomes a no-op.
-    pub fn new(for_humans: bool) -> Self {
+impl<'out> ProgressChannel<'out> {
+    /// Create a new progress channel that writes to stderr only when the associated
+    /// [`OutputChannel`] is configured for human-readable output and stderr is a terminal.
+    /// Otherwise, the channel becomes a no-op.
+    #[inline]
+    fn new(out: &'out mut OutputChannel) -> Self {
         ProgressChannel {
-            inner: if for_humans {
-                let stderr = std::io::stderr();
-                stderr.is_terminal().then_some(stderr)
+            inner: if matches!(out.format, OutputFormat::Human) && out.stderr_is_terminal {
+                Some(out)
             } else {
                 None
             },
@@ -70,10 +74,10 @@ impl ProgressChannel {
     }
 }
 
-impl std::io::Write for ProgressChannel {
+impl std::io::Write for ProgressChannel<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if let Some(stderr) = self.inner.as_mut() {
-            stderr
+        if let Some(out) = &mut self.inner {
+            out.stderr
                 .write(buf)
                 .or_else(|err| ignore_broken_pipe(err).map(|()| buf.len()))
         } else {
@@ -83,15 +87,15 @@ impl std::io::Write for ProgressChannel {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        if let Some(stderr) = self.inner.as_mut() {
-            stderr.flush().or_else(ignore_broken_pipe)
+        if let Some(out) = &mut self.inner {
+            out.stderr.flush().or_else(ignore_broken_pipe)
         } else {
             Ok(())
         }
     }
 }
 
-impl std::fmt::Write for ProgressChannel {
+impl std::fmt::Write for ProgressChannel<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         use std::io::Write;
         self.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
@@ -115,7 +119,7 @@ impl OutputChannel {
 }
 
 /// An [`std::fmt::Write`] implementation that supports additional utility methods for output formatting.
-pub trait WriteWithUtils: std::fmt::Write + 'static {
+pub trait WriteWithUtils: std::fmt::Write {
     /// Truncate the given text to the specified maximum width, unless the output is passed through a pager.
     ///
     /// Note that while copy-on-write is used internally, the returned value is always owned as it's typically
@@ -126,6 +130,10 @@ pub trait WriteWithUtils: std::fmt::Write + 'static {
     ///
     /// This is typically used to avoid truncating text when output is being piped to a pager.
     fn is_paged(&self) -> bool;
+
+    /// A convenience function to create a progress channel that only writes when the output is for humans.
+    /// The progress channel writes to stderr if it's a terminal and the output format is [`OutputFormat::Human`].
+    fn progress_channel(&mut self) -> ProgressChannel<'_>;
 }
 
 impl WriteWithUtils for OutputChannel {
@@ -140,6 +148,11 @@ impl WriteWithUtils for OutputChannel {
     fn is_paged(&self) -> bool {
         self.pager.is_some()
     }
+
+    #[inline]
+    fn progress_channel(&mut self) -> ProgressChannel<'_> {
+        ProgressChannel::new(self)
+    }
 }
 
 /// Output
@@ -148,24 +161,21 @@ impl OutputChannel {
     pub fn for_human(&mut self) -> Option<&mut dyn WriteWithUtils> {
         matches!(self.format, OutputFormat::Human).then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a write implementation for Shell output, if the format setting permits.
     pub fn for_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
         matches!(self.format, OutputFormat::Shell).then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a write implementation for text output (human or shell), if the format setting permits.
     pub fn for_human_or_shell(&mut self) -> Option<&mut dyn WriteWithUtils> {
         matches!(self.format, OutputFormat::Human | OutputFormat::Shell)
             .then(|| self as &mut dyn WriteWithUtils)
     }
+
     /// Provide a handle to receive a serde-serializable value to write to stdout.
     pub fn for_json(&mut self) -> Option<&mut Self> {
         matches!(self.format, OutputFormat::Json).then_some(self)
-    }
-
-    /// A convenience function to create a progress channel that only writes when the output is for humans.
-    /// The progress channel writes to stderr if it's a terminal and the output format is [`OutputFormat::Human`].
-    pub fn progress_channel(&self) -> ProgressChannel {
-        ProgressChannel::new(matches!(self.format, OutputFormat::Human))
     }
 }
 
@@ -177,8 +187,9 @@ impl OutputChannel {
     /// Note that this is implied to be true if [Self::prepare_for_terminal_input()] returns `Some()`.
     pub fn can_prompt(&self) -> bool {
         matches!(self.format, OutputFormat::Human)
-            && std::io::stdin().is_terminal()
+            && std::io::IsTerminal::is_terminal(&std::io::stdin())
             && self.stdout.is_terminal()
+            && self.stdout.can_prompt()
     }
 
     /// Before performing further output, obtain an input channel which always bypasses the pager when writing,
@@ -188,7 +199,7 @@ impl OutputChannel {
     pub fn prepare_for_terminal_input(&mut self) -> Option<InputOutputChannel<'_>> {
         use std::io::IsTerminal;
         let stdin = std::io::stdin();
-        if !stdin.is_terminal() || !self.stdout.is_terminal() {
+        if !stdin.is_terminal() || !self.stdout.is_terminal() || !self.stdout.can_prompt() {
             return None;
         }
         if self.for_human().is_none() {
@@ -215,7 +226,8 @@ impl OutputChannel {
         if self.json_buffer.is_some() {
             let new_value = serde_json::to_value(&value).map_err(std::io::Error::other)?;
             if !matches!(self.json_buffer, Some(serde_json::Value::Null)) {
-                eprintln!(
+                _ = writeln!(
+                    self.stderr,
                     "warning: write_value called while buffer already contains data; previous value will be lost"
                 );
             }
@@ -503,6 +515,12 @@ impl InputOutputChannel<'_> {
             }
         }
     }
+
+    /// A convenience function to create a progress channel that only writes when the output is for humans.
+    /// The progress channel writes to stderr if it's a terminal and the output format is [`OutputFormat::Human`].
+    pub fn progress_channel(&mut self) -> ProgressChannel<'_> {
+        ProgressChannel::new(self.out)
+    }
 }
 
 /// Normalized result of collecting one line of terminal input.
@@ -602,6 +620,7 @@ impl OutputChannel {
     /// to a `/dev/null` equivalent, so callers never have to worry if they interleave JSON with other output.
     pub fn new_with_optional_pager(format: OutputFormat, use_pager: bool) -> Self {
         let stdout = std::io::stdout();
+        let stderr = std::io::stderr();
         let pager = if !use_pager
             || !matches!(format, OutputFormat::Human)
             || std::env::var_os("NOPAGER").is_some()
@@ -614,7 +633,9 @@ impl OutputChannel {
 
         OutputChannel {
             format,
-            stdout,
+            stdout: Box::new(stdout),
+            stderr_is_terminal: stderr.is_terminal(),
+            stderr: Box::new(stderr),
             pager,
             json_buffer: None,
         }
@@ -623,12 +644,32 @@ impl OutputChannel {
     /// Like [`Self::new_with_optional_pager`], but will never create a pager or write JSON.
     /// Use this if a second instance of a channel is needed, and the first one could have a pager.
     pub fn new_without_pager_non_json(format: OutputFormat) -> Self {
+        let stderr = std::io::stderr();
         OutputChannel {
             format: match format {
                 OutputFormat::Human | OutputFormat::Shell | OutputFormat::None => format,
                 OutputFormat::Json => OutputFormat::None,
             },
-            stdout: std::io::stdout(),
+            stdout: Box::new(std::io::stdout()),
+            stderr_is_terminal: stderr.is_terminal(),
+            stderr: Box::new(stderr),
+            pager: None,
+            json_buffer: None,
+        }
+    }
+
+    /// Create a new `OutputChannel` that writes all output to a set of pipes.
+    #[expect(dead_code)]
+    pub fn piped(
+        stdout: std::io::PipeWriter,
+        stderr: std::io::PipeWriter,
+        format: OutputFormat,
+    ) -> Self {
+        OutputChannel {
+            format,
+            stdout: Box::new(stdout),
+            stderr_is_terminal: stderr.is_terminal(),
+            stderr: Box::new(stderr),
             pager: None,
             json_buffer: None,
         }
@@ -660,6 +701,50 @@ impl Drop for OutputChannel {
         }
     }
 }
+
+// [`std::io::IsTerminal`] is sealed so we need our own trait that we can implement for
+// [`std::io::PipeWriter`]
+trait IsButTerminal {
+    fn is_terminal(&self) -> bool;
+
+    fn can_prompt(&self) -> bool;
+}
+
+impl IsButTerminal for std::io::Stdout {
+    fn is_terminal(&self) -> bool {
+        std::io::IsTerminal::is_terminal(self)
+    }
+
+    fn can_prompt(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+impl IsButTerminal for std::io::Stderr {
+    fn is_terminal(&self) -> bool {
+        std::io::IsTerminal::is_terminal(self)
+    }
+
+    fn can_prompt(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+impl IsButTerminal for std::io::PipeWriter {
+    fn is_terminal(&self) -> bool {
+        // treat a pipe as a terminal so we get `ProgressChannel` output
+        true
+    }
+
+    fn can_prompt(&self) -> bool {
+        // but don't allow prompting for user input
+        false
+    }
+}
+
+trait WritePlusIsTerminal: std::io::Write + IsButTerminal {}
+
+impl<T> WritePlusIsTerminal for T where T: std::io::Write + IsButTerminal {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
_This PR is a reincarnation of https://github.com/gitbutlerapp/gitbutler/pull/12981_

# Why

I'm working on aligning the operations performed by the CLI and the TUI. So committing with the TUI should call the same handler function that `but commit` does.

All those CLI handler functions require a `&mut OutputChannel` for printing to stdout. If committing from the TUI I think instead we should instead show the output in a toast. This enables that by adding a variant of `OutputChannel` that writes to a set of anonymous pipes created with [`std::io::pipe`](https://doc.rust-lang.org/stable/std/io/fn.pipe.html). The TUI can create those pipes and read from them to render a ratatui toast after calling the handler.

This also enables reading streaming output from long running tasks.

# What

`OutputChannel` now holds both the stdout and stderr that it uses as trait objects:

```rust
pub struct OutputChannel {
    stdout: Box<dyn WritePlusIsTerminal>,
    stderr: Box<dyn WritePlusIsTerminal>,
}
```

`WritePlusIsTerminal` is just `std::io::Write + std::io::Terminal`. We need this because `std::io::Terminal` isn't implemented `PipeWriter`.

`ProgressChannel` and `InputOutputChannel` now also hold a `&mut OutputChannel` so they can use the same outputs. That lead to some double borrows where we mixed writing to the normal output and the progress. I fixed that by changing

```rust
let progress = out.progress_channel();
writeln!(out, "something for normal output"); // ❌ can't use `out` since `progress` holds a `&mut out`
writeln!(progress, "something for progress");
```

to instead

```rust
writeln!(out, "something for normal output");
writeln!(out.progress_channel(), "something for progress"); // borrows `out` only for this call
```

This solution is a bit boilerplatey but probably fine.

It might also be possible to do something like

```rust
impl OutputChannel {
    fn split(&mut self) -> (NormalOutput<'_>, ProgressChannel<'_>) { ... }
}
```

but it gets more complicated with we also want to get input, so I didn't explore this.