### PR TITLE
but discard commit/file

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -334,6 +334,8 @@ Uncommit changes back to unstaged area.
 ```bash
 but uncommit <commit-id>      # Uncommit entire commit
 but uncommit <file-id>        # Uncommit specific file from its commit
+but uncommit <commit-id> -d   # Discard committed changes instead of moving to unassigned
+but uncommit <file-id> --discard  # Discard committed file changes completely
 but uncommit <commit-id> --status-after  # Uncommit then show workspace status
 ```
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -862,12 +862,17 @@ pub enum Subcommands {
 
     /// Uncommit changes from a commit or file-in-commit to the unstaged area.
     ///
+    /// Use `--discard` to remove the selected committed changes entirely instead.
+    ///
     /// Wrapper for `but rub <source> zz`.
     #[cfg(feature = "legacy")]
     #[clap(verbatim_doc_comment)]
     Uncommit {
         /// Commit ID or file-in-commit ID to uncommit
         source: String,
+        /// Discard the selected committed changes instead of moving them to unassigned
+        #[clap(long, short = 'd')]
+        discard: bool,
     },
 
     /// Amend a file change into a specific commit and rebases any dependent commits.

--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context as _, Result};
 use bstr::BStr;
+use bstr::ByteSlice;
 use but_core::{DiffSpec, diff::tree_changes};
 use but_ctx::Context;
 use gitbutler_branch_actions::update_workspace_commit;
@@ -13,18 +14,7 @@ pub fn commited_file_to_another_commit(
     target_id: gix::ObjectId,
     out: &mut OutputChannel,
 ) -> Result<()> {
-    let relevant_changes = {
-        let repo = ctx.repo.get()?;
-        let source_commit = repo.find_commit(source_id)?;
-        let source_commit_parent_id = source_commit.parent_ids().next().context("First parent")?;
-
-        let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
-        tree_changes
-            .into_iter()
-            .filter(|tc| tc.path == path)
-            .map(Into::into)
-            .collect::<Vec<DiffSpec>>()
-    };
+    let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
 
     but_api::commit::move_changes::commit_move_changes_between_only(
         ctx,
@@ -53,20 +43,7 @@ pub fn uncommit_file(
 ) -> Result<()> {
     // Convert target_branch to StackId if provided (for hunk assignment after uncommit)
     let assign_to = find_stack_id_for_branch(ctx, target_branch)?;
-
-    let relevant_changes = {
-        let repo = ctx.repo.get()?;
-
-        let source_commit = repo.find_commit(source_id)?;
-        let source_commit_parent_id = source_commit.parent_ids().next().context("First parent")?;
-
-        let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
-        tree_changes
-            .into_iter()
-            .filter(|tc| tc.path == path)
-            .map(Into::into)
-            .collect::<Vec<DiffSpec>>()
-    };
+    let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
 
     but_api::commit::uncommit::commit_uncommit_changes_only(
         ctx,
@@ -84,6 +61,66 @@ pub fn uncommit_file(
     }
 
     Ok(())
+}
+
+pub fn uncommit_file_and_discard(
+    ctx: &mut Context,
+    path: &BStr,
+    source_id: gix::ObjectId,
+    out: &mut OutputChannel,
+    emit_output: bool,
+) -> Result<()> {
+    let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
+
+    let context_lines = ctx.settings.context_lines;
+    but_api::commit::uncommit::commit_uncommit_changes(
+        ctx,
+        source_id,
+        relevant_changes.clone(),
+        None,
+    )?;
+
+    let repo = ctx.repo.get()?;
+    let dropped = but_workspace::discard_workspace_changes(&repo, relevant_changes, context_lines)?;
+
+    update_workspace_commit(ctx, false)?;
+
+    if emit_output {
+        if let Some(out) = out.for_human() {
+            if !dropped.is_empty() {
+                writeln!(
+                    out,
+                    "Warning: Some changes could not be discarded (possibly already discarded or modified):"
+                )?;
+                for spec in &dropped {
+                    writeln!(out, "  {}", spec.path.as_bstr())?;
+                }
+            }
+            writeln!(out, "Discarded committed changes")?;
+        } else if let Some(out) = out.for_json() {
+            out.write_value(serde_json::json!({"ok": true}))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn changes_for_path_in_commit(
+    ctx: &Context,
+    path: &BStr,
+    source_id: gix::ObjectId,
+) -> Result<Vec<DiffSpec>> {
+    let repo = ctx.repo.get()?;
+
+    let source_commit = repo.find_commit(source_id)?;
+    let source_commit_parent_id = source_commit.parent_ids().next().context("First parent")?;
+
+    let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), source_id)?;
+    Ok(tree_changes
+        .into_iter()
+        .filter(|tc| tc.path == path)
+        .map(Into::into)
+        .collect())
 }
 
 /// Determine which stack contains the target branch, if any.

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     CliId, IdMap,
     command::commit::r#move::move_commit_to_branch,
     id::parser::{parse_sources_with_disambiguation, prompt_for_disambiguation},
-    utils::OutputChannel,
+    utils::{OutputChannel, shorten_object_id},
 };
 
 /// A description of a set of hunks.
@@ -850,6 +850,7 @@ pub(crate) fn handle_uncommit(
     ctx: &mut Context,
     out: &mut OutputChannel,
     source_str: &str,
+    discard: bool,
 ) -> anyhow::Result<()> {
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let sources = parse_sources_with_disambiguation(ctx, &id_map, source_str, out)?;
@@ -868,6 +869,47 @@ pub(crate) fn handle_uncommit(
                 );
             }
         }
+    }
+
+    if discard {
+        let json_mode = out.for_json().is_some();
+
+        for source in sources {
+            match source {
+                CliId::Commit { commit_id, .. } => {
+                    but_api::commit::discard_commit::commit_discard(ctx, commit_id)?;
+
+                    if !json_mode && let Some(out) = out.for_human() {
+                        let repo = ctx.repo.get()?;
+                        writeln!(
+                            out,
+                            "Discarded {}",
+                            shorten_object_id(&repo, commit_id).blue()
+                        )?;
+                    }
+                }
+                CliId::CommittedFile {
+                    path, commit_id, ..
+                } => {
+                    crate::command::commit::file::uncommit_file_and_discard(
+                        ctx,
+                        path.as_ref(),
+                        commit_id,
+                        out,
+                        !json_mode,
+                    )?;
+                }
+                _ => {
+                    unreachable!("uncommit sources were validated before execution");
+                }
+            }
+        }
+
+        if json_mode && let Some(out) = out.for_json() {
+            out.write_value(serde_json::json!({"ok": true}))?;
+        }
+
+        return Ok(());
     }
 
     // Call the main rub handler with "zz" as target

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1260,7 +1260,7 @@ async fn match_subcommand(
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Uncommit { source } => {
+        Subcommands::Uncommit { source, discard } => {
             let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
                 &args,
@@ -1271,7 +1271,7 @@ async fn match_subcommand(
                 out,
             )?;
             out.begin_status_after(status_after);
-            let result = command::legacy::rub::handle_uncommit(&mut ctx, out, &source)
+            let result = command::legacy::rub::handle_uncommit(&mut ctx, out, &source, discard)
                 .context("Failed to uncommit.")
                 .emit_metrics(metrics_ctx);
             maybe_run_status_after(status_after, &result, &mut ctx, out).await;

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -132,6 +132,35 @@ fn branch_commit_id_for_file(
         })
 }
 
+fn committed_file_id_for_file(
+    status: &serde_json::Value,
+    branch_name: &str,
+    file_path: &str,
+) -> Option<String> {
+    status["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+        .find(|branch| branch["name"].as_str().unwrap() == branch_name)
+        .and_then(|branch| {
+            branch["commits"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find_map(|commit| {
+                    commit["changes"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .find_map(|change| {
+                            (change["filePath"].as_str().unwrap() == file_path)
+                                .then(|| change["cliId"].as_str().unwrap().to_string())
+                        })
+                })
+        })
+}
+
 #[test]
 fn assign_uncommitted_file() -> anyhow::Result<()> {
     let env = assigned_uncommitted_file_env()?;
@@ -625,6 +654,240 @@ Failed to uncommit. Cannot uncommit a.txt - it is an uncommitted file or hunk. O
 Failed to uncommit. Cannot uncommit A - it is a branch. Only commits and files-in-commits can be uncommitted.
 
 "#]]);
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_command_with_discard_on_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
+
+    let before = status_json(&env)?;
+    let commits_before = branch_commit_ids(&before, "A");
+    let source_commit = commits_before[0].clone();
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   fce8ecc create a.txt and b.txt
+┊│     fc:nk A a.txt
+┊│     fc:pn A b.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but(format!("uncommit {source_commit} --discard"))
+        .assert()
+        .success();
+
+    let after = status_json(&env)?;
+    let commits_after = branch_commit_ids(&after, "A");
+
+    assert_eq!(
+        commits_after.len() + 1,
+        commits_before.len(),
+        "discarding a commit via uncommit should remove that commit from branch history"
+    );
+    assert!(
+        !commits_after.contains(&source_commit),
+        "source commit should no longer be present after discard"
+    );
+    assert!(
+        !unassigned_contains_file(&after, "a.txt") && !unassigned_contains_file(&after, "b.txt"),
+        "discarding a commit should not move its changes into unassigned"
+    );
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_command_with_discard_on_committed_file() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
+
+    let before = status_json(&env)?;
+    let committed_file_id = committed_file_id_for_file(&before, "A", "b.txt")
+        .expect("b.txt committed-file id should exist");
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   fce8ecc create a.txt and b.txt
+┊│     fc:nk A a.txt
+┊│     fc:pn A b.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but(format!("uncommit {committed_file_id} -d"))
+        .assert()
+        .success();
+
+    let after = status_json(&env)?;
+    assert!(
+        !unassigned_contains_file(&after, "b.txt"),
+        "discarded committed file changes should not end up unassigned"
+    );
+    assert!(
+        !branch_commits_contain_file(&after, "A", "b.txt"),
+        "discarded committed file changes should no longer be in commit history"
+    );
+    assert!(
+        branch_commits_contain_file(&after, "A", "a.txt"),
+        "other committed file changes should remain in history"
+    );
+
+    env.but("stf")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   993513d create a.txt and b.txt
+┊│     99:nk A a.txt
+┊●   9477ae7 add A
+┊│     94:tm A A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+┊│     d3:pl A B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_help_mentions_discard_flag() -> anyhow::Result<()> {
+    let env = Sandbox::empty()?;
+
+    let output = env.but("uncommit --help").output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(
+        stdout.contains("-d, --discard"),
+        "expected uncommit help to list the discard flag"
+    );
+    assert!(
+        stdout.contains("Discard the selected committed changes"),
+        "expected uncommit help to describe discard behavior"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_discard_multiple_sources_writes_single_json_with_status_after() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+
+    env.setup_metadata(&["A", "B"])?;
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "second commit");
+
+    let before = status_json(&env)?;
+    let commits_before = branch_commit_ids(&before, "A");
+    let sources = format!("{},{}", commits_before[0], commits_before[1]);
+
+    let output = env
+        .but(format!(
+            "--json --status-after uncommit {sources} --discard"
+        ))
+        .allow_json()
+        .output()?;
+    assert!(output.status.success());
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(parsed["result"]["ok"], serde_json::json!(true));
+    assert!(
+        parsed.get("status").is_some(),
+        "--status-after JSON wrapper should include status"
+    );
+
+    let after = status_json(&env)?;
+    let commits_after = branch_commit_ids(&after, "A");
+
+    assert_eq!(
+        commits_after.len() + 2,
+        commits_before.len(),
+        "discarding two commit sources should remove both from branch history"
+    );
+    assert!(
+        !unassigned_contains_file(&after, "a.txt") && !unassigned_contains_file(&after, "b.txt"),
+        "discarded commits should not move their changes into unassigned"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Add the ability to discard a commit or file completely

Usage: 

```
but uncommit <commit-id> -d
but uncommit <committed-file-id> -d
but uncommit <commit-id> --discard
but uncommit <committed-file-id> --discard
```

Update the skills file