### PR TITLE
Add dropped references to graph overlay

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -34,6 +34,14 @@ pub struct Overlay {
     entrypoint: Entrypoint,
     nonoverriding_references: Vec<gix::refs::Reference>,
     overriding_references: Vec<gix::refs::Reference>,
+    /// A list of references that should not be picked up anymore in the
+    /// re-traversal.
+    ///
+    /// For example, if the `but_rebase::graph_rebase::Editor` converts a
+    /// `Reference` step to a `None` step which is the equivalent of running
+    /// `git update-ref -d`, it should no longer be part of the [`Graph`], so we
+    /// would list the particular reference as a dropped reference.
+    dropped_references: Vec<gix::refs::FullName>,
     meta_branches: Vec<(gix::refs::FullName, ref_metadata::Branch)>,
     workspace: Option<(gix::refs::FullName, ref_metadata::Workspace)>,
 }

--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -33,6 +33,21 @@ impl Overlay {
         self
     }
 
+    /// A list of references that should not be picked up anymore in the
+    /// re-traversal.
+    ///
+    /// For example, if the `but_rebase::graph_rebase::Editor` converts a
+    /// `Reference` step to a `None` step which is the equivalent of running
+    /// `git update-ref -d`, it should no longer be part of the [`Graph`], so we
+    /// would list the particular reference as a dropped reference.
+    pub fn with_dropped_references(
+        mut self,
+        refs: impl IntoIterator<Item = gix::refs::FullName>,
+    ) -> Self {
+        self.dropped_references.extend(refs);
+        self
+    }
+
     /// Override the starting position of the traversal by setting it to `id`,
     /// and optionally, by providing the `ref_name` that points to `id`.
     pub fn with_entrypoint(
@@ -84,6 +99,7 @@ impl Overlay {
         let Overlay {
             nonoverriding_references,
             overriding_references,
+            dropped_references,
             meta_branches,
             workspace,
             entrypoint,
@@ -98,6 +114,7 @@ impl Overlay {
                     .into_iter()
                     .map(|r| (r.name.clone(), r))
                     .collect(),
+                dropped_references: dropped_references.into_iter().collect(),
                 inner: repo,
             },
             OverlayMetadata {
@@ -116,6 +133,7 @@ pub(crate) struct OverlayRepo<'repo> {
     inner: &'repo gix::Repository,
     nonoverriding_references: NameToReference,
     overriding_references: NameToReference,
+    dropped_references: BTreeSet<gix::refs::FullName>,
 }
 
 /// Note that functions with `'repo` in their return value technically leak the bare repo, and it's
@@ -129,7 +147,9 @@ impl<'repo> OverlayRepo<'repo> {
         &self,
         ref_name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<Option<gix::Reference<'repo>>> {
-        if let Some(r) = self.overriding_references.get(ref_name) {
+        if self.dropped_references.contains(ref_name) {
+            Ok(None)
+        } else if let Some(r) = self.overriding_references.get(ref_name) {
             Ok(Some(r.clone().attach(self.inner)))
         } else if let Some(rn) = self.inner.try_find_reference(ref_name)? {
             Ok(Some(rn))
@@ -144,6 +164,11 @@ impl<'repo> OverlayRepo<'repo> {
         &self,
         ref_name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<gix::Reference<'repo>> {
+        if self.dropped_references.contains(ref_name) {
+            bail!(
+                "Failed to find reference {ref_name} due to it being dropped in the traversal overlay"
+            );
+        }
         if let Some(r) = self.overriding_references.get(ref_name) {
             return Ok(r.clone().attach(self.inner));
         }
@@ -214,6 +239,10 @@ impl<'repo> OverlayRepo<'repo> {
         let mut seen = (!self.nonoverriding_references.is_empty()).then(BTreeSet::new);
         let mut ref_filter =
             |r: gix::Reference<'_>| -> Option<(gix::ObjectId, gix::refs::FullName)> {
+                if self.dropped_references.contains(r.name()) {
+                    return None;
+                }
+
                 if workspace_ref_names.contains(&r.name()) {
                     return None;
                 }

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -932,6 +932,7 @@ fn commit_with_two_parents() -> anyhow::Result<()> {
     Ok(())
 }
 
+mod overlay;
 mod with_workspace;
 
 pub(crate) mod utils;

--- a/crates/but-graph/tests/graph/init/overlay.rs
+++ b/crates/but-graph/tests/graph/init/overlay.rs
@@ -1,0 +1,162 @@
+//! Some tests that expliclity test the overlay functionality
+
+use but_graph::{Graph, init::Overlay};
+use but_testsupport::{graph_tree, visualize_commit_graph_all};
+
+use crate::init::{read_only_in_memory_scenario, standard_options};
+
+#[test]
+fn drop_and_add_regular_refs() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   8a6c109 (HEAD -> merged) Merge branch 'C' into merged
+    |\  
+    | *   7ed512a (C) Merge branch 'D' into C
+    | |\  
+    | | * ecb1877 (D) D
+    | * | 35ee481 C
+    | |/  
+    * |   62b409a (A) Merge branch 'B' into A
+    |\ \  
+    | * | f16dddf (B) B
+    | |/  
+    * / 592abec A
+    |/  
+    * 965998b (main) base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    let to_reference = repo.rev_parse_single("35ee481")?;
+
+    let overlay = Overlay::default()
+        .with_references([gix::refs::Reference {
+            name: "refs/heads/new-reference".try_into()?,
+            target: gix::refs::Target::Object(to_reference.detach()),
+            peeled: Some(to_reference.detach()),
+        }])
+        .with_dropped_references(["refs/heads/C".try_into()?]);
+
+    let graph = graph.redo_traversal_with_overlay(&repo, &*meta, overlay)?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:anon:
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:new-reference
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn drop_head_ref() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("four-diamond")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   8a6c109 (HEAD -> merged) Merge branch 'C' into merged
+    |\  
+    | *   7ed512a (C) Merge branch 'D' into C
+    | |\  
+    | | * ecb1877 (D) D
+    | * | 35ee481 C
+    | |/  
+    * |   62b409a (A) Merge branch 'B' into A
+    |\ \  
+    | * | f16dddf (B) B
+    | |/  
+    * / 592abec A
+    |/  
+    * 965998b (main) base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+
+    └── 👉►:0[0]:merged[🌳]
+        └── ·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    let overlay = Overlay::default().with_dropped_references(["refs/heads/merged".try_into()?]);
+
+    let graph = graph.redo_traversal_with_overlay(&repo, &*meta, overlay)?;
+
+    insta::assert_snapshot!(graph_tree(&graph), @"
+
+    └── ►:0[0]:anon:
+        └── 👉·8a6c109 (⌂|1)
+            ├── ►:1[1]:A
+            │   └── ·62b409a (⌂|1)
+            │       ├── ►:3[2]:anon:
+            │       │   └── ·592abec (⌂|1)
+            │       │       └── ►:7[3]:main
+            │       │           └── ·965998b (⌂|1)
+            │       └── ►:4[2]:B
+            │           └── ·f16dddf (⌂|1)
+            │               └── →:7: (main)
+            └── ►:2[1]:C
+                └── ·7ed512a (⌂|1)
+                    ├── ►:5[2]:anon:
+                    │   └── ·35ee481 (⌂|1)
+                    │       └── →:7: (main)
+                    └── ►:6[2]:D
+                        └── ·ecb1877 (⌂|1)
+                            └── →:7: (main)
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
This lets us emulate a reference that has been deleted as part of a graph overlay.
uit tool changes