### PR TITLE
feat(tui): inline branch reword

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -1329,7 +1329,7 @@ fn movement_methods_can_move_cursor_in_inline_reword_mode() {
     ];
 
     let mut cursor = Cursor(1);
-    let inline_reword = Mode::InlineReword(InlineRewordMode {
+    let inline_reword = Mode::InlineReword(InlineRewordMode::Commit {
         commit_id: commit_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         textarea: Box::new(TextArea::default()),
     });
@@ -1401,7 +1401,7 @@ fn is_selectable_is_true_in_inline_reword_mode() {
         cli_id: unassigned("s0"),
     });
 
-    let inline_reword = Mode::InlineReword(InlineRewordMode {
+    let inline_reword = Mode::InlineReword(InlineRewordMode::Commit {
         commit_id: commit_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         textarea: Box::new(TextArea::default()),
     });

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, ffi::OsString, process::Command, sync::Arc, time::Duratio
 use anyhow::Context as _;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
-use crossterm::event::{self, Event};
+use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use gitbutler_operating_modes::OperatingMode;
 use gitbutler_stack::StackId;
 use itertools::Either;
@@ -13,6 +13,7 @@ use ratatui::{
     widgets::{List, ListItem},
 };
 use ratatui_textarea::{CursorMove, TextArea};
+use unicode_width::UnicodeWidthStr;
 
 use crate::{
     CliId,
@@ -1249,7 +1250,8 @@ impl App {
 
         let _suspend_guard = terminal_guard.suspend()?;
 
-        let Some(reword_result) = operations::reword_with_editor_legacy(ctx, commit_id)? else {
+        let Some(reword_result) = operations::reword_commit_with_editor_legacy(ctx, commit_id)?
+        else {
             return Ok(());
         };
 
@@ -1260,7 +1262,6 @@ impl App {
         Ok(())
     }
 
-    /// Handles entering inline reword mode for single-line commit messages.
     fn handle_start_reword_inline(
         &mut self,
         ctx: &mut Context,
@@ -1269,27 +1270,50 @@ impl App {
         if !matches!(self.mode, Mode::Normal) {
             return Ok(());
         }
-
-        let Some(commit_id) = self.selected_commit_id() else {
+        let Some(selection) = self.cursor.selected_line(&self.status_lines) else {
+            return Ok(());
+        };
+        let Some(cli_id) = selection.data.cli_id() else {
             return Ok(());
         };
 
-        let current_message = operations::current_commit_message(ctx, commit_id)?;
+        let inline_reword_mode = match &**cli_id {
+            CliId::Branch { name, .. } => {
+                let mut textarea = TextArea::from([name]);
+                textarea.set_cursor_line_style(Style::default().green());
+                textarea.move_cursor(CursorMove::End);
 
-        if operations::commit_message_has_multiple_lines_legacy(&current_message) {
-            messages.push(Message::Reword(RewordMessage::WithEditor));
-            return Ok(());
-        }
+                InlineRewordMode::Branch {
+                    name: name.to_owned(),
+                    textarea: Box::new(textarea),
+                }
+            }
+            CliId::Commit { commit_id, .. } => {
+                let current_message = operations::current_commit_message(ctx, *commit_id)?;
 
-        let first_line = current_message.lines().next().unwrap_or("").to_string();
-        let mut textarea = TextArea::from([first_line]);
-        textarea.set_cursor_line_style(Style::default());
-        textarea.move_cursor(CursorMove::End);
+                if operations::commit_message_has_multiple_lines_legacy(&current_message) {
+                    messages.push(Message::Reword(RewordMessage::WithEditor));
+                    return Ok(());
+                }
 
-        self.mode = Mode::InlineReword(InlineRewordMode::Commit {
-            commit_id,
-            textarea: Box::new(textarea),
-        });
+                let first_line = current_message.lines().next().unwrap_or("").to_string();
+                let mut textarea = TextArea::from([first_line]);
+                textarea.set_cursor_line_style(Style::default());
+                textarea.move_cursor(CursorMove::End);
+
+                InlineRewordMode::Commit {
+                    commit_id: *commit_id,
+                    textarea: Box::new(textarea),
+                }
+            }
+            CliId::Uncommitted(..)
+            | CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Unassigned { .. }
+            | CliId::Stack { .. } => return Ok(()),
+        };
+
+        self.mode = Mode::InlineReword(inline_reword_mode);
 
         Ok(())
     }
@@ -1297,11 +1321,30 @@ impl App {
     /// Handles key input while inline reword mode is active.
     fn handle_reword_inline_input(&mut self, ev: Event) {
         if let Mode::InlineReword(inline_reword_mode) = &mut self.mode {
+            let ev = match inline_reword_mode {
+                InlineRewordMode::Branch { .. } => {
+                    if let Event::Key(key_ev) = ev
+                        && key_ev.is_press()
+                        && key_ev.modifiers == event::KeyModifiers::NONE
+                        && let KeyCode::Char(' ') = key_ev.code
+                    {
+                        Event::Key(KeyEvent {
+                            code: KeyCode::Char('-'),
+                            modifiers: key_ev.modifiers,
+                            kind: key_ev.kind,
+                            state: key_ev.state,
+                        })
+                    } else {
+                        ev
+                    }
+                }
+                InlineRewordMode::Commit { .. } => ev,
+            };
+
             inline_reword_mode.textarea_mut().input(ev);
         }
     }
 
-    /// Handles confirming an inline commit reword.
     fn handle_confirm_inline_reword(
         &mut self,
         ctx: &mut Context,
@@ -1326,7 +1369,7 @@ impl App {
                     .unwrap_or("");
 
                 let Some(reword_result) =
-                    operations::reword_inline_legacy(ctx, *commit_id, new_message)?
+                    operations::reword_commit_inline_legacy(ctx, *commit_id, new_message)?
                 else {
                     messages.push(Message::EnterNormalMode);
                     return Ok(());
@@ -1336,6 +1379,12 @@ impl App {
                     Message::EnterNormalMode,
                     Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
                 ]);
+            }
+            InlineRewordMode::Branch { name, textarea } => {
+                // self.toasts
+                //     .insert(ToastKind::Info, "TODO: renaming branch".to_owned());
+
+                messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
             }
         }
 
@@ -1624,10 +1673,30 @@ impl App {
         };
 
         match &self.mode {
-            Mode::InlineReword(..) => {
+            Mode::InlineReword(inline_reword_mode) => {
                 if is_selected {
-                    if let StatusOutputContent::Commit(commit_content) = content {
-                        line.extend(commit_content.sha.iter().cloned());
+                    match inline_reword_mode {
+                        InlineRewordMode::Commit { .. } => {
+                            if let StatusOutputContent::Commit(commit_content) = content {
+                                line.extend(commit_content.sha.iter().cloned());
+                            }
+                        }
+                        InlineRewordMode::Branch { textarea, .. } => {
+                            if let StatusOutputContent::Branch(branch_content) = content {
+                                line.extend(branch_content.id.iter().cloned());
+                                line.extend(branch_content.decoration_start.iter().cloned());
+
+                                let len = textarea
+                                    .lines()
+                                    .first()
+                                    .map(|line| line.width())
+                                    .unwrap_or(0);
+                                line.push_span(Span::raw(" ".repeat(len + 1)));
+
+                                line.extend(branch_content.decoration_end.iter().cloned());
+                                line.extend(branch_content.suffix.iter().cloned());
+                            }
+                        }
                     }
                 } else {
                     line.extend(content_spans);
@@ -1918,11 +1987,12 @@ impl App {
     }
 
     fn render_inline_reword(&self, area: Rect, frame: &mut Frame) {
-        let textarea = if let Mode::InlineReword(inline_reword_mode) = &self.mode {
-            inline_reword_mode.textarea()
+        let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &self.mode {
+            inline_reword_mode
         } else {
             return;
         };
+
         let selected_idx = self.cursor.index();
         let Some(selected_rows) = self.selected_row_range() else {
             return;
@@ -1937,27 +2007,58 @@ impl App {
         let Some(line) = self.status_lines.get(selected_idx) else {
             return;
         };
-        let StatusOutputLineData::Commit { .. } = &line.data else {
-            return;
-        };
-        let Some(connector) = &line.connector else {
-            return;
-        };
-        let StatusOutputContent::Commit(commit_content) = &line.content else {
-            return;
-        };
-        let connector_and_sha_width = connector
-            .iter()
-            .chain(&commit_content.sha)
-            .map(|span| span.width() as u16)
-            .sum::<u16>();
-        let padding_between_sha_and_message = 1;
 
-        let start_x = connector_and_sha_width + padding_between_sha_and_message;
-        let x = area.x.saturating_add(start_x);
-        let width = area.right().saturating_sub(x);
-        let area = Rect::new(x, area.y.saturating_add(idx as u16), width, 1);
-        frame.render_widget(textarea, area);
+        match inline_reword_mode {
+            InlineRewordMode::Commit { textarea, .. } => {
+                let StatusOutputLineData::Commit { .. } = &line.data else {
+                    return;
+                };
+                let Some(connector) = &line.connector else {
+                    return;
+                };
+                let StatusOutputContent::Commit(commit_content) = &line.content else {
+                    return;
+                };
+                let connector_and_prefix = connector
+                    .iter()
+                    .chain(&commit_content.sha)
+                    .map(|span| span.width() as u16)
+                    .sum::<u16>();
+                let padding = 1;
+
+                let start_x = connector_and_prefix + padding;
+                let x = area.x.saturating_add(start_x);
+                let width = area.right().saturating_sub(x);
+                let area = Rect::new(x, area.y.saturating_add(idx as u16), width, 1);
+                frame.render_widget(&**textarea, area);
+            }
+            InlineRewordMode::Branch { textarea, .. } => {
+                let StatusOutputLineData::Branch { .. } = &line.data else {
+                    return;
+                };
+                let Some(connector) = &line.connector else {
+                    return;
+                };
+                let StatusOutputContent::Branch(branch_content) = &line.content else {
+                    return;
+                };
+
+                let connector_and_prefix = connector
+                    .iter()
+                    .chain(&branch_content.id)
+                    .chain(&branch_content.decoration_start)
+                    .map(|span| span.width() as u16)
+                    .sum::<u16>();
+
+                let padding = 0;
+
+                let start_x = connector_and_prefix + padding;
+                let x = area.x.saturating_add(start_x);
+                let width = area.right().saturating_sub(x);
+                let area = Rect::new(x, area.y.saturating_add(idx as u16), width, 1);
+                frame.render_widget(&**textarea, area);
+            }
+        }
     }
 
     fn render_debug(&self, area: Rect, frame: &mut Frame) {
@@ -2135,18 +2236,17 @@ enum InlineRewordMode {
         commit_id: gix::ObjectId,
         textarea: Box<TextArea<'static>>,
     },
+    Branch {
+        name: String,
+        textarea: Box<TextArea<'static>>,
+    },
 }
 
 impl InlineRewordMode {
-    fn textarea(&self) -> &TextArea<'static> {
-        match self {
-            InlineRewordMode::Commit { textarea, .. } => textarea,
-        }
-    }
-
     fn textarea_mut(&mut self) -> &mut TextArea<'static> {
         match self {
-            InlineRewordMode::Commit { textarea, .. } => textarea,
+            InlineRewordMode::Commit { textarea, .. }
+            | InlineRewordMode::Branch { textarea, .. } => textarea,
         }
     }
 }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1286,7 +1286,7 @@ impl App {
         textarea.set_cursor_line_style(Style::default());
         textarea.move_cursor(CursorMove::End);
 
-        self.mode = Mode::InlineReword(InlineRewordMode {
+        self.mode = Mode::InlineReword(InlineRewordMode::Commit {
             commit_id,
             textarea: Box::new(textarea),
         });
@@ -1296,8 +1296,8 @@ impl App {
 
     /// Handles key input while inline reword mode is active.
     fn handle_reword_inline_input(&mut self, ev: Event) {
-        if let Mode::InlineReword(InlineRewordMode { textarea, .. }) = &mut self.mode {
-            textarea.input(ev);
+        if let Mode::InlineReword(inline_reword_mode) = &mut self.mode {
+            inline_reword_mode.textarea_mut().input(ev);
         }
     }
 
@@ -1307,31 +1307,37 @@ impl App {
         ctx: &mut Context,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()> {
-        let Mode::InlineReword(InlineRewordMode {
-            commit_id,
-            textarea,
-        }) = &self.mode
-        else {
+        let inline_reword_mode = if let Mode::InlineReword(inline_reword_mode) = &self.mode {
+            inline_reword_mode
+        } else {
             messages.push(Message::EnterNormalMode);
             return Ok(());
         };
 
-        let new_message = textarea
-            .lines()
-            .first()
-            .map(std::string::String::as_str)
-            .unwrap_or("");
+        match inline_reword_mode {
+            InlineRewordMode::Commit {
+                commit_id,
+                textarea,
+            } => {
+                let new_message = textarea
+                    .lines()
+                    .first()
+                    .map(std::string::String::as_str)
+                    .unwrap_or("");
 
-        let Some(reword_result) = operations::reword_inline_legacy(ctx, *commit_id, new_message)?
-        else {
-            messages.push(Message::EnterNormalMode);
-            return Ok(());
-        };
+                let Some(reword_result) =
+                    operations::reword_inline_legacy(ctx, *commit_id, new_message)?
+                else {
+                    messages.push(Message::EnterNormalMode);
+                    return Ok(());
+                };
 
-        messages.extend([
-            Message::EnterNormalMode,
-            Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
-        ]);
+                messages.extend([
+                    Message::EnterNormalMode,
+                    Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
+                ]);
+            }
+        }
 
         Ok(())
     }
@@ -1912,7 +1918,9 @@ impl App {
     }
 
     fn render_inline_reword(&self, area: Rect, frame: &mut Frame) {
-        let Mode::InlineReword(InlineRewordMode { textarea, .. }) = &self.mode else {
+        let textarea = if let Mode::InlineReword(inline_reword_mode) = &self.mode {
+            inline_reword_mode.textarea()
+        } else {
             return;
         };
         let selected_idx = self.cursor.index();
@@ -1949,7 +1957,7 @@ impl App {
         let x = area.x.saturating_add(start_x);
         let width = area.right().saturating_sub(x);
         let area = Rect::new(x, area.y.saturating_add(idx as u16), width, 1);
-        frame.render_widget(&**textarea, area);
+        frame.render_widget(textarea, area);
     }
 
     fn render_debug(&self, area: Rect, frame: &mut Frame) {
@@ -2122,9 +2130,25 @@ struct RubMode {
 }
 
 #[derive(Debug)]
-struct InlineRewordMode {
-    commit_id: gix::ObjectId,
-    textarea: Box<TextArea<'static>>,
+enum InlineRewordMode {
+    Commit {
+        commit_id: gix::ObjectId,
+        textarea: Box<TextArea<'static>>,
+    },
+}
+
+impl InlineRewordMode {
+    fn textarea(&self) -> &TextArea<'static> {
+        match self {
+            InlineRewordMode::Commit { textarea, .. } => textarea,
+        }
+    }
+
+    fn textarea_mut(&mut self) -> &mut TextArea<'static> {
+        match self {
+            InlineRewordMode::Commit { textarea, .. } => textarea,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1278,13 +1278,17 @@ impl App {
         };
 
         let inline_reword_mode = match &**cli_id {
-            CliId::Branch { name, .. } => {
+            CliId::Branch { name, stack_id, .. } => {
+                let Some(stack_id) = stack_id else {
+                    return Ok(());
+                };
                 let mut textarea = TextArea::from([name]);
                 textarea.set_cursor_line_style(Style::default().green());
                 textarea.move_cursor(CursorMove::End);
 
                 InlineRewordMode::Branch {
                     name: name.to_owned(),
+                    stack_id: *stack_id,
                     textarea: Box::new(textarea),
                 }
             }
@@ -1357,19 +1361,17 @@ impl App {
             return Ok(());
         };
 
-        match inline_reword_mode {
-            InlineRewordMode::Commit {
-                commit_id,
-                textarea,
-            } => {
-                let new_message = textarea
-                    .lines()
-                    .first()
-                    .map(std::string::String::as_str)
-                    .unwrap_or("");
+        let first_line = inline_reword_mode
+            .textarea()
+            .lines()
+            .first()
+            .map(std::string::String::as_str)
+            .unwrap_or("");
 
+        match inline_reword_mode {
+            InlineRewordMode::Commit { commit_id, .. } => {
                 let Some(reword_result) =
-                    operations::reword_commit_inline_legacy(ctx, *commit_id, new_message)?
+                    operations::reword_commit_inline_legacy(ctx, *commit_id, first_line)?
                 else {
                     messages.push(Message::EnterNormalMode);
                     return Ok(());
@@ -1380,11 +1382,18 @@ impl App {
                     Message::Reload(Some(SelectAfterReload::Commit(reword_result.new_commit))),
                 ]);
             }
-            InlineRewordMode::Branch { name, textarea } => {
-                // self.toasts
-                //     .insert(ToastKind::Info, "TODO: renaming branch".to_owned());
+            InlineRewordMode::Branch { name, stack_id, .. } => {
+                let new_name = operations::reword_branch_inline_legacy(
+                    ctx,
+                    *stack_id,
+                    name.to_owned(),
+                    first_line.to_owned(),
+                )?;
 
-                messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
+                messages.extend([
+                    Message::EnterNormalMode,
+                    Message::Reload(Some(SelectAfterReload::Branch(new_name))),
+                ]);
             }
         }
 
@@ -2238,11 +2247,19 @@ enum InlineRewordMode {
     },
     Branch {
         name: String,
+        stack_id: StackId,
         textarea: Box<TextArea<'static>>,
     },
 }
 
 impl InlineRewordMode {
+    fn textarea(&self) -> &TextArea<'static> {
+        match self {
+            InlineRewordMode::Commit { textarea, .. }
+            | InlineRewordMode::Branch { textarea, .. } => textarea,
+        }
+    }
+
     fn textarea_mut(&mut self) -> &mut TextArea<'static> {
         match self {
             InlineRewordMode::Commit { textarea, .. }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -14,6 +14,7 @@ use but_core::DiffSpec;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use gitbutler_operating_modes::OperatingMode;
+use gitbutler_stack::StackId;
 
 use crate::{
     CliId,
@@ -195,7 +196,7 @@ pub(super) fn rub_using_but_api(
     legacy::status::tui::rub_api::perform_operation(ctx, operation)
 }
 
-pub(super) fn reword_with_editor_legacy(
+pub(super) fn reword_commit_with_editor_legacy(
     ctx: &mut Context,
     commit_id: gix::ObjectId,
 ) -> anyhow::Result<Option<CommitRewordResult>> {
@@ -234,7 +235,7 @@ pub(super) fn commit_message_has_multiple_lines_legacy(message: &str) -> bool {
     legacy::commit_message_prep::commit_message_has_multiple_lines(message)
 }
 
-pub(super) fn reword_inline_legacy(
+pub(super) fn reword_commit_inline_legacy(
     ctx: &mut Context,
     commit_id: gix::ObjectId,
     new_message: &str,
@@ -362,4 +363,13 @@ pub(super) fn has_unassigned_changes(ctx: &mut Context) -> anyhow::Result<bool> 
 pub(super) fn commit_is_empty(ctx: &mut Context, commit_id: gix::ObjectId) -> anyhow::Result<bool> {
     let commit_details = but_api::diff::commit_details(ctx, commit_id, ComputeLineStats::No)?;
     Ok(commit_details.diff_with_first_parent.is_empty())
+}
+
+pub(super) fn reword_branch_inline_legacy(
+    ctx: &mut Context,
+    stack_id: StackId,
+    branch_name: String,
+    new_name: String,
+) -> anyhow::Result<String> {
+    gitbutler_branch_actions::stack::update_branch_name(ctx, stack_id, branch_name, new_name)
 }

--- a/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
@@ -147,3 +147,79 @@ fn focus_reload_in_branch_mode_preserves_merge_base_selection() {
             "snapshots/focus_reload_in_branch_mode_preserves_merge_base_selection_final.txt"
         ]);
 }
+
+#[test]
+fn inline_branch_reword_confirm_renames_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A ]"]);
+
+    tui.input_then_render(KeyCode::Backspace)
+        .assert_current_line_eq(str!["┊╭┄g0 [ ]"]);
+
+    tui.input_then_render("new")
+        .assert_current_line_eq(str!["┊╭┄g0 [new ]"]);
+
+    // spaces get mapped to dashes
+    tui.input_then_render(" ")
+        .assert_current_line_eq(str!["┊╭┄g0 [new- ]"]);
+
+    tui.input_then_render("name")
+        .assert_current_line_eq(str!["┊╭┄g0 [new-name ]"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["[..] [new-name]"]);
+}
+
+#[test]
+fn inline_branch_reword_esc_cancels() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A ]"]);
+
+    tui.input_then_render("new-name")
+        .assert_current_line_eq(str!["┊╭┄g0 [Anew-name ]"]);
+
+    tui.input_then_render(KeyCode::Esc)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+}
+
+#[test]
+fn inline_branch_reword_preserves_selection_after_reload_with_multiple_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊╭┄g0 [A ]"]);
+
+    tui.input_then_render(KeyCode::Backspace)
+        .assert_current_line_eq(str!["┊╭┄g0 [ ]"]);
+
+    tui.input_then_render("renamed-a")
+        .assert_current_line_eq(str!["┊╭┄g0 [renamed-a ]"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["[..] [renamed-a]"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["[..] [B]"]);
+}

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -80,12 +80,14 @@ pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: &str) ->
 
 /// Updates the name an existing branch and resets the pr_number to None.
 /// Same invariants as `create_branch` apply.
+///
+/// Returns the new normalized name of the branch.
 pub fn update_branch_name(
     ctx: &mut Context,
     stack_id: StackId,
     branch_name: String,
     new_name: String,
-) -> Result<()> {
+) -> Result<String> {
     let mut guard = ctx.exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     let _ = ctx.snapshot_update_dependent_branch_name(&branch_name, guard.write_permission());
@@ -97,9 +99,10 @@ pub fn update_branch_name(
         ctx,
         branch_name,
         &PatchReferenceUpdate {
-            name: Some(normalized_head_name),
+            name: Some(normalized_head_name.clone()),
         },
-    )
+    )?;
+    Ok(normalized_head_name)
 }
 
 /// Sets the forge identifier for a given series/branch. Existing value is overwritten.


### PR DESCRIPTION
The TUI supports rewording commits inline by pressing enter. This extends that functionality to also support branches.

https://github.com/user-attachments/assets/dc929bef-af89-4c24-bbd2-afc8b0085e81

