### PR TITLE
commit ordering

### DIFF
--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -319,6 +319,28 @@ impl Workspace {
         })
     }
 
+    /// Try to find the owning graph segment of `commit_id` in the workspace.
+    ///
+    /// This uses the stack segment's `commits_by_segment` offsets to map a projected
+    /// commit back to its source graph segment.
+    pub fn find_commit_segment_index(&self, commit_id: gix::ObjectId) -> Option<SegmentIndex> {
+        let (_, stack_segment, _) = self.find_commit_and_containers(commit_id)?;
+        let commit_offset = stack_segment
+            .commits
+            .iter()
+            .position(|c| c.id == commit_id)?;
+
+        let mut owning_segment = stack_segment.id;
+        for (segment_id, offset) in &stack_segment.commits_by_segment {
+            if *offset > commit_offset {
+                break;
+            }
+            owning_segment = *segment_id;
+        }
+
+        Some(owning_segment)
+    }
+
     /// Like [`Self::find_segment_and_stack_by_refname`], but fails with an error.
     pub fn try_find_segment_and_stack_by_refname(
         &self,

--- a/crates/but-graph/src/projection/workspace/api.rs
+++ b/crates/but-graph/src/projection/workspace/api.rs
@@ -324,11 +324,14 @@ impl Workspace {
     /// This uses the stack segment's `commits_by_segment` offsets to map a projected
     /// commit back to its source graph segment.
     pub fn find_commit_segment_index(&self, commit_id: gix::ObjectId) -> Option<SegmentIndex> {
-        let (_, stack_segment, _) = self.find_commit_and_containers(commit_id)?;
-        let commit_offset = stack_segment
-            .commits
-            .iter()
-            .position(|c| c.id == commit_id)?;
+        let (stack_segment, commit_offset) = self.stacks.iter().find_map(|stack| {
+            stack.segments.iter().find_map(|seg| {
+                seg.commits
+                    .iter()
+                    .enumerate()
+                    .find_map(|(offset, commit)| (commit.id == commit_id).then_some((seg, offset)))
+            })
+        })?;
 
         let mut owning_segment = stack_segment.id;
         for (segment_id, offset) in &stack_segment.commits_by_segment {

--- a/crates/but-rebase/docs/commit_parentage.md
+++ b/crates/but-rebase/docs/commit_parentage.md
@@ -1,0 +1,141 @@
+# Commit Parentage Ordering
+
+This document explains how commit selector ordering works in
+`Editor::order_commit_selectors_by_parentage` (implemented in
+`but-rebase/src/graph_rebase/ordering.rs`), and why the implementation is
+structured the way it is.
+
+## Goal
+
+Given a set of commit selectors, produce a deterministic order such that:
+
+- Parent commits come before child commits.
+- Unrelated commits still have a stable, deterministic order.
+- Duplicate selectors are deduplicated by commit id (first occurrence wins).
+
+This ordering is useful for operations that must apply commits in dependency-safe order.
+
+## Inputs and Output
+
+Method: `editor.order_commit_selectors_by_parentage(selectors) -> Result<Vec<Selector>>`
+
+- Input selectors can be any type implementing `ToCommitSelector`.
+- The output is a list of normalized `Selector` values.
+
+## Preconditions and Errors
+
+The function treats the editor step graph as the single source of truth.
+
+This means:
+
+- Commits must be selectable in the editor graph.
+- If a commit is absent from the editor graph, selector resolution fails (for example: `Failed to find commit <oid> in rebase editor`).
+- No workspace projection lookup is used for ordering.
+
+## High-Level Pipeline
+
+The algorithm has five phases.
+
+1. Normalize and deduplicate input
+- Resolve each incoming selector to `(Selector, CommitOwned)` with `editor.find_selectable_commit`.
+- Keep only the first occurrence of each commit id.
+
+2. Compute deterministic fallback rank
+
+  Build a map: `commit_id -> rank` from editor step graph structure.
+
+  Implementation notes:
+
+  - Consider only `Step::Pick` nodes.
+  - Build pick-to-pick parent/child relations from ordered step-graph parents.
+  - Perform deterministic topological ranking.
+  - Tie-break ready nodes by graph node index for stability.
+
+  - This rank is used only when ancestry does not constrain order.
+
+3. Build ancestry constraint graph
+- For every selected pair `(left, right)`, determine relation.
+- If `left` is ancestor of `right`, add directed edge `left -> right`.
+- If `right` is ancestor of `left`, add directed edge `right -> left`.
+- If unrelated, add no edge.
+
+Ancestry relation is computed by reachability in the editor step graph:
+
+- Starting at the candidate descendant node, walk parent-direction edges (`Outgoing` in this graph representation).
+- If the ancestor selector id is reachable, it is an ancestor.
+
+4. Topological sort with stable tie-breaking
+- Use Kahn's algorithm over indegrees.
+- Keep all currently ready nodes in a min-priority structure keyed by:
+  - `(step_graph_rank, input_order)`
+- Repeatedly pop the best ready node, emit it, and reduce indegree of its children.
+
+5. Validate completeness
+- If output length is smaller than selected length, constraints were cyclic/inconsistent.
+- Return an explicit error in that case.
+
+### Kahn's Algo
+
+We use Kahn's algorithm to topologically sort the nodes.
+
+Indegree:
+- In a directed graph, indegree of a node = how many arrows point into it.
+- If node B has edges A → B and C → B, then indegree(B) = 2.
+- Intuition: indegree tells you how many prerequisites a node still has.
+
+Kahn’s algorithm:
+- It is a way to do topological sorting.
+- Topological sort means ordering nodes so every prerequisite appears before what depends on it.
+- Works only if there is no cycle
+
+How Kahn’s algorithm works:
+1. Compute indegree for every node.
+2. Put all nodes with indegree 0 into a queue (or priority queue if you want deterministic tie-breaking).
+3. Repeatedly:
+   1. Remove one node from the queue and add it to output.
+   2. For each outgoing edge from that node to neighbor N, reduce indegree(N) by 1.
+   3. If indegree(N) becomes 0, push N into the queue.
+4. When done:
+   - If output contains all nodes, that is a valid topological order.
+   - If not, the graph has a cycle (some nodes never reached indegree 0).
+
+Why indegree is the key:
+- Indegree 0 means no remaining unmet dependencies.
+- Removing a node simulates “completing” that task, which can unlock others.
+
+Tiny example:
+- Edges: A → C, B → C, C → D
+- Initial indegrees: A=0, B=0, C=2, D=1
+- Start queue: A, B
+- Pop A: C becomes 1
+- Pop B: C becomes 0, enqueue C
+- Pop C: D becomes 0, enqueue D
+- Pop D
+- Order could be A, B, C, D (or B, A, C, D depending on queue policy)
+
+## Complexity
+
+Let `n` be number of selected unique commits.
+
+- Pairwise relation discovery: `O(n^2)` comparisons.
+- Topological processing:
+  - each push/pop on ready queue: `O(log n)`
+  - overall typically `O((n + e) log n)` where `e` is number of ancestry edges.
+
+Total dominated by pairwise relation checks plus heap operations.
+
+## Determinism Guarantees
+
+Determinism is achieved by:
+
+- deduping by first occurrence,
+- using step-graph-derived rank for unrelated commits,
+- using `input_order` as secondary tiebreaker.
+
+So repeated runs with the same inputs and editor graph state produce the same output.
+
+## Notes for Future Changes
+
+If behavior needs to include commits currently not represented in the editor graph,
+that must be solved before ordering (for example by changing editor graph construction).
+Ordering itself intentionally operates only on what the editor graph already contains.

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -21,6 +21,7 @@ pub mod cherry_pick;
 pub mod commit;
 pub mod materialize;
 pub mod mutate;
+pub mod ordering;
 pub(crate) mod util;
 
 /// Utilities for testing

--- a/crates/but-rebase/src/graph_rebase/ordering.rs
+++ b/crates/but-rebase/src/graph_rebase/ordering.rs
@@ -1,0 +1,265 @@
+#![doc = include_str!("../../docs/commit_parentage.md")]
+
+use std::{
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap, HashSet},
+};
+
+use anyhow::{Context, Result, bail};
+use but_core::RefMetadata;
+use petgraph::visit::EdgeRef as _;
+
+use crate::graph_rebase::{Editor, Pick, Selector, Step, StepGraphIndex, ToCommitSelector, util};
+
+impl<M: RefMetadata> Editor<'_, '_, M> {
+    /// Order commit selectors by parentage, with parents first and children last.
+    ///
+    /// If two commits are unrelated by ancestry, their relative order is determined by
+    /// deterministic editor graph order. Duplicate selectors are deduplicated by commit-id
+    /// with first occurrence winning.
+    pub fn order_commit_selectors_by_parentage<I, S>(&self, selectors: I) -> Result<Vec<Selector>>
+    where
+        I: IntoIterator<Item = S>,
+        S: ToCommitSelector,
+    {
+        // Normalize user input to unique commits while retaining first-seen order for tie-breaking.
+        let mut selected = Vec::<SelectedCommit>::new();
+        let mut seen_ids = HashSet::<gix::ObjectId>::new();
+        for (input_order, selector_like) in selectors.into_iter().enumerate() {
+            let (selector, commit) = self.find_selectable_commit(selector_like)?;
+            if seen_ids.insert(commit.id) {
+                selected.push(SelectedCommit {
+                    selector,
+                    id: commit.id,
+                    input_order,
+                });
+            }
+        }
+
+        if selected.len() <= 1 {
+            return Ok(selected.into_iter().map(|s| s.selector).collect());
+        }
+
+        // Build a deterministic fallback rank from editor step-graph order for unrelated commits.
+        let step_graph_rank = step_graph_parent_to_child_rank(self);
+
+        // Build a DAG over selected commits where edges always point ancestor -> descendant.
+        let mut adjacency = vec![Vec::<usize>::new(); selected.len()];
+        let mut indegree = vec![0usize; selected.len()];
+
+        for (i, left_commit) in selected.iter().enumerate() {
+            for (offset, right_commit) in selected.iter().skip(i + 1).enumerate() {
+                let j = i + 1 + offset;
+                match ancestry_relation(self, left_commit, right_commit) {
+                    Relation::LeftIsAncestorOfRight => {
+                        adjacency
+                            .get_mut(i)
+                            .context("BUG: adjacency index should always be valid")?
+                            .push(j);
+                        *indegree
+                            .get_mut(j)
+                            .context("BUG: indegree index should always be valid")? += 1;
+                    }
+                    Relation::RightIsAncestorOfLeft => {
+                        adjacency
+                            .get_mut(j)
+                            .context("BUG: adjacency index should always be valid")?
+                            .push(i);
+                        *indegree
+                            .get_mut(i)
+                            .context("BUG: indegree index should always be valid")? += 1;
+                    }
+                    Relation::Unrelated => {}
+                }
+            }
+        }
+
+        // Kahn topological sort with a min-priority queue so output order is stable across unrelated nodes.
+        let mut output = Vec::with_capacity(selected.len());
+        let mut ready: BinaryHeap<Reverse<(usize, usize, usize)>> = indegree
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, degree)| {
+                if *degree != 0 {
+                    return None;
+                }
+                let commit = selected.get(idx)?;
+                let rank = *step_graph_rank
+                    .get(&commit.id)
+                    .context("BUG: selected commit should be rankable in editor graph")
+                    .ok()?;
+                Some(Reverse((rank, commit.input_order, idx)))
+            })
+            .collect();
+
+        // Repeatedly emit the best available node and unlock its descendants.
+        while let Some(Reverse((_, _, next))) = ready.pop() {
+            output.push(
+                selected
+                    .get(next)
+                    .context("BUG: ready index should be in-bounds")?
+                    .selector,
+            );
+            for &child in adjacency
+                .get(next)
+                .context("BUG: adjacency index should be in-bounds")?
+            {
+                let degree = indegree
+                    .get_mut(child)
+                    .context("BUG: child index should be in-bounds")?;
+                *degree -= 1;
+                if *degree == 0 {
+                    let commit = selected
+                        .get(child)
+                        .context("BUG: child index should point to selected commits")?;
+                    let rank = *step_graph_rank
+                        .get(&commit.id)
+                        .context("BUG: selected child commit should be rankable in editor graph")?;
+                    ready.push(Reverse((rank, commit.input_order, child)));
+                }
+            }
+        }
+
+        // Any leftovers indicate impossible/cyclic constraints in what should be a DAG.
+        if output.len() != selected.len() {
+            bail!("Cannot order selected commits by parentage due to cyclic ancestry constraints")
+        }
+
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SelectedCommit {
+    selector: Selector,
+    id: gix::ObjectId,
+    input_order: usize,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Relation {
+    LeftIsAncestorOfRight,
+    RightIsAncestorOfLeft,
+    Unrelated,
+}
+
+fn ancestry_relation(
+    editor: &Editor<'_, '_, impl RefMetadata>,
+    left: &SelectedCommit,
+    right: &SelectedCommit,
+) -> Relation {
+    if is_pick_ancestor(editor, left.selector.id, right.selector.id) {
+        return Relation::LeftIsAncestorOfRight;
+    }
+    if is_pick_ancestor(editor, right.selector.id, left.selector.id) {
+        return Relation::RightIsAncestorOfLeft;
+    }
+    Relation::Unrelated
+}
+
+fn is_pick_ancestor(
+    editor: &Editor<'_, '_, impl RefMetadata>,
+    ancestor: StepGraphIndex,
+    descendant: StepGraphIndex,
+) -> bool {
+    let mut stack = vec![descendant];
+    let mut seen = HashSet::from([descendant]);
+
+    while let Some(node) = stack.pop() {
+        for edge in editor
+            .graph
+            .edges_directed(node, petgraph::Direction::Outgoing)
+        {
+            let parent = edge.target();
+            if parent == ancestor {
+                return true;
+            }
+            if seen.insert(parent) {
+                stack.push(parent);
+            }
+        }
+    }
+
+    false
+}
+
+fn step_graph_parent_to_child_rank<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+) -> HashMap<gix::ObjectId, usize> {
+    let pick_nodes: Vec<StepGraphIndex> = editor
+        .graph
+        .node_indices()
+        .filter(|idx| matches!(editor.graph[*idx], Step::Pick(_)))
+        .collect();
+
+    let pick_pos_by_idx: HashMap<StepGraphIndex, usize> = pick_nodes
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(pos, idx)| (idx, pos))
+        .collect();
+
+    // Build parent -> child edges between pick nodes only.
+    let mut adjacency = vec![Vec::<usize>::new(); pick_nodes.len()];
+    let mut indegree = vec![0usize; pick_nodes.len()];
+
+    for (child_pos, child_idx) in pick_nodes.iter().copied().enumerate() {
+        for parent_idx in util::collect_ordered_parents(&editor.graph, child_idx) {
+            let Some(parent_pos) = pick_pos_by_idx.get(&parent_idx).copied() else {
+                continue;
+            };
+            adjacency[parent_pos].push(child_pos);
+            indegree[child_pos] += 1;
+        }
+    }
+
+    // Deterministic tie-break on node index keeps ranking stable.
+    let mut ready: BinaryHeap<Reverse<(usize, usize)>> = indegree
+        .iter()
+        .enumerate()
+        .filter_map(|(pos, degree)| {
+            (*degree == 0).then_some(Reverse((pick_nodes[pos].index(), pos)))
+        })
+        .collect();
+
+    let mut rank_by_id = HashMap::<gix::ObjectId, usize>::new();
+    let mut next_rank = 0usize;
+
+    while let Some(Reverse((_, pos))) = ready.pop() {
+        if let Step::Pick(Pick { id, .. }) = editor.graph[pick_nodes[pos]] {
+            rank_by_id.entry(id).or_insert_with(|| {
+                let rank = next_rank;
+                next_rank += 1;
+                rank
+            });
+        }
+
+        for &child in &adjacency[pos] {
+            let degree = &mut indegree[child];
+            *degree -= 1;
+            if *degree == 0 {
+                ready.push(Reverse((pick_nodes[child].index(), child)));
+            }
+        }
+    }
+
+    // Step-graph cycles are unexpected; rank any leftovers deterministically.
+    let mut leftovers: Vec<usize> = indegree
+        .iter()
+        .enumerate()
+        .filter_map(|(pos, degree)| (*degree > 0).then_some(pos))
+        .collect();
+    leftovers.sort_by_key(|pos| pick_nodes[*pos].index());
+
+    for pos in leftovers {
+        if let Step::Pick(Pick { id, .. }) = editor.graph[pick_nodes[pos]] {
+            rank_by_id.entry(id).or_insert_with(|| {
+                let rank = next_rank;
+                next_rank += 1;
+                rank
+            });
+        }
+    }
+
+    rank_by_id
+}

--- a/crates/but-rebase/tests/fixtures/scenario/disjoint-orphan-branches.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/disjoint-orphan-branches.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo base >base && git add . && git commit -m "main: base"
+echo main-1 >main-1 && git add . && git commit -m "main: tip"
+
+# Build a truly disjoint history rooted at an orphan branch.
+git checkout --orphan orphan
+
+git rm -rf . >/dev/null 2>&1 || true
+echo orphan-base >orphan-base && git add . && git commit -m "orphan: base"
+echo orphan-tip >orphan-tip && git add . && git commit -m "orphan: tip"
+
+git checkout main

--- a/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/mod.rs
@@ -13,6 +13,7 @@ mod insert;
 mod insert_segment;
 mod materialize;
 mod multiple_operations;
+mod order_commit_selectors_by_parentage;
 mod parents_must_be_references_restriction;
 mod rebase_identities;
 mod replace;

--- a/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
@@ -166,7 +166,7 @@ fn orders_disjoint_commits_by_editor_graph_traversal_2() -> Result<()> {
 
     // The tip of A
     let a = repo.rev_parse_single("A")?.detach();
-    // The thip of B
+    // The tip of B
     let b = repo.rev_parse_single("B")?.detach();
     // The first parent of the tip of B
     let b1 = repo.rev_parse_single("B~")?.detach();

--- a/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
@@ -213,7 +213,7 @@ fn orders_disjoint_commits_by_editor_graph_traversal_3() -> Result<()> {
 
     // The tip of A
     let a = repo.rev_parse_single("A")?.detach();
-    // The thip of B
+    // The tip of B
     let b = repo.rev_parse_single("B")?.detach();
     // The first parent of the tip of C
     let c1 = repo.rev_parse_single("C~")?.detach();

--- a/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
@@ -1,0 +1,338 @@
+use anyhow::Result;
+use but_graph::Graph;
+use but_rebase::graph_rebase::{Editor, LookupStep, Step, testing::Testing as _};
+use but_testsupport::visualize_commit_graph_all;
+
+use crate::utils::{fixture, fixture_writable, standard_options};
+
+fn short_ids(
+    editor: &Editor<'_, '_, impl but_core::RefMetadata>,
+    selectors: &[but_rebase::graph_rebase::Selector],
+) -> Result<Vec<String>> {
+    selectors
+        .iter()
+        .map(|selector| {
+            let id = editor.lookup_pick(*selector)?;
+            Ok(id.to_hex_with_len(7).to_string())
+        })
+        .collect()
+}
+
+fn trim_trailing_whitespace(input: &str) -> String {
+    input
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn handles_zero_nodes() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/main
+    ● 120e3a9 c
+    ● a96434e b
+    ● d591dfe a
+    ● 35b8235 base
+    ╵
+    ");
+
+    let ordered = editor.order_commit_selectors_by_parentage(Vec::<gix::ObjectId>::new())?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @"[]");
+
+    Ok(())
+}
+
+#[test]
+fn handles_one_node() -> Result<()> {
+    let (repo, mut meta) = fixture("single-commit")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/main
+    ● 35b8235 base
+    ╵
+    ");
+
+    let base = repo.head_id()?.detach();
+    let ordered = editor.order_commit_selectors_by_parentage([base])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "35b8235",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_linear_commits_parent_first_for_n_nodes() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let base = repo.rev_parse_single("HEAD~3")?.detach();
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let b = repo.rev_parse_single("HEAD~1")?.detach();
+    let c = repo.rev_parse_single("HEAD")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([c, a, b, base])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "35b8235",
+        "d591dfe",
+        "a96434e",
+        "120e3a9",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_disjoint_commits_by_editor_graph_traversal_1() -> Result<()> {
+    let (repo, mut meta) = fixture("three-branches-merged")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let graph = trim_trailing_whitespace(&visualize_commit_graph_all(&repo)?);
+    insta::assert_snapshot!(graph, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/
+    * / add59d2 (A) A: 10 lines on top
+    |/
+    * 8f0d338 (tag: base) base
+    ");
+
+    let a = repo.rev_parse_single("A")?.detach();
+    let b = repo.rev_parse_single("B")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([b, a])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "a748762",
+        "add59d2",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_disjoint_commits_by_editor_graph_traversal_2() -> Result<()> {
+    let (repo, mut meta) = fixture("three-branches-merged")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let graph = trim_trailing_whitespace(&visualize_commit_graph_all(&repo)?);
+    insta::assert_snapshot!(graph, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/
+    * / add59d2 (A) A: 10 lines on top
+    |/
+    * 8f0d338 (tag: base) base
+    ");
+
+    // The tip of A
+    let a = repo.rev_parse_single("A")?.detach();
+    // The thip of B
+    let b = repo.rev_parse_single("B")?.detach();
+    // The first parent of the tip of B
+    let b1 = repo.rev_parse_single("B~")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([b, a, b1])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    // The order should be:
+    // 1. The first parent of B's tip
+    // 2. The tip of B
+    // 3. The tip of A
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "62e05ba",
+        "a748762",
+        "add59d2",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_disjoint_commits_by_editor_graph_traversal_3() -> Result<()> {
+    let (repo, mut meta) = fixture("three-branches-merged")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let graph = trim_trailing_whitespace(&visualize_commit_graph_all(&repo)?);
+    insta::assert_snapshot!(graph, @r"
+    *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+    |\ \
+    | | * 930563a (C) C: add another 10 lines to new file
+    | | * 68a2fc3 C: add 10 lines to new file
+    | | * 984fd1c C: new file with 10 lines
+    | * | a748762 (B) B: another 10 lines at the bottom
+    | * | 62e05ba B: 10 lines at the bottom
+    | |/
+    * / add59d2 (A) A: 10 lines on top
+    |/
+    * 8f0d338 (tag: base) base
+    ");
+
+    // The tip of A
+    let a = repo.rev_parse_single("A")?.detach();
+    // The thip of B
+    let b = repo.rev_parse_single("B")?.detach();
+    // The first parent of the tip of C
+    let c1 = repo.rev_parse_single("C~")?.detach();
+    // The second-level parent of the tip of C
+    let c2 = repo.rev_parse_single("C~2")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([b, c1, a, c2])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    // The order should be:
+    // 1. The second-level parent of the tip of C
+    // 2. The first-level parent of the tip of C
+    // 3. The tip of B
+    // 4. The tip of A
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "984fd1c",
+        "68a2fc3",
+        "a748762",
+        "add59d2",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn errors_when_selected_commit_is_absent_from_editor_graph() -> Result<()> {
+    let (repo, mut meta) = fixture("disjoint-orphan-branches")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 589e8c3 (HEAD -> main) main: tip
+    * 14f3d44 main: base
+    * 74debb1 (orphan) orphan: tip
+    * c7488cd orphan: base
+    ");
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    insta::assert_snapshot!(editor.steps_ascii(), @"
+    ◎ refs/heads/main
+    ● 589e8c3 main: tip
+    ● 14f3d44 main: base
+    ╵
+    ");
+
+    let orphan = repo.rev_parse_single("orphan")?.detach();
+
+    let error = editor
+        .order_commit_selectors_by_parentage([orphan])
+        .expect_err("commits absent from editor graph should fail selection");
+
+    let message = error.to_string();
+    assert!(
+        message.starts_with("Failed to find commit "),
+        "unexpected error message format: {message}"
+    );
+    assert!(
+        message.ends_with(" in rebase editor"),
+        "unexpected error message format: {message}"
+    );
+    insta::assert_snapshot!(
+        "Failed to find commit <oid> in rebase editor",
+        @"Failed to find commit <oid> in rebase editor"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn deduplicates_duplicate_selectors_by_commit_id() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let b = repo.rev_parse_single("HEAD~1")?.detach();
+    let c = repo.rev_parse_single("HEAD")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([b, c, b, a, c])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "d591dfe",
+        "a96434e",
+        "120e3a9",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_commit_present_in_editor_graph_even_if_workspace_projection_stale() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let a = repo.rev_parse_single("HEAD~2")?.detach();
+    let a_obj = repo.find_commit(a)?;
+    let mut a_commit = a_obj.decode()?;
+    a_commit.message = "A rewritten outside workspace traversal".into();
+    let rewritten_a = repo.write_object(a_commit)?.detach();
+
+    let a_selector = editor.select_commit(a)?;
+    editor.replace(a_selector, Step::new_pick(rewritten_a))?;
+
+    let ordered = editor.order_commit_selectors_by_parentage([rewritten_a])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "1787cd0",
+    ]
+    "#);
+
+    Ok(())
+}

--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Result, bail};
 use but_core::RefMetadata;
-use but_graph::{SegmentIndex, SegmentRelation, projection::Workspace};
+use but_graph::{SegmentRelation, projection::Workspace};
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
@@ -17,36 +17,17 @@ enum ReorderDirection {
     MoveSubjectBelowTarget,
 }
 
-fn find_commit_segment_index(
-    workspace: &Workspace,
-    commit_id: gix::ObjectId,
-) -> Option<SegmentIndex> {
-    let (_, stack_segment, _) = workspace.find_commit_and_containers(commit_id)?;
-    let commit_offset = stack_segment
-        .commits
-        .iter()
-        .position(|c| c.id == commit_id)?;
-
-    let mut owning_segment = stack_segment.id;
-    for (segment_id, offset) in &stack_segment.commits_by_segment {
-        if *offset > commit_offset {
-            break;
-        }
-        owning_segment = *segment_id;
-    }
-
-    Some(owning_segment)
-}
-
 fn determine_reorder_direction(
     workspace: &Workspace,
     repo: &gix::Repository,
     subject: &but_core::CommitOwned,
     target: &but_core::CommitOwned,
 ) -> Result<ReorderDirection> {
-    let subject_segment = find_commit_segment_index(workspace, subject.id)
+    let subject_segment = workspace
+        .find_commit_segment_index(subject.id)
         .ok_or_else(|| anyhow::anyhow!("Couldn't resolve subject commit segment"))?;
-    let target_segment = find_commit_segment_index(workspace, target.id)
+    let target_segment = workspace
+        .find_commit_segment_index(target.id)
         .ok_or_else(|| anyhow::anyhow!("Couldn't resolve target commit segment"))?;
 
     match workspace


### PR DESCRIPTION
Create but-workspace commit ordering function that sorts the commits by
their parentage, according to the workspace appearance.

### Cool, but why?
In order to enable graph mutations with multiple commits, I need to sort the commits from parent-most to child-most.
That way I can do one operation at a time in memory, parent to child. And then materialize it at the very end.
 
Ordering should reduce the probability of running into conflicts.

### Disclaimer
This heavily uses AI for the generation of this algorithm

### Comprehensive docs
https://github.com/gitbutlerapp/gitbutler/pull/13153/changes#diff-bb49765eeedd900a433bba2fc60faf0d82730392d9053af079c8c1d2407aa905