### PR TITLE
move branch should keep the stack ordering

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -659,7 +659,14 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
             }
 
             let mut branches_to_create = Vec::new();
-            let mut stack_id = None::<StackId>;
+            // Prefer the incoming stack identity whenever possible. During cross-stack moves,
+            // this avoids picking another stack id just because its branch is visited first,
+            // which could overwrite the intended destination stack later in this pass.
+            let mut stack_id = self
+                .data()
+                .branches
+                .contains_key(&stack.id)
+                .then_some(stack.id);
             for stack_branch in &stack.branches {
                 let branch = self.branch(stack_branch.ref_name.as_ref())?;
                 if branch.is_default() {
@@ -694,6 +701,10 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
                         .heads
                         .push(to_move);
                 }
+            }
+
+            if let Some(stack_id) = stack_id {
+                seen_stack_ids.insert(stack_id);
             }
 
             let vb_stack = match stack_id {

--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -652,6 +652,12 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
         // `stacks` is the target state, and we have to make an actual stack look like it.
         let mut seen_stack_ids = HashSet::new();
         for stack in &value.stacks {
+            if stack.branches.is_empty() {
+                bail!(
+                    "BUG: incoming stack is probably empty, caller should have removed the whole stack"
+                );
+            }
+
             let mut branches_to_create = Vec::new();
             let mut stack_id = None::<StackId>;
             for stack_branch in &stack.branches {

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -89,7 +89,6 @@ pub(super) mod function {
         let Some(workspace_head) = editor.workspace.tip_commit().map(|commit| commit.id) else {
             bail!("Couldn't find workspace head.")
         };
-
         let head_selector = editor
             .select_commit(workspace_head)
             .context("Failed to find the workspace head in the graph.")?;
@@ -213,16 +212,26 @@ pub(super) mod function {
             but_rebase::graph_rebase::mutate::InsertSide::Above,
         )?;
 
-        // Update the workspace meta if any of the branches we're handling is empty.
-        // This is needed in order to disambiguate the intended operation.
-        if let Some(ws_meta) = ws_meta.as_mut()
-            && (subject_segment.commits.is_empty() || target_segment.commits.is_empty())
-        {
+        // Keep workspace metadata aligned with the graph move outcome for all move cases.
+        // We remove the subject branch from its current location and reinsert it above the target.
+        if let Some(ws_meta) = ws_meta.as_mut() {
             ws_meta.remove_segment(subject_branch_name);
-            ws_meta.insert_new_segment_above_anchor_if_not_present(
-                subject_branch_name,
-                target_branch_name,
-            );
+            if ws_meta
+                .insert_new_segment_above_anchor_if_not_present(
+                    subject_branch_name,
+                    target_branch_name,
+                )
+                .is_none()
+            {
+                // If metadata doesn't know the target anchor (stale metadata),
+                // keep the moved branch represented as a stack tip.
+                ws_meta.add_or_insert_new_stack_if_not_present(
+                    subject_branch_name,
+                    None,
+                    but_core::ref_metadata::WorkspaceCommitRelation::Merged,
+                    |_| StackId::generate(),
+                );
+            }
         };
 
         Ok(Outcome {

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1,4 +1,5 @@
 use but_core::RefMetadata;
+use but_core::ref_metadata::StackKind;
 use but_rebase::graph_rebase::Editor;
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 
@@ -68,10 +69,10 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     ├── ≡📙:5:B on 85efbe4 {2}
     │   └── 📙:5:B
     │       └── ·c813d8d (🏘️)
-    └── ≡📙:4:C on 85efbe4 {1}
-        ├── 📙:4:C
+    └── ≡📙:3:C on 85efbe4 {1}
+        ├── 📙:3:C
         │   └── ·3db8c14 (🏘️)
-        └── 📙:3:A
+        └── 📙:4:A
             └── ·09d8e52 (🏘️)
     ");
 
@@ -136,13 +137,13 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    ├── ≡📙:4:C on 85efbe4 {2}
-    │   └── 📙:4:C
+    ├── ≡📙:5:C on 85efbe4 {2}
+    │   └── 📙:5:C
     │       └── ·9f14615 (🏘️)
-    └── ≡📙:5:B on 85efbe4 {1}
-        ├── 📙:5:B
+    └── ≡📙:3:B on 85efbe4 {1}
+        ├── 📙:3:B
         │   └── ·698ccd3 (🏘️)
-        └── 📙:3:A
+        └── 📙:4:A
             └── ·09d8e52 (🏘️)
     ");
 
@@ -206,7 +207,7 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    └── ≡📙:3:A on 85efbe4 {1}
+    └── ≡📙:3:A on 85efbe4 {2}
         ├── 📙:3:A
         │   └── ·8dbfefa (🏘️)
         ├── 📙:4:C
@@ -277,10 +278,10 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    ├── ≡📙:5:B on 85efbe4 {2}
-    │   ├── 📙:5:B
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   ├── 📙:4:B
     │   │   └── ·2c58ac6 (🏘️)
-    │   └── 📙:4:C
+    │   └── 📙:5:C
     │       └── ·9f14615 (🏘️)
     └── ≡📙:3:A on 85efbe4 {1}
         └── 📙:3:A
@@ -347,10 +348,10 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    └── ≡📙:4:C on 85efbe4 {2}
-        ├── 📙:4:C
+    └── ≡📙:3:C on 85efbe4 {2}
+        ├── 📙:3:C
         │   └── ·531d8aa (🏘️)
-        ├── 📙:3:A
+        ├── 📙:4:A
         │   └── ·3df48f1 (🏘️)
         └── 📙:5:B
             └── ·c813d8d (🏘️)
@@ -406,7 +407,7 @@ fn move_empty_branch() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    └── ≡📙:4:B on 85efbe4 {2}
+    └── ≡📙:4:B on 85efbe4 {1}
         ├── 📙:4:B
         └── 📙:5:A
             └── ·09d8e52 (🏘️)
@@ -461,12 +462,169 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(graph_workspace(&ws), @"
     📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-    └── ≡📙:3:A on 85efbe4 {1}
+    └── ≡📙:3:A on 85efbe4 {2}
         ├── 📙:3:A
         │   └── ·09d8e52 (🏘️)
         └── 📙:4:B
     ");
     Ok(())
+}
+
+#[test]
+fn non_empty_move_updates_metadata_but_still_desyncs_display_order() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    let before_display_order = stack_display_order(&ws);
+    let before_metadata_order = metadata_stack_order(&ws);
+    assert_ne!(before_display_order, before_metadata_order);
+
+    // Move non-empty C on top of non-empty A.
+    // This now rewrites metadata as intended, but display order is still inverted
+    // relative to metadata in this two-stack scenario.
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/C".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    let updated_metadata_order = ws_meta
+        .as_ref()
+        .map(|ws_meta| workspace_metadata_stack_order(ws_meta, StackKind::Applied))
+        .unwrap_or_default();
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let after_display_order = stack_display_order(&ws);
+
+    assert_ne!(updated_metadata_order, before_metadata_order);
+    assert_ne!(after_display_order, before_display_order);
+    assert_ne!(after_display_order, updated_metadata_order);
+
+    insta::assert_snapshot!(format!("{before_display_order:#?}"), @r#"
+    [
+        "refs/heads/C",
+        "refs/heads/A",
+    ]
+    "#);
+
+    insta::assert_snapshot!(format!("{after_display_order:#?}"), @r#"
+    [
+        "refs/heads/B",
+        "refs/heads/C",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn empty_move_keeps_display_order_aligned_with_metadata() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("ws-with-empty-stack", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   6d5c23e (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    let mut ws = graph.into_workspace()?;
+    let before_display_order = stack_display_order(&ws);
+    let before_metadata_order = metadata_stack_order(&ws);
+    assert_ne!(before_display_order, before_metadata_order);
+
+    // Move empty B on top of non-empty A.
+    // This path rewrites metadata and keeps display + metadata aligned.
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
+        but_workspace::branch::move_branch(
+            editor,
+            "refs/heads/B".try_into()?,
+            "refs/heads/A".try_into()?,
+        )?;
+
+    let updated_metadata_order = ws_meta
+        .as_ref()
+        .map(|ws_meta| workspace_metadata_stack_order(ws_meta, StackKind::AppliedAndUnapplied))
+        .unwrap_or_default();
+
+    rebase.materialize()?;
+    set_workspace_metadata(&mut meta, &ws, ws_meta)?;
+    ws.refresh_from_head(&repo, &meta)?;
+
+    let after_display_order = stack_display_order(&ws);
+
+    assert_ne!(updated_metadata_order, before_metadata_order);
+    assert_ne!(after_display_order, before_display_order);
+    assert_eq!(after_display_order, updated_metadata_order);
+
+    insta::assert_snapshot!(format!("{before_display_order:#?}"), @r#"
+    [
+        "refs/heads/B",
+        "refs/heads/A",
+    ]
+    "#);
+
+    insta::assert_snapshot!(format!("{after_display_order:#?}"), @r#"
+    [
+        "refs/heads/B",
+    ]
+    "#);
+
+    Ok(())
+}
+
+fn stack_display_order(ws: &but_graph::projection::Workspace) -> Vec<String> {
+    ws.stacks
+        .iter()
+        .filter_map(|stack| stack.ref_name())
+        .map(|name| name.to_string())
+        .collect()
+}
+
+fn metadata_stack_order(ws: &but_graph::projection::Workspace) -> Vec<String> {
+    ws.metadata
+        .as_ref()
+        .map(|ws_meta| workspace_metadata_stack_order(ws_meta, StackKind::Applied))
+        .unwrap_or_default()
+}
+
+fn workspace_metadata_stack_order(
+    ws_meta: &but_core::ref_metadata::Workspace,
+    kind: StackKind,
+) -> Vec<String> {
+    ws_meta
+        .stacks(kind)
+        .filter_map(|stack| stack.name())
+        .map(|name| name.to_string())
+        .collect()
 }
 
 fn set_workspace_metadata(

--- a/crates/but/tests/but/command/branch/move_branch.rs
+++ b/crates/but/tests/but/command/branch/move_branch.rs
@@ -526,3 +526,177 @@ Hint: run `but help` for all commands
         .stderr_eq(str![""]);
     Ok(())
 }
+
+#[test]
+fn moving_branch_away_keeps_stack_order_and_assigned_files() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+
+    env.file("keep-on-source-stack.txt", "source stack assignment\n");
+    env.but("rub keep-on-source-stack.txt C@{stack}")
+        .assert()
+        .success();
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊  ╭┄m0 [staged to C]
+┊  │ pp A keep-on-source-stack.txt
+┊  │
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│     38:wx A C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move B on top of A, effectively moving B away from C/B stack.
+    env.but("branch move i0 g0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'B' on top of 'A'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [B]
+┊●   b40d58b add B
+┊│     b4:pl A B
+┊│
+┊├┄h0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊  ╭┄m0 [staged to C]
+┊  │ pp A keep-on-source-stack.txt
+┊  │
+┊╭┄i0 [C]
+┊●   31e83cd add C
+┊│     31:wx A C
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]])
+        .stderr_eq(str![""]);
+
+    Ok(())
+}
+
+#[test]
+fn moving_branch_to_stack_keeps_stack_order_and_assigned_files() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+    env.setup_metadata(&["A", "B"])?;
+
+    env.file("keep-on-target-stack.txt", "target stack assignment\n");
+    env.but("rub keep-on-target-stack.txt A@{stack}")
+        .assert()
+        .success();
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊  ╭┄l0 [staged to A]
+┊  │ vs A keep-on-target-stack.txt
+┊  │
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│     38:wx A C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]])
+        .stderr_eq(str![""]);
+
+    // Move B on top of A, effectively moving B to A stack.
+    env.but("branch move i0 g0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'B' on top of 'A'.
+
+"#]])
+        .stderr_eq(str![""]);
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊  ╭┄l0 [staged to B]
+┊  │ vs A keep-on-target-stack.txt
+┊  │
+┊╭┄g0 [B]
+┊●   b40d58b add B
+┊│     b4:pl A B
+┊│
+┊├┄h0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄i0 [C]
+┊●   31e83cd add C
+┊│     31:wx A C
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage them to a branch
+
+"#]])
+        .stderr_eq(str![""]);
+
+    Ok(())
+}


### PR DESCRIPTION
Moving branches across stacks won’t change the display order.

The way we fixed this is by always updating the metadata, in order to keep the existing order and just add branches to the right stacks, instead of having everything be recalculated.

~~This doesn't seem to be fixing (at least completely) the issue in which the assigned files get unassigned after moving a branch.~~

Oooh this fixes the assignments issue!!

fixes GB-1196

### Still some todos
Code is ready for review, but I want to do a manual test before

- [ ] Verify that lite doesn't see the reordering.