### PR TITLE
Remove unrequried static constraint

### DIFF
--- a/crates/but-ctx/src/legacy.rs
+++ b/crates/but-ctx/src/legacy.rs
@@ -119,10 +119,7 @@ impl Context {
     pub fn workspace_and_meta_from_head(
         &self,
         _exclusive_access: &RepoExclusive,
-    ) -> anyhow::Result<(
-        impl but_core::RefMetadata + 'static,
-        but_graph::projection::Workspace,
-    )> {
+    ) -> anyhow::Result<(impl but_core::RefMetadata, but_graph::projection::Workspace)> {
         let ws = self.workspace_from_head()?;
         Ok((self.meta()?, ws))
     }

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -925,7 +925,7 @@ impl Context {
     //            based implementation as long as the instances starts a transaction to isolate
     //            reads. For a correct implementation, this would also have to hold on to
     //            `_read_only`.
-    pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata + 'static> {
+    pub fn meta(&self) -> anyhow::Result<impl but_core::RefMetadata> {
         but_meta::VirtualBranchesTomlMetadata::from_path(
             self.project_data_dir().join("virtual_branches.toml"),
         )


### PR DESCRIPTION
As a fly-by refactor, I saw this requiring a static lifetime which was a bit puzzling because we probably don’t want the metadata to have a  static lifetime, so I just tried to take it out.