### PR TITLE
style: remove gap from StackPanel stack-view__inner to use column spacing via children

### DIFF
--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -3,6 +3,7 @@
 		type AddDependentBranchModalProps,
 	} from "$components/branch/AddDependentBranchModal.svelte";
 	import BranchCard from "$components/branch/BranchCard.svelte";
+	import BranchDividerLine from "$components/branch/BranchDividerLine.svelte";
 	import BranchHeaderContextMenu from "$components/branch/BranchHeaderContextMenu.svelte";
 	import BranchReorderDropzone from "$components/branch/BranchReorderDropzone.svelte";
 	import CodegenSessionRow from "$components/codegen/CodegenSessionRow.svelte";
@@ -148,6 +149,8 @@
 						prService={forge.current.prService}
 						isFirst={firstBranch}
 					/>
+				{:else if !firstBranch}
+					<BranchDividerLine {lineColor} />
 				{/if}
 				<BranchCard
 					type="stack-branch"

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -465,7 +465,6 @@
 		flex-direction: column;
 		max-height: 100%;
 		padding: 12px;
-		gap: 12px;
 	}
 
 	.commit-column {

--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -217,6 +217,7 @@
 		display: flex;
 		flex-shrink: 0;
 		flex-direction: column;
+		margin-bottom: 12px;
 		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-ml);

--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -211,7 +211,6 @@
 	.stack-view__inner {
 		display: flex;
 		flex-direction: column;
-		gap: 12px;
 	}
 
 	.assignments-wrap {


### PR DESCRIPTION
by some reason there was a large gap between the lane header and branches below:

<img width="450" height="366" alt="image" src="https://github.com/user-attachments/assets/fd883fa9-4324-4bff-a6dc-0fadc3747e44" />

Fixed:
<img width="431" height="425" alt="image" src="https://github.com/user-attachments/assets/2491ab34-5178-4b91-a817-c49fac6daa4d" />

---

This is also affected the branches page:

<img width="414" height="472" alt="image" src="https://github.com/user-attachments/assets/a3eb80ca-5462-4448-b1b9-5dfc6920865e" />

Fixed:

<img width="455" height="441" alt="image" src="https://github.com/user-attachments/assets/6ab42d64-9bc1-495b-a1d5-5554a694c3ee" />


---

And I noticed some other issues for some cases like this:

<img width="459" height="518" alt="image" src="https://github.com/user-attachments/assets/aaf7a7e6-f8a5-48f5-a869-53be2534aff6" />

Fixed:
<img width="530" height="596" alt="image" src="https://github.com/user-attachments/assets/f0a923d6-33cc-4fa1-a6db-4c4f394b3d4b" />

---


Changes were introduced here https://github.com/gitbutlerapp/gitbutler/commit/db83cffb431d10ebb0e304c05e85ef9323b1ade9

@mtsgrd I'm going to revert some thing because they cause some layout issues.