### PR TITLE
Rebase engine owns workspace and metadata

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -4,7 +4,7 @@ use but_api_macros::but_api;
 use but_core::{RefMetadata, ui::TreeChanges, worktree::checkout::UncommitedWorktreeChanges};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_workspace::branch::{
     OnWorkspaceMergeConflict,
     apply::{WorkspaceMerge, WorkspaceReferenceNaming},
@@ -183,20 +183,19 @@ fn move_branch_impl(
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
     let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::move_branch(editor, &ws, subject_branch, target_branch)?;
+        but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
 
-    let materialization = rebase.materialize()?;
-    if let Some((ws_meta, ref_name)) = ws_meta.zip(ws.ref_name()) {
-        let mut md = meta.workspace(ref_name)?;
+    let materialized = rebase.materialize()?;
+    if let Some((ws_meta, ref_name)) = ws_meta.zip(materialized.workspace.ref_name()) {
+        let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
-        meta.set_workspace(&md)?;
+        materialized.meta.set_workspace(&md)?;
     }
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(MoveBranchResult {
-        replaced_commits: materialization.history.commit_mappings(),
+        replaced_commits: materialized.history.commit_mappings(),
     })
 }
 
@@ -230,19 +229,18 @@ fn tear_off_branch_impl(
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
     let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
-        but_workspace::branch::tear_off_branch(editor, &ws, subject_branch, None)?;
+        but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;
 
-    let materialization = rebase.materialize()?;
-    if let Some((ws_meta, ref_name)) = ws_meta.zip(ws.ref_name()) {
-        let mut md = meta.workspace(ref_name)?;
+    let materialized = rebase.materialize()?;
+    if let Some((ws_meta, ref_name)) = ws_meta.zip(materialized.workspace.ref_name()) {
+        let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
-        meta.set_workspace(&md)?;
+        materialized.meta.set_workspace(&md)?;
     }
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(MoveBranchResult {
-        replaced_commits: materialization.history.commit_mappings(),
+        replaced_commits: materialized.history.commit_mappings(),
     })
 }

--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use but_api_macros::but_api;
 use but_core::{DiffSpec, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{GraphExt, LookupStep as _};
+use but_rebase::graph_rebase::{Editor, LookupStep as _};
 use tracing::instrument;
 
 use super::types::CommitCreateResult;
@@ -35,9 +35,9 @@ pub(crate) fn commit_amend_only_impl(
     context_lines: u32,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let but_workspace::commit::CommitAmendOutcome {
         rebase,
@@ -54,8 +54,6 @@ pub(crate) fn commit_amend_only_impl(
         }
         None => (None, BTreeMap::new()),
     };
-
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(CommitCreateResult {
         new_commit,

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use but_api_macros::but_api;
 use but_core::{DiffSpec, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{GraphExt, LookupStep as _, mutate::InsertSide, mutate::RelativeTo};
+use but_rebase::graph_rebase::{
+    Editor, LookupStep as _,
+    mutate::{InsertSide, RelativeTo},
+};
 use tracing::instrument;
 
 use super::types::CommitCreateResult;
@@ -41,9 +44,10 @@ pub(crate) fn commit_create_only_impl(
     context_lines: u32,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
     let but_workspace::commit::CommitCreateOutcome {
         rebase,
         commit_selector,
@@ -66,8 +70,6 @@ pub(crate) fn commit_create_only_impl(
         }
         None => (None, BTreeMap::new()),
     };
-
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(CommitCreateResult {
         new_commit,

--- a/crates/but-api/src/commit/insert_blank.rs
+++ b/crates/but-api/src/commit/insert_blank.rs
@@ -1,7 +1,10 @@
 use but_api_macros::but_api;
 use but_core::sync::RepoExclusive;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{GraphExt, LookupStep as _, mutate::InsertSide, mutate::RelativeTo};
+use but_rebase::graph_rebase::{
+    Editor, LookupStep as _,
+    mutate::{InsertSide, RelativeTo},
+};
 use tracing::instrument;
 
 use super::types::CommitInsertBlankResult;
@@ -29,9 +32,9 @@ pub(crate) fn commit_insert_blank_only_impl(
     side: InsertSide,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitInsertBlankResult> {
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let (outcome, blank_commit_selector) =
         but_workspace::commit::insert_blank_commit(editor, side, relative_to)?;
@@ -39,8 +42,6 @@ pub(crate) fn commit_insert_blank_only_impl(
     let outcome = outcome.materialize()?;
     let id = outcome.lookup_pick(blank_commit_selector)?;
     let replaced_commits = outcome.history.commit_mappings();
-
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(CommitInsertBlankResult {
         new_commit: id,

--- a/crates/but-api/src/commit/move_changes.rs
+++ b/crates/but-api/src/commit/move_changes.rs
@@ -1,6 +1,6 @@
 use but_api_macros::but_api;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use tracing::instrument;
 
 use super::types::MoveChangesResult;
@@ -21,9 +21,9 @@ pub fn commit_move_changes_between_only(
     changes: Vec<but_core::DiffSpec>,
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let outcome = but_workspace::commit::move_changes_between_commits(
         editor,
@@ -33,8 +33,6 @@ pub fn commit_move_changes_between_only(
         context_lines,
     )?;
     let materialized = outcome.rebase.materialize()?;
-
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(MoveChangesResult {
         replaced_commits: materialized.history.commit_mappings(),

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -1,6 +1,9 @@
 use but_api_macros::but_api;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{GraphExt, mutate::InsertSide, mutate::RelativeTo};
+use but_rebase::graph_rebase::{
+    Editor,
+    mutate::{InsertSide, RelativeTo},
+};
 use tracing::instrument;
 
 use super::types::CommitMoveResult;
@@ -15,15 +18,13 @@ pub fn commit_move_only(
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitMoveResult> {
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
-    let rebase =
-        but_workspace::commit::move_commit(editor, &ws, subject_commit_id, relative_to, side)?;
+    let rebase = but_workspace::commit::move_commit(editor, subject_commit_id, relative_to, side)?;
 
     let materialized = rebase.materialize()?;
-    ws.refresh_from_head(&repo, &meta)?;
 
     Ok(CommitMoveResult {
         replaced_commits: materialized.history.commit_mappings(),

--- a/crates/but-api/src/commit/reword.rs
+++ b/crates/but-api/src/commit/reword.rs
@@ -1,7 +1,7 @@
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::{GraphExt, LookupStep as _};
+use but_rebase::graph_rebase::{Editor, LookupStep as _};
 use tracing::instrument;
 
 use super::types::CommitRewordResult;
@@ -16,8 +16,9 @@ pub fn commit_reword_only(
     commit_id: gix::ObjectId,
     message: BString,
 ) -> anyhow::Result<CommitRewordResult> {
-    let (_guard, repo, ws, _, _cache) = ctx.workspace_and_db_and_cache()?;
-    let editor = ws.graph.to_editor(&repo)?;
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let (outcome, edited_commit_selector) =
         but_workspace::commit::reword(editor, commit_id, message.as_bstr())?;

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use but_api_macros::but_api;
 use but_hunk_assignment::HunkAssignmentRequest;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use tracing::instrument;
 
 use super::types::MoveChangesResult;
@@ -25,7 +25,7 @@ pub fn commit_uncommit_changes_only(
     assign_to: Option<but_core::ref_metadata::StackId>,
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
-    let meta = ctx.meta()?;
+    let mut meta = ctx.meta()?;
     let (_guard, repo, mut ws, mut db, _cache) = ctx.workspace_mut_and_db_mut_and_cache()?;
 
     let before_assignments = if assign_to.is_some() {
@@ -41,18 +41,17 @@ pub fn commit_uncommit_changes_only(
         None
     };
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome =
         but_workspace::commit::uncommit_changes(editor, commit_id, changes, context_lines)?;
 
     let materialized = outcome.rebase.materialize_without_checkout()?;
 
-    ws.refresh_from_head(&repo, &meta)?;
     if let (Some(before_assignments), Some(stack_id)) = (before_assignments, assign_to) {
         let (after_assignments, _) = but_hunk_assignment::assignments_with_fallback(
             db.hunk_assignments_mut()?,
             &repo,
-            &ws,
+            materialized.workspace,
             None::<Vec<but_core::TreeChange>>,
             context_lines,
         )?;
@@ -75,7 +74,7 @@ pub fn commit_uncommit_changes_only(
         but_hunk_assignment::assign(
             db.hunk_assignments_mut()?,
             &repo,
-            &ws,
+            materialized.workspace,
             to_assign,
             context_lines,
         )?;

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -1,6 +1,7 @@
 //! Provides some slightly higher level tools to help with manipulating commits, in preparation for use in the editor.
 
 use anyhow::{Context, Result, bail};
+use but_core::RefMetadata;
 use gix::prelude::ObjectIdExt;
 
 use crate::{
@@ -11,7 +12,7 @@ use crate::{
     },
 };
 
-impl Editor {
+impl<M: RefMetadata> Editor<'_, '_, M> {
     /// Returns a reference to the in-memory repository.
     pub fn repo(&self) -> &gix::Repository {
         &self.repo

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Result, bail};
-use but_graph::{Commit, Graph, SegmentIndex};
+use but_core::RefMetadata;
+use but_graph::{Commit, SegmentIndex};
 use petgraph::{Direction, visit::EdgeRef as _};
 
 use crate::graph_rebase::{
@@ -9,15 +10,14 @@ use crate::graph_rebase::{
     SuccessfulRebase, util,
 };
 
-/// Provides an extension for creating an Editor out of the segment graph
-pub trait GraphExt {
-    /// Creates an editor.
-    fn to_editor(&self, repo: &gix::Repository) -> Result<Editor>;
-}
-
-impl GraphExt for Graph {
-    /// Creates an editor out of the segment graph.
-    fn to_editor(&self, repo: &gix::Repository) -> Result<Editor> {
+/// Creates an editor out of the workspace graph.
+impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
+    /// Creates an editor out of the workspace graph.
+    pub fn create(
+        workspace: &'ws mut but_graph::projection::Workspace,
+        meta: &'meta mut M,
+        repo: &gix::Repository,
+    ) -> Result<Self> {
         // This first creates runs of nodes and associates them with the
         // but-graph segments. We then do a second pass over all the segments
         // and use the but_graph to connect up the runs. Finally, we validate
@@ -28,8 +28,11 @@ impl GraphExt for Graph {
         // TODO(CTO): Look into traversing "in workspace" segments that are not
         // reachable from the entrypoint TODO(CTO): Look into stopping at the
         // common base
-        let entrypoint = self.lookup_entrypoint()?;
-        let workspace_commit_id = self.managed_entrypoint_commit(repo)?.map(|c| c.id);
+        let entrypoint = workspace.graph.lookup_entrypoint()?;
+        let workspace_commit_id = workspace
+            .graph
+            .managed_entrypoint_commit(repo)?
+            .map(|c| c.id);
 
         let mut commits: Vec<Commit> = vec![];
         let mut commit_to_idx = HashMap::<gix::ObjectId, SegmentIndex>::new();
@@ -43,7 +46,7 @@ impl GraphExt for Graph {
 
         let mut segments = HashMap::<SegmentIndex, NodeSegment>::new();
 
-        self.visit_all_segments_including_start_until(
+        workspace.graph.visit_all_segments_including_start_until(
             entrypoint.segment_index,
             Direction::Outgoing,
             |segment| {
@@ -137,7 +140,8 @@ impl GraphExt for Graph {
                 continue;
             };
 
-            'inner: for (order, edge) in self
+            'inner: for (order, edge) in workspace
+                .graph
                 .edges_directed(*sidx, Direction::Outgoing)
                 .collect::<Vec<_>>()
                 .into_iter()
@@ -223,7 +227,7 @@ impl GraphExt for Graph {
             }
         }
 
-        Ok(Editor {
+        Ok(Self {
             graph,
             initial_references: references,
             // TODO(CTO): We need to eventually list all worktrees that we own
@@ -231,19 +235,23 @@ impl GraphExt for Graph {
             checkouts: head_selectors.into_iter().map(Checkout::Head).collect(),
             repo: repo.clone().with_object_memory(),
             history: RevisionHistory::new(),
+            workspace,
+            meta,
         })
     }
 }
 
-impl SuccessfulRebase {
+impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
     /// Converts a SuccessfulRebase back into another editor for multi-step operations
-    pub fn into_editor(self) -> Editor {
+    pub fn into_editor(self) -> Editor<'ws, 'meta, M> {
         Editor {
             graph: self.graph,
             initial_references: self.initial_references,
             checkouts: self.checkouts,
             repo: self.repo,
             history: self.history,
+            workspace: self.workspace,
+            meta: self.meta,
         }
     }
 }

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -1,7 +1,7 @@
 //! Functions for materializing a rebase
 use anyhow::{Context, Result, bail};
 use but_core::{
-    ObjectStorageExt as _,
+    ObjectStorageExt as _, RefMetadata,
     worktree::{
         checkout::{Options, UncommitedWorktreeChanges},
         safe_checkout_from_head,
@@ -12,9 +12,9 @@ use crate::graph_rebase::{
     Checkout, MaterializeOutcome, Pick, Step, SuccessfulRebase, util::collect_ordered_parents,
 };
 
-impl SuccessfulRebase {
+impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
     /// Materializes a history rewrite
-    pub fn materialize(mut self) -> Result<MaterializeOutcome> {
+    pub fn materialize(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
             memory.persist(self.repo)?;
@@ -56,9 +56,13 @@ impl SuccessfulRebase {
 
         repo.edit_references(self.ref_edits.clone())?;
 
+        self.workspace.refresh_from_head(&repo, &*self.meta)?;
+
         Ok(MaterializeOutcome {
             graph: self.graph,
             history: self.history,
+            workspace: self.workspace,
+            meta: self.meta,
         })
     }
 
@@ -77,7 +81,7 @@ impl SuccessfulRebase {
     ///
     /// If I instead called [`Self::materialize`], the changes would instead be
     /// gone from disk.
-    pub fn materialize_without_checkout(mut self) -> Result<MaterializeOutcome> {
+    pub fn materialize_without_checkout(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
             memory.persist(self.repo)?;
@@ -85,9 +89,13 @@ impl SuccessfulRebase {
 
         repo.edit_references(self.ref_edits.clone())?;
 
+        self.workspace.refresh_from_head(&repo, &*self.meta)?;
+
         Ok(MaterializeOutcome {
             graph: self.graph,
             history: self.history,
+            workspace: self.workspace,
+            meta: self.meta,
         })
     }
 }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -9,7 +9,7 @@ pub mod rebase;
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{Context, Result, bail};
-pub use creation::GraphExt;
+use but_core::RefMetadata;
 use gix::refs::transaction::RefEdit;
 pub mod cherry_pick;
 pub mod commit;
@@ -133,7 +133,7 @@ pub trait ToSelector {
     /// Converts a given object into a selector. Calling `to_selector` on an
     /// object asserts that the reciever was a object that is selectable in the
     /// graph.
-    fn to_selector(&self, editor: &Editor) -> Result<Selector>;
+    fn to_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector>;
 }
 
 /// Convert a type to a selector, and ensures that it is type commit.
@@ -141,7 +141,7 @@ pub trait ToCommitSelector {
     /// Converts a given object into a selector. Calling `to_commit_selector` on
     /// an object asserts that the reciever has a selectable pick step in the
     /// graph.
-    fn to_commit_selector(&self, editor: &Editor) -> Result<Selector>;
+    fn to_commit_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector>;
 }
 
 /// Convert a type to a selector, and ensures that it is type reference.
@@ -149,7 +149,7 @@ pub trait ToReferenceSelector {
     /// Converts a given object into a selector. Calling `to_reference_selector` on
     /// an object asserts that the reciever has a selectable reference step in
     /// the graph.
-    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector>;
+    fn to_reference_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector>;
 }
 
 /// Points to a step in the rebase editor.
@@ -159,26 +159,8 @@ pub struct Selector {
     revision: usize,
 }
 
-impl ToSelector for dyn ToCommitSelector {
-    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
-        self.to_commit_selector(editor)
-    }
-}
-
-impl ToSelector for dyn ToReferenceSelector {
-    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
-        self.to_reference_selector(editor)
-    }
-}
-
-impl ToSelector for Selector {
-    fn to_selector(&self, _: &Editor) -> Result<Selector> {
-        Ok(*self)
-    }
-}
-
 impl ToCommitSelector for Selector {
-    fn to_commit_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_commit_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         let selector = editor.history.normalize_selector(*self)?;
         let step = &editor.graph[selector.id];
         if !matches!(step, Step::Pick(_)) {
@@ -190,7 +172,7 @@ impl ToCommitSelector for Selector {
 }
 
 impl ToReferenceSelector for Selector {
-    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_reference_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         let selector = editor.history.normalize_selector(*self)?;
         let step = &editor.graph[selector.id];
         if !matches!(step, Step::Reference { .. }) {
@@ -198,6 +180,12 @@ impl ToReferenceSelector for Selector {
         }
 
         Ok(selector)
+    }
+}
+
+impl ToSelector for Selector {
+    fn to_selector(&self, _: &Editor<impl RefMetadata>) -> Result<Selector> {
+        Ok(*self)
     }
 }
 
@@ -209,8 +197,8 @@ pub(crate) enum Checkout {
 }
 
 /// Used to manipulate a set of picks.
-#[derive(Debug, Clone)]
-pub struct Editor {
+#[derive(Debug)]
+pub struct Editor<'ws, 'meta, M: RefMetadata> {
     /// The internal graph of steps
     graph: StepGraph,
     /// Initial references. This is used to track any references that might need
@@ -222,11 +210,15 @@ pub struct Editor {
     repo: gix::Repository,
     /// Provides data about how the editor instance was transformed.
     history: RevisionHistory,
+    /// A reference to the workspace that the editor was created for.
+    pub workspace: &'ws mut but_graph::projection::Workspace,
+    /// A reference to the metadata that the editor was created for.
+    meta: &'meta mut M,
 }
 
 /// Represents a successful rebase, and any valid, but potentially conflicting scenarios it had.
-#[derive(Debug, Clone)]
-pub struct SuccessfulRebase {
+#[derive(Debug)]
+pub struct SuccessfulRebase<'ws, 'meta, M: RefMetadata> {
     pub(crate) repo: gix::Repository,
     pub(crate) initial_references: Vec<gix::refs::FullName>,
     /// Any reference edits that need to be committed as a result of the history
@@ -237,14 +229,22 @@ pub struct SuccessfulRebase {
     pub(crate) checkouts: Vec<Checkout>,
     /// Provides data about how the editor instance was transformed.
     pub history: RevisionHistory,
+    /// A reference to the workspace that the editor was created for.
+    workspace: &'ws mut but_graph::projection::Workspace,
+    /// A reference to the metadata that the editor was created for.
+    meta: &'meta mut M,
 }
 
 /// The outcome of a materialize
-#[derive(Debug, Clone)]
-pub struct MaterializeOutcome {
+#[derive(Debug)]
+pub struct MaterializeOutcome<'ws, 'meta, M: RefMetadata> {
     pub(crate) graph: StepGraph,
     /// Provides data about how the editor instance was transformed.
     pub history: RevisionHistory,
+    /// A reference to the workspace that the editor was created for.
+    pub workspace: &'ws mut but_graph::projection::Workspace,
+    /// A reference to the metadata that the editor was created for.
+    pub meta: &'meta mut M,
 }
 
 /// Provides lookup for different steps that a selector might point to.
@@ -269,19 +269,19 @@ pub trait LookupStep {
     }
 }
 
-impl LookupStep for Editor {
+impl<M: RefMetadata> LookupStep for Editor<'_, '_, M> {
     fn lookup_step(&self, selector: Selector) -> Result<Step> {
         lookup_step(&self.graph, &self.history, selector)
     }
 }
 
-impl LookupStep for SuccessfulRebase {
+impl<M: RefMetadata> LookupStep for SuccessfulRebase<'_, '_, M> {
     fn lookup_step(&self, selector: Selector) -> Result<Step> {
         lookup_step(&self.graph, &self.history, selector)
     }
 }
 
-impl LookupStep for MaterializeOutcome {
+impl<M: RefMetadata> LookupStep for MaterializeOutcome<'_, '_, M> {
     fn lookup_step(&self, selector: Selector) -> Result<Step> {
         lookup_step(&self.graph, &self.history, selector)
     }

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Result, anyhow};
+use but_core::RefMetadata;
 use petgraph::{Direction, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
 
@@ -83,7 +84,7 @@ pub enum AnySelector {
 }
 
 impl ToSelector for AnySelector {
-    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         match self {
             Self::Selector(selector) => selector.to_selector(editor),
             Self::Commit(id) => editor.select_commit(*id),
@@ -146,7 +147,7 @@ pub enum RelativeToRef<'a> {
 }
 
 impl ToSelector for RelativeToRef<'_> {
-    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         match self {
             Self::Commit(id) => editor.select_commit(*id),
             Self::Reference(reference) => editor.select_reference(reference),
@@ -165,7 +166,7 @@ pub enum RelativeTo {
 }
 
 impl ToSelector for RelativeTo {
-    fn to_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         match self {
             Self::Commit(commit) => editor.select_commit(*commit),
             Self::Reference(reference) => editor.select_reference(reference.as_ref()),
@@ -174,25 +175,25 @@ impl ToSelector for RelativeTo {
 }
 
 impl ToCommitSelector for gix::ObjectId {
-    fn to_commit_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_commit_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         editor.select_commit(*self)
     }
 }
 
 impl ToReferenceSelector for &gix::refs::FullNameRef {
-    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_reference_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         editor.select_reference(self)
     }
 }
 
 impl ToReferenceSelector for gix::refs::FullName {
-    fn to_reference_selector(&self, editor: &Editor) -> Result<Selector> {
+    fn to_reference_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         editor.select_reference(self.as_ref())
     }
 }
 
 /// Operations for mutating the commit graph
-impl Editor {
+impl<M: RefMetadata> Editor<'_, '_, M> {
     /// Get a selector to a particular commit in the graph
     pub fn select_commit(&self, target: gix::ObjectId) -> Result<Selector> {
         match self.try_select_commit(target) {

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use but_core::RefMetadata;
 use gix::refs::{
     Target,
     transaction::{Change, LogChange, PreviousValue, RefEdit},
@@ -18,9 +19,9 @@ use crate::graph_rebase::{
     util::collect_ordered_parents,
 };
 
-impl Editor {
+impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
     /// Perform the rebase
-    pub fn rebase(self) -> Result<SuccessfulRebase> {
+    pub fn rebase(self) -> Result<SuccessfulRebase<'ws, 'graph, M>> {
         // First we want to get a list of nodes that can be reached by
         // traversing downwards from the heads that we care about.
         // Usually there would be just one "head" which is an index to access
@@ -216,6 +217,8 @@ impl Editor {
             graph: output_graph,
             checkouts: self.checkouts.to_owned(),
             history,
+            workspace: self.workspace,
+            meta: self.meta,
         })
     }
 }

--- a/crates/but-rebase/src/graph_rebase/testing.rs
+++ b/crates/but-rebase/src/graph_rebase/testing.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 
+use but_core::RefMetadata;
 use petgraph::{
     dot::{Config, Dot},
     visit::{EdgeRef, IntoEdgeReferences},
@@ -18,13 +19,13 @@ pub trait Testing {
     fn steps_ascii(&self) -> String;
 }
 
-impl Testing for Editor {
+impl<M: RefMetadata> Testing for Editor<'_, '_, M> {
     fn steps_ascii(&self) -> String {
         render_ascii_graph(&self.graph, |id| lookup_commit_title(&self.repo, id))
     }
 }
 
-impl Testing for SuccessfulRebase {
+impl<M: RefMetadata> Testing for SuccessfulRebase<'_, '_, M> {
     fn steps_ascii(&self) -> String {
         render_ascii_graph(&self.graph, |id| lookup_commit_title(&self.repo, id))
     }
@@ -35,13 +36,13 @@ pub trait TestingDot {
     fn steps_dot(&self) -> String;
 }
 
-impl TestingDot for Editor {
+impl<M: RefMetadata> TestingDot for Editor<'_, '_, M> {
     fn steps_dot(&self) -> String {
         self.graph.steps_dot()
     }
 }
 
-impl TestingDot for SuccessfulRebase {
+impl<M: RefMetadata> TestingDot for SuccessfulRebase<'_, '_, M> {
     fn steps_dot(&self) -> String {
         self.graph.steps_dot()
     }

--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use but_graph::Graph;
 use but_rebase::{
     commit::DateMode,
-    graph_rebase::{GraphExt as _, LookupStep, Step, mutate::InsertSide},
+    graph_rebase::{Editor, LookupStep, Step, mutate::InsertSide},
 };
 use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
@@ -12,7 +12,7 @@ use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn by_default_conflicts_are_allowed() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits-one-file")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits-one-file")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f37690f (HEAD -> main, c) c
@@ -23,7 +23,8 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Replacing b with none will cause c to conflict
     let b = repo.rev_parse_single("b")?;
@@ -52,7 +53,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
 #[test]
 fn if_a_commit_has_been_configured_not_to_conflict_but_ends_up_conflicted_an_error_is_raised()
 -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits-one-file")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits-one-file")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f37690f (HEAD -> main, c) c
@@ -63,7 +64,8 @@ fn if_a_commit_has_been_configured_not_to_conflict_but_ends_up_conflicted_an_err
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Replacing b with none will cause c to conflict
     let b = repo.rev_parse_single("b")?;
@@ -92,7 +94,7 @@ fn if_a_commit_has_been_configured_not_to_conflict_but_ends_up_conflicted_an_err
 #[test]
 fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_result_is_ok()
 -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits-one-file")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits-one-file")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f37690f (HEAD -> main, c) c
@@ -103,7 +105,8 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Insert an empty commit above b to cause c to get cherry picked with out a conflict
     let b = repo.rev_parse_single("b")?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step, mutate};
+use but_rebase::graph_rebase::{Editor, Step, mutate};
 use but_testsupport::{git_status, visualize_commit_graph_all};
 use gix::prelude::ObjectIdExt;
 
@@ -11,7 +11,7 @@ use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
 	* 120e3a9 (HEAD -> main) c
@@ -22,7 +22,8 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let b = repo.rev_parse_single("HEAD~")?.detach();
     let b_selector = editor
@@ -57,7 +58,7 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
 
 #[test]
 fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
 	* 120e3a9 (HEAD -> main) c
@@ -68,7 +69,8 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let b = repo.rev_parse_single("HEAD~")?.detach();
     let b_selector = editor
@@ -107,7 +109,7 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
 
 #[test]
 fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -121,7 +123,8 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -163,7 +166,7 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
 
 #[test]
 fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   d1cc4c7 (HEAD -> with-two-children) tip
@@ -181,7 +184,8 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let merge_selector = editor
@@ -256,7 +260,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
 
 #[test]
 fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   d1cc4c7 (HEAD -> with-two-children) tip
@@ -274,7 +278,8 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let m_reference = "refs/heads/M".try_into()?;
@@ -356,7 +361,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
 }
 #[test]
 fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *   d1cc4c7 (HEAD -> with-two-children) tip
@@ -374,7 +379,8 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let m_reference = "refs/heads/M".try_into()?;
@@ -478,12 +484,13 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
 
 #[test]
 fn disconnect_fails_when_parents_to_disconnect_is_none() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     let before = visualize_commit_graph_all(&repo)?;
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let m_reference = "refs/heads/M".try_into()?;
@@ -528,12 +535,13 @@ fn disconnect_fails_when_parents_to_disconnect_is_none() -> Result<()> {
 
 #[test]
 fn disconnect_fails_fast_if_parent_to_disconnect_is_not_direct_parent() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     let before = visualize_commit_graph_all(&repo)?;
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let m_reference = "refs/heads/M".try_into()?;
@@ -578,12 +586,13 @@ fn disconnect_fails_fast_if_parent_to_disconnect_is_not_direct_parent() -> Resul
 
 #[test]
 fn disconnect_fails_fast_if_child_to_disconnect_is_not_direct_child() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-with-two-children")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-with-two-children")?;
 
     let before = visualize_commit_graph_all(&repo)?;
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge = repo.rev_parse_single("M")?.detach();
     let m_reference = "refs/heads/M".try_into()?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, testing::Testing as _};
+use but_rebase::graph_rebase::{Editor, testing::Testing as _};
 use but_testsupport::{StackState, graph_tree, visualize_commit_graph_all};
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
 
 #[test]
 fn four_commits() -> Result<()> {
-    let (repo, meta) = fixture("four-commits")?;
+    let (repo, mut meta) = fixture("four-commits")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 120e3a9 (HEAD -> main) c
@@ -21,7 +21,8 @@ fn four_commits() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/main
@@ -37,7 +38,7 @@ fn four_commits() -> Result<()> {
 
 #[test]
 fn merge_in_the_middle() -> Result<()> {
-    let (repo, meta) = fixture("merge-in-the-middle")?;
+    let (repo, mut meta) = fixture("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -51,7 +52,8 @@ fn merge_in_the_middle() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/with-inner-merge
@@ -74,7 +76,7 @@ fn merge_in_the_middle() -> Result<()> {
 
 #[test]
 fn three_branches_merged() -> Result<()> {
-    let (repo, meta) = fixture("three-branches-merged")?;
+    let (repo, mut meta) = fixture("three-branches-merged")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
@@ -92,7 +94,8 @@ fn three_branches_merged() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/main
@@ -118,7 +121,7 @@ fn three_branches_merged() -> Result<()> {
 
 #[test]
 fn many_references() -> Result<()> {
-    let (repo, meta) = fixture("many-references")?;
+    let (repo, mut meta) = fixture("many-references")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 120e3a9 (HEAD -> main) c
@@ -138,7 +141,8 @@ fn many_references() -> Result<()> {
         └── ·35b8235 (⌂|1)
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/main
@@ -157,7 +161,7 @@ fn many_references() -> Result<()> {
 
 #[test]
 fn first_parent_leg_long() -> Result<()> {
-    let (repo, meta) = fixture("first-parent-leg-long")?;
+    let (repo, mut meta) = fixture("first-parent-leg-long")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * 6ac5745 (HEAD -> with-inner-merge) on top of inner merge
@@ -190,7 +194,8 @@ fn first_parent_leg_long() -> Result<()> {
                             └── →:4: (main)
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/with-inner-merge
@@ -215,7 +220,7 @@ fn first_parent_leg_long() -> Result<()> {
 
 #[test]
 fn second_parent_leg_long() -> Result<()> {
-    let (repo, meta) = fixture("second-parent-leg-long")?;
+    let (repo, mut meta) = fixture("second-parent-leg-long")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * a6775ea (HEAD -> with-inner-merge) on top of inner merge
@@ -248,7 +253,8 @@ fn second_parent_leg_long() -> Result<()> {
                             └── →:4: (main)
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/with-inner-merge
@@ -312,7 +318,8 @@ fn workspace_with_empty_stack() -> Result<()> {
                 └── →:4:
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/gitbutler/workspace
@@ -366,7 +373,8 @@ fn workspace_with_three_empty_stacks() -> Result<()> {
                 └── →:3:
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/gitbutler/workspace
@@ -385,7 +393,7 @@ fn workspace_with_three_empty_stacks() -> Result<()> {
 
 #[test]
 fn commit_with_two_parents() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("single-commit")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("single-commit")?;
 
     let base = repo.rev_parse_single("HEAD")?;
     let base = base.object()?.into_commit();
@@ -408,7 +416,8 @@ fn commit_with_two_parents() -> Result<()> {
             └── →:1:
     ");
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     insta::assert_snapshot!(editor.steps_ascii(), @"
     ◎ refs/heads/main

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -1,7 +1,7 @@
 //! These tests exercise the insert operation.
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step, mutate::InsertSide};
+use but_rebase::graph_rebase::{Editor, Step, mutate::InsertSide};
 use but_testsupport::{git_status, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, standard_options};
@@ -9,7 +9,7 @@ use crate::utils::{fixture_writable, standard_options};
 /// Inserting below a merge commit should inherit all of it's parents
 #[test]
 fn insert_below_merge_commit() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -24,7 +24,8 @@ fn insert_below_merge_commit() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge_id = repo.rev_parse_single("HEAD~")?;
 
@@ -69,7 +70,7 @@ fn insert_below_merge_commit() -> Result<()> {
 /// Inserting below a merge commit should inherit all of it's parents
 #[test]
 fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -84,7 +85,8 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let merge_id = repo.rev_parse_single("HEAD~")?;
 
@@ -132,7 +134,7 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
 /// Inserting above a commit should inherit it's parents
 #[test]
 fn insert_above_commit_with_two_children() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -147,7 +149,8 @@ fn insert_above_commit_with_two_children() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let base_id = repo.rev_parse_single("base")?;
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -1,14 +1,14 @@
 //! These tests exercise the insert segment operation.
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, mutate};
+use but_rebase::graph_rebase::{Editor, mutate};
 use but_testsupport::{git_status, visualize_commit_graph, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn insert_single_node_segment_above() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -25,7 +25,8 @@ fn insert_single_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -68,7 +69,7 @@ fn insert_single_node_segment_above() -> Result<()> {
 
 #[test]
 fn insert_single_node_segment_below() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -85,7 +86,8 @@ fn insert_single_node_segment_below() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -129,7 +131,7 @@ fn insert_single_node_segment_below() -> Result<()> {
 
 #[test]
 fn insert_multi_node_segment_above() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -146,7 +148,8 @@ fn insert_multi_node_segment_above() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -193,7 +196,7 @@ fn insert_multi_node_segment_above() -> Result<()> {
 
 #[test]
 fn insert_multi_node_segment_below() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -210,7 +213,8 @@ fn insert_multi_node_segment_below() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -255,7 +259,7 @@ fn insert_multi_node_segment_below() -> Result<()> {
 
 #[test]
 fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -272,7 +276,8 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor
@@ -326,7 +331,7 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
 
 #[test]
 fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
-    let (repo, _tmp, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmp, mut meta) = fixture_writable("three-branches-merged")?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -343,7 +348,8 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
     insta::assert_snapshot!(git_status(&repo)?, @"");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let a = repo.rev_parse_single("A")?.detach();
     let a_selector = editor

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -1,14 +1,14 @@
 //! Tests for `materialize` vs `materialize_without_checkout` behavior differences
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step};
+use but_rebase::graph_rebase::{Editor, Step};
 use but_testsupport::{visualize_commit_graph_all, visualize_disk_tree_skip_dot_git};
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
     let worktree = repo.workdir().unwrap();
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -28,7 +28,8 @@ fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Drop the 'c' commit (HEAD)
     let c = repo.rev_parse_single("HEAD")?;
@@ -58,7 +59,7 @@ fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
 
 #[test]
 fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
     let worktree = repo.workdir().unwrap();
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -78,7 +79,8 @@ fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Drop the 'c' commit (HEAD)
     let c = repo.rev_parse_single("HEAD")?;
@@ -112,10 +114,11 @@ fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -
 fn both_methods_update_references_identically() -> Result<()> {
     // Test with materialize
     let ref_after_materialize = {
-        let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+        let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
         let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-        let mut editor = graph.to_editor(&repo)?;
+        let mut ws = graph.into_workspace()?;
+        let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
         let c = repo.rev_parse_single("HEAD")?;
         let c_sel = editor.select_commit(c.detach())?;
@@ -129,10 +132,11 @@ fn both_methods_update_references_identically() -> Result<()> {
 
     // Test with materialize_without_checkout
     let ref_after_materialize_without_checkout = {
-        let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+        let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
         let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-        let mut editor = graph.to_editor(&repo)?;
+        let mut ws = graph.into_workspace()?;
+        let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
         let c = repo.rev_parse_single("HEAD")?;
         let c_sel = editor.select_commit(c.detach())?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/parents_must_be_references_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/parents_must_be_references_restriction.rs
@@ -2,14 +2,14 @@
 
 use anyhow::{Result, bail};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt as _, LookupStep, Step};
+use but_rebase::graph_rebase::{Editor, LookupStep, Step};
 use but_testsupport::visualize_commit_graph_all;
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn by_default_parents_can_be_picks() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * 120e3a9 (HEAD -> main) c
@@ -20,7 +20,8 @@ fn by_default_parents_can_be_picks() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // By default, picks can have other picks as parents
     let outcome = editor.rebase()?;
@@ -39,7 +40,7 @@ fn by_default_parents_can_be_picks() -> Result<()> {
 
 #[test]
 fn if_a_commit_requires_reference_parents_but_has_pick_parent_an_error_is_raised() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits-one-file")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits-one-file")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f37690f (HEAD -> main, c) c
@@ -50,7 +51,8 @@ fn if_a_commit_requires_reference_parents_but_has_pick_parent_an_error_is_raised
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Set c to require reference parents
     let c = repo.rev_parse_single("c")?;
@@ -78,7 +80,7 @@ fn if_a_commit_requires_reference_parents_but_has_pick_parent_an_error_is_raised
 
 #[test]
 fn if_a_commit_requires_reference_parents_and_has_reference_parent_result_is_ok() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits-one-file")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits-one-file")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f37690f (HEAD -> main, c) c
@@ -89,7 +91,8 @@ fn if_a_commit_requires_reference_parents_and_has_reference_parent_result_is_ok(
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Set "a" to require reference parents - "a"'s parent is "base" which has
     // a reference pointing to it

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -2,14 +2,14 @@
 /// graphs are returned.
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn four_commits() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -21,7 +21,8 @@ fn four_commits() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
     let outcome = editor.rebase()?;
     let outcome = outcome.materialize()?;
 
@@ -33,7 +34,7 @@ fn four_commits() -> Result<()> {
 
 #[test]
 fn four_commits_with_short_traversal() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -45,7 +46,7 @@ fn four_commits_with_short_traversal() -> Result<()> {
 
     let options = standard_options().with_hard_limit(4);
     let graph = Graph::from_head(&repo, &*meta, options)?.validated()?;
-    let ws = graph.into_workspace()?;
+    let mut ws = graph.into_workspace()?;
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     ⌂:0:main[🌳] <> ✓!
@@ -55,7 +56,7 @@ fn four_commits_with_short_traversal() -> Result<()> {
             └── ❌·a96434e
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
     let outcome = editor.rebase()?;
     let outcome = outcome.materialize()?;
 
@@ -67,7 +68,7 @@ fn four_commits_with_short_traversal() -> Result<()> {
 
 #[test]
 fn merge_in_the_middle() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @r"
@@ -82,7 +83,8 @@ fn merge_in_the_middle() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
     let outcome = editor.rebase()?;
     let outcome = outcome.materialize()?;
 
@@ -94,7 +96,7 @@ fn merge_in_the_middle() -> Result<()> {
 
 #[test]
 fn three_branches_merged() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("three-branches-merged")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("three-branches-merged")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @r"
@@ -113,7 +115,8 @@ fn three_branches_merged() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
     let outcome = editor.rebase()?;
     let outcome = outcome.materialize()?;
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
@@ -1,14 +1,14 @@
 //! These tests exercise the replace operation.
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Step};
+use but_rebase::graph_rebase::{Editor, Step};
 use but_testsupport::{git_status, visualize_commit_graph_all, visualize_tree};
 
 use crate::utils::{fixture_writable, standard_options};
 
 #[test]
 fn reword_a_commit() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -25,7 +25,8 @@ fn reword_a_commit() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // get the original a
     let a = repo.rev_parse_single("A")?.detach();
@@ -70,7 +71,7 @@ fn reword_a_commit() -> Result<()> {
 
 #[test]
 fn amend_a_commit() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("merge-in-the-middle")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("merge-in-the-middle")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
@@ -93,7 +94,8 @@ fn amend_a_commit() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // get the original a
     let a = repo.rev_parse_single("A")?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
@@ -3,7 +3,7 @@ use std::fs;
 /// These tests cover the `sign_if_configured` property on the Step::Pick.
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, Pick, Step};
+use but_rebase::graph_rebase::{Editor, Pick, Step};
 use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable_with_signing, standard_options};
@@ -48,7 +48,7 @@ fn assert_consistent_private_key() -> Result<()> {
 
 #[test]
 fn commits_maintain_state_if_not_cherry_picked() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("four-commits-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("four-commits-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -59,7 +59,8 @@ fn commits_maintain_state_if_not_cherry_picked() -> Result<()> {
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Modify the "c" commit to no longer be signed
     let c = repo.rev_parse_single("c")?;
@@ -78,7 +79,7 @@ fn commits_maintain_state_if_not_cherry_picked() -> Result<()> {
 
 #[test]
 fn commits_are_signed_by_default() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("four-commits-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("four-commits-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -89,7 +90,8 @@ fn commits_are_signed_by_default() -> Result<()> {
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Remove the "b" commit so "c" gets cherry-picked
     let b = repo.rev_parse_single("b")?;
@@ -135,7 +137,7 @@ fn commits_are_signed_by_default() -> Result<()> {
 
 #[test]
 fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("four-commits-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("four-commits-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -146,7 +148,8 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Modify the "c" commit to no longer be signed
     let c = repo.rev_parse_single("c")?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{GraphExt, LookupStep, Pick, Step};
+use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Step};
 use but_testsupport::{cat_commit, visualize_commit_graph_all};
 
 use crate::utils::{fixture_writable, fixture_writable_with_signing, standard_options};
@@ -48,7 +48,7 @@ fn assert_consistent_private_key() -> Result<()> {
 
 #[test]
 fn workspace_remains_unchanged_with_no_operations() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("workspace-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("workspace-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -61,7 +61,8 @@ fn workspace_remains_unchanged_with_no_operations() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let id = repo.rev_parse_single("gitbutler/workspace")?;
     let selector = editor.select_commit(id.detach())?;
@@ -98,7 +99,7 @@ fn workspace_remains_unchanged_with_no_operations() -> Result<()> {
 
 #[test]
 fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("workspace-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("workspace-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -110,7 +111,8 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
     ");
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Remove the "b" commit so "c" and the workspace commit get cherry-picked
     let b = repo.rev_parse_single("b")?;
@@ -169,7 +171,7 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
 
 #[test]
 fn ad_hoc_workspace_keeps_regular_defaults() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable("four-commits")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -181,7 +183,8 @@ fn ad_hoc_workspace_keeps_regular_defaults() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     let id = repo.rev_parse_single("HEAD")?;
     let selector = editor.select_commit(id.detach())?;
@@ -218,7 +221,8 @@ fn ad_hoc_workspace_keeps_regular_defaults() -> Result<()> {
 
 #[test]
 fn workspace_commit_should_not_be_allowed_to_conflict() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("workspace-with-wc-content-signed")?;
+    let (repo, _tmpdir, mut meta) =
+        fixture_writable_with_signing("workspace-with-wc-content-signed")?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
     * f7f22fe (HEAD -> gitbutler/workspace) GitButler Workspace Commit
@@ -230,7 +234,8 @@ fn workspace_commit_should_not_be_allowed_to_conflict() -> Result<()> {
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Dropping c will cause the workspace commit to conflict because the WC
     // depends on a file created in c
@@ -251,7 +256,7 @@ fn workspace_commit_should_not_be_allowed_to_conflict() -> Result<()> {
 
 #[test]
 fn workspace_commit_should_not_be_allowed_to_have_non_reference_parents() -> Result<()> {
-    let (repo, _tmpdir, meta) = fixture_writable_with_signing("workspace-signed")?;
+    let (repo, _tmpdir, mut meta) = fixture_writable_with_signing("workspace-signed")?;
 
     let before = visualize_commit_graph_all(&repo)?;
     insta::assert_snapshot!(before, @"
@@ -264,7 +269,8 @@ fn workspace_commit_should_not_be_allowed_to_have_non_reference_parents() -> Res
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
 
-    let mut editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
 
     // Replace both 'main' and 'c' references with Step::None. The commit 'c'
     // has two references pointing to it, so we need to remove both for the

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, bail};
+use but_core::RefMetadata;
 use but_graph::projection::{Stack, StackSegment};
 use but_rebase::graph_rebase::{
     Editor, Selector, SuccessfulRebase,
@@ -9,9 +10,9 @@ use but_rebase::graph_rebase::{
 ///
 /// Returned by [function::move_branch()].
 #[derive(Debug)]
-pub struct Outcome {
+pub struct Outcome<'ws, 'meta, M: RefMetadata> {
     /// A successful rebase result for continuing operations.
-    pub rebase: SuccessfulRebase,
+    pub rebase: SuccessfulRebase<'ws, 'meta, M>,
     /// The updated workspace metadata that accompanies the move operation.
     /// It should replace the actual workspace metadata to configure moved 'virtual' branches segments, if `Some()`.
     pub ws_meta: Option<but_core::ref_metadata::Workspace>,
@@ -19,6 +20,7 @@ pub struct Outcome {
 
 pub(super) mod function {
 
+    use but_core::RefMetadata;
     use but_core::ref_metadata::StackId;
     use but_rebase::graph_rebase::mutate::SomeSelectors;
 
@@ -45,13 +47,15 @@ pub(super) mod function {
     ///     Mainly used for testing purposes.
     ///
     /// Returns the in memory update [outcome](Outcome) that can then used for materialisation.
-    pub fn tear_off_branch(
-        mut editor: Editor,
-        workspace: &but_graph::projection::Workspace,
+    pub fn tear_off_branch<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         subject_branch_name: &FullNameRef,
         stack_id_override: Option<StackId>,
-    ) -> anyhow::Result<Outcome> {
-        let Some(source) = workspace.find_segment_and_stack_by_refname(subject_branch_name) else {
+    ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
+        let Some(source) = editor
+            .workspace
+            .find_segment_and_stack_by_refname(subject_branch_name)
+        else {
             bail!(
                 "Couldn't find branch to move in workspace with reference name: {subject_branch_name}"
             );
@@ -60,7 +64,7 @@ pub(super) mod function {
         // We're currently stopping the move branch operations imperatively at this stage, in order to
         // reduce the scope of this first iteration of moving the branches.
         // TODO: Enable and test that we can move branches in any kind of workspace.
-        match &workspace.kind {
+        match &editor.workspace.kind {
             WorkspaceKind::Managed { .. } => {}
             WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
                 bail!("Moving branches currently need a workspace commit")
@@ -70,7 +74,7 @@ pub(super) mod function {
             }
         };
 
-        let mut ws_meta = workspace.metadata.clone();
+        let mut ws_meta = editor.workspace.metadata.clone();
 
         let (source_stack, subject_segment) = source;
 
@@ -82,7 +86,7 @@ pub(super) mod function {
             });
         }
 
-        let Some(workspace_head) = workspace.tip_commit().map(|commit| commit.id) else {
+        let Some(workspace_head) = editor.workspace.tip_commit().map(|commit| commit.id) else {
             bail!("Couldn't find workspace head.")
         };
 
@@ -90,9 +94,10 @@ pub(super) mod function {
             .select_commit(workspace_head)
             .context("Failed to find the workspace head in the graph.")?;
 
-        let Some(lower_bound_ref) = workspace
+        let Some(lower_bound_ref) = editor
+            .workspace
             .lower_bound_segment_id
-            .map(|segment_id| &workspace.graph[segment_id])
+            .map(|segment_id| &editor.workspace.graph[segment_id])
             .and_then(|segment| segment.ref_name())
         else {
             bail!("Tearing off a branch requires a workspace common base");
@@ -103,13 +108,7 @@ pub(super) mod function {
             .context("Failed to find target reference in graph.")?;
 
         let (subject_delimiter, children_to_disconnect, parents_to_disconnect) =
-            get_disconnect_parameters(
-                workspace,
-                &editor,
-                source_stack,
-                subject_segment,
-                workspace_head,
-            )?;
+            get_disconnect_parameters(&editor, source_stack, subject_segment, workspace_head)?;
 
         editor.disconnect_segment_from(
             subject_delimiter.clone(),
@@ -159,23 +158,25 @@ pub(super) mod function {
     /// branch on top of.
     ///
     /// Returns an [outcome](Outcome) for potential materialisation.
-    pub fn move_branch(
-        mut editor: Editor,
-        workspace: &but_graph::projection::Workspace,
+    pub fn move_branch<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         subject_branch_name: &FullNameRef,
         target_branch_name: &FullNameRef,
-    ) -> anyhow::Result<Outcome> {
-        let (source, destination) =
-            retrieve_branches_and_containers(workspace, subject_branch_name, target_branch_name)?;
+    ) -> anyhow::Result<Outcome<'ws, 'meta, M>> {
+        let (source, destination) = retrieve_branches_and_containers(
+            editor.workspace,
+            subject_branch_name,
+            target_branch_name,
+        )?;
 
-        let Some(workspace_head) = workspace.tip_commit().map(|commit| commit.id) else {
+        let Some(workspace_head) = editor.workspace.tip_commit().map(|commit| commit.id) else {
             bail!("Couldn't find workspace head.")
         };
 
         // We're currently stopping the move branch operations imperatively at this stage, in order to
         // reduce the scope of this first iteration of moving the branches.
         // TODO: Enable and test that we can move branches in any kind of workspace.
-        match &workspace.kind {
+        match &editor.workspace.kind {
             WorkspaceKind::Managed { .. } => {}
             WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
                 bail!("Moving branches currently need a workspace commit")
@@ -185,7 +186,7 @@ pub(super) mod function {
             }
         };
 
-        let mut ws_meta = workspace.metadata.clone();
+        let mut ws_meta = editor.workspace.metadata.clone();
 
         let (source_stack, subject_segment) = source;
         let (_, target_segment) = destination;
@@ -197,13 +198,7 @@ pub(super) mod function {
             .context("Failed to find target reference in graph.")?;
 
         let (subject_delimiter, children_to_disconnect, parents_to_disconnect) =
-            get_disconnect_parameters(
-                workspace,
-                &editor,
-                source_stack,
-                subject_segment,
-                workspace_head,
-            )?;
+            get_disconnect_parameters(&editor, &source_stack, &subject_segment, workspace_head)?;
 
         let skip_reconnect_step = source_stack.segments.len() == 1;
         editor.disconnect_segment_from(
@@ -237,10 +232,19 @@ pub(super) mod function {
     }
 
     /// A segment and its container stack.
-    type WorkspaceSegmentContext<'a> = (
+    type WorkspaceSegmentContext = (
+        but_graph::projection::Stack,
+        but_graph::projection::StackSegment,
+    );
+
+    type WorkspaceSegmentContextRef<'a> = (
         &'a but_graph::projection::Stack,
         &'a but_graph::projection::StackSegment,
     );
+
+    fn own_context<'a>(ctx: WorkspaceSegmentContextRef<'a>) -> WorkspaceSegmentContext {
+        (ctx.0.to_owned(), ctx.1.to_owned())
+    }
 
     /// Determine the surrounding context of the subject and target branches.
     ///
@@ -266,11 +270,11 @@ pub(super) mod function {
     /// In the future, where we're not afraid of complex graphs, we've figured out UX and data wrangling,
     /// the concept of a segment might not hold, and hence we'll have to figure out a better way of determining
     /// what to cut (e.g. letting the clients decide what to cut).
-    fn retrieve_branches_and_containers<'a>(
-        workspace: &'a but_graph::projection::Workspace,
+    fn retrieve_branches_and_containers(
+        workspace: &but_graph::projection::Workspace,
         subject_branch_name: &FullNameRef,
         target_branch_name: &FullNameRef,
-    ) -> anyhow::Result<(WorkspaceSegmentContext<'a>, WorkspaceSegmentContext<'a>)> {
+    ) -> anyhow::Result<(WorkspaceSegmentContext, WorkspaceSegmentContext)> {
         let Some(source) = workspace.find_segment_and_stack_by_refname(subject_branch_name) else {
             bail!(
                 "Couldn't find branch to move in workspace with reference name: {subject_branch_name}"
@@ -283,7 +287,7 @@ pub(super) mod function {
                 "Couldn't find target branch to move in workspace with reference name: {target_branch_name}"
             );
         };
-        Ok((source, destination))
+        Ok((own_context(source), own_context(destination)))
     }
 }
 
@@ -291,9 +295,8 @@ pub(super) mod function {
 ///
 /// This function determines which are the right parents and children to disconnect,
 /// as well as the right segment delimiter to move.
-fn get_disconnect_parameters(
-    workspace: &but_graph::projection::Workspace,
-    editor: &Editor,
+fn get_disconnect_parameters<'ws, 'meta, M: RefMetadata>(
+    editor: &Editor<'ws, 'meta, M>,
     source_stack: &Stack,
     subject_segment: &StackSegment,
     workspace_head: gix::ObjectId,
@@ -346,7 +349,7 @@ fn get_disconnect_parameters(
     // graph data, and it's probably the target branch, which is not included in the workspace.
     let graph_base_segment = subject_segment
         .base_segment_id
-        .map(|segment_idx| &workspace.graph[segment_idx]);
+        .map(|segment_idx| &editor.workspace.graph[segment_idx]);
 
     let parents_to_disconnect = if let Some(stack_base_segment) = stack_base_segment {
         // Base segment is part of the source stack.

--- a/crates/but-workspace/src/commit/commit_amend.rs
+++ b/crates/but-workspace/src/commit/commit_amend.rs
@@ -2,18 +2,18 @@
 
 pub(crate) mod function {
     use anyhow::{Result, bail};
-    use but_core::DiffSpec;
+    use but_core::{DiffSpec, RefMetadata};
     use but_rebase::graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector};
 
     use crate::commit_engine::{Destination, create_commit};
 
     /// The result of amending a commit in the graph rebase editor.
     #[derive(Debug)]
-    pub struct CommitAmendOutcome {
+    pub struct CommitAmendOutcome<'ws, 'meta, M: RefMetadata> {
         /// A successful rebase result for continuing operations. This will be
         /// always provided regardless of whether a commit was actually
         /// created.
-        pub rebase: SuccessfulRebase,
+        pub rebase: SuccessfulRebase<'ws, 'meta, M>,
         /// Selector pointing to the amended commit, if the amend was
         /// successful.
         ///
@@ -38,12 +38,12 @@ pub(crate) mod function {
     /// this particular function call. The provided `context_lines` MUST align
     /// with the `context_lines` value used to generate the `DiffSpec`s passed
     /// in the `changes` parameter.
-    pub fn commit_amend(
-        mut editor: Editor,
+    pub fn commit_amend<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         commit: impl ToCommitSelector,
         changes: Vec<DiffSpec>,
         context_lines: u32,
-    ) -> Result<CommitAmendOutcome> {
+    ) -> Result<CommitAmendOutcome<'ws, 'meta, M>> {
         let (target_selector, target) = editor.find_selectable_commit(commit)?;
 
         let target_id = target.id;

--- a/crates/but-workspace/src/commit/commit_create.rs
+++ b/crates/but-workspace/src/commit/commit_create.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod function {
     use anyhow::Result;
-    use but_core::DiffSpec;
+    use but_core::{DiffSpec, RefMetadata};
     use but_rebase::graph_rebase::{
         Editor, LookupStep, Pick, Selector, Step, SuccessfulRebase, ToSelector, mutate::InsertSide,
     };
@@ -11,11 +11,11 @@ pub(crate) mod function {
 
     /// The result of creating and inserting a new commit in the graph rebase editor.
     #[derive(Debug)]
-    pub struct CommitCreateOutcome {
+    pub struct CommitCreateOutcome<'ws, 'meta, M: RefMetadata> {
         /// A successful rebase result for continuing operations. This will be
         /// always provided regardless of whether a commit was actually
         /// created.
-        pub rebase: SuccessfulRebase,
+        pub rebase: SuccessfulRebase<'ws, 'meta, M>,
         /// Selector pointing to the newly created commit, if one was created.
         ///
         /// A commit may not be created if all the diff_specs are rejected. See
@@ -44,14 +44,14 @@ pub(crate) mod function {
     /// this particular function call. The provided `context_lines` MUST align
     /// with the `context_lines` value used to generate the `DiffSpec`s passed
     /// in the `changes` parameter.
-    pub fn commit_create(
-        mut editor: Editor,
+    pub fn commit_create<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         changes: Vec<DiffSpec>,
         relative_to: impl ToSelector,
         side: InsertSide,
         message: &str,
         context_lines: u32,
-    ) -> Result<CommitCreateOutcome> {
+    ) -> Result<CommitCreateOutcome<'ws, 'meta, M>> {
         let relative_to_selector = relative_to.to_selector(&editor)?;
         let parent_commit_id = parent_commit_id_for_new_commit(
             &editor,
@@ -91,8 +91,8 @@ pub(crate) mod function {
         })
     }
 
-    fn parent_commit_id_for_new_commit(
-        editor: &Editor,
+    fn parent_commit_id_for_new_commit<'ws, 'meta, M: RefMetadata>(
+        editor: &Editor<'ws, 'meta, M>,
         target_step: Step,
         side: InsertSide,
     ) -> Result<Option<gix::ObjectId>> {

--- a/crates/but-workspace/src/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/src/commit/insert_blank_commit.rs
@@ -2,17 +2,18 @@
 
 pub(crate) mod function {
     use anyhow::Result;
+    use but_core::RefMetadata;
     use but_rebase::{
         commit::DateMode,
         graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToSelector, mutate::InsertSide},
     };
 
     /// Inserts a blank commit relative to either a reference or a commit
-    pub fn insert_blank_commit(
-        mut editor: Editor,
+    pub fn insert_blank_commit<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         side: InsertSide,
         relative_to: impl ToSelector,
-    ) -> Result<(SuccessfulRebase, Selector)> {
+    ) -> Result<(SuccessfulRebase<'ws, 'meta, M>, Selector)> {
         let commit = editor.empty_commit()?;
         let new_id = editor.new_commit_untracked(commit, DateMode::CommitterUpdateAuthorUpdate)?;
 

--- a/crates/but-workspace/src/commit/move_changes.rs
+++ b/crates/but-workspace/src/commit/move_changes.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod function {
     use anyhow::{Result, bail};
-    use but_core::{DiffSpec, RepositoryExt};
+    use but_core::{DiffSpec, RefMetadata, RepositoryExt};
     use but_rebase::{
         commit::DateMode,
         graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector},
@@ -12,9 +12,9 @@ pub(crate) mod function {
 
     /// The result of a move_changes_between_commits operation.
     #[derive(Debug)]
-    pub struct MoveChangesOutcome {
+    pub struct MoveChangesOutcome<'ws, 'meta, M: RefMetadata> {
         /// The successful rebase result
-        pub rebase: SuccessfulRebase,
+        pub rebase: SuccessfulRebase<'ws, 'meta, M>,
         /// Selector pointing to the source commit (with changes removed)
         pub source_selector: Selector,
         /// Selector pointing to the destination commit (with changes added)
@@ -39,13 +39,13 @@ pub(crate) mod function {
     /// Returns the rebase outcome along with selectors pointing to both the
     /// modified source and destination commits. The caller should call
     /// `outcome.rebase.materialize()` to persist the changes.
-    pub fn move_changes_between_commits(
-        mut editor: Editor,
+    pub fn move_changes_between_commits<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         source_commit: impl ToCommitSelector,
         destination_commit: impl ToCommitSelector,
         changes_to_move: impl IntoIterator<Item = DiffSpec>,
         context_lines: u32,
-    ) -> Result<MoveChangesOutcome> {
+    ) -> Result<MoveChangesOutcome<'ws, 'meta, M>> {
         let (source_selector, source_commit) = editor.find_selectable_commit(source_commit)?;
         let (destination_selector, destination_commit) =
             editor.find_selectable_commit(destination_commit)?;

--- a/crates/but-workspace/src/commit/move_commit.rs
+++ b/crates/but-workspace/src/commit/move_commit.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod function {
     use anyhow::{Context, bail};
+    use but_core::RefMetadata;
     use but_rebase::graph_rebase::{
         Editor, SuccessfulRebase, ToCommitSelector, ToSelector,
         mutate::{InsertSide, SegmentDelimiter, SelectorSet, SomeSelectors},
@@ -23,17 +24,16 @@ pub(crate) mod function {
     ///
     /// The subject commit will be detached from the source segment, and inserted relative
     /// to a given anchor (branch or commit).
-    pub fn move_commit(
-        mut editor: Editor,
-        workspace: &but_graph::projection::Workspace,
+    pub fn move_commit<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         subject_commit: impl ToCommitSelector,
         anchor: impl ToSelector,
         side: InsertSide,
-    ) -> anyhow::Result<SuccessfulRebase> {
+    ) -> anyhow::Result<SuccessfulRebase<'ws, 'meta, M>> {
         let (subject_commit_selector, subject_commit) =
             editor.find_selectable_commit(subject_commit)?;
 
-        let subject = retrieve_commit_and_containers(workspace, &subject_commit)?;
+        let subject = retrieve_commit_and_containers(editor.workspace, &subject_commit)?;
 
         let (source_stack, source_segment, _) = subject;
 
@@ -53,7 +53,6 @@ pub(crate) mod function {
             determine_child_selector(&editor, source_segment, index_of_subject_commit)?;
 
         let parent_to_disconnect = determine_parent_selector(
-            workspace,
             &editor,
             source_stack,
             source_segment,
@@ -108,8 +107,8 @@ pub(crate) mod function {
     }
 
     /// Determine which children to disconnect, based on the position of the subject commit in the segment.
-    fn determine_child_selector(
-        editor: &Editor,
+    fn determine_child_selector<'ws, 'meta, M: RefMetadata>(
+        editor: &Editor<'ws, 'meta, M>,
         source_segment: &but_graph::projection::StackSegment,
         index_of_subject_commit: usize,
     ) -> Result<SelectorSet, anyhow::Error> {
@@ -138,9 +137,8 @@ pub(crate) mod function {
 
     /// Determine which parents to disconnect, based on the position of the subject commit in the segment
     /// and the position of the source segment in the source stack.
-    fn determine_parent_selector(
-        workspace: &but_graph::projection::Workspace,
-        editor: &Editor,
+    fn determine_parent_selector<'ws, 'meta, M: RefMetadata>(
+        editor: &Editor<'ws, 'meta, M>,
         source_stack: &but_graph::projection::Stack,
         source_segment: &but_graph::projection::StackSegment,
         index_of_subject_commit: usize,
@@ -163,7 +161,7 @@ pub(crate) mod function {
             // Look for the base segment in the graph data, as a fallback if there's no stack segment found.
             let graph_base_segment_ref_name = source_segment
                 .base_segment_id
-                .map(|base_segment_id| &workspace.graph[base_segment_id])
+                .map(|base_segment_id| &editor.workspace.graph[base_segment_id])
                 .and_then(|segment| segment.ref_name());
 
             match stack_base_segment_ref_name.or(graph_base_segment_ref_name) {

--- a/crates/but-workspace/src/commit/reword.rs
+++ b/crates/but-workspace/src/commit/reword.rs
@@ -3,6 +3,7 @@
 pub(crate) mod function {
     use anyhow::Result;
     use bstr::BStr;
+    use but_core::RefMetadata;
     use but_rebase::{
         commit::DateMode,
         graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector},
@@ -12,11 +13,11 @@ pub(crate) mod function {
     /// the new name.
     ///
     /// Returns a selector to the rewritten commit
-    pub fn reword(
-        mut editor: Editor,
+    pub fn reword<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         commit: impl ToCommitSelector,
         new_message: &BStr,
-    ) -> Result<(SuccessfulRebase, Selector)> {
+    ) -> Result<(SuccessfulRebase<'ws, 'meta, M>, Selector)> {
         let (target_selector, mut commit) = editor.find_selectable_commit(commit)?;
 
         commit.message = new_message.to_owned();

--- a/crates/but-workspace/src/commit/uncommit_changes.rs
+++ b/crates/but-workspace/src/commit/uncommit_changes.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod function {
     use anyhow::{Result, bail};
-    use but_core::DiffSpec;
+    use but_core::{DiffSpec, RefMetadata};
     use but_rebase::{
         commit::DateMode,
         graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector},
@@ -12,9 +12,9 @@ pub(crate) mod function {
 
     /// The result of an uncommit_changes operation.
     #[derive(Debug)]
-    pub struct UncommitChangesOutcome {
+    pub struct UncommitChangesOutcome<'ws, 'meta, M: RefMetadata> {
         /// The successful rebase result
-        pub rebase: SuccessfulRebase,
+        pub rebase: SuccessfulRebase<'ws, 'meta, M>,
         /// Selector pointing to the modified commit (with changes removed)
         pub commit_selector: Selector,
     }
@@ -23,12 +23,12 @@ pub(crate) mod function {
     ///
     /// The changes are removed from the commit's tree, effectively "uncommitting"
     /// them so they appear in the working directory as uncommitted changes.
-    pub fn uncommit_changes(
-        mut editor: Editor,
+    pub fn uncommit_changes<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
         commit: impl ToCommitSelector,
         changes: impl IntoIterator<Item = DiffSpec>,
         context_lines: u32,
-    ) -> Result<UncommitChangesOutcome> {
+    ) -> Result<UncommitChangesOutcome<'ws, 'meta, M>> {
         let (commit_selector, commit) = editor.find_selectable_commit(commit)?;
 
         if commit.clone().attach(editor.repo()).is_conflicted() {

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1,5 +1,5 @@
 use but_core::RefMetadata;
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 
 use crate::ref_info::with_workspace_commit::utils::{
@@ -39,12 +39,11 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put C on top of A
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/C".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
@@ -112,11 +111,10 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
@@ -184,12 +182,11 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of C
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             "refs/heads/C".try_into()?,
         )?;
@@ -254,12 +251,11 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put B on top of C
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             "refs/heads/C".try_into()?,
         )?;
@@ -327,12 +323,11 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of B, and below C
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             "refs/heads/B".try_into()?,
         )?;
@@ -389,12 +384,11 @@ fn move_empty_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put B on top of A
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             "refs/heads/A".try_into()?,
         )?;
@@ -445,12 +439,11 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Put A on top of B
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             "refs/heads/B".try_into()?,
         )?;

--- a/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
@@ -1,5 +1,5 @@
 use but_core::RefMetadata;
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 use gitbutler_stack::StackId;
 
@@ -40,12 +40,11 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off C from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/C".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -115,12 +114,11 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -190,12 +188,11 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack. Should be a no-op.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -254,12 +251,11 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -315,12 +311,11 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -376,12 +371,11 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off B from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/B".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;
@@ -435,12 +429,11 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     // Tear off A from the stack.
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(
             editor,
-            &ws,
             "refs/heads/A".try_into()?,
             Some(StackId::from_number_for_testing(3)),
         )?;

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_core::DiffSpec;
-use but_rebase::graph_rebase::{GraphExt as _, LookupStep as _};
+use but_rebase::graph_rebase::{Editor, LookupStep as _};
 use but_workspace::commit::commit_amend;
 
 use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
@@ -23,7 +23,8 @@ fn amend_commit_smoke_test() -> Result<()> {
         "amended\n",
     )?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = commit_amend(editor, two_id, worktree_changes_as_specs(&repo)?, 0)?;
 
     assert!(outcome.rejected_specs.is_empty());

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use but_core::DiffSpec;
 use but_rebase::graph_rebase::{
-    GraphExt as _, LookupStep as _,
+    Editor, LookupStep as _,
     mutate::{InsertSide, RelativeToRef},
 };
 use but_workspace::commit::commit_create;
@@ -27,7 +27,8 @@ fn commit_above_commit() -> Result<()> {
         "inserted\n",
     )?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = commit_create(
         editor,
         worktree_changes_as_specs(&repo)?,
@@ -73,7 +74,8 @@ fn commit_below_commit() -> Result<()> {
         "inserted\n",
     )?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = commit_create(
         editor,
         worktree_changes_as_specs(&repo)?,
@@ -113,7 +115,8 @@ fn commit_above_reference() -> Result<()> {
         "inserted\n",
     )?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = commit_create(
         editor,
         worktree_changes_as_specs(&repo)?,
@@ -164,7 +167,8 @@ fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
         "inserted\n",
     )?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = commit_create(
         editor,
         worktree_changes_as_specs(&repo)?,
@@ -201,7 +205,8 @@ fn commit_all_rejected_is_noop() -> Result<()> {
     let (_tmp, graph, repo, mut _meta, _description) =
         writable_scenario("reword-three-commits", |_| {})?;
     let two_id = repo.rev_parse_single("two")?.detach();
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
 
     let outcome = commit_create(
         editor,

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_rebase::graph_rebase::{
-    GraphExt as _,
+    Editor,
     mutate::{InsertSide, RelativeToRef},
 };
 use but_testsupport::visualize_commit_graph_all;
@@ -21,7 +21,8 @@ fn insert_below_commit() -> Result<()> {
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("two")?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     insert_blank_commit(
         editor,
         InsertSide::Below,
@@ -57,7 +58,8 @@ fn insert_above_commit() -> Result<()> {
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("two")?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     insert_blank_commit(
         editor,
         InsertSide::Above,
@@ -91,7 +93,8 @@ fn insert_below_reference() -> Result<()> {
     let head_tree = repo.head_tree_id()?;
     let reference = repo.find_reference("two")?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     insert_blank_commit(
         editor,
         InsertSide::Below,
@@ -125,7 +128,8 @@ fn insert_above_reference() -> Result<()> {
     let head_tree = repo.head_tree_id()?;
     let reference = repo.find_reference("two")?;
 
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     insert_blank_commit(
         editor,
         InsertSide::Above,

--- a/crates/but-workspace/tests/workspace/commit/move_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_changes.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_core::DiffSpec;
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_testsupport::visualize_commit_graph_all;
 use but_workspace::commit::move_changes_between_commits;
 use gix::prelude::ObjectIdExt;
@@ -30,7 +30,8 @@ fn move_changes_same_commit_is_noop() -> Result<()> {
     ");
 
     let commit_id = repo.rev_parse_single("three")?.detach();
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
 
     // Moving changes from a commit to itself should be a no-op
     let outcome =
@@ -79,7 +80,8 @@ fn move_file_from_head_to_parent() -> Result<()> {
     "#);
 
     // Move three.txt from commit three to commit two
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = move_changes_between_commits(
         editor,
         three_id,
@@ -144,7 +146,8 @@ fn move_file_from_parent_to_head() -> Result<()> {
     let two_id = repo.rev_parse_single("two")?.detach();
 
     // Move two.txt from commit two up to commit three
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = move_changes_between_commits(
         editor,
         two_id,
@@ -207,7 +210,8 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
     let one_id = repo.rev_parse_single("one")?.detach();
 
     // Move three.txt from commit three to commit one (skipping two)
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = move_changes_between_commits(
         editor,
         three_id,
@@ -277,7 +281,8 @@ fn error_when_changes_not_found_in_source() -> Result<()> {
     let two_id = repo.rev_parse_single("two")?.detach();
 
     // Try to move a file that doesn't exist in source commit
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let result = move_changes_between_commits(
         editor,
         three_id,

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1,4 +1,4 @@
-use but_rebase::graph_rebase::{GraphExt, mutate::InsertSide};
+use but_rebase::graph_rebase::{Editor, mutate::InsertSide};
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 
 use crate::ref_info::with_workspace_commit::utils::{
@@ -7,7 +7,7 @@ use crate::ref_info::with_workspace_commit::utils::{
 
 #[test]
 fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -38,7 +38,7 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_commit = repo.rev_parse_single("B")?.detach();
@@ -48,7 +48,6 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     // Put C commit at the top of A
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         c_commit_selector,
         a_commit_selector,
         InsertSide::Above,
@@ -101,7 +100,7 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
 
 #[test]
 fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -132,7 +131,7 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_commit = repo.rev_parse_single("B")?.detach();
@@ -142,7 +141,6 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     // Put B commit at the top of A
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         b_commit_selector,
         a_commit_selector,
         InsertSide::Above,
@@ -197,7 +195,7 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
 
 #[test]
 fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -228,7 +226,7 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_commit = repo.rev_parse_single("B")?.detach();
@@ -238,7 +236,6 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     // Put C commit below the A commit
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         c_commit_selector,
         a_commit_selector,
         InsertSide::Below,
@@ -291,7 +288,7 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
 
 #[test]
 fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -322,7 +319,7 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_commit = repo.rev_parse_single("B")?.detach();
@@ -332,7 +329,6 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     // Put B commit below the A commit
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         b_commit_selector,
         a_commit_selector,
         InsertSide::Below,
@@ -387,7 +383,7 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
 
 #[test]
 fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -418,7 +414,7 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let c_commit = repo.rev_parse_single("C")?.detach();
@@ -427,7 +423,6 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     // Put A commit at the top of the branch C
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         a_commit_selector,
         c_commit_selector,
         InsertSide::Above,
@@ -474,7 +469,7 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
 
 #[test]
 fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(
             "ws-ref-ws-commit-single-stack-double-stack",
             |meta| {
@@ -505,7 +500,7 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_commit = repo.rev_parse_single("B")?.detach();
@@ -515,7 +510,6 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     // Put A commit below the B commit
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         a_commit_selector,
         b_commit_selector,
         InsertSide::Below,
@@ -570,7 +564,7 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
 
 #[test]
 fn move_commit_to_empty_branch() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph("ws-with-empty-stack", |meta| {
             add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
             add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["B"]);
@@ -593,7 +587,7 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
             └── ·09d8e52 (🏘️)
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let a_commit_selector = editor.select_commit(a_commit)?;
     let b_ref_name = "refs/heads/B".try_into()?;
@@ -602,7 +596,6 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
     // Put A commit in branch B
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         a_commit_selector,
         b_ref_selector,
         InsertSide::Below,
@@ -641,7 +634,7 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
 
 #[test]
 fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph("reword-three-commits", |_| {})?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -662,7 +655,7 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
             └── ❄8b426d0
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let three_commit = repo.rev_parse_single("three")?.detach();
     let three_commit_selector = editor.select_commit(three_commit)?;
     let two_ref_name = "refs/heads/two".try_into()?;
@@ -671,7 +664,6 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     // Put commit three at the top of branch two
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         three_commit_selector,
         two_ref_selector,
         InsertSide::Below,
@@ -715,7 +707,7 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
 
 #[test]
 fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, meta, _description) =
+    let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph("reword-three-commits", |_| {})?;
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
@@ -736,7 +728,7 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
             └── ❄8b426d0
     ");
 
-    let editor = ws.graph.to_editor(&repo)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let three_commit = repo.rev_parse_single("three")?.detach();
     let three_commit_selector = editor.select_commit(three_commit)?;
     let two_commit = repo.rev_parse_single("two")?.detach();
@@ -745,7 +737,6 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     // Put commit three below commit two
     let rebase = but_workspace::commit::move_commit(
         editor,
-        &ws,
         three_commit_selector,
         two_commit_selector,
         InsertSide::Below,

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use but_rebase::graph_rebase::GraphExt;
+use but_rebase::graph_rebase::Editor;
 use but_testsupport::visualize_commit_graph_all;
 use but_workspace::commit::reword;
 
@@ -17,7 +17,8 @@ fn reword_head_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("three")?;
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
         .materialize()?;
@@ -45,7 +46,8 @@ fn reword_middle_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("two")?;
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
         .materialize()?;
@@ -75,7 +77,8 @@ fn reword_base_commit() -> Result<()> {
 
     let head_tree = repo.head_tree_id()?;
     let id = repo.rev_parse_single("one")?;
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
         .materialize()?;

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_core::DiffSpec;
-use but_rebase::graph_rebase::{GraphExt, LookupStep};
+use but_rebase::graph_rebase::{Editor, LookupStep};
 use but_testsupport::{visualize_commit_graph_all, visualize_tree};
 use but_workspace::commit::uncommit_changes;
 use gix::prelude::ObjectIdExt;
@@ -37,7 +37,8 @@ fn uncommit_file_from_head() -> Result<()> {
     "#);
 
     // Uncommit three.txt from commit three
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, three_id, vec![diff_spec_for_file("three.txt")], 0)?;
 
     let materialized = outcome.rebase.materialize()?;
@@ -82,7 +83,8 @@ fn uncommit_file_from_parent() -> Result<()> {
     "#);
 
     // Uncommit two.txt from commit two
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, two_id, vec![diff_spec_for_file("two.txt")], 0)?;
 
     let materialized = outcome.rebase.materialize()?;
@@ -136,7 +138,8 @@ fn uncommit_file_from_root_commit() -> Result<()> {
     "#);
 
     // Uncommit one.txt from commit one (the root commit)
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, one_id, vec![diff_spec_for_file("one.txt")], 0)?;
 
     let materialized = outcome.rebase.materialize()?;
@@ -168,7 +171,8 @@ fn error_when_changes_not_found() -> Result<()> {
     let three_id = repo.rev_parse_single("three")?.detach();
 
     // Try to uncommit a file that doesn't exist in source commit
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let result = uncommit_changes(
         editor,
         three_id,
@@ -200,7 +204,8 @@ fn uncommit_empty_changes_is_noop() -> Result<()> {
     let three_id = repo.rev_parse_single("three")?.detach();
 
     // Uncommit with empty changes should effectively be a no-op rebase
-    let editor = graph.to_editor(&repo)?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, three_id, Vec::<DiffSpec>::new(), 0)?;
 
     outcome.rebase.materialize()?;

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -11,7 +11,7 @@ use but_ctx::{
     access::{RepoExclusive, RepoShared},
 };
 use but_oxidize::{ObjectIdExt as _, OidExt, gix_to_git2_index};
-use but_rebase::graph_rebase::{GraphExt as _, Step};
+use but_rebase::graph_rebase::{Editor, Step};
 use git2::build::CheckoutBuilder;
 use gitbutler_cherry_pick::{ConflictedTreeKey, GixRepositoryExt as _, RepositoryExt as _};
 use gitbutler_commit::commit_ext::{CommitExt, CommitMessageBstr as _};
@@ -299,14 +299,15 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
     let workspace_commit = repo
         .find_reference(WORKSPACE_BRANCH_REF)?
         .peel_to_commit()?;
-    let meta = ctx.meta()?;
-    let graph = but_graph::Graph::from_commit_traversal(
+    let mut meta = ctx.meta()?;
+    let mut workspace = but_graph::Graph::from_commit_traversal(
         workspace_commit.id(),
         Some(gix::refs::FullName::try_from(WORKSPACE_BRANCH_REF)?),
         &meta,
         but_graph::init::Options::limited(),
-    )?;
-    let mut editor = graph.to_editor(repo)?;
+    )?
+    .into_workspace()?;
+    let mut editor = Editor::create(&mut workspace, &mut meta, repo)?;
     let (target_selector, commit) = editor.find_selectable_commit(edit_mode_metadata.commit_oid)?;
 
     let extra_headers: Vec<(BString, BString)> = Headers::try_from_commit(&commit.inner)


### PR DESCRIPTION
In the long run, there should be no need to update metadata manually. The editor should be able to update any relevant metadata itself.

To start driving in this direction, the rebase engine now owns mutable references to both the Workspace and the RefMetadata.

The first practical benifit is that it allows us to remove the manual `ws.refresh_from_head` calls that we were making in favor of the `Editor` how handling that as part of it’s `materialize` call.