### PR TITLE
isolate editor env in reword CLI tests

### DIFF
--- a/crates/but-testsupport/src/prepare_cmd_env.rs
+++ b/crates/but-testsupport/src/prepare_cmd_env.rs
@@ -54,6 +54,9 @@ fn updates() -> Vec<EnvOp> {
         EnvOp::Remove("GIT_COMMON_DIR"),
         EnvOp::Remove("GIT_ASKPASS"),
         EnvOp::Remove("SSH_ASKPASS"),
+        EnvOp::Remove("GIT_EDITOR"),
+        EnvOp::Remove("VISUAL"),
+        EnvOp::Remove("EDITOR"),
     ]
     .into_iter()
     .chain(

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -89,7 +89,7 @@ fn reword_branch_from_editor_trims_trailing_newlines_in_confirmation_output() ->
         "#!/usr/bin/env bash\nprintf 'renamed-branch\\n\\n' > \"$1\"\n",
     );
     env.but("reword branch-to-rename-123")
-        .env("EDITOR", "bash editor.sh")
+        .env("GIT_EDITOR", "bash editor.sh")
         .assert()
         .success()
         .stdout_eq(str![[r#"


### PR DESCRIPTION
Clear inherited GIT_EDITOR, VISUAL, and EDITOR in the shared test harness so CLI tests don't pick up the developer's shell settings.

Othewise the test may fail as it tries to open the user editor under GIT_EDITOR which takes precedence.

