### PR TITLE
Filter workspace commit parents by in_workspace flag

### DIFF
--- a/crates/but-workspace/src/legacy/head.rs
+++ b/crates/but-workspace/src/legacy/head.rs
@@ -104,6 +104,7 @@ pub fn remerged_workspace_commit_v2(ctx: &Context) -> Result<gix::ObjectId> {
     let author = signature_gix(SignaturePurpose::Author);
     let mut heads = stacks
         .iter()
+        .filter(|stack| stack.in_workspace)
         .filter_map(|stack| stack.head_oid(ctx).ok())
         .collect::<Vec<_>>();
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -24,7 +24,7 @@ pub fn writable_context(script_name: &str, repo_name: &str) -> Result<(Context, 
     let (tmp, _) = gix_testtools::scripted_fixture_writable_with_args_with_post(
         script_name.clone(),
         None::<String>,
-        if script_name == "reorder.sh" {
+        if script_name == "reorder.sh" || script_name == "workspace-commit.sh" {
             gix_testtools::Creation::Execute
         } else {
             gix_testtools::Creation::CopyFromReadOnly
@@ -151,6 +151,18 @@ fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> R
             branches_base_to_top: &["a-branch-1"],
             in_workspace: true,
         }],
+        ("workspace-commit.sh", "conflicting-stacks") => vec![
+            StackSpec {
+                id: 1,
+                branches_base_to_top: &["stack_a"],
+                in_workspace: true,
+            },
+            StackSpec {
+                id: 2,
+                branches_base_to_top: &["stack_b"],
+                in_workspace: true,
+            },
+        ],
         unsupported => anyhow::bail!("unsupported driverless fixture {unsupported:?}"),
     };
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/main.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/main.rs
@@ -4,3 +4,4 @@ mod hooks;
 mod reorder;
 mod squash;
 mod virtual_branches;
+mod workspace_commit;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -21,7 +21,7 @@ fn command_ctx(name: &str) -> Result<(Context, TempDir)> {
 /// when diffing the workspace commit against its parents.
 #[test]
 fn conflicting_stacks_evicted_from_workspace_commit_parents() -> Result<()> {
-    let (mut ctx, _temp_dir) = command_ctx("conflicting-stacks")?;
+    let (ctx, _temp_dir) = command_ctx("conflicting-stacks")?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
     let stacks_before = vb_state.list_stacks_in_workspace()?;
@@ -37,9 +37,7 @@ fn conflicting_stacks_evicted_from_workspace_commit_parents() -> Result<()> {
     //   - The second stack conflicts (same file, different content) → in_workspace = false
     // remerged_workspace_commit_v2 (with our fix) then excludes the evicted stack
     // from the workspace commit's parent list.
-    let _guard = ctx.exclusive_worktree_access();
     gitbutler_branch_actions::update_workspace_commit(&ctx, false)?;
-    drop(_guard);
 
     let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use gitbutler_stack::VirtualBranchesHandle;
+use tempfile::TempDir;
+
+use but_ctx::Context;
+
+use crate::driverless;
+
+fn command_ctx(name: &str) -> Result<(Context, TempDir)> {
+    driverless::writable_context("workspace-commit.sh", name)
+}
+
+/// When two applied stacks have trees that conflict on the same file,
+/// `remerged_workspace_tree_v2` (called by `update_workspace_commit`) detects the
+/// gix merge conflict and marks the later stack as `in_workspace = false`.
+/// With the fix in `remerged_workspace_commit_v2`, that evicted stack's head must
+/// be excluded from the workspace commit's parent list.
+///
+/// Without the fix, the workspace commit tree would not contain the evicted stack's
+/// changes but its head would still be a parent — causing phantom uncommitted changes
+/// when diffing the workspace commit against its parents.
+#[test]
+fn conflicting_stacks_evicted_from_workspace_commit_parents() -> Result<()> {
+    let (mut ctx, _temp_dir) = command_ctx("conflicting-stacks")?;
+
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks_before = vb_state.list_stacks_in_workspace()?;
+    assert_eq!(
+        stacks_before.len(),
+        2,
+        "precondition: 2 stacks in workspace"
+    );
+
+    // Rebuild the workspace commit through the legacy path.
+    // remerged_workspace_tree_v2 iterates both stacks and merges each tree:
+    //   - The first stack merges cleanly onto the target tree
+    //   - The second stack conflicts (same file, different content) → in_workspace = false
+    // remerged_workspace_commit_v2 (with our fix) then excludes the evicted stack
+    // from the workspace commit's parent list.
+    let _guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::update_workspace_commit(&ctx, false)?;
+    drop(_guard);
+
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+
+    // Exactly one of the two conflicting stacks should have been evicted.
+    let stacks_after = vb_state.list_stacks_in_workspace()?;
+    assert_eq!(
+        stacks_after.len(),
+        1,
+        "Only the non-conflicting stack should remain in workspace"
+    );
+    let surviving_stack = &stacks_after[0];
+
+    // The workspace commit must have exactly 1 parent: the surviving stack's head.
+    let repo = ctx.repo.get()?;
+    let ws_ref = repo.find_reference("refs/heads/gitbutler/workspace")?;
+    let ws_commit = ws_ref.into_fully_peeled_id()?.object()?.try_into_commit()?;
+    let parent_ids: Vec<_> = ws_commit.parent_ids().collect();
+
+    assert_eq!(
+        parent_ids.len(),
+        1,
+        "Workspace commit should have only the surviving stack as parent"
+    );
+
+    let surviving_head = surviving_stack.head_oid(&ctx)?;
+    assert_eq!(
+        parent_ids[0].detach(),
+        surviving_head,
+        "The only parent should be the surviving stack's head"
+    );
+
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+function tick () {
+  if test -z "${tick+set}"; then
+    tick=1675176957
+  else
+    tick=$(($tick + 60))
+  fi
+  GIT_COMMITTER_DATE="$tick +0100"
+  GIT_AUTHOR_DATE="$tick +0100"
+  export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
+
+function commit_exact () {
+  local message=${1:?}
+  git add -A
+  local tree
+  tree=$(git write-tree)
+  local parent_args=()
+  if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    parent_args=(-p HEAD)
+  fi
+  local commit
+  commit=$(printf "%s" "$message" | git commit-tree "$tree" "${parent_args[@]}")
+  local current_branch
+  current_branch=$(git symbolic-ref -q HEAD || true)
+  if [[ -n "$current_branch" ]]; then
+    git update-ref "$current_branch" "$commit"
+  fi
+  git reset --hard "$commit" >/dev/null
+}
+
+function commit_with_tick () {
+  local message=${1:?}
+  tick
+  commit_exact "$message"
+}
+
+git init --initial-branch=main remote
+(cd remote
+  git config user.name "Author"
+  git config user.email "author@example.com"
+  echo "base content" > shared.txt
+  git add . && git commit -m "init"
+)
+
+# Two stacks that both modify shared.txt with conflicting content.
+# This triggers a merge conflict in remerged_workspace_tree_v2 (gix),
+# which sets the later stack's in_workspace to false.
+git clone remote conflicting-stacks
+(cd conflicting-stacks
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  git checkout -b stack_a main
+  echo "content from stack a" > shared.txt
+  commit_with_tick "stack_a commit"
+
+  git checkout -b stack_b main
+  echo "content from stack b" > shared.txt
+  commit_with_tick "stack_b commit"
+
+  # The workspace commit merges both stacks.
+  # remerged_workspace_tree_v2 will detect that they conflict.
+  git checkout -b gitbutler/workspace main
+  # We can't actually merge conflicting branches, so just point workspace
+  # at main. The seed + update_workspace_commit call in the test will
+  # rebuild it properly.
+)


### PR DESCRIPTION
remerged_workspace_tree_v2 sets in_workspace=false on stacks whose
trees fail to merge into the workspace (e.g. due to merge differences
between git2 and gix). However, remerged_workspace_commit_v2 was
including ALL stack heads as parents of the workspace commit regardless
of this flag. This meant the workspace commit's tree excluded a stack's
changes while its parents still referenced that stack — an inconsistent
state that caused phantom uncommitted changes (the diff between the
wrong index tree and the correct worktree) and confused the graph
projection.

Filter the heads by in_workspace so the workspace commit is
self-consistent: if a stack's tree couldn't be merged, its head
is not a parent either.