### PR TITLE
fix: update rusqlite to 0.39.0 to resolve SQLite WAL deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2143,7 +2143,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3136,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6136,7 +6136,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6211,7 +6211,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6495,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7111,7 +7111,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7671,7 +7671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8416,7 +8416,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9013,9 +9013,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -9084,7 +9084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9142,7 +9142,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10657,7 +10657,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12131,7 +12131,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,9 +208,8 @@ gitbutler-cherry-pick = { path = "crates/gitbutler-cherry-pick" }
 gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 
-# Bundled rusqlite for Windows.
-# TODO: is 'bundled' still needed?
-rusqlite = { version = "0.38.0", features = ["bundled"] }
+# Bundled to ensure a consistent SQLite version across all platforms.
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.


### PR DESCRIPTION
While investigating a deadlocked but-server instance, we identified an
ABBA lock-order inversion in SQLite 3.51.1's Unix VFS between two
internal mutexes:

  - `unixBigLock` (a global static mutex, alias SQLITE_MUTEX_STATIC_VFS1)
  - per-inode `pLockMutex` (heap-allocated per open database file)

The documented invariant in os_unix.c requires that unixBigLock is
always acquired before pLockMutex, but `unixIsSharingShmNode()` violated
this by acquiring pLockMutex first and then calling `unixEnterMutex()`
(which acquires unixBigLock). This path is exercised during WAL close
(`sqlite3WalClose` → `sqlite3OsLock(EXCLUSIVE)` → `unixLock` →
`unixIsSharingShmNode`), which `but-db` triggers because it enables WAL
mode via `PRAGMA journal_mode = WAL` and opens a fresh connection per
request.

Under concurrent open/close on the same database file the two threads
deadlock:
  Thread A: unixClose()        — holds unixBigLock, waits for pLockMutex
  Thread B: unixLock() via WAL — holds pLockMutex, waits for unixBigLock

The cascade effect: threads holding a `RepoExclusiveGuard` (RwLock write)
cannot complete, causing the global `WORKTREE_LOCKS` mutex in
`but-core/src/sync.rs` to be held indefinitely, which blocks all
subsequent `shared_repo_access`/`exclusive_repo_access` calls process-wide.

The bug was fixed by the SQLite project in commit 67767084b6
(https://github.com/sqlite/sqlite/commit/67767084b6782de00d1409bf740f54525eba1ab4,
December 2025) — released as SQLite 3.51.2 — by removing the
`unixEnterMutex()`/`unixLeaveMutex()` calls from `unixIsSharingShmNode()`.

rusqlite picked up the fix in PR #1788 (merged 2026-01-13), shipping
libsqlite3-sys 0.37.0 with SQLite 3.51.3 as part of rusqlite 0.39.0.

This commit bumps rusqlite from 0.38.0 (SQLite 3.51.1, broken) to 0.39.0
(SQLite 3.51.3, fixed).

Resolves: #13025