### PR TITLE
Another stab at making concurrent commits possible

### DIFF
--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -25,6 +25,14 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 /// signature on a pure Rust type while generated wrappers accept a transport-oriented serde type.
 /// This is currently limited to owned parameters and requires `impl From<TransportType> for ParamType`.
 ///
+/// Functions may also take an explicit repository permission token which stays internal to generated
+/// wrappers:
+/// * `perm: &mut RepoExclusive` acquires exclusive access from the generated wrapper.
+/// * `perm: &RepoShared` acquires shared access from the generated wrapper.
+///
+/// These permission-bearing variants are more composable for Rust callers because they reuse a
+/// caller-held lock instead of acquiring one themselves.
+///
 /// These can be combined with commas, e.g. `#[but_api(napi, try_from = json::CommitDetails)]`
 /// or `#[but_api(napi, json::CommitDetails)]`.
 ///
@@ -40,6 +48,8 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 ///           which will be translated to `project_id`:
 ///           - `but_ctx::ProjectHandleOrLegacyProjectId`
 ///         - `gix::ObjectId` will be translated into `json::HexHash`.
+///         - `&mut RepoExclusive` and `&RepoShared` stay internal and are derived from the context
+///           parameter by acquiring the matching lock in the generated wrapper.
 /// * `func_cmd` for calls from the `but-server`, taking `(params: Params) ` and returning `Result<serde_json::Value, json::Error>`.
 ///     - It performs all **Parameter Transformations** of `func_json`.
 /// * `func_napi` (opt-in) for calls from Node.js via napi-rs, taking individual typed parameters and returning `napi::Result<serde_json::Value>`.
@@ -49,6 +59,8 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 ///         - `Context`/`&Context`/`&mut Context`/`ThreadSafeContext` → `String` named `project_id`
 ///         - `gix::ObjectId` / `HexHash` → `String` (hex-encoded)
 ///         - `BString` → `String`
+///         - `&mut RepoExclusive` and `&RepoShared` stay internal and are derived from the context
+///           parameter by acquiring the matching lock in the generated wrapper
 ///         - Other serde-compatible types → `serde_json::Value`
 ///     - Automatically converts `anyhow::Error` → `napi::Error`.
 #[proc_macro_attribute]
@@ -370,6 +382,29 @@ struct WrapperParamsInfo {
     requires_legacy: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ContextParamKind {
+    Context,
+    ThreadSafeContext,
+}
+
+struct ContextParamBinding {
+    ident: syn::Ident,
+    kind: ContextParamKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PermissionParamKind {
+    Exclusive,
+    Shared,
+}
+
+struct PermissionParamBinding {
+    ty: syn::Type,
+    kind: PermissionParamKind,
+    guard_ident: syn::Ident,
+}
+
 struct WrapperParameterMapping {
     transport_ty: syn::Type,
     binding_ty: syn::Type,
@@ -408,6 +443,8 @@ fn build_wrapper_params<'a>(
     let mut param_conversions = Vec::new();
     let mut call_arg_idents = Vec::new();
     let mut requires_legacy = false;
+    let mut context_bindings = Vec::new();
+    let mut permission_bindings = Vec::new();
 
     for arg in input {
         let FnArg::Typed(pat_ty) = arg else {
@@ -424,6 +461,13 @@ fn build_wrapper_params<'a>(
         };
         let ident = &pat_ident.ident;
 
+        if let Some(context_kind) = context_param_kind(&pat_ty.ty) {
+            context_bindings.push(ContextParamBinding {
+                ident: ident.clone(),
+                kind: context_kind,
+            });
+        }
+
         if let Some(custom_transport) = parse_param_transport_mapping(pat_ty)? {
             let transport_ty = &custom_transport.transport_ty;
             let binding_ty = &pat_ty.ty;
@@ -434,6 +478,20 @@ fn build_wrapper_params<'a>(
                 let mut #ident: #binding_ty = <#binding_ty>::from(#ident);
             });
             call_arg_idents.push(quote! { #ident });
+            continue;
+        }
+
+        if let Some(permission_kind) = permission_param_kind(&pat_ty.ty)? {
+            let guard_ident = permission_guard_ident(ident);
+            permission_bindings.push(PermissionParamBinding {
+                ty: (*pat_ty.ty).clone(),
+                kind: permission_kind,
+                guard_ident: guard_ident.clone(),
+            });
+            call_arg_idents.push(match permission_kind {
+                PermissionParamKind::Exclusive => quote! { #guard_ident.write_permission() },
+                PermissionParamKind::Shared => quote! { #guard_ident.read_permission() },
+            });
             continue;
         }
 
@@ -475,6 +533,49 @@ fn build_wrapper_params<'a>(
             json_fn_input_params.push(arg.clone());
             call_arg_idents.push(quote! { #ident });
         }
+    }
+
+    if let Some(permission) = permission_bindings.first() {
+        if permission_bindings.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                &permission.ty,
+                "Only one explicit repository permission parameter is supported",
+            ));
+        }
+
+        let context_binding = match context_bindings.as_slice() {
+            [] => {
+                return Err(syn::Error::new_spanned(
+                    &permission.ty,
+                    "Explicit repository permission parameters require a `Context`, `&Context`, or `&mut Context` parameter",
+                ));
+            }
+            [binding] => binding,
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    &permission.ty,
+                    "Explicit repository permission parameters require exactly one context parameter",
+                ));
+            }
+        };
+
+        if context_binding.kind == ContextParamKind::ThreadSafeContext {
+            return Err(syn::Error::new_spanned(
+                &permission.ty,
+                "Explicit repository permission parameters are not supported with `ThreadSafeContext`; convert it to `Context` before locking",
+            ));
+        }
+
+        let context_ident = &context_binding.ident;
+        let guard_ident = &permission.guard_ident;
+        param_conversions.push(match permission.kind {
+            PermissionParamKind::Exclusive => quote! {
+                let mut #guard_ident = #context_ident.exclusive_worktree_access();
+            },
+            PermissionParamKind::Shared => quote! {
+                let #guard_ident = #context_ident.shared_worktree_access();
+            },
+        });
     }
 
     Ok(WrapperParamsInfo {
@@ -651,6 +752,77 @@ fn build_wrapper_parameter_mapping(
     }
 }
 
+fn context_param_kind(ty: &syn::Type) -> Option<ContextParamKind> {
+    let path = match ty {
+        syn::Type::Reference(reference) => match &*reference.elem {
+            syn::Type::Path(type_path) => &type_path.path,
+            _ => return None,
+        },
+        syn::Type::Path(type_path) => &type_path.path,
+        _ => return None,
+    };
+
+    if !is_context_path(path) {
+        return None;
+    }
+
+    path.segments.last().map(|segment| {
+        if segment.ident == "ThreadSafeContext" {
+            ContextParamKind::ThreadSafeContext
+        } else {
+            ContextParamKind::Context
+        }
+    })
+}
+
+fn permission_param_kind(ty: &syn::Type) -> Result<Option<PermissionParamKind>, syn::Error> {
+    let syn::Type::Reference(reference) = ty else {
+        return Ok(None);
+    };
+    let syn::Type::Path(type_path) = &*reference.elem else {
+        return Ok(None);
+    };
+    let path = &type_path.path;
+    let Some(last) = path.segments.last() else {
+        return Ok(None);
+    };
+
+    let kind = match last.ident.to_string().as_str() {
+        "RepoExclusive" => PermissionParamKind::Exclusive,
+        "RepoShared" => PermissionParamKind::Shared,
+        _ => return Ok(None),
+    };
+
+    let supported_root = path.segments.len() == 1
+        || path
+            .segments
+            .first()
+            .is_some_and(|first| first.ident == "but_core" || first.ident == "but_ctx");
+    if !supported_root {
+        return Ok(None);
+    }
+
+    match kind {
+        PermissionParamKind::Exclusive if reference.mutability.is_some() => Ok(Some(kind)),
+        PermissionParamKind::Shared if reference.mutability.is_none() => Ok(Some(kind)),
+        PermissionParamKind::Exclusive => Err(syn::Error::new_spanned(
+            ty,
+            "Explicit repository permission parameters must use `&mut RepoExclusive` for exclusive access",
+        )),
+        PermissionParamKind::Shared => Err(syn::Error::new_spanned(
+            ty,
+            "Explicit repository permission parameters must use `&RepoShared` for shared access",
+        )),
+    }
+}
+
+fn permission_guard_ident(ident: &syn::Ident) -> syn::Ident {
+    let ident = ident.to_string();
+    let ident = ident.trim_start_matches('_');
+    let suffix = if ident.is_empty() { "perm" } else { ident };
+    format_ident!("__but_api_{}_guard", suffix)
+}
+
 fn is_context_path(path: &syn::Path) -> bool {
     path.segments
         .last()
@@ -777,10 +949,12 @@ fn build_json_type_mapping<'a>(
                     json_ident: None,
                 },
             )
+        } else if permission_param_kind(ty)?.is_some() {
+            continue;
         } else if is_reference {
             return Err(syn::Error::new_spanned(
                 ty,
-                "Only `&Context`, `&but_ctx::Context`, `&ThreadSafeContext`, or `&gix::refs::FullNameRef` may be references",
+                "Only `&Context`, `&but_ctx::Context`, `&ThreadSafeContext`, `&RepoShared`, `&mut RepoExclusive`, or `&gix::refs::FullNameRef` may be references",
             ));
         } else {
             continue;
@@ -980,6 +1154,8 @@ fn build_napi_params<'a>(
     let mut params = Vec::new();
     let mut conversions = Vec::new();
     let mut call_arg_idents = Vec::new();
+    let mut context_bindings = Vec::new();
+    let mut permission_bindings = Vec::new();
 
     for arg in input {
         let syn::FnArg::Typed(pat_ty) = arg else {
@@ -993,6 +1169,13 @@ fn build_napi_params<'a>(
         };
         let ident = &pat_ident.ident;
 
+        if let Some(context_kind) = context_param_kind(&pat_ty.ty) {
+            context_bindings.push(ContextParamBinding {
+                ident: ident.clone(),
+                kind: context_kind,
+            });
+        }
+
         if let Some(custom_transport) = parse_param_transport_mapping(pat_ty)? {
             let transport_ty = &custom_transport.transport_ty;
             let ts_type_str = type_to_ts_name(transport_ty);
@@ -1005,6 +1188,20 @@ fn build_napi_params<'a>(
                 let #ident: #actual_ty = <#actual_ty>::from(#transport_ident);
             });
             call_arg_idents.push(quote! { #ident });
+            continue;
+        }
+
+        if let Some(permission_kind) = permission_param_kind(&pat_ty.ty)? {
+            let guard_ident = permission_guard_ident(ident);
+            permission_bindings.push(PermissionParamBinding {
+                ty: (*pat_ty.ty).clone(),
+                kind: permission_kind,
+                guard_ident: guard_ident.clone(),
+            });
+            call_arg_idents.push(match permission_kind {
+                PermissionParamKind::Exclusive => quote! { #guard_ident.write_permission() },
+                PermissionParamKind::Shared => quote! { #guard_ident.read_permission() },
+            });
             continue;
         }
 
@@ -1178,6 +1375,49 @@ fn build_napi_params<'a>(
         }
     }
 
+    if let Some(permission) = permission_bindings.first() {
+        if permission_bindings.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                &permission.ty,
+                "Only one explicit repository permission parameter is supported",
+            ));
+        }
+
+        let context_binding = match context_bindings.as_slice() {
+            [] => {
+                return Err(syn::Error::new_spanned(
+                    &permission.ty,
+                    "Explicit repository permission parameters require a `Context`, `&Context`, or `&mut Context` parameter",
+                ));
+            }
+            [binding] => binding,
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    &permission.ty,
+                    "Explicit repository permission parameters require exactly one context parameter",
+                ));
+            }
+        };
+
+        if context_binding.kind == ContextParamKind::ThreadSafeContext {
+            return Err(syn::Error::new_spanned(
+                &permission.ty,
+                "Explicit repository permission parameters are not supported with `ThreadSafeContext`; convert it to `Context` before locking",
+            ));
+        }
+
+        let context_ident = &context_binding.ident;
+        let guard_ident = &permission.guard_ident;
+        conversions.push(match permission.kind {
+            PermissionParamKind::Exclusive => quote! {
+                let mut #guard_ident = #context_ident.exclusive_worktree_access();
+            },
+            PermissionParamKind::Shared => quote! {
+                let #guard_ident = #context_ident.shared_worktree_access();
+            },
+        });
+    }
+
     Ok(NapiParamsInfo {
         params,
         conversions,
@@ -1304,8 +1544,9 @@ mod tests {
     use syn::{FnArg, ItemFn, parse_quote};
 
     use super::{
-        WrapperCallArgKind, WrapperConversionKind, build_wrapper_parameter_mapping,
-        build_wrapper_params, doc_attributes,
+        ContextParamKind, PermissionParamKind, WrapperCallArgKind, WrapperConversionKind,
+        build_wrapper_parameter_mapping, build_wrapper_params, context_param_kind, doc_attributes,
+        permission_param_kind,
     };
 
     #[test]
@@ -1406,6 +1647,45 @@ mod tests {
         assert!(
             params.requires_legacy,
             "context parameters should require the legacy project-id wrapper setup"
+        );
+    }
+
+    #[test]
+    fn detects_supported_permission_tokens() {
+        let exclusive_ty = parse_quote!(&mut but_ctx::access::RepoExclusive);
+        let shared_ty = parse_quote!(&but_core::sync::RepoShared);
+
+        assert_eq!(
+            permission_param_kind(&exclusive_ty).unwrap(),
+            Some(PermissionParamKind::Exclusive)
+        );
+        assert_eq!(
+            permission_param_kind(&shared_ty).unwrap(),
+            Some(PermissionParamKind::Shared)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_permission_token_forms() {
+        let exclusive_ty = parse_quote!(&but_ctx::access::RepoExclusive);
+        let shared_ty = parse_quote!(&mut but_ctx::access::RepoShared);
+
+        assert!(permission_param_kind(&exclusive_ty).is_err());
+        assert!(permission_param_kind(&shared_ty).is_err());
+    }
+
+    #[test]
+    fn detects_thread_safe_context_bindings() {
+        let thread_safe_ctx: syn::Type = parse_quote!(but_ctx::ThreadSafeContext);
+        let borrowed_ctx: syn::Type = parse_quote!(&mut but_ctx::Context);
+
+        assert_eq!(
+            context_param_kind(&thread_safe_ctx),
+            Some(ContextParamKind::ThreadSafeContext)
+        );
+        assert_eq!(
+            context_param_kind(&borrowed_ctx),
+            Some(ContextParamKind::Context)
         );
     }
 

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_repoexclusive_shared_ref.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_repoexclusive_shared_ref.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::panic_capture;
+
+#[but_api]
+pub fn invalid_exclusive_form(
+    _ctx: &mut but_ctx::Context,
+    _perm: &but_ctx::access::RepoExclusive,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_repoexclusive_shared_ref.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_repoexclusive_shared_ref.stderr
@@ -1,0 +1,5 @@
+error: Explicit repository permission parameters must use `&mut RepoExclusive` for exclusive access
+ --> tests/ui/fail/base_permission_param_repoexclusive_shared_ref.rs:8:12
+  |
+8 |     _perm: &but_ctx::access::RepoExclusive,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_reposhared_mut_ref.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_reposhared_mut_ref.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::panic_capture;
+
+#[but_api]
+pub fn invalid_shared_form(
+    _ctx: &but_ctx::Context,
+    _perm: &mut but_ctx::access::RepoShared,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_reposhared_mut_ref.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_reposhared_mut_ref.stderr
@@ -1,0 +1,5 @@
+error: Explicit repository permission parameters must use `&RepoShared` for shared access
+ --> tests/ui/fail/base_permission_param_reposhared_mut_ref.rs:8:12
+  |
+8 |     _perm: &mut but_ctx::access::RepoShared,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_requires_context.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_requires_context.rs
@@ -1,0 +1,10 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::panic_capture;
+
+#[but_api]
+pub fn missing_context(_perm: &mut but_ctx::access::RepoExclusive) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_requires_context.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_requires_context.stderr
@@ -1,0 +1,5 @@
+error: Explicit repository permission parameters require a `Context`, `&Context`, or `&mut Context` parameter
+ --> tests/ui/fail/base_permission_param_requires_context.rs:6:31
+  |
+6 | pub fn missing_context(_perm: &mut but_ctx::access::RepoExclusive) -> anyhow::Result<()> {
+  |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_thread_safe_context.rs
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_thread_safe_context.rs
@@ -1,0 +1,13 @@
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::panic_capture;
+
+#[but_api]
+pub fn thread_safe_context(
+    _ctx: but_ctx::ThreadSafeContext,
+    _perm: &but_ctx::access::RepoShared,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_thread_safe_context.stderr
+++ b/crates/but-api-macros/tests/tests/ui/fail/base_permission_param_thread_safe_context.stderr
@@ -1,0 +1,5 @@
+error: Explicit repository permission parameters are not supported with `ThreadSafeContext`; convert it to `Context` before locking
+ --> tests/ui/fail/base_permission_param_thread_safe_context.rs:8:12
+  |
+8 |     _perm: &but_ctx::access::RepoShared,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/but-api-macros/tests/tests/ui/pass/legacy_permission_params.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/legacy_permission_params.rs
@@ -1,0 +1,41 @@
+// Case: explicit repository permission tokens are hidden from generated legacy wrappers.
+// It verifies:
+// - `&mut RepoExclusive` acquires exclusive access internally
+// - `&RepoShared` acquires shared access internally
+// - generated `_json` and `_cmd` entrypoints do not expose the permission parameter
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api]
+pub fn exclusive_surface(
+    _ctx: &mut but_ctx::Context,
+    value: i32,
+    _perm: &mut but_ctx::access::RepoExclusive,
+) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+#[but_api]
+pub fn shared_surface(
+    _perm: &but_ctx::access::RepoShared,
+    _ctx: &but_ctx::Context,
+    value: i32,
+) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+fn main() {
+    let project_id: but_ctx::LegacyProjectId =
+        "d7377618-b9cd-4964-a3c3-05c58ed5602b".parse().unwrap();
+    let project = but_ctx::ProjectHandleOrLegacyProjectId::LegacyProjectId(project_id.clone());
+
+    let _ = exclusive_surface_json(project.clone(), 1);
+    let _ = shared_surface_json(project.clone(), 2);
+
+    let _ = exclusive_surface_cmd(
+        serde_json::json!({ "projectId": project_id.to_string(), "value": 1 }),
+    );
+    let _ = shared_surface_cmd(serde_json::json!({ "projectId": project_id.to_string(), "value": 2 }));
+}

--- a/crates/but-api-macros/tests/tests/ui/pass/napi_permission_params.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/napi_permission_params.rs
@@ -1,0 +1,20 @@
+// Case: `#[but_api(napi)]` generation hides explicit repository permission tokens.
+// It verifies napi wrapper generation when the annotated function takes `RepoExclusive`.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture};
+
+#[but_api(napi)]
+pub fn napi_surface_with_perm(
+    _ctx: &mut but_ctx::Context,
+    _perm: &mut but_ctx::access::RepoExclusive,
+    value: i32,
+) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+fn main() {
+    let _ = napi_surface_with_perm_napi;
+    let _ = napi_napi_surface_with_perm::napi_surface_with_perm;
+}

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -110,3 +110,36 @@ pub fn commit_create(
     };
     res
 }
+
+/// Creates and inserts a commit relative to either a commit or a reference, with oplog support.
+#[instrument(skip_all, fields(relative_to, side, message), err(Debug))]
+pub fn commit_create_with_perm(
+    ctx: &mut but_ctx::Context,
+    relative_to: RelativeTo,
+    side: InsertSide,
+    changes: Vec<DiffSpec>,
+    message: String,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitCreateResult> {
+    let context_lines = ctx.settings.context_lines;
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::CreateCommit),
+        perm.read_permission(),
+    )
+    .ok();
+
+    let res = commit_create_only_impl(
+        ctx,
+        relative_to,
+        side,
+        changes,
+        message,
+        context_lines,
+        perm,
+    );
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx, perm).ok();
+    };
+    res
+}

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -80,42 +80,10 @@ pub(crate) fn commit_create_only_impl(
 
 /// Creates and inserts a commit relative to either a commit or a reference, with oplog support.
 #[but_api(napi, crate::commit::json::UICommitCreateResult)]
-#[instrument(err(Debug))]
+#[instrument(skip_all, fields(relative_to, side, message), err(Debug))]
 pub fn commit_create(
     ctx: &mut but_ctx::Context,
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
-    side: InsertSide,
-    changes: Vec<DiffSpec>,
-    message: String,
-) -> anyhow::Result<CommitCreateResult> {
-    let context_lines = ctx.settings.context_lines;
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
-        ctx,
-        SnapshotDetails::new(OperationKind::CreateCommit),
-    )
-    .ok();
-
-    let mut guard = ctx.exclusive_worktree_access();
-    let res = commit_create_only_impl(
-        ctx,
-        relative_to,
-        side,
-        changes,
-        message,
-        context_lines,
-        guard.write_permission(),
-    );
-    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        snapshot.commit(ctx, guard.write_permission()).ok();
-    };
-    res
-}
-
-/// Creates and inserts a commit relative to either a commit or a reference, with oplog support.
-#[instrument(skip_all, fields(relative_to, side, message), err(Debug))]
-pub fn commit_create_with_perm(
-    ctx: &mut but_ctx::Context,
-    relative_to: RelativeTo,
     side: InsertSide,
     changes: Vec<DiffSpec>,
     message: String,

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -1,5 +1,5 @@
 use but_api_macros::but_api;
-use but_core::ui::TreeChange;
+use but_core::{sync::RepoExclusive, ui::TreeChange};
 use but_ctx::Context;
 use but_hunk_assignment::{HunkAssignmentRequest, WorktreeChanges};
 use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
@@ -90,6 +90,14 @@ pub fn tree_change_diffs(
     change.unified_patch(&repo, ctx.settings.context_lines)
 }
 
+/// See [`changes_in_worktree_with_perm()`].
+#[but_api(napi)]
+#[instrument(err(Debug))]
+pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges> {
+    let mut guard = ctx.exclusive_worktree_access();
+    changes_in_worktree_with_perm(ctx, guard.write_permission())
+}
+
 /// This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
 /// the user interface as it is right now. From here, it's always possible to add more information as the need arises.
 ///
@@ -99,15 +107,14 @@ pub fn tree_change_diffs(
 /// * conflicts are ignored
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
-#[but_api(napi)]
-#[instrument(err(Debug))]
-pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges> {
+#[instrument(skip_all, err(Debug))]
+pub fn changes_in_worktree_with_perm(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<WorktreeChanges> {
     let context_lines = ctx.settings.context_lines;
 
-    #[cfg(feature = "legacy")]
-    let (mut guard, repo, ws, mut db) = ctx.workspace_mut_and_db_mut()?;
-    #[cfg(not(feature = "legacy"))]
-    let (_guard, repo, ws, mut db) = ctx.workspace_mut_and_db_mut()?;
+    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
 
     let changes = but_core::diff::worktree_changes(&repo)?;
 
@@ -131,7 +138,7 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
     trans.commit()?;
     drop((repo, ws, db));
     #[cfg(feature = "legacy")]
-    but_rules::handler::process_workspace_rules(ctx, &assignments, guard.write_permission()).ok();
+    but_rules::handler::process_workspace_rules(ctx, &assignments, perm).ok();
 
     Ok(WorktreeChanges {
         worktree_changes: changes.into(),

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -107,6 +107,7 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
 /// * conflicts are ignored
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
+#[but_api(napi)]
 #[instrument(skip_all, err(Debug))]
 pub fn changes_in_worktree_with_perm(
     ctx: &mut Context,

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -48,7 +48,8 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
         )
         .ok(); // Ignore errors for snapshot creation
 
-    let total_rejected = absorb_impl(absorption_plan, guard.write_permission(), &repo, &data_dir)?;
+    let total_rejected =
+        absorb_with_perm(absorption_plan, guard.write_permission(), &repo, &data_dir)?;
 
     // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
     // with the rewritten branch commits. Without this, tools that inspect HEAD
@@ -58,7 +59,12 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
     Ok(total_rejected)
 }
 
-pub fn absorb_impl(
+/// Absorb the changes described by `absorption_plan` using the exclusive repository
+/// access granted by `perm`, applying the updates against `repo` and using `data_dir`
+/// for project data needed during commit amendment and rebasing.
+///
+/// Returns the total amount of rejected diff specs.
+pub fn absorb_with_perm(
     absorption_plan: Vec<CommitAbsorption>,
     perm: &mut RepoExclusive,
     repo: &gix::Repository,

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -57,7 +57,7 @@ pub fn create_reference(
 /// Returns the stack id owning the created or attached reference when one exists, together with
 /// the full refname that was created.
 ///
-/// This variant is more composable than [`create_reference`] when the caller already holds a lock,
+/// This variant is more composable than [`create_reference()`] when the caller already holds a lock,
 /// as it reuses the provided permission token instead of obtaining exclusive access itself.
 #[but_api]
 #[instrument(skip(ctx, perm), err(Debug))]

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use anyhow::{Context as _, Result, anyhow};
 use but_api_macros::but_api;
-use but_core::branch;
+use but_core::{branch, sync::RepoExclusive};
 use but_ctx::Context;
 use gitbutler_branch_actions::{internal::PushResult, stack::CreateSeriesRequest};
 use gitbutler_oplog::SnapshotExt;
@@ -44,6 +44,27 @@ pub fn create_reference(
     ctx: &mut Context,
     request: create_reference::Request,
 ) -> Result<(Option<StackId>, gix::refs::FullName)> {
+    let mut guard = ctx.exclusive_worktree_access();
+    create_reference_with_perm(ctx, request, guard.write_permission())
+}
+
+/// Create a local branch reference using an existing `perm` for exclusive access.
+///
+/// It normalizes the requested branch name in `request` into a full local refname,
+/// translates the legacy anchor payload into the `but_workspace` representation,
+/// and updates the workspace state in place without acquiring its own repository lock.
+///
+/// Returns the stack id owning the created or attached reference when one exists, together with
+/// the full refname that was created.
+///
+/// This variant is more composable than [`create_reference`] when the caller already holds a lock,
+/// as it reuses the provided permission token instead of obtaining exclusive access itself.
+#[instrument(skip(ctx, perm), err(Debug))]
+pub fn create_reference_with_perm(
+    ctx: &mut Context,
+    request: create_reference::Request,
+    perm: &mut RepoExclusive,
+) -> Result<(Option<StackId>, gix::refs::FullName)> {
     use bstr::ByteSlice;
     let create_reference::Request { new_name, anchor } = request;
     let new_ref = Category::LocalBranch
@@ -75,7 +96,7 @@ pub fn create_reference(
         .transpose()?;
 
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let new_ws = but_workspace::branch::create_reference(
         new_ref.clone(),
         anchor,
@@ -163,7 +184,7 @@ pub fn create_branch(
 pub fn remove_branch_only(
     ctx: &mut Context,
     branch_name: &str,
-    perm: &mut but_core::sync::RepoExclusive,
+    perm: &mut RepoExclusive,
 ) -> Result<()> {
     let ref_name = Category::LocalBranch
         .to_full_name(branch_name)

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -59,6 +59,7 @@ pub fn create_reference(
 ///
 /// This variant is more composable than [`create_reference`] when the caller already holds a lock,
 /// as it reuses the provided permission token instead of obtaining exclusive access itself.
+#[but_api]
 #[instrument(skip(ctx, perm), err(Debug))]
 pub fn create_reference_with_perm(
     ctx: &mut Context,

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -169,6 +169,11 @@ pub fn switch_back_to_workspace(ctx: &mut but_ctx::Context) -> Result<BaseBranch
 }
 
 #[instrument(skip(perm), err(Debug))]
+/// Switch back to the workspace branch using an existing exclusive permission token.
+///
+/// This variant is more composable than [`switch_back_to_workspace`] when the caller already
+/// holds a lock, as it reuses the provided permission token instead of obtaining exclusive access
+/// itself.
 pub fn switch_back_to_workspace_with_perm(
     ctx: &mut but_ctx::Context,
     perm: &mut RepoExclusive,
@@ -208,6 +213,10 @@ pub fn set_base_branch(
 }
 
 #[instrument(skip(perm), err(Debug))]
+/// Set the base branch using an existing exclusive permission token.
+///
+/// This variant is more composable than [`set_base_branch`] when the caller already holds a lock,
+/// as it reuses the provided permission token instead of obtaining exclusive access itself.
 pub fn set_base_branch_with_perm(
     ctx: &mut but_ctx::Context,
     branch: String,

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -379,7 +379,7 @@ pub fn amend_commit_from_worktree_changes(
 }
 
 /// Amend a commit with the given changes and return the number of rejected files
-pub fn amend_commit_and_count_failures(
+pub(crate) fn amend_commit_and_count_failures(
     stack_id: StackId,
     commit_id: gix::ObjectId,
     worktree_changes: Vec<but_core::DiffSpec>,

--- a/crates/but-core/src/sync.rs
+++ b/crates/but-core/src/sync.rs
@@ -76,6 +76,12 @@ pub fn try_exclusive_inter_process_access(
 /// Also use `project_data_dir` if `Some` to create an *inter-process* exclusive lock.
 /// Creating, opening, or locking that file is best-effort. Failures are logged and ignored, so
 /// the hard guarantee provided by this function remains in-process exclusivity only.
+///
+/// If the current process inherits Git's commit-hook environment (`GIT_EDITOR=:` together with
+/// `GIT_INDEX_FILE`), acquiring the inter-process lock becomes non-blocking: if another process
+/// already holds it, we continue without that file lock instead of waiting. This avoids
+/// deadlocking hook re-entry when the parent GitButler command is already holding the same
+/// inter-process lock while waiting for the hook to finish.
 /// If `project_data_dir` is `None`, no inter-process lock is obtained.
 ///
 /// Use this only at the boundary where the lock is acquired. Keep the returned [`RepoExclusiveGuard`]
@@ -279,6 +285,17 @@ impl LockFile {
     }
 }
 
+/// Try to take the best-effort inter-process write lock used by [`exclusive_repo_access()`].
+///
+/// The lock file is created at `project_data_dir/gitbutler.write-lock`.
+/// Failures to create the directory, open the file, or acquire the lock are logged and ignored so
+/// callers still keep their in-process lock.
+///
+/// Normally this blocks until the file lock is acquired. However, if the current process inherits
+/// Git's commit-hook environment (`GIT_EDITOR=:` together with `GIT_INDEX_FILE`), we only try once
+/// and immediately continue without the inter-process lock when it is already held. This prevents
+/// a hook that re-enters GitButler from hanging forever behind the parent process that launched the
+/// hook and is itself waiting for the hook to exit.
 fn best_effort_inter_process_lock(project_data_dir: &Path) -> Option<LockFile> {
     if let Err(err) = std::fs::create_dir_all(project_data_dir) {
         tracing::warn!(
@@ -301,7 +318,27 @@ fn best_effort_inter_process_lock(project_data_dir: &Path) -> Option<LockFile> {
             return None;
         }
     };
-    if let Err(err) = lock.lock() {
+
+    if current_process_looks_like_git_commit_hook() {
+        match lock.try_lock() {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::info!(
+                    path = %inter_process_lock_path.display(),
+                    "Inter-process lock already held while running from a Git commit hook; continuing without it to avoid deadlock"
+                );
+                return None;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    path = %inter_process_lock_path.display(),
+                    "Failed to try acquiring inter-process lock from a Git commit hook; continuing with in-process lock only"
+                );
+                return None;
+            }
+        }
+    } else if let Err(err) = lock.lock() {
         tracing::warn!(
             ?err,
             path = %inter_process_lock_path.display(),
@@ -323,4 +360,9 @@ fn log_error_if_unsupported(err: std::io::Error, self_path: &Path) -> Result<boo
     } else {
         Err(err)
     }
+}
+
+fn current_process_looks_like_git_commit_hook() -> bool {
+    std::env::var_os("GIT_INDEX_FILE").is_some()
+        && std::env::var_os("GIT_EDITOR").is_some_and(|value| value == ":")
 }

--- a/crates/but-ctx/src/access.rs
+++ b/crates/but-ctx/src/access.rs
@@ -24,6 +24,10 @@ impl Context {
     /// When `project_data_dir` is available we also attempt to obtain a best-effort
     /// inter-process file lock, but failures to create, open, or lock that file are logged and
     /// ignored, so the hard guarantee remains in-process exclusivity only.
+    /// If this process inherits Git's commit-hook environment (`GIT_EDITOR=:` together with
+    /// `GIT_INDEX_FILE`), that inter-process lock attempt is non-blocking and may be skipped when
+    /// another GitButler process already holds it. This avoids deadlocking hook re-entry while the
+    /// parent GitButler command waits for the hook.
     /// Note that this works on a shared reference as internal state isn't changed.
     ///
     /// # IMPORTANT: KEEP THE GUARD ALIVE!

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -636,7 +636,7 @@ impl Context {
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(guard, &repo, &mut ws, &mut db)`, given a read-`perm`ission.
+    /// along with `(&repo, &mut ws, &mut db)`, given a read-`perm`ission.
     /// The `db` is writable as this is more useful and naturally synced.
     /// The guard is for shared access to the repository.
     ///
@@ -723,7 +723,7 @@ impl Context {
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(guard, &repo, &mut ws, &db)`, given a read-`perm`ission.
+    /// along with `(&repo, &mut ws, &db)`, given a read-`perm`ission.
     /// The `db` is read-only.
     ///
     /// # IMPORTANT
@@ -833,7 +833,7 @@ impl Context {
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(guard, &repo, &ws, &db)`, given a read-`perm`ission.
+    /// along with `(&repo, &ws, &db)`, given a read-`perm`ission.
     /// The `db` is read-only.
     #[instrument(
         name = "Context::workspace_and_db_with_perm",
@@ -913,6 +913,19 @@ impl Context {
 
 /// Utilities
 impl Context {
+    /// Reload the cached repository handle and drop the cached workspace projection.
+    ///
+    /// Call this after taking exclusive repository access when earlier read-only setup may have
+    /// cached a workspace view from an outdated `HEAD`.
+    pub fn reload_repo_and_invalidate_workspace(
+        &mut self,
+        _perm: &mut RepoExclusive,
+    ) -> anyhow::Result<()> {
+        self.repo.get_mut()?.reload()?;
+        *self.workspace.try_borrow_mut()? = None;
+        Ok(())
+    }
+
     /// Return a wrapper for metadata that only supports read-only access when presented with the project wide permission
     /// to read data.
     /// This is helping to prevent races with mutable instances.

--- a/crates/but-oplog/src/lib.rs
+++ b/crates/but-oplog/src/lib.rs
@@ -75,7 +75,10 @@ pub mod legacy {
 
 #[cfg(feature = "legacy")]
 mod oplog_snapshot {
-    use but_ctx::{Context, access::RepoExclusive};
+    use but_ctx::{
+        Context,
+        access::{RepoExclusive, RepoShared},
+    };
     use gitbutler_oplog::OplogExt;
 
     use crate::UnmaterializedOplogSnapshot;
@@ -84,6 +87,7 @@ mod oplog_snapshot {
     impl UnmaterializedOplogSnapshot {
         /// Create a new instance from `details`, which is a snapshot that isn't committed to the oplog yet.
         /// This fails if the snapshot creation fails.
+        // TODO: deprecate this in favor of `_with_perm` version
         pub fn from_details(
             ctx: &but_ctx::Context,
             details: gitbutler_oplog::entry::SnapshotDetails,
@@ -91,6 +95,17 @@ mod oplog_snapshot {
             // TODO: these guards are probably something to remove as they don't belong into a plumbing crate, neither does Context.
             let guard = ctx.shared_worktree_access();
             let tree_id = ctx.prepare_snapshot(guard.read_permission())?;
+            Ok(Self { tree_id, details })
+        }
+
+        /// Create a new instance from `details`, which is a snapshot that isn't committed to the oplog yet.
+        /// This fails if the snapshot creation fails.
+        pub fn from_details_with_perm(
+            ctx: &but_ctx::Context,
+            details: gitbutler_oplog::entry::SnapshotDetails,
+            perm: &RepoShared,
+        ) -> anyhow::Result<Self> {
+            let tree_id = ctx.prepare_snapshot(perm)?;
             Ok(Self { tree_id, details })
         }
     }

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -8,7 +8,7 @@ pub fn move_branch(
     target_branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(&mut ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
     let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
         .context("Failed to determine information for the branch to move.")?;
     let target_branch_name = resolve_branch_information(&mut ctx, &id_map, target_branch)
@@ -38,7 +38,7 @@ pub fn tear_off_branch(
     branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(&mut ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
     let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
         .context("Failed to determine information for the branch to tear off.")?;
 

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -25,7 +25,7 @@ pub(crate) fn handle(
     target_str: &str,
     after: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve source
     let source_matches = id_map.parse_using_context(source_str, ctx)?;

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -139,7 +139,7 @@ fn absorb_assignments(
     let total_rejected = if new {
         but_action::auto_commit_simple(repo, data_dir, context_lines, None, absorption_plan, perm)?
     } else {
-        but_api::legacy::absorb::absorb_impl(absorption_plan, perm, repo, data_dir)?
+        but_api::legacy::absorb::absorb_with_perm(absorption_plan, perm, repo, data_dir)?
     };
 
     // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -39,7 +39,7 @@ pub(crate) fn handle(
     dry_run: bool,
     new: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let source: Option<CliId> = source
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -48,7 +48,7 @@ pub fn new(
     branch_name: Option<String>,
     anchor: Option<String>,
 ) -> Result<(), anyhow::Error> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     // Get branch name or use canned name
     let branch_name = branch_name
         .map(Ok)

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,10 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::{
-        create::{commit_create_with_perm},
-        insert_blank::commit_insert_blank,
-    },
+    commit::{create::commit_create_with_perm, insert_blank::commit_insert_blank},
     diff,
     legacy::{repo, workspace},
 };

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,11 +3,14 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::{create::commit_create, insert_blank::commit_insert_blank},
+    commit::{
+        create::{commit_create_with_perm},
+        insert_blank::commit_insert_blank,
+    },
     diff,
     legacy::{repo, workspace},
 };
-use but_core::{DiffSpec, ui::TreeChange};
+use but_core::{DiffSpec, sync::RepoExclusive, ui::TreeChange};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use colored::Colorize;
 use gitbutler_repo::hooks;
@@ -26,7 +29,7 @@ pub(crate) fn insert_blank_commit(
     target: &str,
     insert_side: InsertSide,
 ) -> Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve the target ID
     let cli_ids = id_map.parse_using_context(target, ctx)?;
@@ -289,7 +292,8 @@ pub(crate) fn commit(
     generate_message: Option<Option<String>>,
     show_diff_in_editor: ShowDiffInEditor,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Get all stacks using but-api
     let stack_entries = workspace::stacks(ctx, None)?;
@@ -312,11 +316,18 @@ pub(crate) fn commit(
         bail!("Multiple branches found. Specify a branch to commit to using the branch argument");
     }
 
-    let (target_stack_id, target_stack) =
-        select_stack(&id_map, ctx, &stacks, branch_hint, create_branch, out)?;
+    let (target_stack_id, target_stack) = select_stack(
+        &id_map,
+        ctx,
+        &stacks,
+        branch_hint,
+        create_branch,
+        out,
+        guard.write_permission(),
+    )?;
 
     // Get changes and assignments using but-api
-    let worktree_changes = diff::changes_in_worktree(ctx)?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.write_permission())?;
     let changes = worktree_changes.worktree_changes.changes;
 
     // Get files to commit - either specific files by ID or all eligible files
@@ -454,12 +465,13 @@ pub(crate) fn commit(
     };
 
     // Insert relative to the branch reference itself so only that branch tip is advanced.
-    let outcome = commit_create(
+    let outcome = commit_create_with_perm(
         ctx,
         RelativeTo::Reference(target_branch.reference.clone()),
         InsertSide::Below,
         diff_specs,
         final_commit_message,
+        guard.write_permission(),
     )?;
 
     if !outcome.rejected_specs.is_empty() {
@@ -523,17 +535,19 @@ fn create_independent_branch(
     branch_name: &str,
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<(
     but_core::ref_metadata::StackId,
     but_workspace::ui::StackDetails,
 )> {
     // Create a new independent stack with the given branch name
-    let (new_stack_id_opt, _new_ref) = but_api::legacy::stack::create_reference(
+    let (new_stack_id_opt, _new_ref) = but_api::legacy::stack::create_reference_with_perm(
         ctx,
         but_api::legacy::stack::create_reference::Request {
             new_name: branch_name.to_string(),
             anchor: None,
         },
+        perm,
     )?;
 
     if let Some(new_stack_id) = new_stack_id_opt {
@@ -559,6 +573,7 @@ fn select_stack(
     branch_hint: Option<&str>,
     create_branch: bool,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<(
     but_core::ref_metadata::StackId,
     but_workspace::ui::StackDetails,
@@ -569,7 +584,7 @@ fn select_stack(
             Some(hint) => String::from(hint),
             None => but_api::legacy::workspace::canned_branch_name(ctx)?,
         };
-        return create_independent_branch(&branch_name, ctx, out);
+        return create_independent_branch(&branch_name, ctx, out, perm);
     }
 
     match branch_hint {
@@ -581,7 +596,7 @@ fn select_stack(
 
             // Branch not found - create if flag is set, otherwise error
             if create_branch {
-                create_independent_branch(hint, ctx, out)
+                create_independent_branch(hint, ctx, out, perm)
             } else {
                 bail!("Branch '{hint}' not found")
             }
@@ -589,7 +604,7 @@ fn select_stack(
         None if create_branch => {
             // Create with canned name
             let branch_name = but_api::legacy::workspace::canned_branch_name(ctx)?;
-            create_independent_branch(&branch_name, ctx, out)
+            create_independent_branch(&branch_name, ctx, out, perm)
         }
         None if stacks.len() == 1 => {
             // Only one stack - use it

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::{create::commit_create_with_perm, insert_blank::commit_insert_blank},
+    commit::{create::commit_create, insert_blank::commit_insert_blank},
     diff,
     legacy::{repo, workspace},
 };
@@ -462,7 +462,7 @@ pub(crate) fn commit(
     };
 
     // Insert relative to the branch reference itself so only that branch tip is advanced.
-    let outcome = commit_create_with_perm(
+    let outcome = commit_create(
         ctx,
         RelativeTo::Reference(target_branch.reference.clone()),
         InsertSide::Below,

--- a/crates/but/src/command/legacy/diff/mod.rs
+++ b/crates/but/src/command/legacy/diff/mod.rs
@@ -13,7 +13,7 @@ pub fn handle_tui(ctx: &mut Context, target_str: Option<&str>) -> anyhow::Result
     use crate::tui::diff_viewer::{DiffFileEntry, WorktreeFilter};
 
     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
-    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
+    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
 
     let files = if let Some(entity) = target_str {
         let id = id_map
@@ -59,7 +59,7 @@ pub fn handle(
     target_str: Option<&str>,
 ) -> anyhow::Result<()> {
     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
-    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
+    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments.clone()))?;
 
     if let Some(entity) = target_str {
         let id = id_map

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -20,7 +20,7 @@ use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
 /// The ID should be a file or hunk ID as shown in `but status`.
 pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()> {
     // Build ID map to resolve the user's ID
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve the ID to get file information
     let resolved_ids =

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -431,7 +431,7 @@ fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<St
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
     let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
     let branch_ids = id_map
-        .parse_using_context(branch_id, &mut ctx)?
+        .parse_using_context(branch_id, &ctx)?
         .iter()
         .filter_map(|clid| match clid {
             CliId::Branch { name, .. } => Some(name.clone()),

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -429,7 +429,7 @@ fn get_branches_without_prs(
 
 fn get_branch_names(project: &Project, branch_id: &str) -> anyhow::Result<Vec<String>> {
     let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    let id_map = IdMap::new_from_context(&mut ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
     let branch_ids = id_map
         .parse_using_context(branch_id, &mut ctx)?
         .iter()
@@ -1153,7 +1153,7 @@ fn resolve_review_selection(
     ctx: &mut Context,
     selector: Option<String>,
 ) -> anyhow::Result<Vec<usize>> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let applied_stacks = but_api::legacy::workspace::stacks(
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -14,7 +14,7 @@ pub(crate) fn handle(
     target_str: &str,
     delete: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let target_result = id_map.parse_using_context(target_str, ctx)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -16,7 +16,7 @@ pub async fn handle(
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
 
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve the branch ID
     let resolved_ids = id_map.parse_using_context(branch_id, ctx)?;

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -164,7 +164,7 @@ fn resolve_source_commits(
     }
 
     // Try using IdMap for CLI IDs
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let cli_ids = id_map.parse_using_context(source, ctx)?;
 
     for cli_id in &cli_ids {
@@ -396,7 +396,7 @@ fn find_stack_by_target(
     target: &str,
 ) -> Result<(StackId, String)> {
     // Try parsing as CLI ID first
-    if let Ok(id_map) = IdMap::new_from_context(ctx, None)
+    if let Ok(id_map) = IdMap::legacy_new_from_context(ctx, None)
         && let Ok(cli_ids) = id_map.parse_using_context(target, ctx)
     {
         for cli_id in &cli_ids {

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -45,7 +45,7 @@ pub fn handle(
     ctx: &mut Context,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Check gerrit mode early
     let gerrit_mode = {
@@ -154,7 +154,7 @@ fn handle_dry_run(
     // Filter based on branch_id if provided
     let branches_to_show: Vec<_> = if let Some(branch_id) = branch_id {
         // Resolve branch name
-        let id_map = IdMap::new_from_context(ctx, None)?;
+        let id_map = IdMap::legacy_new_from_context(ctx, None)?;
         let branch_name = resolve_branch_name(ctx, &id_map, branch_id)?;
 
         branches_with_info

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -55,7 +55,7 @@ fn enter_resolution(ctx: &mut Context, out: &mut OutputChannel, commit_id_str: &
     use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
 
     // Create an IdMap to resolve commit IDs (supports both CLI IDs and partial SHAs)
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve the commit ID using the IdMap
     let matches = id_map.parse_using_context(commit_id_str, ctx)?;

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -21,7 +21,7 @@ pub(crate) fn reword_target(
     format: bool,
     show_diff_in_editor: ShowDiffInEditor,
 ) -> Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve the commit ID
     let cli_ids = id_map.parse_using_context(target, ctx)?;

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -718,7 +718,7 @@ pub(crate) fn handle(
     source_str: &str,
     target_str: &str,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str, out)?;
 
     for source in sources {
@@ -851,7 +851,7 @@ pub(crate) fn handle_uncommit(
     out: &mut OutputChannel,
     source_str: &str,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let sources = parse_sources_with_disambiguation(ctx, &id_map, source_str, out)?;
 
     // Validate that all sources are commits or committed files
@@ -882,7 +882,7 @@ pub(crate) fn handle_amend(
     file_str: &str,
     commit_str: &str,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_str, out)?;
     let commit = resolve_single_id(ctx, &id_map, commit_str, "Commit", out)?;
 
@@ -928,7 +928,7 @@ pub(crate) fn handle_stage(
     file_or_hunk_str: &str,
     branch_str: &str,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
     let branch = resolve_single_id(ctx, &id_map, branch_str, "Branch", out)?;
 
@@ -975,7 +975,7 @@ pub(crate) fn handle_stage_tui(
 ) -> anyhow::Result<()> {
     use crate::tui::stage_viewer::{StageFileEntry, StageResult};
 
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // Resolve branch: from flag, or interactive selection
     let branch_name = if let Some(branch_str) = branch_str {
@@ -1084,7 +1084,7 @@ pub(crate) fn handle_unstage(
     file_or_hunk_str: &str,
     branch_str: Option<&str>,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
 
     // Validate that all files are uncommitted or a path prefix

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -47,7 +47,7 @@ pub(crate) fn handle(
         bail!("At least one commit or branch name must be provided");
     }
 
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     // If there's only one argument, it could be a branch name or a range
     if commits.len() == 1 {

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -48,7 +48,7 @@ pub(crate) fn show_commit(
 
     // Not a branch, proceed with commit logic
     // Try to resolve the commit ID through the IdMap
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
 
     let cli_ids = id_map.parse_using_context(commit_id_str, ctx)?;
 

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -302,7 +302,7 @@ impl Details {
                 )?,
                 CliId::Uncommitted(uncommitted) => {
                     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
-                    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments))?;
+                    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
                     let uncommitted_hunks = filter_uncommitted_hunks(&id_map, |hunk_assignment| {
                         uncommitted_hunk_matches_selection(hunk_assignment, uncommitted)
                     })?;
@@ -340,7 +340,7 @@ impl Details {
                 )?,
                 CliId::Unassigned { .. } => {
                     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
-                    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments))?;
+                    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
                     let uncommitted_hunks = filter_uncommitted_hunks(&id_map, |hunk_assignment| {
                         hunk_assignment.stack_id.is_none()
                     })?;
@@ -353,7 +353,7 @@ impl Details {
                 }
                 CliId::Stack { stack_id, .. } => {
                     let wt_changes = but_api::diff::changes_in_worktree(ctx)?;
-                    let id_map = IdMap::new_from_context(ctx, Some(wt_changes.assignments))?;
+                    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
                     let uncommitted_hunks = filter_uncommitted_hunks(&id_map, |hunk_assignment| {
                         hunk_assignment.stack_id.is_some_and(|id| id == *stack_id)
                     })?;

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -93,6 +93,7 @@ pub(super) fn create_commit_legacy(
     scope_to_stack: Option<gitbutler_stack::StackId>,
     insert_side: InsertSide,
 ) -> anyhow::Result<Option<CommitCreateResult>> {
+    let mut guard = ctx.exclusive_worktree_access();
     let (insert_commit_relative_to, insert_side) = match target {
         CliId::Branch { name, .. } => {
             let repo = ctx.repo.get()?;
@@ -116,7 +117,7 @@ pub(super) fn create_commit_legacy(
     let changes_to_commit = match source {
         CommitSource::Unassigned(..) => {
             let context_lines = ctx.settings.context_lines;
-            let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
             let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
             let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
                 db.hunk_assignments_mut()?,
@@ -140,7 +141,7 @@ pub(super) fn create_commit_legacy(
             .collect::<Vec<_>>(),
         CommitSource::Stack(StackCommitSource { stack_id, .. }) => {
             let context_lines = ctx.settings.context_lines;
-            let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+            let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
             let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;
             let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
                 db.hunk_assignments_mut()?,
@@ -167,6 +168,7 @@ pub(super) fn create_commit_legacy(
         changes_to_commit,
         // we reword the commit with the editor before the next render
         String::new(),
+        guard.write_permission(),
     )
     .context("failed to create commit")
     .map(Some)

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -28,7 +28,7 @@ pub fn handle(
         Some(but_workspace::legacy::StacksFilter::InWorkspace),
     )?;
 
-    let id_map = IdMap::new_from_context(ctx, None)?;
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let parsed_ids = id_map.parse_using_context(identifier, ctx)?;
 
     // Try to find the stack to unapply

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -10,6 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr as _;
 
 use bstr::{BStr, BString, ByteSlice};
+use but_core::sync::RepoShared;
 use but_core::{ChangeId, ref_metadata::StackId};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
@@ -533,9 +534,25 @@ impl IdMap {
     ///
     /// # NOTE: claims a read-only workspace lock!
     /// TODO(ctx|ai): make it use perm so the caller keeps the state exclusive/shared over greater periods.
+    /// USE `new_from_context` instead - it takes `perm`
+    pub fn legacy_new_from_context(
+        ctx: &mut Context,
+        assignments: Option<Vec<HunkAssignment>>,
+    ) -> anyhow::Result<Self> {
+        let guard = ctx.shared_worktree_access();
+        Self::new_from_context(ctx, assignments, guard.read_permission())
+    }
+
+    ///
+    /// Creates a new instance from `ctx` for more convenience over calling [IdMap::new].
+    /// `perm` is needed to obtain a read-only workspace.
+    ///
+    /// # NOTE: claims a read-only workspace lock!
+    /// TODO(ctx|ai): Use a `ws` directly instead of creating a whole new RefInfo uncached.
     pub fn new_from_context(
         ctx: &mut Context,
         assignments: Option<Vec<HunkAssignment>>,
+        perm: &RepoShared,
     ) -> anyhow::Result<Self> {
         let meta = ctx.meta()?;
         let head_info = {
@@ -552,7 +569,7 @@ impl IdMap {
             )?
         };
         let context_lines = ctx.settings.context_lines;
-        let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
 
         let hunk_assignments = match assignments {
             Some(assignments) => assignments,
@@ -852,11 +869,7 @@ impl IdMap {
     }
 
     /// Convenience for [IdMap::parse] if a [Context] is available.
-    pub fn parse_using_context(
-        &self,
-        entity: &str,
-        ctx: &mut Context,
-    ) -> anyhow::Result<Vec<CliId>> {
+    pub fn parse_using_context(&self, entity: &str, ctx: &Context) -> anyhow::Result<Vec<CliId>> {
         let repo = &*ctx.repo.get()?;
         self.parse_using_repo(entity, repo)
     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -533,8 +533,9 @@ impl IdMap {
     /// Creates a new instance from `ctx` for more convenience over calling [IdMap::new].
     ///
     /// # NOTE: claims a read-only workspace lock!
-    /// TODO(ctx|ai): make it use perm so the caller keeps the state exclusive/shared over greater periods.
-    /// USE `new_from_context` instead - it takes `perm`
+    // TODO(ctx|ai): make it use perm so the caller keeps the state exclusive/shared over greater periods.
+    // Use `new_from_context` instead - it takes `perm`, and forces you to think about repository locks
+    // in the light of mutations.
     pub fn legacy_new_from_context(
         ctx: &mut Context,
         assignments: Option<Vec<HunkAssignment>>,

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -175,6 +175,7 @@ pub fn init_ctx(
                         }
                     }
                 }
+                ctx.reload_repo_and_invalidate_workspace(guard.write_permission())?;
             }
 
             let fetch_interval_minutes = ctx.settings.fetch.auto_fetch_interval_minutes;

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1231,9 +1231,6 @@ mod concurrent_commits {
     /// This test creates three independent branches, adds a file to each, then
     /// fires three `but commit` processes simultaneously. All three should
     /// succeed without errors or lost data.
-    ///
-    /// Currently fails with: "Specified HEAD <sha> didn't match actual HEAD^{tree} <sha>"
-    /// — the workspace commit is updated by one process while another is mid-commit.
     #[test]
     fn concurrent_commits_to_independent_branches() -> anyhow::Result<()> {
         let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1235,7 +1235,6 @@ mod concurrent_commits {
     /// Currently fails with: "Specified HEAD <sha> didn't match actual HEAD^{tree} <sha>"
     /// — the workspace commit is updated by one process while another is mid-commit.
     #[test]
-    #[ignore = "concurrent commit race condition — workspace HEAD contention"]
     fn concurrent_commits_to_independent_branches() -> anyhow::Result<()> {
         let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
         env.setup_metadata(&["A"])?;

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -25,6 +25,9 @@ export declare function branchDetails(projectId: string, branchName: string, rem
 /** Gets the changes for a given branch. */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
+/** See [`changes_in_worktree_with_perm()`]. */
+export declare function changesInWorktree(projectId: string): Promise<WorktreeChanges>
+
 /**
  * This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
  * the user interface as it is right now. From here, it's always possible to add more information as the need arises.
@@ -36,7 +39,7 @@ export declare function branchDiff(projectId: string, branch: string): Promise<T
  *
  * All ignored status changes are also provided so they can be displayed separately.
  */
-export declare function changesInWorktree(projectId: string): Promise<WorktreeChanges>
+export declare function changesInWorktreeWithPerm(projectId: string): Promise<WorktreeChanges>
 
 /** Amends an existing commit with selected changes, with oplog support. */
 export declare function commitAmend(projectId: string, commitId: string, changes: Array<DiffSpec>): Promise<UICommitCreateResult>

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -587,6 +587,7 @@ export { assignHunk }
 export { branchDetails }
 export { branchDiff }
 export { changesInWorktree }
+export { changesInWorktreeWithPerm }
 export { commitAmend }
 export { commitCreate }
 export { commitDetailsWithLineStats }


### PR DESCRIPTION
This lock covers the first reads and the final writes, effectively synchronizing this whole operation, which is certainly what all mutations should do.

Follow-up on #13094 .

### Tasks

* [x] early write-lock on commit
* [x] figure out why `cargo test -p but --test but -- concurrent_commits::concurrent_commits_to_independent_branches --ignored` still isn't working
* [x] but-api support for permission-based and thus more composable api functions


### Notes for the reviewer

* Most lines are in `but-api-macros-tests`, and the macro itself which now supports `perm: &Repo(Shared|Exclusive)`
* The real culprit among the locks was a stale workspace, left like this after `init_ctx()`. Quite subtle for sure.
* We can now officially have API calls that take permissions, and the GUI clients can also call these just as if `perm` doesn't exist.
* `create_commit` now only exists in its more composable form, taking the permission directly.