### PR TITLE
style: add bottom margin to branch actions container

### DIFF
--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -481,6 +481,7 @@
 
 	.branch-actions {
 		display: flex;
+		margin-bottom: 12px;
 		padding: 12px;
 		gap: 6px;
 		border: 1px solid var(--clr-border-2);


### PR DESCRIPTION
Bug:
<img width="415" height="146" alt="image" src="https://github.com/user-attachments/assets/e55922d0-800e-46eb-9596-5d594daeff3d" />

Fix:
<img width="414" height="297" alt="image" src="https://github.com/user-attachments/assets/e3ef9f57-0cd8-4da0-99e2-0e188ba2e05f" />
