### PR TITLE
Multi-process safety

### DIFF
--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 
 use but_api_macros::but_api;
-use but_core::{RefMetadata, ui::TreeChanges, worktree::checkout::UncommitedWorktreeChanges};
+use but_core::{
+    RefMetadata, sync::RepoExclusive, ui::TreeChanges,
+    worktree::checkout::UncommitedWorktreeChanges,
+};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
 use but_rebase::graph_rebase::Editor;
@@ -86,13 +89,33 @@ pub mod json {
     }
 }
 
-/// Apply `existing_branch` to the workspace in the repository that `ctx` refers to, or create the workspace with default name.
+/// Applies a branch using the behavior described by [`apply_only_with_perm()`].
+///
+/// This acquires exclusive worktree access from `ctx` before applying
+/// `existing_branch`.
 pub fn apply_only(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+    let mut guard = ctx.exclusive_worktree_access();
+    apply_only_with_perm(ctx, existing_branch, guard.write_permission())
+}
+
+/// Applies `existing_branch` to the current workspace under caller-held
+/// exclusive repository access.
+///
+/// It applies the branch with the default workspace-apply options, updates the
+/// in-memory workspace stored in `ctx` to the returned workspace state, and
+/// returns the apply outcome. This variant does not create an oplog
+/// entry. For lower-level implementation details, see
+/// [`but_workspace::branch::apply()`].
+pub fn apply_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    existing_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let out = but_workspace::branch::apply(
         existing_branch,
         &ws,
@@ -115,33 +138,57 @@ pub fn apply_only(
     Ok(out)
 }
 
-/// Just like [apply_only()], but will create an oplog entry as well on success.
+/// Applies `existing_branch` using the behavior described by
+/// [`apply_with_perm()`].
+///
+/// This acquires exclusive worktree access from `ctx`, applies
+/// `existing_branch`, and records an oplog snapshot on success.
 #[but_api(napi, json::ApplyOutcome)]
 #[instrument(err(Debug))]
 pub fn apply(
     ctx: &mut but_ctx::Context,
     existing_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
+    let mut guard = ctx.exclusive_worktree_access();
+    apply_with_perm(ctx, existing_branch, guard.write_permission())
+}
+
+/// Apply `existing_branch` to the workspace under caller-held exclusive
+/// repository access and record an oplog snapshot on success.
+///
+/// It behaves like [`apply_only_with_perm()`], but first prepares a best-effort
+/// oplog snapshot for a create-branch operation, annotated with the branch
+/// name, and commits that snapshot only if the apply succeeds. For lower-level
+/// implementation details, see [`but_workspace::branch::apply()`].
+pub fn apply_with_perm(
+    ctx: &mut but_ctx::Context,
+    existing_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<but_workspace::branch::apply::Outcome<'static>> {
     // NOTE: since this is optional by nature, the same would be true if snapshotting/undo would be disabled via `ctx` app settings, for instance.
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::CreateBranch).with_trailers(vec![Trailer {
             key: "name".into(),
             value: existing_branch.to_string(),
         }]),
+        perm.read_permission(),
     )
     .ok();
 
-    let res = apply_only(ctx, existing_branch);
+    let res = apply_only_with_perm(ctx, existing_branch, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     }
     res
 }
 
-/// Gets the changes for a given branch.
-#[but_api(napi, TreeChanges)]
+/// Computes the worktree-visible diff for `branch` in the current workspace.
+///
+/// `branch` is resolved by name in the repository referenced by `ctx`, and the
+/// diff is computed against the current workspace state. For lower-level
+/// implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
+#[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges> {
     let (_guard, repo, ws, _) = ctx.workspace_and_db()?;
@@ -149,7 +196,10 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
     but_workspace::ui::diff::changes_in_branch(&repo, &ws, branch.name())
 }
 
-/// Move a branch on top of another
+/// Moves a branch using the behavior described by [`move_branch_with_perm()`].
+///
+/// This acquires exclusive worktree access from `ctx`, moves `subject_branch`
+/// on top of `target_branch`, and records an oplog snapshot on success.
 #[but_api(napi, json::UIMoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn move_branch(
@@ -157,32 +207,47 @@ pub fn move_branch(
     subject_branch: &gix::refs::FullNameRef,
     target_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<MoveBranchResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    move_branch_with_perm(ctx, subject_branch, target_branch, guard.write_permission())
+}
+
+/// Move `subject_branch` on top of `target_branch` under caller-held
+/// exclusive repository access and record an oplog snapshot on success.
+///
+/// It prepares a best-effort move-branch oplog snapshot, rebases the subject
+/// branch onto the target branch, updates workspace metadata, and commits the
+/// snapshot only if the move succeeds. The returned [`MoveBranchResult`]
+/// contains the commit-id mapping produced by materializing the rebase. For
+/// lower-level implementation details, see
+/// [`but_workspace::branch::move_branch()`].
+pub fn move_branch_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+    target_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<MoveBranchResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveBranch),
+        perm.read_permission(),
     )
     .ok();
 
-    let move_branch_result = move_branch_impl(ctx, subject_branch, target_branch);
+    let move_branch_result = move_branch_impl_with_perm(ctx, subject_branch, target_branch, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| move_branch_result.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     }
     move_branch_result
 }
 
-/// Move the branch, updating the workspace and the metadata.
-///
-/// `subject_branch` - The branch to move.
-///
-/// `target_branch` - The branch to move `subject_branch` on top of.
-fn move_branch_impl(
+fn move_branch_impl_with_perm(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
     target_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
@@ -199,36 +264,55 @@ fn move_branch_impl(
     })
 }
 
-/// Take a branch out of a stack
+/// Tears off a branch using the behavior described by [`tear_off_branch_with_perm()`].
 ///
-/// `subject_branch` - The branch to take out of its stack, and create a new one out of.
+/// This acquires exclusive worktree access from `ctx`, tears `subject_branch`
+/// out of its current stack, and records an oplog snapshot on success.
 #[but_api(napi, json::UIMoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn tear_off_branch(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<MoveBranchResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    tear_off_branch_with_perm(ctx, subject_branch, guard.write_permission())
+}
+
+/// Removes `subject_branch` from its current stack, creating a new stack for
+/// it, under caller-held exclusive repository access.
+///
+/// It prepares a best-effort tear-off oplog snapshot, performs the tear-off
+/// rebase and workspace metadata update under `perm`, and commits the snapshot
+/// only if the mutation succeeds. The returned [`MoveBranchResult`] contains
+/// the commit-id mapping produced by materializing the rebase. For lower-level
+/// implementation details, see [`but_workspace::branch::tear_off_branch()`].
+pub fn tear_off_branch_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<MoveBranchResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::TearOffBranch),
+        perm.read_permission(),
     )
     .ok();
 
-    let move_branch_result = tear_off_branch_impl(ctx, subject_branch);
+    let move_branch_result = tear_off_branch_impl_with_perm(ctx, subject_branch, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| move_branch_result.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     }
     move_branch_result
 }
 
 /// Move the branch, updating the workspace and the metadata.
-fn tear_off_branch_impl(
+fn tear_off_branch_impl_with_perm(
     ctx: &mut but_ctx::Context,
     subject_branch: &gix::refs::FullNameRef,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;

--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -8,7 +8,10 @@ use tracing::instrument;
 
 use super::types::CommitCreateResult;
 
-/// Amends an existing commit with selected changes.
+/// Amends the commit at `commit_id` with `changes`.
+///
+/// See [`but_workspace::commit::commit_amend()`] for lower-level implementation
+/// details.
 #[but_api(crate::commit::json::UICommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_amend_only(
@@ -27,7 +30,6 @@ pub fn commit_amend_only(
     )
 }
 
-/// Amends an existing commit with selected changes.
 pub(crate) fn commit_amend_only_impl(
     ctx: &mut but_ctx::Context,
     commit_id: gix::ObjectId,
@@ -62,7 +64,12 @@ pub(crate) fn commit_amend_only_impl(
     })
 }
 
-/// Amends an existing commit with selected changes, with oplog support.
+/// Amend the commit at `commit_id` with `changes` and record an oplog snapshot on success.
+///
+/// This performs the rewrite under exclusive worktree access and creates a
+/// best-effort `AmendCommit` oplog entry if the operation succeeds. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::commit_amend()`].
 #[but_api(napi, crate::commit::json::UICommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_amend(

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -11,7 +11,12 @@ use tracing::instrument;
 
 use super::types::CommitCreateResult;
 
-/// Creates and inserts a commit relative to either a commit or a reference.
+/// Creates a commit from `changes` with `message`, inserted on `side` of
+/// `relative_to`.
+///
+/// This acquires exclusive worktree access from `ctx` before creating the
+/// commit. For lower-level implementation details, see
+/// [`but_workspace::commit::commit_create()`].
 #[but_api(crate::commit::json::UICommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_create_only(
@@ -78,7 +83,14 @@ pub(crate) fn commit_create_only_impl(
     })
 }
 
-/// Creates and inserts a commit relative to either a commit or a reference, with oplog support.
+/// Insert a new commit built from `changes` and record an oplog snapshot on
+/// success.
+///
+/// `relative_to` and `side` choose where the commit is inserted. `message` is
+/// the entire commit message text, not just the title. On success, this commits
+/// a best-effort `CreateCommit` oplog snapshot using the same lock. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::commit_create()`].
 #[but_api(napi, crate::commit::json::UICommitCreateResult)]
 #[instrument(skip_all, fields(relative_to, side, message), err(Debug))]
 pub fn commit_create(

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -1,20 +1,35 @@
 use but_api_macros::but_api;
+use but_core::sync::RepoExclusive;
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
 use but_rebase::graph_rebase::Editor;
 use tracing::instrument;
 
 use crate::commit::types::CommitDiscardResult;
 
-/// Discards a commit, no snapshots. No strings attached.
-///
-/// Returns the replaced commits that resulted from the operation.
+/// Discard `subject_commit_id` using the behavior described by
+/// [`commit_discard_only_with_perm()`].
 #[but_api(crate::commit::json::UICommitDiscardResult)]
 pub fn commit_discard_only(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
 ) -> anyhow::Result<CommitDiscardResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_discard_only_with_perm(ctx, subject_commit_id, guard.write_permission())
+}
+
+/// Discard `subject_commit_id` under caller-held exclusive repository access.
+///
+/// This materializes the discard rebase and returns the commit-ID mapping for
+/// rewritten descendants. This variant does not create an oplog entry. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::discard_commit()`].
+pub fn commit_discard_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitDiscardResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _) = ctx.workspace_mut_and_db()?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let rebase = but_workspace::commit::discard_commit(editor, subject_commit_id)?;
@@ -27,25 +42,44 @@ pub fn commit_discard_only(
     })
 }
 
-/// Discards a commit.
-///
-/// Returns the replaced commits that resulted from the operation.
+/// Discard `subject_commit_id` using the behavior described by
+/// [`commit_discard_with_perm()`].
 #[but_api(napi, crate::commit::json::UICommitDiscardResult)]
 #[instrument(err(Debug))]
 pub fn commit_discard(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
 ) -> anyhow::Result<CommitDiscardResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_discard_with_perm(ctx, subject_commit_id, guard.write_permission())
+}
+
+/// Discard `subject_commit_id` under caller-held exclusive repository access
+/// and record an oplog snapshot on success.
+///
+/// This prepares a best-effort `DiscardCommit` oplog snapshot annotated with
+/// `subject_commit_id`, discards the commit, and commits the snapshot only if
+/// the operation succeeds. For lower-level implementation details, see
+/// [`but_workspace::commit::discard_commit()`].
+pub fn commit_discard_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitDiscardResult> {
     let details = SnapshotDetails::new(OperationKind::DiscardCommit).with_trailers(vec![Trailer {
         key: "sha".to_string(),
         value: subject_commit_id.to_string(),
     }]);
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(ctx, details).ok();
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        details,
+        perm.read_permission(),
+    )
+    .ok();
 
-    let res = commit_discard_only(ctx, subject_commit_id);
+    let res = commit_discard_only_with_perm(ctx, subject_commit_id, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
     res
 }

--- a/crates/but-api/src/commit/insert_blank.rs
+++ b/crates/but-api/src/commit/insert_blank.rs
@@ -9,9 +9,9 @@ use tracing::instrument;
 
 use super::types::CommitInsertBlankResult;
 
-/// Inserts a blank commit relative to either a commit or a reference.
+/// Inserts a blank commit on `side` of `relative_to`.
 ///
-/// Returns the result including the new commit ID and any replaced commits.
+/// `side` chooses whether the blank commit lands before or after `relative_to`.
 #[but_api(crate::commit::json::UICommitInsertBlankResult)]
 #[instrument(err(Debug))]
 pub fn commit_insert_blank_only(
@@ -23,9 +23,6 @@ pub fn commit_insert_blank_only(
     commit_insert_blank_only_impl(ctx, relative_to, side, guard.write_permission())
 }
 
-/// Implementation of inserting a blank commit relative to either a commit or a reference.
-///
-/// Returns the result including the new commit ID and any replaced commits.
 pub(crate) fn commit_insert_blank_only_impl(
     ctx: &mut but_ctx::Context,
     relative_to: RelativeTo,
@@ -49,9 +46,10 @@ pub(crate) fn commit_insert_blank_only_impl(
     })
 }
 
-/// Inserts a blank commit relative to either a commit or a reference, with oplog support.
+/// Inserts a blank commit on `side` of `relative_to` and records an oplog
+/// snapshot on success.
 ///
-/// Returns the result including the new commit ID and any replaced commits.
+/// For details, see [`commit_insert_blank_with_perm()`].
 #[but_api(napi, crate::commit::json::UICommitInsertBlankResult)]
 #[instrument(err(Debug))]
 pub fn commit_insert_blank(
@@ -59,16 +57,34 @@ pub fn commit_insert_blank(
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitInsertBlankResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_insert_blank_with_perm(ctx, relative_to, side, guard.write_permission())
+}
+
+/// Create an empty commit next to `relative_to` under caller-held exclusive
+/// repository access and record an oplog snapshot on success.
+///
+/// `side` chooses whether the blank commit lands before or after `relative_to`.
+/// This prepares a best-effort `InsertBlankCommit` oplog snapshot, creates the
+/// commit, and commits the snapshot only if the operation succeeds. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::insert_blank_commit()`].
+pub fn commit_insert_blank_with_perm(
+    ctx: &mut but_ctx::Context,
+    relative_to: RelativeTo,
+    side: InsertSide,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitInsertBlankResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::InsertBlankCommit),
+        perm.read_permission(),
     )
     .ok();
 
-    let mut guard = ctx.exclusive_worktree_access();
-    let res = commit_insert_blank_only_impl(ctx, relative_to, side, guard.write_permission());
+    let res = commit_insert_blank_only_impl(ctx, relative_to, side, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
     res
 }

--- a/crates/but-api/src/commit/move_changes.rs
+++ b/crates/but-api/src/commit/move_changes.rs
@@ -1,17 +1,17 @@
 use but_api_macros::but_api;
+use but_core::sync::RepoExclusive;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::Editor;
 use tracing::instrument;
 
 use super::types::MoveChangesResult;
 
-/// Moves changes between two commits.
+/// Moves `changes` from `source_commit_id` to `destination_commit_id`.
 ///
-/// Returns where the source and destination commits were mapped to.
+/// This acquires exclusive worktree access from `ctx` before moving the
+/// changes.
 ///
-/// TODO(CTO): Create a way of extracting _all_ mapped commits. Copoilot, have
-/// made linear ticket GB-980 for this. I will do this in a follow up PR. Please
-/// don't complain.
+/// For details, see [`commit_move_changes_between_only_with_perm()`].
 #[but_api(crate::commit::json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_move_changes_between_only(
@@ -20,9 +20,32 @@ pub fn commit_move_changes_between_only(
     destination_commit_id: gix::ObjectId,
     changes: Vec<but_core::DiffSpec>,
 ) -> anyhow::Result<MoveChangesResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_move_changes_between_only_with_perm(
+        ctx,
+        source_commit_id,
+        destination_commit_id,
+        changes,
+        guard.write_permission(),
+    )
+}
+
+/// Move `changes` from `source_commit_id` into `destination_commit_id`
+/// under caller-held exclusive repository access.
+///
+/// It materializes the move-changes rebase and returns the replaced-commit
+/// mapping. For lower-level implementation details, see
+/// [`but_workspace::commit::move_changes_between_commits()`].
+pub fn commit_move_changes_between_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    source_commit_id: gix::ObjectId,
+    destination_commit_id: gix::ObjectId,
+    changes: Vec<but_core::DiffSpec>,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let outcome = but_workspace::commit::move_changes_between_commits(
@@ -39,9 +62,13 @@ pub fn commit_move_changes_between_only(
     })
 }
 
-/// Moves changes between two commits.
+/// Moves `changes` from `source_commit_id` to `destination_commit_id` and
+/// records an oplog snapshot on success.
 ///
-/// Returns where the source and destination commits were mapped to.
+/// This acquires exclusive worktree access from `ctx` before moving the
+/// changes.
+///
+/// For details, see [`commit_move_changes_between_with_perm()`].
 #[but_api(napi, crate::commit::json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_move_changes_between(
@@ -50,17 +77,47 @@ pub fn commit_move_changes_between(
     destination_commit_id: gix::ObjectId,
     changes: Vec<but_core::DiffSpec>,
 ) -> anyhow::Result<MoveChangesResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_move_changes_between_with_perm(
+        ctx,
+        source_commit_id,
+        destination_commit_id,
+        changes,
+        guard.write_permission(),
+    )
+}
+
+/// Move `changes` from `source_commit_id` into `destination_commit_id`
+/// under caller-held exclusive repository access and record an oplog snapshot
+/// on success.
+///
+/// This prepares a best-effort `MoveCommitFile` oplog snapshot, performs the
+/// rebase, and commits the snapshot only if the operation succeeds. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::move_changes_between_commits()`].
+pub fn commit_move_changes_between_with_perm(
+    ctx: &mut but_ctx::Context,
+    source_commit_id: gix::ObjectId,
+    destination_commit_id: gix::ObjectId,
+    changes: Vec<but_core::DiffSpec>,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<MoveChangesResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveCommitFile),
+        perm.read_permission(),
     )
     .ok();
 
-    let res =
-        commit_move_changes_between_only(ctx, source_commit_id, destination_commit_id, changes);
+    let res = commit_move_changes_between_only_with_perm(
+        ctx,
+        source_commit_id,
+        destination_commit_id,
+        changes,
+        perm,
+    );
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
     res
 }

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -1,4 +1,5 @@
 use but_api_macros::but_api;
+use but_core::sync::RepoExclusive;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{
     Editor,
@@ -8,9 +9,12 @@ use tracing::instrument;
 
 use super::types::CommitMoveResult;
 
-/// Moves commit, no snapshots. No strings attached.
+/// Moves `subject_commit_id` to `side` of `relative_to`.
 ///
-/// Returns the replaced that resulted from the operation.
+/// This acquires exclusive worktree access from `ctx` before moving the
+/// commit.
+///
+/// For details, see [`commit_move_only_with_perm()`].
 #[but_api(crate::commit::json::UICommitMoveResult)]
 pub fn commit_move_only(
     ctx: &mut but_ctx::Context,
@@ -18,8 +22,31 @@ pub fn commit_move_only(
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitMoveResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_move_only_with_perm(
+        ctx,
+        subject_commit_id,
+        relative_to,
+        side,
+        guard.write_permission(),
+    )
+}
+
+/// Move `subject_commit_id` to the `side` of `relative_to` under
+/// caller-held exclusive repository access.
+///
+/// This materializes the rebase and returns the commit-ID mapping for rewritten
+/// descendants. This variant does not create an oplog entry. For lower-level
+/// implementation details, see [`but_workspace::commit::move_commit()`].
+pub fn commit_move_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    relative_to: RelativeTo,
+    side: InsertSide,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitMoveResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let rebase = but_workspace::commit::move_commit(editor, subject_commit_id, relative_to, side)?;
@@ -31,9 +58,13 @@ pub fn commit_move_only(
     })
 }
 
-/// Moves a commit within or across stacks.
+/// Moves `subject_commit_id` to `side` of `relative_to` and records an oplog
+/// snapshot on success.
 ///
-/// Returns the replaced that resulted from the operation.
+/// This acquires exclusive worktree access from `ctx` before moving the
+/// commit.
+///
+/// For details, see [`commit_move_with_perm()`].
 #[but_api(napi, crate::commit::json::UICommitMoveResult)]
 #[instrument(err(Debug))]
 pub fn commit_move(
@@ -42,16 +73,39 @@ pub fn commit_move(
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<CommitMoveResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_move_with_perm(
+        ctx,
+        subject_commit_id,
+        relative_to,
+        side,
+        guard.write_permission(),
+    )
+}
+
+/// Moves `subject_commit_id` to `side` of `relative_to` under caller-held
+/// exclusive repository access and records an oplog snapshot on success.
+///
+/// It prepares a best-effort `MoveCommit` oplog snapshot, performs the move,
+/// and commits the snapshot only if the operation succeeds. For lower-level
+/// implementation details, see [`but_workspace::commit::move_commit()`].
+pub fn commit_move_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    relative_to: RelativeTo,
+    side: InsertSide,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitMoveResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveCommit),
+        perm.read_permission(),
     )
     .ok();
 
-    let res = commit_move_only(ctx, subject_commit_id, relative_to, side);
+    let res = commit_move_only_with_perm(ctx, subject_commit_id, relative_to, side, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
     res
 }

--- a/crates/but-api/src/commit/reword.rs
+++ b/crates/but-api/src/commit/reword.rs
@@ -1,14 +1,20 @@
 use bstr::{BString, ByteSlice};
 use but_api_macros::but_api;
+use but_core::sync::RepoExclusive;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{Editor, LookupStep as _};
 use tracing::instrument;
 
 use super::types::CommitRewordResult;
 
-/// Rewords a commit.
+/// Replace the title and message of `commit_id` with `message`.
 ///
-/// Returns the result including the new commit ID and any replaced commits.
+/// This acquires exclusive worktree access from `ctx` before rewriting the
+/// commit message.
+///
+/// `message` must be the full commit message payload: the title line, and when a
+/// body is present, `\n\n` followed by the body.
+/// See [`commit_reword_only_with_perm()`] for details.
 #[but_api(crate::commit::json::UICommitRewordResult)]
 #[instrument(err(Debug))]
 pub fn commit_reword_only(
@@ -16,8 +22,24 @@ pub fn commit_reword_only(
     commit_id: gix::ObjectId,
     message: BString,
 ) -> anyhow::Result<CommitRewordResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_reword_only_with_perm(ctx, commit_id, message, guard.write_permission())
+}
+
+/// Replace the stored message of `commit_id` under caller-held exclusive
+/// repository access.
+///
+/// It materializes the reword rebase and returns the new commit id plus the
+/// replaced-commit mapping. This variant does not create an oplog entry. For
+/// lower-level implementation details, see [`but_workspace::commit::reword()`].
+pub fn commit_reword_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    message: BString,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitRewordResult> {
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let (outcome, edited_commit_selector) =
@@ -33,9 +55,11 @@ pub fn commit_reword_only(
     })
 }
 
-/// Rewords a commit, with oplog support.
+/// Reword `commit_id` to `message` using the behavior described by
+/// [`commit_reword_with_perm()`].
 ///
-/// Returns the result including the new commit ID and any replaced commits.
+/// This acquires exclusive worktree access from `ctx` before rewriting the
+/// commit message and recording the oplog entry.
 #[but_api(napi, crate::commit::json::UICommitRewordResult)]
 #[instrument(err(Debug))]
 pub fn commit_reword(
@@ -43,16 +67,32 @@ pub fn commit_reword(
     commit_id: gix::ObjectId,
     message: BString,
 ) -> anyhow::Result<CommitRewordResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_reword_with_perm(ctx, commit_id, message, guard.write_permission())
+}
+
+/// Rewords `commit_id` to `message` under caller-held exclusive repository
+/// access and records an oplog snapshot on success.
+///
+/// It prepares a best-effort `UpdateCommitMessage` oplog snapshot, performs
+/// the reword, and commits the snapshot only if the operation succeeds. For
+/// lower-level implementation details, see [`but_workspace::commit::reword()`].
+pub fn commit_reword_with_perm(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    message: BString,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitRewordResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::UpdateCommitMessage),
+        perm.read_permission(),
     )
     .ok();
 
-    let res = commit_reword_only(ctx, commit_id, message);
+    let res = commit_reword_only_with_perm(ctx, commit_id, message, perm);
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
     res
 }

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -11,11 +11,10 @@ use super::types::MoveChangesResult;
 /// Uncommits changes from a commit (removes them from the commit tree) without
 /// performing a checkout.
 ///
-/// This has the practical effect of leaving the changes that were in the commit
-/// as uncommitted changes in the worktree.
+/// This acquires exclusive worktree access from `ctx` before extracting the
+/// changes.
 ///
-/// If `assign_to` is provided, the newly uncommitted changes will be assigned
-/// to the specified stack.
+/// See [`commit_uncommit_changes_only_with_perm()`] for details.
 #[but_api(crate::commit::json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_uncommit_changes_only(
@@ -24,9 +23,33 @@ pub fn commit_uncommit_changes_only(
     changes: Vec<but_core::DiffSpec>,
     assign_to: Option<but_core::ref_metadata::StackId>,
 ) -> anyhow::Result<MoveChangesResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_uncommit_changes_only_with_perm(
+        ctx,
+        commit_id,
+        changes,
+        assign_to,
+        guard.write_permission(),
+    )
+}
+
+/// Extract `changes` from `commit_id` without performing a checkout, under
+/// caller-held exclusive repository access.
+///
+/// The removed diff stays in the workspace as uncommitted changes. When
+/// `assign_to` is set, newly surfaced hunks are reassigned to that stack after
+/// the rebase is materialized. For lower-level implementation details, see
+/// [`but_workspace::commit::uncommit_changes()`].
+pub fn commit_uncommit_changes_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    changes: Vec<but_core::DiffSpec>,
+    assign_to: Option<but_core::ref_metadata::StackId>,
+    perm: &mut but_ctx::access::RepoExclusive,
+) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
     let mut meta = ctx.meta()?;
-    let (_guard, repo, mut ws, mut db, _cache) = ctx.workspace_mut_and_db_mut_and_cache()?;
+    let (repo, mut ws, mut db, _cache) = ctx.workspace_mut_and_db_mut_and_cache_with_perm(perm)?;
 
     let before_assignments = if assign_to.is_some() {
         let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
@@ -85,10 +108,12 @@ pub fn commit_uncommit_changes_only(
     })
 }
 
-/// Uncommits changes from a commit, with oplog and optional assign_to support.
+/// Extract `changes` from `commit_id` and record the rewrite in the oplog.
 ///
-/// If `assign_to` is provided, the newly uncommitted changes will be assigned
-/// to the specified stack.
+/// This acquires exclusive worktree access from `ctx` before extracting the
+/// changes.
+///
+/// See [`commit_uncommit_changes_with_perm()`] for details.
 #[but_api(napi, crate::commit::json::UIMoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_uncommit_changes(
@@ -97,17 +122,36 @@ pub fn commit_uncommit_changes(
     changes: Vec<but_core::DiffSpec>,
     assign_to: Option<but_core::ref_metadata::StackId>,
 ) -> anyhow::Result<MoveChangesResult> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details(
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_uncommit_changes_with_perm(ctx, commit_id, changes, assign_to, guard.write_permission())
+}
+
+/// Extract `changes` from `commit_id` under caller-held exclusive repository
+/// access and record an oplog snapshot on success.
+///
+/// When `assign_to` is set, newly surfaced hunks are assigned to that stack
+/// after the rebase is materialized. This prepares a best-effort
+/// `DiscardChanges` oplog snapshot and commits it only if the operation
+/// succeeds. For lower-level implementation details, see
+/// [`but_workspace::commit::uncommit_changes()`].
+pub fn commit_uncommit_changes_with_perm(
+    ctx: &mut but_ctx::Context,
+    commit_id: gix::ObjectId,
+    changes: Vec<but_core::DiffSpec>,
+    assign_to: Option<but_core::ref_metadata::StackId>,
+    perm: &mut but_ctx::access::RepoExclusive,
+) -> anyhow::Result<MoveChangesResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::DiscardChanges),
+        perm.read_permission(),
     )
     .ok();
 
-    let res = commit_uncommit_changes_only(ctx, commit_id, changes, assign_to);
+    let res = commit_uncommit_changes_only_with_perm(ctx, commit_id, changes, assign_to, perm);
 
     if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
-        let mut guard = ctx.exclusive_worktree_access();
-        snapshot.commit(ctx, guard.write_permission()).ok();
+        snapshot.commit(ctx, perm).ok();
     };
 
     res

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -55,7 +55,11 @@ pub mod json {
     }
 }
 
-/// Compute the tree-diff for `commit_id` with its first parent and optionally calculate `line_stats`.
+/// Computes the tree diff for `commit_id` against its first parent and
+/// optionally calculates `line_stats`.
+///
+/// For lower-level implementation details, see
+/// [`but_core::diff::CommitDetails::from_commit_id()`].
 #[but_api(json::CommitDetails)]
 #[instrument(err(Debug))]
 pub fn commit_details(
@@ -67,7 +71,10 @@ pub fn commit_details(
     CommitDetails::from_commit_id(commit_id.attach(&repo), line_stats.into())
 }
 
-/// This function just exists for the frontend to work without the need for line-stats to be enabled explicitly.
+/// Computes commit details for `commit_id` with line statistics enabled.
+///
+/// This exists for callers that always want line statistics without passing
+/// `line_stats` explicitly.
 #[but_api(napi, json::CommitDetails)]
 #[instrument(err(Debug))]
 pub fn commit_details_with_line_stats(
@@ -77,8 +84,10 @@ pub fn commit_details_with_line_stats(
     commit_details(ctx, commit_id, ComputeLineStats::Yes)
 }
 
-/// Provide a unified diff for `change`, but fail if `change` is a [type-change](but_core::ModeFlags::TypeChange)
-/// or if it involves a change to a [submodule](gix::object::Kind::Commit).
+/// Produces a unified patch for `change`.
+///
+/// `change` must not be a type change or a submodule change. For lower-level
+/// implementation details, see [`but_core::TreeChange::unified_patch()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn tree_change_diffs(
@@ -107,6 +116,11 @@ pub fn changes_in_worktree(ctx: &mut Context) -> anyhow::Result<WorktreeChanges>
 /// * conflicts are ignored
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
+///
+/// For lower-level implementation details, see
+/// [`but_core::diff::worktree_changes()`],
+/// [`but_hunk_assignment::assignments_with_fallback()`], and
+/// [`but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir()`].
 #[but_api(napi)]
 #[instrument(skip_all, err(Debug))]
 pub fn changes_in_worktree_with_perm(
@@ -153,9 +167,11 @@ pub fn changes_in_worktree_with_perm(
     })
 }
 
-/// Persist hunk-to-commit assignments for the current workspace.
+/// Persists `assignments` for the current workspace.
 ///
-/// `assignments` is a list of hunk assignment requests produced by the UI.
+/// `assignments` is applied against the current workspace state and stored in
+/// the hunk-assignment database. For lower-level implementation details, see
+/// [`but_hunk_assignment::assign()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn assign_hunk(

--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -4,7 +4,7 @@ use but_github::{AuthStatusResponse, AuthenticatedUser, Verification, json};
 use but_secret::Sensitive;
 use tracing::instrument;
 
-/// Initiates the GitHub device OAuth flow.
+/// Starts the GitHub device OAuth flow.
 ///
 /// This starts the OAuth device authorization flow, which allows users to authenticate
 /// by visiting a URL and entering a code. Returns verification details including the
@@ -14,6 +14,9 @@ use tracing::instrument;
 ///
 /// * `Ok(Verification)` - Contains the user code, device code, and verification URL
 /// * `Err(_)` - If the OAuth initialization request fails
+///
+/// For lower-level implementation details,
+/// see [`but_github::init_github_device_oauth()`].
 #[but_api]
 #[instrument(err(Debug))]
 pub async fn init_github_device_oauth() -> Result<Verification> {
@@ -33,6 +36,8 @@ pub async fn init_github_device_oauth() -> Result<Verification> {
 ///
 /// * `Ok(AuthStatusResponse)` - User is authenticated, contains access token and user details
 /// * `Err(_)` - If the authorization is pending, denied, or the request fails
+///
+/// For lower-level implementation details, see [`but_github::check_github_auth_status()`].
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusResponse> {

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -26,13 +26,18 @@ use itertools::Itertools;
 use tracing::instrument;
 
 use crate::{
-    commit::insert_blank::commit_insert_blank_only_impl, diff::changes_in_worktree,
+    commit::insert_blank::commit_insert_blank_only_impl,
     legacy::workspace::amend_commit_and_count_failures,
 };
 
-/// Absorb multiple changes into their target commits as per the provided absorption plan.
+/// Absorb the changes described by `absorption_plan` using the behavior documented by
+/// [`absorb_with_perm()`].
 ///
-/// Returns the total amount of rejected diff specs.
+/// This acquires exclusive worktree access from `ctx` before creating the
+/// snapshot and rewriting commits.
+///
+/// Before applying the plan, this records an `Absorb` oplog snapshot and refreshes the
+/// synthetic workspace commit after the rewritten commits are in place.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyhow::Result<usize> {
@@ -101,19 +106,37 @@ pub fn absorb_with_perm(
     Ok(total_rejected)
 }
 
-/// Generate an absorption plan based on the provided target, based on hunk dependencies, assignments and other heuristics
+/// Build an absorption plan for `target` using the behavior documented by
+/// [`absorption_plan_with_perm()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn absorption_plan(
     ctx: &mut Context,
     target: AbsorptionTarget,
 ) -> anyhow::Result<Vec<CommitAbsorption>> {
+    let mut guard = ctx.exclusive_worktree_access();
+    absorption_plan_with_perm(ctx, target, guard.write_permission())
+}
+
+/// Build an absorption plan for `target` while reusing the exclusive repository access
+/// in `perm`.
+///
+/// Depending on `target`, this reads assigned worktree changes, stack state, and hunk
+/// dependencies under the same locked view, then groups the selected hunks by destination
+/// commit for display and later absorption.
+///
+/// The worktree inspection is driven by [`crate::diff::changes_in_worktree_with_perm()`].
+pub fn absorption_plan_with_perm(
+    ctx: &mut Context,
+    target: AbsorptionTarget,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<Vec<CommitAbsorption>> {
     let (assignments, dependencies) = match target {
         AbsorptionTarget::Branch { branch_name } => {
             // Get all worktree changes, assignments, and dependencies
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
-            let worktree_changes = changes_in_worktree(ctx)?;
+            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -150,7 +173,7 @@ pub fn absorption_plan(
             assigned_stack_id,
         } => {
             // Get all worktree changes, assignments, and dependencies
-            let worktree_changes = changes_in_worktree(ctx)?;
+            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
@@ -172,30 +195,24 @@ pub fn absorption_plan(
         }
         AbsorptionTarget::HunkAssignments { assignments } => {
             // Compute hunk dependencies only for this target since changes_in_worktree isn't called
-            let (_read_guard, repo, ws, _db) = ctx.workspace_and_db()?;
+            let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
             let dependencies =
                 hunk_dependencies_for_workspace_changes_by_worktree_dir(&repo, &ws, None).ok();
-            drop((_read_guard, repo, ws, _db));
+            drop((repo, ws, _db));
             (assignments, dependencies)
         }
         AbsorptionTarget::All => {
             // Get all worktree changes, assignments, and dependencies
             // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
             // At this time, the context is passed pretty deep into the function.
-            let worktree_changes = changes_in_worktree(ctx)?;
+            let worktree_changes = crate::diff::changes_in_worktree_with_perm(ctx, perm)?;
             (worktree_changes.assignments, worktree_changes.dependencies)
         }
     };
 
-    let mut guard = ctx.exclusive_worktree_access();
-
     // Group all changes by their target commit
-    let changes_by_commit = group_changes_by_target_commit(
-        ctx,
-        &assignments,
-        dependencies.as_ref(),
-        guard.write_permission(),
-    )?;
+    let changes_by_commit =
+        group_changes_by_target_commit(ctx, &assignments, dependencies.as_ref(), perm)?;
 
     // Prepare commit absorptions for display
     let commit_absorptions = prepare_commit_absorptions(ctx, changes_by_commit)?;

--- a/crates/but-api/src/legacy/cherry_apply.rs
+++ b/crates/but-api/src/legacy/cherry_apply.rs
@@ -4,18 +4,38 @@ use but_cherry_apply::CherryApplyStatus;
 use gitbutler_stack::StackId;
 use tracing::instrument;
 
-/// Return the cherry-pick applicability of `subject` in the current workspace state.
+/// Return the cherry-pick applicability of `subject` using the behavior documented by
+/// [`cherry_apply_status_with_perm()`].
+///
+/// This acquires exclusive worktree access from `ctx` before reading the
+/// workspace state used for the applicability check.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn cherry_apply_status(
     ctx: &mut but_ctx::Context,
     subject: gix::ObjectId,
 ) -> Result<CherryApplyStatus> {
-    let guard = ctx.exclusive_worktree_access();
-    but_cherry_apply::cherry_apply_status(ctx, guard.read_permission(), subject)
+    let guard = ctx.shared_worktree_access();
+    cherry_apply_status_with_perm(ctx, subject, guard.read_permission())
 }
 
-/// Cherry-pick `subject` into the stack identified by `target`.
+/// Return the cherry-pick applicability of `subject` while reusing the shared repository
+/// access in `perm`.
+///
+/// This reports whether `subject` can be applied in the current workspace state using
+/// [`but_cherry_apply::cherry_apply_status()`].
+pub fn cherry_apply_status_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject: gix::ObjectId,
+    perm: &but_core::sync::RepoShared,
+) -> Result<CherryApplyStatus> {
+    but_cherry_apply::cherry_apply_status(ctx, perm, subject)
+}
+
+/// Cherry-pick `subject` into the stack identified by `target` using the behavior
+/// documented by [`cherry_apply_with_perm()`].
+///
+/// This acquires exclusive worktree access from `ctx` before applying the commit.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn cherry_apply(
@@ -24,6 +44,18 @@ pub fn cherry_apply(
     target: StackId,
 ) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
+    cherry_apply_with_perm(ctx, subject, target, guard.write_permission())
+}
 
-    but_cherry_apply::cherry_apply(ctx, guard.write_permission(), subject, target)
+/// Cherry-pick `subject` into the stack identified by `target` while reusing the
+/// exclusive repository access in `perm`.
+///
+/// The actual apply operation is performed by [`but_cherry_apply::cherry_apply()`].
+pub fn cherry_apply_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject: gix::ObjectId,
+    target: StackId,
+    perm: &mut but_core::sync::RepoExclusive,
+) -> Result<()> {
+    but_cherry_apply::cherry_apply(ctx, perm, subject, target)
 }

--- a/crates/but-api/src/legacy/cherry_apply.rs
+++ b/crates/but-api/src/legacy/cherry_apply.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 /// Return the cherry-pick applicability of `subject` using the behavior documented by
 /// [`cherry_apply_status_with_perm()`].
 ///
-/// This acquires exclusive worktree access from `ctx` before reading the
+/// This acquires shared worktree access from `ctx` before reading the
 /// workspace state used for the applicability check.
 #[but_api]
 #[instrument(err(Debug))]

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -38,6 +38,13 @@ pub mod create_reference {
     }
 }
 
+/// Create the local branch reference described by `request`.
+///
+/// This acquires exclusive worktree access from `ctx` before normalizing and
+/// creating the reference.
+///
+/// See [`create_reference_with_perm()`] for how `request` is normalized and
+/// applied through [`but_workspace::branch::create_reference()`].
 #[but_api]
 #[instrument(err(Debug))]
 pub fn create_reference(
@@ -57,8 +64,7 @@ pub fn create_reference(
 /// Returns the stack id owning the created or attached reference when one exists, together with
 /// the full refname that was created.
 ///
-/// This variant is more composable than [`create_reference()`] when the caller already holds a lock,
-/// as it reuses the provided permission token instead of obtaining exclusive access itself.
+/// The underlying implementation is [`but_workspace::branch::create_reference()`],
 #[but_api]
 #[instrument(skip(ctx, perm), err(Debug))]
 pub fn create_reference_with_perm(
@@ -116,6 +122,11 @@ pub fn create_reference_with_perm(
     Ok((stack_id, new_ref))
 }
 
+/// Create a dependent branch named by `request.name` in the stack identified by
+/// `stack_id`.
+///
+/// This acquires exclusive worktree access from `ctx` before creating the
+/// dependent-branch snapshot and mutating the workspace.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn create_branch(
@@ -211,18 +222,41 @@ pub fn remove_branch_only(
 
 /// Remove a branch from a stack.
 ///
+/// This acquires exclusive worktree access from `ctx` before creating the
+/// removal snapshot and detaching the branch.
+///
 /// This can only be called on a branch that's inside of a stack of multiple branches and is not the top branch,
 /// or on a branch that's empty.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn remove_branch(ctx: &mut Context, stack_id: StackId, branch_name: String) -> Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.snapshot_remove_dependent_branch(&branch_name, guard.write_permission())
-        .ok();
-    remove_branch_only(ctx, &branch_name, guard.write_permission())
+    remove_branch_with_perm(ctx, stack_id, branch_name, guard.write_permission())
 }
 
-/// Rename a branch
+/// Remove a branch from a stack while reusing caller-held exclusive access.
+///
+/// This records the dependent-branch removal snapshot and then delegates to
+/// [`remove_branch_only()`] for the actual workspace mutation.
+pub fn remove_branch_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    branch_name: String,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    let _ = stack_id;
+    ctx.snapshot_remove_dependent_branch(&branch_name, perm)
+        .ok();
+    remove_branch_only(ctx, &branch_name, perm)
+}
+
+/// Change the branch name from `branch_name` to `new_name` in the stack
+/// identified by `stack_id`.
+///
+/// This acquires exclusive worktree access from `ctx` before applying the
+/// rename.
+///
+/// See [`update_branch_name_with_perm()`] for the underlying mutation.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn update_branch_name(
@@ -231,7 +265,36 @@ pub fn update_branch_name(
     branch_name: String,
     new_name: String,
 ) -> Result<()> {
-    gitbutler_branch_actions::stack::update_branch_name(ctx, stack_id, branch_name, new_name)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    update_branch_name_with_perm(
+        ctx,
+        stack_id,
+        branch_name,
+        new_name,
+        guard.write_permission(),
+    )?;
+    Ok(())
+}
+
+/// Apply the rename from `branch_name` to `new_name` in the stack identified by
+/// `stack_id` while reusing caller-held exclusive access.
+///
+/// This delegates to
+/// [`gitbutler_branch_actions::stack::update_branch_name_with_perm()`].
+pub fn update_branch_name_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    branch_name: String,
+    new_name: String,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    gitbutler_branch_actions::stack::update_branch_name_with_perm(
+        ctx,
+        stack_id,
+        branch_name,
+        new_name,
+        perm,
+    )?;
     Ok(())
 }
 

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -419,9 +419,8 @@ pub fn squash_commits(
     Ok(())
 }
 
-/// by `stack_id` while reusing caller-held exclusive access.
-/// Squash `source_commit_ids` into `target_commit_id` within the stack identified by `stack_id`
-/// while reusing caller-held exclusive access.
+/// Squash `source_commit_ids` into `target_commit_id` within the stack identified by `stack_id`,
+/// reusing caller-held exclusive access.
 ///
 /// This delegates to [`gitbutler_branch_actions::squash_commits_with_perm()`].
 pub fn squash_commits_with_perm(

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -101,6 +101,14 @@ pub fn delete_local_branch(
     Ok(())
 }
 
+/// Turn `branch` into an applied virtual branch, optionally associating
+/// `remote` and `pr_number`.
+///
+/// This acquires exclusive worktree access from `ctx` before applying the
+/// branch in the workspace.
+///
+/// See [`create_virtual_branch_from_branch_with_perm()`] for the underlying
+/// mutation.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn create_virtual_branch_from_branch(
@@ -109,8 +117,31 @@ pub fn create_virtual_branch_from_branch(
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
 ) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome> {
-    let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch(
-        ctx, &branch, remote, pr_number,
+    let mut guard = ctx.exclusive_worktree_access();
+    let outcome = create_virtual_branch_from_branch_with_perm(
+        ctx,
+        &branch,
+        remote,
+        pr_number,
+        guard.write_permission(),
+    )?;
+    Ok(outcome)
+}
+
+/// Turn `branch` into an applied virtual branch, optionally associating
+/// `remote` and `pr_number`, while reusing caller-held exclusive access.
+///
+/// This delegates to
+/// [`gitbutler_branch_actions::create_virtual_branch_from_branch_with_perm()`].
+pub fn create_virtual_branch_from_branch_with_perm(
+    ctx: &mut but_ctx::Context,
+    branch: &Refname,
+    remote: Option<RemoteRefname>,
+    pr_number: Option<usize>,
+    perm: &mut RepoExclusive,
+) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome> {
+    let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch_with_perm(
+        ctx, branch, remote, pr_number, perm,
     )?;
     Ok(outcome.into())
 }
@@ -161,6 +192,10 @@ pub fn integrate_branch_with_steps(
     gitbutler_branch_actions::integrate_branch_with_steps(ctx, stack_id, branch_name, steps)
 }
 
+/// Switch back to the workspace branch state.
+///
+/// This acquires exclusive worktree access from `ctx` before restoring the
+/// workspace branch.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn switch_back_to_workspace(ctx: &mut but_ctx::Context) -> Result<BaseBranch> {
@@ -201,6 +236,10 @@ pub fn get_base_branch_data(ctx: &but_ctx::Context) -> Result<Option<BaseBranch>
     }
 }
 
+/// Set the base branch to `branch`, optionally updating `push_remote` as well.
+///
+/// This acquires exclusive worktree access from `ctx` before updating the base
+/// branch state.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn set_base_branch(
@@ -258,9 +297,30 @@ pub fn update_stack_order(
 
 #[but_api(napi)]
 #[instrument(err(Debug))]
+/// Take the stack identified by `stack_id` out of the workspace.
+///
+/// This acquires exclusive worktree access from `ctx` before collecting the
+/// assigned changes and unapplying the stack.
+///
+/// See [`unapply_stack_with_perm()`] for how assigned changes are collected before
+/// delegating to the underlying mutation.
 pub fn unapply_stack(ctx: &mut Context, stack_id: StackId) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    unapply_stack_with_perm(ctx, stack_id, guard.write_permission())
+}
+
+/// Take the stack identified by `stack_id` out of the workspace while reusing
+/// caller-held exclusive access.
+///
+/// This computes the currently assigned diffspecs for `stack_id` from the
+/// workspace and then delegates to [`gitbutler_branch_actions::unapply_stack()`].
+pub fn unapply_stack_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
     let context_lines = ctx.settings.context_lines;
-    let (mut guard, repo, ws, mut db) = ctx.workspace_mut_and_db_mut()?;
+    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
         db.hunk_assignments_mut()?,
         &repo,
@@ -276,12 +336,7 @@ pub fn unapply_stack(ctx: &mut Context, stack_id: StackId) -> Result<()> {
             .collect::<Vec<DiffSpec>>(),
     );
     drop((repo, ws, db));
-    gitbutler_branch_actions::unapply_stack(
-        ctx,
-        guard.write_permission(),
-        stack_id,
-        assigned_diffspec,
-    )?;
+    gitbutler_branch_actions::unapply_stack(ctx, perm, stack_id, assigned_diffspec)?;
     Ok(())
 }
 
@@ -340,6 +395,11 @@ pub fn get_branch_listing_details(
 }
 
 /// Squash `source_commit_ids` into `target_commit_id` within the stack identified by `stack_id`.
+///
+/// This acquires exclusive worktree access from `ctx` before rewriting the
+/// stack.
+///
+/// See [`squash_commits_with_perm()`] for the underlying mutation.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn squash_commits(
@@ -348,7 +408,36 @@ pub fn squash_commits(
     source_commit_ids: Vec<gix::ObjectId>,
     target_commit_id: gix::ObjectId,
 ) -> Result<()> {
-    gitbutler_branch_actions::squash_commits(ctx, stack_id, source_commit_ids, target_commit_id)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    squash_commits_with_perm(
+        ctx,
+        stack_id,
+        source_commit_ids,
+        target_commit_id,
+        guard.write_permission(),
+    )?;
+    Ok(())
+}
+
+/// by `stack_id` while reusing caller-held exclusive access.
+/// Squash `source_commit_ids` into `target_commit_id` within the stack identified by `stack_id`
+/// while reusing caller-held exclusive access.
+///
+/// This delegates to [`gitbutler_branch_actions::squash_commits_with_perm()`].
+pub fn squash_commits_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    source_commit_ids: Vec<gix::ObjectId>,
+    target_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    gitbutler_branch_actions::squash_commits_with_perm(
+        ctx,
+        stack_id,
+        source_commit_ids,
+        target_commit_id,
+        perm,
+    )?;
     Ok(())
 }
 

--- a/crates/but/src/command/branch/apply.rs
+++ b/crates/but/src/command/branch/apply.rs
@@ -5,11 +5,16 @@ use crate::utils::OutputChannel;
 
 /// Apply a branch to the workspace, and return the full ref name to it.
 pub fn apply(mut ctx: Context, branch_name: &str, out: &mut OutputChannel) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
     let reference = {
         let repo = ctx.repo.get()?;
         repo.find_reference(branch_name)?.detach()
     };
-    let mut outcome = but_api::branch::apply(&mut ctx, reference.name.as_ref())?;
+    let mut outcome = but_api::branch::apply_with_perm(
+        &mut ctx,
+        reference.name.as_ref(),
+        guard.write_permission(),
+    )?;
 
     if let Some(out) = out.for_human() {
         // Since `applied_branches` is the actual applied branches, turning remotes into local branches,

--- a/crates/but/src/command/branch/mod.rs
+++ b/crates/but/src/command/branch/mod.rs
@@ -4,4 +4,4 @@ mod move_branch;
 #[cfg(not(feature = "legacy"))]
 pub use apply::apply;
 pub use move_branch::{move_branch, tear_off_branch};
-pub(crate) use move_branch::{move_branch_by_name, tear_off_branch_by_name};
+pub(crate) use move_branch::{move_branch_by_name_with_perm, tear_off_branch_by_name_with_perm};

--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -1,3 +1,5 @@
+use but_core::sync::RepoExclusive;
+
 use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
 use anyhow::{Context, bail};
 
@@ -8,28 +10,37 @@ pub fn move_branch(
     target_branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let branch_name = resolve_branch_information(ctx, &id_map, branch)
         .context("Failed to determine information for the branch to move.")?;
     let target_branch_name = resolve_branch_information(ctx, &id_map, target_branch)
         .context("Failed to determine information for the target branch.")?;
 
-    move_branch_by_name(ctx, &branch_name, &target_branch_name, out)
+    move_branch_by_name_with_perm(
+        ctx,
+        &branch_name,
+        &target_branch_name,
+        out,
+        guard.write_permission(),
+    )
 }
 
-pub(crate) fn move_branch_by_name(
+pub(crate) fn move_branch_by_name_with_perm(
     ctx: &mut but_ctx::Context,
     branch_name: &str,
     target_branch_name: &str,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
     let target_ref_name_str = &format!("refs/heads/{target_branch_name}");
 
-    but_api::branch::move_branch(
+    but_api::branch::move_branch_with_perm(
         ctx,
         branch_ref_name_str.try_into()?,
         target_ref_name_str.try_into()?,
+        perm,
     )?;
 
     if let Some(out) = out.for_human() {
@@ -47,21 +58,23 @@ pub fn tear_off_branch(
     branch: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let branch_name = resolve_branch_information(ctx, &id_map, branch)
         .context("Failed to determine information for the branch to tear off.")?;
 
-    tear_off_branch_by_name(ctx, &branch_name, out)
+    tear_off_branch_by_name_with_perm(ctx, &branch_name, out, guard.write_permission())
 }
 
-pub(crate) fn tear_off_branch_by_name(
+pub(crate) fn tear_off_branch_by_name_with_perm(
     ctx: &mut but_ctx::Context,
     branch_name: &str,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
 
-    but_api::branch::tear_off_branch(ctx, branch_ref_name_str.try_into()?)?;
+    but_api::branch::tear_off_branch_with_perm(ctx, branch_ref_name_str.try_into()?, perm)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Unstacked branch '{branch_name}'.")?;

--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use bstr::BStr;
 use bstr::ByteSlice;
-use but_core::{DiffSpec, diff::tree_changes};
+use but_core::{DiffSpec, diff::tree_changes, sync::RepoExclusive};
 use but_ctx::Context;
 use gitbutler_branch_actions::update_workspace_commit;
 
@@ -14,13 +14,33 @@ pub fn commited_file_to_another_commit(
     target_id: gix::ObjectId,
     out: &mut OutputChannel,
 ) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commited_file_to_another_commit_with_perm(
+        ctx,
+        path,
+        source_id,
+        target_id,
+        out,
+        guard.write_permission(),
+    )
+}
+
+pub fn commited_file_to_another_commit_with_perm(
+    ctx: &mut Context,
+    path: &BStr,
+    source_id: gix::ObjectId,
+    target_id: gix::ObjectId,
+    out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
     let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
 
-    but_api::commit::move_changes::commit_move_changes_between_only(
+    but_api::commit::move_changes::commit_move_changes_between_only_with_perm(
         ctx,
         source_id,
         target_id,
         relevant_changes,
+        perm,
     )?;
 
     update_workspace_commit(ctx, false)?;
@@ -41,15 +61,35 @@ pub fn uncommit_file(
     target_branch: Option<&str>,
     out: &mut OutputChannel,
 ) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    uncommit_file_with_perm(
+        ctx,
+        path,
+        source_id,
+        target_branch,
+        out,
+        guard.write_permission(),
+    )
+}
+
+pub fn uncommit_file_with_perm(
+    ctx: &mut Context,
+    path: &BStr,
+    source_id: gix::ObjectId,
+    target_branch: Option<&str>,
+    out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
     // Convert target_branch to StackId if provided (for hunk assignment after uncommit)
-    let assign_to = find_stack_id_for_branch(ctx, target_branch)?;
+    let assign_to = find_stack_id_for_branch_with_perm(ctx, target_branch, perm)?;
     let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
 
-    but_api::commit::uncommit::commit_uncommit_changes_only(
+    but_api::commit::uncommit::commit_uncommit_changes_only_with_perm(
         ctx,
         source_id,
         relevant_changes,
         assign_to,
+        perm,
     )?;
 
     update_workspace_commit(ctx, false)?;
@@ -70,14 +110,34 @@ pub fn uncommit_file_and_discard(
     out: &mut OutputChannel,
     emit_output: bool,
 ) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    uncommit_file_and_discard_with_perm(
+        ctx,
+        path,
+        source_id,
+        out,
+        emit_output,
+        guard.write_permission(),
+    )
+}
+
+pub fn uncommit_file_and_discard_with_perm(
+    ctx: &mut Context,
+    path: &BStr,
+    source_id: gix::ObjectId,
+    out: &mut OutputChannel,
+    emit_output: bool,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
     let relevant_changes = changes_for_path_in_commit(ctx, path, source_id)?;
 
     let context_lines = ctx.settings.context_lines;
-    but_api::commit::uncommit::commit_uncommit_changes(
+    but_api::commit::uncommit::commit_uncommit_changes_with_perm(
         ctx,
         source_id,
         relevant_changes.clone(),
         None,
+        perm,
     )?;
 
     let repo = ctx.repo.get()?;
@@ -123,17 +183,17 @@ fn changes_for_path_in_commit(
         .collect())
 }
 
-/// Determine which stack contains the target branch, if any.
-fn find_stack_id_for_branch(
+fn find_stack_id_for_branch_with_perm(
     ctx: &Context,
     target_branch: Option<&str>,
+    perm: &mut RepoExclusive,
 ) -> Result<Option<but_core::Id<'S'>>, anyhow::Error> {
-    let (_guard, _, workspace, _) = ctx.workspace_and_db()?;
+    let (_, ws, _) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
     let target_branch_full_name = target_branch
         .map(|branch| gix::refs::FullName::try_from(format!("refs/heads/{branch}")))
         .transpose()?;
     let assign_to = target_branch_full_name
-        .and_then(|full_name| workspace.find_segment_and_stack_by_refname(full_name.as_ref()))
+        .and_then(|full_name| ws.find_segment_and_stack_by_refname(full_name.as_ref()))
         .and_then(|(stack, _)| stack.id);
     Ok(assign_to)
 }

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use but_core::sync::RepoExclusive;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use colored::Colorize;
@@ -8,12 +9,13 @@ use crate::{
     utils::{OutputChannel, shorten_object_id},
 };
 
-pub(crate) fn handle_resolved(
+pub(crate) fn handle_resolved_with_perm(
     ctx: &mut Context,
     out: &mut OutputChannel,
     source_id: &CliId,
     target_id: &CliId,
     after: bool,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     // Validate --after flag usage
     if after {
@@ -47,7 +49,7 @@ pub(crate) fn handle_resolved(
         );
     };
 
-    operation.execute(ctx, out)
+    operation.execute_with_perm(ctx, out, perm)
 }
 
 /// Represents the operation to perform for a given source and target combination in `but move`.
@@ -73,40 +75,47 @@ enum MoveOperation<'a> {
 }
 
 impl<'a> MoveOperation<'a> {
-    /// Executes this move operation
-    fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    /// Executes this move operation with an existing exclusive permission token.
+    fn execute_with_perm(
+        self,
+        ctx: &mut Context,
+        out: &mut OutputChannel,
+        perm: &mut RepoExclusive,
+    ) -> anyhow::Result<()> {
         match self {
             MoveOperation::CommitToCommit {
                 source,
                 target,
                 after,
-            } => move_commit_to_commit(ctx, source, target, after, out),
+            } => move_commit_to_commit_with_perm(ctx, source, target, after, out, perm),
             MoveOperation::CommitToBranch {
                 source,
                 target_branch,
-            } => move_commit_to_branch(ctx, source, target_branch, out),
+            } => move_commit_to_branch_with_perm(ctx, source, target_branch, out, perm),
             MoveOperation::CommittedFileToCommit {
                 path,
                 source_commit,
                 target_commit,
-            } => super::file::commited_file_to_another_commit(
+            } => super::file::commited_file_to_another_commit_with_perm(
                 ctx,
                 path,
                 source_commit,
                 target_commit,
                 out,
+                perm,
             ),
         }
     }
 }
 
 /// Mova a commit to a new position relative to another one.
-pub fn move_commit_to_commit(
+pub fn move_commit_to_commit_with_perm(
     ctx: &mut Context,
     source: gix::ObjectId,
     target: gix::ObjectId,
     after: bool,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> Result<(), anyhow::Error> {
     let side = if after {
         InsertSide::Above
@@ -124,7 +133,13 @@ pub fn move_commit_to_commit(
         return Ok(());
     }
 
-    but_api::commit::move_commit::commit_move(ctx, source, RelativeTo::Commit(target), side)?;
+    but_api::commit::move_commit::commit_move_with_perm(
+        ctx,
+        source,
+        RelativeTo::Commit(target),
+        side,
+        perm,
+    )?;
 
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
@@ -149,12 +164,24 @@ pub fn move_commit_to_branch(
     target_branch: &str,
     out: &mut OutputChannel,
 ) -> Result<(), anyhow::Error> {
+    let mut guard = ctx.exclusive_worktree_access();
+    move_commit_to_branch_with_perm(ctx, source, target_branch, out, guard.write_permission())
+}
+
+pub fn move_commit_to_branch_with_perm(
+    ctx: &mut Context,
+    source: gix::ObjectId,
+    target_branch: &str,
+    out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
+) -> Result<(), anyhow::Error> {
     let target_full_name = gix::refs::FullName::try_from(format!("refs/heads/{target_branch}"))?;
-    but_api::commit::move_commit::commit_move(
+    but_api::commit::move_commit::commit_move_with_perm(
         ctx,
         source,
         RelativeTo::Reference(target_full_name),
         InsertSide::Below,
+        perm,
     )?;
 
     if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -39,7 +39,8 @@ pub(crate) fn handle(
     dry_run: bool,
     new: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let source: Option<CliId> = source
         .and_then(|s| parse_sources(ctx, &id_map, s).ok())
         .and_then(|s| {
@@ -75,7 +76,8 @@ pub(crate) fn handle(
 
     // TODO: Ideally, there's a simpler way of getting the worktree changes without passing the context to it.
     // At this time, the context is passed pretty deep into the function.
-    let absorption_plan = but_api::legacy::absorb::absorption_plan(ctx, target)?;
+    let absorption_plan =
+        but_api::legacy::absorb::absorption_plan_with_perm(ctx, target, guard.write_permission())?;
 
     // Display the plan (in JSON mode for non-dry-run, collect without writing — we'll
     // combine it with the result in absorb_assignments to avoid a double-write that
@@ -94,7 +96,6 @@ pub(crate) fn handle(
         return Ok(());
     }
 
-    let mut guard = ctx.exclusive_worktree_access();
     let repo = ctx.repo.get()?;
     let data_dir = ctx.project_data_dir();
     let context_lines = ctx.settings.context_lines;

--- a/crates/but/src/command/legacy/branch/apply.rs
+++ b/crates/but/src/command/legacy/branch/apply.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, str::FromStr};
 use anyhow::bail;
 use bstr::ByteSlice;
 use but_ctx::Context;
-use gitbutler_reference::RemoteRefname;
+use gitbutler_reference::{Refname, RemoteRefname};
 use gix::reference::Category;
 
 use crate::utils::OutputChannel;
@@ -14,105 +14,18 @@ use crate::utils::OutputChannel;
 /// If no exact match is found, look for branches whose names contain the given string
 /// and offer an interactive selection.
 pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> anyhow::Result<()> {
-    let repo = ctx.repo.get()?;
-    let reference = if let Some(r) = repo.try_find_reference(branch_name)? {
-        // Look for the branch in the local repository
-        let ref_name = gitbutler_reference::Refname::from_str(&r.name().to_string())?;
-        let remote_ref_name = r
-            .remote_ref_name(gix::remote::Direction::Push)
-            .transpose()?
-            .as_deref()
-            .and_then(|ref_name| {
-                gitbutler_reference::RemoteRefname::from_str(&ref_name.to_string()).ok()
-            });
-
-        let r = r.detach();
-        drop(repo);
-        but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
-            ctx,
-            ref_name,
-            remote_ref_name,
-            None,
-        )?;
-        r
-    } else if let Some((remote_ref, r)) = find_remote_reference(&repo, branch_name)? {
-        let remote = remote_ref.remote();
-        let name = remote_ref.branch();
-        // Look for the branch in the remote references
-        let ref_name =
-            gitbutler_reference::Refname::from_str(&format!("refs/remotes/{remote}/{name}"))?;
-        let r = r.detach();
-        drop(repo);
-        but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
-            ctx,
-            ref_name,
-            Some(remote_ref.clone()),
-            None,
-        )?;
-        r
-    } else {
-        // No exact match - look for branches whose names contain the given string
-        let mut partial = find_partial_matches(&repo, branch_name)?;
-        drop(repo);
-
-        if partial.is_empty() {
-            // NOTE: this is aligned with the 'modern' version for now which doesn't handle this specifically.
-            //       Once there is only one impl, this can be adjusted more easily.
-            bail!("The reference '{branch_name}' did not exist");
-        }
-
-        // Sort by last commit date, most recent first
-        partial.sort_by_key(|b| std::cmp::Reverse(b.timestamp()));
-
-        let chosen = select_partial_match(partial, branch_name, out)?;
-
-        // Apply the chosen match using the same logic as the exact-match paths above
-        let repo = ctx.repo.get()?;
-        match chosen {
-            PartialMatch::Local {
-                display, full_name, ..
-            } => {
-                let r = repo
-                    .try_find_reference(&full_name)?
-                    .ok_or_else(|| anyhow::anyhow!("Branch '{display}' not found"))?;
-                let ref_name = gitbutler_reference::Refname::from_str(&full_name.to_string())?;
-                let remote_ref_name = r
-                    .remote_ref_name(gix::remote::Direction::Push)
-                    .transpose()?
-                    .as_deref()
-                    .and_then(|rn| {
-                        gitbutler_reference::RemoteRefname::from_str(&rn.to_string()).ok()
-                    });
-                let r = r.detach();
-                drop(repo);
-                but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
-                    ctx,
-                    ref_name,
-                    remote_ref_name,
-                    None,
-                )?;
-                r
-            }
-            PartialMatch::Remote {
-                display, full_name, ..
-            } => {
-                let remote_ref = RemoteRefname::from_str(&full_name.to_string())?;
-                let ref_name = gitbutler_reference::Refname::from_str(&full_name.to_string())?;
-                let r = repo
-                    .try_find_reference(&full_name)?
-                    .ok_or_else(|| anyhow::anyhow!("Branch '{display}' not found"))?;
-                let r = r.detach();
-                drop(repo);
-                but_api::legacy::virtual_branches::create_virtual_branch_from_branch(
-                    ctx,
-                    ref_name,
-                    Some(remote_ref),
-                    None,
-                )?;
-                r
-            }
-        }
+    let mut guard = ctx.exclusive_worktree_access();
+    let (reference, ref_name, remote_ref_name) = {
+        let repo = &*ctx.repo.get()?;
+        resolve_reference_to_apply(repo, branch_name, out)?
     };
+    but_api::legacy::virtual_branches::create_virtual_branch_from_branch_with_perm(
+        ctx,
+        &ref_name,
+        remote_ref_name,
+        None,
+        guard.write_permission(),
+    )?;
 
     if let Some(out) = out.for_human() {
         let short_name = reference.name.shorten();
@@ -133,6 +46,73 @@ pub fn apply(ctx: &mut Context, branch_name: &str, out: &mut OutputChannel) -> a
         out.write_value(but_api::json::Reference::from(reference))?;
     }
     Ok(())
+}
+
+/// Resolve `branch_name` to the detached reference and metadata needed to apply it.
+fn resolve_reference_to_apply(
+    repo: &gix::Repository,
+    branch_name: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<(gix::refs::Reference, Refname, Option<RemoteRefname>)> {
+    if let Some(reference) = repo.try_find_reference(branch_name)? {
+        return local_reference_to_apply(reference);
+    }
+
+    if let Some((remote_ref_name, reference)) = find_remote_reference(repo, branch_name)? {
+        return remote_reference_to_apply(remote_ref_name, reference);
+    }
+
+    // No exact match - look for branches whose names contain the given string.
+    let mut partial = find_partial_matches(repo, branch_name)?;
+    if partial.is_empty() {
+        // NOTE: this is aligned with the 'modern' version for now which doesn't handle this specifically.
+        //       Once there is only one impl, this can be adjusted more easily.
+        bail!("The reference '{branch_name}' did not exist");
+    }
+
+    // Sort by last commit date, most recent first.
+    partial.sort_by_key(|branch| std::cmp::Reverse(branch.timestamp()));
+
+    match select_partial_match(partial, branch_name, out)? {
+        PartialMatch::Local {
+            display, full_name, ..
+        } => {
+            let reference = repo
+                .try_find_reference(&full_name)?
+                .ok_or_else(|| anyhow::anyhow!("Branch '{display}' not found"))?;
+            local_reference_to_apply(reference)
+        }
+        PartialMatch::Remote {
+            display, full_name, ..
+        } => {
+            let reference = repo
+                .try_find_reference(&full_name)?
+                .ok_or_else(|| anyhow::anyhow!("Branch '{display}' not found"))?;
+            remote_reference_to_apply(RemoteRefname::from_str(&full_name.to_string())?, reference)
+        }
+    }
+}
+
+/// Convert a local reference into the detached reference and metadata needed to apply it.
+fn local_reference_to_apply(
+    reference: gix::Reference<'_>,
+) -> anyhow::Result<(gix::refs::Reference, Refname, Option<RemoteRefname>)> {
+    let ref_name = Refname::from_str(&reference.name().to_string())?;
+    let remote_ref_name = reference
+        .remote_ref_name(gix::remote::Direction::Push)
+        .transpose()?
+        .as_deref()
+        .and_then(|ref_name| RemoteRefname::from_str(&ref_name.to_string()).ok());
+    Ok((reference.detach(), ref_name, remote_ref_name))
+}
+
+/// Convert a remote-tracking reference into the detached reference and metadata needed to apply it.
+fn remote_reference_to_apply(
+    remote_ref_name: RemoteRefname,
+    reference: gix::Reference<'_>,
+) -> anyhow::Result<(gix::refs::Reference, Refname, Option<RemoteRefname>)> {
+    let ref_name = Refname::from_str(&remote_ref_name.to_string())?;
+    Ok((reference.detach(), ref_name, Some(remote_ref_name)))
 }
 
 enum PartialMatch {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use but_api::json::HexHash;
-use but_core::ref_metadata::StackId;
+use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use colored::Colorize;
 
 use crate::{
@@ -19,6 +19,7 @@ pub fn delete(
     branch_name: String,
     force: bool,
 ) -> Result<(), anyhow::Error> {
+    let mut guard = ctx.exclusive_worktree_access();
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),
@@ -32,7 +33,14 @@ pub fn delete(
         }
 
         if let Some(sid) = stack_entry.id {
-            return confirm_branch_deletion(ctx, sid, &branch_name, force, out);
+            return confirm_branch_deletion(
+                ctx,
+                sid,
+                &branch_name,
+                force,
+                out,
+                guard.write_permission(),
+            );
         }
     }
 
@@ -48,7 +56,8 @@ pub fn new(
     branch_name: Option<String>,
     anchor: Option<String>,
 ) -> Result<(), anyhow::Error> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     // Get branch name or use canned name
     let branch_name = branch_name
         .map(Ok)
@@ -111,12 +120,13 @@ pub fn new(
         })
     };
 
-    but_api::legacy::stack::create_reference(
+    but_api::legacy::stack::create_reference_with_perm(
         ctx,
         but_api::legacy::stack::create_reference::Request {
             new_name: branch_name.clone(),
             anchor,
         },
+        guard.write_permission(),
     )?;
 
     if let Some(out) = out.for_human() {
@@ -199,6 +209,7 @@ fn confirm_branch_deletion(
     branch_name: &str,
     force: bool,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> Result<(), anyhow::Error> {
     if !force
         && let Some(mut inout) = out.prepare_for_terminal_input()
@@ -210,7 +221,7 @@ fn confirm_branch_deletion(
         bail!("Aborted branch deletion.");
     }
 
-    but_api::legacy::stack::remove_branch(ctx, sid, branch_name.to_owned())?;
+    but_api::legacy::stack::remove_branch_with_perm(ctx, sid, branch_name.to_owned(), perm)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Deleted branch {branch_name}")?;

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use anyhow::{Context, Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::{
-    commit::{create::commit_create, insert_blank::commit_insert_blank},
+    commit::create::commit_create,
     diff,
     legacy::{repo, workspace},
 };
@@ -26,7 +26,8 @@ pub(crate) fn insert_blank_commit(
     target: &str,
     insert_side: InsertSide,
 ) -> Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Resolve the target ID
     let cli_ids = id_map.parse_using_context(target, ctx)?;
@@ -60,7 +61,12 @@ pub(crate) fn insert_blank_commit(
                 let repo = ctx.repo.get()?;
                 shorten_object_id(&repo, *oid)
             };
-            commit_insert_blank(ctx, RelativeTo::Commit(*oid), insert_side)?;
+            but_api::commit::insert_blank::commit_insert_blank_with_perm(
+                ctx,
+                RelativeTo::Commit(*oid),
+                insert_side,
+                guard.write_permission(),
+            )?;
             format!("Created blank commit {position_desc} commit {short_oid}")
         }
         CliId::Branch { name, .. } => {
@@ -68,7 +74,12 @@ pub(crate) fn insert_blank_commit(
                 let repo = ctx.repo.get()?;
                 repo.find_reference(name)?.detach()
             };
-            commit_insert_blank(ctx, RelativeTo::Reference(reference.name), insert_side)?;
+            but_api::commit::insert_blank::commit_insert_blank_with_perm(
+                ctx,
+                RelativeTo::Reference(reference.name),
+                insert_side,
+                guard.write_permission(),
+            )?;
             match insert_side {
                 InsertSide::Above => format!("Created blank commit at the top of stack '{name}'"),
                 InsertSide::Below => {

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_api::diff;
-use but_core::DiffSpec;
+use but_core::{DiffSpec, sync::RepoExclusive};
 use but_ctx::Context;
 use gitbutler_oplog::{
     OplogExt,
@@ -19,8 +19,9 @@ use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
 /// Discards changes to files or hunks identified by the given ID.
 /// The ID should be a file or hunk ID as shown in `but status`.
 pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
     // Build ID map to resolve the user's ID
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Resolve the ID to get file information
     let resolved_ids =
@@ -32,7 +33,7 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
 
     // Get worktree changes once for the Unassigned case
     // Also used to determine file status for additions/deletions
-    let worktree_changes = diff::changes_in_worktree(ctx)?;
+    let worktree_changes = diff::changes_in_worktree_with_perm(ctx, guard.write_permission())?;
     let path_status: std::collections::HashMap<_, _> = worktree_changes
         .worktree_changes
         .changes
@@ -136,7 +137,12 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
 
     // Create a snapshot before performing discard operation
     // This allows the user to undo with `but undo` if needed
-    create_snapshot(ctx, OperationKind::Discard, &file_names);
+    create_snapshot(
+        ctx,
+        OperationKind::Discard,
+        &file_names,
+        guard.write_permission(),
+    );
 
     // Perform the discard operation
     let repo = ctx.repo.get()?;
@@ -195,10 +201,13 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
 }
 
 /// Create a snapshot in the oplog before performing an operation
-fn create_snapshot(ctx: &mut Context, operation: OperationKind, file_names: &[String]) {
+fn create_snapshot(
+    ctx: &mut Context,
+    operation: OperationKind,
+    file_names: &[String],
+    perm: &mut RepoExclusive,
+) {
     use gitbutler_oplog::entry::Trailer;
-
-    let mut guard = ctx.exclusive_worktree_access();
 
     // Create trailers with file names
     let trailers: Vec<Trailer> = file_names
@@ -210,5 +219,5 @@ fn create_snapshot(ctx: &mut Context, operation: OperationKind, file_names: &[St
         .collect();
 
     let details = SnapshotDetails::new(operation).with_trailers(trailers);
-    let _snapshot = ctx.create_snapshot(details, guard.write_permission()).ok();
+    let _snapshot = ctx.create_snapshot(details, perm).ok();
 }

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::bail;
-use but_core::ref_metadata::StackId;
+use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_rules::Operation;
 use gitbutler_commit::commit_ext::CommitExt;
@@ -14,7 +14,8 @@ pub(crate) fn handle(
     target_str: &str,
     delete: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let target_result = id_map.parse_using_context(target_str, ctx)?;
     if target_result.len() != 1 {
         return Err(anyhow::anyhow!(
@@ -26,8 +27,10 @@ pub(crate) fn handle(
         but_rules::delete_rule(ctx, &rule.id())?;
     }
     match target_result[0].clone() {
-        CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out),
-        CliId::Commit { commit_id: oid, .. } => mark_commit(ctx, oid, delete, out),
+        CliId::Branch { name, .. } => mark_branch(ctx, name, delete, out, guard.write_permission()),
+        CliId::Commit { commit_id: oid, .. } => {
+            mark_commit(ctx, oid, delete, out, guard.write_permission())
+        }
         _ => bail!("Nope"),
     }
 }
@@ -37,6 +40,7 @@ fn mark_commit(
     oid: gix::ObjectId,
     delete: bool,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     if delete {
         let repo = ctx.repo.get()?.clone();
@@ -53,8 +57,6 @@ fn mark_commit(
         return Ok(());
     }
 
-    let mut guard = ctx.exclusive_worktree_access();
-
     let req = {
         let repo = ctx.repo.get()?;
         let commit = repo.find_commit(oid)?;
@@ -70,7 +72,7 @@ fn mark_commit(
             action,
         }
     };
-    but_rules::create_rule(ctx, req, guard.write_permission())?;
+    but_rules::create_rule(ctx, req, perm)?;
     if let Some(out) = out.for_human() {
         writeln!(
             out,
@@ -86,6 +88,7 @@ fn mark_branch(
     branch_name: String,
     delete: bool,
     out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     let stack_id = branch_name_to_stack_id(ctx, Some(&branch_name))?;
     if delete {
@@ -101,8 +104,6 @@ fn mark_branch(
         return Ok(());
     }
 
-    let mut guard = ctx.exclusive_worktree_access();
-
     // TODO: if there are other marks of this kind, get rid of them
     let stack_id = stack_id.expect("Cannot find stack for this branch");
     let action = but_rules::Action::Explicit(Operation::Assign {
@@ -115,7 +116,7 @@ fn mark_branch(
         )?)],
         action,
     };
-    but_rules::create_rule(ctx, req, guard.write_permission())?;
+    but_rules::create_rule(ctx, req, perm)?;
     if let Some(out) = out.for_human() {
         writeln!(out, "Changes will be assigned to → {branch_name}")?;
     }
@@ -144,6 +145,9 @@ pub(crate) fn commit_marked(ctx: &Context, commit_id: String) -> anyhow::Result<
 }
 
 pub(crate) fn unmark(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    // TODO: do we need an exclusive lock here? This only affects metadata. This is very safe for now,
+    // and `create_rule()` already needs a write guards, so this is just symmetic.
+    let _guard = ctx.exclusive_worktree_access();
     let rules = but_rules::list_rules(ctx)?;
     let rule_count = rules.len();
 

--- a/crates/but/src/command/legacy/mark.rs
+++ b/crates/but/src/command/legacy/mark.rs
@@ -146,7 +146,7 @@ pub(crate) fn commit_marked(ctx: &Context, commit_id: String) -> anyhow::Result<
 
 pub(crate) fn unmark(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
     // TODO: do we need an exclusive lock here? This only affects metadata. This is very safe for now,
-    // and `create_rule()` already needs a write guards, so this is just symmetic.
+    // and `create_rule()` already needs a write guard, so this is just symmetric.
     let _guard = ctx.exclusive_worktree_access();
     let rules = but_rules::list_rules(ctx)?;
     let rule_count = rules.len();

--- a/crates/but/src/command/legacy/merge.rs
+++ b/crates/but/src/command/legacy/merge.rs
@@ -15,8 +15,9 @@ pub async fn handle(
     branch_id: &str,
 ) -> anyhow::Result<()> {
     let mut progress = out.progress_channel();
+    let guard = ctx.exclusive_worktree_access();
 
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Resolve the branch ID
     let resolved_ids = id_map.parse_using_context(branch_id, ctx)?;
@@ -119,6 +120,8 @@ pub async fn handle(
             "GitButler local merge",
         )?;
 
+        // TODO: Drop the guard as we can't keep it across await, and `handle` will obtain its own as well.
+        drop(guard);
         crate::command::legacy::pull::handle(ctx, out, false).await?;
 
         writeln!(

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -30,6 +30,9 @@ pub fn handle(
     source: &str,
     target_branch: Option<&str>,
 ) -> Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+
     // Get applied stacks first - we'll need them for target resolution
     let stacks =
         workspace::stacks(ctx, Some(StacksFilter::InWorkspace)).context("Failed to list stacks")?;
@@ -52,32 +55,42 @@ pub fn handle(
     };
 
     // Resolve the source to commit(s) (may involve interactive multi-selection for branches)
-    let commit_oids = resolve_source_commits(ctx, out, source)?;
+    let commit_oids = resolve_source_commits(ctx, out, &id_map, source)?;
 
     // Save an oplog snapshot before applying picks so the operation can be undone
-    {
-        let mut guard = ctx.exclusive_worktree_access();
-        let _ = ctx.create_snapshot(
-            SnapshotDetails::new(OperationKind::CherryPick),
-            guard.write_permission(),
-        );
-    }
+    let _ = ctx.create_snapshot(
+        SnapshotDetails::new(OperationKind::CherryPick),
+        guard.write_permission(),
+    );
 
     let mut picked = Vec::new();
     for commit_oid in &commit_oids {
         let commit_hex = commit_oid.to_string();
 
         // Check cherry-apply status for each commit
-        let status = cherry_apply::cherry_apply_status(ctx, *commit_oid)
-            .context("Failed to check cherry-apply status")?;
+        let status =
+            cherry_apply::cherry_apply_status_with_perm(ctx, *commit_oid, guard.read_permission())
+                .context("Failed to check cherry-apply status")?;
 
         // Resolve the target stack based on status and user input
-        let (target_stack_id, target_branch_name) =
-            resolve_target_stack(ctx, out, &stacks, effective_target, &status, &commit_hex)?;
+        let (target_stack_id, target_branch_name) = resolve_target_stack(
+            ctx,
+            out,
+            &id_map,
+            &stacks,
+            effective_target,
+            &status,
+            &commit_hex,
+        )?;
 
         // Execute cherry-apply
-        cherry_apply::cherry_apply(ctx, *commit_oid, target_stack_id)
-            .context("Failed to cherry-pick commit")?;
+        cherry_apply::cherry_apply_with_perm(
+            ctx,
+            *commit_oid,
+            target_stack_id,
+            guard.write_permission(),
+        )
+        .context("Failed to cherry-pick commit")?;
 
         picked.push((commit_hex, target_branch_name, target_stack_id));
     }
@@ -141,6 +154,7 @@ pub fn handle(
 fn resolve_source_commits(
     ctx: &mut Context,
     out: &mut OutputChannel,
+    id_map: &IdMap,
     source: &str,
 ) -> Result<Vec<gix::ObjectId>> {
     // Try as an unapplied branch name first (case-insensitive)
@@ -164,7 +178,6 @@ fn resolve_source_commits(
     }
 
     // Try using IdMap for CLI IDs
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let cli_ids = id_map.parse_using_context(source, ctx)?;
 
     for cli_id in &cli_ids {
@@ -302,6 +315,7 @@ fn select_commits_from_branch(
 fn resolve_target_stack(
     ctx: &mut Context,
     out: &mut OutputChannel,
+    id_map: &IdMap,
     stacks: &[StackEntry],
     target_branch: Option<&str>,
     status: &CherryApplyStatus,
@@ -331,7 +345,7 @@ fn resolve_target_stack(
 
     // If target is specified, find matching stack (by CLI ID or name)
     if let Some(target) = target_branch {
-        return find_stack_by_target(ctx, stacks, target);
+        return find_stack_by_target(ctx, id_map, stacks, target);
     }
 
     // If only one stack, use it automatically
@@ -392,13 +406,12 @@ fn handle_locked_to_stack(
 /// Find a stack by CLI ID or branch name (case-insensitive).
 fn find_stack_by_target(
     ctx: &mut Context,
+    id_map: &IdMap,
     stacks: &[StackEntry],
     target: &str,
 ) -> Result<(StackId, String)> {
     // Try parsing as CLI ID first
-    if let Ok(id_map) = IdMap::legacy_new_from_context(ctx, None)
-        && let Ok(cli_ids) = id_map.parse_using_context(target, ctx)
-    {
+    if let Ok(cli_ids) = id_map.parse_using_context(target, ctx) {
         for cli_id in &cli_ids {
             if let CliId::Branch {
                 stack_id: Some(stack_id),

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -1,6 +1,7 @@
 use anyhow::{Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
+use but_core::sync::RepoExclusive;
 use but_ctx::Context;
 use gix::prelude::ObjectIdExt;
 
@@ -21,7 +22,8 @@ pub(crate) fn reword_target(
     format: bool,
     show_diff_in_editor: ShowDiffInEditor,
 ) -> Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Resolve the commit ID
     let cli_ids = id_map.parse_using_context(target, ctx)?;
@@ -48,7 +50,7 @@ pub(crate) fn reword_target(
             if !matches!(show_diff_in_editor, ShowDiffInEditor::Unspecified) {
                 bail!("--diff and --no-diff flags can only be used with commits, not branches");
             }
-            edit_branch_name(ctx, name, out, message)?;
+            edit_branch_name(ctx, name, out, message, guard.write_permission())?;
         }
         CliId::Commit { commit_id: oid, .. } => {
             edit_commit_message_by_id_and_reword_commit(
@@ -58,6 +60,7 @@ pub(crate) fn reword_target(
                 message,
                 format,
                 show_diff_in_editor,
+                guard.write_permission(),
             )?;
         }
         _ => {
@@ -76,6 +79,7 @@ fn edit_branch_name(
     branch_name: &str,
     out: &mut OutputChannel,
     message: Option<&str>,
+    perm: &mut RepoExclusive,
 ) -> Result<()> {
     // Find which stack this branch belongs to
     let stacks = but_api::legacy::workspace::stacks(
@@ -91,11 +95,12 @@ fn edit_branch_name(
         if let Some(sid) = stack_entry.id {
             let new_name = prepare_provided_message(message, "branch name")
                 .unwrap_or_else(|| get_branch_name_from_editor(branch_name))?;
-            but_api::legacy::stack::update_branch_name(
+            but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
                 sid,
                 branch_name.to_owned(),
                 new_name.clone(),
+                perm,
             )?;
             if let Some(out) = out.for_human() {
                 writeln!(out, "Renamed branch '{branch_name}' to '{new_name}'")?;
@@ -156,6 +161,7 @@ fn edit_commit_message_by_id_and_reword_commit(
     message: Option<&str>,
     format: bool,
     show_diff_in_editor: ShowDiffInEditor,
+    perm: &mut RepoExclusive,
 ) -> Result<()> {
     // Get commit details directly - no need to iterate through stacks
     let commit_details = but_api::diff::commit_details(ctx, commit_oid, ComputeLineStats::No)?;
@@ -183,10 +189,11 @@ fn edit_commit_message_by_id_and_reword_commit(
     .filter(|new_message| should_update_commit_message(&current_message, new_message));
 
     if let Some(new_message) = new_message {
-        let new_commit_oid = but_api::commit::reword::commit_reword_only(
+        let new_commit_oid = but_api::commit::reword::commit_reword_only_with_perm(
             ctx,
             commit_oid,
             BString::from(new_message),
+            perm,
         )?;
 
         if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -17,6 +17,25 @@ pub(crate) fn uncommitted_to_commit(
     oid: ObjectId,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    uncommitted_to_commit_with_perm(
+        ctx,
+        hunk_assignments,
+        description,
+        oid,
+        out,
+        guard.write_permission(),
+    )
+}
+
+pub(crate) fn uncommitted_to_commit_with_perm(
+    ctx: &mut Context,
+    hunk_assignments: NonEmpty<&HunkAssignment>,
+    description: String,
+    oid: ObjectId,
+    out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<()> {
     let first_hunk_assignment = hunk_assignments.first();
     let stack_id = first_hunk_assignment.stack_id;
 
@@ -25,10 +44,7 @@ pub(crate) fn uncommitted_to_commit(
         .map(|assignment| assignment.to_owned().into())
         .collect();
 
-    let outcome = {
-        let mut guard = ctx.exclusive_worktree_access();
-        amend_diff_specs(ctx, diff_specs, stack_id, oid, guard.write_permission())?
-    };
+    let outcome = amend_diff_specs(ctx, diff_specs, stack_id, oid, perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
@@ -56,15 +72,24 @@ pub(crate) fn assignments_to_commit(
     oid: ObjectId,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    assignments_to_commit_with_perm(ctx, branch_name, oid, out, guard.write_permission())
+}
+
+pub(crate) fn assignments_to_commit_with_perm(
+    ctx: &mut Context,
+    branch_name: Option<&str>,
+    oid: ObjectId,
+    out: &mut OutputChannel,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<()> {
     let stack_id = branch_name_to_stack_id(ctx, branch_name)?;
-    let diff_specs: Vec<DiffSpec> = wt_assignments(ctx)?
+    let diff_specs: Vec<DiffSpec> = wt_assignments_with_perm(ctx, perm)?
         .into_iter()
         .filter(|assignment| assignment.stack_id == stack_id)
         .map(|assignment| assignment.into())
         .collect();
-    let mut guard = ctx.exclusive_worktree_access();
-    let outcome = amend_diff_specs(ctx, diff_specs, stack_id, oid, guard.write_permission())?;
-    drop(guard);
+    let outcome = amend_diff_specs(ctx, diff_specs, stack_id, oid, perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
@@ -95,10 +120,13 @@ pub(crate) fn assignments_to_commit(
     Ok(())
 }
 
-fn wt_assignments(ctx: &mut Context) -> anyhow::Result<Vec<HunkAssignment>> {
+fn wt_assignments_with_perm(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<Vec<HunkAssignment>> {
     let changes = but_core::diff::ui::worktree_changes(&*ctx.repo.get()?)?.changes;
     let context_lines = ctx.settings.context_lines;
-    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
+    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let (assignments, _assignments_error) = but_hunk_assignment::assignments_with_fallback(
         db.hunk_assignments_mut()?,
         &repo,

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use bstr::BStr;
-use but_core::ref_metadata::StackId;
+use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use colored::Colorize;
 mod amend;
@@ -803,8 +803,16 @@ fn ids(
 }
 fn create_snapshot(ctx: &mut Context, operation: OperationKind) {
     let mut guard = ctx.exclusive_worktree_access();
+    create_snapshot_with_perm(ctx, operation, guard.write_permission());
+}
+
+fn create_snapshot_with_perm(
+    ctx: &mut Context,
+    operation: OperationKind,
+    perm: &mut RepoExclusive,
+) {
     let _snapshot = ctx
-        .create_snapshot(SnapshotDetails::new(operation), guard.write_permission())
+        .create_snapshot(SnapshotDetails::new(operation), perm)
         .ok(); // Ignore errors for snapshot creation
 }
 
@@ -924,7 +932,8 @@ pub(crate) fn handle_amend(
     file_str: &str,
     commit_str: &str,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let files = parse_sources_with_disambiguation(ctx, &id_map, file_str, out)?;
     let commit = resolve_single_id(ctx, &id_map, commit_str, "Commit", out)?;
 
@@ -945,9 +954,31 @@ pub(crate) fn handle_amend(
     }
 
     // Validate that commit is a commit
-    match &commit {
-        CliId::Commit { .. } => {
-            // Valid type for target
+    match commit {
+        CliId::Commit { commit_id, .. } => {
+            // TODO(dp by st): This is a duplication of the UncommittedToCommitOperation which was previously
+            //                 called through `handle()` after validation. The problem is that it does its own locking.
+            //                 Since these are all mutations, it would have to be changed to take `perm` as well.
+            for file in files {
+                match file {
+                    CliId::Uncommitted(uncommitted) => {
+                        create_snapshot_with_perm(
+                            ctx,
+                            OperationKind::AmendCommit,
+                            guard.write_permission(),
+                        );
+                        amend::uncommitted_to_commit_with_perm(
+                            ctx,
+                            uncommitted.hunk_assignments.as_ref(),
+                            uncommitted.describe(),
+                            commit_id,
+                            out,
+                            guard.write_permission(),
+                        )?;
+                    }
+                    _ => unreachable!("validated beforehand"),
+                }
+            }
         }
         other => {
             bail!(
@@ -957,9 +988,7 @@ pub(crate) fn handle_amend(
             );
         }
     }
-
-    // Call the main rub handler
-    handle(ctx, out, file_str, commit_str)
+    Ok(())
 }
 
 /// Handler for `but stage <file_or_hunk> <branch>` - runs `but rub <file_or_hunk> <branch>`

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -1,8 +1,9 @@
 use anyhow::bail;
 use bstr::BString;
-use but_core::ref_metadata::StackId;
+use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use colored::Colorize;
+use gitbutler_branch_actions::squash_commits_with_perm;
 use gix::ObjectId;
 
 use super::undo::stack_id_by_commit_id;
@@ -19,6 +20,7 @@ pub(crate) fn commits(
     custom_message: Option<&str>,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
     // Delegate to the shared squashing logic
     squash_commits_internal(
         ctx,
@@ -27,6 +29,7 @@ pub(crate) fn commits(
         false,
         custom_message,
         None,
+        guard.write_permission(),
         out,
     )
 }
@@ -47,7 +50,8 @@ pub(crate) fn handle(
         bail!("At least one commit or branch name must be provided");
     }
 
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // If there's only one argument, it could be a branch name or a range
     if commits.len() == 1 {
@@ -71,6 +75,7 @@ pub(crate) fn handle(
                     custom_message,
                     ai,
                     &id_map,
+                    guard.write_permission(),
                 );
             }
 
@@ -95,7 +100,15 @@ pub(crate) fn handle(
             if sources.len() < 2 {
                 bail!("Need at least 2 commits to squash");
             }
-            return handle_multi_commit_squash(ctx, out, sources, drop_message, custom_message, ai);
+            return handle_multi_commit_squash(
+                ctx,
+                out,
+                sources,
+                drop_message,
+                custom_message,
+                ai,
+                guard.write_permission(),
+            );
         }
 
         if entity_str.contains(',') {
@@ -103,7 +116,15 @@ pub(crate) fn handle(
             if sources.len() < 2 {
                 bail!("Need at least 2 commits to squash");
             }
-            return handle_multi_commit_squash(ctx, out, sources, drop_message, custom_message, ai);
+            return handle_multi_commit_squash(
+                ctx,
+                out,
+                sources,
+                drop_message,
+                custom_message,
+                ai,
+                guard.write_permission(),
+            );
         }
 
         // If it contains a single dash (but not ..), it might be a branch name with a dash
@@ -126,7 +147,15 @@ pub(crate) fn handle(
         sources.push(matches[0].clone());
     }
 
-    handle_multi_commit_squash(ctx, out, sources, drop_message, custom_message, ai)
+    handle_multi_commit_squash(
+        ctx,
+        out,
+        sources,
+        drop_message,
+        custom_message,
+        ai,
+        guard.write_permission(),
+    )
 }
 
 /// Helper function to handle squashing multiple commits
@@ -137,6 +166,7 @@ fn handle_multi_commit_squash(
     drop_message: bool,
     custom_message: Option<&str>,
     ai: Option<Option<String>>,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     if sources.len() < 2 {
         bail!("Need at least 2 commits to squash");
@@ -170,11 +200,13 @@ fn handle_multi_commit_squash(
         drop_message,
         custom_message,
         ai,
+        perm,
         out,
     )
 }
 
 /// Internal shared logic for squashing commits
+#[expect(clippy::too_many_arguments)]
 fn squash_commits_internal(
     ctx: &mut Context,
     source_oids: Vec<ObjectId>,
@@ -182,6 +214,7 @@ fn squash_commits_internal(
     drop_message: bool,
     custom_message: Option<&str>,
     ai: Option<Option<String>>,
+    perm: &mut RepoExclusive,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     // Validate all commits are on the same stack
@@ -242,12 +275,8 @@ fn squash_commits_internal(
     };
 
     // Perform the squash using the API - it can handle multiple source commits
-    let new_commit_oid = gitbutler_branch_actions::squash_commits(
-        ctx,
-        target_stack,
-        source_oids.clone(),
-        target_oid,
-    )?;
+    let new_commit_oid =
+        squash_commits_with_perm(ctx, target_stack, source_oids.clone(), target_oid, perm)?;
 
     // Determine the final message and apply if needed
     let final_commit_oid = if let Some(user_summary) = ai {
@@ -258,14 +287,29 @@ fn squash_commits_internal(
             destination_message.unwrap_or_default(),
             user_summary,
         )?;
-        but_api::commit::reword::commit_reword_only(ctx, new_commit_oid, BString::from(ai_message))?
-            .new_commit
+        but_api::commit::reword::commit_reword_only_with_perm(
+            ctx,
+            new_commit_oid,
+            BString::from(ai_message),
+            perm,
+        )?
+        .new_commit
     } else if let Some(msg) = custom_message {
-        but_api::commit::reword::commit_reword_only(ctx, new_commit_oid, BString::from(msg))?
-            .new_commit
+        but_api::commit::reword::commit_reword_only_with_perm(
+            ctx,
+            new_commit_oid,
+            BString::from(msg),
+            perm,
+        )?
+        .new_commit
     } else if let Some(target_msg) = target_message {
-        but_api::commit::reword::commit_reword_only(ctx, new_commit_oid, BString::from(target_msg))?
-            .new_commit
+        but_api::commit::reword::commit_reword_only_with_perm(
+            ctx,
+            new_commit_oid,
+            BString::from(target_msg),
+            perm,
+        )?
+        .new_commit
     } else {
         new_commit_oid
     };
@@ -312,6 +356,7 @@ fn squash_branch_commits(
     custom_message: Option<&str>,
     ai: Option<Option<String>>,
     id_map: &IdMap,
+    perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     // Find the stack containing this branch
     let stack_id = stack_id
@@ -357,6 +402,7 @@ fn squash_branch_commits(
         drop_message,
         custom_message,
         ai,
+        perm,
         out,
     )?;
 

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -22,13 +22,14 @@ pub fn handle(
     identifier: &str,
     force: bool,
 ) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
     // Fetch stacks once at the start
     let stacks = but_api::legacy::workspace::stacks(
         ctx,
         Some(but_workspace::legacy::StacksFilter::InWorkspace),
     )?;
 
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let parsed_ids = id_map.parse_using_context(identifier, ctx)?;
 
     // Try to find the stack to unapply
@@ -69,7 +70,14 @@ pub fn handle(
         );
     };
 
-    confirm_and_unapply_stack(ctx, stack_id, &branches, force, out)
+    confirm_and_unapply_stack(
+        ctx,
+        stack_id,
+        &branches,
+        force,
+        out,
+        guard.write_permission(),
+    )
 }
 
 /// Get branches for a stack by ID, validating the stack exists.
@@ -120,6 +128,7 @@ fn confirm_and_unapply_stack(
     branches: &[String],
     force: bool,
     out: &mut OutputChannel,
+    perm: &mut but_core::sync::RepoExclusive,
 ) -> anyhow::Result<()> {
     let branches_display = branches.join(", ");
 
@@ -133,7 +142,7 @@ fn confirm_and_unapply_stack(
         bail!("Aborted unapply operation.");
     }
 
-    but_api::legacy::virtual_branches::unapply_stack(ctx, sid)?;
+    but_api::legacy::virtual_branches::unapply_stack_with_perm(ctx, sid, perm)?;
 
     if let Some(out) = out.for_human() {
         writeln!(

--- a/crates/but/src/command/move.rs
+++ b/crates/but/src/command/move.rs
@@ -9,7 +9,8 @@ pub(crate) fn handle(
     target: &str,
     after: bool,
 ) -> anyhow::Result<()> {
-    let id_map = IdMap::legacy_new_from_context(ctx, None)?;
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let source_id =
         resolve_single(&id_map, ctx, source, "Source").context("Failed to move commit.")?;
     let target_id =
@@ -40,17 +41,33 @@ pub(crate) fn handle(
             ))
         } else {
             match target_id {
-                CliId::Unassigned { .. } => {
-                    super::branch::tear_off_branch_by_name(ctx, source_name, out)
-                }
+                CliId::Unassigned { .. } => super::branch::tear_off_branch_by_name_with_perm(
+                    ctx,
+                    source_name,
+                    out,
+                    guard.write_permission(),
+                ),
                 CliId::Branch {
                     name: target_name, ..
-                } => super::branch::move_branch_by_name(ctx, source_name, target_name, out),
+                } => super::branch::move_branch_by_name_with_perm(
+                    ctx,
+                    source_name,
+                    target_name,
+                    out,
+                    guard.write_permission(),
+                ),
                 _ => unreachable!("branch_route guarantees target is branch or unassigned"),
             }
         }
     } else {
-        super::commit::r#move::handle_resolved(ctx, out, &source_id, &target_id, after)
+        super::commit::r#move::handle_resolved_with_perm(
+            ctx,
+            out,
+            &source_id,
+            &target_id,
+            after,
+            guard.write_permission(),
+        )
     };
 
     if branch_route {

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -2,9 +2,17 @@ use bstr::ByteSlice;
 use snapbox::str;
 
 use crate::{
-    command::util::commit_file_with_worktree_changes_as_two_hunks,
+    command::util::{self, commit_file_with_worktree_changes_as_two_hunks},
     utils::{CommandExt, Sandbox},
 };
+
+fn find_unassigned_cli_id(status: &serde_json::Value, path: &str) -> Option<String> {
+    status["unassignedChanges"]
+        .as_array()?
+        .iter()
+        .find(|change| change["filePath"].as_str() == Some(path))
+        .and_then(|change| change["cliId"].as_str().map(ToOwned::to_owned))
+}
 
 #[test]
 fn uncommitted_file() -> anyhow::Result<()> {
@@ -383,6 +391,48 @@ Hint: run `but help` for all commands
     line
     last new
     ");
+
+    Ok(())
+}
+
+#[test]
+fn concurrent_absorb_of_independent_files_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
+    env.setup_metadata(&["A", "B"])?;
+
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+    commit_file_with_worktree_changes_as_two_hunks(&env, "B", "b.txt");
+
+    let status = util::status_json(&env)?;
+    let id_a = find_unassigned_cli_id(&status, "a.txt").expect("should find a.txt CLI ID");
+    let id_b = find_unassigned_cli_id(&status, "b.txt").expect("should find b.txt CLI ID");
+
+    let child_a = util::but_std_cmd(&env, &format!("absorb {id_a}")).spawn()?;
+    let child_b = util::but_std_cmd(&env, &format!("absorb {id_b}")).spawn()?;
+
+    let out_a = child_a.wait_with_output()?;
+    let out_b = child_b.wait_with_output()?;
+
+    assert!(
+        out_a.status.success(),
+        "absorb a.txt failed: {}",
+        out_a.stderr.as_bstr()
+    );
+    assert!(
+        out_b.status.success(),
+        "absorb b.txt failed: {}",
+        out_b.stderr.as_bstr()
+    );
+
+    let status = util::status_json(&env)?;
+    assert_eq!(
+        status["unassignedChanges"]
+            .as_array()
+            .map(|changes| changes.len())
+            .unwrap_or(0),
+        0,
+        "both files should be absorbed from the worktree"
+    );
 
     Ok(())
 }

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -1,5 +1,7 @@
+use bstr::ByteSlice;
 use snapbox::str;
 
+use crate::command::util;
 use crate::utils::{CommandExt, Sandbox};
 
 #[cfg(not(feature = "legacy"))]
@@ -242,6 +244,38 @@ Applied remote branch 'origin/remote-feature' to workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
+
+    Ok(())
+}
+
+#[test]
+fn concurrent_apply_of_independent_branches_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    create_local_branch_with_commit(&env, "feature-branch-a");
+    create_local_branch_with_commit_with_message(&env, "feature-branch-b", "Add other feature");
+
+    let child_a = util::but_std_cmd(&env, "apply feature-branch-a").spawn()?;
+    let child_b = util::but_std_cmd(&env, "apply feature-branch-b").spawn()?;
+
+    let out_a = child_a.wait_with_output()?;
+    let out_b = child_b.wait_with_output()?;
+
+    assert!(
+        out_a.status.success(),
+        "apply feature-branch-a failed: {}",
+        out_a.stderr.as_bstr()
+    );
+    assert!(
+        out_b.status.success(),
+        "apply feature-branch-b failed: {}",
+        out_b.stderr.as_bstr()
+    );
+
+    let status = util::status_json(&env)?;
+    util::find_branch(&status, "feature-branch-a")?;
+    util::find_branch(&status, "feature-branch-b")?;
 
     Ok(())
 }

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -1,7 +1,11 @@
+use bstr::ByteSlice;
 use snapbox::str;
 use utils::create_local_branch_with_commit;
 
-use crate::utils::{CommandExt, Sandbox};
+use crate::{
+    command::util,
+    utils::{CommandExt, Sandbox},
+};
 
 #[test]
 fn single_branch() -> anyhow::Result<()> {
@@ -245,6 +249,45 @@ Unapplied stack with branches 'remote-feature' from workspace
     |/  
     * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
     ");
+
+    Ok(())
+}
+
+#[test]
+fn concurrent_unapply_of_independent_branches_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    create_local_branch_with_commit(&env, "feature-branch-a");
+
+    env.but("apply feature-branch-a").assert().success();
+
+    let child_a = util::but_std_cmd(&env, "unapply A").spawn()?;
+    let child_b = util::but_std_cmd(&env, "unapply feature-branch-a").spawn()?;
+
+    let out_a = child_a.wait_with_output()?;
+    let out_b = child_b.wait_with_output()?;
+
+    assert!(
+        out_a.status.success(),
+        "unapply A failed: {}",
+        out_a.stderr.as_bstr()
+    );
+    assert!(
+        out_b.status.success(),
+        "unapply feature-branch-a failed: {}",
+        out_b.stderr.as_bstr()
+    );
+
+    let status = util::status_json(&env)?;
+    assert!(
+        util::find_branch(&status, "A").is_err(),
+        "A should no longer be applied"
+    );
+    assert!(
+        util::find_branch(&status, "feature-branch-a").is_err(),
+        "feature-branch-a should no longer be applied"
+    );
 
     Ok(())
 }

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -1,0 +1,83 @@
+use bstr::ByteSlice;
+
+use crate::{command::util, utils::Sandbox};
+
+fn find_unassigned_cli_id(status: &serde_json::Value, path_contains: &str) -> Option<String> {
+    status["unassignedChanges"]
+        .as_array()?
+        .iter()
+        .find(|change| {
+            change["filePath"]
+                .as_str()
+                .map(|path| path.contains(path_contains))
+                .unwrap_or(false)
+        })
+        .and_then(|change| change["cliId"].as_str().map(ToOwned::to_owned))
+}
+
+#[test]
+fn discard_removes_selected_change() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("src/discard-me.ts", "export const value = true;\n");
+
+    let status = util::status_json(&env)?;
+    let cli_id = find_unassigned_cli_id(&status, "discard-me").expect("should find CLI ID");
+
+    env.but(format!("discard {cli_id}")).assert().success();
+
+    let status = util::status_json(&env)?;
+    assert!(
+        find_unassigned_cli_id(&status, "discard-me").is_none(),
+        "discarded file should no longer appear in unassigned changes"
+    );
+    assert!(
+        !env.projects_root().join("src/discard-me.ts").exists(),
+        "discarding a new file should remove it from the worktree"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn concurrent_discard_to_independent_files_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("src/a/discard.ts", "export const a = true;\n");
+    env.file("src/b/discard.ts", "export const b = true;\n");
+
+    let status = util::status_json(&env)?;
+    let id_a = find_unassigned_cli_id(&status, "a/discard").expect("should find first CLI ID");
+    let id_b = find_unassigned_cli_id(&status, "b/discard").expect("should find second CLI ID");
+
+    let child_a = util::but_std_cmd(&env, &format!("discard {id_a}")).spawn()?;
+    let child_b = util::but_std_cmd(&env, &format!("discard {id_b}")).spawn()?;
+
+    let out_a = child_a.wait_with_output()?;
+    let out_b = child_b.wait_with_output()?;
+
+    assert!(
+        out_a.status.success(),
+        "first discard failed: {}",
+        out_a.stderr.as_bstr()
+    );
+    assert!(
+        out_b.status.success(),
+        "second discard failed: {}",
+        out_b.stderr.as_bstr()
+    );
+
+    let status = util::status_json(&env)?;
+    assert_eq!(
+        status["unassignedChanges"]
+            .as_array()
+            .map(|changes| changes.len())
+            .unwrap_or(0),
+        0,
+        "both discarded files should be removed from the workspace"
+    );
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -16,6 +16,8 @@ mod config;
 mod cursor;
 #[cfg(feature = "legacy")]
 mod diff;
+#[cfg(feature = "legacy")]
+mod discard;
 mod format;
 mod gui;
 mod help;
@@ -98,6 +100,22 @@ mod util {
     pub fn status_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
         let output = env.but("--json status").allow_json().output()?;
         serde_json::from_slice(&output.stdout).context("status output should be valid JSON")
+    }
+
+    /// Build an isolated `std::process::Command` for `but` with the same environment as the Sandbox.
+    pub fn but_std_cmd(env: &Sandbox, args: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new(snapbox::cmd::cargo_bin!("but"));
+        cmd.args(shell_words::split(args).unwrap());
+        cmd.current_dir(env.projects_root());
+        cmd.env("E2E_TEST_APP_DATA_DIR", env.app_data_dir());
+        cmd.env("GITBUTLER_CHANGE_ID", "42");
+        cmd.env("BUT_OUTPUT_FORMAT", "human");
+        cmd.env("NOPAGER", "1");
+        cmd.stdin(std::process::Stdio::null());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        but_testsupport::isolate_env_std_cmd(&mut cmd);
+        cmd
     }
 
     /// Find a branch by name in `status` output.

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -1,15 +1,29 @@
+use bstr::ByteSlice;
 use snapbox::str;
 
-use crate::utils::Sandbox;
+use crate::{command::util, utils::Sandbox};
 
 /// Helper to create multiple commits on a branch for testing
 fn setup_branch_with_commits(env: &Sandbox, branch: &str, num_commits: usize) {
+    let branch_prefix = branch.replace('/', "_");
     for i in 1..=num_commits {
-        env.file(format!("file{i}.txt"), format!("content for commit {i}\n"));
+        env.file(
+            format!("{branch_prefix}-file{i}.txt"),
+            format!("content for commit {i}\n"),
+        );
         env.but(format!("commit {branch} -m 'commit {i}'"))
             .assert()
             .success();
     }
+}
+
+fn branch_commit_count(env: &Sandbox, branch: &str) -> anyhow::Result<usize> {
+    let status = util::status_json(env)?;
+    let branch = util::find_branch(&status, branch)?;
+    Ok(branch["commits"]
+        .as_array()
+        .map(|commits| commits.len())
+        .unwrap_or(0))
 }
 
 #[test]
@@ -231,6 +245,38 @@ Usage: but squash --ai[=<AI>] <COMMITS>...
 For more information, try '--help'.
 
 "#]]);
+
+    Ok(())
+}
+
+#[test]
+fn concurrent_squashes_on_independent_branches_succeed() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new branchB").assert().success();
+    setup_branch_with_commits(&env, "A", 1);
+    setup_branch_with_commits(&env, "branchB", 2);
+
+    let child_a = util::but_std_cmd(&env, "squash A").spawn()?;
+    let child_b = util::but_std_cmd(&env, "squash branchB").spawn()?;
+
+    let out_a = child_a.wait_with_output()?;
+    let out_b = child_b.wait_with_output()?;
+
+    assert!(
+        out_a.status.success(),
+        "squash on A failed: {}",
+        out_a.stderr.as_bstr()
+    );
+    assert!(
+        out_b.status.success(),
+        "squash on branchB failed: {}",
+        out_b.stderr.as_bstr()
+    );
+
+    assert_eq!(branch_commit_count(&env, "A")?, 1);
+    assert_eq!(branch_commit_count(&env, "branchB")?, 1);
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -315,16 +315,26 @@ pub fn squash_commits(
     destination_id: gix::ObjectId,
 ) -> Result<gix::ObjectId> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx, guard.read_permission())
-        .context("Squashing a commit requires open workspace mode")?;
-    crate::squash::squash_commits(
+    squash_commits_with_perm(
         ctx,
         stack_id,
         source_ids,
         destination_id,
         guard.write_permission(),
     )
+}
+
+pub fn squash_commits_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    source_ids: Vec<gix::ObjectId>,
+    destination_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> Result<gix::ObjectId> {
+    ctx.verify(perm)?;
+    ensure_open_workspace_mode(ctx, perm.read_permission())
+        .context("Squashing a commit requires open workspace mode")?;
+    crate::squash::squash_commits(ctx, stack_id, source_ids, destination_id, perm)
 }
 
 pub fn update_commit_message(
@@ -453,16 +463,27 @@ pub fn create_virtual_branch_from_branch(
     pr_number: Option<usize>,
 ) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.verify(guard.write_permission())?;
-    ensure_open_workspace_mode(ctx, guard.read_permission())
-        .context("Creating a virtual branch from a branch open workspace mode")?;
-    let branch_manager = ctx.branch_manager();
-    branch_manager.create_virtual_branch_from_branch(
+    create_virtual_branch_from_branch_with_perm(
+        ctx,
         branch,
         remote,
         pr_number,
         guard.write_permission(),
     )
+}
+
+pub fn create_virtual_branch_from_branch_with_perm(
+    ctx: &mut Context,
+    branch: &Refname,
+    remote: Option<RemoteRefname>,
+    pr_number: Option<usize>,
+    perm: &mut RepoExclusive,
+) -> Result<(StackId, Vec<StackId>, Vec<String>)> {
+    ctx.verify(perm)?;
+    ensure_open_workspace_mode(ctx, perm.read_permission())
+        .context("Creating a virtual branch from a branch open workspace mode")?;
+    let branch_manager = ctx.branch_manager();
+    branch_manager.create_virtual_branch_from_branch(branch, remote, pr_number, perm)
 }
 
 pub fn upstream_integration_statuses(

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -2,11 +2,12 @@
 mod actions;
 // This is our API
 pub use actions::{
-    amend, create_virtual_branch, create_virtual_branch_from_branch, delete_local_branch,
-    fetch_from_remotes, get_initial_integration_steps_for_branch, integrate_branch_with_steps,
-    integrate_upstream, integrate_upstream_commits, move_branch, move_commit, push_base_branch,
-    reorder_stack, resolve_upstream_integration, set_base_branch, set_target_push_remote,
-    squash_commits, tear_off_branch, unapply_stack, undo_commit, update_commit_message,
+    amend, create_virtual_branch, create_virtual_branch_from_branch,
+    create_virtual_branch_from_branch_with_perm, delete_local_branch, fetch_from_remotes,
+    get_initial_integration_steps_for_branch, integrate_branch_with_steps, integrate_upstream,
+    integrate_upstream_commits, move_branch, move_commit, push_base_branch, reorder_stack,
+    resolve_upstream_integration, set_base_branch, set_target_push_remote, squash_commits,
+    squash_commits_with_perm, tear_off_branch, unapply_stack, undo_commit, update_commit_message,
     update_stack_order, upstream_integration_statuses,
 };
 mod squash;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -89,9 +89,25 @@ pub fn update_branch_name(
     new_name: String,
 ) -> Result<String> {
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.verify(guard.write_permission())?;
-    let _ = ctx.snapshot_update_dependent_branch_name(&branch_name, guard.write_permission());
-    ensure_open_workspace_mode(ctx, guard.read_permission())
+    update_branch_name_with_perm(
+        ctx,
+        stack_id,
+        branch_name,
+        new_name,
+        guard.write_permission(),
+    )
+}
+
+pub fn update_branch_name_with_perm(
+    ctx: &mut Context,
+    stack_id: StackId,
+    branch_name: String,
+    new_name: String,
+    perm: &mut but_core::sync::RepoExclusive,
+) -> Result<String> {
+    ctx.verify(perm)?;
+    let _ = ctx.snapshot_update_dependent_branch_name(&branch_name, perm);
+    ensure_open_workspace_mode(ctx, perm.read_permission())
         .context("Requires an open workspace mode")?;
     let mut stack = ctx.virtual_branches().get_stack(stack_id)?;
     let normalized_head_name = normalize_branch_name(&new_name)?;


### PR DESCRIPTION
Adjust major `but` CLI mutators to hold a write lock before the first read.
This serialises them effectively and *should* make `but` way more usable in such situations.

Notably, long-running CLI commands are unaffected, i.e. the TUI is untouched, and editor invocations
are made while the write lock is held.

### Tasks

* [x] hopefully improve the docs of all touched `but-api` functions
* [x] refackiew

### Notes for the reviewer

* It went a bit off the rails with documentation changes that affected more than just the functions it actually modified. The ones I reviewed I kept, but decided to cancel these later.
