### PR TITLE
Copy file paths from TUI

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -22,8 +22,7 @@ use crate::{
     command::legacy::{
         forge::review,
         status::output::{
-            BranchLineContent, CommitLineContent, CommittedFileLineContent, StatusOutput,
-            StatusOutputLine,
+            BranchLineContent, CommitLineContent, FileLineContent, StatusOutput, StatusOutputLine,
         },
     },
     id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
@@ -771,17 +770,18 @@ fn print_assignments(
             "uncommitted file",
         )?;
 
-        let file_line = Vec::from([
-            Span::raw(id_padding.clone()),
-            Span::styled(cli_id.to_string(), Style::default().bold().blue()),
-            Span::raw(" "),
-            Span::raw(status.to_string()),
-            Span::raw(" "),
-            path,
-        ]);
+        let file_line = FileLineContent {
+            id: Vec::from([
+                Span::raw(id_padding.clone()),
+                Span::styled(cli_id.to_string(), Style::default().bold().blue()),
+                Span::raw(" "),
+            ]),
+            status: Vec::from([Span::raw(status.to_string()), Span::raw(" ")]),
+            path: Vec::from([path]),
+        };
 
         if unstaged {
-            output.unstaged_file(Vec::from([Span::raw("┊   ")]), file_line, file_cli_id)?;
+            output.unassigned_file(Vec::from([Span::raw("┊   ")]), file_line, file_cli_id)?;
         } else {
             output.staged_file(Vec::from([Span::raw("┊  │ ")]), file_line, file_cli_id)?;
         }
@@ -1257,7 +1257,7 @@ fn print_commit(
                     let (status, path) = tree_change_display_cli(inner);
                     output.file(
                         Vec::from([Span::raw("┊│     ")]),
-                        CommittedFileLineContent {
+                        FileLineContent {
                             id: Vec::from([
                                 Span::styled(short_id.to_owned(), Style::default().blue().bold()),
                                 Span::raw(" "),
@@ -1274,7 +1274,7 @@ fn print_commit(
                     let (status, path) = tree_change_display_cli(change);
                     output.file(
                         Vec::from([Span::raw("┊│     ")]),
-                        CommittedFileLineContent {
+                        FileLineContent {
                             id: Vec::new(),
                             status: Vec::from([status]),
                             path: Vec::from([path]),

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -21,7 +21,10 @@ use crate::{
     CLI_DATE, CliId, IdMap,
     command::legacy::{
         forge::review,
-        status::output::{BranchLineContent, CommitLineContent, StatusOutput, StatusOutputLine},
+        status::output::{
+            BranchLineContent, CommitLineContent, CommittedFileLineContent, StatusOutput,
+            StatusOutputLine,
+        },
     },
     id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
@@ -1251,27 +1254,31 @@ fn print_commit(
                         id: short_id.to_owned(),
                     };
 
+                    let (status, path) = tree_change_display_cli(inner);
                     output.file(
                         Vec::from([Span::raw("┊│     ")]),
-                        [
-                            Span::styled(short_id.to_owned(), Style::default().blue().bold()),
-                            Span::raw(" "),
-                        ]
-                        .into_iter()
-                        .chain(inner.display_cli(false, status_ctx.should_truncate_for_terminal))
-                        .collect(),
+                        CommittedFileLineContent {
+                            id: Vec::from([
+                                Span::styled(short_id.to_owned(), Style::default().blue().bold()),
+                                Span::raw(" "),
+                            ]),
+                            status: Vec::from([status]),
+                            path: Vec::from([path]),
+                        },
                         file_cli_id,
                     )?;
                 }
             }
             CommitChanges::Remote(tree_changes) => {
                 for change in tree_changes {
+                    let (status, path) = tree_change_display_cli(change);
                     output.file(
                         Vec::from([Span::raw("┊│     ")]),
-                        change
-                            .display_cli(false, status_ctx.should_truncate_for_terminal)
-                            .into_iter()
-                            .collect(),
+                        CommittedFileLineContent {
+                            id: Vec::new(),
+                            status: Vec::from([status]),
+                            path: Vec::from([path]),
+                        },
                         commit_cli_id.clone(),
                     )?;
                 }
@@ -1289,15 +1296,20 @@ trait CliDisplay {
     ) -> impl IntoIterator<Item = Span<'static>>;
 }
 
+fn tree_change_display_cli(change: &but_core::TreeChange) -> (Span<'static>, Span<'static>) {
+    let path = path_with_color(&change.status, change.path.to_string());
+    let status_letter = status_letter(&change.status);
+    (Span::raw(format!("{status_letter} ")), path)
+}
+
 impl CliDisplay for but_core::TreeChange {
     fn display_cli(
         &self,
         _verbose: bool,
         _should_truncate_for_terminal: bool,
     ) -> impl IntoIterator<Item = Span<'static>> {
-        let path = path_with_color(&self.status, self.path.to_string());
-        let status_letter = status_letter(&self.status);
-        [Span::raw(format!("{status_letter} ")), path]
+        let (status, path) = tree_change_display_cli(self);
+        [status, path]
     }
 }
 

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -79,12 +79,12 @@ impl StatusOutput<'_> {
     pub(super) fn staged_file(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: Vec<Span<'static>>,
+        line: FileLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            StatusOutputContent::Plain(line),
+            StatusOutputContent::File(line),
             StatusOutputLineData::StagedFile {
                 cli_id: Arc::new(id),
             },
@@ -106,15 +106,15 @@ impl StatusOutput<'_> {
         )
     }
 
-    pub(super) fn unstaged_file(
+    pub(super) fn unassigned_file(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: Vec<Span<'static>>,
+        line: FileLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            StatusOutputContent::Plain(line),
+            StatusOutputContent::File(line),
             StatusOutputLineData::UnassignedFile {
                 cli_id: Arc::new(id),
             },
@@ -139,12 +139,12 @@ impl StatusOutput<'_> {
     pub(super) fn file(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: CommittedFileLineContent,
+        line: FileLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            StatusOutputContent::CommittedFile(line),
+            StatusOutputContent::File(line),
             StatusOutputLineData::File {
                 cli_id: Arc::new(id),
             },
@@ -250,17 +250,12 @@ impl StatusOutput<'_> {
 /// The non-connector content rendered for one status line.
 #[derive(Debug, Clone)]
 pub(super) enum StatusOutputContent {
-    /// Generic status content represented as one flat list of spans.
     Plain(Vec<Span<'static>>),
-    /// Structured content for commit rows.
     Commit(CommitLineContent),
-    /// Structured content for branch rows.
     Branch(BranchLineContent),
-    /// Structured content for committed file rows.
-    CommittedFile(CommittedFileLineContent),
+    File(FileLineContent),
 }
 
-/// Structured content for a commit row in status output.
 #[derive(Debug, Default, Clone)]
 pub(super) struct CommitLineContent {
     pub(super) sha: Vec<Span<'static>>,
@@ -269,8 +264,6 @@ pub(super) struct CommitLineContent {
     pub(super) suffix: Vec<Span<'static>>,
 }
 
-/// Structured content for a branch row in status output.
-///
 /// Consdering the example "dp [dp-branch-1] (no commits)" see the field docs for what exactly they
 /// correspond to.
 #[derive(Debug, Default, Clone)]
@@ -287,12 +280,10 @@ pub(super) struct BranchLineContent {
     pub(super) suffix: Vec<Span<'static>>,
 }
 
-/// Structured content for a committed file row in status output.
-///
 /// Consdering the example "ae:sv A a/b/c.rs" see the field docs for what exactly they
 /// correspond to.
 #[derive(Debug, Default, Clone)]
-pub(super) struct CommittedFileLineContent {
+pub(super) struct FileLineContent {
     /// "ae:sv" in the example
     pub(super) id: Vec<Span<'static>>,
     /// "A" in the example

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -100,7 +100,7 @@ impl StatusOutput<'_> {
         self.push_line(
             Some(connector),
             StatusOutputContent::Plain(line),
-            StatusOutputLineData::UnstagedChanges {
+            StatusOutputLineData::UnassignedChanges {
                 cli_id: Arc::new(id),
             },
         )
@@ -115,7 +115,7 @@ impl StatusOutput<'_> {
         self.push_line(
             Some(connector),
             StatusOutputContent::Plain(line),
-            StatusOutputLineData::UnstagedFile {
+            StatusOutputLineData::UnassignedFile {
                 cli_id: Arc::new(id),
             },
         )
@@ -338,8 +338,8 @@ impl StatusOutputLine {
             },
             StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::Branch { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::MergeBase
@@ -365,10 +365,10 @@ pub(super) enum StatusOutputLineData {
     StagedFile {
         cli_id: Arc<CliId>,
     },
-    UnstagedChanges {
+    UnassignedChanges {
         cli_id: Arc<CliId>,
     },
-    UnstagedFile {
+    UnassignedFile {
         cli_id: Arc<CliId>,
     },
     Branch {
@@ -394,8 +394,8 @@ pub(super) enum StatusOutputLineData {
 impl StatusOutputLineData {
     pub(super) fn cli_id(&self) -> Option<&Arc<CliId>> {
         match self {
-            StatusOutputLineData::UnstagedChanges { cli_id }
-            | StatusOutputLineData::UnstagedFile { cli_id }
+            StatusOutputLineData::UnassignedChanges { cli_id }
+            | StatusOutputLineData::UnassignedFile { cli_id }
             | StatusOutputLineData::Branch { cli_id }
             | StatusOutputLineData::StagedChanges { cli_id }
             | StatusOutputLineData::StagedFile { cli_id }

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -139,12 +139,12 @@ impl StatusOutput<'_> {
     pub(super) fn file(
         &mut self,
         connector: Vec<Span<'static>>,
-        line: Vec<Span<'static>>,
+        line: CommittedFileLineContent,
         id: CliId,
     ) -> anyhow::Result<()> {
         self.push_line(
             Some(connector),
-            StatusOutputContent::Plain(line),
+            StatusOutputContent::CommittedFile(line),
             StatusOutputLineData::File {
                 cli_id: Arc::new(id),
             },
@@ -256,6 +256,8 @@ pub(super) enum StatusOutputContent {
     Commit(CommitLineContent),
     /// Structured content for branch rows.
     Branch(BranchLineContent),
+    /// Structured content for committed file rows.
+    CommittedFile(CommittedFileLineContent),
 }
 
 /// Structured content for a commit row in status output.
@@ -283,6 +285,20 @@ pub(super) struct BranchLineContent {
     pub(super) decoration_end: Vec<Span<'static>>,
     /// "(no commits)" in the example
     pub(super) suffix: Vec<Span<'static>>,
+}
+
+/// Structured content for a committed file row in status output.
+///
+/// Consdering the example "ae:sv A a/b/c.rs" see the field docs for what exactly they
+/// correspond to.
+#[derive(Debug, Default, Clone)]
+pub(super) struct CommittedFileLineContent {
+    /// "ae:sv" in the example
+    pub(super) id: Vec<Span<'static>>,
+    /// "A" in the example
+    pub(super) status: Vec<Span<'static>>,
+    /// "a/b/c.rs" in the example
+    pub(super) path: Vec<Span<'static>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/but/src/command/legacy/status/render_oneshot.rs
+++ b/crates/but/src/command/legacy/status/render_oneshot.rs
@@ -3,7 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 
 use crate::{
     command::legacy::status::{
-        StatusOutputLine,
+        CommittedFileLineContent, StatusOutputLine,
         output::{BranchLineContent, CommitLineContent, StatusOutputContent},
     },
     utils::WriteWithUtils,
@@ -55,6 +55,15 @@ pub(super) fn render_oneshot(
             spans.append(&mut branch_name);
             spans.append(&mut decoration_end);
             spans.append(&mut suffix);
+        }
+        StatusOutputContent::CommittedFile(CommittedFileLineContent {
+            mut id,
+            mut status,
+            mut path,
+        }) => {
+            spans.append(&mut id);
+            spans.append(&mut status);
+            spans.append(&mut path);
         }
     }
 

--- a/crates/but/src/command/legacy/status/render_oneshot.rs
+++ b/crates/but/src/command/legacy/status/render_oneshot.rs
@@ -3,7 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 
 use crate::{
     command::legacy::status::{
-        CommittedFileLineContent, StatusOutputLine,
+        FileLineContent, StatusOutputLine,
         output::{BranchLineContent, CommitLineContent, StatusOutputContent},
     },
     utils::WriteWithUtils,
@@ -56,7 +56,7 @@ pub(super) fn render_oneshot(
             spans.append(&mut decoration_end);
             spans.append(&mut suffix);
         }
-        StatusOutputContent::CommittedFile(CommittedFileLineContent {
+        StatusOutputContent::File(FileLineContent {
             mut id,
             mut status,
             mut path,

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -155,11 +155,11 @@ impl Cursor {
                 StatusOutputLineData::Commit { .. }
                 | StatusOutputLineData::Branch { .. }
                 | StatusOutputLineData::StagedChanges { .. }
-                | StatusOutputLineData::UnstagedChanges { .. } => line.data.cli_id(),
+                | StatusOutputLineData::UnassignedChanges { .. } => line.data.cli_id(),
                 StatusOutputLineData::UpdateNotice
                 | StatusOutputLineData::Connector
                 | StatusOutputLineData::StagedFile { .. }
-                | StatusOutputLineData::UnstagedFile { .. }
+                | StatusOutputLineData::UnassignedFile { .. }
                 | StatusOutputLineData::CommitMessage
                 | StatusOutputLineData::EmptyCommitMessage
                 | StatusOutputLineData::File { .. }
@@ -354,7 +354,7 @@ fn is_section_header(line: &StatusOutputLine) -> bool {
         line.data,
         StatusOutputLineData::Branch { .. }
             | StatusOutputLineData::StagedChanges { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
             | StatusOutputLineData::MergeBase
     )
 }

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -67,7 +67,7 @@ fn new_selects_first_selectable_line() {
     let lines = vec![
         line(StatusOutputLineData::Connector),
         line(StatusOutputLineData::Hint),
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedFile {
@@ -100,7 +100,7 @@ fn restore_returns_matching_line_by_cli_id() {
                 stack_id: None,
             }),
         }),
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
     ];
@@ -116,7 +116,7 @@ fn restore_returns_matching_line_by_cli_id() {
 
 #[test]
 fn restore_returns_none_when_cli_id_is_not_present() {
-    let lines = vec![line(StatusOutputLineData::UnstagedChanges {
+    let lines = vec![line(StatusOutputLineData::UnassignedChanges {
         cli_id: unassigned("u0"),
     })];
 
@@ -136,7 +136,7 @@ fn restore_returns_none_when_cli_id_is_not_present() {
 #[test]
 fn restore_selects_first_matching_line_when_cli_id_appears_multiple_times() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -335,7 +335,7 @@ fn select_unassigned_finds_unassigned_line() {
                 stack_id: None,
             }),
         }),
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
     ];
@@ -346,7 +346,7 @@ fn select_unassigned_finds_unassigned_line() {
 #[test]
 fn select_unassigned_uses_first_matching_line() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -402,7 +402,7 @@ fn select_merge_base_returns_none_when_missing() {
 #[test]
 fn index_returns_the_selected_line_index() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -420,7 +420,7 @@ fn index_returns_the_selected_line_index() {
 
 #[test]
 fn selected_line_returns_none_when_cursor_out_of_bounds() {
-    let lines = vec![line(StatusOutputLineData::UnstagedChanges {
+    let lines = vec![line(StatusOutputLineData::UnassignedChanges {
         cli_id: unassigned("u0"),
     })];
 
@@ -431,14 +431,14 @@ fn selected_line_returns_none_when_cursor_out_of_bounds() {
 fn selected_line_returns_line_when_cursor_is_in_bounds() {
     let lines = vec![
         line(StatusOutputLineData::Hint),
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
     ];
 
     assert!(matches!(
         Cursor(1).selected_line(&lines).map(|line| &line.data),
-        Some(StatusOutputLineData::UnstagedChanges { .. })
+        Some(StatusOutputLineData::UnassignedChanges { .. })
     ));
 }
 
@@ -548,7 +548,7 @@ fn selection_cli_id_for_reload_uses_nearest_parent_section_for_file() {
         line(StatusOutputLineData::File {
             cli_id: unassigned("file0"),
         }),
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: nearest_parent.clone(),
         }),
         line(StatusOutputLineData::File {
@@ -603,7 +603,7 @@ fn selection_cli_id_for_reload_uses_staged_changes_as_parent_for_hidden_file() {
 #[test]
 fn move_up_moves_to_previous_selectable_line() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::Hint),
@@ -623,7 +623,7 @@ fn move_up_moves_to_previous_selectable_line() {
 #[test]
 fn move_up_does_not_move_when_already_at_first_selectable_line() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -642,7 +642,7 @@ fn move_up_does_not_move_when_already_at_first_selectable_line() {
 #[test]
 fn move_down_moves_to_next_selectable_line() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::Hint),
@@ -662,7 +662,7 @@ fn move_down_moves_to_next_selectable_line() {
 #[test]
 fn move_down_does_not_move_when_no_selectable_line_below() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::Hint),
@@ -679,7 +679,7 @@ fn move_down_does_not_move_when_no_selectable_line_below() {
 #[test]
 fn movement_does_not_panic_or_move_when_cursor_is_out_of_bounds() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -711,10 +711,10 @@ fn movement_does_not_panic_or_move_when_cursor_is_out_of_bounds() {
 #[test]
 fn move_next_section_moves_to_next_jump_target() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
-        line(StatusOutputLineData::UnstagedFile {
+        line(StatusOutputLineData::UnassignedFile {
             cli_id: unassigned("u1"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -734,10 +734,10 @@ fn move_next_section_moves_to_next_jump_target() {
 #[test]
 fn move_next_section_does_not_move_when_no_jump_target_below() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
-        line(StatusOutputLineData::UnstagedFile {
+        line(StatusOutputLineData::UnassignedFile {
             cli_id: unassigned("u1"),
         }),
     ];
@@ -754,10 +754,10 @@ fn move_next_section_does_not_move_when_no_jump_target_below() {
 #[test]
 fn move_previous_section_moves_to_current_section_header_when_cursor_is_inside_it() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
-        line(StatusOutputLineData::UnstagedFile {
+        line(StatusOutputLineData::UnassignedFile {
             cli_id: unassigned("u1"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -781,10 +781,10 @@ fn move_previous_section_moves_to_current_section_header_when_cursor_is_inside_i
 #[test]
 fn move_previous_section_moves_to_immediate_previous_when_already_on_section_header() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
-        line(StatusOutputLineData::UnstagedFile {
+        line(StatusOutputLineData::UnassignedFile {
             cli_id: unassigned("u1"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -805,10 +805,10 @@ fn move_previous_section_moves_to_immediate_previous_when_already_on_section_hea
 #[test]
 fn move_previous_section_moves_to_current_header_when_only_current_section_exists_above_cursor() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
-        line(StatusOutputLineData::UnstagedFile {
+        line(StatusOutputLineData::UnassignedFile {
             cli_id: unassigned("u1"),
         }),
     ];
@@ -826,7 +826,7 @@ fn move_previous_section_moves_to_current_header_when_only_current_section_exist
 #[test]
 fn move_previous_section_does_not_move_when_on_first_jump_target() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedFile {
@@ -909,7 +909,7 @@ fn closest_branch_cursor_from_branch_is_noop() {
 #[test]
 fn closest_branch_cursor_from_unassigned_changes_selects_first_branch() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::Branch {
@@ -979,7 +979,7 @@ fn closest_branch_cursor_from_merge_base_is_noop() {
 #[test]
 fn closest_branch_cursor_falls_back_to_merge_base_when_no_branch_exists() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::MergeBase),
@@ -992,7 +992,7 @@ fn closest_branch_cursor_falls_back_to_merge_base_when_no_branch_exists() {
 
 #[test]
 fn closest_branch_cursor_is_none_when_no_branch_exists() {
-    let lines = vec![line(StatusOutputLineData::UnstagedChanges {
+    let lines = vec![line(StatusOutputLineData::UnassignedChanges {
         cli_id: unassigned("u0"),
     })];
 
@@ -1014,7 +1014,7 @@ fn move_up_in_rub_mode_skips_unavailable_targets() {
         stack_id: None,
     });
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: allowed.clone(),
         }),
         line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
@@ -1048,7 +1048,7 @@ fn move_down_in_rub_mode_skips_unavailable_targets() {
         stack_id: None,
     });
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: allowed.clone(),
         }),
         line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
@@ -1224,7 +1224,7 @@ fn move_next_section_in_rub_mode_skips_unavailable_sections() {
         line(StatusOutputLineData::Branch {
             cli_id: blocked.clone(),
         }),
-        line(StatusOutputLineData::UnstagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::UnassignedChanges { cli_id: blocked }),
         line(StatusOutputLineData::StagedChanges {
             cli_id: allowed.clone(),
         }),
@@ -1255,7 +1255,7 @@ fn move_previous_section_in_rub_mode_moves_to_current_available_section_header()
         stack_id: None,
     });
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: allowed.clone(),
         }),
         line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
@@ -1304,7 +1304,7 @@ fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_pre
         line(StatusOutputLineData::StagedChanges {
             cli_id: allowed_b.clone(),
         }),
-        line(StatusOutputLineData::UnstagedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::UnassignedChanges { cli_id: blocked }),
     ];
     let mode = Mode::Rub(RubMode {
         source: unassigned("source"),
@@ -1322,7 +1322,7 @@ fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_pre
 #[test]
 fn movement_methods_can_move_cursor_in_inline_reword_mode() {
     let lines = vec![
-        line(StatusOutputLineData::UnstagedChanges {
+        line(StatusOutputLineData::UnassignedChanges {
             cli_id: unassigned("u0"),
         }),
         line(StatusOutputLineData::StagedChanges {
@@ -1372,7 +1372,7 @@ fn is_selectable_in_rub_mode_requires_available_target() {
     let selectable_line = line(StatusOutputLineData::StagedFile {
         cli_id: allowed.clone(),
     });
-    let blocked_line = line(StatusOutputLineData::UnstagedFile { cli_id: blocked });
+    let blocked_line = line(StatusOutputLineData::UnassignedFile { cli_id: blocked });
     let not_selectable_line = line(StatusOutputLineData::Hint);
 
     let mode = Mode::Rub(RubMode {

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, ffi::OsString, process::Command, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
+use bstr::ByteSlice;
 use but_core::tree::create_tree::RejectionReason;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
@@ -22,7 +23,8 @@ use crate::{
     command::legacy::{
         rub::{RubOperation, route_operation},
         status::{
-            CommitLineContent, StatusFlags, StatusOutputLine, TuiLaunchOptions,
+            CommitLineContent, CommittedFileLineContent, StatusFlags, StatusOutputLine,
+            TuiLaunchOptions,
             output::BranchLineContent,
             tui::{
                 confirm::{Confirm, ConfirmMessage},
@@ -1427,8 +1429,8 @@ impl App {
         let what_to_copy = match &**cli_id {
             CliId::Branch { name, .. } => Cow::Borrowed(&**name),
             CliId::Commit { commit_id, .. } => Cow::Owned(commit_id.to_hex_with_len(7).to_string()),
+            CliId::CommittedFile { path, .. } => path.to_str_lossy(),
             CliId::PathPrefix { .. }
-            | CliId::CommittedFile { .. }
             | CliId::Unassigned { .. }
             | CliId::Stack { .. }
             | CliId::Uncommitted(_) => return Ok(()),
@@ -1924,6 +1926,17 @@ impl App {
                 }
                 spans.extend(decoration_end.iter().cloned());
                 spans.extend(suffix.iter().cloned());
+                spans
+            }
+            StatusOutputContent::CommittedFile(CommittedFileLineContent { id, status, path }) => {
+                let mut spans = Vec::with_capacity(id.len() + status.len() + path.len());
+                spans.extend(id.iter().cloned());
+                spans.extend(status.iter().cloned());
+                if data.cli_id().is_some_and(|id| self.highlight.contains(id)) {
+                    spans.extend(path.iter().cloned().map(with_highlight));
+                } else {
+                    spans.extend(path.iter().cloned());
+                }
                 spans
             }
         };

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -23,8 +23,7 @@ use crate::{
     command::legacy::{
         rub::{RubOperation, route_operation},
         status::{
-            CommitLineContent, CommittedFileLineContent, StatusFlags, StatusOutputLine,
-            TuiLaunchOptions,
+            CommitLineContent, FileLineContent, StatusFlags, StatusOutputLine, TuiLaunchOptions,
             output::BranchLineContent,
             tui::{
                 confirm::{Confirm, ConfirmMessage},
@@ -1430,10 +1429,12 @@ impl App {
             CliId::Branch { name, .. } => Cow::Borrowed(&**name),
             CliId::Commit { commit_id, .. } => Cow::Owned(commit_id.to_hex_with_len(7).to_string()),
             CliId::CommittedFile { path, .. } => path.to_str_lossy(),
-            CliId::PathPrefix { .. }
-            | CliId::Unassigned { .. }
-            | CliId::Stack { .. }
-            | CliId::Uncommitted(_) => return Ok(()),
+            CliId::Uncommitted(uncommitted) => {
+                Cow::Borrowed(&*uncommitted.hunk_assignments.first().path)
+            }
+            CliId::PathPrefix { .. } | CliId::Unassigned { .. } | CliId::Stack { .. } => {
+                return Ok(());
+            }
         };
 
         arboard::Clipboard::new()
@@ -1928,7 +1929,7 @@ impl App {
                 spans.extend(suffix.iter().cloned());
                 spans
             }
-            StatusOutputContent::CommittedFile(CommittedFileLineContent { id, status, path }) => {
+            StatusOutputContent::File(FileLineContent { id, status, path }) => {
                 let mut spans = Vec::with_capacity(id.len() + status.len() + path.len());
                 spans.extend(id.iter().cloned());
                 spans.extend(status.iter().cloned());

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -980,8 +980,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -1004,7 +1004,7 @@ impl App {
         };
 
         let commit_mode = match &selection.data {
-            StatusOutputLineData::UnstagedChanges { cli_id } => {
+            StatusOutputLineData::UnassignedChanges { cli_id } => {
                 let Ok(has_unassigned_changes) = operations::has_unassigned_changes(ctx) else {
                     return;
                 };
@@ -1021,7 +1021,7 @@ impl App {
                     insert_side: InsertSide::Above,
                 }
             }
-            StatusOutputLineData::UnstagedFile { cli_id }
+            StatusOutputLineData::UnassignedFile { cli_id }
             | StatusOutputLineData::StagedChanges { cli_id }
             | StatusOutputLineData::StagedFile { cli_id } => {
                 let Ok(source) = CommitSource::try_from(Arc::unwrap_or_clone(Arc::clone(cli_id)))
@@ -1086,8 +1086,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -1198,8 +1198,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -1268,8 +1268,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -1352,8 +1352,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::Commit { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
@@ -1398,8 +1398,8 @@ impl App {
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::Commit { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
@@ -2599,8 +2599,8 @@ fn commit_operation_display(
         }
         StatusOutputLineData::StagedChanges { .. }
         | StatusOutputLineData::StagedFile { .. }
-        | StatusOutputLineData::UnstagedChanges { .. }
-        | StatusOutputLineData::UnstagedFile { .. }
+        | StatusOutputLineData::UnassignedChanges { .. }
+        | StatusOutputLineData::UnassignedFile { .. }
         | StatusOutputLineData::UpdateNotice
         | StatusOutputLineData::Connector
         | StatusOutputLineData::CommitMessage
@@ -2626,8 +2626,8 @@ fn move_operation_display(data: &StatusOutputLineData, mode: &MoveMode) -> Optio
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -2645,8 +2645,8 @@ fn move_operation_display(data: &StatusOutputLineData, mode: &MoveMode) -> Optio
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnstagedChanges { .. }
-            | StatusOutputLineData::UnstagedFile { .. }
+            | StatusOutputLineData::UnassignedChanges { .. }
+            | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
             | StatusOutputLineData::File { .. }
@@ -2665,8 +2665,8 @@ fn branch_operation_display(data: &StatusOutputLineData) -> Option<&'static str>
         | StatusOutputLineData::Connector
         | StatusOutputLineData::StagedChanges { .. }
         | StatusOutputLineData::StagedFile { .. }
-        | StatusOutputLineData::UnstagedChanges { .. }
-        | StatusOutputLineData::UnstagedFile { .. }
+        | StatusOutputLineData::UnassignedChanges { .. }
+        | StatusOutputLineData::UnassignedFile { .. }
         | StatusOutputLineData::Commit { .. }
         | StatusOutputLineData::CommitMessage
         | StatusOutputLineData::EmptyCommitMessage


### PR DESCRIPTION
Pressing `shift+c` on a commit or branch copies the sha or branch name respectively. With this pressing `shift+c` on a line that contains a file will now copy the path. I often find myself wanting this to open a file in my editor or send it to an LLM.