### PR TITLE
remove BStringForFrontend in but-api

### DIFF
--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -148,7 +148,7 @@
 
 			if (response.pathsToRejectedChanges.length > 0) {
 				const pathsToRejectedChanges = response.pathsToRejectedChanges.reduce(
-					(acc: Record<string, RejectionReason>, [reason, path]) => {
+					(acc: Record<string, RejectionReason>, { reason, path }) => {
 						acc[path] = reason;
 						return acc;
 					},

--- a/apps/desktop/src/lib/files/filetreeV3.ts
+++ b/apps/desktop/src/lib/files/filetreeV3.ts
@@ -96,7 +96,11 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		const minLength = Math.min(partsA.length, partsB.length);
 
 		for (let i = 0; i < minLength - 1; i++) {
-			const comparison = partsA[i]!.localeCompare(partsB[i]!, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
+			const partA = partsA[i];
+			const partB = partsB[i];
+			if (partA == null || partB == null) continue;
+
+			const comparison = partA.localeCompare(partB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 			if (comparison !== 0) {
 				return comparison;
 			}
@@ -108,11 +112,11 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		}
 
 		// Same depth, compare final component
-		return partsA[partsA.length - 1]!.localeCompare(
-			partsB[partsB.length - 1]!,
-			FILE_SORT_LOCALE,
-			FILE_SORT_CONFIG,
-		);
+		const lastPartA = partsA[partsA.length - 1];
+		const lastPartB = partsB[partsB.length - 1];
+		if (lastPartA == null || lastPartB == null) return 0;
+
+		return lastPartA.localeCompare(lastPartB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 	});
 }
 

--- a/apps/desktop/src/lib/files/filetreeV3.ts
+++ b/apps/desktop/src/lib/files/filetreeV3.ts
@@ -96,10 +96,8 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		const minLength = Math.min(partsA.length, partsB.length);
 
 		for (let i = 0; i < minLength - 1; i++) {
-			const partA = partsA[i];
-			const partB = partsB[i];
-			if (partA == null || partB == null) continue;
-
+			const partA = partsA[i]!;
+			const partB = partsB[i]!;
 			const comparison = partA.localeCompare(partB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 			if (comparison !== 0) {
 				return comparison;
@@ -112,10 +110,8 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		}
 
 		// Same depth, compare final component
-		const lastPartA = partsA[partsA.length - 1];
-		const lastPartB = partsB[partsB.length - 1];
-		if (lastPartA == null || lastPartB == null) return 0;
-
+		const lastPartA = partsA[partsA.length - 1]!;
+		const lastPartB = partsB[partsB.length - 1]!;
 		return lastPartA.localeCompare(lastPartB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 	});
 }

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -342,12 +342,13 @@ export function isFileDeletionHunk(hunk: DiffHunk): boolean {
 }
 
 export function canBePartiallySelected(patch: Patch): boolean {
-	if (patch.hunks.length === 0) {
+	const firstHunk = patch.hunks[0];
+	if (!firstHunk) {
 		// Should never happen, but just in case
 		return false;
 	}
 
-	if (patch.hunks.length === 1 && isFileDeletionHunk(patch.hunks[0]!)) {
+	if (patch.hunks.length === 1 && isFileDeletionHunk(firstHunk)) {
 		// Only one hunk and it's a file deletion
 		return false;
 	}

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -70,7 +70,7 @@ export default class StackMacros {
 
 		if (outcome.pathsToRejectedChanges.length > 0) {
 			const pathsToRejectedChanges = outcome.pathsToRejectedChanges.reduce(
-				(acc: Record<string, RejectionReason>, [reason, path]) => {
+				(acc: Record<string, RejectionReason>, { reason, path }) => {
 					acc[path] = reason;
 					return acc;
 				},

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -80,16 +80,21 @@ export const REJECTTION_REASONS = [
 ] as const;
 
 type ReplacedCommit = [string, string];
+type RejectedChange = {
+	reason: RejectionReason;
+	path: string;
+	pathBytes: number[];
+};
 
 type BackendCreateCommitOutcome = {
 	newCommit?: string | null;
-	pathsToRejectedChanges: [RejectionReason, string][];
+	pathsToRejectedChanges: RejectedChange[];
 	replacedCommits: Record<string, string>;
 };
 
 export type CreateCommitOutcome = {
 	newCommit: string | null;
-	pathsToRejectedChanges: [RejectionReason, string][];
+	pathsToRejectedChanges: RejectedChange[];
 	commitMapping: ReplacedCommit[];
 };
 
@@ -526,7 +531,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				}
 
 				const rejected = normalizedResponse.pathsToRejectedChanges
-					.map(([reason, path]) => `${reason}: ${path}`)
+					.map(({ reason, path }) => `${reason}: ${path}`)
 					.join(", ");
 				const details = rejected ? ` Rejected changes: ${rejected}` : "";
 				throw new Error(`Failed to amend commit: no commit was created.${details}`);

--- a/apps/lite/ui/src/Operation.ts
+++ b/apps/lite/ui/src/Operation.ts
@@ -2,7 +2,10 @@ import { Toast } from "@base-ui/react";
 import { useMutation } from "@tanstack/react-query";
 import { Match } from "effect";
 import { CommitMoveParams, MoveBranchParams, TearOffBranchParams } from "#electron/ipc.ts";
-import { RejectedChange, rejectedChangesToastOptions } from "#ui/components/RejectedChanges.tsx";
+import {
+	normalizeRejectedChanges,
+	rejectedChangesToastOptions,
+} from "#ui/components/RejectedChanges.tsx";
 import {
 	commitMoveMutationOptions,
 	moveBranchMutationOptions,
@@ -45,13 +48,14 @@ export const useRunOperation = (projectId: string) => {
 					},
 					{
 						onSuccess: (response) => {
-							const pathsToRejectedChanges = response.pathsToRejectedChanges ?? [];
+							const pathsToRejectedChanges = normalizeRejectedChanges(
+								response.pathsToRejectedChanges ?? [],
+							);
 							if (pathsToRejectedChanges.length > 0)
 								toastManager.add(
 									rejectedChangesToastOptions({
 										newCommit: response.newCommit,
-										pathsToRejectedChanges:
-											response.pathsToRejectedChanges as Array<RejectedChange>,
+										pathsToRejectedChanges,
 									}),
 								);
 							return;

--- a/apps/lite/ui/src/api/rub.ts
+++ b/apps/lite/ui/src/api/rub.ts
@@ -1,10 +1,6 @@
-import {
-	HunkAssignmentRequest,
-	HunkHeader,
-	TreeChange,
-	UICommitCreateResult,
-} from "@gitbutler/but-sdk";
+import { HunkAssignmentRequest, HunkHeader, TreeChange } from "@gitbutler/but-sdk";
 import { Match } from "effect";
+import { normalizeRejectedChanges, type RejectedChange } from "#ui/components/RejectedChanges.tsx";
 import { type ChangeUnit } from "#ui/domain/ChangeUnit.ts";
 import { createDiffSpec } from "#ui/domain/DiffSpec.ts";
 
@@ -33,7 +29,7 @@ export type RubResult = {
 	replacedCommits?: Record<string, string>;
 	newCommit?: string | null;
 	amendedCommitId?: string;
-	pathsToRejectedChanges?: UICommitCreateResult["pathsToRejectedChanges"];
+	pathsToRejectedChanges?: Array<RejectedChange>;
 };
 
 // In the future this may be implemented as a single API endpoint on the backend.
@@ -68,7 +64,7 @@ export const rub = async ({ projectId, source, target }: RubParams): Promise<Rub
 								replacedCommits: response.replacedCommits,
 								newCommit: response.newCommit ?? null,
 								amendedCommitId: target.commitId,
-								pathsToRejectedChanges: response.pathsToRejectedChanges,
+								pathsToRejectedChanges: normalizeRejectedChanges(response.pathsToRejectedChanges),
 							};
 						}),
 						Match.exhaustive,

--- a/apps/lite/ui/src/components/RejectedChanges.tsx
+++ b/apps/lite/ui/src/components/RejectedChanges.tsx
@@ -24,18 +24,7 @@ export type RejectedChange = Omit<UIRejectedPath, "reason"> & {
 };
 
 function isRejectionReason(reason: string): reason is Exclude<RejectionReason, "unknown"> {
-	return (
-		reason === "noEffectiveChanges" ||
-		reason === "cherryPickMergeConflict" ||
-		reason === "workspaceMergeConflict" ||
-		reason === "workspaceMergeConflictOfUnrelatedFile" ||
-		reason === "worktreeFileMissingForObjectConversion" ||
-		reason === "fileToLargeOrBinary" ||
-		reason === "pathNotFoundInBaseTree" ||
-		reason === "unsupportedDirectoryEntry" ||
-		reason === "unsupportedTreeEntry" ||
-		reason === "missingDiffSpecAssociation"
-	);
+	return REJECTION_REASONS.includes(reason as RejectionReason) && reason !== "unknown";
 }
 
 export function normalizeRejectedChanges(

--- a/apps/lite/ui/src/components/RejectedChanges.tsx
+++ b/apps/lite/ui/src/components/RejectedChanges.tsx
@@ -1,22 +1,51 @@
+import { type UIRejectedPath } from "@gitbutler/but-sdk";
 import { type ToastManagerAddOptions } from "@base-ui/react";
 import { Array, pipe } from "effect";
 import { FC } from "react";
 
-// TODO: generate into but-sdk
-export type RejectedChange = [RejectionReason, string];
+export const REJECTION_REASONS = [
+	"noEffectiveChanges",
+	"cherryPickMergeConflict",
+	"workspaceMergeConflict",
+	"workspaceMergeConflictOfUnrelatedFile",
+	"worktreeFileMissingForObjectConversion",
+	"fileToLargeOrBinary",
+	"pathNotFoundInBaseTree",
+	"unsupportedDirectoryEntry",
+	"unsupportedTreeEntry",
+	"missingDiffSpecAssociation",
+	"unknown",
+] as const;
 
-// TODO: generate into but-sdk
-export type RejectionReason =
-	| "noEffectiveChanges"
-	| "cherryPickMergeConflict"
-	| "workspaceMergeConflict"
-	| "workspaceMergeConflictOfUnrelatedFile"
-	| "worktreeFileMissingForObjectConversion"
-	| "fileToLargeOrBinary"
-	| "pathNotFoundInBaseTree"
-	| "unsupportedDirectoryEntry"
-	| "unsupportedTreeEntry"
-	| "missingDiffSpecAssociation";
+export type RejectionReason = (typeof REJECTION_REASONS)[number];
+
+export type RejectedChange = Omit<UIRejectedPath, "reason"> & {
+	reason: RejectionReason;
+};
+
+function isRejectionReason(reason: string): reason is Exclude<RejectionReason, "unknown"> {
+	return (
+		reason === "noEffectiveChanges" ||
+		reason === "cherryPickMergeConflict" ||
+		reason === "workspaceMergeConflict" ||
+		reason === "workspaceMergeConflictOfUnrelatedFile" ||
+		reason === "worktreeFileMissingForObjectConversion" ||
+		reason === "fileToLargeOrBinary" ||
+		reason === "pathNotFoundInBaseTree" ||
+		reason === "unsupportedDirectoryEntry" ||
+		reason === "unsupportedTreeEntry" ||
+		reason === "missingDiffSpecAssociation"
+	);
+}
+
+export function normalizeRejectedChanges(
+	pathsToRejectedChanges: Array<UIRejectedPath>,
+): Array<RejectedChange> {
+	return pathsToRejectedChanges.map((change) => ({
+		...change,
+		reason: isRejectionReason(change.reason) ? change.reason : "unknown",
+	}));
+}
 
 const listFormatter = new Intl.ListFormat(undefined, {
 	style: "long",
@@ -52,6 +81,10 @@ const readableRejectionReason = (reason: RejectionReason): string => {
 			return "Unsupported tree entry";
 		case "missingDiffSpecAssociation":
 			return "Missing diff spec association";
+		case "unknown":
+			return "Unknown rejection reason";
+		default:
+			return reason;
 	}
 };
 
@@ -60,7 +93,7 @@ const RejectedChanges: FC<{
 }> = ({ rejectedChanges }) => {
 	const pathsByReason = new Map<RejectionReason, Array<string>>();
 
-	for (const [reason, path] of rejectedChanges) {
+	for (const { reason, path } of rejectedChanges) {
 		const paths = pathsByReason.get(reason);
 		if (paths) paths.push(path);
 		else pathsByReason.set(reason, [path]);

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -37,6 +37,27 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
     }
 }
 
+/// UI payload describing a rejected diff-spec path.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct UIRejectedPath {
+    /// The reason the diff spec was rejected.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub reason: but_core::tree::create_tree::RejectionReason,
+    /// The worktree-relative path, potentially degenerated if it can't be represented in Unicode.
+    pub path: String,
+    /// `path` without degeneration, as plain bytes.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(schema_with = "but_schemars::bstring_bytes")
+    )]
+    pub path_bytes: bstr::BString,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(UIRejectedPath);
+
 /// UI type for creating a commit in the rebase graph.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -46,11 +67,7 @@ pub struct UICommitCreateResult {
     #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub new_commit: Option<HexHash>,
     /// Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics.
-    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<(String, String)>"))]
-    pub paths_to_rejected_changes: Vec<(
-        but_core::tree::create_tree::RejectionReason,
-        but_serde::BStringForFrontend,
-    )>,
+    pub paths_to_rejected_changes: Vec<UIRejectedPath>,
     /// Commits that have been replaced as a side-effect of the create/amend.
     /// Maps `oldId -> newId`.
     #[cfg_attr(
@@ -75,7 +92,11 @@ impl From<CommitCreateResult> for UICommitCreateResult {
             new_commit: new_commit.map(Into::into),
             paths_to_rejected_changes: rejected_specs
                 .into_iter()
-                .map(|(reason, diff)| (reason, diff.path.into()))
+                .map(|(reason, diff)| UIRejectedPath {
+                    reason,
+                    path: diff.path.to_string(),
+                    path_bytes: diff.path,
+                })
                 .collect(),
             replaced_commits: replaced_commits
                 .into_iter()

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -943,7 +943,7 @@ export type UICommitCreateResult = {
   /** The new commit if one was created. */
   newCommit?: string | null;
   /** Paths that contained at least one rejected hunk, matching legacy rejection reporting semantics. */
-  pathsToRejectedChanges: Array<[string, string]>;
+  pathsToRejectedChanges: Array<UIRejectedPath>;
   /**
    * Commits that have been replaced as a side-effect of the create/amend.
    * Maps `oldId -> newId`.
@@ -998,6 +998,16 @@ export type UIMoveChangesResult = {
    * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;
+};
+
+/** UI payload describing a rejected diff-spec path. */
+export type UIRejectedPath = {
+  /** The reason the diff spec was rejected. */
+  reason: string;
+  /** The worktree-relative path, potentially degenerated if it can't be represented in Unicode. */
+  path: string;
+  /** `path` without degeneration, as plain bytes. */
+  pathBytes: Array<number>;
 };
 
 /**
@@ -1093,4 +1103,3 @@ export type WorktreeChanges = {
   dependencies?: HunkDependencies | null;
   dependenciesError: SerdeError | null;
 };
-

--- a/packages/shared/src/lib/branches/Minimap.svelte
+++ b/packages/shared/src/lib/branches/Minimap.svelte
@@ -2,11 +2,11 @@
 	import { goto } from "$app/navigation";
 	import ChangeStatus from "$lib/patches/ChangeStatus.svelte";
 	import { WEB_ROUTES_SERVICE } from "$lib/routing/webRoutes.svelte";
+	import { inject } from "@gitbutler/core/context";
 	import { getBranchReview } from "@gitbutler/shared/branches/branchesPreview.svelte";
 	import { isFound, map } from "@gitbutler/shared/network/loadable";
 	import { getPatch } from "@gitbutler/shared/patches/patchCommitsPreview.svelte";
 	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
-	import { inject } from "@gitbutler/core/context";
 	import { CommitStatusBadge } from "@gitbutler/ui";
 	import {
 		EXTERNAL_LINK_SERVICE,


### PR DESCRIPTION
Replace the remaining BStringForFrontend usage in but-api with an explicit SDK-facing payload that carries both a lossy path string and the original path bytes.

This is a better contract for but-sdk because the generated TypeScript types can describe the two values explicitly, instead of hiding the path inside a tuple element that loses the raw bytes. Frontends keep a display-friendly string while still being able to round-trip the original path losslessly when Unicode degeneration would otherwise throw information away.

Note: for now the `path_bytes` field is exported unconditionally even though it should be gated behind the `path-bytes` feature. As the `but-sdk` relies on it, it should probably be updated to also specify this flag - this can be a follow-up.

### Tasks

* [x] refackview
* [x] UI fixes

### Notes for the Reviewer

I did not run any actual UI tests, and rely on typechecking.
