### PR TITLE
Implement `but clean`

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -156,17 +156,20 @@ pub fn create_branch(
     Ok(())
 }
 
-#[but_api]
-#[instrument(err(Debug))]
-pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) -> Result<()> {
+/// Remove a branch without creating an oplog snapshot.
+///
+/// This is the core implementation used by both [`remove_branch`] (which creates its own snapshot)
+/// and batch operations like `but clean` (which create a single snapshot for multiple removals).
+pub fn remove_branch_only(
+    ctx: &mut Context,
+    branch_name: &str,
+    perm: &mut but_core::sync::RepoExclusive,
+) -> Result<()> {
     let ref_name = Category::LocalBranch
-        .to_full_name(branch_name.as_str())
+        .to_full_name(branch_name)
         .map_err(anyhow::Error::from)?;
-    let mut guard = ctx.exclusive_worktree_access();
-    ctx.snapshot_remove_dependent_branch(&branch_name, guard.write_permission())
-        .ok();
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let new_ws = but_workspace::branch::remove_reference(
         ref_name.as_ref(),
         &repo,
@@ -174,9 +177,6 @@ pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) 
         &mut meta,
         but_workspace::branch::remove_reference::Options {
             avoid_anonymous_stacks: true,
-            // The UI kind of keeps it, but we can't do that somehow
-            // the object id is null, and stuff breaks. Fine for now.
-            // Delete is delete.
             keep_metadata: false,
         },
     )?;
@@ -185,6 +185,15 @@ pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) 
         *ws = new_ws;
     }
     Ok(())
+}
+
+#[but_api]
+#[instrument(err(Debug))]
+pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    ctx.snapshot_remove_dependent_branch(&branch_name, guard.write_permission())
+        .ok();
+    remove_branch_only(ctx, &branch_name, guard.write_permission())
 }
 
 #[but_api]

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -12,6 +12,7 @@ Comprehensive reference for all `but` commands.
 - [Conflict Resolution](#conflict-resolution) - `resolve`
 - [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `merge`
 - [Automation](#automation) - `mark`, `unmark`
+- [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
 - [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `gui`, `update`, `alias`
 - [Global Options](#global-options)
@@ -480,6 +481,23 @@ but unmark
 ```
 
 Use marks when working on a focused area to automatically organize changes.
+
+## Workspace Maintenance
+
+### `but clean`
+
+Remove empty branches from the workspace.
+
+```bash
+but clean                   # Delete all empty branches
+but clean --dry-run         # Preview which branches would be deleted
+but clean --pull            # Pull latest changes first, then clean
+but clean --include-upstream # Also remove branches with upstream-only commits
+```
+
+A branch is considered empty if it has no local commits and no assigned changes. Branches with upstream-only commits are preserved by default unless `--include-upstream` is used.
+
+The entire operation is a single oplog entry — use `but undo` to restore all deleted branches.
 
 ## History & Undo
 

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -61,6 +61,7 @@ pub enum CommandName {
     SkillInstall,
     SkillCheck,
     Pick,
+    Clean,
     #[default]
     Unknown,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -454,6 +454,54 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Push(push::Command),
 
+    /// Remove empty branches from the workspace.
+    ///
+    /// A branch is considered empty if it has no local commits, no assigned
+    /// changes, and (by default) no upstream-only commits.
+    ///
+    /// The entire operation is recorded as a single oplog entry, so it can
+    /// be undone with `but undo`.
+    ///
+    /// ## Examples
+    ///
+    /// Remove all empty branches:
+    ///
+    /// ```text
+    /// but clean
+    /// ```
+    ///
+    /// Preview which branches would be removed:
+    ///
+    /// ```text
+    /// but clean --dry-run
+    /// ```
+    ///
+    /// Pull latest changes first, then clean:
+    ///
+    /// ```text
+    /// but clean --pull
+    /// ```
+    ///
+    /// Also remove branches that only have upstream commits:
+    ///
+    /// ```text
+    /// but clean --include-upstream
+    /// ```
+    ///
+    #[cfg(feature = "legacy")]
+    #[clap(verbatim_doc_comment)]
+    Clean {
+        /// Preview which branches would be removed without actually deleting them.
+        #[clap(long)]
+        dry_run: bool,
+        /// Pull latest changes from the remote before cleaning.
+        #[clap(long)]
+        pull: bool,
+        /// Also remove branches that have upstream-only commits but no local commits or changes.
+        #[clap(long)]
+        include_upstream: bool,
+    },
+
     /// Edit the commit message of the specified commit.
     ///
     /// You can easily change the commit message of any of your commits by

--- a/crates/but/src/command/legacy/clean.rs
+++ b/crates/but/src/command/legacy/clean.rs
@@ -1,0 +1,224 @@
+use std::collections::HashSet;
+
+use but_core::ref_metadata::StackId;
+use colored::Colorize;
+use gitbutler_oplog::{
+    OplogExt,
+    entry::{OperationKind, SnapshotDetails},
+};
+
+use crate::utils::OutputChannel;
+
+/// Options for the clean command.
+pub struct CleanOptions {
+    pub dry_run: bool,
+    pub include_upstream: bool,
+}
+
+/// A branch that was deleted (or would be deleted in dry-run mode).
+#[derive(Debug, serde::Serialize)]
+struct CleanedBranch {
+    name: String,
+}
+
+/// A branch deletion that failed.
+#[derive(Debug, Clone, serde::Serialize)]
+struct FailedBranch {
+    name: String,
+    error: String,
+}
+
+/// JSON output for the clean command.
+#[derive(Debug, serde::Serialize)]
+struct CleanResult<'a> {
+    deleted: &'a [CleanedBranch],
+    #[serde(skip_serializing_if = "<[FailedBranch]>::is_empty")]
+    failed: &'a [FailedBranch],
+    dry_run: bool,
+}
+
+pub fn handle(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    options: CleanOptions,
+) -> anyhow::Result<()> {
+    let empty_branches = find_empty_branches(ctx, options.include_upstream)?;
+
+    if empty_branches.is_empty() {
+        if let Some(out) = out.for_json() {
+            out.write_value(&CleanResult {
+                deleted: &[],
+                failed: &[],
+                dry_run: options.dry_run,
+            })?;
+        } else if let Some(out) = out.for_human() {
+            writeln!(out, "No empty branches found.")?;
+        } else if let Some(_out) = out.for_shell() {
+            // No output for shell when nothing to clean.
+        }
+        return Ok(());
+    }
+
+    if options.dry_run {
+        let cleaned: Vec<CleanedBranch> = empty_branches
+            .iter()
+            .map(|(_, name)| CleanedBranch { name: name.clone() })
+            .collect();
+
+        if let Some(out) = out.for_json() {
+            out.write_value(&CleanResult {
+                deleted: &cleaned,
+                failed: &[],
+                dry_run: true,
+            })?;
+        } else if let Some(out) = out.for_human() {
+            for (_, name) in &empty_branches {
+                writeln!(out, "Would delete branch: {}", name.yellow())?;
+            }
+            let count = empty_branches.len();
+            writeln!(out, "Found {} empty branch(es)", count.to_string().bold())?;
+        } else if let Some(out) = out.for_shell() {
+            for (_, name) in &empty_branches {
+                writeln!(out, "{name}")?;
+            }
+        }
+        return Ok(());
+    }
+
+    // Create a single oplog snapshot before performing all deletions.
+    let mut guard = ctx.exclusive_worktree_access();
+    ctx.create_snapshot(
+        SnapshotDetails::new(OperationKind::CleanWorkspace),
+        guard.write_permission(),
+    )
+    .ok();
+
+    let mut deleted = Vec::new();
+    let mut failed = Vec::new();
+
+    for (_stack_id, branch_name) in &empty_branches {
+        match but_api::legacy::stack::remove_branch_only(ctx, branch_name, guard.write_permission())
+        {
+            Ok(()) => {
+                deleted.push(CleanedBranch {
+                    name: branch_name.clone(),
+                });
+            }
+            Err(err) => {
+                failed.push(FailedBranch {
+                    name: branch_name.clone(),
+                    error: err.to_string(),
+                });
+            }
+        }
+    }
+
+    let num_failed = failed.len();
+
+    if let Some(out) = out.for_json() {
+        out.write_value(&CleanResult {
+            deleted: &deleted,
+            failed: &failed,
+            dry_run: false,
+        })?;
+    } else if let Some(out) = out.for_human() {
+        for branch in &deleted {
+            writeln!(out, "  Deleted branch: {}", branch.name.green())?;
+        }
+        if !deleted.is_empty() {
+            writeln!(
+                out,
+                "{} Deleted {} empty branch(es)",
+                "✓".green().bold(),
+                deleted.len().to_string().bold()
+            )?;
+        }
+        for f in &failed {
+            writeln!(
+                out,
+                "{} Failed to delete branch '{}': {}",
+                "!".red().bold(),
+                f.name,
+                f.error
+            )?;
+        }
+    } else if let Some(out) = out.for_shell() {
+        for branch in &deleted {
+            writeln!(out, "{}", branch.name)?;
+        }
+    }
+
+    if num_failed == 0 {
+        Ok(())
+    } else {
+        anyhow::bail!("failed to delete {num_failed} branch(es)")
+    }
+}
+
+/// Find all empty branches in the workspace.
+///
+/// Returns a list of `(StackId, branch_name)` pairs for branches that are empty.
+/// A branch is considered empty if:
+/// - It has no local commits
+/// - The stack has no assigned worktree changes
+/// - It has no upstream-only commits (unless `include_upstream` is true)
+fn find_empty_branches(
+    ctx: &mut but_ctx::Context,
+    include_upstream: bool,
+) -> anyhow::Result<Vec<(StackId, String)>> {
+    // Get the set of stack IDs that have worktree changes assigned to them.
+    let stacks_with_changes = stacks_with_assigned_changes(ctx)?;
+
+    let stacks = but_api::legacy::workspace::stacks(
+        ctx,
+        Some(but_workspace::legacy::StacksFilter::InWorkspace),
+    )?;
+
+    let mut empty_branches = Vec::new();
+
+    for stack_entry in &stacks {
+        let Some(stack_id) = stack_entry.id else {
+            continue;
+        };
+
+        // If the stack has assigned worktree changes, none of its branches are empty.
+        if stacks_with_changes.contains(&stack_id) {
+            continue;
+        }
+
+        let details = but_api::legacy::workspace::stack_details(ctx, Some(stack_id))?;
+
+        for branch in &details.branch_details {
+            let has_local_commits = !branch.commits.is_empty();
+            let has_upstream_commits = !branch.upstream_commits.is_empty();
+
+            if has_local_commits {
+                continue;
+            }
+
+            if has_upstream_commits && !include_upstream {
+                continue;
+            }
+
+            empty_branches.push((stack_id, branch.name.to_string()));
+        }
+    }
+
+    Ok(empty_branches)
+}
+
+/// Returns the set of stack IDs that have at least one worktree change assigned to them.
+fn stacks_with_assigned_changes(ctx: &mut but_ctx::Context) -> anyhow::Result<HashSet<StackId>> {
+    let context_lines = ctx.settings.context_lines;
+    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+    let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
+    let (assignments, _err) = but_hunk_assignment::assignments_with_fallback(
+        db.hunk_assignments_mut()?,
+        &repo,
+        &ws,
+        Some(changes),
+        context_lines,
+    )?;
+
+    Ok(assignments.into_iter().filter_map(|a| a.stack_id).collect())
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -8,6 +8,7 @@ pub mod absorb;
 pub mod actions;
 pub mod ai;
 pub mod branch;
+pub mod clean;
 pub mod commit;
 pub mod commit_message_prep;
 pub mod diff;

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -100,6 +100,7 @@ pub(crate) fn show_oplog(
                     OperationKind::DeleteBranch => "DELETE",
                     OperationKind::DiscardChanges => "DISCARD",
                     OperationKind::Discard => "DISCARD",
+                    OperationKind::CleanWorkspace => "CLEAN",
                     OperationKind::OnDemandSnapshot => "SNAPSHOT",
                     _ => "OTHER",
                 };

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -567,6 +567,43 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
+        Subcommands::Clean {
+            dry_run,
+            pull,
+            include_upstream,
+        } => {
+            let status_after = args.status_after;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    background_sync: BackgroundSync::Enabled { silent: false },
+                    ..Default::default()
+                },
+                out,
+            )?;
+            if pull {
+                use std::fmt::Write;
+                let mut progress = out.progress_channel();
+                writeln!(progress, "Pulling latest...")?;
+                let mut pull_out =
+                    OutputChannel::new_with_optional_pager(OutputFormat::None, false);
+                command::legacy::pull::handle(&ctx, &mut pull_out, false).await?;
+                writeln!(progress, "Pull complete.")?;
+            }
+            out.begin_status_after(status_after);
+            let result = command::legacy::clean::handle(
+                &mut ctx,
+                out,
+                command::legacy::clean::CleanOptions {
+                    dry_run,
+                    include_upstream,
+                },
+            )
+            .emit_metrics(metrics_ctx);
+            maybe_run_status_after(status_after, &result, &mut ctx, out).await;
+            result
+        }
+        #[cfg(feature = "legacy")]
         Subcommands::Worktree(worktree::Platform { cmd }) => {
             let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             command::legacy::worktree::handle(cmd, &mut ctx, out)

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -217,6 +217,8 @@ impl Subcommands {
                 skill::Subcommands::Check { .. } => SkillCheck,
             },
             Subcommands::Edit { .. } => Edit,
+            #[cfg(feature = "legacy")]
+            Subcommands::Clean { .. } => Clean,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
         }
     }

--- a/crates/but/tests/but/command/clean.rs
+++ b/crates/but/tests/but/command/clean.rs
@@ -1,0 +1,190 @@
+use snapbox::str;
+
+use crate::utils::{CommandExt, Sandbox};
+
+#[test]
+fn no_empty_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("clean")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+No empty branches found.
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn removes_empty_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new empty-branch").assert().success();
+
+    env.but("clean")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+  Deleted branch: empty-branch
+✓ Deleted 1 empty branch(es)
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn dry_run_does_not_delete() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new empty-branch").assert().success();
+
+    env.but("clean --dry-run")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Would delete branch: empty-branch
+Found 1 empty branch(es)
+
+"#]]);
+
+    // Branch should still exist — clean again would still find it
+    env.but("clean --dry-run")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Would delete branch: empty-branch
+Found 1 empty branch(es)
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn does_not_remove_branch_with_commits() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // A has a commit, so clean should find nothing
+    env.but("clean").assert().success().stdout_eq(str![[r#"
+No empty branches found.
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn json_output() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new empty-branch").assert().success();
+
+    env.but("--json clean")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "deleted": [
+    {
+      "name": "empty-branch"
+    }
+  ],
+  "dry_run": false
+}
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn json_output_dry_run() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new empty-branch").assert().success();
+
+    env.but("--json clean --dry-run")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "deleted": [
+    {
+      "name": "empty-branch"
+    }
+  ],
+  "dry_run": true
+}
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn json_output_no_empty_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("--json clean")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "deleted": [],
+  "dry_run": false
+}
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn does_not_remove_branch_with_assigned_changes() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    // Create a new empty branch
+    env.but("branch new my-branch").assert().success();
+
+    // Assign a file change to this branch's stack
+    env.file("new-file.txt", "content");
+    env.but("rub new-file.txt my-branch").assert().success();
+
+    // my-branch has assigned changes, should not be cleaned
+    env.but("clean").assert().success().stdout_eq(str![[r#"
+No empty branches found.
+
+"#]]);
+    Ok(())
+}
+
+#[test]
+fn creates_oplog_entry() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new empty-branch").assert().success();
+    env.but("clean").assert().success();
+
+    // Verify oplog has a CLEAN entry
+    let output = env.but("oplog").output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("CLEAN"),
+        "oplog should contain a CLEAN entry, got:\n{stdout}"
+    );
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -8,6 +8,8 @@ mod branch;
 #[cfg(feature = "legacy")]
 mod claude;
 #[cfg(feature = "legacy")]
+mod clean;
+#[cfg(feature = "legacy")]
 mod commit;
 #[cfg(feature = "legacy")]
 mod cursor;

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -165,6 +165,7 @@ pub enum OperationKind {
     AutoHandleChangesBefore,
     AutoHandleChangesAfter,
     SplitBranch,
+    CleanWorkspace,
     OnDemandSnapshot,
     #[default]
     Unknown,


### PR DESCRIPTION
## Summary

Implements `but clean` — a workspace housekeeping command that removes empty branches. Closes #13005.

### How it works

A branch is considered **empty** if it has:
- No local commits
- No assigned worktree changes
- No upstream-only commits (by default)

```
$ but clean
  Deleted branch: old-experiment
  Deleted branch: scratch-pad
✓ Deleted 2 empty branch(es)
```

The entire operation creates a **single oplog entry**, so `but undo` restores all deleted branches at once.

### Flags

| Flag | Effect |
|------|--------|
| `--dry-run` | Preview which branches would be removed |
| `--pull` | Pull latest changes before cleaning |
| `--include-upstream` | Also remove branches that only have upstream commits |

Supports `--status-after` and all output formats (human, JSON, shell).

### Implementation

- New `OperationKind::CleanWorkspace` oplog variant
- Extracted `remove_branch_only()` from `remove_branch()` to allow batch deletions without per-branch snapshots
- 9 integration tests covering happy path, dry-run, JSON output, assigned changes protection, and oplog verification