### PR TITLE
Re-enable modern-but testing

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -220,6 +220,7 @@ jobs:
           cargo check -p but-workspace --all-targets
           cargo check -p but-api --all-targets
           cargo check -p but --all-targets
+          make check-modern-but
         name: Special `cargo check` runs
         env:
           RUSTFLAGS: "--deny warnings"
@@ -301,6 +302,8 @@ jobs:
         run: sudo ./scripts/install-minimal-debian-dependencies.sh
       - run: cargo test --workspace --exclude gitbutler-tauri --exclude but-server --exclude but-api-macros-tests
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
+      - run: cargo test -p but
+      - run: make test-modern-but
       - run: cargo test -p but
       - run: cargo test -p but-server
       - name: test vendored

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -304,7 +304,6 @@ jobs:
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
       - run: cargo test -p but
       - run: make test-modern-but
-      - run: cargo test -p but
       - run: cargo test -p but-server
       - name: test vendored
         run: |

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,14 @@ check:
 clippy:
 	cargo clippy --workspace --all-targets -- -D warnings
 
+# An alias for nextest
 .PHONY: test
 test: nextest
+
+# build and test a version of `but` without any legacy code
+.PHONY: test-modern-but
+test-modern-but:
+	cargo test -p but --no-default-features
 
 # Run all tests in the entire workspace and show all failures in the end.
 .PHONY: nextest

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ clippy:
 .PHONY: test
 test: nextest
 
-# build and test a version of `but` without any legacy code
+# CI executes this to build a version of `but` without any legacy code.
+.PHONY: check-modern-but
+check-modern-but:
+	cargo check -p but --all-targets --no-default-features
+
+# CI executes this to test a version of `but` without any legacy code.
 .PHONY: test-modern-but
 test-modern-but:
 	cargo test -p but --no-default-features

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 
+#[cfg(feature = "legacy")]
 mod commit;
+#[cfg(feature = "legacy")]
 mod reword;
 
 mod config_ai {

--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -1,11 +1,9 @@
+use crate::utils::OutputChannel;
 use anyhow::{Context as _, Result};
 use bstr::BStr;
 use bstr::ByteSlice;
 use but_core::{DiffSpec, diff::tree_changes, sync::RepoExclusive};
 use but_ctx::Context;
-use gitbutler_branch_actions::update_workspace_commit;
-
-use crate::utils::OutputChannel;
 
 pub fn commited_file_to_another_commit(
     ctx: &mut Context,
@@ -43,7 +41,7 @@ pub fn commited_file_to_another_commit_with_perm(
         perm,
     )?;
 
-    update_workspace_commit(ctx, false)?;
+    legacy_update_workspace_commit(ctx)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Moved files between commits!")?;
@@ -92,7 +90,7 @@ pub fn uncommit_file_with_perm(
         perm,
     )?;
 
-    update_workspace_commit(ctx, false)?;
+    legacy_update_workspace_commit(ctx)?;
 
     if let Some(out) = out.for_human() {
         writeln!(out, "Uncommitted changes")?;
@@ -140,10 +138,12 @@ pub fn uncommit_file_and_discard_with_perm(
         perm,
     )?;
 
-    let repo = ctx.repo.get()?;
-    let dropped = but_workspace::discard_workspace_changes(&repo, relevant_changes, context_lines)?;
+    let dropped = {
+        let repo = ctx.repo.get()?;
+        but_workspace::discard_workspace_changes(&repo, relevant_changes, context_lines)?
+    };
 
-    update_workspace_commit(ctx, false)?;
+    legacy_update_workspace_commit(ctx)?;
 
     if emit_output {
         if let Some(out) = out.for_human() {
@@ -196,4 +196,12 @@ fn find_stack_id_for_branch_with_perm(
         .and_then(|full_name| ws.find_segment_and_stack_by_refname(full_name.as_ref()))
         .and_then(|(stack, _)| stack.id);
     Ok(assign_to)
+}
+
+/// Refresh the workspace commit when legacy workspace state is available.
+/// TODO: remove this as it shouldn't be needed - all the functions it calls use the rebase engine which takes care of that.
+fn legacy_update_workspace_commit(ctx: &mut Context) -> Result<()> {
+    #[cfg(feature = "legacy")]
+    gitbutler_branch_actions::update_workspace_commit(ctx, false)?;
+    Ok(())
 }

--- a/crates/but/src/command/commit/file.rs
+++ b/crates/but/src/command/commit/file.rs
@@ -200,8 +200,8 @@ fn find_stack_id_for_branch_with_perm(
 
 /// Refresh the workspace commit when legacy workspace state is available.
 /// TODO: remove this as it shouldn't be needed - all the functions it calls use the rebase engine which takes care of that.
-fn legacy_update_workspace_commit(ctx: &mut Context) -> Result<()> {
+fn legacy_update_workspace_commit(_ctx: &mut Context) -> Result<()> {
     #[cfg(feature = "legacy")]
-    gitbutler_branch_actions::update_workspace_commit(ctx, false)?;
+    gitbutler_branch_actions::update_workspace_commit(_ctx, false)?;
     Ok(())
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -37,8 +37,9 @@ use but_settings::AppSettings;
 use colored::Colorize;
 use gix::date::time::CustomFormat;
 
+#[cfg(feature = "legacy")]
+use crate::command::legacy::ShowDiffInEditor;
 use crate::{
-    command::legacy::ShowDiffInEditor,
     setup::{BackgroundSync, InitCtxOptions},
     utils::{
         OneshotMetricsContext, OutputChannel, ResultErrorExt, ResultJsonExt, ResultMetricsExt,
@@ -1486,6 +1487,16 @@ async fn maybe_run_status_after(
         // will flush any buffered JSON (e.g. structured illegal_move details)
         // to stdout, so the mutation result is never silently lost.
     }
+}
+
+/// Ignore `--status-after` in non-legacy builds until a non-legacy status command exists.
+#[cfg(not(feature = "legacy"))]
+async fn maybe_run_status_after(
+    _status_after: bool,
+    _result: &anyhow::Result<()>,
+    _ctx: &mut but_ctx::Context,
+    _out: &mut OutputChannel,
+) {
 }
 
 /// Run workspace status output after a mutation command completes.

--- a/crates/but/tests/but/command/branch/mod.rs
+++ b/crates/but/tests/but/command/branch/mod.rs
@@ -1,6 +1,5 @@
 mod apply;
 mod move_branch;
-#[cfg(feature = "legacy")]
 mod new;
 mod tear_off;
 mod unapply;

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -37,6 +37,7 @@ fn ai_openai_defaults_to_global_config() -> anyhow::Result<()> {
 fn ai_ollama_local_writes_repo_config() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
     env.invoke_bash("git init repo");
+    #[cfg(feature = "legacy")]
     env.but("-C repo setup").assert().success();
 
     env.but("-C repo config ai --local ollama --endpoint localhost:11434 --model llama3.1")
@@ -113,6 +114,7 @@ fn ai_show_outputs_current_global_configuration_json() -> anyhow::Result<()> {
 fn ai_show_outputs_current_local_configuration_json() -> anyhow::Result<()> {
     let env = Sandbox::empty()?;
     env.invoke_bash("git init repo");
+    #[cfg(feature = "legacy")]
     env.but("-C repo setup").assert().success();
 
     env.but("-C repo config ai --local ollama --endpoint localhost:11434 --model llama3.1")

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "legacy")]
 mod absorb;
 mod alias;
+#[cfg(feature = "legacy")]
 mod branch;
 #[cfg(feature = "legacy")]
 mod claude;


### PR DESCRIPTION
Previously CI was testing the 'modern' but build to have an indication of progress towards the goal of not using legacy code.
This PR re-enables it and makes local testing easier, to help chipping away at it over time.
