### PR TITLE
Fix workspace merge failure when stacks have adjacent edits

### DIFF
--- a/crates/but-worktrees/src/integrate.rs
+++ b/crates/but-worktrees/src/integrate.rs
@@ -244,12 +244,13 @@ fn worktree_integration_inner(
     let wd_tree = repo.create_wd_tree(0)?;
 
     let working_dir_conflicts = {
+        let gix_repo = ctx.clone_repo_for_merging()?;
         let before_heads = stacks
             .iter()
             .map(|s| s.head_oid(ctx))
             .collect::<Result<Vec<_>>>()?;
         let before = WorkspaceState::create_from_heads(ctx, perm, &before_heads)?;
-        let before = merge_workspace(&*ctx.git2_repo.get()?, before)?;
+        let before = merge_workspace(&gix_repo, &before)?.to_git2();
         let mut after_heads = stacks
             .iter()
             .filter(|s| s.id != stack.id)
@@ -257,7 +258,7 @@ fn worktree_integration_inner(
             .collect::<Result<Vec<_>>>()?;
         after_heads.push(output.top_commit);
         let after = WorkspaceState::create_from_heads(ctx, perm, &after_heads)?;
-        let after = merge_workspace(&*ctx.git2_repo.get()?, after)?;
+        let after = merge_workspace(&gix_repo, &after)?.to_git2();
         let index = move_tree(&*ctx.git2_repo.get()?, wd_tree.to_git2(), before, after)?;
 
         index.has_conflicts()

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -163,6 +163,18 @@ fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> R
                 in_workspace: true,
             },
         ],
+        ("workspace-commit.sh", "adjacent-stacks") => vec![
+            StackSpec {
+                id: 1,
+                branches_base_to_top: &["stack_a"],
+                in_workspace: true,
+            },
+            StackSpec {
+                id: 2,
+                branches_base_to_top: &["stack_b"],
+                in_workspace: true,
+            },
+        ],
         unsupported => anyhow::bail!("unsupported driverless fixture {unsupported:?}"),
     };
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -71,3 +71,35 @@ fn conflicting_stacks_evicted_from_workspace_commit_parents() -> Result<()> {
 
     Ok(())
 }
+
+/// When two applied stacks modify adjacent but non-overlapping sections of the same
+/// file, `merge_workspace` must produce a clean merge.
+///
+/// Stack A owns lines 1–5 and 11–15; Stack B owns lines 6–10.
+/// A's top hunk immediately precedes B's hunk (adjacency from above) and B's hunk
+/// immediately precedes A's bottom hunk (adjacency from below).
+///
+/// Before the fix, `merge_workspace` used git2's Myers diff which incorrectly flagged
+/// these adjacent hunks as conflicting (`MergeConflict (-24)`), breaking every workspace
+/// mutation (squash, reorder, etc.) that recomputed the workspace tree.
+#[test]
+fn merge_workspace_succeeds_with_adjacent_hunks_from_both_sides() -> Result<()> {
+    let (ctx, _temp_dir) = command_ctx("adjacent-stacks")?;
+
+    // Build the workspace commit so both stacks are properly registered.
+    gitbutler_branch_actions::update_workspace_commit(&ctx, false)?;
+
+    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
+    let stacks = vb_state.list_stacks_in_workspace()?;
+    assert_eq!(stacks.len(), 2, "both stacks should be in workspace");
+
+    // Build a WorkspaceState from both stacks and call merge_workspace directly.
+    // This is the exact function that was fixed from git2 to gix.
+    let guard = ctx.shared_worktree_access();
+    let workspace =
+        gitbutler_workspace::branch_trees::WorkspaceState::create(&ctx, guard.read_permission())?;
+    let gix_repo = ctx.clone_repo_for_merging()?;
+    gitbutler_workspace::branch_trees::merge_workspace(&gix_repo, &workspace)?;
+
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/workspace-commit.sh
@@ -42,6 +42,7 @@ git init --initial-branch=main remote
   git config user.name "Author"
   git config user.email "author@example.com"
   echo "base content" > shared.txt
+  seq 15 > file
   git add . && git commit -m "init"
 )
 
@@ -67,4 +68,32 @@ git clone remote conflicting-stacks
   # We can't actually merge conflicting branches, so just point workspace
   # at main. The seed + update_workspace_commit call in the test will
   # rebuild it properly.
+)
+
+# Two stacks each modifying adjacent (non-overlapping) sections of the same file,
+# with zero lines of buffer between the changed regions.
+# Stack A owns lines 1-5 and lines 11-15; Stack B owns lines 6-10.
+# A's top hunk immediately precedes B's hunk (adjacency from above), and
+# B's hunk immediately precedes A's bottom hunk (adjacency from below).
+# This exercises the gix fix for the git2 bug where adjacent hunks in an
+# octopus workspace merge were incorrectly flagged as conflicting.
+git clone remote adjacent-stacks
+(cd adjacent-stacks
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  git checkout -b stack_a main
+
+  # Change lines 1-5 (top) and lines 11-15 (bottom); lines 6-10 untouched.
+  printf 'a1\na2\na3\na4\na5\n6\n7\n8\n9\n10\na11\na12\na13\na14\na15\n' > file
+  commit_with_tick "stack_a: change top and bottom sections"
+
+  git checkout -b stack_b main
+  # Change only lines 6-10 (middle); lines 1-5 and 11-15 untouched from base.
+  printf '1\n2\n3\n4\n5\nb6\nb7\nb8\nb9\nb10\n11\n12\n13\n14\n15\n' > file
+  commit_with_tick "stack_b: change middle section"
+
+  # Point workspace at main; update_workspace_commit in the test rebuilds it properly.
+  git checkout -b gitbutler/workspace main
+  git commit --allow-empty -m "GitButler Workspace Commit"
 )

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -99,10 +99,11 @@ pub fn update_uncommitted_changes_with_tree(
     always_checkout: Option<bool>,
     _perm: &mut RepoExclusive,
 ) -> Result<()> {
+    let gix_repo = ctx.clone_repo_for_merging()?;
     let repo = &*ctx.git2_repo.get()?;
     if let Some(worktree_id) = old_uncommitted_changes {
         let mut new_uncommitted_changes =
-            move_tree_between_workspaces(repo, worktree_id, old, new)?;
+            move_tree_between_workspaces(repo, &gix_repo, worktree_id, old, new)?;
 
         // If the new tree and old tree are the same, then we don't need to do anything
         if !new_uncommitted_changes.has_conflicts() && !always_checkout.unwrap_or(false) {
@@ -122,9 +123,8 @@ pub fn update_uncommitted_changes_with_tree(
             ),
         )?;
     } else {
-        let old_tree_id = merge_workspace(repo, old)?.to_gix();
-        let new_tree_id = merge_workspace(repo, new)?.to_gix();
-        let gix_repo = ctx.clone_repo_for_merging()?;
+        let old_tree_id = merge_workspace(&gix_repo, &old)?;
+        let new_tree_id = merge_workspace(&gix_repo, &new)?;
         but_core::worktree::safe_checkout(
             old_tree_id,
             new_tree_id,
@@ -139,12 +139,13 @@ pub fn update_uncommitted_changes_with_tree(
 /// like if they were on top of the new workspace.
 fn move_tree_between_workspaces(
     repo: &git2::Repository,
+    gix_repo: &gix::Repository,
     tree: git2::Oid,
     old: WorkspaceState,
     new: WorkspaceState,
 ) -> Result<git2::Index> {
-    let old_workspace = merge_workspace(repo, old)?;
-    let new_workspace = merge_workspace(repo, new)?;
+    let old_workspace = merge_workspace(gix_repo, &old)?.to_git2();
+    let new_workspace = merge_workspace(gix_repo, &new)?.to_git2();
     move_tree(repo, tree, old_workspace, new_workspace)
 }
 
@@ -167,26 +168,32 @@ pub fn move_tree(
     Ok(merge)
 }
 
-/// Octopus merge
-/// What: Takes N trees and a base tree and all the heads together with respect
-/// to the given base.
+/// Octopus merge using gix, which correctly resolves adjacent-hunk changes that git2 treats as conflicts.
+/// Takes N trees and a base tree and merges all the heads together with respect to the given base.
 ///
 /// If there are no heads provided, the base will be returned.
-pub fn merge_workspace(repo: &git2::Repository, workspace: WorkspaceState) -> Result<git2::Oid> {
-    let mut output = workspace.base;
+pub fn merge_workspace(
+    repo: &gix::Repository,
+    workspace: &WorkspaceState,
+) -> Result<gix::ObjectId> {
+    let mut output = workspace.base.to_gix();
+    let base = workspace.base.to_gix();
 
-    for head in workspace.heads {
-        let mut merge_options = git2::MergeOptions::new();
-        merge_options.fail_on_conflict(true);
+    let (merge_options, conflict_kind) = repo.merge_options_fail_fast()?;
 
+    for head in &workspace.heads {
         let mut merge = repo.merge_trees(
-            &repo.find_tree(workspace.base)?,
-            &repo.find_tree(output)?,
-            &repo.find_tree(head)?,
-            Some(&merge_options),
+            base,
+            output,
+            head.to_gix(),
+            repo.default_merge_labels(),
+            merge_options.clone(),
         )?;
 
-        output = merge.write_tree_to(repo)?;
+        if merge.has_unresolved_conflicts(conflict_kind) {
+            anyhow::bail!("merge conflict when computing workspace tree");
+        }
+        output = merge.tree.write()?.detach();
     }
 
     Ok(output)


### PR DESCRIPTION
When two stacks each modify adjacent but non-overlapping lines in the
same file, git2 treats the adjacent hunks as conflicting. This caused
`update_uncommitted_changes` to fail with `MergeConflict (-24)` on any
mutation that recomputed the workspace tree (squash, reorder, etc.)
— even though the stacks don't actually conflict.

The workspace commit was already built using gix
(`remerged_workspace_tree_v2`), which resolves adjacent hunks cleanly,
so it was possible to reach a valid workspace state that then broke on
every subsequent operation.

**Fix**

Replace the git2 octopus merge in `merge_workspace` with the same
gix-based approach used for workspace commit creation:
`merge_options_fail_fast` + `has_unresolved_conflicts`. The function
now returns `gix::ObjectId`; callers in `integrate.rs` that pass the
result into git2 APIs convert with `.to_git2()`.

**Test**

Add a regression test that calls `merge_workspace` directly with two
stacks whose edits are adjacent from both sides (Stack A owns lines 1–5
and 11–15, Stack B owns lines 6–10). Verified the test fails with
`MergeConflict (-24)` under git2 and passes under gix.