### PR TITLE
Replace rejected changes tuple with typed UIRejectedChange struct

### DIFF
--- a/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
+++ b/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
@@ -26,6 +26,8 @@
 				return "No effective changes";
 			case "workspaceMergeConflict":
 				return "Workspace merge conflict";
+			case "workspaceMergeConflictOfUnrelatedFile":
+				return "Workspace merge conflict of unrelated file";
 			case "worktreeFileMissingForObjectConversion":
 				return "Worktree file missing for object conversion";
 			case "fileToLargeOrBinary":

--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -146,9 +146,9 @@
 				idSelection.clear(createWorktreeSelection({ stackId }));
 			}
 
-			if (response.pathsToRejectedChanges.length > 0) {
-				const pathsToRejectedChanges = response.pathsToRejectedChanges.reduce(
-					(acc: Record<string, RejectionReason>, [reason, path]) => {
+			if (response.rejectedChanges.length > 0) {
+				const pathsToRejectedChanges = response.rejectedChanges.reduce(
+					(acc: Record<string, RejectionReason>, { reason, path }) => {
 						acc[path] = reason;
 						return acc;
 					},

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -68,9 +68,9 @@ export default class StackMacros {
 			worktreeChanges,
 		});
 
-		if (outcome.pathsToRejectedChanges.length > 0) {
-			const pathsToRejectedChanges = outcome.pathsToRejectedChanges.reduce(
-				(acc: Record<string, RejectionReason>, [reason, path]) => {
+		if (outcome.rejectedChanges.length > 0) {
+			const pathsToRejectedChanges = outcome.rejectedChanges.reduce(
+				(acc: Record<string, RejectionReason>, { reason, path }) => {
 					acc[path] = reason;
 					return acc;
 				},

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -69,6 +69,7 @@ export interface BranchPushResult {
  */
 export const REJECTTION_REASONS = [
 	"workspaceMergeConflict",
+	"workspaceMergeConflictOfUnrelatedFile",
 	"cherryPickMergeConflict",
 	"noEffectiveChanges",
 	"worktreeFileMissingForObjectConversion",
@@ -81,15 +82,20 @@ export const REJECTTION_REASONS = [
 
 type ReplacedCommit = [string, string];
 
+type BackendRejectedChange = {
+	reason: RejectionReason;
+	path: string;
+};
+
 type BackendCreateCommitOutcome = {
 	newCommit?: string | null;
-	pathsToRejectedChanges: [RejectionReason, string][];
+	rejectedChanges: BackendRejectedChange[];
 	replacedCommits: Record<string, string>;
 };
 
 export type CreateCommitOutcome = {
 	newCommit: string | null;
-	pathsToRejectedChanges: [RejectionReason, string][];
+	rejectedChanges: BackendRejectedChange[];
 	commitMapping: ReplacedCommit[];
 };
 
@@ -122,7 +128,7 @@ export function normalizeCreateCommitOutcome(
 ): CreateCommitOutcome {
 	return {
 		newCommit: response.newCommit ?? null,
-		pathsToRejectedChanges: response.pathsToRejectedChanges,
+		rejectedChanges: response.rejectedChanges,
 		commitMapping: Object.entries(response.replacedCommits),
 	};
 }
@@ -525,8 +531,8 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 					return normalizedResponse.newCommit;
 				}
 
-				const rejected = normalizedResponse.pathsToRejectedChanges
-					.map(([reason, path]) => `${reason}: ${path}`)
+				const rejected = normalizedResponse.rejectedChanges
+					.map(({ reason, path }) => `${reason}: ${path}`)
 					.join(", ");
 				const details = rejected ? ` Rejected changes: ${rejected}` : "";
 				throw new Error(`Failed to amend commit: no commit was created.${details}`);

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -24,6 +24,7 @@ export type GeneralSettingsPageId =
 export type ProjectSettingsPageId = "project" | "git" | "ai" | "agent" | "experimental";
 export type RejectionReason =
 	| "workspaceMergeConflict"
+	| "workspaceMergeConflictOfUnrelatedFile"
 	| "cherryPickMergeConflict"
 	| "noEffectiveChanges"
 	| "worktreeFileMissingForObjectConversion"

--- a/apps/lite/ui/src/Operation.ts
+++ b/apps/lite/ui/src/Operation.ts
@@ -2,7 +2,7 @@ import { Toast } from "@base-ui/react";
 import { useMutation } from "@tanstack/react-query";
 import { Match } from "effect";
 import { CommitMoveParams, MoveBranchParams, TearOffBranchParams } from "#electron/ipc.ts";
-import { RejectedChange, rejectedChangesToastOptions } from "#ui/components/RejectedChanges.tsx";
+import { rejectedChangesToastOptions } from "#ui/components/RejectedChanges.tsx";
 import {
 	commitMoveMutationOptions,
 	moveBranchMutationOptions,
@@ -45,13 +45,12 @@ export const useRunOperation = (projectId: string) => {
 					},
 					{
 						onSuccess: (response) => {
-							const pathsToRejectedChanges = response.pathsToRejectedChanges ?? [];
-							if (pathsToRejectedChanges.length > 0)
+							const rejectedChanges = response.rejectedChanges ?? [];
+							if (rejectedChanges.length > 0)
 								toastManager.add(
 									rejectedChangesToastOptions({
 										newCommit: response.newCommit,
-										pathsToRejectedChanges:
-											response.pathsToRejectedChanges as Array<RejectedChange>,
+										rejectedChanges,
 									}),
 								);
 							return;

--- a/apps/lite/ui/src/api/rub.ts
+++ b/apps/lite/ui/src/api/rub.ts
@@ -33,7 +33,7 @@ export type RubResult = {
 	replacedCommits?: Record<string, string>;
 	newCommit?: string | null;
 	amendedCommitId?: string;
-	pathsToRejectedChanges?: UICommitCreateResult["pathsToRejectedChanges"];
+	rejectedChanges?: UICommitCreateResult["rejectedChanges"];
 };
 
 // In the future this may be implemented as a single API endpoint on the backend.
@@ -66,7 +66,7 @@ export const rub = async ({ projectId, source, target }: RubParams): Promise<Rub
 								replacedCommits: response.replacedCommits,
 								newCommit: response.newCommit ?? null,
 								amendedCommitId: target.commitId,
-								pathsToRejectedChanges: response.pathsToRejectedChanges,
+								rejectedChanges: response.rejectedChanges,
 							};
 						}),
 						Match.exhaustive,

--- a/apps/lite/ui/src/components/RejectedChanges.tsx
+++ b/apps/lite/ui/src/components/RejectedChanges.tsx
@@ -1,22 +1,7 @@
+import type { RejectionReason, UIRejectedChange } from "@gitbutler/but-sdk";
 import { type ToastManagerAddOptions } from "@base-ui/react";
 import { Array, pipe } from "effect";
 import { FC } from "react";
-
-// TODO: generate into but-sdk
-export type RejectedChange = [RejectionReason, string];
-
-// TODO: generate into but-sdk
-export type RejectionReason =
-	| "noEffectiveChanges"
-	| "cherryPickMergeConflict"
-	| "workspaceMergeConflict"
-	| "workspaceMergeConflictOfUnrelatedFile"
-	| "worktreeFileMissingForObjectConversion"
-	| "fileToLargeOrBinary"
-	| "pathNotFoundInBaseTree"
-	| "unsupportedDirectoryEntry"
-	| "unsupportedTreeEntry"
-	| "missingDiffSpecAssociation";
 
 const listFormatter = new Intl.ListFormat(undefined, {
 	style: "long",
@@ -56,11 +41,11 @@ const readableRejectionReason = (reason: RejectionReason): string => {
 };
 
 const RejectedChanges: FC<{
-	rejectedChanges: Array<RejectedChange>;
+	rejectedChanges: Array<UIRejectedChange>;
 }> = ({ rejectedChanges }) => {
 	const pathsByReason = new Map<RejectionReason, Array<string>>();
 
-	for (const [reason, path] of rejectedChanges) {
+	for (const { reason, path } of rejectedChanges) {
 		const paths = pathsByReason.get(reason);
 		if (paths) paths.push(path);
 		else pathsByReason.set(reason, [path]);
@@ -83,12 +68,12 @@ const RejectedChanges: FC<{
 
 export const rejectedChangesToastOptions = ({
 	newCommit,
-	pathsToRejectedChanges,
+	rejectedChanges,
 }: {
 	newCommit?: string | null;
-	pathsToRejectedChanges: Array<RejectedChange>;
+	rejectedChanges: Array<UIRejectedChange>;
 }): ToastManagerAddOptions<never> => ({
 	title: newCommit != null ? "Some changes were not committed" : "Failed to create commit",
-	description: <RejectedChanges rejectedChanges={pathsToRejectedChanges} />,
+	description: <RejectedChanges rejectedChanges={rejectedChanges} />,
 	priority: "high",
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
@@ -14,7 +14,7 @@ import {
 import { type RubSource } from "#ui/api/rub.ts";
 import { classes } from "#ui/classes.ts";
 import { DependencyIcon, ExpandCollapseIcon, MenuTriggerIcon } from "#ui/components/icons.tsx";
-import { RejectedChange, rejectedChangesToastOptions } from "#ui/components/RejectedChanges.tsx";
+import { rejectedChangesToastOptions } from "#ui/components/RejectedChanges.tsx";
 import { type ChangeUnit } from "#ui/domain/ChangeUnit.ts";
 import { createDiffSpec } from "#ui/domain/DiffSpec.ts";
 import {
@@ -1350,13 +1350,11 @@ const CommitForm: FC<{
 					},
 					{
 						onSuccess: (response) => {
-							if (response.pathsToRejectedChanges.length > 0)
+							if (response.rejectedChanges.length > 0)
 								toastManager.add(
 									rejectedChangesToastOptions({
 										newCommit: response.newCommit,
-										// Assertion is temporary until API response types have been fixed.
-										pathsToRejectedChanges:
-											response.pathsToRejectedChanges as Array<RejectedChange>,
+										rejectedChanges: response.rejectedChanges,
 									}),
 								);
 

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -37,6 +37,21 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
     }
 }
 
+/// A change that was rejected during commit creation, with the reason for rejection.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct UIRejectedChange {
+    /// The reason the change was rejected.
+    pub reason: but_core::tree::create_tree::RejectionReason,
+    /// The file path of the rejected change.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub path: but_serde::BStringForFrontend,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(UIRejectedChange);
+
 /// UI type for creating a commit in the rebase graph.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -45,12 +60,8 @@ pub struct UICommitCreateResult {
     /// The new commit if one was created.
     #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub new_commit: Option<HexHash>,
-    /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<(String, String)>"))]
-    pub paths_to_rejected_changes: Vec<(
-        but_core::tree::create_tree::RejectionReason,
-        but_serde::BStringForFrontend,
-    )>,
+    /// Changes that were rejected during commit creation.
+    pub rejected_changes: Vec<UIRejectedChange>,
     /// Commits that have been replaced as a side-effect of the create/amend.
     /// Maps `oldId -> newId`.
     #[cfg_attr(
@@ -73,9 +84,12 @@ impl From<CommitCreateResult> for UICommitCreateResult {
 
         Self {
             new_commit: new_commit.map(Into::into),
-            paths_to_rejected_changes: rejected_specs
+            rejected_changes: rejected_specs
                 .into_iter()
-                .map(|(reason, diff)| (reason, diff.path.into()))
+                .map(|(reason, diff)| UIRejectedChange {
+                    reason,
+                    path: diff.path.into(),
+                })
                 .collect(),
             replaced_commits: replaced_commits
                 .into_iter()

--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -11,6 +11,7 @@ pub mod create_tree {
 
     /// Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit.
     #[derive(Default, Debug, Copy, Clone, PartialEq, serde::Serialize)]
+    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
     pub enum RejectionReason {
         /// All changes were applied, but they didn't end up effectively change the tree to something differing from the target tree.
@@ -46,6 +47,9 @@ pub mod create_tree {
         /// However, at least one hunk was not fully contained.
         MissingDiffSpecAssociation,
     }
+
+    #[cfg(feature = "export-schema")]
+    but_schemars::register_sdk_type!(RejectionReason);
 }
 use create_tree::RejectionReason;
 

--- a/crates/but-workspace/src/commit_engine/ui.rs
+++ b/crates/but-workspace/src/commit_engine/ui.rs
@@ -5,12 +5,22 @@ use serde::Serialize;
 
 use crate::commit_engine::RejectionReason;
 
+/// A rejected change with its reason and path.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RejectedChange {
+    /// The reason for the rejection.
+    pub reason: RejectionReason,
+    /// The path of the rejected change.
+    pub path: BStringForFrontend,
+}
+
 /// The JSON serializable type of [super::CreateCommitOutcome].
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCommitOutcome {
-    /// Paths that contained at least one rejected hunk, for instance, a change that didn't apply, along with the reason for the rejection.
-    pub paths_to_rejected_changes: Vec<(RejectionReason, BStringForFrontend)>,
+    /// Changes that were rejected, for instance because a hunk didn't apply, along with the reason for the rejection.
+    pub rejected_changes: Vec<RejectedChange>,
     /// The newly created commit, if there was one. It maybe that a couple of paths were rejected, but the commit was created anyway.
     #[serde(with = "but_serde::object_id_opt")]
     pub new_commit: Option<gix::ObjectId>,
@@ -39,9 +49,12 @@ impl From<super::CreateCommitOutcome> for CreateCommitOutcome {
             Vec::new()
         };
         CreateCommitOutcome {
-            paths_to_rejected_changes: rejected_specs
+            rejected_changes: rejected_specs
                 .into_iter()
-                .map(|(reason, spec)| (reason, spec.path.into()))
+                .map(|(reason, spec)| RejectedChange {
+                    reason,
+                    path: spec.path.into(),
+                })
                 .collect(),
             new_commit,
             commit_mapping,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -737,6 +737,9 @@ export type RefInfo = {
   isEntrypoint: boolean;
 };
 
+/** Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit. */
+export type RejectionReason = "noEffectiveChanges" | "cherryPickMergeConflict" | "workspaceMergeConflict" | "workspaceMergeConflictOfUnrelatedFile" | "worktreeFileMissingForObjectConversion" | "fileToLargeOrBinary" | "pathNotFoundInBaseTree" | "unsupportedDirectoryEntry" | "unsupportedTreeEntry" | "missingDiffSpecAssociation";
+
 /**
  * Specifies a location, usually used to either have something inserted
  * relative to it, or for the selected object to actually be replaced.
@@ -942,8 +945,8 @@ export type TreeStatus = {
 export type UICommitCreateResult = {
   /** The new commit if one was created. */
   newCommit?: string | null;
-  /** Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics. */
-  pathsToRejectedChanges: Array<[string, string]>;
+  /** Changes that were rejected during commit creation. */
+  rejectedChanges: Array<UIRejectedChange>;
   /**
    * Commits that have been replaced as a side-effect of the create/amend.
    * Maps `oldId -> newId`.
@@ -998,6 +1001,14 @@ export type UIMoveChangesResult = {
    * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
+};
+
+/** A change that was rejected during commit creation, with the reason for rejection. */
+export type UIRejectedChange = {
+  /** The reason the change was rejected. */
+  reason: RejectionReason;
+  /** The file path of the rejected change. */
+  path: string;
 };
 
 /**


### PR DESCRIPTION
- Replaces the `Vec<(RejectionReason, BStringForFrontend)>` tuple in `UICommitCreateResult` with a proper `UIRejectedChange` struct containing `reason` and `path` fields
- Adds `RejectionReason` as a generated SDK type (proper string union instead of `string`)
- Renames field from `pathsToRejectedChanges` to `rejectedChanges`
- Updates desktop and lite frontends to use the new object shape
- Lite app now imports `UIRejectedChange` and `RejectionReason` from `@gitbutler/but-sdk` instead of defining them manually (resolves TODO comments)