### PR TITLE
but config ai

### DIFF
--- a/crates/but-llm/src/anthropic.rs
+++ b/crates/but-llm/src/anthropic.rs
@@ -11,14 +11,13 @@ use schemars::{JsonSchema, schema_for};
 use serde::de::DeserializeOwned;
 
 use crate::{
+    AI_ANTHROPIC_KEY_OPTION_KEY, AI_ANTHROPIC_MODEL_NAME_KEY, AI_ANTHROPIC_SECRET_HANDLE,
     StreamToolCallResult, ToolCall, ToolCallContent, ToolResponseContent, chat::ChatMessage,
     client::LLMClient, key::CredentialsKeyOption,
 };
 
 const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com/v1";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-const ANTHROPIC_KEY_OPTION: &str = "gitbutler.aiAnthropicKeyOption";
-const ANTHROPIC_MODEL_NAME: &str = "gitbutler.aiAnthropicModelName";
 pub const GB_ANTHROPIC_API_BASE: &str = "https://app.gitbutler.com/api/proxy/anthropic";
 
 /// Result of a tool calling loop with streaming
@@ -36,7 +35,9 @@ pub enum CredentialsKind {
 
 impl CredentialsKind {
     fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
-        let key_option_str = config.string(ANTHROPIC_KEY_OPTION).map(|v| v.to_string())?;
+        let key_option_str = config
+            .string(AI_ANTHROPIC_KEY_OPTION_KEY)
+            .map(|v| v.to_string())?;
         let key_option = CredentialsKeyOption::from_str(&key_option_str)?;
         match key_option {
             CredentialsKeyOption::BringYourOwn => Some(CredentialsKind::OwnAnthropicKey),
@@ -155,11 +156,10 @@ impl AnthropicProvider {
     }
 
     fn anthropic_own_key_creds() -> Result<(CredentialsKind, Sensitive<String>)> {
-        let creds = secret::retrieve("aiAnthropicKey", secret::Namespace::Global)?.ok_or(
-            anyhow::anyhow!(
+        let creds = secret::retrieve(AI_ANTHROPIC_SECRET_HANDLE, secret::Namespace::Global)?
+            .ok_or(anyhow::anyhow!(
                 "No Anthropic own key configured. Add this through the GitButler settings"
-            ),
-        )?;
+            ))?;
         Ok((CredentialsKind::OwnAnthropicKey, creds))
     }
 
@@ -182,7 +182,9 @@ impl LLMClient for AnthropicProvider {
         Self: Sized,
     {
         let credentials_kind = CredentialsKind::from_git_config(config)?;
-        let model = config.string(ANTHROPIC_MODEL_NAME).map(|v| v.to_string());
+        let model = config
+            .string(AI_ANTHROPIC_MODEL_NAME_KEY)
+            .map(|v| v.to_string());
         AnthropicProvider::with(Some(credentials_kind), model)
     }
 

--- a/crates/but-llm/src/lib.rs
+++ b/crates/but-llm/src/lib.rs
@@ -15,7 +15,19 @@ use serde::de::DeserializeOwned;
 
 use crate::client::LLMClient;
 
-const MODEL_PROVIDER: &str = "gitbutler.aiModelProvider";
+pub const AI_MODEL_PROVIDER_KEY: &str = "gitbutler.aiModelProvider";
+pub const AI_OPENAI_KEY_OPTION_KEY: &str = "gitbutler.aiOpenAIKeyOption";
+pub const AI_OPENAI_MODEL_NAME_KEY: &str = "gitbutler.aiOpenAIModelName";
+pub const AI_OPENAI_CUSTOM_ENDPOINT_KEY: &str = "gitbutler.aiOpenAICustomEndpoint";
+pub const AI_ANTHROPIC_KEY_OPTION_KEY: &str = "gitbutler.aiAnthropicKeyOption";
+pub const AI_ANTHROPIC_MODEL_NAME_KEY: &str = "gitbutler.aiAnthropicModelName";
+pub const AI_OLLAMA_ENDPOINT_KEY: &str = "gitbutler.aiOllamaEndpoint";
+pub const AI_OLLAMA_MODEL_NAME_KEY: &str = "gitbutler.aiOllamaModelName";
+pub const AI_LMSTUDIO_ENDPOINT_KEY: &str = "gitbutler.aiLMStudioEndpoint";
+pub const AI_LMSTUDIO_MODEL_NAME_KEY: &str = "gitbutler.aiLMStudioModelName";
+
+pub const AI_OPENAI_SECRET_HANDLE: &str = "aiOpenAIKey";
+pub const AI_ANTHROPIC_SECRET_HANDLE: &str = "aiAnthropicKey";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -27,7 +39,7 @@ pub enum LLMProviderKind {
 }
 
 impl LLMProviderKind {
-    fn from_str(s: &str) -> Option<Self> {
+    pub fn from_git_config_value(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "openai" => Some(LLMProviderKind::OpenAi),
             "anthropic" => Some(LLMProviderKind::Anthropic),
@@ -35,6 +47,30 @@ impl LLMProviderKind {
             "lmstudio" => Some(LLMProviderKind::LMStudio),
             _ => None,
         }
+    }
+
+    pub fn as_git_config_value(self) -> &'static str {
+        match self {
+            LLMProviderKind::OpenAi => "openai",
+            LLMProviderKind::Anthropic => "anthropic",
+            LLMProviderKind::Ollama => "ollama",
+            LLMProviderKind::LMStudio => "lmstudio",
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            LLMProviderKind::OpenAi => "OpenAI",
+            LLMProviderKind::Anthropic => "Anthropic",
+            LLMProviderKind::Ollama => "Ollama",
+            LLMProviderKind::LMStudio => "LM Studio",
+        }
+    }
+}
+
+impl From<LLMProviderKind> for String {
+    fn from(value: LLMProviderKind) -> Self {
+        value.display_name().to_string()
     }
 }
 
@@ -124,8 +160,10 @@ impl LLMProvider {
     /// - The configured provider is not supported
     /// - Provider-specific initialization fails (e.g., missing credentials)
     pub fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
-        let provider_str = config.string(MODEL_PROVIDER).map(|v| v.to_string())?;
-        let provider = LLMProviderKind::from_str(&provider_str);
+        let provider_str = config
+            .string(AI_MODEL_PROVIDER_KEY)
+            .map(|v| v.to_string())?;
+        let provider = LLMProviderKind::from_git_config_value(&provider_str);
         match provider {
             Some(LLMProviderKind::OpenAi) => {
                 let client = openai::OpenAiProvider::from_git_config(config)?;

--- a/crates/but-llm/src/lmstudio.rs
+++ b/crates/but-llm/src/lmstudio.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
+    AI_LMSTUDIO_ENDPOINT_KEY, AI_LMSTUDIO_MODEL_NAME_KEY,
     chat::ChatMessage,
     client::LLMClient,
     openai_utils::{
@@ -14,8 +15,6 @@ use crate::{
 };
 
 const LMSTUDIO_API_BASE_DEFAULT: &str = "http://localhost:1234/v1";
-const LMSTUDIO_API_BASE_OPTION: &str = "gitbutler.aiLMStudioEndpoint";
-const LMSTUDIO_MODEL_NAME: &str = "gitbutler.aiLMStudioModelName";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LMStudioConfig {
@@ -33,7 +32,7 @@ impl Default for LMStudioConfig {
 impl LMStudioConfig {
     fn from_git_config(config: &gix::config::File<'static>) -> Self {
         let api_base = config
-            .string(LMSTUDIO_API_BASE_OPTION)
+            .string(AI_LMSTUDIO_ENDPOINT_KEY)
             .map(|v| v.to_string())
             .unwrap_or_else(|| LMSTUDIO_API_BASE_DEFAULT.to_string());
 
@@ -74,7 +73,9 @@ impl LLMClient for LMStudioProvider {
         Self: Sized,
     {
         let lmstudio_config = LMStudioConfig::from_git_config(config);
-        let model = config.string(LMSTUDIO_MODEL_NAME).map(|v| v.to_string());
+        let model = config
+            .string(AI_LMSTUDIO_MODEL_NAME_KEY)
+            .map(|v| v.to_string());
         Some(Self {
             config: lmstudio_config,
             model,

--- a/crates/but-llm/src/ollama.rs
+++ b/crates/but-llm/src/ollama.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    ChatMessage,
+    AI_OLLAMA_ENDPOINT_KEY, AI_OLLAMA_MODEL_NAME_KEY, ChatMessage,
     client::LLMClient,
     openai_utils::{
         OpenAIClientProvider, response_blocking, stream_response_blocking,
@@ -14,8 +14,6 @@ use crate::{
 };
 
 const OLLAMA_API_BASE_DEFAULT: &str = "http://localhost:11434/v1/";
-const OLLAMA_ENDPOINT: &str = "gitbutler.aiOllamaEndpoint";
-const OLLAMA_MODEL_NAME: &str = "gitbutler.aiOllamaModelName";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OllamaHostConfig {
@@ -77,10 +75,12 @@ impl LLMClient for OllamaProvider {
         Self: Sized,
     {
         let endpoint = config
-            .string(OLLAMA_ENDPOINT)
+            .string(AI_OLLAMA_ENDPOINT_KEY)
             .map(|v| v.to_string())
             .map(OllamaHostConfig::from);
-        let model = config.string(OLLAMA_MODEL_NAME).map(|v| v.to_string());
+        let model = config
+            .string(AI_OLLAMA_MODEL_NAME_KEY)
+            .map(|v| v.to_string());
         let ollama_config = OllamaConfig {
             host_config: endpoint,
         };

--- a/crates/but-llm/src/openai.rs
+++ b/crates/but-llm/src/openai.rs
@@ -7,6 +7,8 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
+    AI_OPENAI_CUSTOM_ENDPOINT_KEY, AI_OPENAI_KEY_OPTION_KEY, AI_OPENAI_MODEL_NAME_KEY,
+    AI_OPENAI_SECRET_HANDLE,
     chat::ChatMessage,
     client::LLMClient,
     key::CredentialsKeyOption,
@@ -18,10 +20,6 @@ use crate::{
 
 pub const GB_OPENAI_API_BASE: &str = "https://app.gitbutler.com/api/proxy/openai";
 
-const OPEN_AI_KEY_OPTION: &str = "gitbutler.aiOpenAIKeyOption";
-const OPEN_AI_MODEL_NAME: &str = "gitbutler.aiOpenAIModelName";
-const OPEN_AI_CUSTOM_ENDPOINT: &str = "gitbutler.aiOpenAICustomEndpoint";
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, strum::Display)]
 pub enum CredentialsKind {
     EnvVarOpenAiKey,
@@ -31,7 +29,9 @@ pub enum CredentialsKind {
 
 impl CredentialsKind {
     fn from_git_config(config: &gix::config::File<'static>) -> Option<Self> {
-        let key_option_str = config.string(OPEN_AI_KEY_OPTION).map(|v| v.to_string())?;
+        let key_option_str = config
+            .string(AI_OPENAI_KEY_OPTION_KEY)
+            .map(|v| v.to_string())?;
         let key_option = CredentialsKeyOption::from_str(&key_option_str)?;
         match key_option {
             CredentialsKeyOption::BringYourOwn => Some(CredentialsKind::OwnOpenAiKey),
@@ -103,10 +103,11 @@ impl OpenAiProvider {
     }
 
     fn openai_own_key_creds() -> Result<(CredentialsKind, Sensitive<String>)> {
-        let creds =
-            secret::retrieve("aiOpenAIKey", secret::Namespace::Global)?.ok_or(anyhow::anyhow!(
+        let creds = secret::retrieve(AI_OPENAI_SECRET_HANDLE, secret::Namespace::Global)?.ok_or(
+            anyhow::anyhow!(
                 "No OpenAI own key configured. Add this through the GitButler settings"
-            ))?;
+            ),
+        )?;
         Ok((CredentialsKind::OwnOpenAiKey, creds))
     }
 
@@ -162,9 +163,11 @@ impl LLMClient for OpenAiProvider {
         Self: Sized,
     {
         let credentials_kind = CredentialsKind::from_git_config(config)?;
-        let model = config.string(OPEN_AI_MODEL_NAME).map(|v| v.to_string());
+        let model = config
+            .string(AI_OPENAI_MODEL_NAME_KEY)
+            .map(|v| v.to_string());
         let custom_endpoint = config
-            .string(OPEN_AI_CUSTOM_ENDPOINT)
+            .string(AI_OPENAI_CUSTOM_ENDPOINT_KEY)
             .map(|v| v.to_string());
 
         OpenAiProvider::with(Some(credentials_kind), model, custom_endpoint)

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -161,6 +161,125 @@ pub enum Subcommands {
         #[clap(subcommand)]
         cmd: Option<UiSubcommand>,
     },
+
+    /// View and configure AI provider settings.
+    ///
+    /// Without subcommands, this starts an interactive setup flow.
+    /// Use provider subcommands for non-interactive configuration.
+    ///
+    /// ## Examples
+    ///
+    /// Interactive setup:
+    ///
+    /// ```text
+    /// but config ai
+    /// ```
+    ///
+    /// View current AI configuration:
+    ///
+    /// ```text
+    /// but config ai show
+    /// ```
+    ///
+    /// Configure OpenAI non-interactively:
+    ///
+    /// ```text
+    /// but config ai openai --key-option bring-your-own --api-key-env OPENAI_API_KEY --model gpt-5.4-nano
+    /// ```
+    ///
+    /// Configure Ollama locally:
+    ///
+    /// ```text
+    /// but config ai --local ollama --endpoint localhost:11434 --model llama3.1
+    /// ```
+    Ai {
+        /// Configure local repository git config instead of global user config
+        #[clap(long, conflicts_with = "global")]
+        local: bool,
+        /// Configure global user git config
+        #[clap(long)]
+        global: bool,
+        #[clap(subcommand)]
+        cmd: Option<AiSubcommand>,
+    },
+}
+
+/// Subcommands for `but config ai`
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum AiSubcommand {
+    /// Show current AI provider configuration.
+    Show,
+
+    /// Configure OpenAI as the active AI provider.
+    Openai {
+        /// Which credential source to use.
+        #[clap(long, value_enum)]
+        key_option: Option<AiKeyOption>,
+        /// Preferred model name (for example, gpt-5.4-nano).
+        #[clap(long)]
+        model: Option<String>,
+        /// Optional custom OpenAI-compatible endpoint URL.
+        #[clap(long)]
+        endpoint: Option<String>,
+        /// OpenAI API key. Prefer --api-key-env to avoid shell history exposure.
+        #[clap(long, hide_env_values = true)]
+        api_key: Option<String>,
+        /// Name of an environment variable holding the OpenAI API key.
+        #[clap(long)]
+        api_key_env: Option<String>,
+    },
+
+    /// Configure Anthropic as the active AI provider.
+    Anthropic {
+        /// Which credential source to use.
+        #[clap(long, value_enum)]
+        key_option: Option<AiKeyOption>,
+        /// Preferred model name (for example, claude-3-5-haiku-latest).
+        #[clap(long)]
+        model: Option<String>,
+        /// Anthropic API key. Prefer --api-key-env to avoid shell history exposure.
+        #[clap(long, hide_env_values = true)]
+        api_key: Option<String>,
+        /// Name of an environment variable holding the Anthropic API key.
+        #[clap(long)]
+        api_key_env: Option<String>,
+    },
+
+    /// Configure Ollama as the active AI provider.
+    Ollama {
+        /// Ollama endpoint in host:port form (for example, localhost:11434).
+        #[clap(long)]
+        endpoint: Option<String>,
+        /// Preferred model name.
+        #[clap(long)]
+        model: Option<String>,
+    },
+
+    /// Configure LM Studio as the active AI provider.
+    Lmstudio {
+        /// LM Studio API base endpoint (for example, http://localhost:1234/v1).
+        #[clap(long)]
+        endpoint: Option<String>,
+        /// Preferred model name.
+        #[clap(long)]
+        model: Option<String>,
+    },
+}
+
+/// Credential source options for OpenAI/Anthropic.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum AiKeyOption {
+    BringYourOwn,
+    ButlerApi,
+}
+
+impl AiKeyOption {
+    pub fn as_git_value(self) -> &'static str {
+        match self {
+            AiKeyOption::BringYourOwn => "bringYourOwn",
+            AiKeyOption::ButlerApi => "butlerAPI",
+        }
+    }
 }
 
 /// Subcommands for `but config user`

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -3,6 +3,131 @@ use super::*;
 mod commit;
 mod reword;
 
+mod config_ai {
+    use clap::Parser;
+
+    use crate::args::{
+        Args, Subcommands,
+        config::{AiKeyOption, AiSubcommand, Platform as ConfigPlatform, Subcommands as ConfigCmd},
+    };
+
+    #[test]
+    fn interactive_defaults_to_global_scope() {
+        let args = Args::try_parse_from(["but", "config", "ai"]).expect("parse args");
+        let cmd = args.cmd.expect("subcommand");
+
+        match cmd {
+            Subcommands::Config(ConfigPlatform {
+                cmd: Some(ConfigCmd::Ai { local, global, cmd }),
+            }) => {
+                assert!(!local);
+                assert!(!global);
+                assert!(cmd.is_none());
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn openai_non_interactive_parses_provider_flags() {
+        let args = Args::try_parse_from([
+            "but",
+            "config",
+            "ai",
+            "openai",
+            "--key-option",
+            "bring-your-own",
+            "--model",
+            "gpt-5.4-nano",
+            "--endpoint",
+            "https://api.openai.com/v1",
+            "--api-key-env",
+            "OPENAI_API_KEY",
+        ])
+        .expect("parse args");
+
+        let cmd = args.cmd.expect("subcommand");
+        match cmd {
+            Subcommands::Config(ConfigPlatform {
+                cmd:
+                    Some(ConfigCmd::Ai {
+                        cmd:
+                            Some(AiSubcommand::Openai {
+                                key_option,
+                                model,
+                                endpoint,
+                                api_key,
+                                api_key_env,
+                            }),
+                        ..
+                    }),
+            }) => {
+                assert!(matches!(key_option, Some(AiKeyOption::BringYourOwn)));
+                assert_eq!(model.as_deref(), Some("gpt-5.4-nano"));
+                assert_eq!(endpoint.as_deref(), Some("https://api.openai.com/v1"));
+                assert!(api_key.is_none());
+                assert_eq!(api_key_env.as_deref(), Some("OPENAI_API_KEY"));
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn local_scope_flag_parses_before_provider() {
+        let args = Args::try_parse_from([
+            "but",
+            "config",
+            "ai",
+            "--local",
+            "ollama",
+            "--endpoint",
+            "localhost:11434",
+            "--model",
+            "llama3.1",
+        ])
+        .expect("parse args");
+
+        let cmd = args.cmd.expect("subcommand");
+        match cmd {
+            Subcommands::Config(ConfigPlatform {
+                cmd:
+                    Some(ConfigCmd::Ai {
+                        local,
+                        global,
+                        cmd: Some(AiSubcommand::Ollama { endpoint, model }),
+                    }),
+            }) => {
+                assert!(local);
+                assert!(!global);
+                assert_eq!(endpoint.as_deref(), Some("localhost:11434"));
+                assert_eq!(model.as_deref(), Some("llama3.1"));
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+
+    #[test]
+    fn show_subcommand_parses() {
+        let args = Args::try_parse_from(["but", "config", "ai", "show"]).expect("parse args");
+
+        let cmd = args.cmd.expect("subcommand");
+        match cmd {
+            Subcommands::Config(ConfigPlatform {
+                cmd:
+                    Some(ConfigCmd::Ai {
+                        local,
+                        global,
+                        cmd: Some(AiSubcommand::Show),
+                    }),
+            }) => {
+                assert!(!local);
+                assert!(!global);
+            }
+            _ => panic!("unexpected command shape"),
+        }
+    }
+}
+
 #[test]
 fn clap() {
     use clap::CommandFactory;

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -8,6 +8,13 @@ use std::fmt::{Display, Write};
 use anyhow::{Context as _, Result};
 use but_core::git_config::{remove_config_value, set_config_value};
 use but_ctx::Context;
+use but_llm::{
+    AI_ANTHROPIC_KEY_OPTION_KEY, AI_ANTHROPIC_MODEL_NAME_KEY, AI_ANTHROPIC_SECRET_HANDLE,
+    AI_LMSTUDIO_ENDPOINT_KEY, AI_LMSTUDIO_MODEL_NAME_KEY, AI_MODEL_PROVIDER_KEY,
+    AI_OLLAMA_ENDPOINT_KEY, AI_OLLAMA_MODEL_NAME_KEY, AI_OPENAI_CUSTOM_ENDPOINT_KEY,
+    AI_OPENAI_KEY_OPTION_KEY, AI_OPENAI_MODEL_NAME_KEY, AI_OPENAI_SECRET_HANDLE, LLMProviderKind,
+};
+use but_secret::{Sensitive, secret};
 use but_settings::{AppSettingsWithDiskSync, api::TelemetryUpdate};
 use cfg_if::cfg_if;
 use colored::Colorize;
@@ -16,10 +23,62 @@ use serde::Serialize;
 
 use super::git_config::edit_git_config;
 use crate::{
-    args::config::{ForgeSubcommand, MetricsStatus, Subcommands, UiSubcommand, UserSubcommand},
+    args::config::{
+        AiKeyOption, AiSubcommand, ForgeSubcommand, MetricsStatus, Subcommands, UiSubcommand,
+        UserSubcommand,
+    },
     tui,
     utils::{ConfirmOrEmpty, InputOutputChannel, OutputChannel},
 };
+
+impl From<AiKeyOption> for String {
+    fn from(value: AiKeyOption) -> Self {
+        match value {
+            AiKeyOption::BringYourOwn => "Bring your own key".to_string(),
+            AiKeyOption::ButlerApi => "Use GitButler API".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AiScope {
+    Global,
+    Local,
+}
+
+impl AiScope {
+    fn from_flags(local: bool, global: bool) -> Result<Self> {
+        if local && global {
+            anyhow::bail!("Cannot pass both --local and --global")
+        }
+        if local {
+            Ok(AiScope::Local)
+        } else {
+            Ok(AiScope::Global)
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            AiScope::Global => "global",
+            AiScope::Local => "local",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AiConfigInfo {
+    provider: Option<String>,
+    openai_key_option: Option<String>,
+    openai_model: Option<String>,
+    openai_endpoint: Option<String>,
+    anthropic_key_option: Option<String>,
+    anthropic_model: Option<String>,
+    ollama_endpoint: Option<String>,
+    ollama_model: Option<String>,
+    lmstudio_endpoint: Option<String>,
+    lmstudio_model: Option<String>,
+}
 
 /// Main entry point for config command
 pub async fn exec(
@@ -32,9 +91,27 @@ pub async fn exec(
         Some(Subcommands::Target { branch }) => target_config(ctx, out, branch).await,
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
+        Some(Subcommands::Ai { local, global, cmd }) => {
+            ai_config_with_repo(ctx, out, cmd, local, global)
+        }
         Some(Subcommands::Ui { cmd }) => ui_config(ctx, out, cmd),
         None => show_overview(ctx, out).await,
     }
+}
+
+/// Handle AI config subcommand without repository context.
+///
+/// This supports global configuration from outside of a git repository.
+pub(crate) fn ai_config(
+    out: &mut OutputChannel,
+    cmd: Option<AiSubcommand>,
+    local: bool,
+    global: bool,
+) -> Result<()> {
+    if local {
+        anyhow::bail!("Local AI configuration requires running inside a git repository")
+    }
+    ai_config_inner(None, out, cmd, local, global)
 }
 
 /// Show overview of important settings
@@ -154,6 +231,11 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
             out,
             "  {} - Metrics settings",
             "but config metrics".blue().dimmed()
+        )?;
+        writeln!(
+            out,
+            "  {}      - AI provider settings",
+            "but config ai".blue().dimmed()
         )?;
         writeln!(
             out,
@@ -933,6 +1015,539 @@ async fn forge_forget(username: Option<String>, out: &mut OutputChannel) -> Resu
     }
 
     Ok(())
+}
+
+fn ai_config_with_repo(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    cmd: Option<AiSubcommand>,
+    local: bool,
+    global: bool,
+) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    ai_config_inner(Some(&*repo), out, cmd, local, global)
+}
+
+fn ai_config_inner(
+    repo: Option<&gix::Repository>,
+    out: &mut OutputChannel,
+    cmd: Option<AiSubcommand>,
+    local: bool,
+    global: bool,
+) -> Result<()> {
+    let scope = AiScope::from_flags(local, global)?;
+
+    match cmd {
+        None => {
+            if out.for_human().is_some() {
+                return ai_config_interactive(repo, out, scope);
+            }
+            show_ai_config(repo, out, scope)
+        }
+        Some(AiSubcommand::Show) => show_ai_config(repo, out, scope),
+        Some(cmd) => ai_config_non_interactive(repo, out, scope, cmd),
+    }
+}
+
+fn show_ai_config(
+    repo: Option<&gix::Repository>,
+    out: &mut OutputChannel,
+    scope: AiScope,
+) -> Result<()> {
+    let info = get_ai_config_info(repo, scope)?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{} ({})",
+            "AI Configuration".bold(),
+            scope.as_str().dimmed()
+        )?;
+        writeln!(out)?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "Provider".dimmed(),
+            info.provider
+                .as_deref()
+                .map(|provider| provider.cyan().to_string())
+                .unwrap_or_else(|| "(not set)".red().to_string())
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "OpenAI key option".dimmed(),
+            info.openai_key_option
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "OpenAI model".dimmed(),
+            info.openai_model.as_deref().unwrap_or("(not set)").cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "OpenAI endpoint".dimmed(),
+            info.openai_endpoint
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "Anthropic key option".dimmed(),
+            info.anthropic_key_option
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "Anthropic model".dimmed(),
+            info.anthropic_model
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "Ollama endpoint".dimmed(),
+            info.ollama_endpoint
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "Ollama model".dimmed(),
+            info.ollama_model.as_deref().unwrap_or("(not set)").cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "LM Studio endpoint".dimmed(),
+            info.lmstudio_endpoint
+                .as_deref()
+                .unwrap_or("(not set)")
+                .cyan()
+        )?;
+        writeln!(
+            out,
+            "  {}: {}",
+            "LM Studio model".dimmed(),
+            info.lmstudio_model.as_deref().unwrap_or("(not set)").cyan()
+        )?;
+    } else if let Some(out) = out.for_shell() {
+        writeln!(out, "{}", info.provider.as_deref().unwrap_or(""))?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!(info))?;
+    }
+
+    Ok(())
+}
+
+fn ai_config_non_interactive(
+    repo: Option<&gix::Repository>,
+    out: &mut OutputChannel,
+    scope: AiScope,
+    cmd: AiSubcommand,
+) -> Result<()> {
+    match cmd {
+        AiSubcommand::Show => {
+            return show_ai_config(repo, out, scope);
+        }
+        AiSubcommand::Openai {
+            key_option,
+            model,
+            endpoint,
+            api_key,
+            api_key_env,
+        } => {
+            let selected_key_option = key_option.unwrap_or(AiKeyOption::ButlerApi);
+            let secret = resolve_secret_input(api_key, api_key_env)?;
+            require_non_interactive_secret_if_byok(selected_key_option, secret.as_ref(), "OpenAI")?;
+            apply_openai_config(repo, scope, selected_key_option, model, endpoint, secret)?;
+            write_ai_config_success(out, scope, LLMProviderKind::OpenAi)?;
+        }
+        AiSubcommand::Anthropic {
+            key_option,
+            model,
+            api_key,
+            api_key_env,
+        } => {
+            let selected_key_option = key_option.unwrap_or(AiKeyOption::ButlerApi);
+            let secret = resolve_secret_input(api_key, api_key_env)?;
+            require_non_interactive_secret_if_byok(
+                selected_key_option,
+                secret.as_ref(),
+                "Anthropic",
+            )?;
+            apply_anthropic_config(repo, scope, selected_key_option, model, secret)?;
+            write_ai_config_success(out, scope, LLMProviderKind::Anthropic)?;
+        }
+        AiSubcommand::Ollama { endpoint, model } => {
+            apply_ollama_config(repo, scope, endpoint, model)?;
+            write_ai_config_success(out, scope, LLMProviderKind::Ollama)?;
+        }
+        AiSubcommand::Lmstudio { endpoint, model } => {
+            apply_lmstudio_config(repo, scope, endpoint, model)?;
+            write_ai_config_success(out, scope, LLMProviderKind::LMStudio)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn ai_config_interactive(
+    repo: Option<&gix::Repository>,
+    out: &mut OutputChannel,
+    scope: AiScope,
+) -> Result<()> {
+    use cli_prompts::DisplayPrompt;
+
+    let mut inout = out
+        .prepare_for_terminal_input()
+        .context("Human input required - run this in a terminal")?;
+
+    let provider_prompt = cli_prompts::prompts::Selection::new(
+        "Select an AI provider",
+        vec!["OpenAI", "Anthropic", "Ollama", "LM Studio"].into_iter(),
+    );
+
+    let provider_label = provider_prompt
+        .display()
+        .map_err(|_| anyhow::anyhow!("Could not determine selected AI provider"))?;
+    let provider = match provider_label {
+        "OpenAI" => LLMProviderKind::OpenAi,
+        "Anthropic" => LLMProviderKind::Anthropic,
+        "Ollama" => LLMProviderKind::Ollama,
+        "LM Studio" => LLMProviderKind::LMStudio,
+        _ => anyhow::bail!("Unsupported AI provider selection: {provider_label}"),
+    };
+
+    match provider {
+        LLMProviderKind::OpenAi => {
+            let key_option_prompt = cli_prompts::prompts::Selection::new(
+                "Select OpenAI credential source",
+                vec![AiKeyOption::ButlerApi, AiKeyOption::BringYourOwn].into_iter(),
+            );
+            let key_option = key_option_prompt
+                .display()
+                .map_err(|_| anyhow::anyhow!("Could not determine OpenAI credential source"))?;
+
+            let model = inout.prompt("Preferred OpenAI model (leave empty for default):")?;
+            let endpoint = inout.prompt("Custom endpoint URL (optional):")?;
+
+            let secret = if matches!(key_option, AiKeyOption::BringYourOwn) {
+                Some(
+                    inout
+                        .prompt_secret("Enter OpenAI API key:")?
+                        .context("No API key provided. Aborting configuration.")?,
+                )
+            } else {
+                None
+            };
+
+            apply_openai_config(repo, scope, key_option, model, endpoint, secret)?;
+        }
+        LLMProviderKind::Anthropic => {
+            let key_option_prompt = cli_prompts::prompts::Selection::new(
+                "Select Anthropic credential source",
+                vec![AiKeyOption::ButlerApi, AiKeyOption::BringYourOwn].into_iter(),
+            );
+            let key_option = key_option_prompt
+                .display()
+                .map_err(|_| anyhow::anyhow!("Could not determine Anthropic credential source"))?;
+
+            let model = inout.prompt("Preferred Anthropic model (leave empty for default):")?;
+            let secret = if matches!(key_option, AiKeyOption::BringYourOwn) {
+                Some(
+                    inout
+                        .prompt_secret("Enter Anthropic API key:")?
+                        .context("No API key provided. Aborting configuration.")?,
+                )
+            } else {
+                None
+            };
+
+            apply_anthropic_config(repo, scope, key_option, model, secret)?;
+        }
+        LLMProviderKind::Ollama => {
+            let endpoint = inout.prompt("Ollama endpoint host:port (optional):")?;
+            let model = inout.prompt("Preferred Ollama model (optional):")?;
+            apply_ollama_config(repo, scope, endpoint, model)?;
+        }
+        LLMProviderKind::LMStudio => {
+            let endpoint = inout.prompt("LM Studio endpoint URL (optional):")?;
+            let model = inout.prompt("Preferred LM Studio model (optional):")?;
+            apply_lmstudio_config(repo, scope, endpoint, model)?;
+        }
+    }
+
+    writeln!(
+        inout,
+        "{} AI provider set to {} ({})",
+        "✓".green(),
+        provider.display_name().cyan(),
+        scope.as_str().dimmed()
+    )?;
+    Ok(())
+}
+
+fn write_ai_config_success(
+    out: &mut OutputChannel,
+    scope: AiScope,
+    provider: LLMProviderKind,
+) -> Result<()> {
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "{} AI provider set to {} ({})",
+            "✓".green(),
+            provider.display_name().cyan(),
+            scope.as_str().dimmed()
+        )?;
+    } else if let Some(out) = out.for_shell() {
+        writeln!(out, "{}", provider.as_git_config_value())?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "provider": provider.as_git_config_value(),
+            "scope": scope.as_str(),
+        }))?;
+    }
+    Ok(())
+}
+
+fn resolve_secret_input(
+    api_key: Option<String>,
+    api_key_env: Option<String>,
+) -> Result<Option<Sensitive<String>>> {
+    if api_key.is_some() && api_key_env.is_some() {
+        anyhow::bail!("Pass either --api-key or --api-key-env, not both")
+    }
+
+    if let Some(value) = api_key {
+        return Ok(Some(Sensitive(value)));
+    }
+
+    if let Some(env_name) = api_key_env {
+        let value = std::env::var(&env_name)
+            .with_context(|| format!("Environment variable '{env_name}' is not set"))?;
+        return Ok(Some(Sensitive(value)));
+    }
+
+    Ok(None)
+}
+
+fn require_non_interactive_secret_if_byok(
+    key_option: AiKeyOption,
+    secret: Option<&Sensitive<String>>,
+    provider: &str,
+) -> Result<()> {
+    if matches!(key_option, AiKeyOption::BringYourOwn) && secret.is_none() {
+        anyhow::bail!(
+            "{provider} with --key-option bring-your-own requires --api-key or --api-key-env"
+        );
+    }
+    Ok(())
+}
+
+fn maybe_set_secret(handle: &str, secret_value: Option<Sensitive<String>>) -> Result<()> {
+    if let Some(secret_value) = secret_value {
+        secret::persist(handle, &secret_value, secret::Namespace::Global)?;
+    }
+    Ok(())
+}
+
+fn edit_ai_git_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    edit: impl FnOnce(&mut gix::config::File<'static>) -> Result<bool>,
+) -> Result<()> {
+    match scope {
+        AiScope::Global => {
+            let (mut config, path) = but_core::git_config::open_user_global_config_for_editing()?;
+            let changed = edit(&mut config)?;
+            if changed {
+                but_core::git_config::write_config(&path, &config)?;
+            }
+            Ok(())
+        }
+        AiScope::Local => {
+            let repo = repo.context("Local AI configuration requires a git repository")?;
+            edit_git_config(repo, false.into(), edit)?;
+            Ok(())
+        }
+    }
+}
+
+fn set_optional_config_value(
+    config: &mut gix::config::File<'static>,
+    key: &str,
+    value: Option<String>,
+) -> Result<()> {
+    match value {
+        Some(value) if !value.trim().is_empty() => set_config_value(config, key, &value),
+        _ => remove_config_value(config, key),
+    }
+}
+
+fn apply_openai_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    key_option: AiKeyOption,
+    model: Option<String>,
+    endpoint: Option<String>,
+    api_key: Option<Sensitive<String>>,
+) -> Result<()> {
+    edit_ai_git_config(repo, scope, |config| {
+        set_config_value(
+            config,
+            AI_MODEL_PROVIDER_KEY,
+            LLMProviderKind::OpenAi.as_git_config_value(),
+        )?;
+        set_config_value(config, AI_OPENAI_KEY_OPTION_KEY, key_option.as_git_value())?;
+        set_optional_config_value(config, AI_OPENAI_MODEL_NAME_KEY, model)?;
+        set_optional_config_value(config, AI_OPENAI_CUSTOM_ENDPOINT_KEY, endpoint)?;
+        Ok(true)
+    })?;
+
+    if matches!(key_option, AiKeyOption::BringYourOwn) {
+        maybe_set_secret(AI_OPENAI_SECRET_HANDLE, api_key)?;
+    }
+    Ok(())
+}
+
+fn apply_anthropic_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    key_option: AiKeyOption,
+    model: Option<String>,
+    api_key: Option<Sensitive<String>>,
+) -> Result<()> {
+    edit_ai_git_config(repo, scope, |config| {
+        set_config_value(
+            config,
+            AI_MODEL_PROVIDER_KEY,
+            LLMProviderKind::Anthropic.as_git_config_value(),
+        )?;
+        set_config_value(
+            config,
+            AI_ANTHROPIC_KEY_OPTION_KEY,
+            key_option.as_git_value(),
+        )?;
+        set_optional_config_value(config, AI_ANTHROPIC_MODEL_NAME_KEY, model)?;
+        Ok(true)
+    })?;
+
+    if matches!(key_option, AiKeyOption::BringYourOwn) {
+        maybe_set_secret(AI_ANTHROPIC_SECRET_HANDLE, api_key)?;
+    }
+    Ok(())
+}
+
+fn apply_ollama_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    endpoint: Option<String>,
+    model: Option<String>,
+) -> Result<()> {
+    edit_ai_git_config(repo, scope, |config| {
+        set_config_value(
+            config,
+            AI_MODEL_PROVIDER_KEY,
+            LLMProviderKind::Ollama.as_git_config_value(),
+        )?;
+        set_optional_config_value(config, AI_OLLAMA_ENDPOINT_KEY, endpoint)?;
+        set_optional_config_value(config, AI_OLLAMA_MODEL_NAME_KEY, model)?;
+        Ok(true)
+    })
+}
+
+fn apply_lmstudio_config(
+    repo: Option<&gix::Repository>,
+    scope: AiScope,
+    endpoint: Option<String>,
+    model: Option<String>,
+) -> Result<()> {
+    edit_ai_git_config(repo, scope, |config| {
+        set_config_value(
+            config,
+            AI_MODEL_PROVIDER_KEY,
+            LLMProviderKind::LMStudio.as_git_config_value(),
+        )?;
+        set_optional_config_value(config, AI_LMSTUDIO_ENDPOINT_KEY, endpoint)?;
+        set_optional_config_value(config, AI_LMSTUDIO_MODEL_NAME_KEY, model)?;
+        Ok(true)
+    })
+}
+
+fn get_ai_config_info(repo: Option<&gix::Repository>, scope: AiScope) -> Result<AiConfigInfo> {
+    match scope {
+        AiScope::Global => {
+            let file = gix::config::File::from_globals()?;
+            Ok(AiConfigInfo {
+                provider: file.string(AI_MODEL_PROVIDER_KEY).map(|v| v.to_string()),
+                openai_key_option: file.string(AI_OPENAI_KEY_OPTION_KEY).map(|v| v.to_string()),
+                openai_model: file.string(AI_OPENAI_MODEL_NAME_KEY).map(|v| v.to_string()),
+                openai_endpoint: file
+                    .string(AI_OPENAI_CUSTOM_ENDPOINT_KEY)
+                    .map(|v| v.to_string()),
+                anthropic_key_option: file
+                    .string(AI_ANTHROPIC_KEY_OPTION_KEY)
+                    .map(|v| v.to_string()),
+                anthropic_model: file
+                    .string(AI_ANTHROPIC_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+                ollama_endpoint: file.string(AI_OLLAMA_ENDPOINT_KEY).map(|v| v.to_string()),
+                ollama_model: file.string(AI_OLLAMA_MODEL_NAME_KEY).map(|v| v.to_string()),
+                lmstudio_endpoint: file.string(AI_LMSTUDIO_ENDPOINT_KEY).map(|v| v.to_string()),
+                lmstudio_model: file
+                    .string(AI_LMSTUDIO_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+            })
+        }
+        AiScope::Local => {
+            let repo = repo.context("Local AI configuration requires a git repository")?;
+            let config = repo.config_snapshot();
+            Ok(AiConfigInfo {
+                provider: config.string(AI_MODEL_PROVIDER_KEY).map(|v| v.to_string()),
+                openai_key_option: config
+                    .string(AI_OPENAI_KEY_OPTION_KEY)
+                    .map(|v| v.to_string()),
+                openai_model: config
+                    .string(AI_OPENAI_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+                openai_endpoint: config
+                    .string(AI_OPENAI_CUSTOM_ENDPOINT_KEY)
+                    .map(|v| v.to_string()),
+                anthropic_key_option: config
+                    .string(AI_ANTHROPIC_KEY_OPTION_KEY)
+                    .map(|v| v.to_string()),
+                anthropic_model: config
+                    .string(AI_ANTHROPIC_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+                ollama_endpoint: config.string(AI_OLLAMA_ENDPOINT_KEY).map(|v| v.to_string()),
+                ollama_model: config
+                    .string(AI_OLLAMA_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+                lmstudio_endpoint: config
+                    .string(AI_LMSTUDIO_ENDPOINT_KEY)
+                    .map(|v| v.to_string()),
+                lmstudio_model: config
+                    .string(AI_LMSTUDIO_MODEL_NAME_KEY)
+                    .map(|v| v.to_string()),
+            })
+        }
+    }
 }
 
 /// Handle target config subcommand

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -284,6 +284,12 @@ async fn match_subcommand(
                         .await
                         .emit_metrics(metrics_ctx)
                 }
+                Some(args::config::Subcommands::Ai {
+                    cmd: ai_cmd,
+                    local,
+                    global,
+                }) if !local => command::config::ai_config(out, ai_cmd.clone(), *local, *global)
+                    .emit_metrics(metrics_ctx),
                 _ => {
                     // Other subcommands need a repo context
                     cfg_if! {

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -1,0 +1,220 @@
+use crate::utils::{CommandExt as _, Sandbox};
+use snapbox::str;
+
+#[test]
+fn ai_openai_defaults_to_global_config() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    env.invoke_bash("git init repo");
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    env.but("-C repo config ai openai --key-option butler-api --model gpt-5.4-nano")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiModelProvider"),
+        "openai"
+    );
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiOpenAIKeyOption"),
+        "butlerAPI"
+    );
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiOpenAIModelName"),
+        "gpt-5.4-nano"
+    );
+
+    env.invoke_git_fails(
+        "-C repo config --local --get gitbutler.aiModelProvider",
+        "default AI config should not write repo-local keys",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ai_ollama_local_writes_repo_config() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    env.invoke_bash("git init repo");
+    env.but("-C repo setup").assert().success();
+
+    env.but("-C repo config ai --local ollama --endpoint localhost:11434 --model llama3.1")
+        .assert()
+        .success();
+
+    assert_eq!(
+        env.invoke_git("-C repo config --local --get gitbutler.aiModelProvider"),
+        "ollama"
+    );
+    assert_eq!(
+        env.invoke_git("-C repo config --local --get gitbutler.aiOllamaEndpoint"),
+        "localhost:11434"
+    );
+    assert_eq!(
+        env.invoke_git("-C repo config --local --get gitbutler.aiOllamaModelName"),
+        "llama3.1"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ai_global_config_works_outside_repository() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    env.but("config ai lmstudio --endpoint http://localhost:1234/v1 --model local-model")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiModelProvider"),
+        "lmstudio"
+    );
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiLMStudioEndpoint"),
+        "http://localhost:1234/v1"
+    );
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get gitbutler.aiLMStudioModelName"),
+        "local-model"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ai_show_outputs_current_global_configuration_json() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    env.but("config ai openai --key-option butler-api --model gpt-5.4-nano")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    let output = env
+        .but("--json config ai show")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .allow_json()
+        .output()?;
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    assert_eq!(json["provider"], "openai");
+    assert_eq!(json["openai_key_option"], "butlerAPI");
+    assert_eq!(json["openai_model"], "gpt-5.4-nano");
+
+    Ok(())
+}
+
+#[test]
+fn ai_show_outputs_current_local_configuration_json() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    env.invoke_bash("git init repo");
+    env.but("-C repo setup").assert().success();
+
+    env.but("-C repo config ai --local ollama --endpoint localhost:11434 --model llama3.1")
+        .assert()
+        .success();
+
+    let output = env
+        .but("-C repo --json config ai --local show")
+        .allow_json()
+        .output()?;
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    assert_eq!(json["provider"], "ollama");
+    assert_eq!(json["ollama_endpoint"], "localhost:11434");
+    assert_eq!(json["ollama_model"], "llama3.1");
+
+    Ok(())
+}
+
+#[test]
+fn ai_show_outputs_current_global_configuration_human() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    env.but("config ai openai --key-option butler-api --model gpt-5.4-nano")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    env.but("config ai show")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+AI Configuration (global)
+
+  Provider: openai
+  OpenAI key option: butlerAPI
+  OpenAI model: gpt-5.4-nano
+  OpenAI endpoint: (not set)
+  Anthropic key option: (not set)
+  Anthropic model: (not set)
+  Ollama endpoint: (not set)
+  Ollama model: (not set)
+  LM Studio endpoint: (not set)
+  LM Studio model: (not set)
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn ai_openai_byok_without_api_key_fails_non_interactive() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    let output = env
+        .but("config ai openai --key-option bring-your-own --model gpt-5.4-nano")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .output()?;
+
+    assert!(!output.status.success(), "command should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "OpenAI with --key-option bring-your-own requires --api-key or --api-key-env"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    env.invoke_git_fails(
+        "config --file global.gitconfig --get gitbutler.aiModelProvider",
+        "provider should not be written when BYOK key is missing",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ai_anthropic_byok_without_api_key_fails_non_interactive() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+    let global_config = env.projects_root().join("global.gitconfig");
+
+    let output = env
+        .but("config ai anthropic --key-option bring-your-own --model claude-3-5-haiku-latest")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .output()?;
+
+    assert!(!output.status.success(), "command should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "Anthropic with --key-option bring-your-own requires --api-key or --api-key-env"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    env.invoke_git_fails(
+        "config --file global.gitconfig --get gitbutler.aiModelProvider",
+        "provider should not be written when BYOK key is missing",
+    );
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -11,6 +11,7 @@ mod claude;
 mod clean;
 #[cfg(feature = "legacy")]
 mod commit;
+mod config;
 #[cfg(feature = "legacy")]
 mod cursor;
 #[cfg(feature = "legacy")]


### PR DESCRIPTION
Add a command to configure the LLM provider to be used in the CLI.

Without subcommands, this starts an interactive setup flow.
Use provider subcommands for non-interactive configuration.
Interactive setup:
`but config ai`

View current AI configuration:
`but config ai show`


Configure OpenAI non-interactively:
`but config ai openai --key-option bring-your-own --api-key-env OPENAI_API_KEY --model gpt-5.4-nano`

Configure Ollama locally:
`but config ai --local ollama --endpoint localhost:11434 --model llama3.1`

resolves GB-1021
