### PR TITLE
sdk: Update branch name and remove branch

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -187,7 +187,11 @@ pub fn remove_branch_only(
     Ok(())
 }
 
-#[but_api]
+/// Remove a branch from a stack.
+///
+/// This can only be called on a branch that's inside of a stack of multiple branches and is not the top branch,
+/// or on a branch that's empty.
+#[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
@@ -196,7 +200,8 @@ pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) 
     remove_branch_only(ctx, &branch_name, guard.write_permission())
 }
 
-#[but_api]
+/// Rename a branch
+#[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn update_branch_name(
     ctx: &mut Context,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -118,6 +118,14 @@ export declare function publishReview(projectId: string, params: CreateForgeRevi
 export declare function pushStackLegacy(projectId: string, stackId: string, withForce: boolean, skipForcePushProtection: boolean, branch: string, runHooks: boolean): Promise<PushResult>
 
 /**
+ * Remove a branch from a stack.
+ *
+ * This can only be called on a branch that's inside of a stack of multiple branches and is not the top branch,
+ * or on a branch that's empty.
+ */
+export declare function removeBranch(projectId: string, stackId: string, branchName: string): Promise<void>
+
+/**
  * Get the review template content for the given project and relative path.
  *
  * This function determines the forge of a project and retrieves the review template
@@ -151,6 +159,9 @@ export declare function tearOffBranch(projectId: string, subjectBranch: string):
 export declare function treeChangeDiffs(projectId: string, change: TreeChange): Promise<UnifiedPatch | null>
 
 export declare function unapplyStack(projectId: string, stackId: string): Promise<void>
+
+/** Rename a branch */
+export declare function updateBranchName(projectId: string, stackId: string, branchName: string, newName: string): Promise<void>
 
 /** Update the stacked review descriptions to have the correct footers. */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewDescriptionUpdate>): Promise<void>

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -608,6 +608,7 @@ export { mergeReview }
 export { moveBranch }
 export { publishReview }
 export { pushStackLegacy }
+export { removeBranch }
 export { reviewTemplate }
 export { setReviewAutoMerge }
 export { setReviewDraftiness }
@@ -615,6 +616,7 @@ export { setReviewTemplate }
 export { tearOffBranch }
 export { treeChangeDiffs }
 export { unapplyStack }
+export { updateBranchName }
 export { updateReviewFooters }
 export { warmCiChecksCache }
 export { WatcherHandle }


### PR DESCRIPTION
Export the functions to rename a branch and to remove one from the
stack.

@OliverJAsh This two APIs are legacy, and take in string branch names. We should migrate this (and all other APIs) to use byte-backed full ref names. For now, these should unblock you to add more functionality to lite