### PR TITLE
When acquiring a mutable repository guard, also obtain a file-lock.

### DIFF
--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -70,26 +70,40 @@ pub fn try_exclusive_inter_process_access(
     Ok(lock)
 }
 
-/// Return a guard for exclusive (read+write) *in-process* repository access for the project at `git_dir`,
-/// blocking while waiting for someone else to release it, or for all readers to disappear.
-/// Locking is fair.
+/// Return a guard for exclusive (read+write) *in-process* repository access for the project at
+/// `git_dir`, blocking while waiting for someone else in this process to release it, or for all
+/// readers to disappear. Locking is fair.
+/// Also use `project_data_dir` if `Some` to create an *inter-process* exclusive lock.
+/// Opening or locking that file is best-effort and failures are ignored, so the hard
+/// guarantee provided by this function remains in-process exclusivity only.
+/// If `project_data_dir` is `None`, no inter-process lock is obtained.
 ///
 /// Use this only at the boundary where the lock is acquired. Keep the returned [`RepoExclusiveGuard`]
 /// alive in the caller that owns the lock, and pass [`RepoExclusive`] further down instead via
 /// [`RepoExclusiveGuard::write_permission()`].
-///
-/// Note that this **in-process** locking works only under the assumption that no two instances of
-/// GitButler are able to read or write the same repository.
-pub fn exclusive_repo_access(git_dir: impl Into<PathBuf>) -> RepoExclusiveGuard {
+pub fn exclusive_repo_access(
+    git_dir: impl Into<PathBuf>,
+    project_data_dir: Option<&Path>,
+) -> RepoExclusiveGuard {
     let lock = {
-        let mut map = WORKTREE_LOCKS.lock();
         let git_dir = git_dir.into();
+        let mut map = WORKTREE_LOCKS.lock();
         Arc::clone(map.entry(git_dir).or_default())
     };
     // The global `WORKTREE_LOCKS` mutex is released before blocking on the per-repo RwLock,
     // so contention on one repo cannot block access to unrelated repos.
+    let in_process_lock = lock.write_arc();
+    // After the in-process lock was obtained we know there is no in-process contention.
+    // Now it's much safer to blockingly wait on the inter-porcess lock to protect against
+    // multiple writers. Note that as a filesystem lock, no fairness is guaraneteed
+    let inter_proces_lock_path = project_data_dir.map(|dir| dir.join("gitbutler.write-lock"));
+    let mut inter_process_lock = inter_proces_lock_path.and_then(|path| LockFile::open(path).ok());
+    if let Some(file_lock) = inter_process_lock.as_mut() {
+        file_lock.lock().ok();
+    }
     RepoExclusiveGuard {
-        inner: lock.write_arc().into(),
+        in_process_fair_lock: Some(in_process_lock),
+        inter_process_unfair_lock: inter_process_lock,
         perm: RepoExclusive(()),
     }
 }
@@ -113,27 +127,34 @@ pub fn shared_repo_access(git_dir: impl Into<PathBuf>) -> RepoSharedGuard {
     RepoSharedGuard(Some(lock.read_arc()))
 }
 
-/// Owns an *exclusive* in-process repository lock and releases it on drop.
+/// Owns the *exclusive* in-process repository lock and the optional best-effort inter-process file
+/// lock associated with it.
 ///
 /// This type is for lock acquisition and lock lifetime management only.
-/// Keep it in the top-level caller that actually acquires the lock.
+/// Keep it in the top-level caller that actually acquires the lock, or face deadlocks.
 ///
 /// Do not pass this type through application APIs unless the API itself is responsible for lock
 /// ownership. Instead, derive a [`RepoExclusive`] with [`Self::write_permission()`] and pass that
 /// permission token to lower-level functions while keeping the guard alive in the caller.
 #[must_use]
 pub struct RepoExclusiveGuard {
-    inner: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
+    in_process_fair_lock: Option<parking_lot::ArcRwLockWriteGuard<RawRwLock, ()>>,
+    inter_process_unfair_lock: Option<LockFile>,
     perm: RepoExclusive,
 }
 
 impl Drop for RepoExclusiveGuard {
     fn drop(&mut self) {
         let lock = self
-            .inner
+            .in_process_fair_lock
             .take()
             .expect("it's always set, and only taken once when dropping");
         ArcRwLockWriteGuard::unlock_fair(lock);
+        if let Some(mut inter_process_lock) = self.inter_process_unfair_lock.take()
+            && let Err(err) = inter_process_lock.unlock()
+        {
+            tracing::error!(?err, "Failed to release inter-process lock")
+        }
     }
 }
 
@@ -218,6 +239,7 @@ static WORKTREE_LOCKS: parking_lot::Mutex<BTreeMap<PathBuf, Arc<parking_lot::RwL
 /// A file-based lock that can indicate exclusive access.
 ///
 /// As opposed to its actual implementation, it will ignore failures due to lack of filesystem support.
+/// It also prints traces using the path to the locked file to aid observability.
 pub struct LockFile {
     /// The actual lock implementation.
     inner: fslock::LockFile,
@@ -235,20 +257,21 @@ impl LockFile {
             path,
         })
     }
+    /// Lock the resource, and block until the lock was obtained. Note that this will deadlock if the same process tries
+    /// to obtain the same lock.
+    ///
+    /// Pretend it was locked if the underlying filesystem didn't support it.
+    pub fn lock(&mut self) -> Result<(), fslock::Error> {
+        self.inner
+            .lock()
+            .or_else(|err| log_error_if_unsupported(err, &self.path).map(|_| ()))
+    }
 
     /// Try to lock the resource, or pretend it was locked if the underlying filesystem didn't support it.
     pub fn try_lock(&mut self) -> Result<bool, fslock::Error> {
-        self.inner.try_lock().or_else(|err| {
-            if err.kind() == std::io::ErrorKind::Unsupported {
-                tracing::warn!(
-                    "Filesystem hosting '{}' doesn't support file locking - pretending to own lock to avoid failure",
-                    self.path.display()
-                );
-                Ok(true)
-            } else {
-                Err(err)
-            }
-        })
+        self.inner
+            .try_lock()
+            .or_else(|err| log_error_if_unsupported(err, &self.path))
     }
 
     /// Drop the lock on this file, or do nothing if we don't own the lock.
@@ -257,5 +280,19 @@ impl LockFile {
             return Ok(());
         }
         self.inner.unlock()
+    }
+}
+
+fn log_error_if_unsupported(err: std::io::Error, self_path: &Path) -> Result<bool, std::io::Error> {
+    if err.kind() == std::io::ErrorKind::Unsupported {
+        tracing::warn!(
+            "Filesystem hosting '{}' doesn't support file locking - pretending to own exclusive lock to avoid possibly needless failure.
+            Consider using {gb_storage_path_key} to move project data to a different location",
+            self_path.display(),
+            gb_storage_path_key = but_project_handle::storage_path_config_key(),
+        );
+        Ok(true)
+    } else {
+        Err(err)
     }
 }

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -74,8 +74,8 @@ pub fn try_exclusive_inter_process_access(
 /// `git_dir`, blocking while waiting for someone else in this process to release it, or for all
 /// readers to disappear. Locking is fair.
 /// Also use `project_data_dir` if `Some` to create an *inter-process* exclusive lock.
-/// Opening or locking that file is best-effort and failures are ignored, so the hard
-/// guarantee provided by this function remains in-process exclusivity only.
+/// Creating, opening, or locking that file is best-effort. Failures are logged and ignored, so
+/// the hard guarantee provided by this function remains in-process exclusivity only.
 /// If `project_data_dir` is `None`, no inter-process lock is obtained.
 ///
 /// Use this only at the boundary where the lock is acquired. Keep the returned [`RepoExclusiveGuard`]
@@ -94,13 +94,9 @@ pub fn exclusive_repo_access(
     // so contention on one repo cannot block access to unrelated repos.
     let in_process_lock = lock.write_arc();
     // After the in-process lock was obtained we know there is no in-process contention.
-    // Now it's much safer to blockingly wait on the inter-porcess lock to protect against
-    // multiple writers. Note that as a filesystem lock, no fairness is guaraneteed
-    let inter_proces_lock_path = project_data_dir.map(|dir| dir.join("gitbutler.write-lock"));
-    let mut inter_process_lock = inter_proces_lock_path.and_then(|path| LockFile::open(path).ok());
-    if let Some(file_lock) = inter_process_lock.as_mut() {
-        file_lock.lock().ok();
-    }
+    // Now it's much safer to blockingly wait on the inter-process lock to protect against
+    // multiple writers. Note that as a filesystem lock, no fairness is guaranteed.
+    let inter_process_lock = project_data_dir.and_then(best_effort_inter_process_lock);
     RepoExclusiveGuard {
         in_process_fair_lock: Some(in_process_lock),
         inter_process_unfair_lock: inter_process_lock,
@@ -145,16 +141,16 @@ pub struct RepoExclusiveGuard {
 
 impl Drop for RepoExclusiveGuard {
     fn drop(&mut self) {
-        let lock = self
-            .in_process_fair_lock
-            .take()
-            .expect("it's always set, and only taken once when dropping");
-        ArcRwLockWriteGuard::unlock_fair(lock);
         if let Some(mut inter_process_lock) = self.inter_process_unfair_lock.take()
             && let Err(err) = inter_process_lock.unlock()
         {
             tracing::error!(?err, "Failed to release inter-process lock")
         }
+        let lock = self
+            .in_process_fair_lock
+            .take()
+            .expect("it's always set, and only taken once when dropping");
+        ArcRwLockWriteGuard::unlock_fair(lock);
     }
 }
 
@@ -283,11 +279,43 @@ impl LockFile {
     }
 }
 
+fn best_effort_inter_process_lock(project_data_dir: &Path) -> Option<LockFile> {
+    if let Err(err) = std::fs::create_dir_all(project_data_dir) {
+        tracing::warn!(
+            ?err,
+            path = %project_data_dir.display(),
+            "Failed to create project data directory for inter-process lock; continuing with in-process lock only"
+        );
+        return None;
+    }
+
+    let inter_process_lock_path = project_data_dir.join("gitbutler.write-lock");
+    let mut lock = match LockFile::open(&inter_process_lock_path) {
+        Ok(lock) => lock,
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                path = %inter_process_lock_path.display(),
+                "Failed to open inter-process lock file; continuing with in-process lock only"
+            );
+            return None;
+        }
+    };
+    if let Err(err) = lock.lock() {
+        tracing::warn!(
+            ?err,
+            path = %inter_process_lock_path.display(),
+            "Failed to acquire inter-process lock; continuing with in-process lock only"
+        );
+        return None;
+    }
+    Some(lock)
+}
+
 fn log_error_if_unsupported(err: std::io::Error, self_path: &Path) -> Result<bool, std::io::Error> {
     if err.kind() == std::io::ErrorKind::Unsupported {
         tracing::warn!(
-            "Filesystem hosting '{}' doesn't support file locking - pretending to own exclusive lock to avoid possibly needless failure.
-            Consider using {gb_storage_path_key} to move project data to a different location",
+            "Filesystem hosting '{}' doesn't support file locking - pretending to own exclusive lock to avoid possibly needless failure. Consider using {gb_storage_path_key} to move project data to a different location",
             self_path.display(),
             gb_storage_path_key = but_project_handle::storage_path_config_key(),
         );

--- a/crates/but-core/tests/core/sync.rs
+++ b/crates/but-core/tests/core/sync.rs
@@ -114,7 +114,7 @@ fn default_lock_scope_is_all_operations() {
 #[test]
 fn repo_lock_contention_does_not_block_unrelated_repos() {
     // Thread 1: hold exclusive access to repo "A".
-    let exclusive_a = but_core::sync::exclusive_repo_access("/test/repo-a");
+    let exclusive_a = but_core::sync::exclusive_repo_access("/test/repo-a", None);
 
     // Thread 2: try to acquire shared access to repo "A".
     // This will block because thread 1 holds the exclusive lock.

--- a/crates/but-core/tests/core/sync.rs
+++ b/crates/but-core/tests/core/sync.rs
@@ -155,3 +155,18 @@ fn repo_lock_contention_does_not_block_unrelated_repos() {
     drop(exclusive_a);
     blocked_thread.join().unwrap();
 }
+
+#[test]
+fn exclusive_repo_access_creates_project_data_dir_for_inter_process_lock() -> anyhow::Result<()> {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+    let project_data_dir = tmp.path().join("missing-project-data-dir");
+
+    let _guard = but_core::sync::exclusive_repo_access("/test/repo-b", Some(&project_data_dir));
+
+    assert!(
+        project_data_dir.join("gitbutler.write-lock").exists(),
+        "expected inter-process lock file to be created in the project data directory"
+    );
+
+    Ok(())
+}

--- a/crates/but-ctx/src/access.rs
+++ b/crates/but-ctx/src/access.rs
@@ -18,13 +18,13 @@ impl Context {
     pub fn try_exclusive_access(&mut self) -> anyhow::Result<LockFile> {
         but_core::sync::try_exclusive_inter_process_access(&self.gitdir, AllOperations)
     }
-    /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for someone else,
-    /// in the same process only, to release it, or for all readers to disappear.
-    /// Locking is fair.
+    /// Return a guard for exclusive (read+write) worktree access, blocking while waiting for
+    /// someone else in the same process to release it, or for all readers to disappear.
+    /// Locking is fair within this process.
+    /// When `project_data_dir` is available we also attempt to obtain a best-effort
+    /// inter-process file lock, but failures to create, open, or lock that file are logged and
+    /// ignored, so the hard guarantee remains in-process exclusivity only.
     /// Note that this works on a shared reference as internal state isn't changed.
-    ///
-    /// Note that this in-process locking works only under the assumption that no two instances of
-    /// GitButler are able to read or write the same repository.
     ///
     /// # IMPORTANT: KEEP THE GUARD ALIVE!
     pub fn exclusive_worktree_access(&mut self) -> RepoExclusiveGuard {

--- a/crates/but-ctx/src/access.rs
+++ b/crates/but-ctx/src/access.rs
@@ -28,7 +28,7 @@ impl Context {
     ///
     /// # IMPORTANT: KEEP THE GUARD ALIVE!
     pub fn exclusive_worktree_access(&mut self) -> RepoExclusiveGuard {
-        but_core::sync::exclusive_repo_access(&self.gitdir)
+        but_core::sync::exclusive_repo_access(&self.gitdir, Some(&self.project_data_dir))
     }
 
     /// Return a guard for shared (read) worktree access, and block while waiting for writers to disappear.

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1202,7 +1202,29 @@ fn unassigned_file_count(env: &Sandbox) -> usize {
 }
 
 mod concurrent_commits {
+    use bstr::ByteSlice;
+
     use super::*;
+
+    fn commit_matching_change(
+        env: &Sandbox,
+        branch_name: &str,
+        message: &str,
+        path_contains: &str,
+    ) -> anyhow::Result<()> {
+        // Refresh status before each commit so this control test isolates
+        // serialization from any possible CLI-ID churn across commands.
+        let status = util::status_json(env)?;
+        let cli_id = find_unassigned_cli_id(&status, path_contains)
+            .expect("should find CLI ID for requested unassigned change");
+
+        env.but(format!(
+            "commit {branch_name} -m {message} --changes {cli_id}"
+        ))
+        .assert()
+        .success();
+        Ok(())
+    }
 
     /// Concurrent commits to independent (parallel) branches should all succeed.
     ///
@@ -1258,17 +1280,17 @@ mod concurrent_commits {
         assert!(
             out_a.status.success(),
             "commit to A failed: {}",
-            String::from_utf8_lossy(&out_a.stderr)
+            out_a.stderr.as_bstr(),
         );
         assert!(
             out_b.status.success(),
             "commit to branchB failed: {}",
-            String::from_utf8_lossy(&out_b.stderr)
+            out_b.stderr.as_bstr()
         );
         assert!(
             out_c.status.success(),
             "commit to branchC failed: {}",
-            String::from_utf8_lossy(&out_c.stderr)
+            out_c.stderr.as_bstr()
         );
 
         // All files should be committed (not left unassigned)
@@ -1279,6 +1301,52 @@ mod concurrent_commits {
         );
 
         // Each branch should have the new commit
+        let a_msgs = branch_commit_messages(&env, "A");
+        let b_msgs = branch_commit_messages(&env, "branchB");
+        let c_msgs = branch_commit_messages(&env, "branchC");
+
+        assert!(
+            a_msgs.iter().any(|m| m.contains("commit-a")),
+            "branch A should have commit-a, got: {a_msgs:?}"
+        );
+        assert!(
+            b_msgs.iter().any(|m| m.contains("commit-b")),
+            "branch branchB should have commit-b, got: {b_msgs:?}"
+        );
+        assert!(
+            c_msgs.iter().any(|m| m.contains("commit-c")),
+            "branch branchC should have commit-c, got: {c_msgs:?}"
+        );
+
+        Ok(())
+    }
+
+    /// The serial version of [`concurrent_commits_to_independent_branches`] to validate
+    /// it can work if done in serial, if there is definitely no race.
+    #[test]
+    fn serialized_commits_to_independent_branches() -> anyhow::Result<()> {
+        let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+        env.setup_metadata(&["A"])?;
+
+        // Create two more independent branches
+        env.but("branch new branchB").assert().success();
+        env.but("branch new branchC").assert().success();
+
+        // Add files for each branch
+        env.file("src/a/new.ts", "export const a = true;");
+        env.file("src/b/new.ts", "export const b = true;");
+        env.file("src/c/new.ts", "export const c = true;");
+
+        commit_matching_change(&env, "A", "commit-a", "a/new")?;
+        commit_matching_change(&env, "branchB", "commit-b", "b/new")?;
+        commit_matching_change(&env, "branchC", "commit-c", "c/new")?;
+
+        let remaining = unassigned_file_count(&env);
+        assert_eq!(
+            remaining, 0,
+            "all files should be committed, but {remaining} are still unassigned"
+        );
+
         let a_msgs = branch_commit_messages(&env, "A");
         let b_msgs = branch_commit_messages(&env, "branchB");
         let c_msgs = branch_commit_messages(&env, "branchC");

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1151,6 +1151,7 @@ fn commit_single_hunk_leaves_other_hunks_uncommitted() -> anyhow::Result<()> {
 
 /// Helper to build an isolated `std::process::Command` for `but` with the same
 /// environment as the Sandbox test harness.
+/// That way it can be spawned, which isn't possible in the [`Sandbox`] version.
 fn but_std_cmd(env: &Sandbox, args: &str) -> std::process::Command {
     let mut cmd = std::process::Command::new(snapbox::cmd::cargo_bin!("but"));
     cmd.args(shell_words::split(args).unwrap());


### PR DESCRIPTION
Previously, the guard is a mere RwLock from the `std` as there was no need to protect against other GitButler processes.

With agents operating in parallel on multiple branches, this assumptions won't hold an longer and for at least the most basic protection a writes should be protected by a lock that is observable across GitButler processes.

Note that this solution still allows races with Git itself.

Follow-up to #13079.

### Tasks

* [x] add file-based lock for exclusive repo guards
* [x] ~~`cargo test -p but --test but -- concurrent_commits::concurrent_commits_to_independent_branches --ignored` passes~~ - it can't right now, and making this work needs… more work and I can't do it now.
* [x] refackiew
* [x] validate in GUI

### Outcome

This PR doesn't fix `but commit` yet, but it adds the primitive to do it: an *inter-process* file based lock that is implemented so that it won't cause permanent failure. Thus, it will synchronize multiple processes, but only if it's available. If not, we are merely back to where we are now, with locks that fail.

Follow ups should be:
- make `db` act like `cache` and remove `cache`, to simplify and reduce data sources, while benefiting from cache-semantics everywhere automatically.
- modernize `but commit` to be able to obtain a write-lock before the first read (DB semantics)
   - This accidentally means it must use plumbing under the hood, which makes it a candidate for becoming a `but-api` function itself, along with CLI-IDs (!)
- modernization of more mutations would mean the same thing, we'd have to acquire the write lock tbefore the first read.

### Research Notes

Despite inter-process lock, `but commit` needs to acquire its lock way earlier, to not base its writes on reads which can be invalidated. Basically we need DB semantics for the repository mutation, and the only way to get close enough is to obtain an exclusive lock early.

Now that this is fixed, it fails because the spawned commands aren't independent, and CLI IDs change after the first commit went through. But also, the lock happens too late and… it's all a bit of a mess as it depends writes on invalidated reads.

<details><summary>Agent Details (no independent commands)</summary>
<p>

If `but commit` acquires the exclusive lock before reading any repository state, then it serializes the command against the live repo state. That is enough only if the command’s inputs are also valid against that live state.

Your current test does not satisfy that.

What the test actually does:
- call `status` once in the parent
- derive `id_a`, `id_b`, `id_c` from that one snapshot
- spawn 3 `but commit` processes with those precomputed IDs

So even if each child acquires the lock immediately on startup, child B is still carrying an input that was derived from `W0`, while it will execute against `W1` after child A finishes.

That distinction matters because those file CLI IDs are not durable patch identities. They are names for “the current uncommitted entity as seen in that status snapshot”. After A commits, the shared workspace state changes. B is then no longer operating on the exact same world its selector came from.

So the precise answer is:

- If each `but commit` locks first and then resolves its target change from the current repo state, yes, it should behave like the serialized control test.
- If each `but commit` locks first but is given stale state-derived selectors from an earlier snapshot, no, serialization alone does not guarantee success.

That is why:
- the serialized control with refreshed status before each commit passes
- the parallel test still fails after earlier locking
- and `safe_checkout` can still complain, because B is asking to materialize a commit based on stale selection intent into a repo/workspace that has already moved

The clean way to verify this is a sequential stale-input test:
1. get `id_a/id_b/id_c` once
2. run the 3 commits sequentially, reusing those same IDs
3. if that fails too, the real culprit is stale selectors, not lack of serialization

My expectation is that this stale-input sequential test will reproduce the remaining failure.

</p>
</details> 

Here is some agent details (low-level failures, fixed):

<details><summary>Agent Details (low-level)</summary>
<p>

I’m running the ignored parallel test repeatedly against the current tree and comparing the concrete failures. After that I’ll trace where `but commit` does mutable work before the exclusive guard is actually in place.

First rerun hit index-level contention, not a checkout safety error: one process reached `.git/index` writes while another still held Git’s own index lock. I’m collecting a few more samples to see the spread.

The dominant failures are now lower-level mutable resource races: `.git/index` lock and SQLite `database is locked`. That points to work happening before the per-repo exclusive guard covers the whole command path, not just `safe_checkout()`.

The CLI command path does a lot before it reaches `but_api::commit::create::commit_create()`: stack discovery, diff/status loading, file-ID resolution, and hooks. I’m tracing which of those touch the DB or repo without an exclusive guard.

`changes_in_worktree()` is already serializing its own critical section, but `but commit` is not holding one guard across the entire command. It calls a series of APIs that each acquire and release their own locks, which leaves gaps for another process to interleave.

I’ve got five fresh samples: four `.git/index` lock failures and one SQLite `database is locked`. I want one more pass with backtraces enabled to check whether the index lock is happening inside the actual commit materialization path or earlier in CLI setup.

I ran the ignored parallel test 6 times. The current failure mix is:

- `the index is locked` 5 times
- `database is locked` 1 time

Representative command:

```sh
cargo test -p but --test but -- command::commit::concurrent_commits::concurrent_commits_to_independent_branches --ignored --nocapture
```

The serialized control I added in [commit.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but/tests/but/command/commit.rs#L1322) passes, so the test expectation is sound in the non-concurrent case. The failure is in concurrency, not in the expected end state.

What the failures mean:

- `index is locked` means two `but commit` processes are still reaching Git index-mutating code concurrently. If the effective exclusive guard covered the whole mutable commit flow, this should not happen.
- `database is locked` means two processes are also interleaving SQLite-backed state work, again indicating the command is not serialized as one critical section.

Why I agree with your “acquire the guard earlier” diagnosis:

- The CLI commit path in [commit.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but/src/command/legacy/commit.rs#L239) does a lot before `commit_create()`:
  - `IdMap::new_from_context()` [id/mod.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but/src/id/mod.rs#L536)
  - `workspace::stacks()` / `stack_details()` [workspace.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but-api/src/legacy/workspace.rs#L67), [workspace.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but-api/src/legacy/workspace.rs#L182)
  - `diff::changes_in_worktree()` [diff.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but-api/src/diff.rs#L104)
  - hook execution [repo.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but-api/src/legacy/repo.rs#L89)
- Those APIs acquire and release their own locks internally, but `but commit` does not hold one exclusive guard across the whole operation.
- `IdMap::new_from_context()` even has a comment saying it only takes a read lock and should eventually use a caller-held permission token [id/mod.rs](/Users/byron/dev/github.com/gitbutlerapp/gitbutler/crates/but/src/id/mod.rs#L532).

So yes: the lock likely needs to move earlier than `commit_create()`, and practically earlier than the state derivation used to choose the branch and build `diff_specs`. That said, I would not hold it across the editor prompt path by default. The cleaner shape is:

- collect message first if interactive
- then acquire one `RepoExclusiveGuard`
- rebuild `IdMap`, stack selection inputs, worktree changes, and commit under that same guard
- thread `&mut RepoExclusive` through helpers instead of letting each helper reacquire/release independently

</p>
</details> 

### Possible Follow-ups

* To gain a little more safety, one could and probably should obtain the `.git/index.lock` early when running `safe_checkout` to prevent Git from interfering.