### PR TITLE
Fix broken lint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"knip:prod:fix": "knip --strict --fix",
 		"tauri": "cross-env \"CARGO_TARGET_DIR=$PNPM_SCRIPT_SRC_DIR/target/tauri\" tauri",
 		"tauri-for-release": "tauri",
-		"lint": "turbo run //#globallint --no-daemon",
+		"lint": "turbo run globallint --no-daemon",
 		"globallint": "prettier --check . && eslint . && pnpm run oxlint && pnpm knip:non-prod && pnpm knip:prod",
 		"oxlint": "oxlint",
 		"oxlint:fix": "oxlint --fix",


### PR DESCRIPTION
Previously we had "No tasks were executed as part of this run" ([example](https://github.com/gitbutlerapp/gitbutler/actions/runs/23514254384/job/68443242098#step:4:25)).

I guess this means linting wasn't enforced in CI?

It's been like this for years… I'm confused why it hasn't been noticed before now?