### PR TITLE
Move-commit should prevent inter-stack conflicts + Myers diff false positive causes hard failure

### DIFF
--- a/crates/but-workspace/tests/fixtures/scenario/move-commit-dependent-changes.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/move-commit-dependent-changes.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two stacked commits on a single branch editing different parts of the same file.
+# An empty second branch is set up as a move target.
+#
+# Base file: alpha\nbravo\ncharlie\n
+# Commit 1: adds "first" at the top → first\nalpha\nbravo\ncharlie\n
+# Commit 2: adds "last" at the bottom → first\nalpha\nbravo\ncharlie\nlast\n
+#
+# Moving commit 2 to the empty branch cherry-picks it onto main. The 3-way merge:
+#   base = first\nalpha\nbravo\ncharlie\n  (parent of commit 2)
+#   ours = alpha\nbravo\ncharlie\n          (main)
+#   theirs = first\nalpha\nbravo\ncharlie\nlast\n  (commit 2)
+#
+# base→ours removes "first" at top; base→theirs adds "last" at bottom.
+# These are non-overlapping edits that should merge cleanly.
+
+git init
+
+printf 'alpha\nbravo\ncharlie\n' > shared-file
+git add shared-file
+git commit -m "M"
+setup_target_to_match_main
+
+git branch B
+
+git checkout -b A
+  printf 'first\nalpha\nbravo\ncharlie\n' > shared-file
+  git add shared-file
+  git commit -m "add first at top"
+
+  printf 'first\nalpha\nbravo\ncharlie\nlast\n' > shared-file
+  git add shared-file
+  git commit -m "add last at bottom"
+
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/fixtures/scenario/move-commit-myers-false-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/move-commit-myers-false-conflict.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two stacked commits on a single branch, both editing a file with the blank-line
+# pattern that triggers the Myers diff false conflict (GitoxideLabs/gitoxide#2475).
+# An empty second branch is set up as a move target.
+#
+# Base file: alpha_x\n\nbravo_x\ncharlie_x\n\n
+# Commit 1 (delete-alpha): deletes alpha_x (replaces with blank, removes trailing blank)
+# Commit 2 (delete-bravo): deletes bravo_x
+#
+# Moving commit 2 to the empty branch cherry-picks it onto main, producing a 3-way
+# merge whose base tree has the blank-line structure that triggers the Myers bug.
+
+git init
+
+printf 'alpha_x\n\nbravo_x\ncharlie_x\n\n' > shared-file
+git add shared-file
+git commit -m "M"
+setup_target_to_match_main
+
+git branch B
+
+git checkout -b A
+  printf '\n\nbravo_x\ncharlie_x\n' > shared-file
+  git add shared-file
+  git commit -m "delete alpha_x"
+
+  printf '\n\ncharlie_x\n' > shared-file
+  git add shared-file
+  git commit -m "delete bravo_x"
+
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/fixtures/scenario/move-commit-overlapping-changes.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/move-commit-overlapping-changes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two stacked commits on a single branch, both editing the SAME line of a file.
+# An empty second branch is set up as a move target.
+#
+# Base file: alpha\nbravo\ncharlie\n
+# Commit 1: changes bravo → bravo_modified
+# Commit 2: changes bravo_modified → bravo_replaced
+#
+# Moving commit 2 to the empty branch cherry-picks it onto main. The 3-way merge
+# has a genuine conflict: base has bravo_modified, ours has bravo, theirs has
+# bravo_replaced — all three differ on the same line.
+
+git init
+
+printf 'alpha\nbravo\ncharlie\n' > shared-file
+git add shared-file
+git commit -m "M"
+setup_target_to_match_main
+
+git branch B
+
+git checkout -b A
+  printf 'alpha\nbravo_modified\ncharlie\n' > shared-file
+  git add shared-file
+  git commit -m "modify bravo"
+
+  printf 'alpha\nbravo_replaced\ncharlie\n' > shared-file
+  git add shared-file
+  git commit -m "replace bravo"
+
+git checkout B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1,5 +1,6 @@
 use but_rebase::graph_rebase::{Editor, mutate::InsertSide};
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+use gix::prelude::ObjectIdExt;
 
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
@@ -783,6 +784,162 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
         └── :2:one
             └── ·8b426d0
     ");
+
+    Ok(())
+}
+
+/// Moving the top commit of a two-commit stack to an empty branch when the file
+/// has the blank-line pattern (`item\n\nitem\nitem\n\n`) that triggers the Myers
+/// diff false conflict (GitoxideLabs/gitoxide#2475).
+///
+/// The cherry-pick's 3-way merge base has the exact blank-line structure that
+/// causes Myers to produce an empty insertion hunk colliding with the other
+/// side's deletion. Currently this causes a `FailedToMergeBases` error.
+///
+/// Once the upstream gitoxide fix lands, this test should be updated to assert
+/// that the move succeeds and the resulting commit is NOT conflicted.
+#[test]
+fn move_top_commit_to_empty_branch_myers_false_conflict() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "move-commit-myers-false-conflict",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
+    // Select the top commit of A (delete bravo_x) and move it to empty branch B.
+    let a_tip = repo.rev_parse_single("A")?.detach();
+    let a_tip_selector = editor.select_commit(a_tip)?;
+    let b_ref_selector = editor.select_reference("refs/heads/B".try_into()?)?;
+
+    let result = but_workspace::commit::move_commit(
+        editor,
+        a_tip_selector,
+        b_ref_selector,
+        InsertSide::Below,
+    );
+
+    // BUG (gitoxide#2475): The blank-line pattern triggers a Myers diff false
+    // conflict that causes the cherry-pick to fail with FailedToMergeBases.
+    // Once fixed upstream, this should succeed and produce a non-conflicted commit.
+    let err = result.expect_err(
+        "Expected FailedToMergeBases error due to Myers false conflict (gitoxide#2475). \
+         If this starts passing, the upstream fix has landed — update this test to \
+         assert the commit is not conflicted.",
+    );
+    let err_str = format!("{err:#}");
+    assert!(
+        err_str.contains("Failed to merge bases"),
+        "Expected 'Failed to merge bases' error, got: {err_str}"
+    );
+
+    Ok(())
+}
+
+/// Moving the top commit of a two-commit stack to an empty branch when the file
+/// edits different, non-overlapping parts of the same file.
+/// Commit 1 adds "first" at the top, commit 2 adds "last" at the bottom.
+///
+/// Cherry-picking commit 2 onto main produces a 3-way merge where:
+///   base→ours removes "first" at top, base→theirs adds "last" at bottom.
+/// These are clearly non-overlapping edits that should merge cleanly.
+#[test]
+fn move_top_commit_to_empty_branch_dependent_changes() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "move-commit-dependent-changes",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
+    // Select the top commit of A ("add last at bottom") and move it to empty branch B.
+    let a_tip = repo.rev_parse_single("A")?.detach();
+    let a_tip_selector = editor.select_commit(a_tip)?;
+    let b_ref_selector = editor.select_reference("refs/heads/B".try_into()?)?;
+
+    let rebase = but_workspace::commit::move_commit(
+        editor,
+        a_tip_selector,
+        b_ref_selector,
+        InsertSide::Below,
+    )?;
+
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_commit_id = commit_mapping
+        .get(&a_tip)
+        .expect("moved commit should appear in mapping");
+    let moved_commit = but_core::Commit::from_id((*new_commit_id).attach(&repo))?;
+
+    // The edits are on opposite ends of the file (top vs bottom) and should merge
+    // cleanly. The moved commit should NOT be conflicted.
+    assert!(
+        !moved_commit.is_conflicted(),
+        "Non-overlapping edits (add at top vs add at bottom) should merge cleanly."
+    );
+
+    Ok(())
+}
+
+/// Moving the top commit of a two-commit stack to an empty branch when both
+/// commits modify the SAME line of the same file (genuinely overlapping edits).
+///
+/// Commit 1 changes `bravo` → `bravo_modified`, commit 2 changes `bravo_modified`
+/// → `bravo_replaced`. Cherry-picking commit 2 onto main produces a 3-way merge
+/// where base has `bravo_modified`, ours has `bravo`, theirs has `bravo_replaced` —
+/// a real conflict on the same line.
+#[test]
+fn move_top_commit_to_empty_branch_overlapping_changes() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "move-commit-overlapping-changes",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
+    let a_tip = repo.rev_parse_single("A")?.detach();
+    let a_tip_selector = editor.select_commit(a_tip)?;
+    let b_ref_selector = editor.select_reference("refs/heads/B".try_into()?)?;
+
+    let rebase = but_workspace::commit::move_commit(
+        editor,
+        a_tip_selector,
+        b_ref_selector,
+        InsertSide::Below,
+    )?;
+
+    let materialization = rebase.materialize()?;
+    let commit_mapping = materialization.history.commit_mappings();
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let new_commit_id = commit_mapping
+        .get(&a_tip)
+        .expect("moved commit should appear in mapping");
+    let moved_commit = but_core::Commit::from_id((*new_commit_id).attach(&repo))?;
+
+    // This is a genuine conflict — both sides modify the same line differently.
+    assert!(
+        moved_commit.is_conflicted(),
+        "The moved commit should be conflicted — both commits edit the same line, \
+         so cherry-picking onto main creates a real 3-way conflict."
+    );
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/move_commit_to_vbranch.rs
@@ -4,7 +4,7 @@ use gitbutler_branch::BranchCreateRequest;
 use gitbutler_stack::StackId;
 use gitbutler_testsupport::stack_details;
 
-use super::Test;
+use super::{Test, create_commit};
 
 #[test]
 fn no_diffs() {
@@ -629,5 +629,319 @@ fn no_branch() {
             .unwrap_err()
             .to_string(),
         "Destination branch not found"
+    );
+}
+
+/// Moving the top commit of a two-commit stack (both editing the same file) to an
+/// empty branch, where the file has the blank-line pattern that triggers the Myers
+/// diff false conflict (GitoxideLabs/gitoxide#2475).
+///
+/// The 3-way merge base has the exact blank-line structure (`item\n\nitem\nitem\n\n`)
+/// that causes Myers to produce an empty insertion hunk colliding with the other
+/// side's deletion.
+///
+/// Once the upstream gitoxide fix lands, this test should be updated to assert that
+/// the move succeeds cleanly.
+#[test]
+fn myers_false_conflict_on_move_to_empty_branch() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Set up initial file content on origin/master so it becomes the merge base.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "alpha_x\n\nbravo_x\ncharlie_x\n\n",
+    )
+    .unwrap();
+    repo.commit_all("M");
+    repo.push();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // First commit: delete alpha_x (keep the blank-line structure).
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "\n\nbravo_x\ncharlie_x\n",
+    )
+    .unwrap();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let _stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    let details = stack_details(ctx);
+    assert_eq!(details.len(), 1);
+    let source_branch_id = details[0].0;
+
+    create_commit(ctx, source_branch_id, "delete alpha_x").unwrap();
+
+    // Second commit: delete bravo_x.
+    std::fs::write(repo.path().join("shared-file"), "\n\ncharlie_x\n").unwrap();
+    let top_commit_oid = create_commit(ctx, source_branch_id, "delete bravo_x").unwrap();
+
+    // Create empty target branch.
+    let mut guard = ctx.exclusive_worktree_access();
+    let target_stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    gitbutler_branch_actions::move_commit(
+        ctx,
+        target_stack_entry.id,
+        top_commit_oid.to_gix(),
+        source_branch_id,
+    )
+    .unwrap();
+
+    let destination = stack_details(ctx)
+        .into_iter()
+        .find(|d| d.0 == target_stack_entry.id)
+        .unwrap();
+
+    assert_eq!(
+        destination.1.branch_details[0].commits.len(),
+        1,
+        "The moved commit should be on the destination branch"
+    );
+
+    // BUG (gitoxide#2475): The legacy rebase uses merge_options_force_ours, so the
+    // Myers false conflict is silently auto-resolved rather than producing an error
+    // or a conflicted commit. The commit appears clean but may have incorrect content
+    // (the "ours" side wins where the merge should have combined both sides).
+    //
+    // Verify the commit exists and is not marked conflicted — but note the tree
+    // content may be wrong due to the forced resolution.
+    assert!(
+        !destination.1.branch_details[0].commits[0].has_conflicts,
+        "The legacy path force-resolves conflicts, so the commit should appear clean. \
+         If this changes, the rebase strategy may have been updated."
+    );
+
+    // Check the actual tree content of the moved commit.
+    let gix_repo = ctx.repo.get().unwrap();
+    let moved_commit_id = destination.1.branch_details[0].commits[0].id;
+    let moved_commit = gix_repo.find_commit(moved_commit_id).unwrap();
+    let tree = gix_repo
+        .find_tree(moved_commit.tree_id().unwrap())
+        .unwrap();
+    let entry = tree.find_entry("shared-file").expect("shared-file should exist in tree");
+    let blob = gix_repo.find_blob(entry.id()).unwrap();
+    let content = std::str::from_utf8(blob.data.as_ref()).unwrap();
+
+    // The correct result of cherry-picking "delete bravo_x" onto origin/master
+    // (which has `alpha_x\n\nbravo_x\ncharlie_x\n\n`) should be:
+    // `alpha_x\n\ncharlie_x\n\n` (bravo_x removed, alpha_x kept).
+    //
+    // TODO: Once the upstream gitoxide fix lands, assert the correct content.
+    // For now, just record what the legacy path actually produces.
+    assert!(
+        !content.is_empty(),
+        "The moved commit should have content in shared-file"
+    );
+}
+
+/// Moving the top commit of a two-commit stack to an empty branch, where the two
+/// commits edit different, non-overlapping parts of the same file. Commit 1 adds
+/// "first" at the top, commit 2 adds "last" at the bottom.
+///
+/// Cherry-picking commit 2 onto origin/master produces a 3-way merge where
+/// base→ours removes "first" at top, base→theirs adds "last" at bottom.
+/// These are non-overlapping edits that should merge cleanly.
+#[test]
+fn dependent_changes_move_to_empty_branch() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Set up initial file content on origin/master.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "alpha\nbravo\ncharlie\n",
+    )
+    .unwrap();
+    repo.commit_all("M");
+    repo.push();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // First commit: add "first" at the top.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "first\nalpha\nbravo\ncharlie\n",
+    )
+    .unwrap();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let _stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    let details = stack_details(ctx);
+    assert_eq!(details.len(), 1);
+    let source_branch_id = details[0].0;
+
+    create_commit(ctx, source_branch_id, "add first at top").unwrap();
+
+    // Second commit: add "last" at the bottom.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "first\nalpha\nbravo\ncharlie\nlast\n",
+    )
+    .unwrap();
+    let top_commit_oid = create_commit(ctx, source_branch_id, "add last at bottom").unwrap();
+
+    // Create empty target branch.
+    let mut guard = ctx.exclusive_worktree_access();
+    let target_stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // Non-overlapping edits (top vs bottom of file) — should merge cleanly.
+    gitbutler_branch_actions::move_commit(
+        ctx,
+        target_stack_entry.id,
+        top_commit_oid.to_gix(),
+        source_branch_id,
+    )
+    .unwrap();
+
+    let destination = stack_details(ctx)
+        .into_iter()
+        .find(|d| d.0 == target_stack_entry.id)
+        .unwrap();
+
+    assert_eq!(
+        destination.1.branch_details[0].commits.len(),
+        1,
+        "The moved commit should be on the destination branch"
+    );
+
+    assert!(
+        !destination.1.branch_details[0].commits[0].has_conflicts,
+        "Non-overlapping edits (add at top vs add at bottom) should merge cleanly."
+    );
+}
+
+/// Moving the top commit of a two-commit stack (both editing the SAME line) to an
+/// empty branch. This is a genuinely overlapping edit — commit 1 changes `bravo` →
+/// `bravo_modified`, commit 2 changes `bravo_modified` → `bravo_replaced`.
+///
+/// Cherry-picking commit 2 onto origin/master produces a real 3-way conflict:
+/// base=`bravo_modified`, ours=`bravo`, theirs=`bravo_replaced`.
+#[test]
+fn overlapping_changes_move_to_empty_branch() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+
+    // Set up initial file content on origin/master.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "alpha\nbravo\ncharlie\n",
+    )
+    .unwrap();
+    repo.commit_all("M");
+    repo.push();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    // First commit: modify bravo → bravo_modified.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "alpha\nbravo_modified\ncharlie\n",
+    )
+    .unwrap();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let _stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    let details = stack_details(ctx);
+    assert_eq!(details.len(), 1);
+    let source_branch_id = details[0].0;
+
+    create_commit(ctx, source_branch_id, "modify bravo").unwrap();
+
+    // Second commit: replace bravo_modified → bravo_replaced.
+    std::fs::write(
+        repo.path().join("shared-file"),
+        "alpha\nbravo_replaced\ncharlie\n",
+    )
+    .unwrap();
+    let top_commit_oid = create_commit(ctx, source_branch_id, "replace bravo").unwrap();
+
+    // Create empty target branch.
+    let mut guard = ctx.exclusive_worktree_access();
+    let target_stack_entry = gitbutler_branch_actions::create_virtual_branch(
+        ctx,
+        &BranchCreateRequest::default(),
+        guard.write_permission(),
+    )
+    .unwrap();
+    drop(guard);
+
+    gitbutler_branch_actions::move_commit(
+        ctx,
+        target_stack_entry.id,
+        top_commit_oid.to_gix(),
+        source_branch_id,
+    )
+    .unwrap();
+
+    let destination = stack_details(ctx)
+        .into_iter()
+        .find(|d| d.0 == target_stack_entry.id)
+        .unwrap();
+
+    assert_eq!(
+        destination.1.branch_details[0].commits.len(),
+        1,
+        "The moved commit should be on the destination branch"
+    );
+
+    // This is a genuine conflict — both sides modify the same line. The legacy
+    // path correctly produces a conflicted commit here.
+    assert!(
+        destination.1.branch_details[0].commits[0].has_conflicts,
+        "The moved commit should be conflicted — both commits edit the same line, \
+         so cherry-picking onto main creates a real 3-way conflict."
     );
 }


### PR DESCRIPTION
There are two related problems with commit moves in GitButler:

### 1. Move-commit allows creating conflicted commits between stacks

When a user moves a commit from one stack to another (e.g. dragging from stack A to empty stack B), the cherry-pick can produce a conflicted commit on the destination stack. GitButler currently allows this — the move succeeds and a conflicted commit silently lands on the target branch.

This is a problem because GitButler's core value proposition is managing multiple branch checkouts in the same working directory. Inter-stack conflicts are extremely difficult to resolve in this context and should be prevented at the operation level, not surfaced after the fact. Ensuring stacks remain mutually exclusive should be our top priority.

### 2. Myers diff false positive causes hard failure on the graph-based path (gitoxide#2475)

A specific file content pattern involving blank lines (`item\n\nitem\nitem\n\n`) triggers a [false conflict in gitoxide's Myers diff implementation](https://github.com/GitoxideLabs/gitoxide/issues/2475) ([fix PR](https://github.com/GitoxideLabs/gitoxide/pull/2476)). When this pattern appears in the 3-way merge base during a cherry-pick, the two code paths behave differently:

- **Graph-based path** (desktop app, `but-workspace::commit::move_commit`): Hard `FailedToMergeBases` error. The operation fails completely.
- **Legacy path** (`gitbutler-branch-actions::move_commit`): Silently succeeds via `merge_options_force_ours`, but the resulting tree content may be incorrect (the "ours" side wins where the merge should have combined both sides).

## Reproduction

The user sees this in the logs during the failed move:

```
Failed to merge bases while cherry picking commit <sha>.
Encountered a conflict while merging the commit's new bases: <sha>, <sha>.
Any ids mentioned may be in-memory and inaccessible through the git CLI.
```

A reproduction repo is available (ask Mattias), or run the tests below.

## Test coverage

Six tests have been added covering a 3×2 matrix (3 scenarios × 2 code paths):

| Scenario | Graph-based (`but-workspace`) | Legacy (`gitbutler-branch-actions`) | Correct behavior |
|---|---|---|---|
| **Myers false conflict** (blank-line trigger) | `FailedToMergeBases` error | Silently clean (wrong tree content) | Should be prevented or merge cleanly |
| **Non-overlapping edits** (add at top + add at bottom) | Clean merge | Clean merge | Clean merge |
| **Overlapping edits** (same line modified) | Conflicted commit (accepted) | Conflicted commit (accepted) | **Should be prevented** |

### Run the tests

```bash
# Graph-based (3 tests)
cargo test -p but-workspace --test workspace "move_top_commit_to_empty_branch"

# Legacy (3 tests)
cargo test -p gitbutler-branch-actions --test branch-actions "move_commit_to_vbranch" \
  -- --skip no_diffs --skip multiple --skip diffs_on --skip locked --skip no_commit --skip no_branch
```

### Test files

- **Graph-based**: `crates/but-workspace/tests/workspace/commit/move_commit.rs`
  - `move_top_commit_to_empty_branch_myers_false_conflict`
  - `move_top_commit_to_empty_branch_dependent_changes`
  - `move_top_commit_to_empty_branch_overlapping_changes`
- **Legacy**: `crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/move_commit_to_vbranch.rs`
  - `myers_false_conflict_on_move_to_empty_branch`
  - `dependent_changes_move_to_empty_branch`
  - `overlapping_changes_move_to_empty_branch`
- **Fixtures**: `crates/but-workspace/tests/fixtures/scenario/move-commit-{myers-false-conflict,dependent-changes,overlapping-changes}.sh`

## Proposed fixes

### 1. Prevent moves that would produce inter-stack conflicts

The graph-based rebase engine already has a `conflictable: bool` flag on `Pick` (in `but-rebase::graph_rebase`). Workspace commits use `conflictable: false`, which causes the rebase to bail if the workspace merge itself conflicts. The same mechanism could be used for move-commit operations: when cherry-picking the moved commit onto the destination branch, set `conflictable: false` so the rebase aborts rather than creating a conflicted commit. The move operation can then return an error to the UI, allowing the user to see that the move isn't possible.

For the legacy path, the `cherry_pick_one` function in `but-rebase::cherry_pick` already checks `has_unresolved_conflicts` after the merge — a similar pre-flight check or early-return could prevent persisting a conflicted commit.

### 2. Upstream Myers fix

The false-positive conflict is a bug in gitoxide's Myers diff algorithm, tracked at [GitoxideLabs/gitoxide#2475](https://github.com/GitoxideLabs/gitoxide/issues/2475) with a fix in [#2476](https://github.com/GitoxideLabs/gitoxide/pull/2476). Once that fix lands and we update our gitoxide dependency, the Myers-specific tests should start failing (indicating the bug is fixed) and can be updated to assert clean merges.

### What to update when gitoxide#2476 lands

1. **Graph-based Myers test**: Change `expect_err` to assert the move succeeds and the commit is NOT conflicted
2. **Legacy Myers test**: Assert the tree content is correct (`alpha_x\n\ncharlie_x\n\n` — bravo_x removed, alpha_x kept)

## Technical details

### The 3-way merge during cherry-pick

When commit 2 is moved from stack A to empty stack B, it is cherry-picked onto `main` (the merge base). The 3-way merge is:

```
base:   tree of commit 1 (parent of commit 2)
ours:   tree of main (target branch)
theirs: tree of commit 2
```

For the Myers false-positive case:
```
base:   \n\nbravo_x\ncharlie_x\n                (after commit 1 deleted alpha_x)
ours:   alpha_x\n\nbravo_x\ncharlie_x\n\n       (main, with blank-line pattern)
theirs: \n\ncharlie_x\n                          (commit 2 deleted bravo_x)
```

base→ours adds `alpha_x` at top + trailing newline. base→theirs removes `bravo_x`. These don't overlap, but Myers produces a spurious empty insertion hunk on the blank-line boundaries that collides with the deletion.

### Code path divergence

| | Graph-based | Legacy |
|---|---|---|
| Entry point | `but-api::commit::move_commit::commit_move_only` | `gitbutler-branch-actions::move_commit` |
| Cherry-pick | `but-rebase::graph_rebase::cherry_pick` (N-to-M generalized) | `but-rebase::cherry_pick::cherry_pick_one` |
| Merge options | Default | `merge_options_force_ours` |
| On conflict | `ConflictedCommit` (accepted if `conflictable: true`) or `FailedToMergeBases` (always bails) | Force-resolves (ours wins), then checks `has_unresolved_conflicts` |
