### PR TITLE
Share forge credentials across dev, nightly, and release builds

### DIFF
--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -36,7 +36,7 @@ pub async fn init_github_device_oauth() -> Result<Verification> {
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusResponse> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::check_github_auth_status(device_code, &storage).await
 }
 
@@ -56,7 +56,7 @@ pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusR
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::store_pat(&access_token, &storage).await
 }
 
@@ -80,7 +80,7 @@ pub async fn store_github_enterprise_pat(
     access_token: Sensitive<String>,
     host: String,
 ) -> Result<AuthStatusResponse> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::store_enterprise_pat(&host, &access_token, &storage).await
 }
 
@@ -99,7 +99,7 @@ pub async fn store_github_enterprise_pat(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn forget_github_account(account: but_github::GithubAccountIdentifier) -> Result<()> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::forget_gh_access_token(&account, &storage).ok();
     Ok(())
 }
@@ -116,7 +116,7 @@ pub fn forget_github_account(account: but_github::GithubAccountIdentifier) -> Re
 #[but_api]
 #[instrument(err(Debug))]
 pub fn clear_all_github_tokens() -> Result<()> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::clear_all_github_tokens(&storage)
 }
 
@@ -139,7 +139,7 @@ pub fn clear_all_github_tokens() -> Result<()> {
 pub async fn get_gh_user(
     account: but_github::GithubAccountIdentifier,
 ) -> Result<Option<AuthenticatedUser>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::get_gh_user(&account, &storage).await
 }
 
@@ -155,7 +155,7 @@ pub async fn get_gh_user(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdentifier>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::list_known_github_accounts(&storage)
 }
 
@@ -177,6 +177,6 @@ pub fn list_known_github_accounts() -> Result<Vec<but_github::GithubAccountIdent
 pub async fn check_github_credentials(
     account: but_github::GithubAccountIdentifier,
 ) -> Result<but_github::CredentialCheckResult> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_github::check_credentials(&account, &storage).await
 }

--- a/crates/but-api/src/gitlab.rs
+++ b/crates/but-api/src/gitlab.rs
@@ -20,7 +20,7 @@ use tracing::instrument;
 #[but_api(json::AuthStatusResponseSensitive)]
 #[instrument(err(Debug))]
 pub async fn store_gitlab_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::store_pat(&access_token, &storage).await
 }
 
@@ -44,7 +44,7 @@ pub async fn store_gitlab_selfhosted_pat(
     access_token: Sensitive<String>,
     host: String,
 ) -> Result<AuthStatusResponse> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::store_selfhosted_pat(&host, &access_token, &storage).await
 }
 
@@ -63,7 +63,7 @@ pub async fn store_gitlab_selfhosted_pat(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn forget_gitlab_account(account: but_gitlab::GitlabAccountIdentifier) -> Result<()> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::forget_gl_access_token(&account, &storage).ok();
     Ok(())
 }
@@ -80,7 +80,7 @@ pub fn forget_gitlab_account(account: but_gitlab::GitlabAccountIdentifier) -> Re
 #[but_api]
 #[instrument(err(Debug))]
 pub fn clear_all_gitlab_tokens() -> Result<()> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::clear_all_gitlab_tokens(&storage)
 }
 
@@ -103,7 +103,7 @@ pub fn clear_all_gitlab_tokens() -> Result<()> {
 pub async fn get_gl_user(
     account: but_gitlab::GitlabAccountIdentifier,
 ) -> Result<Option<AuthenticatedUser>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::get_gl_user(&account, &storage).await
 }
 
@@ -119,7 +119,7 @@ pub async fn get_gl_user(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn list_known_gitlab_accounts() -> Result<Vec<but_gitlab::GitlabAccountIdentifier>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::list_known_gitlab_accounts(&storage)
 }
 
@@ -141,6 +141,6 @@ pub fn list_known_gitlab_accounts() -> Result<Vec<but_gitlab::GitlabAccountIdent
 pub async fn check_gitlab_credentials(
     account: but_gitlab::GitlabAccountIdentifier,
 ) -> Result<but_gitlab::CredentialCheckResult> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     but_gitlab::check_credentials(&account, &storage).await
 }

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -171,7 +171,7 @@ pub fn list_reviews(
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -197,7 +197,7 @@ pub fn get_review(ctx: &mut Context, review_id: usize) -> Result<but_forge::Forg
             .context("No forge could be determined for this repository.")?;
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -225,7 +225,7 @@ pub fn list_ci_checks_and_update_cache(
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -263,7 +263,7 @@ pub async fn publish_review(
         };
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             forge_push_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
@@ -290,7 +290,7 @@ pub async fn merge_review(ctx: ThreadSafeContext, review_id: usize) -> Result<()
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -319,7 +319,7 @@ pub async fn set_review_auto_merge(
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -349,7 +349,7 @@ pub async fn set_review_draftiness(
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -378,7 +378,7 @@ pub async fn update_review_footers(
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
 
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
@@ -405,7 +405,7 @@ pub async fn list_reviews_for_branch(
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(&ctx)?;
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.clone(),
         )

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -528,7 +528,7 @@ async fn resolve_review_map(
     let mut ctx = ctx;
     let mut resolved_reviews = HashMap::new();
     let db = &mut *ctx.db.get_mut()?;
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     for (key, pr_number) in reviews.drain() {
         if let Ok(resolved) = but_forge::get_forge_review(
             &preferred_forge_user,

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -129,7 +129,7 @@ fn normalize_host_for_comparison(value: &str) -> String {
 
 /// Get all known forge accounts
 pub fn get_all_forge_accounts() -> anyhow::Result<Vec<ForgeUser>> {
-    let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
+    let storage = but_forge_storage::Controller::from_path(but_path::app_config_dir()?);
     let gh_accounts = but_github::list_known_github_accounts(&storage)?;
     let gl_accounts = but_gitlab::list_known_gitlab_accounts(&storage)?;
 

--- a/crates/but-github/src/token.rs
+++ b/crates/but-github/src/token.rs
@@ -233,7 +233,7 @@ impl GitHubAccount {
 fn retrieve_github_secret(account_secret_key: &str) -> Result<Option<Sensitive<String>>> {
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    secret::retrieve(account_secret_key, secret::Namespace::BuildKind)
+    secret::retrieve(account_secret_key, secret::Namespace::Global)
 }
 
 fn persist_github_account(
@@ -248,7 +248,7 @@ fn persist_github_account(
     secret::persist(
         &secret_key,
         &account.secret_value()?,
-        secret::Namespace::BuildKind,
+        secret::Namespace::Global,
     )
 }
 
@@ -261,7 +261,7 @@ fn delete_github_account(
 
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    secret::delete(&secret_key, secret::Namespace::BuildKind)
+    secret::delete(&secret_key, secret::Namespace::Global)
 }
 
 fn delete_all_github_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
@@ -269,7 +269,7 @@ fn delete_all_github_accounts(storage: &but_forge_storage::Controller) -> Result
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
     for key in keys_to_delete {
-        secret::delete(&key, secret::Namespace::BuildKind)?;
+        secret::delete(&key, secret::Namespace::Global)?;
     }
     Ok(())
 }

--- a/crates/but-gitlab/src/token.rs
+++ b/crates/but-gitlab/src/token.rs
@@ -202,7 +202,7 @@ impl GitLabAccount {
 fn retrieve_gitlab_secret(account_secret_key: &str) -> Result<Option<Sensitive<String>>> {
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    secret::retrieve(account_secret_key, secret::Namespace::BuildKind)
+    secret::retrieve(account_secret_key, secret::Namespace::Global)
 }
 
 fn persist_gitlab_account(
@@ -217,7 +217,7 @@ fn persist_gitlab_account(
     secret::persist(
         &secret_key,
         &account.secret_value()?,
-        secret::Namespace::BuildKind,
+        secret::Namespace::Global,
     )
 }
 
@@ -230,7 +230,7 @@ fn delete_gitlab_account(
 
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
-    secret::delete(&secret_key, secret::Namespace::BuildKind)
+    secret::delete(&secret_key, secret::Namespace::Global)
 }
 
 fn delete_all_gitlab_accounts(storage: &but_forge_storage::Controller) -> Result<()> {
@@ -238,7 +238,7 @@ fn delete_all_gitlab_accounts(storage: &but_forge_storage::Controller) -> Result
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
     for key in keys_to_delete {
-        secret::delete(&key, secret::Namespace::BuildKind)?;
+        secret::delete(&key, secret::Namespace::Global)?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -354,7 +354,7 @@ async fn ensure_forge_authentication(ctx: &mut Context) -> Result<(), anyhow::Er
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
         (
-            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            but_forge_storage::Controller::from_path(but_path::app_config_dir()?),
             forge_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )


### PR DESCRIPTION
GitHub and GitLab tokens were stored in per-channel keychain namespaces
and the account list (forge_settings.json) lived in per-channel data
directories. This made it impossible to be signed into GitHub on more
than one of dev/nightly/release at the same time — each build required
its own separate authentication.

Move keychain entries to the global namespace and the forge settings
file to the shared config directory so all builds share a single set
of forge credentials.