### PR TITLE
fix: prevent naming a branch HEAD

### DIFF
--- a/crates/but-core/src/branch/normalize.rs
+++ b/crates/but-core/src/branch/normalize.rs
@@ -37,8 +37,9 @@ pub fn normalize_short_name<'a>(name: impl Into<&'a BStr>) -> anyhow::Result<BSt
         true
     });
 
-    if sanitized.is_empty() {
+    if sanitized.is_empty() || sanitized == "HEAD" {
         bail!("Could not turn {name:?} into a valid reference name")
     }
+
     Ok(sanitized)
 }

--- a/crates/but-core/tests/core/branch/normalize_short_name.rs
+++ b/crates/but-core/tests/core/branch/normalize_short_name.rs
@@ -42,6 +42,24 @@ fn clear_error_on_failure() {
 }
 
 #[test]
+/// HEAD is not a valid branch name, so when we normalize names we should disallow it.
+///
+/// To validate this claim, run `git check-ref-format --branch 'HEAD'` or `git branch HEAD`, they
+/// will reject with `fatal: 'HEAD' is not a valid branch name`.
+fn head_is_rejected() {
+    assert_eq!(
+        normalize_short_name("HEAD").unwrap_err().to_string(),
+        "Could not turn \"HEAD\" into a valid reference name",
+        "HEAD is rejected"
+    );
+    assert_eq!(
+        normalize_short_name("HEAD-").unwrap_err().to_string(),
+        "Could not turn \"HEAD-\" into a valid reference name",
+        "name that normalizes to HEAD is rejected"
+    );
+}
+
+#[test]
 fn complex_valid() -> anyhow::Result<()> {
     assert_eq!(normalize_short_name("feature/branch")?, "feature/branch");
     assert_eq!(

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -34,6 +34,38 @@ fn outputs_branch_name() -> anyhow::Result<()> {
 }
 
 #[test]
+fn rejects_head() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new HEAD")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Could not turn "HEAD" into a valid reference name
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_name_that_normalizes_to_head() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new HEAD-")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Could not turn "HEAD-" into a valid reference name
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -101,6 +101,24 @@ Renamed branch 'branch-to-rename-123' to 'renamed-branch'
 }
 
 #[test]
+fn reword_branch_rejects_head() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.but("branch new branch-to-rename").assert().success();
+
+    env.but("reword branch-to-rename -m HEAD")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Could not turn "HEAD" into a valid reference name
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"


### PR DESCRIPTION
NOTE: I've pinged @Byron for review in Discord. If you're not @Byron, feel free to review anyway if that interests you, but just know that I'll be waiting for our Byromation to trigger before I proceed with anything here. Code owners cannot be removed as reviewers, so I have no way of indicating whom I'm expecting a review from ...

## 🧢 Changes
Git disallows the name HEAD for a branch.

Try running e.g. `git check-ref-format --branch HEAD` or `git branch HEAD` and you should see an error message along the lines of `fatal: 'HEAD' is not a valid branch name`

I can't find this properly documented in Git's refspec, but it's clearly hard coded into `refs.c#check_branch_ref`.

https://github.com/git/git/blob/cf2139f8e1680b076e115bc0b349e369b4b0ecc4/refs.c#L776-L778

## Note
This fix applies to the GUI as well as we use the same normalization function there, but I've only implemented high-level tests for the CLI. I felt like unit-testing the function and having one high-level path tested is sufficient.

## ☕️ Reasoning
We want to check the name _after_ normalization, so I think the most reasonable place to perform the check is in the function that does the normalization so as not to normalize and then forget this validation check.

## Open questions
* What about case insensitive file systems (like macOS is by default, and I believe Windows as well)? Git does _not_ prevent creating a branch named e.g. `head`, but if you _do_ it starts printing warnings that "HEAD is ambiguous". For strict Git-compatibility, `head` (or `hEAd` or any other capitalization) is an allowed branch name, but for case insensitive file systems they seem to cause the same issues that `HEAD` as a branch name does. I feel like to some extent, Git just doesn't play nicely with case insensitive file systems, but maybe GitButler should?
* Why do case insensitive file systems exist?
* After writing tests that strip trailing dashes all day, I realize that there's absolutely nothing in the refspec that prevents trailing dashes. _Leading_ dashes are prohibited in branch names specifically, but trailing ones are fine.

```bash
[gitbutler]$ git check-ref-format --branch hello----
hello----
[gitbutler]$ git check-ref-format --branch HEAD-
HEAD-
[gitbutler]$ git check-ref-format --branch -hello
fatal: '-hello' is not a valid branch name
```

I don't see a reason to deviate from Git here?