### PR TITLE
refactor(tui): move tui `Mode` and related types into their own module

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -10,7 +10,9 @@ use crate::{
     command::legacy::status::{
         CommitClassification, FilesStatusFlag,
         output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
-        tui::{CommitMode, CommitSource, InlineRewordMode, Mode, RubMode, UnassignedCommitSource},
+        tui::{
+            CommitMode, CommitSource, InlineRewordMode, Mode, RubMode, mode::UnassignedCommitSource,
+        },
     },
 };
 

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -5,7 +5,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use strum::IntoEnumIterator;
 
 use crate::command::legacy::status::tui::{
-    CommandMessage, ConfirmMessage, Message, Mode, ModeDiscriminant, RewordMessage, RubMessage,
+    CommandMessage, ConfirmMessage, Message, Mode, RewordMessage, RubMessage,
+    mode::ModeDiscriminant,
 };
 
 use super::{BranchMessage, CommitMessage, DetailsMessage, FilesMessage, MoveMessage};

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -6,7 +6,6 @@ use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
 use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use gitbutler_operating_modes::OperatingMode;
-use gitbutler_stack::StackId;
 use itertools::Either;
 use ratatui::{
     Frame,
@@ -31,11 +30,14 @@ use crate::{
                 graph_extension::{ExtensionDirection, extend_connector_spans},
                 highlight::{Highlights, with_highlight},
                 key_bind::{KeyBinds, confirm_key_binds, default_key_binds},
+                mode::{
+                    CommandMode, CommitMode, CommitSource, InlineRewordMode, Mode, MoveMode,
+                    MoveSource, RubMode,
+                },
                 toast::{ToastKind, Toasts},
             },
         },
     },
-    id::{ShortId, UncommittedCliId},
     tui::{CrosstermTerminalGuard, TerminalGuard},
     utils::{DebugAsType, OutputChannel},
 };
@@ -51,6 +53,7 @@ mod details;
 mod graph_extension;
 mod highlight;
 mod key_bind;
+mod mode;
 mod operations;
 mod rub_api;
 mod toast;
@@ -2359,224 +2362,6 @@ enum BranchMessage {
 enum FilesMessage {
     ToggleGlobalFilesList,
     ToggleFilesForCommit,
-}
-
-#[derive(Debug, Default, strum::EnumDiscriminants)]
-#[strum_discriminants(derive(strum::EnumIter, Hash))]
-#[strum_discriminants(name(ModeDiscriminant))]
-enum Mode {
-    #[default]
-    Normal,
-    Rub(RubMode),
-    RubButApi(RubMode),
-    InlineReword(InlineRewordMode),
-    Command(CommandMode),
-    Commit(CommitMode),
-    Move(MoveMode),
-    Branch,
-}
-
-#[derive(Debug)]
-struct RubMode {
-    source: Arc<CliId>,
-    available_targets: Vec<Arc<CliId>>,
-}
-
-#[derive(Debug)]
-enum InlineRewordMode {
-    Commit {
-        commit_id: gix::ObjectId,
-        textarea: Box<TextArea<'static>>,
-    },
-    Branch {
-        name: String,
-        stack_id: StackId,
-        textarea: Box<TextArea<'static>>,
-    },
-}
-
-impl InlineRewordMode {
-    fn textarea(&self) -> &TextArea<'static> {
-        match self {
-            InlineRewordMode::Commit { textarea, .. }
-            | InlineRewordMode::Branch { textarea, .. } => textarea,
-        }
-    }
-
-    fn textarea_mut(&mut self) -> &mut TextArea<'static> {
-        match self {
-            InlineRewordMode::Commit { textarea, .. }
-            | InlineRewordMode::Branch { textarea, .. } => textarea,
-        }
-    }
-}
-
-#[derive(Debug)]
-struct CommandMode {
-    textarea: Box<TextArea<'static>>,
-}
-
-#[derive(Debug)]
-struct CommitMode {
-    source: Arc<CommitSource>,
-    /// If set, then the commit must be made on this stack
-    ///
-    /// Used when committing changes staged to a specific stack
-    scope_to_stack: Option<StackId>,
-    /// The side to insert the new commit on, relative to the target commit.
-    ///
-    /// Note this is only respected when inserting at a commit. If inserting at a branch we'll
-    /// always use [`InsertSide::Below`].
-    insert_side: InsertSide,
-}
-
-/// A subset of [`CliId`] that supports being committed
-#[derive(Debug)]
-enum CommitSource {
-    Unassigned(UnassignedCommitSource),
-    Uncommitted(Box<UncommittedCliId>),
-    Stack(StackCommitSource),
-}
-
-#[derive(Debug)]
-struct UnassignedCommitSource {
-    id: ShortId,
-}
-
-#[derive(Debug)]
-struct StackCommitSource {
-    id: ShortId,
-    stack_id: StackId,
-}
-
-impl TryFrom<CliId> for CommitSource {
-    type Error = anyhow::Error;
-
-    fn try_from(id: CliId) -> Result<Self, Self::Error> {
-        match id {
-            CliId::Unassigned { id } => Ok(Self::Unassigned(UnassignedCommitSource { id })),
-            CliId::Uncommitted(uncommitted_cli_id) => {
-                Ok(Self::Uncommitted(Box::new(uncommitted_cli_id)))
-            }
-            CliId::Stack { id, stack_id } => Ok(Self::Stack(StackCommitSource { id, stack_id })),
-            CliId::PathPrefix { .. }
-            | CliId::CommittedFile { .. }
-            | CliId::Branch { .. }
-            | CliId::Commit { .. } => anyhow::bail!("cannot commit: {id:?}"),
-        }
-    }
-}
-
-impl PartialEq<CliId> for CommitSource {
-    fn eq(&self, other: &CliId) -> bool {
-        match self {
-            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
-                if let CliId::Unassigned { id: rhs_id } = other {
-                    lhs_id == rhs_id
-                } else {
-                    false
-                }
-            }
-            CommitSource::Uncommitted(lhs) => {
-                if let CliId::Uncommitted(rhs) = other {
-                    &**lhs == rhs
-                } else {
-                    false
-                }
-            }
-            CommitSource::Stack(StackCommitSource {
-                id: id_lhs,
-                stack_id: stack_id_lhs,
-            }) => {
-                if let CliId::Stack {
-                    id: id_rhs,
-                    stack_id: stack_id_rhs,
-                } = other
-                {
-                    id_lhs == id_rhs && stack_id_lhs == stack_id_rhs
-                } else {
-                    false
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-struct MoveMode {
-    source: Arc<MoveSource>,
-    insert_side: InsertSide,
-}
-
-/// A subset of [`CliId`] that supports being moved
-#[derive(Debug)]
-enum MoveSource {
-    Commit {
-        commit_id: gix::ObjectId,
-        id: ShortId,
-    },
-    Branch {
-        name: String,
-        id: ShortId,
-        stack_id: Option<StackId>,
-    },
-}
-
-impl TryFrom<CliId> for MoveSource {
-    type Error = anyhow::Error;
-
-    fn try_from(id: CliId) -> Result<Self, Self::Error> {
-        match id {
-            CliId::Branch { name, id, stack_id } => Ok(Self::Branch { name, id, stack_id }),
-            CliId::Commit { commit_id, id } => Ok(Self::Commit { commit_id, id }),
-            CliId::Uncommitted(uncommitted_cli_id) => {
-                anyhow::bail!("cannot move: {:?}", uncommitted_cli_id.id)
-            }
-            CliId::PathPrefix { id, .. }
-            | CliId::CommittedFile { id, .. }
-            | CliId::Unassigned { id }
-            | CliId::Stack { id, .. } => {
-                anyhow::bail!("cannot move: {id:?}")
-            }
-        }
-    }
-}
-
-impl PartialEq<CliId> for MoveSource {
-    fn eq(&self, other: &CliId) -> bool {
-        match self {
-            MoveSource::Commit {
-                commit_id: commit_id_lhs,
-                id: id_lhs,
-            } => {
-                if let CliId::Commit {
-                    commit_id: commit_id_rhs,
-                    id: id_rhs,
-                } = other
-                {
-                    commit_id_lhs == commit_id_rhs && id_lhs == id_rhs
-                } else {
-                    false
-                }
-            }
-            MoveSource::Branch {
-                name: name_lhs,
-                id: id_lhs,
-                stack_id: stack_id_lhs,
-            } => {
-                if let CliId::Branch {
-                    name: name_rhs,
-                    id: id_rhs,
-                    stack_id: stack_id_rhs,
-                } = other
-                {
-                    name_lhs == name_rhs && id_lhs == id_rhs && stack_id_lhs == stack_id_rhs
-                } else {
-                    false
-                }
-            }
-        }
-    }
 }
 
 /// What to select after reloading

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -1,0 +1,228 @@
+use std::sync::Arc;
+
+use but_rebase::graph_rebase::mutate::InsertSide;
+use gitbutler_stack::StackId;
+use ratatui_textarea::TextArea;
+
+use crate::{
+    CliId,
+    id::{ShortId, UncommittedCliId},
+};
+
+#[derive(Debug, Default, strum::EnumDiscriminants)]
+#[strum_discriminants(derive(strum::EnumIter, Hash))]
+#[strum_discriminants(name(ModeDiscriminant))]
+pub(super) enum Mode {
+    #[default]
+    Normal,
+    Rub(RubMode),
+    RubButApi(RubMode),
+    InlineReword(InlineRewordMode),
+    Command(CommandMode),
+    Commit(CommitMode),
+    Move(MoveMode),
+    Branch,
+}
+
+#[derive(Debug)]
+pub(super) struct RubMode {
+    pub(super) source: Arc<CliId>,
+    pub(super) available_targets: Vec<Arc<CliId>>,
+}
+
+#[derive(Debug)]
+pub(super) enum InlineRewordMode {
+    Commit {
+        commit_id: gix::ObjectId,
+        textarea: Box<TextArea<'static>>,
+    },
+    Branch {
+        name: String,
+        stack_id: StackId,
+        textarea: Box<TextArea<'static>>,
+    },
+}
+
+impl InlineRewordMode {
+    pub(super) fn textarea(&self) -> &TextArea<'static> {
+        match self {
+            InlineRewordMode::Commit { textarea, .. }
+            | InlineRewordMode::Branch { textarea, .. } => textarea,
+        }
+    }
+
+    pub(super) fn textarea_mut(&mut self) -> &mut TextArea<'static> {
+        match self {
+            InlineRewordMode::Commit { textarea, .. }
+            | InlineRewordMode::Branch { textarea, .. } => textarea,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct CommandMode {
+    pub(super) textarea: Box<TextArea<'static>>,
+}
+
+#[derive(Debug)]
+pub(super) struct CommitMode {
+    pub(super) source: Arc<CommitSource>,
+    /// If set, then the commit must be made on this stack
+    ///
+    /// Used when committing changes staged to a specific stack
+    pub(super) scope_to_stack: Option<StackId>,
+    /// The side to insert the new commit on, relative to the target commit.
+    ///
+    /// Note this is only respected when inserting at a commit. If inserting at a branch we'll
+    /// always use [`InsertSide::Below`].
+    pub(super) insert_side: InsertSide,
+}
+
+/// A subset of [`CliId`] that supports being committed
+#[derive(Debug)]
+pub(super) enum CommitSource {
+    Unassigned(UnassignedCommitSource),
+    Uncommitted(Box<UncommittedCliId>),
+    Stack(StackCommitSource),
+}
+
+#[derive(Debug)]
+pub(super) struct UnassignedCommitSource {
+    pub(super) id: ShortId,
+}
+
+#[derive(Debug)]
+pub(super) struct StackCommitSource {
+    pub(super) id: ShortId,
+    pub(super) stack_id: StackId,
+}
+
+impl TryFrom<CliId> for CommitSource {
+    type Error = anyhow::Error;
+
+    fn try_from(id: CliId) -> Result<Self, Self::Error> {
+        match id {
+            CliId::Unassigned { id } => Ok(Self::Unassigned(UnassignedCommitSource { id })),
+            CliId::Uncommitted(uncommitted_cli_id) => {
+                Ok(Self::Uncommitted(Box::new(uncommitted_cli_id)))
+            }
+            CliId::Stack { id, stack_id } => Ok(Self::Stack(StackCommitSource { id, stack_id })),
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::Branch { .. }
+            | CliId::Commit { .. } => anyhow::bail!("cannot commit: {id:?}"),
+        }
+    }
+}
+
+impl PartialEq<CliId> for CommitSource {
+    fn eq(&self, other: &CliId) -> bool {
+        match self {
+            CommitSource::Unassigned(UnassignedCommitSource { id: lhs_id }) => {
+                if let CliId::Unassigned { id: rhs_id } = other {
+                    lhs_id == rhs_id
+                } else {
+                    false
+                }
+            }
+            CommitSource::Uncommitted(lhs) => {
+                if let CliId::Uncommitted(rhs) = other {
+                    &**lhs == rhs
+                } else {
+                    false
+                }
+            }
+            CommitSource::Stack(StackCommitSource {
+                id: id_lhs,
+                stack_id: stack_id_lhs,
+            }) => {
+                if let CliId::Stack {
+                    id: id_rhs,
+                    stack_id: stack_id_rhs,
+                } = other
+                {
+                    id_lhs == id_rhs && stack_id_lhs == stack_id_rhs
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct MoveMode {
+    pub(super) source: Arc<MoveSource>,
+    pub(super) insert_side: InsertSide,
+}
+
+/// A subset of [`CliId`] that supports being moved
+#[derive(Debug)]
+pub(super) enum MoveSource {
+    Commit {
+        commit_id: gix::ObjectId,
+        id: ShortId,
+    },
+    Branch {
+        name: String,
+        id: ShortId,
+        stack_id: Option<StackId>,
+    },
+}
+
+impl TryFrom<CliId> for MoveSource {
+    type Error = anyhow::Error;
+
+    fn try_from(id: CliId) -> Result<Self, Self::Error> {
+        match id {
+            CliId::Branch { name, id, stack_id } => Ok(Self::Branch { name, id, stack_id }),
+            CliId::Commit { commit_id, id } => Ok(Self::Commit { commit_id, id }),
+            CliId::Uncommitted(uncommitted_cli_id) => {
+                anyhow::bail!("cannot move: {:?}", uncommitted_cli_id.id)
+            }
+            CliId::PathPrefix { id, .. }
+            | CliId::CommittedFile { id, .. }
+            | CliId::Unassigned { id }
+            | CliId::Stack { id, .. } => {
+                anyhow::bail!("cannot move: {id:?}")
+            }
+        }
+    }
+}
+
+impl PartialEq<CliId> for MoveSource {
+    fn eq(&self, other: &CliId) -> bool {
+        match self {
+            MoveSource::Commit {
+                commit_id: commit_id_lhs,
+                id: id_lhs,
+            } => {
+                if let CliId::Commit {
+                    commit_id: commit_id_rhs,
+                    id: id_rhs,
+                } = other
+                {
+                    commit_id_lhs == commit_id_rhs && id_lhs == id_rhs
+                } else {
+                    false
+                }
+            }
+            MoveSource::Branch {
+                name: name_lhs,
+                id: id_lhs,
+                stack_id: stack_id_lhs,
+            } => {
+                if let CliId::Branch {
+                    name: name_rhs,
+                    id: id_rhs,
+                    stack_id: stack_id_rhs,
+                } = other
+                {
+                    name_lhs == name_rhs && id_lhs == id_rhs && stack_id_lhs == stack_id_rhs
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -23,7 +23,7 @@ use crate::{
         rub::RubOperation,
         status::{
             StatusFlags, StatusOutput, StatusOutputLine, StatusRenderMode,
-            tui::{CommitSource, SelectAfterReload, StackCommitSource},
+            tui::{CommitSource, SelectAfterReload, mode::StackCommitSource},
         },
     },
     utils::OutputChannel,


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #13073
- <kbd>&nbsp;3&nbsp;</kbd> #13072
- <kbd>&nbsp;2&nbsp;</kbd> #13063 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13062
<!-- GitButler Footer Boundary Bottom -->