### PR TITLE
feat(but-core): add programmatic signing control to commit creation

### DIFF
--- a/crates/but-core/src/commit.rs
+++ b/crates/but-core/src/commit.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow, collections::HashSet, io::Write, path::Path, path::PathBuf, process::Stdio,
 };
 
-use anyhow::{Context as _, anyhow, bail};
+use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice};
 use but_error::Code;
 use gix::objs::WriteTo;
@@ -148,6 +148,33 @@ impl From<&Headers> for Vec<(BString, BString)> {
     }
 }
 
+/// Determines how to sign the commit.
+#[derive(Default, PartialEq, Copy, Clone, Debug)]
+pub enum SignCommit {
+    /// Unconditionally sign the commit. Note that this places responsibility on the caller to
+    /// ensure that commit signing is configured, or at least handling that it was not.
+    Yes,
+    /// Do not sign the commit.
+    No,
+    /// Sign the commit only if `gitbutler.signCommits=true`, *or* `gitbutler.signCommits` is unset
+    /// but `commit.gpgSign=true`. In other words, `gitbutler.signCommits` takes precedence over
+    /// `commit.gpgSign`, the latter only being checked if the former is not at all configured.
+    ///
+    /// If signing fails, `gitbutler.signCommits` is set to `false` locally, preventing further
+    /// signing when this variant is supplied. This step is however skipped if
+    /// `gitbutler.signCommits` has been explicitly configured in non-local Git Config.
+    ///
+    /// The need for `gitbutler.signCommits` stems from the fact that it can be difficult to
+    /// impossible to validate before hand that signing is properly configured. Signing may also
+    /// break after validation has been performed. If signing is enabled for *all* committing but
+    /// fails, GitButler basically can't do anything, so we flip `gitbutler.signCommits=false` as a
+    /// kill switch to disable signing for GitButler. `gitbutler.signCommits` taking precedence
+    /// over `commit.gpgSign` means we can honor Git's signing settings by default, but disable it
+    /// in the event that we fail to sign without affecting Git.
+    #[default]
+    IfSignCommitsEnabled,
+}
+
 /// Write `commit` into `repo`, removing any existing commit signature first, optionally creating a
 /// new one based on repository configuration, and optionally updating `update_ref` to the new ID.
 ///
@@ -156,7 +183,7 @@ pub fn create(
     repo: &gix::Repository,
     mut commit: gix::objs::Commit,
     update_ref: Option<&gix::refs::FullNameRef>,
-    sign_if_configured: bool,
+    sign_commit: SignCommit,
 ) -> anyhow::Result<gix::ObjectId> {
     if let Some(pos) = commit
         .extra_headers()
@@ -165,7 +192,10 @@ pub fn create(
         commit.extra_headers.remove(pos);
     }
 
-    if sign_if_configured && repo.git_settings()?.gitbutler_sign_commits.unwrap_or(false) {
+    if (sign_commit == SignCommit::IfSignCommitsEnabled
+        && repo.git_settings()?.gitbutler_sign_commits.unwrap_or(false))
+        || sign_commit == SignCommit::Yes
+    {
         let mut buf = Vec::new();
         commit.write_to(&mut buf)?;
         match sign_buffer(repo, &buf) {
@@ -175,26 +205,28 @@ pub fn create(
                     .push((gix::objs::commit::SIGNATURE_FIELD_NAME.into(), signature));
             }
             Err(err) => {
-                if repo
-                    .config_snapshot()
-                    .boolean_filter("gitbutler.signCommits", |md| {
-                        md.source != gix::config::Source::Local
-                    })
-                    .is_none()
-                {
-                    repo.set_git_settings(&GitConfigSettings {
-                        gitbutler_sign_commits: Some(false),
-                        ..GitConfigSettings::default()
-                    })?;
-                    return Err(
-                        anyhow!("Failed to sign commit: {err}").context(Code::CommitSigningFailed)
-                    );
-                } else {
-                    tracing::warn!(
-                        "Commit signing failed but remains enabled as gitbutler.signCommits is explicitly enabled globally"
-                    );
-                    return Err(err);
+                tracing::warn!("Commit signing failed with sign_commit={sign_commit:?}");
+                if sign_commit == SignCommit::IfSignCommitsEnabled {
+                    if repo
+                        .config_snapshot()
+                        .boolean_filter("gitbutler.signCommits", |md| {
+                            md.source != gix::config::Source::Local
+                        })
+                        .is_none()
+                    {
+                        repo.set_git_settings(&GitConfigSettings {
+                            gitbutler_sign_commits: Some(false),
+                            ..GitConfigSettings::default()
+                        })?;
+                    } else {
+                        tracing::warn!(
+                            "Commit signing failed but remains enabled as gitbutler.signCommits is explicitly enabled globally"
+                        );
+                    }
                 }
+                return Err(err
+                    .context("Failed to sign commit")
+                    .context(Code::CommitSigningFailed));
             }
         }
     }

--- a/crates/but-core/tests/core/commit.rs
+++ b/crates/but-core/tests/core/commit.rs
@@ -162,15 +162,21 @@ mod headers {
 mod create {
     use anyhow::Context as _;
     use bstr::ByteSlice;
-    use but_core::commit;
-    use but_testsupport::writable_scenario_with_ssh_key;
+    use but_core::commit::{self, SignCommit};
+    use but_error::Code;
+    use but_testsupport::{writable_scenario, writable_scenario_with_ssh_key};
     use gix::{objs::commit::SIGNATURE_FIELD_NAME, refs};
 
     #[test]
     fn signs_commits_when_enabled() -> anyhow::Result<()> {
         let (repo, _tmp) = writable_scenario_with_ssh_key("single-signed");
 
-        let oid = commit::create(&repo, commit_from_head(&repo, "signed again")?, None, true)?;
+        let oid = commit::create(
+            &repo,
+            commit_from_head(&repo, "signed again")?,
+            None,
+            SignCommit::IfSignCommitsEnabled,
+        )?;
         let commit = repo.find_commit(oid)?;
         let commit = commit.decode()?;
 
@@ -178,6 +184,82 @@ mod create {
             commit.extra_headers().find(SIGNATURE_FIELD_NAME).is_some(),
             "a new signature should be written, the new commit needs to be signed"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn sign_commit_yes_forcefully_signs_commit() -> anyhow::Result<()> {
+        let (mut repo, _tmp) = writable_scenario_with_ssh_key("single-signed");
+        repo.config_snapshot_mut()
+            .set_raw_value(&"gitbutler.signCommits", "false")?;
+        repo.config_snapshot_mut()
+            .set_raw_value(&"commit.gpgSign", "false")?;
+
+        let oid = commit::create(
+            &repo,
+            commit_from_head(&repo, "should sign")?,
+            None,
+            SignCommit::Yes,
+        )?;
+        let commit = repo.find_commit(oid)?;
+        let commit = commit.decode()?;
+
+        assert!(
+            commit.extra_headers().pgp_signature().is_some(),
+            "despite the settings saying everything is disabled, it still signs the commit"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn sign_commit_yes_without_signing_key_errors() -> anyhow::Result<()> {
+        let (mut repo, _tmp) = writable_scenario("single-unsigned");
+
+        let err = commit::create(
+            &repo,
+            commit_from_head(&repo, "should not sign")?,
+            None,
+            SignCommit::Yes,
+        )
+        .expect_err("commit creation should fail as there is no signing key configured");
+
+        let error_code: Option<&Code> = err.downcast_ref();
+        assert_eq!(error_code, Some(&Code::CommitSigningFailed));
+
+        repo.reload()?;
+        assert_eq!(
+            repo.config_snapshot().boolean("gitbutler.signCommits"),
+            None,
+            "we do not touch this setting in this mode"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn sign_commit_if_enabled_without_signing_key_errors_and_sets_config() -> anyhow::Result<()> {
+        let (mut repo, _tmp) = writable_scenario_with_ssh_key("single-signed");
+        repo.config_snapshot_mut()
+            .set_raw_value(&"user.signingKey", "BAD-key")?;
+
+        let err = commit::create(
+            &repo,
+            commit_from_head(&repo, "should not sign")?,
+            None,
+            SignCommit::IfSignCommitsEnabled,
+        )
+        .expect_err("commit creation should fail as there is no signing key configured");
+
+        let error_code: Option<&Code> = err.downcast_ref();
+        assert_eq!(error_code, Some(&Code::CommitSigningFailed));
+
+        repo.reload()?;
+        assert_eq!(
+            repo.config_snapshot().boolean("gitbutler.signCommits"),
+            Some(false),
+            "prevent future failures by disabling signing for gitbutler"
+        );
+
         Ok(())
     }
 
@@ -193,7 +275,12 @@ mod create {
             "the fixture starts with a signed commit"
         );
 
-        let oid = commit::create(&repo, commit_from_head(&repo, "unsigned")?, None, false)?;
+        let oid = commit::create(
+            &repo,
+            commit_from_head(&repo, "unsigned")?,
+            None,
+            SignCommit::No,
+        )?;
         let commit = repo.find_commit(oid)?;
         let commit = commit.decode()?;
 
@@ -214,7 +301,7 @@ mod create {
             &repo,
             commit_from_head(&repo, "updates ref")?,
             Some(update_ref.as_ref()),
-            false,
+            SignCommit::No,
         )?;
         let reference = repo.find_reference(update_ref.as_ref())?;
 
@@ -238,7 +325,7 @@ mod create {
             .extra_headers
             .push(("x-test-header".into(), "kept".into()));
 
-        let oid = commit::create(&repo, new_commit, None, false)?;
+        let oid = commit::create(&repo, new_commit, None, SignCommit::No)?;
         let commit = repo.find_commit(oid)?;
         let commit = commit.decode()?;
 

--- a/crates/but-core/tests/fixtures/scenario/single-unsigned.sh
+++ b/crates/but-core/tests/fixtures/scenario/single-unsigned.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base
+git add .
+git commit -m "base"

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, bail};
 use bstr::BStr;
-use but_core::RepositoryExt;
+use but_core::{RepositoryExt, commit::SignCommit};
 use gix::config::Source;
 
 /// What to do with the committer (actor) and the commit time when [creating a new commit](create()).
@@ -102,7 +102,16 @@ pub fn create(
     if settings.gitbutler_gerrit_mode.unwrap_or(false) {
         but_gerrit::set_trailers(&mut commit);
     }
-    but_core::commit::create(repo, commit, None, sign_if_configured)
+    but_core::commit::create(
+        repo,
+        commit,
+        None,
+        if sign_if_configured {
+            SignCommit::IfSignCommitsEnabled
+        } else {
+            SignCommit::No
+        },
+    )
 }
 
 /// Update the committer of `commit` to be the current one.

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -2,7 +2,10 @@ use std::str;
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use bstr::{BStr, BString};
-use but_core::{RepositoryExt as RepositoryExtGix, commit::Headers};
+use but_core::{
+    RepositoryExt as RepositoryExtGix,
+    commit::{Headers, SignCommit},
+};
 use but_error::Code;
 use but_oxidize::{
     ObjectIdExt as _, OidExt, git2_signature_to_gix_signature, gix_to_git2_signature,
@@ -64,7 +67,7 @@ fn commit_gix(
     tree: gix::ObjectId,
     parents: &[gix::ObjectId],
     commit_headers: Option<Headers>,
-    sign_if_configured: bool,
+    sign_commit: SignCommit,
 ) -> Result<gix::ObjectId> {
     let mut commit = gix::objs::Commit {
         message: message.into(),
@@ -87,7 +90,7 @@ fn commit_gix(
         repo,
         commit,
         update_ref.as_ref().map(|name| name.as_ref()),
-        sign_if_configured,
+        sign_commit,
     )
 }
 
@@ -112,7 +115,7 @@ pub fn commit_with_signature_gix(
         tree,
         parents,
         commit_headers,
-        true,
+        SignCommit::IfSignCommitsEnabled,
     )
 }
 
@@ -137,7 +140,7 @@ pub fn commit_without_signature_gix(
         tree,
         parents,
         commit_headers,
-        false,
+        SignCommit::No,
     )
 }
 


### PR DESCRIPTION
This PR introduces programmatic overrides to signing behavior for the core commit flow. This will later be used to allow the graph rebase engine to decide when to sign programmatically  to be able to implement sign-on-push where we never sign for "local" operations.

`but-rebase` changes coming up in a separate PR.

<details>
<summary>Old description kept for historical reasons</summary>
This is big, but I couldn't find any super reasonable way to cut it down any more than I've done with this stack. It turns out that overhauling how we sign commits touches a lot of things :)

This PR puts down the groundwork for enabling sign-on-push functionality. Importantly, it contributes but-workspace abstractions to list unsigned commits and forcibly sign commits, as well as the underlying graph rebase engine work to actually accomplish the signing.

Note that there is still full backwards compatibility with the current sign-all-the-flippin-time functionality, and this PR alone should result in zero changes to end users as the new functionality isn't used anywhere.

See the tests in `crates/but-workspace/tests/workspace/commit/commits_list_unsigned.rs` and `crates/but-workspace/tests/workspace/commit/commits_sign.rs` for details about the new behavior.

Integration into the `but` CLI is done in a separate PR. I feel that the UX there still needs some polish, but I really need to land this PR as I've now had to fix two sets of merge conflicts just today :s

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13046 
- <kbd>&nbsp;1&nbsp;</kbd> #12999 👈 
<!-- GitButler Footer Boundary Bottom -->

</details>