### PR TITLE
Upgrade `gix` to 0.81 and pin it to a version with performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2129,7 +2129,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2873,7 +2873,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3122,7 +3122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4365,8 +4365,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.80.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.81.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4396,7 +4396,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -4409,7 +4409,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4438,8 +4438,8 @@ dependencies = [
 
 [[package]]
 name = "gix-archive"
-version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4451,13 +4451,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "kstring",
  "serde",
  "smallvec",
@@ -4468,15 +4468,15 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-blame"
-version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.11.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4485,7 +4485,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-error",
 ]
@@ -4503,19 +4503,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.35.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4528,14 +4528,14 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.54.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features",
  "gix-glob",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-ref",
  "gix-sec",
  "memchr",
@@ -4548,28 +4548,28 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "libc",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.37.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
  "gix-date",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4577,8 +4577,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.15.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4590,8 +4590,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.61.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4601,10 +4601,10 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-traverse",
  "gix-worktree",
  "imara-diff 0.1.8",
@@ -4614,8 +4614,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.23.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4623,9 +4623,9 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4633,13 +4633,13 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.49.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-ref",
  "gix-sec",
  "thiserror 2.0.18",
@@ -4647,22 +4647,22 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.2.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.46.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.11.1",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.2",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4675,8 +4675,8 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4685,9 +4685,9 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4695,13 +4695,13 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.19.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "fastrand",
  "gix-features",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-utils",
  "thiserror 2.0.18",
 ]
@@ -4709,19 +4709,19 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
  "gix-features",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.23.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4732,8 +4732,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.13.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4742,21 +4742,21 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.19.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.11.1",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.11.2",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "serde",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.49.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4783,8 +4783,8 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "21.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "21.0.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4805,8 +4805,8 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.14.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4816,12 +4816,12 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-quote",
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-worktree",
  "imara-diff 0.1.8",
  "nonempty",
@@ -4830,8 +4830,8 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.29.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4843,8 +4843,8 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.58.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4852,7 +4852,6 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path 0.11.1",
  "gix-utils",
  "gix-validate 0.11.0",
  "itoa",
@@ -4864,8 +4863,8 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.77.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.78.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4874,7 +4873,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-quote",
  "parking_lot",
  "serde",
@@ -4884,8 +4883,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.67.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.68.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4894,7 +4893,7 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-tempfile",
  "memmap2",
  "parking_lot",
@@ -4906,12 +4905,12 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.21.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "thiserror 2.0.18",
 ]
 
@@ -4929,33 +4928,33 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.11.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pathspec"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.16.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.14.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4966,8 +4965,8 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.59.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4981,7 +4980,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -4994,7 +4993,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5003,8 +5002,8 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.61.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5012,7 +5011,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-tempfile",
  "gix-utils",
  "gix-validate 0.11.0",
@@ -5024,8 +5023,8 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.39.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5039,8 +5038,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.43.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5051,15 +5050,15 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56)",
  "nonempty",
  "serde",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.29.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5073,11 +5072,11 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.13.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -5085,8 +5084,8 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.10.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5098,8 +5097,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "filetime",
@@ -5111,7 +5110,7 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
@@ -5120,12 +5119,12 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -5134,8 +5133,8 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "21.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "21.0.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5149,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "crc",
@@ -5178,15 +5177,15 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.55.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5204,8 +5203,8 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.55.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5221,10 +5220,10 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "percent-encoding",
  "serde",
  "thiserror 2.0.18",
@@ -5233,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5253,15 +5252,15 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.50.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5271,15 +5270,15 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-validate 0.11.0",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5287,7 +5286,7 @@ dependencies = [
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
@@ -5295,8 +5294,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#1a72380ac5077fc143a18a59794a35191cd0f39b"
+version = "0.30.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56#700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5305,7 +5304,7 @@ dependencies = [
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.11.1",
+ "gix-path 0.11.2",
  "gix-traverse",
  "parking_lot",
 ]
@@ -6123,7 +6122,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6198,7 +6197,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7098,7 +7097,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7658,7 +7657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8403,7 +8402,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9071,7 +9070,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9129,7 +9128,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10644,7 +10643,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12118,7 +12117,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,11 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
 backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { version = "0.80.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
+# When adjusting this, update `gix-testtools` as well!
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "700ad9ea517d8b2f2a2f7948d9e0bd0df1962a56" }
 
 ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
 insta = { version = "1.45.1", features = ["json"] }


### PR DESCRIPTION
The pinning also helps with `cargo install` which might fail if `gix` has seen a new release as it auto-updates dependencies.
