### PR TITLE
but move: branches

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -43,7 +43,9 @@ but <mutation> ... --status-after
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id> --status-after`
 - Amend: `but amend <file-id> <commit-id> --status-after`
 - Reorder commits: `but move <source-commit-id> <target-commit-id> --status-after` (**commit IDs**, not branch names)
-- Stack branches: `but branch move <branch-name> <target-branch-name>` (**branch names**, not IDs — e.g. `but branch move feature/frontend feature/backend`)
+- Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id> --status-after` (**branch names or branch CLI IDs**)
+- Tear off a branch: `but move <branch-name-or-id> zz --status-after` (`zz` = unassigned; branch name or branch CLI ID)
+- Equivalent branch subcommand syntax remains available: `but branch move <branch-name> <target-branch-name>` and `but branch move --unstack <branch-name>`
 - Push: `but push` or `but push <branch-id>`
 - Pull: `but pull --check` then `but pull --status-after`
 
@@ -63,9 +65,9 @@ but <mutation> ... --status-after
 2. Locate file ID and target commit ID.
 3. `but amend <file-id> <commit-id> --status-after`
 
-### Reorder commits (not branches)
+### Reorder commits
 
-**`but move` reorders commits within a branch. To stack branches, use `but branch move` instead.**
+`but move` supports both commit reordering and branch stack operations. Use commit IDs when reordering commits.
 
 1. `but status -fv`
 2. `but move <commit-a> <commit-b> --status-after` — uses commit IDs like `c3`, `c5`
@@ -73,23 +75,35 @@ but <mutation> ... --status-after
 
 ### Stack existing branches
 
-To make one existing branch depend on (stack on top of) another, use `but branch move`:
+To make one existing branch depend on (stack on top of) another, use top-level `move`:
+
+```bash
+but move feature/frontend feature/backend
+```
+
+This moves the frontend branch on top of the backend branch in one step.
+
+Equivalent subcommand syntax:
 
 ```bash
 but branch move feature/frontend feature/backend
 ```
 
-This moves the frontend branch on top of the backend branch in one step.
-
-**DO NOT** use `uncommit` + `branch delete` + `branch new -a` to stack existing branches. That approach fails because git branch names persist even after `but branch delete`. Always use `but branch move`.
+**DO NOT** use `uncommit` + `branch delete` + `branch new -a` to stack existing branches. That approach fails because git branch names persist even after `but branch delete`. Always use `but move <branch> <target-branch>` (or the equivalent `but branch move ...`).
 
 **To unstack** (make a stacked branch independent again):
+
+```bash
+but move feature/logging zz
+```
+
+Equivalent subcommand syntax:
 
 ```bash
 but branch move --unstack feature/logging
 ```
 
-**Note:** `but branch move` uses branch **names** (like `feature/frontend`), while `but move` uses commit **IDs** (like `c3`). Do not confuse them. Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
+**Note:** branch stack/tear-off operations use branch **names** (like `feature/frontend`) or branch CLI IDs, while commit reordering uses commit **IDs** (like `c3`). Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
 
 ### Stacked dependency / commit-lock recovery
 
@@ -100,11 +114,11 @@ A **dependency lock** occurs when a file was originally committed on branch A, b
 **Recovery:** Stack your branch on the dependency branch, then commit:
 
 1. `but status -fv` — identify which branch originally owns the file (check commit history).
-2. `but branch move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
+2. `but move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
 3. `but status -fv` — the file should now be assignable. Commit it.
 4. `but commit <branch> -m "<msg>" --changes <id> --status-after`
 
-**If `but branch move` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry `but branch move` with exact branch names from the status output.
+**If `but move <branch> <target-branch>` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry with exact branch names from the status output.
 
 ### Resolve conflicts after reorder/move
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -85,7 +85,9 @@ Example: Adding a new API endpoint and updating button styles are independent.
 
 ### Stacked Branches (Dependent Work)
 
-**To stack an existing branch** on top of another: `but branch move <child-branch-name> <parent-branch-name>` — this is the primary way to stack branches.
+**To stack an existing branch** on top of another: `but move <child-branch-name> <parent-branch-name>`.
+
+Equivalent syntax: `but branch move <child-branch-name> <parent-branch-name>`.
 
 **To create a new stacked branch** from scratch: `but branch new <name> -a <anchor>` — only use this when the child branch doesn't exist yet.
 
@@ -102,10 +104,16 @@ Use when:
 
 Example: User profile page needs authentication to be implemented first.
 
-**Stacking two existing branches:** If both branches already exist and you need to make one depend on the other, use `but branch move`:
+**Stacking two existing branches:** If both branches already exist and you need to make one depend on the other, use top-level `move`:
 ```bash
-but branch move feature/frontend feature/backend
+but move feature/frontend feature/backend
 # Now frontend is stacked on top of backend — both in the same stack
+```
+
+To tear off a branch from a stack:
+
+```bash
+but move feature/frontend zz
 ```
 
 **Dependency tracking:** GitButler automatically tracks which changes depend on which commits. You can't stage dependent changes to the wrong branch.
@@ -156,15 +164,15 @@ File-in-Commit       │ Uncommit        │ Move       │ Uncommit & assign �
 
 **Common examples:**
 
-| Source | Target | Operation | Example |
-|--------|--------|-----------|---------|
-| File | Branch | Stage file to branch | `but rub a1 bu` |
-| File | Commit | Amend file into commit | `but rub a1 c3` |
-| Commit | Commit | Squash commits | `but rub c2 c3` |
-| Commit | Branch | Move commit to branch | `but rub c2 bu` |
-| File | `zz` | Unstage file | `but rub a1 zz` |
-| Commit | `zz` | Undo commit | `but rub c2 zz` |
-| `zz` | Branch | Stage all unassigned | `but rub zz bu` |
+| Source | Target | Operation              | Example         |
+| ------ | ------ | ---------------------- | --------------- |
+| File   | Branch | Stage file to branch   | `but rub a1 bu` |
+| File   | Commit | Amend file into commit | `but rub a1 c3` |
+| Commit | Commit | Squash commits         | `but rub c2 c3` |
+| Commit | Branch | Move commit to branch  | `but rub c2 bu` |
+| File   | `zz`   | Unstage file           | `but rub a1 zz` |
+| Commit | `zz`   | Undo commit            | `but rub c2 zz` |
+| `zz`   | Branch | Stage all unassigned   | `but rub zz bu` |
 
 ### Higher-Level Conveniences
 
@@ -173,7 +181,7 @@ These commands are wrappers around `but rub`:
 - `but stage <file> <branch>` = `but rub <file> <branch>`
 - `but amend <file> <commit>` = `but rub <file> <commit>`
 - `but squash` = Multiple `but rub <commit> <commit>` operations
-- `but move` = `but rub <commit> <target>` with position control
+- `but move` = commit move/reorder with position control, plus branch stack/tear-off (`<branch> <target-branch>` and `<branch> zz`)
 
 **Why this design?** One powerful primitive is easier to understand and maintain than many specialized commands. Once you understand `but rub`, you understand the editing model.
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -186,8 +186,8 @@ but status -fv
 # Stack 2: feature/frontend (bv) — 1 commit
 
 # 2. Frontend now depends on backend API — stack frontend on backend
-#    IMPORTANT: Use full branch NAMES here, not CLI IDs
-but branch move feature/frontend feature/backend
+#    IMPORTANT: Prefer full branch NAMES here; branch CLI IDs are also accepted
+but move feature/frontend feature/backend
 
 # Result: Both branches are now in the same stack:
 # Stack 1: feature/backend → feature/frontend (stacked)
@@ -198,7 +198,7 @@ but commit bu -m "Add caching layer" --changes <id> --status-after   # To backen
 but commit bv -m "Add dialog component" --changes <id> --status-after # To frontend
 ```
 
-**Key point:** `but branch move` takes full branch **names** (like `feature/frontend`), NOT CLI IDs (like `bv`). This is different from `but move` which takes commit IDs.
+**Key point:** branch stack moves use branch **names** (like `feature/frontend`) or branch CLI IDs. The equivalent subcommand syntax is `but branch move <branch> <target-branch>`. Commit reordering still uses commit IDs.
 
 ## Example 6: Using Marks for Focused Work
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -133,19 +133,18 @@ but branch show <id> -r       # Fetch and display review information (PRs/MRs)
 Move an existing branch on top of another branch, stacking them.
 
 ```bash
-but branch move feature/frontend feature/backend    # Stack frontend on top of backend
-```
-
-To unstack (tear off) a branch, use:
-
-```bash
+but branch move feature/frontend feature/backend
 but branch move --unstack feature/frontend
 ```
 
-**This is the primary command for stacking/unstacking existing branches.** Uses full branch **names**, not CLI IDs.
+Equivalent top-level syntax:
 
-Alias: `but stack <branch> <target-branch>`
+```bash
+but move feature/frontend feature/backend
+but move feature/frontend zz
+```
 
+Uses branch names or branch CLI IDs.
 ### `but pick <source> [target]`
 
 Cherry-pick commits from unapplied branches into applied branches.
@@ -316,16 +315,20 @@ but amend <file-id> <commit-id> --status-after   # Amend then show workspace sta
 
 Alias for `but rub <file> <commit>`.
 
-### `but move <commit> <target>`
+### `but move <source> <target>`
 
-Move a commit to a different location.
+Move commits or branches to a different location.
 
 ```bash
-but move <source> <target>           # Move before target
-but move <source> <target> --after   # Move after target
-but move <commit> <branch>           # Move to top of branch
-but move <commit> <branch> --status-after  # Move then show workspace status
+but move <commit> <target-commit>            # Move before target commit
+but move <commit> <target-commit> --after    # Move after target commit
+but move <commit> <branch>                   # Move commit to top of branch
+but move <branch> <target-branch>            # Stack branch on top of target branch
+but move <branch> zz                          # Tear off (unstack) branch
+but move <source> <target> --status-after    # Move then show workspace status
 ```
+
+`--after` is valid only for commit-to-commit moves.
 
 ### `but uncommit <source>`
 

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -10,6 +10,7 @@ pub enum CommandName {
     Tui,
     Stf,
     Rub,
+    Move,
     Diff,
     Edit,
     Show,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -350,17 +350,6 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Branch(branch::Platform),
 
-    /// Move branches on top of others to stack them.
-    #[clap(verbatim_doc_comment)]
-    Stack {
-        /// The branch being moved.
-        #[clap(value_name = "BRANCH")]
-        branch: String,
-        /// The branch to move the other on top of.
-        #[clap(value_name = "TARGET_BRANCH")]
-        target_branch: String,
-    },
-
     /// Commands for managing worktrees.
     ///
     /// GitButler worktrees allow you to have multiple working directories
@@ -914,12 +903,17 @@ pub enum Subcommands {
         branch: String,
     },
 
-    /// Move a commit to a different location in the stack.
+    /// Move a commit or branch to a different location.
     ///
-    /// By default, commits are moved to be before (below) the target.
-    /// Use `--after` to move the commit after (above) the target instead.
+    /// Commit moves:
+    /// - By default, commits are moved to be before (below) the target.
+    /// - Use `--after` to move the commit after (above) the target instead.
     ///
-    /// When moving to a branch, the commit is placed at the top of that branch's stack.
+    /// - When moving to a branch, the commit is placed at the top of that branch's stack.
+    ///
+    /// Branch moves:
+    /// - Move one branch on top of another to stack them.
+    /// - Move a branch to `zz` to tear it off (unstack it).
     ///
     /// ## Examples
     ///
@@ -940,13 +934,26 @@ pub enum Subcommands {
     /// ```text
     /// but move abc123 my-feature-branch
     /// ```
+    ///
+    /// Stack one branch on top of another:
+    ///
+    /// ```text
+    /// but move feature/frontend feature/backend
+    /// ```
+    ///
+    /// Tear off (unstack) a branch:
+    ///
+    /// ```text
+    /// but move feature/frontend zz
+    /// ```
     #[clap(verbatim_doc_comment)]
     Move {
-        /// Commit ID to move
-        source_commit: String,
-        /// Target commit ID or branch name
+        /// Commit/branch identifier to move
+        source: String,
+        /// Target commit/branch identifier, or `zz` to unstack a branch
         target: String,
-        /// Move the commit after (above) the target instead of before (below)
+        /// Move the commit after (above) the target instead of before (below).
+        /// Only valid for commit-to-commit moves.
         #[clap(short = 'a', long = "after")]
         after: bool,
     },

--- a/crates/but/src/command/branch/mod.rs
+++ b/crates/but/src/command/branch/mod.rs
@@ -4,3 +4,4 @@ mod move_branch;
 #[cfg(not(feature = "legacy"))]
 pub use apply::apply;
 pub use move_branch::{move_branch, tear_off_branch};
+pub(crate) use move_branch::{move_branch_by_name, tear_off_branch_by_name};

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -3,22 +3,31 @@ use anyhow::{Context, bail};
 
 /// Move a branch on top of another
 pub fn move_branch(
-    mut ctx: but_ctx::Context,
+    ctx: &mut but_ctx::Context,
     branch: &str,
     target_branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
-    let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let branch_name = resolve_branch_information(ctx, &id_map, branch)
         .context("Failed to determine information for the branch to move.")?;
-    let target_branch_name = resolve_branch_information(&mut ctx, &id_map, target_branch)
+    let target_branch_name = resolve_branch_information(ctx, &id_map, target_branch)
         .context("Failed to determine information for the target branch.")?;
 
+    move_branch_by_name(ctx, &branch_name, &target_branch_name, out)
+}
+
+pub(crate) fn move_branch_by_name(
+    ctx: &mut but_ctx::Context,
+    branch_name: &str,
+    target_branch_name: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
     let target_ref_name_str = &format!("refs/heads/{target_branch_name}");
 
     but_api::branch::move_branch(
-        &mut ctx,
+        ctx,
         branch_ref_name_str.try_into()?,
         target_ref_name_str.try_into()?,
     )?;
@@ -34,17 +43,25 @@ pub fn move_branch(
 }
 
 pub fn tear_off_branch(
-    mut ctx: but_ctx::Context,
+    ctx: &mut but_ctx::Context,
     branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(&mut ctx, None)?;
-    let branch_name = resolve_branch_information(&mut ctx, &id_map, branch)
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let branch_name = resolve_branch_information(ctx, &id_map, branch)
         .context("Failed to determine information for the branch to tear off.")?;
 
+    tear_off_branch_by_name(ctx, &branch_name, out)
+}
+
+pub(crate) fn tear_off_branch_by_name(
+    ctx: &mut but_ctx::Context,
+    branch_name: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<()> {
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
 
-    but_api::branch::tear_off_branch(&mut ctx, branch_ref_name_str.try_into()?)?;
+    but_api::branch::tear_off_branch(ctx, branch_ref_name_str.try_into()?)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Unstacked branch '{branch_name}'.")?;

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -4,55 +4,17 @@ use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use colored::Colorize;
 
 use crate::{
-    CliId, IdMap,
+    CliId,
     utils::{OutputChannel, shorten_object_id},
 };
 
-/// Move a commit to a new location in the stack.
-///
-/// This handles two scenarios:
-/// 1. Moving a commit to be before/after another commit (reordering within or across stacks)
-/// 2. Moving a commit to a branch (places at top)
-///
-/// # Limitations
-/// - When moving commits within the same stack, you can specify exact position (before/after target)
-/// - When moving commits to a different stack, the commit goes to the top (API limitation)
-/// - You cannot currently move a commit to a specific position in a different stack in one operation
-pub(crate) fn handle(
+pub(crate) fn handle_resolved(
     ctx: &mut Context,
     out: &mut OutputChannel,
-    source_str: &str,
-    target_str: &str,
+    source_id: &CliId,
+    target_id: &CliId,
     after: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
-
-    // Resolve source
-    let source_matches = id_map.parse_using_context(source_str, ctx)?;
-    if source_matches.is_empty() {
-        bail!(
-            "Source '{source_str}' not found. If you just performed a Git operation, try running 'but status' to refresh."
-        );
-    }
-    if source_matches.len() > 1 {
-        bail!("Source '{source_str}' is ambiguous. Try using more characters to disambiguate.");
-    }
-
-    let source_id = &source_matches[0];
-
-    // Resolve target
-    let target_matches = id_map.parse_using_context(target_str, ctx)?;
-    if target_matches.is_empty() {
-        bail!(
-            "Target '{target_str}' not found. If you just performed a Git operation, try running 'but status' to refresh."
-        );
-    }
-    if target_matches.len() > 1 {
-        bail!("Target '{target_str}' is ambiguous. Try using more characters to disambiguate.");
-    }
-
-    let target_id = &target_matches[0];
-
     // Validate --after flag usage
     if after {
         // Check if target is a branch (--after only makes sense for commit-to-commit moves)

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -11,6 +11,7 @@ pub mod eval_hook;
 pub(crate) mod git_config;
 pub mod gui;
 pub mod help;
+pub mod r#move;
 pub mod onboarding;
 pub mod push;
 pub mod skill;

--- a/crates/but/src/command/move.rs
+++ b/crates/but/src/command/move.rs
@@ -1,0 +1,81 @@
+use anyhow::Context as _;
+
+use crate::{CliId, IdMap, utils::OutputChannel};
+
+pub(crate) fn handle(
+    ctx: &mut but_ctx::Context,
+    out: &mut OutputChannel,
+    source: &str,
+    target: &str,
+    after: bool,
+) -> anyhow::Result<()> {
+    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let source_id =
+        resolve_single(&id_map, ctx, source, "Source").context("Failed to move commit.")?;
+    let target_id =
+        resolve_single(&id_map, ctx, target, "Target").context("Failed to move commit.")?;
+
+    let branch_route = matches!(
+        (&source_id, &target_id),
+        (
+            CliId::Branch { .. },
+            CliId::Branch { .. } | CliId::Unassigned { .. }
+        )
+    );
+
+    let move_result = if branch_route {
+        let (
+            CliId::Branch {
+                name: source_name, ..
+            },
+            target_id,
+        ) = (&source_id, &target_id)
+        else {
+            unreachable!("branch_route guarantees source is a branch")
+        };
+        if after {
+            // TODO: Allow to move branch after another below another branch.
+            Err(anyhow::anyhow!(
+                "The --after flag only makes sense when moving a commit to another commit."
+            ))
+        } else {
+            match target_id {
+                CliId::Unassigned { .. } => {
+                    super::branch::tear_off_branch_by_name(ctx, source_name, out)
+                }
+                CliId::Branch {
+                    name: target_name, ..
+                } => super::branch::move_branch_by_name(ctx, source_name, target_name, out),
+                _ => unreachable!("branch_route guarantees target is branch or unassigned"),
+            }
+        }
+    } else {
+        super::commit::r#move::handle_resolved(ctx, out, &source_id, &target_id, after)
+    };
+
+    if branch_route {
+        move_result.context("Failed to move branch.")
+    } else {
+        move_result.context("Failed to move commit.")
+    }
+}
+
+fn resolve_single(
+    id_map: &IdMap,
+    ctx: &but_ctx::Context,
+    selector: &str,
+    kind: &str,
+) -> anyhow::Result<CliId> {
+    let matches = id_map.parse_using_context(selector, ctx)?;
+    if matches.is_empty() {
+        anyhow::bail!(
+            "{kind} '{selector}' not found. If you just performed a Git operation, try running 'but status' to refresh."
+        );
+    }
+    if matches.len() > 1 {
+        anyhow::bail!(
+            "{kind} '{selector}' is ambiguous. Try using more characters to disambiguate."
+        );
+    }
+    Ok(matches[0].clone())
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -329,14 +329,6 @@ async fn match_subcommand(
 
             result.emit_metrics(metrics_ctx)
         }
-        Subcommands::Stack {
-            branch,
-            target_branch,
-        } => {
-            let ctx = but_ctx::Context::discover(&args.current_dir)?;
-            command::branch::move_branch(ctx, &branch, &target_branch, out)
-                .emit_metrics(metrics_ctx)
-        }
         Subcommands::Branch(branch::Platform { cmd }) => {
             let result = match cmd {
                 #[cfg(not(feature = "legacy"))]
@@ -434,16 +426,16 @@ async fn match_subcommand(
                     target_branch,
                     unstack,
                 }) => {
-                    let ctx = but_ctx::Context::discover(&args.current_dir)?;
+                    let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
                     if unstack {
-                        command::branch::tear_off_branch(ctx, &branch, out)
+                        command::branch::tear_off_branch(&mut ctx, &branch, out)
                     } else {
                         let target_branch = target_branch.ok_or_else(|| {
                             anyhow::anyhow!(
                                 "`but branch move` requires <TARGET_BRANCH> unless --unstack is used"
                             )
                         })?;
-                        command::branch::move_branch(ctx, &branch, &target_branch, out)
+                        command::branch::move_branch(&mut ctx, &branch, &target_branch, out)
                     }
                 }
             };
@@ -1392,17 +1384,15 @@ async fn match_subcommand(
                 .show_root_cause_error_then_exit_without_destructors(output)
         }
         Subcommands::Move {
-            source_commit,
+            source,
             target,
             after,
         } => {
             let status_after = args.status_after;
             let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
             out.begin_status_after(status_after);
-            let result =
-                command::commit::r#move::handle(&mut ctx, out, &source_commit, &target, after)
-                    .context("Failed to move commit.")
-                    .emit_metrics(metrics_ctx);
+            let result = command::r#move::handle(&mut ctx, out, &source, &target, after)
+                .emit_metrics(metrics_ctx);
             maybe_run_status_after(status_after, &result, &mut ctx, out).await;
             result.show_root_cause_error_then_exit_without_destructors(output)
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -87,7 +87,6 @@ impl Subcommands {
             Subcommands::Pull { .. } => Pull,
             #[cfg(feature = "legacy")]
             Subcommands::Fetch => Pull,
-            Subcommands::Stack { .. } => BranchMove,
             Subcommands::Branch(branch::Platform { cmd }) => match cmd {
                 None => BranchList,
                 #[cfg(feature = "legacy")]
@@ -209,7 +208,7 @@ impl Subcommands {
             Subcommands::Squash { .. } => Rub,
             #[cfg(feature = "legacy")]
             Subcommands::Merge { .. } => Merge,
-            Subcommands::Move { .. } => Rub,
+            Subcommands::Move { .. } => Move,
             #[cfg(feature = "legacy")]
             Subcommands::Pick { .. } => Pick,
             Subcommands::Skill(skill::Platform { cmd }) => match cmd {

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use snapbox::str;
 
 use crate::{
@@ -326,4 +327,339 @@ Moved files between commits!
     );
 
     Ok(())
+}
+
+#[test]
+fn move_branch_by_name_from_top_level_move() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("move A C").assert().success().stdout_eq(str![[r#"
+Moved branch 'A' on top of 'C'.
+
+"#]]);
+
+    let status_json = status_json(&env)?;
+    let layout = stack_branch_layout(&status_json)?;
+    assert_eq!(
+        layout,
+        vec![vec!["A".to_string(), "C".to_string(), "B".to_string()]]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   afff88e add A
+┊│
+┊├┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_branch_by_cli_id_from_top_level_move() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let initial_status = status_json(&env)?;
+    let source_branch_id = initial_status["stacks"][0]["branches"][0]["cliId"]
+        .as_str()
+        .context("Missing source branch cliId")?;
+    let target_branch_id = initial_status["stacks"][1]["branches"][0]["cliId"]
+        .as_str()
+        .context("Missing target branch cliId")?;
+
+    env.but(format!("move {source_branch_id} {target_branch_id}"))
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Moved branch 'A' on top of 'C'.
+
+"#]]);
+
+    let status_json = status_json(&env)?;
+    let layout = stack_branch_layout(&status_json)?;
+    assert_eq!(
+        layout,
+        vec![vec!["A".to_string(), "C".to_string(), "B".to_string()]]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   afff88e add A
+┊│
+┊├┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn tear_off_branch_with_top_level_move_to_zz() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("move C zz").assert().success().stdout_eq(str![[r#"
+Unstacked branch 'C'.
+
+"#]]);
+
+    let status_json = status_json(&env)?;
+    let mut all_branches = stack_branch_layout(&status_json)?
+        .into_iter()
+        .flat_map(|stack| {
+            assert_eq!(
+                stack.len(),
+                1,
+                "Each branch should be in its own stack after tear-off"
+            );
+            stack
+        })
+        .collect::<Vec<_>>();
+    all_branches.sort();
+
+    assert_eq!(
+        all_branches,
+        vec!["A".to_string(), "B".to_string(), "C".to_string()]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┊╭┄i0 [C]
+┊●   31e83cd add C
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_branch_with_after_flag_fails_from_top_level_move() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "two-stacks-one-single-and-ready-to-mingle-one-double",
+    )?;
+
+    env.setup_metadata(&["A", "B"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("move A C --after")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to move branch. The --after flag only makes sense when moving a commit to another commit.
+
+"#]]);
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unstaged changes]
+┊     no changes
+┊
+┊╭┄g0 [A]
+┊●   9477ae7 add A
+├╯
+┊
+┊╭┄h0 [C]
+┊●   3842fc0 add C
+┊│
+┊├┄i0 [B]
+┊●   d3e2ba3 add B
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    Ok(())
+}
+
+fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+    let output = env.but("--json status").allow_json().output()?;
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+fn stack_branch_layout(status_json: &serde_json::Value) -> anyhow::Result<Vec<Vec<String>>> {
+    status_json["stacks"]
+        .as_array()
+        .context("Missing stacks array")?
+        .iter()
+        .map(|stack| {
+            stack["branches"]
+                .as_array()
+                .context("Missing branches array")?
+                .iter()
+                .map(|branch| {
+                    branch["name"]
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .context("Missing branch name")
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .collect()
 }


### PR DESCRIPTION
Add support for moving branches using `but move`.
This unifies the move operations under a top-level command.
Add tests and update the skills reference.