### PR TITLE
Add `but branch move --unstack <branch>` flag

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -86,9 +86,7 @@ This moves the frontend branch on top of the backend branch in one step.
 **To unstack** (make a stacked branch independent again):
 
 ```bash
-but branch new temp-unstack              # create an empty dummy branch
-but branch move feature/logging temp-unstack   # move the branch to the dummy
-but branch delete temp-unstack           # delete the dummy, leaving branch independent
+but branch move --unstack feature/logging
 ```
 
 **Note:** `but branch move` uses branch **names** (like `feature/frontend`), while `but move` uses commit **IDs** (like `c3`). Do not confuse them. Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -135,7 +135,13 @@ Move an existing branch on top of another branch, stacking them.
 but branch move feature/frontend feature/backend    # Stack frontend on top of backend
 ```
 
-**This is the primary command for stacking existing branches.** Use it when two branches already exist and one needs to depend on the other. Uses full branch **names**, not CLI IDs.
+To unstack (tear off) a branch, use:
+
+```bash
+but branch move --unstack feature/frontend
+```
+
+**This is the primary command for stacking/unstacking existing branches.** Uses full branch **names**, not CLI IDs.
 
 Alias: `but stack <branch> <target-branch>`
 

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -133,6 +133,12 @@ pub enum Subcommands {
         #[clap(value_name = "TARGET_BRANCH")]
         target_branch: String,
     },
+    /// Tear a branch out of a stack, effectively unstacking it.
+    TearOff {
+        /// The name or CLI ID of the branch to tear off
+        #[clap(value_name = "BRANCH")]
+        branch: String,
+    },
     /// Apply a branch to the workspace (non-legacy path)
     ///
     /// If you want to apply an unapplied branch to your workspace so you

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -123,21 +123,19 @@ pub enum Subcommands {
     ///
     /// This allows you to e.g. create a stack out of two branches.
     ///
-    /// Just specify the branch to move (or take out of a stack) and insert it into another stack,
-    /// on top of another branch.
+    /// Specify the branch to move and the target branch to stack on top of.
+    ///
+    /// To unstack a branch instead, use `--unstack` without a target branch.
     Move {
         /// The name or CLI ID of the branch to move
         #[clap(value_name = "BRANCH")]
         branch: String,
         /// The name or CLI ID of the branch to move the branch on top of
         #[clap(value_name = "TARGET_BRANCH")]
-        target_branch: String,
-    },
-    /// Tear a branch out of a stack, effectively unstacking it.
-    TearOff {
-        /// The name or CLI ID of the branch to tear off
-        #[clap(value_name = "BRANCH")]
-        branch: String,
+        target_branch: Option<String>,
+        /// Tear a branch out of a stack, effectively unstacking it
+        #[clap(long, conflicts_with = "target_branch")]
+        unstack: bool,
     },
     /// Apply a branch to the workspace (non-legacy path)
     ///

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -32,6 +32,7 @@ pub enum CommandName {
     BranchUnapply,
     BranchApply,
     BranchMove,
+    BranchTearOff,
     ClaudePreTool,
     ClaudePostTool,
     ClaudeStop,

--- a/crates/but/src/command/branch/mod.rs
+++ b/crates/but/src/command/branch/mod.rs
@@ -3,4 +3,4 @@ mod apply;
 mod move_branch;
 #[cfg(not(feature = "legacy"))]
 pub use apply::apply;
-pub use move_branch::move_branch;
+pub use move_branch::{move_branch, tear_off_branch};

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -33,6 +33,26 @@ pub fn move_branch(
     Ok(())
 }
 
+pub fn tear_off_branch(
+    mut ctx: but_ctx::Context,
+    branch: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
+    let id_map = IdMap::new_from_context(&mut ctx, None)?;
+    let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
+        .context("Failed to determine information for the branch to tear off.")?;
+
+    let branch_ref_name_str = &format!("refs/heads/{branch_name}");
+
+    but_api::branch::tear_off_branch(&mut ctx, branch_ref_name_str.try_into()?)?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Tore off branch '{branch_name}'.")?;
+    }
+
+    Ok(())
+}
+
 fn resolve_branch_information(
     ctx: &mut but_ctx::Context,
     id_map: &IdMap,

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -47,7 +47,7 @@ pub fn tear_off_branch(
     but_api::branch::tear_off_branch(&mut ctx, branch_ref_name_str.try_into()?)?;
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "Tore off branch '{branch_name}'.")?;
+        writeln!(out, "Unstacked branch '{branch_name}'.")?;
     }
 
     Ok(())

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -428,6 +428,10 @@ async fn match_subcommand(
                     let ctx = but_ctx::Context::discover(&args.current_dir)?;
                     command::branch::move_branch(ctx, &branch, &target_branch, out)
                 }
+                Some(branch::Subcommands::TearOff { branch }) => {
+                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                    command::branch::tear_off_branch(ctx, &branch, out)
+                }
             };
             result.emit_metrics(metrics_ctx)
         }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -424,13 +424,19 @@ async fn match_subcommand(
                 Some(branch::Subcommands::Move {
                     branch,
                     target_branch,
+                    unstack,
                 }) => {
                     let ctx = but_ctx::Context::discover(&args.current_dir)?;
-                    command::branch::move_branch(ctx, &branch, &target_branch, out)
-                }
-                Some(branch::Subcommands::TearOff { branch }) => {
-                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
-                    command::branch::tear_off_branch(ctx, &branch, out)
+                    if unstack {
+                        command::branch::tear_off_branch(ctx, &branch, out)
+                    } else {
+                        let target_branch = target_branch.ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "`but branch move` requires <TARGET_BRANCH> unless --unstack is used"
+                            )
+                        })?;
+                        command::branch::move_branch(ctx, &branch, &target_branch, out)
+                    }
                 }
             };
             result.emit_metrics(metrics_ctx)

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -98,8 +98,13 @@ impl Subcommands {
                 Some(branch::Subcommands::Delete { .. }) => BranchDelete,
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Show { .. }) => BranchShow,
-                Some(branch::Subcommands::Move { .. }) => BranchMove,
-                Some(branch::Subcommands::TearOff { .. }) => BranchTearOff,
+                Some(branch::Subcommands::Move { unstack, .. }) => {
+                    if *unstack {
+                        BranchTearOff
+                    } else {
+                        BranchMove
+                    }
+                }
                 #[cfg(not(feature = "legacy"))]
                 Some(branch::Subcommands::Apply { .. }) => BranchApply,
             },

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -99,6 +99,7 @@ impl Subcommands {
                 #[cfg(feature = "legacy")]
                 Some(branch::Subcommands::Show { .. }) => BranchShow,
                 Some(branch::Subcommands::Move { .. }) => BranchMove,
+                Some(branch::Subcommands::TearOff { .. }) => BranchTearOff,
                 #[cfg(not(feature = "legacy"))]
                 Some(branch::Subcommands::Apply { .. }) => BranchApply,
             },

--- a/crates/but/tests/but/command/branch/mod.rs
+++ b/crates/but/tests/but/command/branch/mod.rs
@@ -2,4 +2,5 @@ mod apply;
 mod move_branch;
 #[cfg(feature = "legacy")]
 mod new;
+mod tear_off;
 mod unapply;

--- a/crates/but/tests/but/command/branch/tear_off.rs
+++ b/crates/but/tests/but/command/branch/tear_off.rs
@@ -10,11 +10,11 @@ fn tear_off_by_name() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
     assert_initial_status(&env);
 
-    env.but("branch tear-off C")
+    env.but("branch move --unstack C")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Tore off branch 'C'.
+Unstacked branch 'C'.
 
 "#]])
         .stderr_eq(str![""]);
@@ -56,11 +56,11 @@ fn tear_off_by_cli_id() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
     assert_initial_status(&env);
 
-    env.but("branch tear-off h0")
+    env.but("branch move --unstack h0")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Tore off branch 'C'.
+Unstacked branch 'C'.
 
 "#]])
         .stderr_eq(str![""]);
@@ -102,11 +102,11 @@ fn tear_off_single_branch_stack_succeeds() -> anyhow::Result<()> {
     env.setup_metadata(&["A", "B"])?;
     assert_initial_status(&env);
 
-    env.but("branch tear-off A")
+    env.but("branch move --unstack A")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Tore off branch 'A'.
+Unstacked branch 'A'.
 
 "#]])
         .stderr_eq(str![""]);
@@ -135,6 +135,28 @@ Hint: run `but help` for all commands
 
 "#]])
         .stderr_eq(str![""]);
+
+    Ok(())
+}
+
+#[test]
+fn move_requires_target_branch_without_unstack() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.but("branch move A").assert().failure();
+
+    Ok(())
+}
+
+#[test]
+fn move_unstack_conflicts_with_target_branch() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.but("branch move --unstack A B").assert().failure();
 
     Ok(())
 }

--- a/crates/but/tests/but/command/branch/tear_off.rs
+++ b/crates/but/tests/but/command/branch/tear_off.rs
@@ -1,0 +1,167 @@
+use snapbox::str;
+
+use crate::utils::Sandbox;
+
+#[test]
+fn tear_off_by_name() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+    assert_initial_status(&env);
+
+    env.but("branch tear-off C")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Tore off branch 'C'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┊╭┄i0 [C]
+┊●   31e83cd add C
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    Ok(())
+}
+
+#[test]
+fn tear_off_by_cli_id() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+    assert_initial_status(&env);
+
+    env.but("branch tear-off h0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Tore off branch 'C'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┊╭┄i0 [C]
+┊●   31e83cd add C
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    Ok(())
+}
+
+#[test]
+fn tear_off_single_branch_stack_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+    assert_initial_status(&env);
+
+    env.but("branch tear-off A")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Tore off branch 'A'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+
+    Ok(())
+}
+
+fn assert_initial_status(env: &Sandbox) {
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]])
+        .stderr_eq(str![""]);
+}


### PR DESCRIPTION
The command was changed from `but branch tear-off <branch>` to `but branch move --unstack <branch>`.

---

The TUI has the ability to move branches around. They can be moved onto other branches (stacking) and moved onto the merge base (torn off).

However the CLI only supports moving branches onto other branches. It doesn't support tearing them off. This adds that via a new `but branch tear-off` command.

Its pretty straight forward since a function in `but_api` already exists for doing this.

In the future PR I'll change the TUI to call this function so they're aligned.

## Naming

Tbh I'm not a big fan of `but branch tear-off <branch>`. The "tear-off" bit specifically. Sounds very harsh to me for some reason. I think I'd call it `unstack` as in `but branch unstack <branch>`. I guess the only potential downside to that is that `but branch stack` so its not symmetric.

Jujutsu has a very similar command called `jj parallelize` but I'm not a fan of "parallelize" either because its hard to spell. More generally jj does most "moving things around" via `jj rebase` so `jj parallelize` is just a convenience for doing a few rebases manually.