### PR TITLE
refactor(tui): move `DebugAsType` into its own module

### DIFF
--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -32,7 +32,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::{
     CliId,
     command::legacy::status::tui::{
-        CommandMessage, CommitMessage, DebugType, FilesMessage, Message, MoveMessage,
+        CommandMessage, CommitMessage, DebugAsType, FilesMessage, Message, MoveMessage,
         RewordMessage, RubMessage,
     },
     id::UncommittedCliId,
@@ -78,8 +78,8 @@ pub(super) struct Details {
     is_dirty: bool,
     scroll_top: usize,
     widget: Option<DetailsAndDiffWidget>,
-    syntax_set: DebugType<OnDemand<SyntaxSet>>,
-    dark_theme: DebugType<OnDemand<Theme>>,
+    syntax_set: DebugAsType<OnDemand<SyntaxSet>>,
+    dark_theme: DebugAsType<OnDemand<Theme>>,
     visibility: DetailsVisibility,
 }
 

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,11 +1,4 @@
-use std::{
-    borrow::Cow,
-    ffi::OsString,
-    ops::{Deref, DerefMut},
-    process::Command,
-    sync::Arc,
-    time::Duration,
-};
+use std::{borrow::Cow, ffi::OsString, process::Command, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use but_core::tree::create_tree::RejectionReason;
@@ -44,7 +37,7 @@ use crate::{
     },
     id::{ShortId, UncommittedCliId},
     tui::{CrosstermTerminalGuard, TerminalGuard},
-    utils::OutputChannel,
+    utils::{DebugAsType, OutputChannel},
 };
 
 use super::{
@@ -2316,7 +2309,7 @@ enum Message {
     CopySelection,
     #[expect(clippy::type_complexity)]
     RunAfterConfirmation(
-        DebugType<Arc<dyn Fn(&mut App, &mut Context, &mut Vec<Message>) -> anyhow::Result<()>>>,
+        DebugAsType<Arc<dyn Fn(&mut App, &mut Context, &mut Vec<Message>) -> anyhow::Result<()>>>,
     ),
 }
 
@@ -2842,41 +2835,12 @@ enum MoveTarget<'a> {
     MergeBase,
 }
 
-#[derive(Clone)]
-struct DebugType<T>(T);
-
-impl<T> std::fmt::Debug for DebugType<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(std::any::type_name::<T>())
-    }
-}
-
-impl<T> From<T> for DebugType<T> {
-    fn from(value: T) -> Self {
-        Self(value)
-    }
-}
-
-impl<T> Deref for DebugType<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for DebugType<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 #[expect(dead_code)]
 fn run_after_confirmation_msg<F>(f: F) -> Message
 where
     F: Fn(&mut App, &mut Context, &mut Vec<Message>) -> anyhow::Result<()> + 'static,
 {
-    Message::RunAfterConfirmation(DebugType(Arc::new(move |app, ctx, messages| {
+    Message::RunAfterConfirmation(DebugAsType(Arc::new(move |app, ctx, messages| {
         f(app, ctx, messages)
     })))
 }

--- a/crates/but/src/utils/debug_as_type.rs
+++ b/crates/but/src/utils/debug_as_type.rs
@@ -1,5 +1,9 @@
 use std::ops::{Deref, DerefMut};
 
+/// Transparent wrapper type that adds a blanket `Debug` implementation that uses the type name,
+/// instead of the runtime value.
+///
+/// This is useful when including some non-`Debug` field in a type with `#[derive(Debug)]`.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct DebugAsType<T>(pub(crate) T);
 

--- a/crates/but/src/utils/debug_as_type.rs
+++ b/crates/but/src/utils/debug_as_type.rs
@@ -1,0 +1,30 @@
+use std::ops::{Deref, DerefMut};
+
+#[derive(Clone)]
+pub(crate) struct DebugAsType<T>(pub(crate) T);
+
+impl<T> std::fmt::Debug for DebugAsType<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(std::any::type_name::<T>())
+    }
+}
+
+impl<T> From<T> for DebugAsType<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Deref for DebugAsType<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for DebugAsType<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/but/src/utils/debug_as_type.rs
+++ b/crates/but/src/utils/debug_as_type.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-#[derive(Clone)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct DebugAsType<T>(pub(crate) T);
 
 impl<T> std::fmt::Debug for DebugAsType<T> {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -10,6 +10,9 @@ pub use object_id::{shorten_hex_object_id, shorten_object_id, split_short_id};
 
 mod pager;
 
+mod debug_as_type;
+pub(crate) use debug_as_type::DebugAsType;
+
 pub mod metrics;
 #[cfg(feature = "legacy")]
 pub use metrics::types::BackgroundMetrics;


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #13073
- <kbd>&nbsp;3&nbsp;</kbd> #13072
- <kbd>&nbsp;2&nbsp;</kbd> #13063
- <kbd>&nbsp;1&nbsp;</kbd> #13062 👈 
<!-- GitButler Footer Boundary Bottom -->