### PR TITLE
Don't prompt for user input in TUI tests

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1409,7 +1409,13 @@ impl App {
 
     /// Prompts the user to press enter before returning from a command execution.
     fn prompt_to_continue(&mut self, out: &mut OutputChannel) -> anyhow::Result<()> {
-        if let Some(mut input_channel) = out.prepare_for_terminal_input() {
+        // don't prompt for user input during tests
+        //
+        // `cfg!(test)` is false for integration tests but we currently don't have integration
+        // tests of the TUI so thats fine for now.
+        const IN_TEST: bool = cfg!(test);
+
+        if !IN_TEST && let Some(mut input_channel) = out.prepare_for_terminal_input() {
             input_channel.prompt_single_line("\npress enter to continue...")?;
         }
 


### PR DESCRIPTION
When running `cargo test -p but --lib -- command_mode_runs_successful_command_and_returns_to_normal_mode` the test would stop and wait for the user to press enter. This happened because `std::io::stdin().is_terminal()` returns true even when running through cargo's test harness. I didn't notice this because I use cargo-nextest in which it returns false.

I think a decent fix is just to check `cfg!(test)`. That wont work in integration tests but since we don't have any integration tests of the TUI it should be fine.

We don't have integration tests of the TUI because of how [ratatui's test setup works](https://ratatui.rs/recipes/testing/snapshots/).