### PR TITLE
Add empty osv-scanner config

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -1,0 +1,1 @@
+IgnoredVulns = []


### PR DESCRIPTION
https://github.com/gitbutlerapp/gitbutler/pull/13047 adds an indirect dependency on bincode which has an open RUSTSEC (https://rustsec.org/advisories/RUSTSEC-2025-0141.html) about it being unmaintained.

@krlvi and I agreed to just ignore that RUSTSEC for now. Its gonna take some time for the ecosystem to move away from bincode. It has no other open RUSTSECs.

So in https://github.com/gitbutlerapp/gitbutler/pull/13047 I want to add a config file for osv-scanner that ignores RUSTSEC-2025-0141. That requires passing `--config=.github/osv-scanner.toml` to `google/osv-scanner-action/osv-scanner-action@c5996e0193a3df57d695c1b8a1dec2a4c62e8730`.

However `.github/workflows/osv-scanner.yml` works by checking out the target branch and running the scanner, then checking out the current branch and running the scanner again, then comparing the results. That breaks `--config=.github/osv-scanner.toml` because `.github/osv-scanner.toml` doesn't exist on the target. So this PR adds an empty `.github/osv-scanner.toml` file so CI on https://github.com/gitbutlerapp/gitbutler/pull/13047 can find it.