### PR TITLE
feat(tui): confirm component

### DIFF
--- a/crates/but/src/command/legacy/status/tui/confirm.rs
+++ b/crates/but/src/command/legacy/status/tui/confirm.rs
@@ -1,0 +1,115 @@
+use std::borrow::Cow;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Clear, List, ListItem, Padding},
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::command::legacy::status::tui::Message;
+
+#[derive(Debug)]
+pub(super) struct Confirm {
+    text: Cow<'static, str>,
+    yes_selected: bool,
+    message_if_yes: Message,
+}
+
+impl Confirm {
+    #[expect(dead_code)]
+    pub(super) fn new(text: impl Into<Cow<'static, str>>, message_if_yes: Message) -> Self {
+        Self {
+            text: text.into(),
+            yes_selected: true,
+            message_if_yes,
+        }
+    }
+
+    pub(super) fn render(&self, area: Rect, frame: &mut Frame) {
+        let padding = Padding::new(3, 6, 1, 1);
+        let horizontal_padding = padding.left + padding.right;
+        let vertical_padding = padding.top + padding.bottom;
+
+        let space_taken_up_by_border: u16 = 2;
+
+        let items = Vec::from([
+            ListItem::new(&*self.text),
+            ListItem::new(""),
+            ListItem::new(Line::from_iter([
+                style_button(Span::raw("  Yes  "), self.yes_selected),
+                style_button(Span::raw("  No  "), !self.yes_selected),
+            ])),
+        ]);
+
+        let horizontal_layout = Layout::horizontal([Constraint::Length(
+            (self.text.width() as u16) + space_taken_up_by_border + horizontal_padding,
+        )])
+        .flex(Flex::Center)
+        .split(area);
+
+        let centered_layout = Layout::vertical([Constraint::Length(
+            (items.len() as u16) + space_taken_up_by_border + vertical_padding,
+        )])
+        .flex(Flex::Center)
+        .split(horizontal_layout[0]);
+
+        let content = List::new(items).block(
+            Block::bordered()
+                .padding(padding)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().dark_gray()),
+        );
+
+        frame.render_widget(Clear, centered_layout[0]);
+
+        frame.render_widget(content, centered_layout[0]);
+    }
+
+    pub(super) fn handle_message(
+        self,
+        msg: ConfirmMessage,
+        messages: &mut Vec<Message>,
+    ) -> Option<Self> {
+        match msg {
+            ConfirmMessage::Left => Some(Self {
+                yes_selected: true,
+                ..self
+            }),
+            ConfirmMessage::Right => Some(Self {
+                yes_selected: false,
+                ..self
+            }),
+            ConfirmMessage::Yes => {
+                messages.push(self.message_if_yes);
+                None
+            }
+            ConfirmMessage::No => None,
+            ConfirmMessage::Confirm => {
+                if self.yes_selected {
+                    messages.push(self.message_if_yes);
+                }
+                None
+            }
+        }
+    }
+}
+
+fn style_button(span: Span<'static>, selected: bool) -> Span<'static> {
+    if selected {
+        span.white().on_dark_gray()
+    } else {
+        span.dim()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum ConfirmMessage {
+    Confirm,
+    Left,
+    Right,
+    Yes,
+    No,
+}

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -5,7 +5,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use strum::IntoEnumIterator;
 
 use crate::command::legacy::status::tui::{
-    CommandMessage, Message, Mode, ModeDiscriminant, RewordMessage, RubMessage,
+    CommandMessage, ConfirmMessage, Message, Mode, ModeDiscriminant, RewordMessage, RubMessage,
 };
 
 use super::{BranchMessage, CommitMessage, FilesMessage, MoveMessage};
@@ -43,6 +43,61 @@ pub(super) fn default_key_binds() -> KeyBinds {
             }
         }
     }
+
+    key_binds
+}
+
+pub(super) fn confirm_key_binds() -> KeyBinds {
+    let mut key_binds = KeyBinds::new();
+
+    let all_modes = ModeDiscriminant::iter().collect::<Vec<_>>();
+
+    register_quit_key_binds(&mut key_binds, all_modes.clone());
+
+    key_binds.register(StaticKeyBind {
+        short_description: "select",
+        chord_display: "enter",
+        key_matcher: press().code(KeyCode::Enter),
+        modes: all_modes.clone(),
+        message: Message::Confirm(ConfirmMessage::Confirm),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "yes",
+        chord_display: "y",
+        key_matcher: press().code(KeyCode::Char('y')),
+        modes: all_modes.clone(),
+        message: Message::Confirm(ConfirmMessage::Yes),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "no",
+        chord_display: "esc/n",
+        key_matcher: press().code(KeyCode::Char('n')).alt_code(KeyCode::Esc),
+        modes: all_modes.clone(),
+        message: Message::Confirm(ConfirmMessage::No),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "left",
+        chord_display: "←/h",
+        key_matcher: press().code(KeyCode::Char('h')).alt_code(KeyCode::Left),
+        modes: all_modes.clone(),
+        message: Message::Confirm(ConfirmMessage::Left),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "right",
+        chord_display: "→/l",
+        key_matcher: press().code(KeyCode::Char('l')).alt_code(KeyCode::Right),
+        modes: all_modes.clone(),
+        message: Message::Confirm(ConfirmMessage::Right),
+        hide_from_hotbar: false,
+    });
 
     key_binds
 }
@@ -98,14 +153,7 @@ fn register_global_key_binds(key_binds: &mut KeyBinds) {
         hide_from_hotbar: true,
     });
 
-    key_binds.register(StaticKeyBind {
-        short_description: "quit",
-        chord_display: "q",
-        key_matcher: press().code(KeyCode::Char('q')),
-        modes: all_except_text_input_modes.clone(),
-        message: Message::Quit,
-        hide_from_hotbar: false,
-    });
+    register_quit_key_binds(key_binds, all_except_text_input_modes.clone());
 
     key_binds.register(StaticKeyBind {
         short_description: "normal mode",
@@ -114,6 +162,17 @@ fn register_global_key_binds(key_binds: &mut KeyBinds) {
         modes: all_modes,
         message: Message::EnterNormalMode,
         hide_from_hotbar: true,
+    });
+}
+
+fn register_quit_key_binds(key_binds: &mut KeyBinds, modes: Vec<ModeDiscriminant>) {
+    key_binds.register(StaticKeyBind {
+        short_description: "quit",
+        chord_display: "q",
+        key_matcher: press().code(KeyCode::Char('q')),
+        modes,
+        message: Message::Quit,
+        hide_from_hotbar: false,
     });
 }
 
@@ -187,8 +246,8 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
 
     key_binds.register(StaticKeyBind {
         short_description: "reword",
-        chord_display: "shift+d",
-        key_matcher: press().shift().code(KeyCode::Char('D')),
+        chord_display: "shift+m",
+        key_matcher: press().shift().code(KeyCode::Char('M')),
         modes: Vec::from([ModeDiscriminant::Normal]),
         message: Message::Reword(RewordMessage::WithEditor),
         hide_from_hotbar: false,

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -25,10 +25,11 @@ use crate::{
             CommitLineContent, StatusFlags, StatusOutputLine,
             output::BranchLineContent,
             tui::{
+                confirm::{Confirm, ConfirmMessage},
                 cursor::{Cursor, is_selectable_in_mode},
                 graph_extension::{ExtensionDirection, extend_connector_spans},
                 highlight::{Highlights, with_highlight},
-                key_bind::{KeyBinds, default_key_binds},
+                key_bind::{KeyBinds, confirm_key_binds, default_key_binds},
                 toast::{ToastKind, Toasts},
             },
         },
@@ -43,6 +44,7 @@ use super::{
     output::{StatusOutputContent, StatusOutputLineData},
 };
 
+mod confirm;
 mod cursor;
 mod graph_extension;
 mod highlight;
@@ -170,7 +172,7 @@ where
 {
     // poll events
     for event in event_polling.poll()? {
-        event_to_messages(event, &app.key_binds, &app.mode, messages);
+        event_to_messages(event, app.active_key_binds(), &app.mode, messages);
     }
 
     // handle messages
@@ -221,10 +223,12 @@ struct App {
     scroll_top: usize,
     mode: Mode,
     key_binds: KeyBinds,
+    confirm_key_binds: KeyBinds,
     debug_enabled: bool,
     toasts: Toasts,
     renders: u64,
     highlight: Highlights,
+    confirm: Option<Confirm>,
 }
 
 impl App {
@@ -240,10 +244,20 @@ impl App {
             should_render: true,
             mode: Mode::default(),
             key_binds: default_key_binds(),
+            confirm_key_binds: confirm_key_binds(),
             debug_enabled: debug,
             toasts: Default::default(),
             renders: 0,
             highlight: Default::default(),
+            confirm: None,
+        }
+    }
+
+    fn active_key_binds(&self) -> &KeyBinds {
+        if self.confirm.is_some() {
+            &self.confirm_key_binds
+        } else {
+            &self.key_binds
         }
     }
 
@@ -466,6 +480,15 @@ impl App {
             }
             Message::ShowToast { kind, text } => {
                 self.toasts.insert(kind, text);
+            }
+            Message::Confirm(confirm_message) => {
+                self.confirm = self
+                    .confirm
+                    .take()
+                    .and_then(|confirm| confirm.handle_message(confirm_message, messages));
+            }
+            Message::RunAfterConfirmation(f) => {
+                (f.0)(self, ctx, messages)?;
             }
         }
 
@@ -1583,6 +1606,10 @@ impl App {
 
         self.render_toasts(content_area, frame);
 
+        if let Some(confirm) = &self.confirm {
+            confirm.render(content_area, frame);
+        }
+
         if let Some(debug_area) = debug_area {
             self.render_debug(debug_area, frame);
         }
@@ -1777,7 +1804,7 @@ impl App {
             }
         }
 
-        if is_selected {
+        if is_selected && self.confirm.is_none() {
             line = line.bg(CURSOR_BG);
         }
 
@@ -2008,7 +2035,7 @@ impl App {
             | Mode::InlineReword(..) => {
                 let mut line = Line::default();
                 let mut key_binds_iter = self
-                    .key_binds
+                    .active_key_binds()
                     .iter_key_binds_available_in_mode(&self.mode)
                     .filter(|key_bind| !key_bind.hide_from_hotbar())
                     .peekable();
@@ -2192,7 +2219,11 @@ enum Message {
     EnterNormalMode,
     Reload(Option<SelectAfterReload>),
     ShowError(Arc<anyhow::Error>),
-    ShowToast { kind: ToastKind, text: String },
+    ShowToast {
+        kind: ToastKind,
+        text: String,
+    },
+    Confirm(ConfirmMessage),
 
     // Cursor movement
     MoveCursorUp,
@@ -2211,6 +2242,10 @@ enum Message {
 
     // Utilities
     CopySelection,
+    #[expect(clippy::type_complexity)]
+    RunAfterConfirmation(
+        DebugType<Arc<dyn Fn(&mut App, &mut Context, &mut Vec<Message>) -> anyhow::Result<()>>>,
+    ),
 }
 
 #[derive(Debug, Clone)]
@@ -2733,4 +2768,23 @@ enum MoveTarget<'a> {
     Branch { name: &'a str },
     Commit { commit_id: gix::ObjectId },
     MergeBase,
+}
+
+#[derive(Clone)]
+struct DebugType<T>(T);
+
+impl<T> std::fmt::Debug for DebugType<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(std::any::type_name::<T>())
+    }
+}
+
+#[expect(dead_code)]
+fn run_after_confirmation_msg<F>(f: F) -> Message
+where
+    F: Fn(&mut App, &mut Context, &mut Vec<Message>) -> anyhow::Result<()> + 'static,
+{
+    Message::RunAfterConfirmation(DebugType(Arc::new(move |app, ctx, messages| {
+        f(app, ctx, messages)
+    })))
 }


### PR DESCRIPTION
Adds a general confirm component that we can use to get extra confirmation from the user before performing destructive actions

<img width="360" height="189" alt="image" src="https://github.com/user-attachments/assets/f67fb3a0-35db-4b5b-bfb5-0942351aa9a6" />

Not actually used yet