### PR TITLE
Fix VirtualList jumpToIndex landing on wrong item when index is 0

### DIFF
--- a/packages/ui/src/lib/components/VirtualList.svelte
+++ b/packages/ui/src/lib/components/VirtualList.svelte
@@ -750,7 +750,7 @@
 		) {
 			// Maintain position as off-viewport elements resize after a jump.
 			// Skip during init — heightMap is incomplete.
-			const target = calculateHeightSum(0, lastJumpToIndex || startIndex || 0);
+			const target = calculateHeightSum(0, lastJumpToIndex ?? startIndex ?? 0);
 			// Subpixel tolerance: scrollTop is fractional, heightSum is integer.
 			if (Math.abs(viewport.scrollTop - target) < 1) return;
 			viewport.scrollTop = target;


### PR DESCRIPTION
When jumpToIndex(0) was called and an item subsequently resized after
initialization, compensateScrollForResize used `lastJumpToIndex || startIndex`
to recalculate the target scroll position. Because 0 is falsy, the expression
fell through to `startIndex`, scrolling to the previously stored selection
index instead of staying at the top.

Fix by replacing `||` with `??` so that index 0 is preserved.