### PR TITLE
graph: squash commits

### DIFF
--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -14,7 +14,7 @@ use petgraph::{
 
 use crate::{
     Commit, CommitIndex, Edge, EntryPoint, Graph, Segment, SegmentFlags, SegmentIndex,
-    init::PetGraph, projection::commit::is_managed_workspace_by_message,
+    SegmentRelation, init::PetGraph, projection::commit::is_managed_workspace_by_message,
 };
 
 /// Mutation
@@ -74,6 +74,24 @@ impl Graph {
 
 /// Merge-base computation
 impl Graph {
+    /// Determine the ancestry relationship of `a` relative to `b`.
+    ///
+    /// `Ancestor` means `a` is reachable from `b` when walking towards history,
+    /// `Descendant` means the inverse, and `Diverged` means they share history
+    /// but neither is ancestor of the other.
+    pub fn relation_between(&self, a: SegmentIndex, b: SegmentIndex) -> SegmentRelation {
+        if a == b {
+            return SegmentRelation::Identity;
+        }
+
+        match self.find_git_merge_base(a, b) {
+            Some(base) if base == a => SegmentRelation::Ancestor,
+            Some(base) if base == b => SegmentRelation::Descendant,
+            Some(_) => SegmentRelation::Diverged,
+            None => SegmentRelation::Disjoint,
+        }
+    }
+
     /// Compute the merge-base just like Git would between segments `a` and `b`, but finding all possible merge-bases of a walk,
     /// which are then truncated to the highest merge-base that includes all the other merge-bases.
     ///

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -263,6 +263,21 @@ pub struct EntryPoint<'graph> {
     pub commit: Option<&'graph Commit>,
 }
 
+/// Relationship of one segment to another in terms of graph ancestry.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SegmentRelation {
+    /// Both segment indices point to the same segment.
+    Identity,
+    /// The first segment is an ancestor of the second segment.
+    Ancestor,
+    /// The first segment is a descendant of the second segment.
+    Descendant,
+    /// Segments share history, but neither is ancestor of the other.
+    Diverged,
+    /// Segments do not share any history.
+    Disjoint,
+}
+
 /// This structure is used as data associated with each edge and is mainly for collecting
 /// the intent of an edge, which should always represent the connection of a commit to another.
 /// Sometimes, it represents the connection from a commit (or segment) to an empty segment which

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -20,6 +20,8 @@ pub mod move_commit;
 pub use move_commit::function::move_commit;
 pub mod discard_commit;
 pub use discard_commit::function::discard_commit;
+pub mod squash_commits;
+pub use squash_commits::function::{SquashCommitsOutcome, squash_commits};
 
 /// A minimal stack for use by [WorkspaceCommit::new_from_stacks()].
 #[derive(Clone)]

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -1,0 +1,186 @@
+//! An action to squash one commit into another.
+
+pub(crate) mod function {
+    use anyhow::{Result, bail};
+    use but_core::RefMetadata;
+    use but_graph::{SegmentIndex, SegmentRelation, projection::Workspace};
+    use but_rebase::{
+        commit::DateMode,
+        graph_rebase::{
+            Editor, Selector, Step, SuccessfulRebase, ToCommitSelector,
+            mutate::{SegmentDelimiter, SelectorSet},
+        },
+    };
+
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    enum ReorderDirection {
+        MoveSubjectAboveTarget,
+        MoveSubjectBelowTarget,
+    }
+
+    fn find_commit_segment_index(
+        workspace: &Workspace,
+        commit_id: gix::ObjectId,
+    ) -> Option<SegmentIndex> {
+        let (_, stack_segment, _) = workspace.find_commit_and_containers(commit_id)?;
+        let commit_offset = stack_segment
+            .commits
+            .iter()
+            .position(|c| c.id == commit_id)?;
+
+        let mut owning_segment = stack_segment.id;
+        for (segment_id, offset) in &stack_segment.commits_by_segment {
+            if *offset > commit_offset {
+                break;
+            }
+            owning_segment = *segment_id;
+        }
+
+        Some(owning_segment)
+    }
+
+    fn determine_reorder_direction(
+        workspace: &Workspace,
+        repo: &gix::Repository,
+        subject: &but_core::CommitOwned,
+        target: &but_core::CommitOwned,
+    ) -> Result<ReorderDirection> {
+        let subject_segment = find_commit_segment_index(workspace, subject.id)
+            .ok_or_else(|| anyhow::anyhow!("Couldn't resolve subject commit segment"))?;
+        let target_segment = find_commit_segment_index(workspace, target.id)
+            .ok_or_else(|| anyhow::anyhow!("Couldn't resolve target commit segment"))?;
+
+        match workspace
+            .graph
+            .relation_between(subject_segment, target_segment)
+        {
+            SegmentRelation::Descendant => return Ok(ReorderDirection::MoveSubjectAboveTarget),
+            SegmentRelation::Ancestor => return Ok(ReorderDirection::MoveSubjectBelowTarget),
+            SegmentRelation::Disjoint | SegmentRelation::Diverged => {
+                return Ok(ReorderDirection::MoveSubjectAboveTarget);
+            }
+            SegmentRelation::Identity => {
+                // Commits can differ while still belonging to the same segment, so use commit-level
+                // ancestry in this case.
+            }
+        }
+
+        let merge_base = match repo.merge_base(subject.id, target.id) {
+            Ok(base) => base,
+            // If commits don't have a merge-base (or merge-base resolution fails),
+            // we still allow squashing by using a deterministic default ordering.
+            Err(error) => match error {
+                gix::repository::merge_base::Error::FindMergeBase(_)
+                | gix::repository::merge_base::Error::NotFound { .. } => {
+                    return Ok(ReorderDirection::MoveSubjectAboveTarget);
+                }
+                _ => return Err(error.into()),
+            },
+        };
+
+        if merge_base == target.id {
+            return Ok(ReorderDirection::MoveSubjectAboveTarget);
+        }
+
+        if merge_base == subject.id {
+            return Ok(ReorderDirection::MoveSubjectBelowTarget);
+        }
+
+        Ok(ReorderDirection::MoveSubjectAboveTarget)
+    }
+
+    /// The result of a squash_commits operation.
+    #[derive(Debug)]
+    pub struct SquashCommitsOutcome<'ws, 'meta, M: RefMetadata> {
+        /// The successful rebase result.
+        pub rebase: SuccessfulRebase<'ws, 'meta, M>,
+        /// Selector pointing to the squashed replacement commit.
+        pub commit_selector: Selector,
+    }
+
+    /// Squash `subject_commit` into `target_commit`.
+    ///
+    /// Depending on the ancestry relationship between the two commits, this operation may
+    /// reorder them so that the subject ends up either above or below the target.
+    ///
+    /// After any reordering, one of the two original commit positions (either the subject or
+    /// the target) is replaced by a single squashed commit that has:
+    /// - The tree of the commit that was top-most after reordering (subject or target)
+    /// - The combined message `subject\n\ntarget`
+    ///
+    /// The other original commit (subject or target, depending on the chosen ordering) is
+    /// removed from history.
+    pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
+        editor: Editor<'ws, 'meta, M>,
+        subject_commit: impl ToCommitSelector,
+        target_commit: impl ToCommitSelector,
+    ) -> Result<SquashCommitsOutcome<'ws, 'meta, M>> {
+        let (subject_selector, subject) = editor.find_selectable_commit(subject_commit)?;
+        let (target_selector, target) = editor.find_selectable_commit(target_commit)?;
+
+        if subject.id == target.id {
+            bail!("Cannot squash a commit into itself")
+        }
+
+        if subject.clone().attach(editor.repo()).is_conflicted() {
+            bail!("Subject commit must not be conflicted")
+        }
+
+        if target.clone().attach(editor.repo()).is_conflicted() {
+            bail!("Target commit must not be conflicted")
+        }
+
+        let direction =
+            determine_reorder_direction(editor.workspace, editor.repo(), &subject, &target)?;
+        let mut editor = editor;
+
+        let mut combined_message = Vec::new();
+        combined_message.extend_from_slice(subject.message.as_ref());
+        if !combined_message.ends_with(b"\n") {
+            combined_message.push(b'\n');
+        }
+        combined_message.push(b'\n');
+        combined_message.extend_from_slice(target.message.as_ref());
+
+        let (replace_selector, dropped_selector, mut commit_to_replace, top_tree_id) =
+            match direction {
+                ReorderDirection::MoveSubjectAboveTarget => (
+                    target_selector,
+                    subject_selector,
+                    target.clone(),
+                    subject.tree,
+                ),
+                ReorderDirection::MoveSubjectBelowTarget => (
+                    subject_selector,
+                    target_selector,
+                    subject.clone(),
+                    target.tree,
+                ),
+            };
+
+        let new_commit_id = {
+            commit_to_replace.tree = top_tree_id;
+            commit_to_replace.message = combined_message.into();
+            editor.new_commit(commit_to_replace, DateMode::CommitterUpdateAuthorKeep)?
+        };
+
+        let dropped_delimiter = SegmentDelimiter {
+            child: dropped_selector,
+            parent: dropped_selector,
+        };
+        editor.disconnect_segment_from(
+            dropped_delimiter,
+            SelectorSet::All,
+            SelectorSet::All,
+            false,
+        )?;
+
+        editor.replace(replace_selector, Step::new_pick(new_commit_id))?;
+        editor.replace(dropped_selector, Step::None)?;
+
+        Ok(SquashCommitsOutcome {
+            rebase: editor.rebase()?,
+            commit_selector: replace_selector,
+        })
+    }
+}

--- a/crates/but-workspace/tests/fixtures/scenario/squash-shared-file-three-commits.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/squash-shared-file-three-commits.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+git init
+
+git checkout -b one
+echo "v1" > shared.txt
+git add shared.txt
+git commit -m "commit one"
+
+git checkout -b two
+echo "v2" > shared.txt
+git add shared.txt
+git commit -m "commit two"
+
+git checkout -b three
+echo "v3" > shared.txt
+git add shared.txt
+git commit -m "commit three"

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -5,6 +5,7 @@ mod insert_blank_commit;
 mod move_changes;
 mod move_commit;
 mod reword;
+mod squash_commits;
 mod uncommit_changes;
 
 mod from_new_merge_with_metadata {

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -1,0 +1,375 @@
+use anyhow::Result;
+use bstr::ByteSlice as _;
+use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use but_testsupport::{graph_workspace, visualize_commit_graph_all};
+use but_workspace::commit::squash_commits;
+
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments,
+    named_writable_scenario_with_description_and_graph as writable_scenario,
+};
+
+#[test]
+fn squash_top_commit_into_parent() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit three\n\ncommit two\n",
+        "combined message should be subject followed by target with one blank line"
+    );
+    assert_eq!(
+        squashed_commit.tree_id()?.detach(),
+        subject_tree,
+        "squashed commit should take the top-most (subject) tree"
+    );
+
+    let two_tip = repo.find_reference("two")?.peel_to_id()?.detach();
+    let three_tip = repo.find_reference("three")?.peel_to_id()?.detach();
+    assert_eq!(
+        two_tip, squashed_id,
+        "target reference should point to squashed commit"
+    );
+    assert_eq!(
+        three_tip, squashed_id,
+        "subject reference should be reconnected to squashed commit"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 6426178 (HEAD -> three, two) commit three
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    // Subject starts below target in history and needs internal reorder first.
+    let subject_id = repo.rev_parse_single("two")?.detach();
+    let target_id = repo.rev_parse_single("three")?.detach();
+    let target_tree = repo.find_commit(target_id)?.tree_id()?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit two\n\ncommit three\n",
+        "combined message should respect subject-then-target order"
+    );
+    assert_eq!(
+        squashed_commit.tree_id()?.detach(),
+        target_tree,
+        "when subject is above target in ancestry, the target tree is top-most and must be kept"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 655b033 (HEAD -> three, two) commit two
+    | * 16fd221 (origin/two) commit two
+    |/  
+    * 8b426d0 (one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_same_commit_is_rejected() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("reword-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    let commit_id = repo.rev_parse_single("two")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+
+    let err = squash_commits(editor, commit_id, commit_id).expect_err("must fail");
+    assert!(
+        err.to_string()
+            .contains("Cannot squash a commit into itself"),
+        "error should make same-commit squash invalid"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * c9f444c (HEAD -> three) commit three
+    * 16fd221 (origin/two, two) commit two
+    * 8b426d0 (one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("squash-shared-file-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * a209f1b (HEAD -> three) commit three
+    * c0570de (two) commit two
+    * 8df0fa3 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("two")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let spec = format!("{squashed_id}:shared.txt");
+    let object = repo.rev_parse_single(spec.as_str())?.object()?;
+    assert_eq!(object.data.as_bstr(), "v3\n");
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 4fbac4b (HEAD -> three, two) commit three
+    * 8df0fa3 (one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_up_reorders_subject_below_target_for_shared_file_lineage() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("squash-shared-file-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * a209f1b (HEAD -> three) commit three
+    * c0570de (two) commit two
+    * 8df0fa3 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("two")?.detach();
+    let target_id = repo.rev_parse_single("three")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let spec = format!("{squashed_id}:shared.txt");
+    let object = repo.rev_parse_single(spec.as_str())?.object()?;
+    assert_eq!(object.data.as_bstr(), "v3\n");
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit two\n\ncommit three\n"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 69e6e54 (HEAD -> three, two) commit two
+    * 8df0fa3 (one) commit one
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_down_out_of_order_reorders_subject_below_target_for_shared_file_lineage() -> Result<()> {
+    let (_tmp, graph, repo, mut _meta, _description) =
+        writable_scenario("squash-shared-file-three-commits", |_| {})?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * a209f1b (HEAD -> three) commit three
+    * c0570de (two) commit two
+    * 8df0fa3 (one) commit one
+    ");
+
+    let subject_id = repo.rev_parse_single("three")?.detach();
+    let target_id = repo.rev_parse_single("one")?.detach();
+
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let spec = format!("{squashed_id}:shared.txt");
+    let object = repo.rev_parse_single(spec.as_str())?.object()?;
+    assert_eq!(object.data.as_bstr(), "v3\n");
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(
+        squashed_commit.message_raw()?,
+        "commit three\n\ncommit one\n"
+    );
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 09ef005 (HEAD -> three, two) commit two
+    * f297a08 (one) commit three
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_across_stacks_subject_into_target() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("ws-ref-ws-commit-two-stacks", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+
+    let mut ws = graph.into_workspace()?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   c49e4d8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let subject_id = repo.rev_parse_single("A")?.detach();
+    let target_id = repo.rev_parse_single("B")?.detach();
+    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(squashed_commit.message_raw()?, "A\n\nB\n");
+    assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   f0f9abb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 17e27b0 (B) A
+    |/  
+    * 85efbe4 (origin/main, main, A) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:3:B on 85efbe4 {2}
+    │   └── 📙:3:B
+    │       └── ·17e27b0 (🏘️)
+    └── ≡📙:4:A on 85efbe4 {1}
+        └── 📙:4:A
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn squash_across_stacks_target_into_subject() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("ws-ref-ws-commit-two-stacks", |meta| {
+            add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+        })?;
+
+    let mut ws = graph.into_workspace()?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   c49e4d8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 09d8e52 (A) A
+    * | c813d8d (B) B
+    |/  
+    * 85efbe4 (origin/main, main) M
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    │       └── ·c813d8d (🏘️)
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·09d8e52 (🏘️)
+    ");
+
+    let subject_id = repo.rev_parse_single("B")?.detach();
+    let target_id = repo.rev_parse_single("A")?.detach();
+    let subject_tree = repo.find_commit(subject_id)?.tree_id()?.detach();
+
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    let outcome = squash_commits(editor, subject_id, target_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
+
+    let squashed_commit = repo.find_commit(squashed_id)?;
+    assert_eq!(squashed_commit.message_raw()?, "B\n\nA\n");
+    assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   3d10054 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    * | 82d6f41 (A) B
+    |/  
+    * 85efbe4 (origin/main, main, B) M
+    ");
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+    ├── ≡📙:4:B on 85efbe4 {2}
+    │   └── 📙:4:B
+    └── ≡📙:3:A on 85efbe4 {1}
+        └── 📙:3:A
+            └── ·82d6f41 (🏘️)
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
Add an API that squashes commits using the new rebase engine.