### PR TITLE
Add `--log-file` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,7 @@ dependencies = [
  "textwrap",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-forest",
  "tracing-subscriber",
  "unicode-width",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -150,6 +150,7 @@ syntect = { version = "5.3.0", default-features = false, features = [
     "metadata",
     "html",
 ] }
+tracing-appender = "0.2.4"
 
 [dev-dependencies]
 but-graph.workspace = true

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -21,6 +21,11 @@ pub struct Args {
     /// Repeat up to 4 times for increasingly verbose output.
     #[clap(short = 't', long, action = clap::ArgAction::Count, hide = true, env = "BUT_TRACE")]
     pub trace: u8,
+    /// Log to this file instead of stderr.
+    ///
+    /// If the file does not exist it will be created. If it does exist it will be truncated.
+    #[clap(long, hide = true)]
+    pub log_file: Option<PathBuf>,
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]
     pub current_dir: PathBuf,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -118,9 +118,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         }) => file_or_hunk.is_some(),
         _ => false,
     };
-    if args.trace > 0 {
-        trace::init(args.trace)?;
-    }
+    let _tracing_appender_worker_guard = if args.trace > 0 {
+        trace::init(args.trace, args.log_file.as_deref())?
+    } else {
+        None
+    };
     let _span =
         tracing::info_span!("CLI", cmd = ?args.cmd.as_ref().map(|cmd| cmd.to_metrics_command()))
             .entered();

--- a/crates/but/src/trace.rs
+++ b/crates/but/src/trace.rs
@@ -1,9 +1,17 @@
+use std::path::Path;
+
+use anyhow::Context;
 use tracing::Level;
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
-    Layer, filter::DynFilterFn, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    Layer,
+    filter::DynFilterFn,
+    fmt::{format::FmtSpan, writer::BoxMakeWriter},
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
 };
 
-pub fn init(level: u8) -> anyhow::Result<()> {
+pub fn init(level: u8, log_file_path: Option<&Path>) -> anyhow::Result<Option<WorkerGuard>> {
     let level_t = match level {
         1 => Level::INFO,
         2 => Level::DEBUG,
@@ -33,13 +41,23 @@ pub fn init(level: u8) -> anyhow::Result<()> {
         false
     });
 
+    let (make_writer, with_ansi, guard) = if let Some(log_file_path) = log_file_path {
+        let file = std::fs::File::create(log_file_path)
+            .with_context(|| format!("failed to open log file path {}", log_file_path.display()))?;
+        let (non_blocking, guard) = tracing_appender::non_blocking(file);
+        (BoxMakeWriter::new(non_blocking), false, Some(guard))
+    } else {
+        (BoxMakeWriter::new(std::io::stderr), true, None)
+    };
+
     if level >= 4 {
         tracing_subscriber::registry()
             .with(
                 tracing_subscriber::fmt::layer()
                     .compact()
                     .with_span_events(FmtSpan::CLOSE)
-                    .with_writer(std::io::stderr)
+                    .with_writer(make_writer)
+                    .with_ansi(with_ansi)
                     .with_filter(filter),
             )
             .init()
@@ -47,11 +65,12 @@ pub fn init(level: u8) -> anyhow::Result<()> {
         tracing_subscriber::registry()
             .with(
                 tracing_forest::ForestLayer::from(
-                    tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+                    tracing_forest::printer::PrettyPrinter::new().writer(make_writer),
                 )
                 .with_filter(filter),
             )
             .init();
     }
-    Ok(())
+
+    Ok(guard)
 }


### PR DESCRIPTION
I sometimes want to add debug logging to the TUI but logging to stderr break the rendering:

<img width="1243" height="371" alt="image" src="https://github.com/user-attachments/assets/f81d833a-b61a-43c0-bbad-6565aa1db9e7" />

So this adds a `--log-file` flag that you can set to log to a file instead of `stderr`. Example command would be `but -ttttt --log-file /tmp/but.log tui`. Then you can tail that file in another window.