### PR TITLE
discard commit

### DIFF
--- a/apps/desktop/src/components/history/SnapshotCard.svelte
+++ b/apps/desktop/src/components/history/SnapshotCard.svelte
@@ -129,6 +129,12 @@
 					icon: "undo",
 					commitMessage: entryTrailer("message"),
 				};
+			case "DiscardCommit":
+				return {
+					text: `Discard commit ${getShortSha(entryTrailer("sha"))}`,
+					icon: "cross",
+					commitMessage: entryTrailer("message"),
+				};
 			case "SquashCommit":
 				return { text: "Squash commit", icon: "commit-arrow-down" };
 			case "MoveCommit":

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -20,6 +20,7 @@ export type Operation =
 	| "Absorb"
 	| "AutoCommit"
 	| "UndoCommit"
+	| "DiscardCommit"
 	| "UnapplyBranch"
 	| "CherryPick"
 	| "SquashCommit"

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -1,0 +1,51 @@
+use but_api_macros::but_api;
+use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
+use but_rebase::graph_rebase::Editor;
+use tracing::instrument;
+
+use crate::commit::types::CommitDiscardResult;
+
+/// Discards a commit, no snapshots. No strings attached.
+///
+/// Returns the replaced commits that resulted from the operation.
+#[but_api(crate::commit::json::UICommitDiscardResult)]
+pub fn commit_discard_only(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitDiscardResult> {
+    let mut meta = ctx.meta()?;
+    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
+    let rebase = but_workspace::commit::discard_commit(editor, subject_commit_id)?;
+
+    let materialized = rebase.materialize()?;
+
+    Ok(CommitDiscardResult {
+        discarded_commit: subject_commit_id,
+        replaced_commits: materialized.history.commit_mappings(),
+    })
+}
+
+/// Discards a commit.
+///
+/// Returns the replaced commits that resulted from the operation.
+#[but_api(napi, crate::commit::json::UICommitDiscardResult)]
+#[instrument(err(Debug))]
+pub fn commit_discard(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitDiscardResult> {
+    let details = SnapshotDetails::new(OperationKind::DiscardCommit).with_trailers(vec![Trailer {
+        key: "sha".to_string(),
+        value: subject_commit_id.to_string(),
+    }]);
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(ctx, details).ok();
+
+    let res = commit_discard_only(ctx, subject_commit_id);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        let mut guard = ctx.exclusive_worktree_access();
+        snapshot.commit(ctx, guard.write_permission()).ok();
+    };
+    res
+}

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -14,7 +14,7 @@ pub fn commit_discard_only(
     subject_commit_id: gix::ObjectId,
 ) -> anyhow::Result<CommitDiscardResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let rebase = but_workspace::commit::discard_commit(editor, subject_commit_id)?;

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -1,7 +1,7 @@
 use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 
-use crate::json::HexHash;
+use crate::{commit::types::CommitDiscardResult, json::HexHash};
 
 use super::types::{
     CommitCreateResult, CommitInsertBlankResult, CommitMoveResult, CommitRewordResult,
@@ -202,6 +202,41 @@ impl From<CommitMoveResult> for UICommitMoveResult {
         let CommitMoveResult { replaced_commits } = value;
 
         Self {
+            replaced_commits: replaced_commits
+                .into_iter()
+                .map(|(old, new)| (old.into(), new.into()))
+                .collect(),
+        }
+    }
+}
+/// UI type for discarding a commit.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct UICommitDiscardResult {
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub discarded_commit: HexHash,
+    /// Commits that have been replaced as a side-effect of the commit discard.
+    /// Maps `oldId -> newId`.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(with = "std::collections::BTreeMap<String, String>")
+    )]
+    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(UICommitDiscardResult);
+
+impl From<CommitDiscardResult> for UICommitDiscardResult {
+    fn from(value: CommitDiscardResult) -> Self {
+        let CommitDiscardResult {
+            replaced_commits,
+            discarded_commit,
+        } = value;
+
+        Self {
+            discarded_commit: discarded_commit.into(),
             replaced_commits: replaced_commits
                 .into_iter()
                 .map(|(old, new)| (old.into(), new.into()))

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -214,6 +214,7 @@ impl From<CommitMoveResult> for UICommitMoveResult {
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UICommitDiscardResult {
+    /// The commit that was discarded as a result of this operation.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub discarded_commit: HexHash,
     /// Commits that have been replaced as a side-effect of the commit discard.

--- a/crates/but-api/src/commit/mod.rs
+++ b/crates/but-api/src/commit/mod.rs
@@ -4,6 +4,9 @@ pub mod amend;
 /// Functions for creating new commits.
 pub mod create;
 
+/// Functions for discarding commits.
+pub mod discard_commit;
+
 /// JSON transport types for commit APIs.
 pub mod json;
 

--- a/crates/but-api/src/commit/types.rs
+++ b/crates/but-api/src/commit/types.rs
@@ -39,3 +39,11 @@ pub struct CommitInsertBlankResult {
     /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
     pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
 }
+
+/// Outcome of discarding a commit.
+pub struct CommitDiscardResult {
+    /// The ID of the commit discarded.
+    pub discarded_commit: gix::ObjectId,
+    /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
+    pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+}

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -180,6 +180,12 @@ impl ToCommitSelector for gix::ObjectId {
     }
 }
 
+impl ToCommitSelector for gix::Id<'_> {
+    fn to_commit_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
+        editor.select_commit(self.detach())
+    }
+}
+
 impl ToReferenceSelector for &gix::refs::FullNameRef {
     fn to_reference_selector(&self, editor: &Editor<impl RefMetadata>) -> Result<Selector> {
         editor.select_reference(self)

--- a/crates/but-workspace/src/commit/discard_commit.rs
+++ b/crates/but-workspace/src/commit/discard_commit.rs
@@ -1,0 +1,43 @@
+//! Discard a commit from the graph.
+
+pub(crate) mod function {
+    use anyhow::bail;
+    use but_core::RefMetadata;
+    use but_rebase::graph_rebase::{
+        Editor, Step, SuccessfulRebase, ToCommitSelector,
+        mutate::{SegmentDelimiter, SelectorSet},
+    };
+
+    /// Discard a commit by removing it from history and reconnecting all its
+    /// parents to all of its children.
+    ///
+    /// `subject_commit` - The selector of the commit to discard.
+    ///
+    /// Returns the rebase result.
+    pub fn discard_commit<'ws, 'meta, M: RefMetadata>(
+        mut editor: Editor<'ws, 'meta, M>,
+        subject_commit: impl ToCommitSelector,
+    ) -> anyhow::Result<SuccessfulRebase<'ws, 'meta, M>> {
+        let (subject_commit_selector, subject_commit) =
+            editor.find_selectable_commit(subject_commit)?;
+
+        if subject_commit.clone().attach(editor.repo()).is_conflicted() {
+            bail!("Cannot discard a conflicted commit")
+        }
+
+        let commit_delimiter = SegmentDelimiter {
+            child: subject_commit_selector,
+            parent: subject_commit_selector,
+        };
+
+        editor.disconnect_segment_from(
+            commit_delimiter,
+            SelectorSet::All,
+            SelectorSet::All,
+            false,
+        )?;
+
+        editor.replace(subject_commit_selector, Step::None)?;
+        editor.rebase()
+    }
+}

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -18,6 +18,8 @@ pub mod uncommit_changes;
 pub use uncommit_changes::function::{UncommitChangesOutcome, uncommit_changes};
 pub mod move_commit;
 pub use move_commit::function::move_commit;
+pub mod discard_commit;
+pub use discard_commit::function::discard_commit;
 
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
 #[derive(Clone)]

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -1,0 +1,198 @@
+use anyhow::Result;
+use but_rebase::graph_rebase::Editor;
+use but_testsupport::visualize_commit_graph_all;
+use but_workspace::commit::discard_commit;
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments, named_writable_scenario_with_description_and_graph,
+};
+
+#[test]
+fn discard_middle_commit_in_non_managed_workspace() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let one = repo.rev_parse_single("one")?.detach();
+    let two = repo.rev_parse_single("two")?.detach();
+    let three = repo.rev_parse_single("three")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = discard_commit(editor, two)?;
+
+    outcome.materialize()?;
+
+    let tip_of_two = repo.rev_parse_single("two")?.detach();
+    assert_eq!(tip_of_two, one, "The tip of two should now point to one");
+
+    let tip_of_three = repo.rev_parse_single("three")?.detach();
+    assert_ne!(tip_of_three, three, "three should have been rewritten");
+
+    let rewritten_three = repo.find_commit(tip_of_three)?;
+    let parent_ids: Vec<_> = rewritten_three.parent_ids().map(|id| id.detach()).collect();
+    assert_eq!(parent_ids, vec![one], "three should now have one as parent");
+
+    assert!(
+        repo.rev_parse_single(format!("{tip_of_three}:one.txt").as_str())
+            .is_ok()
+    );
+    assert!(
+        repo.rev_parse_single(format!("{tip_of_three}:three.txt").as_str())
+            .is_ok()
+    );
+    assert!(
+        repo.rev_parse_single(format!("{tip_of_three}:two.txt").as_str())
+            .is_err(),
+        "discarding two should remove its introduced changes from descendants"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * fc5e5e6 (HEAD -> three) commit three
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (two, one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn discard_tip_commit_in_workspace_stack() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let b = repo.rev_parse_single("B")?.detach();
+    let c = repo.rev_parse_single("C")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = discard_commit(editor, c)?;
+
+    outcome.materialize()?;
+
+    let tip_of_c = repo.rev_parse_single("C")?.detach();
+    assert_eq!(tip_of_c, b, "The C ref should now point to B");
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   5e34c6d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * c813d8d (C, B) B
+    * | 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f3e1bf2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | 09bc93e (C) C
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    let b = repo.rev_parse_single("B")?.detach();
+    let c = repo.rev_parse_single("C")?.detach();
+    let main = repo.rev_parse_single("main")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = discard_commit(editor, b)?;
+
+    outcome.materialize()?;
+
+    let tip_of_b = repo.rev_parse_single("B")?.detach();
+    assert_eq!(tip_of_b, main, "The B ref should now point to main");
+
+    let tip_of_c = repo.rev_parse_single("C")?.detach();
+    assert_ne!(tip_of_c, c, "The C commit should have been rewritten");
+    let rewritten_c = repo.find_commit(tip_of_c)?;
+    let parent_ids: Vec<_> = rewritten_c.parent_ids().map(|id| id.detach()).collect();
+    assert_eq!(
+        parent_ids,
+        vec![main],
+        "C should now directly descend from main"
+    );
+
+    assert_ne!(b, tip_of_c, "Discarded commit must not remain as C tip");
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   ec062b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 9f14615 (C) C
+    * | 09d8e52 (A) A
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn cannot_discard_conflicted_commit() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph("with-conflict", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 8450331 (HEAD -> main, tag: conflicted) GitButler WIP Commit
+    * a047f81 (tag: normal) init
+    ");
+
+    let conflicted = repo.rev_parse_single("conflicted")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let result = discard_commit(editor, conflicted);
+
+    assert!(result.is_err(), "Discarding a conflicted commit must fail");
+    let err = result.expect_err("expected error");
+    assert!(
+        err.to_string()
+            .contains("Cannot discard a conflicted commit"),
+        "unexpected error: {err}"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 8450331 (HEAD -> main, tag: conflicted) GitButler WIP Commit
+    * a047f81 (tag: normal) init
+    ");
+
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_rebase::graph_rebase::Editor;
-use but_testsupport::visualize_commit_graph_all;
+use but_testsupport::{graph_workspace, visualize_commit_graph_all};
 use but_workspace::commit::discard_commit;
 
 use crate::ref_info::with_workspace_commit::utils::{
@@ -18,9 +18,9 @@ fn discard_middle_commit_in_non_managed_workspace() -> Result<()> {
     * 8b426d0 (one) commit one
     ");
 
-    let one = repo.rev_parse_single("one")?.detach();
-    let two = repo.rev_parse_single("two")?.detach();
-    let three = repo.rev_parse_single("three")?.detach();
+    let one = repo.rev_parse_single("one")?;
+    let two = repo.rev_parse_single("two")?;
+    let three = repo.rev_parse_single("three")?;
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
@@ -28,14 +28,14 @@ fn discard_middle_commit_in_non_managed_workspace() -> Result<()> {
 
     outcome.materialize()?;
 
-    let tip_of_two = repo.rev_parse_single("two")?.detach();
+    let tip_of_two = repo.rev_parse_single("two")?;
     assert_eq!(tip_of_two, one, "The tip of two should now point to one");
 
-    let tip_of_three = repo.rev_parse_single("three")?.detach();
+    let tip_of_three = repo.rev_parse_single("three")?;
     assert_ne!(tip_of_three, three, "three should have been rewritten");
 
     let rewritten_three = repo.find_commit(tip_of_three)?;
-    let parent_ids: Vec<_> = rewritten_three.parent_ids().map(|id| id.detach()).collect();
+    let parent_ids: Vec<_> = rewritten_three.parent_ids().collect();
     assert_eq!(parent_ids, vec![one], "three should now have one as parent");
 
     assert!(
@@ -83,16 +83,37 @@ fn discard_tip_commit_in_workspace_stack() -> Result<()> {
     * 85efbe4 (origin/main, main) M
     ");
 
-    let b = repo.rev_parse_single("B")?.detach();
-    let c = repo.rev_parse_single("C")?.detach();
+    let b = repo.rev_parse_single("B")?;
+    let c = repo.rev_parse_single("C")?;
 
     let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commit(editor, c)?;
 
-    outcome.materialize()?;
+    let outcome = outcome.materialize()?;
+    insta::assert_snapshot!(graph_workspace(outcome.workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:5:C on 85efbe4 {2}
+    │   ├── 📙:5:C
+    │   └── 📙:6:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
 
-    let tip_of_c = repo.rev_parse_single("C")?.detach();
+    let tip_of_c = repo.rev_parse_single("C")?;
     assert_eq!(tip_of_c, b, "The C ref should now point to B");
 
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -128,23 +149,44 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     * 85efbe4 (origin/main, main) M
     ");
 
-    let b = repo.rev_parse_single("B")?.detach();
-    let c = repo.rev_parse_single("C")?.detach();
-    let main = repo.rev_parse_single("main")?.detach();
+    let b = repo.rev_parse_single("B")?;
+    let c = repo.rev_parse_single("C")?;
+    let main = repo.rev_parse_single("main")?;
 
     let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·09bc93e (🏘️)
+    │   └── 📙:5:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commit(editor, b)?;
 
-    outcome.materialize()?;
+    let outcome = outcome.materialize()?;
+    insta::assert_snapshot!(graph_workspace(outcome.workspace), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:C on 85efbe4 {2}
+    │   ├── 📙:4:C
+    │   │   └── ·9f14615 (🏘️)
+    │   └── 📙:5:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
 
-    let tip_of_b = repo.rev_parse_single("B")?.detach();
+    let tip_of_b = repo.rev_parse_single("B")?;
     assert_eq!(tip_of_b, main, "The B ref should now point to main");
 
-    let tip_of_c = repo.rev_parse_single("C")?.detach();
+    let tip_of_c = repo.rev_parse_single("C")?;
     assert_ne!(tip_of_c, c, "The C commit should have been rewritten");
     let rewritten_c = repo.find_commit(tip_of_c)?;
-    let parent_ids: Vec<_> = rewritten_c.parent_ids().map(|id| id.detach()).collect();
+    let parent_ids: Vec<_> = rewritten_c.parent_ids().collect();
     assert_eq!(
         parent_ids,
         vec![main],
@@ -175,14 +217,13 @@ fn cannot_discard_conflicted_commit() -> Result<()> {
     * a047f81 (tag: normal) init
     ");
 
-    let conflicted = repo.rev_parse_single("conflicted")?.detach();
+    let conflicted = repo.rev_parse_single("conflicted")?;
 
     let mut ws = graph.into_workspace()?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let result = discard_commit(editor, conflicted);
 
-    assert!(result.is_err(), "Discarding a conflicted commit must fail");
-    let err = result.expect_err("expected error");
+    let err = result.expect_err("Discarding a conflicted commit must fail");
     assert!(
         err.to_string()
             .contains("Cannot discard a conflicted commit"),

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -1,5 +1,6 @@
 mod commit_amend;
 mod commit_create;
+mod discard_commit;
 mod insert_blank_commit;
 mod move_changes;
 mod move_commit;

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -84,6 +84,7 @@ pub(crate) fn show_oplog(
                     OperationKind::Absorb => "ABSORB",
                     OperationKind::AutoCommit => "AUTO_COMMIT",
                     OperationKind::UndoCommit => "UNDO",
+                    OperationKind::DiscardCommit => "DISCARD_COMMIT",
                     OperationKind::SquashCommit => "SQUASH",
                     OperationKind::UpdateCommitMessage => "REWORD",
                     OperationKind::MoveCommit => "MOVE",

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -143,6 +143,7 @@ pub enum OperationKind {
     Absorb,
     AutoCommit,
     UndoCommit,
+    DiscardCommit,
     UnapplyBranch,
     CherryPick,
     SquashCommit,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -51,6 +51,13 @@ export declare function commitCreate(projectId: string, relativeTo: RelativeTo, 
 export declare function commitDetailsWithLineStats(projectId: string, commitId: string): Promise<CommitDetails>
 
 /**
+ * Discards a commit.
+ *
+ * Returns the replaced commits that resulted from the operation.
+ */
+export declare function commitDiscard(projectId: string, subjectCommitId: string): Promise<UICommitDiscardResult>
+
+/**
  * Inserts a blank commit relative to either a commit or a reference, with oplog support.
  *
  * Returns the result including the new commit ID and any replaced commits.
@@ -1230,6 +1237,17 @@ export type UICommitCreateResult = {
   rejectedChanges: Array<UIRejectedChange>;
   /**
    * Commits that have been replaced as a side-effect of the create/amend.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** UI type for discarding a commit. */
+export type UICommitDiscardResult = {
+  /** The commit that was discarded as a result of this operation. */
+  discardedCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the commit discard.
    * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -591,6 +591,7 @@ export { changesInWorktreeWithPerm }
 export { commitAmend }
 export { commitCreate }
 export { commitDetailsWithLineStats }
+export { commitDiscard }
 export { commitInsertBlank }
 export { commitMove }
 export { commitMoveChangesBetween }


### PR DESCRIPTION
Ability to completely ‘delete’ a commit and its associated changes.

- Add tests
- Add Oplog entry
- Expose API in the SDK