### PR TITLE
fix(ui): use --text-danger for InfoMessage color

### DIFF
--- a/packages/ui/src/lib/components/InfoMessage.svelte
+++ b/packages/ui/src/lib/components/InfoMessage.svelte
@@ -242,7 +242,7 @@
 		overflow: auto;
 		border-radius: var(--radius-s);
 		background-color: var(--bg-danger);
-		color: var(--fill-danger-fg);
+		color: var(--text-danger);
 		font-size: 12px;
 		white-space: pre-wrap;
 		overflow-wrap: break-word;


### PR DESCRIPTION
Fixing this:
<img width="562" height="259" alt="image" src="https://github.com/user-attachments/assets/e8a2650d-6310-4cdb-b59d-d6ad77c493d9" />

Because of the [design tokens refactor](https://github.com/gitbutlerapp/gitbutler/pull/13096) some artefacts were produces.