### PR TITLE
fix: validate stack has branches before processing

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -652,6 +652,12 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
         // `stacks` is the target state, and we have to make an actual stack look like it.
         let mut seen_stack_ids = HashSet::new();
         for stack in &value.stacks {
+            if stack.branches.is_empty() {
+                bail!(
+                    "BUG: incoming stack is probably empty, caller should have removed the whole stack"
+                );
+            }
+
             let mut branches_to_create = Vec::new();
             let mut stack_id = None::<StackId>;
             for stack_branch in &stack.branches {


### PR DESCRIPTION
Fixes a test were setting workspace metadata with an empty stack would expect an error.

Add validation to ensure incoming stacks are not empty
before processing them. This catches a bug where callers
should have removed empty stacks entirely rather than
passing them through to this function.