### PR TITLE
Remove `BStringForFrontend` from `but-api`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,10 +302,13 @@ urlencoding = "2.1"
 inventory = "0.3"
 
 [workspace.lints.clippy]
-all = "deny"
+all = { level = "deny", priority = -1 }
 # Note that `all` doesn't include everything, so extra lints should be added here.
 # You can try `pedantic = deny` to see those extra lints (alongside `all`).
 uninlined_format_args = "deny"
+# This comes mostly from `thiserror` in `gix`, and it's going to be converted
+# to `Exn`, which will box erorrs and keep them small (much like `anyhow`).
+result_large_err = "allow"
 
 [profile.release]
 # There are no overrides here as we optimise for fast release builds,

--- a/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/default_cmd_requires_legacy.stderr
@@ -5,7 +5,7 @@ error[E0425]: cannot find function `with_context_cmd` in this scope
    | ------------------------------------------------------------------------------ similarly named function `with_context` defined here
 ...
 17 |     let _ = with_context_cmd(serde_json::json!({
-   |             ^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `with_context`
+   |             ^^^^^^^^^^^^^^^^
    |
 note: found an item that was configured out
   --> tests/ui/fail/default_cmd_requires_legacy.rs:12:8
@@ -14,3 +14,8 @@ note: found an item that was configured out
    | ---------- the item is gated behind the `legacy` feature
 12 | pub fn with_context(_ctx: but_ctx::Context, value: i32) -> anyhow::Result<i32> {
    |        ^^^^^^^^^^^^
+help: a function with a similar name exists
+   |
+17 -     let _ = with_context_cmd(serde_json::json!({
+17 +     let _ = with_context(serde_json::json!({
+   |

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -1,3 +1,4 @@
+use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 
 use crate::json::HexHash;
@@ -93,7 +94,7 @@ impl From<CommitCreateResult> for UICommitCreateResult {
                 .into_iter()
                 .map(|(reason, diff)| UIRejectedChange {
                     reason,
-                    path: diff.path.to_string(),
+                    path: diff.path.to_str_lossy().into(),
                     path_bytes: diff.path,
                 })
                 .collect(),

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -44,9 +44,14 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
 pub struct UIRejectedChange {
     /// The reason the change was rejected.
     pub reason: but_core::tree::create_tree::RejectionReason,
-    /// The file path of the rejected change.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
-    pub path: but_serde::BStringForFrontend,
+    /// The file path of the rejected change, potentially degenerated if it can't be represented in Unicode.
+    pub path: String,
+    /// `path` without degeneration, as plain bytes.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(schema_with = "but_schemars::bstring_bytes")
+    )]
+    pub path_bytes: bstr::BString,
 }
 
 #[cfg(feature = "export-schema")]
@@ -88,7 +93,8 @@ impl From<CommitCreateResult> for UICommitCreateResult {
                 .into_iter()
                 .map(|(reason, diff)| UIRejectedChange {
                     reason,
-                    path: diff.path.into(),
+                    path: diff.path.to_string(),
+                    path_bytes: diff.path,
                 })
                 .collect(),
             replaced_commits: replaced_commits

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -1285,8 +1285,10 @@ export type UIMoveChangesResult = {
 export type UIRejectedChange = {
   /** The reason the change was rejected. */
   reason: RejectionReason;
-  /** The file path of the rejected change. */
+  /** The file path of the rejected change, potentially degenerated if it can't be represented in Unicode. */
   path: string;
+  /** `path` without degeneration, as plain bytes. */
+  pathBytes: Array<number>;
 };
 
 /**


### PR DESCRIPTION
Mainly to prevent spread of this type in favor of offering a bytes type in future.

> [!WARNING]
> This PR also fixes CI on `master` by updating expectations.

### Tasks

* [x] review
