### PR TITLE
Fix deadlock between file watcher, broadcaster mutex, and Tokio worker pool

### DIFF
--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -101,7 +101,10 @@ impl ActiveProjects {
                     }
                 };
 
-                broadcaster.blocking_lock().send(frontend_event);
+                let broadcaster = broadcaster.clone();
+                tokio::task::spawn(async move {
+                    broadcaster.lock().await.send(frontend_event);
+                });
                 Ok(())
             }
         });


### PR DESCRIPTION
The file watcher handler (running on a `spawn_blocking` thread) used
`broadcaster.blocking_lock()` to emit frontend events. This created a
three-way deadlock cycle:

1. File watcher (blocking thread): holds the exclusive worktree WRITE
   lock (parking_lot RwLock) while doing heavy computation, then calls
   `broadcaster.blocking_lock()` which enters the tokio Mutex FIFO
   queue — potentially behind async broadcaster tasks spawned by the
   IRC event emitter.

2. Spawned broadcaster task (from IRC `BroadcasterEmitter::emit`):
   already in the Mutex FIFO queue ahead of the file watcher, gets
   woken when the previous lock holder releases, but needs a Tokio
   worker thread to actually run and acquire the lock.

3. All Tokio worker threads (running HTTP/WS handlers): the frontend
   received IRC events and sent requests (stacks, stack_details, etc.)
   whose handlers call `shared_worktree_access()` synchronously via
   `but_post` — `parking_lot::RwLock::read_arc()` blocks each worker
   thread waiting for the worktree WRITE lock held by the file watcher.

The cycle closes: file watcher waits for broadcaster lock → broadcaster
lock will go to async Task T next (FIFO) → Task T needs a worker thread
→ all worker threads blocked on worktree read lock → worktree read lock
waits for file watcher to release write lock → file watcher waits for
broadcaster lock.

Fix: replace `blocking_lock()` with a spawned async task (matching the
pattern already used by the DB watcher on the adjacent line). This way
the file watcher never blocks on the broadcaster mutex, so the worktree
lock is released promptly and worker threads can proceed.