### PR TITLE
Improve keyboard focus/navigation for file list

### DIFF
--- a/apps/desktop/src/components/files/FileListItems.svelte
+++ b/apps/desktop/src/components/files/FileListItems.svelte
@@ -27,6 +27,7 @@
 	} from "$lib/selection/fileListController.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import { FOCUS_MANAGER } from "@gitbutler/ui/focus/focusManager";
 	import type { ConflictEntriesObj } from "$lib/files/conflicts";
 	import type { TreeChange } from "$lib/hunks/change";
 
@@ -66,6 +67,7 @@
 
 	const controller = getFileListContext();
 	const dependencyService = inject(DEPENDENCY_SERVICE);
+	const focusManager = inject(FOCUS_MANAGER);
 
 	/** Invert nick→paths map to path→nicks for per-file lookup. */
 	const ircWorkingUsersByPath = $derived.by(() => {
@@ -135,7 +137,25 @@
 						if (handler(change, idx, e)) return true;
 					}
 				}
-				// 3. Arrow/vim navigation — only claim the event if we moved
+				// 3. Arrow/vim navigation.
+				// In tree mode with shift held: use flat-array multi-select (handleNavigation)
+				// so shift+arrows extend the selection across files, skipping folders.
+				// In tree mode without shift: let FM navigate naturally through folder
+				// headers too — file selection happens via onActive below.
+				// In list mode: always intercept and drive selection ourselves.
+				if (mode === "tree") {
+					if (e.shiftKey) {
+						const navigatedIndex = controller.handleNavigation(e);
+						if (navigatedIndex !== undefined) {
+							const navigatedChange = controller.changes[navigatedIndex];
+							if (navigatedChange) {
+								onselect?.(navigatedChange, navigatedIndex);
+							}
+							return true;
+						}
+					}
+					return false;
+				}
 				const navigatedIndex = controller.handleNavigation(e);
 				if (navigatedIndex !== undefined && navigatedIndex !== idx) {
 					const navigatedChange = controller.changes[navigatedIndex];
@@ -145,6 +165,21 @@
 					return true;
 				}
 			},
+			// In tree mode, FM fires onActive when plain arrow keys land on a file
+			// item. We use this to drive single-file selection so folders are
+			// navigable. Shift+arrows are handled in onKeydown above instead.
+			// Guard: skip when controller.isKeyboardSelecting is true — that means
+			// shift-range-select called focusByElement to move the ring, and we
+			// must not overwrite the multi-select with a single-file set().
+			onActive:
+				mode === "tree"
+					? (active) => {
+							if (active && focusManager.isKeyboardNavigation && !controller.isKeyboardSelecting) {
+								controller.selectSingle(change, idx);
+								onselect?.(change, idx);
+							}
+						}
+					: undefined,
 			focusable: true,
 		}}
 		onclick={(e) => {
@@ -179,6 +214,7 @@
 				draggableFiles={draggable}
 				changes={controller.changes}
 				{fileTemplate}
+				active={controller.active}
 			/>
 		{:else}
 			<LazyList items={controller.changes} chunkSize={100}>

--- a/apps/desktop/src/lib/selection/fileListController.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileListController.svelte.ts
@@ -56,8 +56,19 @@ export class FileListController {
 	private getChanges: () => TreeChange[];
 	private getSelectionId: () => SelectionId;
 	private getAllowUnselect: () => boolean;
+	// Tracks whether the current selection change was explicitly triggered by a
+	// keyboard action handled by this controller (arrow nav or Enter/Space/l on
+	// a file item). Only when true should the focus ring be activated. This
+	// correctly excludes mouse clicks, folder clicks, and programmatic changes
+	// that should not show the ring.
+	private _selectionFromKeyboard = false;
 
 	active = $state(false);
+
+	/** True while handleNavigation/handleActivation is on the call stack. */
+	get isKeyboardSelecting(): boolean {
+		return this._selectionFromKeyboard;
+	}
 	readonly selectedPaths = $derived(new Set(this.selectedFileIds.map((f) => f.path)));
 	readonly hasSelectionInList = $derived(
 		this.changes.some((change) => this.selectedPaths.has(change.path)),
@@ -79,8 +90,19 @@ export class FileListController {
 			return store.subscribe((value) => {
 				if (value?.index !== undefined) {
 					untrack(() => {
-						if (this.active) {
-							this.focusManager.focusNthSibling(value.index);
+						// Skip selections that came from a mouse click: FM's own click
+						// handler already moved the cursor and the ring should stay hidden.
+						// For keyboard navigation (arrows, Enter/Space) we look up the
+						// selected file's DOM element by id (value.key == the element's DOM
+						// id set in FileListItem) and focus it directly. This avoids the
+						// flat-index → FM-children-index mismatch that caused infinite loops
+						// in tree mode when focusNthSibling accidentally landed on a folder.
+						if (this.active && this._selectionFromKeyboard) {
+							const el = document.getElementById(value.key);
+							if (el) {
+								this.focusManager.focusByElement(el);
+								this.focusManager.activateOutline();
+							}
 						}
 					});
 				}
@@ -125,29 +147,45 @@ export class FileListController {
 	handleActivation(change: TreeChange, idx: number, e: KeyboardEvent): boolean {
 		if (e.key === "Enter" || e.key === " " || e.key === "l") {
 			e.stopPropagation();
+			this._selectionFromKeyboard = true;
 			this.select(e, change, idx);
+			this._selectionFromKeyboard = false;
 			return true;
 		}
 		return false;
 	}
 
+	/**
+	 * Select a single file without modifying multi-select state. Used in tree
+	 * mode where FM handles folder navigation and calls `onActive` on the newly
+	 * focused file item — we just need to record the selection.
+	 */
+	selectSingle(change: TreeChange, index: number): void {
+		// Do NOT set _selectionFromKeyboard here: FM has already moved the cursor
+		// to this element and activated the outline via its own navigation path.
+		// Setting the flag would trigger focusByElement in the $effect, which would
+		// re-trigger onActive causing an infinite loop.
+		this.idSelection.set(change.path, this.selectionId, index);
+	}
+
 	/** Handles arrow/vim navigation. Returns the index of the newly focused item, or undefined. */
 	handleNavigation(e: KeyboardEvent): number | undefined {
-		if (
-			updateSelection({
-				allowMultiple: true,
-				ctrlKey: e.ctrlKey,
-				metaKey: e.metaKey,
-				shiftKey: e.shiftKey,
-				key: e.key,
-				targetElement: e.currentTarget as HTMLElement,
-				files: this.changes,
-				selectedFileIds: this.selectedFileIds,
-				fileIdSelection: this.idSelection,
-				selectionId: this.selectionId,
-				preventDefault: () => e.preventDefault(),
-			})
-		) {
+		this._selectionFromKeyboard = true;
+		const moved = updateSelection({
+			allowMultiple: true,
+			ctrlKey: e.ctrlKey,
+			metaKey: e.metaKey,
+			shiftKey: e.shiftKey,
+			key: e.key,
+			targetElement: e.currentTarget as HTMLElement,
+			files: this.changes,
+			selectedFileIds: this.selectedFileIds,
+			fileIdSelection: this.idSelection,
+			selectionId: this.selectionId,
+			preventDefault: () => e.preventDefault(),
+		});
+		this._selectionFromKeyboard = false;
+		if (moved) {
 			const lastAdded = get(this.idSelection.getById(this.selectionId).lastAdded);
 			return lastAdded?.index;
 		}

--- a/packages/ui/src/lib/components/file/FileListItem.svelte
+++ b/packages/ui/src/lib/components/file/FileListItem.svelte
@@ -98,6 +98,7 @@
 
 <div
 	bind:this={ref}
+	{id}
 	data-locked={locked}
 	data-file-id={id}
 	class="file-list-item"

--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -56,6 +56,15 @@ export class FocusManager {
 	// ============================================
 
 	// Handles keyboard navigation with arrow keys, Tab, and custom handlers
+	// True while processKeyboardEvent is on the call stack. Readable by focusable
+	// onActive callbacks to distinguish keyboard-initiated focus changes from
+	// mouse-initiated ones (handleClick does not set this flag).
+	private _inKeyboardNav = false;
+
+	get isKeyboardNavigation(): boolean {
+		return this._inKeyboardNav;
+	}
+
 	private handleKeydown(event: KeyboardEvent) {
 		if (this.processKeyboardEvent(event)) {
 			event.stopPropagation();
@@ -64,24 +73,29 @@ export class FocusManager {
 	}
 
 	private processKeyboardEvent(event: KeyboardEvent): boolean {
-		// Allow Tab and Escape through even in input elements for focus trap handling
-		const isTabOrEscape = event.key === "Tab" || event.key === "Escape";
-		if (!isTabOrEscape && this.shouldSkipEvent(event)) return false;
+		this._inKeyboardNav = true;
+		try {
+			// Allow Tab and Escape through even in input elements for focus trap handling
+			const isTabOrEscape = event.key === "Tab" || event.key === "Escape";
+			if (!isTabOrEscape && this.shouldSkipEvent(event)) return false;
 
-		if (this.handleFModeInput(event)) return true;
-		if (this.handleHotkeyPress(event)) return true;
+			if (this.handleFModeInput(event)) return true;
+			if (this.handleHotkeyPress(event)) return true;
 
-		const node = this.updateCurrentNode(event);
-		if (!node) return false;
+			const node = this.updateCurrentNode(event);
+			if (!node) return false;
 
-		const context = this.buildNavigationContext(event, node);
+			const context = this.buildNavigationContext(event, node);
 
-		if (this.handleTabKey(context, event)) return true;
-		if (this.handleEscapeKey(event)) return true;
-		if (this.hasSelection()) return false;
-		if (this.handleActions(event)) return true;
+			if (this.handleTabKey(context, event)) return true;
+			if (this.handleEscapeKey(event)) return true;
+			if (this.hasSelection()) return false;
+			if (this.handleActions(event)) return true;
 
-		return this.handleNavigation(event, context);
+			return this.handleNavigation(event, context);
+		} finally {
+			this._inKeyboardNav = false;
+		}
 	}
 
 	// Handles mouse clicks to update focus, traversing up to find focusables
@@ -280,6 +294,21 @@ export class FocusManager {
 		const navigableChildren = this.getNavigableChildNodes(this.currentNode.parent);
 		const child = navigableChildren.at(n);
 		return this.setActiveNode(child);
+	}
+
+	/** Show the keyboard focus ring on the current cursor element. */
+	activateOutline(): void {
+		this.setOutline(true);
+	}
+
+	/**
+	 * Move FM focus directly to a known DOM element (bypasses index arithmetic).
+	 * Safe to call from outside because it looks up the FM node by element reference,
+	 * so it cannot accidentally land on a folder header.
+	 */
+	focusByElement(element: HTMLElement): boolean {
+		const node = this.nodeMap.get(element);
+		return this.setActiveNode(node);
 	}
 
 	updateElementOptions(element: HTMLElement, updates: Partial<FocusableOptions>): boolean {


### PR DESCRIPTION


https://github.com/user-attachments/assets/dd94a5eb-2e00-4e9d-9050-2b3a24ba2250



Integrate FocusManager with the file list selection to fix navigation/focus loops and properly show the keyboard focus ring.

Key changes:
- FileListItems: inject FOCUS_MANAGER, handle tree/list modes differently for arrow/Shift+arrow navigation, handle onActive to drive single-file selection when FM moves to a file, and pass active state to LazyList.
- FileListController: track _selectionFromKeyboard and expose isKeyboardSelecting; ensure keyboard-initiated selections focus the correct DOM element via focusByElement and activate the outline; add selectSingle for FM-driven single selection; set/reset the keyboard flag around navigation and activation to avoid focus loops.
- FileListItem: bind the element id so controller can look up the DOM element by id.
- FocusManager: expose isKeyboardNavigation, track when processing keyboard events, add focusByElement and activateOutline helpers, and ensure _inKeyboardNav is cleared after processing.

These changes allow folder headers to remain navigable in tree mode while enabling accurate file selection and outline activation for keyboard interactions, preventing infinite loops and mismatched focus indices.