### PR TITLE
Add flags for perf testing the tui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ storybook-static
 packages/ui/src/styles/tokens.css
 
 debug-graph-??.svg
+
+# written to by cargo-flamegraph
+/cargo-flamegraph.trace/

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -44,6 +44,8 @@ legacy = [
     "dep:gitbutler-repo",
     "dep:gitbutler-repo-actions",
 ]
+# Feature that enables profiling related features of the TUI.
+tui-profiling = []
 
 [dependencies]
 but-core.workspace = true

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1147,22 +1147,40 @@ pub enum Subcommands {
     #[cfg(feature = "legacy")]
     Tui {
         /// Show debug pane with selected-line metadata.
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
         #[clap(long, default_value_t = false)]
         debug: bool,
         /// Quit after rendering this many frames.
-        #[clap(long, hide = true)]
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
+        #[clap(long)]
         quit_after: Option<u64>,
         /// Run the TUI with an in-memory terminal and no terminal event polling.
-        #[clap(long, hide = true)]
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
+        #[clap(long)]
         headless: bool,
         /// Do not print status when the TUI exits.
-        #[clap(long, hide = true)]
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
+        #[clap(long)]
         skip_status_after: bool,
         /// Automatically show the diff when opening the TUI.
-        #[clap(long, hide = true)]
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
+        #[clap(long)]
         diff: bool,
         /// Automatically select this commit when opening the TUI.
-        #[clap(long, hide = true)]
+        ///
+        /// Requires `tui-profiling` feature.
+        #[cfg(feature = "tui-profiling")]
+        #[clap(long)]
         select_commit: Option<gix::ObjectId>,
     },
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1149,6 +1149,18 @@ pub enum Subcommands {
         /// Show debug pane with selected-line metadata.
         #[clap(long, default_value_t = false)]
         debug: bool,
+        /// Quit after rendering this many frames.
+        #[clap(long, hide = true)]
+        quit_after: Option<u64>,
+        /// Do not print status when the TUI exits.
+        #[clap(long, hide = true)]
+        skip_status_after: bool,
+        /// Automatically show the diff when opening the TUI.
+        #[clap(long, hide = true)]
+        diff: bool,
+        /// Automatically select this commit when opening the TUI.
+        #[clap(long, hide = true)]
+        select_commit: Option<gix::ObjectId>,
     },
 }
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1152,6 +1152,9 @@ pub enum Subcommands {
         /// Quit after rendering this many frames.
         #[clap(long, hide = true)]
         quit_after: Option<u64>,
+        /// Run the TUI with an in-memory terminal and no terminal event polling.
+        #[clap(long, hide = true)]
+        headless: bool,
         /// Do not print status when the TUI exits.
         #[clap(long, hide = true)]
         skip_status_after: bool,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -88,7 +88,16 @@ impl FilesStatusFlag {
 #[derive(Debug, Copy, Clone)]
 pub enum StatusRenderMode {
     Oneshot,
-    Tui { debug: bool },
+    Tui(TuiLaunchOptions),
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct TuiLaunchOptions {
+    pub debug: bool,
+    pub quit_after: Option<u64>,
+    pub skip_status_after: bool,
+    pub show_diff: bool,
+    pub select_commit: Option<gix::ObjectId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -187,7 +196,7 @@ pub(crate) async fn worktree(
             let mut output = StatusOutput::Immediate { out: human_out };
             build_status_output(ctx, &status_ctx, &mut output)?;
         }
-        StatusRenderMode::Tui { debug } => {
+        StatusRenderMode::Tui(options) => {
             if out.for_human().is_none() {
                 return Ok(());
             }
@@ -195,9 +204,11 @@ pub(crate) async fn worktree(
             let mut lines = Vec::new();
             let mut output = StatusOutput::Buffer { lines: &mut lines };
             build_status_output(ctx, &status_ctx, &mut output)?;
-            let final_lines = tui::render_tui(ctx, out, &mode, flags, lines, debug).await?;
+            let final_lines = tui::render_tui(ctx, out, &mode, flags, lines, options).await?;
 
-            if let Some(human_out) = out.for_human() {
+            if !options.skip_status_after
+                && let Some(human_out) = out.for_human()
+            {
                 for line in final_lines {
                     render_oneshot::render_oneshot(line, human_out)?;
                 }
@@ -1629,6 +1640,8 @@ async fn compute_branch_merge_statuses(
 
 #[cfg(test)]
 mod tests {
+    use crate::command::legacy::status::TuiLaunchOptions;
+
     use super::{StatusRenderMode, truncate_when_needed, truncation_policy};
 
     #[test]
@@ -1659,11 +1672,17 @@ mod tests {
     #[test]
     fn truncation_policy_disables_truncation_for_tui() {
         assert!(!truncation_policy(
-            StatusRenderMode::Tui { debug: false },
+            StatusRenderMode::Tui(TuiLaunchOptions {
+                debug: false,
+                ..Default::default()
+            }),
             false,
         ));
         assert!(!truncation_policy(
-            StatusRenderMode::Tui { debug: false },
+            StatusRenderMode::Tui(TuiLaunchOptions {
+                debug: false,
+                ..Default::default()
+            }),
             true,
         ));
     }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -95,6 +95,7 @@ pub enum StatusRenderMode {
 pub struct TuiLaunchOptions {
     pub debug: bool,
     pub quit_after: Option<u64>,
+    pub headless: bool,
     pub skip_status_after: bool,
     pub show_diff: bool,
     pub select_commit: Option<gix::ObjectId>,

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -83,10 +83,10 @@ pub(super) struct Details {
     visibility: DetailsVisibility,
 }
 
-impl Default for Details {
-    fn default() -> Self {
+impl Details {
+    pub(super) fn new_hidden() -> Self {
         Self {
-            is_dirty: true,
+            is_dirty: false,
             widget: Default::default(),
             scroll_top: Default::default(),
             visibility: Default::default(),
@@ -97,9 +97,15 @@ impl Default for Details {
             .into(),
         }
     }
-}
 
-impl Details {
+    pub(super) fn new_visible() -> Self {
+        Self {
+            is_dirty: true,
+            visibility: DetailsVisibility::VisibleVertical,
+            ..Self::new_hidden()
+        }
+    }
+
     pub(super) fn mark_dirty(&mut self) {
         self.is_dirty = true;
     }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -38,7 +38,7 @@ use crate::{
             },
         },
     },
-    tui::{CrosstermTerminalGuard, TerminalGuard},
+    tui::{CrosstermTerminalGuard, HeadlessTerminalGuard, TerminalGuard},
     utils::{DebugAsType, OutputChannel},
 };
 
@@ -73,8 +73,6 @@ pub(super) async fn render_tui(
     status_lines: Vec<StatusOutputLine>,
     options: TuiLaunchOptions,
 ) -> anyhow::Result<Vec<StatusOutputLine>> {
-    let mut terminal_guard = CrosstermTerminalGuard::new(true)?;
-
     let mut app = App::new(status_lines, flags, options);
 
     let mut messages = Vec::new();
@@ -82,18 +80,11 @@ pub(super) async fn render_tui(
     // second buffer so we can send messages from `App::handle_message`
     let mut other_messages = Vec::new();
 
-    let event_polling = CrosstermEventPolling;
+    if app.options.headless {
+        let mut terminal_guard = HeadlessTerminalGuard::new(240, 240)?;
+        let event_polling = NoopEventPolling;
 
-    loop {
-        if app
-            .options
-            .quit_after
-            .is_some_and(|quit_after| quit_after <= app.updates)
-        {
-            break;
-        }
-
-        render_loop_once(
+        render_loop(
             &mut app,
             &mut terminal_guard,
             event_polling,
@@ -104,10 +95,21 @@ pub(super) async fn render_tui(
             mode,
         )
         .await?;
+    } else {
+        let mut terminal_guard = CrosstermTerminalGuard::new(true)?;
+        let event_polling = CrosstermEventPolling;
 
-        if app.should_quit {
-            break;
-        }
+        render_loop(
+            &mut app,
+            &mut terminal_guard,
+            event_polling,
+            &mut messages,
+            &mut other_messages,
+            ctx,
+            out,
+            mode,
+        )
+        .await?;
     }
 
     Ok(app.status_lines)
@@ -132,6 +134,64 @@ impl EventPolling for CrosstermEventPolling {
             Ok(Some(event::read()?))
         } else {
             Ok(None)
+        }
+    }
+}
+
+/// An [`EventPolling`] implementation that never yields events.
+///
+/// This is used for non-interactive runs where touching terminal input can stop the process when
+/// profilers launch the target in a background process group.
+#[derive(Copy, Clone)]
+struct NoopEventPolling;
+
+impl EventPolling for NoopEventPolling {
+    type Error = std::io::Error;
+
+    fn poll(self) -> Result<impl IntoIterator<Item = Event>, Self::Error> {
+        Ok(None)
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn render_loop<T, E>(
+    app: &mut App,
+    terminal_guard: &mut T,
+    event_polling: E,
+    messages: &mut Vec<Message>,
+    other_messages: &mut Vec<Message>,
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    mode: &OperatingMode,
+) -> anyhow::Result<()>
+where
+    T: TerminalGuard,
+    anyhow::Error: From<<T::Backend as Backend>::Error>,
+    E: EventPolling + Copy,
+{
+    loop {
+        if app
+            .options
+            .quit_after
+            .is_some_and(|quit_after| quit_after <= app.updates)
+        {
+            break Ok(());
+        }
+
+        render_loop_once(
+            app,
+            terminal_guard,
+            event_polling,
+            messages,
+            other_messages,
+            ctx,
+            out,
+            mode,
+        )
+        .await?;
+
+        if app.should_quit {
+            break Ok(());
         }
     }
 }
@@ -185,7 +245,10 @@ where
 {
     app.updates += 1;
 
-    // poll events
+    // Poll terminal events.
+    //
+    // In headless mode, the configured event poller is a no-op and this loop does not touch the
+    // real terminal.
     for event in event_polling.poll()? {
         event_to_messages(event, app.active_key_binds(), &app.mode, messages);
     }

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     command::legacy::{
         rub::{RubOperation, route_operation},
         status::{
-            CommitLineContent, StatusFlags, StatusOutputLine,
+            CommitLineContent, StatusFlags, StatusOutputLine, TuiLaunchOptions,
             output::BranchLineContent,
             tui::{
                 confirm::{Confirm, ConfirmMessage},
@@ -71,11 +71,11 @@ pub(super) async fn render_tui(
     mode: &OperatingMode,
     flags: StatusFlags,
     status_lines: Vec<StatusOutputLine>,
-    debug: bool,
+    options: TuiLaunchOptions,
 ) -> anyhow::Result<Vec<StatusOutputLine>> {
     let mut terminal_guard = CrosstermTerminalGuard::new(true)?;
 
-    let mut app = App::new(status_lines, flags, debug);
+    let mut app = App::new(status_lines, flags, options);
 
     let mut messages = Vec::new();
 
@@ -85,6 +85,14 @@ pub(super) async fn render_tui(
     let event_polling = CrosstermEventPolling;
 
     loop {
+        if app
+            .options
+            .quit_after
+            .is_some_and(|quit_after| quit_after <= app.updates)
+        {
+            break;
+        }
+
         render_loop_once(
             &mut app,
             &mut terminal_guard,
@@ -175,6 +183,8 @@ where
     anyhow::Error: From<<T::Backend as Backend>::Error>,
     E: EventPolling,
 {
+    app.updates += 1;
+
     // poll events
     for event in event_polling.poll()? {
         event_to_messages(event, app.active_key_binds(), &app.mode, messages);
@@ -241,17 +251,33 @@ struct App {
     mode: Mode,
     key_binds: KeyBinds,
     confirm_key_binds: KeyBinds,
-    debug_enabled: bool,
     toasts: Toasts,
     renders: u64,
+    updates: u64,
     highlight: Highlights,
     confirm: Option<Confirm>,
     details: Details,
+    options: TuiLaunchOptions,
 }
 
 impl App {
-    fn new(status_lines: Vec<StatusOutputLine>, flags: StatusFlags, debug: bool) -> Self {
-        let cursor = Cursor::new(&status_lines);
+    fn new(
+        status_lines: Vec<StatusOutputLine>,
+        flags: StatusFlags,
+        options: TuiLaunchOptions,
+    ) -> Self {
+        let cursor = if let Some(object_id) = options.select_commit {
+            Cursor::select_commit(object_id, &status_lines)
+                .unwrap_or_else(|| Cursor::new(&status_lines))
+        } else {
+            Cursor::new(&status_lines)
+        };
+
+        let details = if options.show_diff {
+            Details::new_visible()
+        } else {
+            Details::new_hidden()
+        };
 
         Self {
             status_lines,
@@ -263,12 +289,13 @@ impl App {
             mode: Mode::default(),
             key_binds: default_key_binds(),
             confirm_key_binds: confirm_key_binds(),
-            debug_enabled: debug,
             toasts: Default::default(),
             renders: 0,
+            updates: 0,
             highlight: Default::default(),
             confirm: None,
-            details: Default::default(),
+            details,
+            options,
         }
     }
 
@@ -780,8 +807,7 @@ impl App {
         mode: &OperatingMode,
         select_after_reload: Option<SelectAfterReload>,
     ) -> anyhow::Result<()> {
-        let new_lines =
-            operations::reload_legacy(ctx, out, mode, self.flags, self.debug_enabled).await?;
+        let new_lines = operations::reload_legacy(ctx, out, mode, self.flags, self.options).await?;
 
         self.cursor = if let Some(select_after_reload) = select_after_reload {
             match select_after_reload {
@@ -1618,7 +1644,7 @@ impl App {
     }
 
     fn status_layout(&self, area: Rect) -> StatusLayout {
-        let (main_content_area, debug_area) = if self.debug_enabled {
+        let (main_content_area, debug_area) = if self.options.debug {
             let layout =
                 Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
                     .split(area);

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -22,7 +22,7 @@ use crate::{
         self, ShowDiffInEditor,
         rub::RubOperation,
         status::{
-            StatusFlags, StatusOutput, StatusOutputLine, StatusRenderMode,
+            StatusFlags, StatusOutput, StatusOutputLine, StatusRenderMode, TuiLaunchOptions,
             tui::{CommitSource, SelectAfterReload, mode::StackCommitSource},
         },
     },
@@ -34,7 +34,7 @@ pub(super) async fn reload_legacy(
     out: &mut OutputChannel,
     mode: &OperatingMode,
     flags: StatusFlags,
-    debug_enabled: bool,
+    options: TuiLaunchOptions,
 ) -> anyhow::Result<Vec<StatusOutputLine>> {
     {
         let meta = ctx.meta()?;
@@ -49,9 +49,7 @@ pub(super) async fn reload_legacy(
         out,
         mode,
         flags,
-        StatusRenderMode::Tui {
-            debug: debug_enabled,
-        },
+        StatusRenderMode::Tui(options),
     )
     .await
     .and_then(|status_ctx| {

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -44,23 +44,17 @@ pub(super) async fn reload_legacy(
 
     let mut new_lines = Vec::new();
 
-    legacy::status::build_status_context(
-        ctx,
-        out,
-        mode,
-        flags,
-        StatusRenderMode::Tui(options),
-    )
-    .await
-    .and_then(|status_ctx| {
-        legacy::status::build_status_output(
-            ctx,
-            &status_ctx,
-            &mut StatusOutput::Buffer {
-                lines: &mut new_lines,
-            },
-        )
-    })?;
+    legacy::status::build_status_context(ctx, out, mode, flags, StatusRenderMode::Tui(options))
+        .await
+        .and_then(|status_ctx| {
+            legacy::status::build_status_output(
+                ctx,
+                &status_ctx,
+                &mut StatusOutput::Buffer {
+                    lines: &mut new_lines,
+                },
+            )
+        })?;
 
     Ok(new_lines)
 }

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -13,7 +13,8 @@ use temp_env::with_var;
 use crate::{
     args::OutputFormat,
     command::legacy::status::{
-        StatusFlags, StatusOutput, StatusRenderMode, build_status_context, build_status_output,
+        StatusFlags, StatusOutput, StatusRenderMode, TuiLaunchOptions, build_status_context,
+        build_status_output,
         tui::{App, EventPolling, Message, render_loop_once},
     },
     tui::TerminalGuard,
@@ -48,7 +49,10 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
     let mut out = OutputChannel::new_without_pager_non_json(OutputFormat::Human);
 
     let flags = StatusFlags::all_false();
-    let debug = false;
+    let options = TuiLaunchOptions {
+        debug: false,
+        ..Default::default()
+    };
 
     let status_ctx = async_runtime
         .block_on(build_status_context(
@@ -56,7 +60,7 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
             &mut out,
             &mode,
             flags,
-            StatusRenderMode::Tui { debug },
+            StatusRenderMode::Tui(options),
         ))
         .expect("failed to build status context");
     let mut lines = Vec::new();
@@ -64,7 +68,7 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
     build_status_output(&mut ctx, &status_ctx, &mut status_output)
         .expect("failed to build status output");
 
-    let app = App::new(lines, flags, debug);
+    let app = App::new(lines, flags, options);
     let terminal =
         Terminal::new(TestBackend::new(width, height)).expect("failed to create test terminal");
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -656,6 +656,7 @@ async fn match_subcommand(
         Subcommands::Tui {
             debug,
             quit_after,
+            headless,
             skip_status_after,
             diff,
             select_commit,
@@ -677,6 +678,7 @@ async fn match_subcommand(
                 StatusRenderMode::Tui(TuiLaunchOptions {
                     debug,
                     quit_after,
+                    headless,
                     skip_status_after,
                     show_diff: diff,
                     select_commit,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -653,8 +653,14 @@ async fn match_subcommand(
             .emit_metrics(metrics_ctx)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Tui { debug } => {
-            use crate::command::legacy::status::{StatusFlags, StatusRenderMode};
+        Subcommands::Tui {
+            debug,
+            quit_after,
+            skip_status_after,
+            diff,
+            select_commit,
+        } => {
+            use crate::command::legacy::status::{StatusFlags, StatusRenderMode, TuiLaunchOptions};
 
             let mut ctx = setup::init_ctx(
                 &args,
@@ -668,7 +674,13 @@ async fn match_subcommand(
                 &mut ctx,
                 out,
                 StatusFlags::all_false(),
-                StatusRenderMode::Tui { debug },
+                StatusRenderMode::Tui(TuiLaunchOptions {
+                    debug,
+                    quit_after,
+                    skip_status_after,
+                    show_diff: diff,
+                    select_commit,
+                }),
             )
             .await
             .emit_metrics(metrics_ctx)

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -654,11 +654,17 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Tui {
+            #[cfg(feature = "tui-profiling")]
             debug,
+            #[cfg(feature = "tui-profiling")]
             quit_after,
+            #[cfg(feature = "tui-profiling")]
             headless,
+            #[cfg(feature = "tui-profiling")]
             skip_status_after,
+            #[cfg(feature = "tui-profiling")]
             diff,
+            #[cfg(feature = "tui-profiling")]
             select_commit,
         } => {
             use crate::command::legacy::status::{StatusFlags, StatusRenderMode, TuiLaunchOptions};
@@ -671,18 +677,22 @@ async fn match_subcommand(
                 },
                 out,
             )?;
+            #[cfg(feature = "tui-profiling")]
+            let _options = TuiLaunchOptions {
+                debug,
+                quit_after,
+                headless,
+                skip_status_after,
+                show_diff: diff,
+                select_commit,
+            };
+            #[cfg(not(feature = "tui-profiling"))]
+            let _options = TuiLaunchOptions::default();
             command::legacy::status::worktree(
                 &mut ctx,
                 out,
                 StatusFlags::all_false(),
-                StatusRenderMode::Tui(TuiLaunchOptions {
-                    debug,
-                    quit_after,
-                    headless,
-                    skip_status_after,
-                    show_diff: diff,
-                    select_commit,
-                }),
+                StatusRenderMode::Tui(_options),
             )
             .await
             .emit_metrics(metrics_ctx)

--- a/crates/but/src/tui/mod.rs
+++ b/crates/but/src/tui/mod.rs
@@ -22,7 +22,10 @@ use crossterm::{
     event::{DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{
+    Terminal,
+    backend::{CrosstermBackend, TestBackend},
+};
 
 type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync>;
 
@@ -112,6 +115,50 @@ impl Drop for CrosstermTerminalGuard {
             std::panic::set_hook(hook);
         }
     }
+}
+
+/// A terminal guard that renders into an in-memory backend without touching the real terminal.
+///
+/// This is useful for non-interactive runs (for example profiling with `xctrace`) where terminal
+/// input/output APIs can stop the target process due to job-control semantics.
+#[must_use]
+pub(crate) struct HeadlessTerminalGuard {
+    /// The in-memory terminal used by ratatui during headless rendering.
+    terminal: Terminal<TestBackend>,
+}
+
+impl HeadlessTerminalGuard {
+    /// Create a headless terminal guard with a fixed terminal size.
+    pub fn new(width: u16, height: u16) -> anyhow::Result<Self> {
+        let backend = TestBackend::new(width, height);
+        let terminal = Terminal::new(backend)?;
+        Ok(Self { terminal })
+    }
+}
+
+impl TerminalGuard for HeadlessTerminalGuard {
+    type Backend = TestBackend;
+
+    type SuspendGuard<'a>
+        = HeadlessSuspendGuard
+    where
+        Self: 'a;
+
+    fn suspend(&mut self) -> anyhow::Result<Self::SuspendGuard<'_>> {
+        Ok(HeadlessSuspendGuard)
+    }
+
+    fn terminal_mut(&mut self) -> &mut Terminal<Self::Backend> {
+        &mut self.terminal
+    }
+}
+
+/// A no-op suspend guard used by [`HeadlessTerminalGuard`].
+#[must_use]
+pub(crate) struct HeadlessSuspendGuard;
+
+impl Drop for HeadlessSuspendGuard {
+    fn drop(&mut self) {}
 }
 
 pub(crate) trait TerminalGuard {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
           pkgs.nodejs_22
           pkgs.pnpm
           pkgs.playwright-driver.browsers
+          pkgs.cargo-flamegraph
         ];
 
         env = {


### PR DESCRIPTION
This adds the following flags that help with benchmarking the TUI:

- `--quit-after <frames>`: Quit the TUI after the given number of frames. This is the most useful one as it allows you to see how long time it takes to launch the TUI, render a few frames, and then quit. That might be slowed down by rendering a large diff for example.
- `--headless`: Render to ratatui's `TestBackend` instead of a real terminal. Without this I couldn't get [cargo-flamegraph](https://github.com/flamegraph-rs/flamegraph) to work.
- `--diff`: Immediately show the diff view, which is otherwise not shown by default.
- `--select-commit <commit>`: Select a specific commit when opening the TUI.
- `--skip-status-after`: Dont print the status when exiting the TUI. Just slightly easier when the TUI doesn't print to the primary terminal screen.

With this you can benchmark the diff rendering with

```
hyperfine --warmup 2 "./target/release/but tui --quit-after 2 --skip-status-after --headless --select-commit fddbe8b378b55de48102efbc2bb2e54bc5be6802 --diff"
```

Where `fddbe8b378b55de48102efbc2bb2e54bc5be6802` is some commit with a large diff.

All these flags are only available if the CLI is compiled with `--features tui-profiling` so they wont be available in production builds.