### PR TITLE
Suppress Svelte 5 state_referenced_locally warnings with untrack()

### DIFF
--- a/apps/desktop/src/components/branch/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/branch/BranchIntegrationModal.svelte
@@ -24,6 +24,7 @@
 	} from "$lib/upstream/integrationStepUtils";
 	import { inject } from "@gitbutler/core/context";
 	import { Modal, ModalFooter, Button, ScrollableContainer, SimpleCommitRow } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import { flip } from "svelte/animate";
 	import type { InteractiveIntegrationStep } from "$lib/stacks/stack";
 
@@ -44,9 +45,9 @@
 	const stackService = inject(STACK_SERVICE);
 	const [integrate, integrating] = stackService.integrateBranchWithSteps;
 	const initialIntegrationSteps = stackService.initialIntegrationSteps(
-		projectId,
-		stackId,
-		branchName,
+		untrack(() => projectId),
+		untrack(() => stackId),
+		untrack(() => branchName),
 	);
 
 	let editableSteps = $derived(initialIntegrationSteps.response ?? []);

--- a/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPromptConfigModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Codeblock } from "@gitbutler/ui";
 	import { Modal, SegmentControl, Button } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { PromptDir } from "$lib/codegen/types";
 
 	type Props = {
@@ -16,7 +17,7 @@
 
 	const { promptDirs, openPromptConfigDir }: Props = $props();
 
-	let selectedSegment = $state<string>(promptDirs[0]?.label || "");
+	let selectedSegment = $state<string>(untrack(() => promptDirs[0]?.label || ""));
 </script>
 
 {#snippet pathContent({ path, caption }: { path: string; caption: string })}

--- a/apps/desktop/src/components/codegen/CodegenServiceMessageThinking.svelte
+++ b/apps/desktop/src/components/codegen/CodegenServiceMessageThinking.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CodegenServiceMessage from "$components/codegen/CodegenServiceMessage.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		startAt: Date;
@@ -71,7 +72,9 @@
 	}
 
 	let currentWord = $state(getWord());
-	let currentDuration = $state(milisToEnglish(Date.now() - startAt.getTime() - msSpentWaiting));
+	let currentDuration = $state(
+		untrack(() => milisToEnglish(Date.now() - startAt.getTime() - msSpentWaiting)),
+	);
 
 	$effect(() => {
 		const updateWordInterval = setInterval(() => {

--- a/apps/desktop/src/components/codegen/CodegenSessionRow.svelte
+++ b/apps/desktop/src/components/codegen/CodegenSessionRow.svelte
@@ -23,6 +23,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { Badge, Icon, type IconName } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import { untrack } from "svelte";
 	import { slide } from "svelte/transition";
 	import type { ClaudeStatus, PromptAttachment } from "$lib/codegen/types";
 
@@ -46,12 +47,13 @@
 		draft = false,
 	}: Props = $props();
 
-	const uiState = draft ? undefined : inject(UI_STATE);
-	const laneState = draft || !stackId ? undefined : uiState?.lane(stackId);
+	const uiState = untrack(() => draft) ? undefined : inject(UI_STATE);
+	const laneState = untrack(() => (draft || !stackId ? undefined : uiState?.lane(stackId)));
 
-	const claudeService = draft ? undefined : inject(CLAUDE_CODE_SERVICE);
-	const messages =
-		draft || !projectId || !stackId ? undefined : claudeService?.messages({ projectId, stackId });
+	const claudeService = untrack(() => draft) ? undefined : inject(CLAUDE_CODE_SERVICE);
+	const messages = untrack(() =>
+		draft || !projectId || !stackId ? undefined : claudeService?.messages({ projectId, stackId }),
+	);
 	const permissionRequests = $derived(
 		draft || !projectId ? undefined : claudeService?.permissionRequests({ projectId }),
 	);
@@ -69,7 +71,7 @@
 		return "ai";
 	}
 
-	const attachmentService = draft ? undefined : inject(ATTACHMENT_SERVICE);
+	const attachmentService = untrack(() => draft) ? undefined : inject(ATTACHMENT_SERVICE);
 
 	function addAttachment(items: PromptAttachment[]) {
 		if (!branchName || !attachmentService) return;

--- a/apps/desktop/src/components/codegen/CodegenToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenToolCall.svelte
@@ -3,6 +3,7 @@
 	import { formatToolCall, getToolIcon, getToolLabel } from "$lib/codegen/codegenTools";
 	import { toolCallLoading, type ToolCall } from "$lib/codegen/messages";
 	import { Codeblock } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	type Props = {
 		projectId: string;
@@ -26,10 +27,11 @@
 	}: Props = $props();
 
 	// Initialize expanded state from map, default to false (collapsed)
-	const initialExpanded =
+	const initialExpanded = untrack(() =>
 		toolCallKey && toolCallExpandedState
 			? (toolCallExpandedState.individual.get(toolCallKey) ?? false)
-			: false;
+			: false,
+	);
 
 	function handleToggle(newExpanded: boolean) {
 		// Persist to map if available

--- a/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
+++ b/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
@@ -3,6 +3,7 @@
 	import AppScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
 	import { REJECTTION_REASONS, type RejectionReason } from "$lib/stacks/stackService.svelte";
 	import { Icon, ModalHeader, TestId, Tooltip } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { CommitFailedModalState } from "$lib/state/uiState.svelte";
 
 	type Props = {
@@ -63,7 +64,7 @@
 		return result;
 	}
 
-	const groupedData = groupByReason(data);
+	const groupedData = groupByReason(untrack(() => data));
 
 	let isScrollTopVisible = $state(true);
 </script>

--- a/apps/desktop/src/components/diff/FloatingDiffModal.svelte
+++ b/apps/desktop/src/components/diff/FloatingDiffModal.svelte
@@ -19,7 +19,7 @@
 	import { Button, FileViewHeader, HunkDiffSkeleton, Icon, VirtualList } from "@gitbutler/ui";
 	import { FOCUS_MANAGER, type FocusableOptions } from "@gitbutler/ui/focus/focusManager";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
-	import { tick } from "svelte";
+	import { tick, untrack } from "svelte";
 
 	interface Props {
 		projectId: string;
@@ -61,7 +61,7 @@
 
 	let listMode: "list" | "tree" = $state("list");
 	// Seeded from prop once on mount; subsequent user selection is independent.
-	let selectedIndex = $state(initialIndex);
+	let selectedIndex = $state(untrack(() => initialIndex));
 	// Prevents VirtualList scroll events from overwriting a user-clicked selection.
 	const scrollLock = new ScrollSelectionLock(getInitialLockedIndex());
 	let headerElRef = $state<HTMLDivElement | undefined>(undefined);

--- a/apps/desktop/src/components/diff/MultiDiffView.svelte
+++ b/apps/desktop/src/components/diff/MultiDiffView.svelte
@@ -23,6 +23,7 @@
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, FileViewHeader, HunkDiffSkeleton, VirtualList } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	type Props = {
 		projectId: string;
@@ -69,7 +70,7 @@
 	}
 
 	let virtualList = $state<VirtualList<TreeChange>>();
-	let highlightedIndex = $state<number | undefined>(startIndex);
+	let highlightedIndex = $state<number | undefined>(untrack(() => startIndex));
 	// Prevents VirtualList scroll events from overwriting a user-clicked selection.
 	const scrollLock = new ScrollSelectionLock(getInitialLockedIndex());
 	let floatingDiffOpen = $state(false);

--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -39,7 +39,7 @@
 		type DropFileResult,
 	} from "@gitbutler/ui/richText/plugins/FileUpload.svelte";
 
-	import { tick } from "svelte";
+	import { tick, untrack } from "svelte";
 
 	const ACCEPTED_FILE_TYPES = ["image/*", "application/*", "text/*", "audio/*", "video/*"];
 
@@ -92,9 +92,11 @@
 
 	const uploadsService = inject(UPLOADS_SERVICE);
 	const userSettings = inject(SETTINGS);
-	const commitGenerationExtraConcise = projectCommitGenerationExtraConcise(projectId);
-	const commitGenerationUseEmojis = projectCommitGenerationUseEmojis(projectId);
-	const commitGenerationHaiku = projectCommitGenerationHaiku(projectId);
+	const commitGenerationExtraConcise = projectCommitGenerationExtraConcise(
+		untrack(() => projectId),
+	);
+	const commitGenerationUseEmojis = projectCommitGenerationUseEmojis(untrack(() => projectId));
+	const commitGenerationHaiku = projectCommitGenerationHaiku(untrack(() => projectId));
 
 	const useFloatingBox = uiState.global.useFloatingBox;
 

--- a/apps/desktop/src/components/files/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/files/WorktreeChanges.svelte
@@ -24,7 +24,7 @@
 	import { Badge, TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
-	import { type Snippet } from "svelte";
+	import { untrack, type Snippet } from "svelte";
 	import type { DropzoneHandler } from "$lib/dragging/handler";
 	import type { TreeChange } from "$lib/hunks/change";
 	import type { FileListKeyHandler } from "$lib/selection/fileListController.svelte";
@@ -58,7 +58,7 @@
 	}: Props = $props();
 
 	// Create a unique persist ID based on stackId and mode (both are static props)
-	const persistId = stackId ? `worktree-${mode}-${stackId}` : `worktree-${mode}`;
+	const persistId = untrack(() => (stackId ? `worktree-${mode}-${stackId}` : `worktree-${mode}`));
 
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);

--- a/apps/desktop/src/components/forge/GerritPushModal.svelte
+++ b/apps/desktop/src/components/forge/GerritPushModal.svelte
@@ -12,6 +12,7 @@
 
 <script lang="ts">
 	import { Button, Modal, Select, SelectItem, Textbox, TagInput, Toggle } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { GerritPushFlag } from "$lib/stacks/stack";
 
 	const {
@@ -30,7 +31,7 @@
 	let status = $state<"wip" | "ready">("ready");
 
 	// Topic section
-	let topicValue = $state(branchName);
+	let topicValue = $state(untrack(() => branchName));
 
 	// Tags section
 	let tags = $state<Array<{ id: string; label: string }>>([]);

--- a/apps/desktop/src/components/forge/MergeButton.svelte
+++ b/apps/desktop/src/components/forge/MergeButton.svelte
@@ -6,6 +6,7 @@
 	import { persisted, type Persisted } from "@gitbutler/shared/persisted";
 
 	import { ContextMenuItem, ContextMenuSection, DropdownButton } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { ButtonProps } from "@gitbutler/ui";
 
 	interface Props {
@@ -40,7 +41,7 @@
 		return persisted<MergeMethod>(MergeMethod.Merge, key + projectId);
 	}
 
-	const action = persistedAction(projectId);
+	const action = persistedAction(untrack(() => projectId));
 
 	// If GitLab and action is rebase, reset to merge
 	$effect(() => {

--- a/apps/desktop/src/components/forge/ReviewCreation.svelte
+++ b/apps/desktop/src/components/forge/ReviewCreation.svelte
@@ -39,7 +39,7 @@
 	import { chipToasts, TestId } from "@gitbutler/ui";
 	import { IME_COMPOSITION_HANDLER } from "@gitbutler/ui/utils/imeHandling";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
-	import { tick } from "svelte";
+	import { tick, untrack } from "svelte";
 
 	type Props = {
 		projectId: string;
@@ -95,7 +95,7 @@
 	const imeHandler = inject(IME_COMPOSITION_HANDLER);
 
 	// AI things
-	const aiGenEnabled = projectAiGenEnabled(projectId);
+	const aiGenEnabled = projectAiGenEnabled(untrack(() => projectId));
 	let aiConfigurationValid = $state(false);
 	const canUseAI = $derived($aiGenEnabled && aiConfigurationValid);
 	let aiIsLoading = $state(false);
@@ -120,8 +120,11 @@
 		return branchName;
 	}
 
-	const templatePath = persisted<string | undefined>(undefined, `last-template-${projectId}`);
-	const templateEnabled = persisted(false, `enable-template-${projectId}`);
+	const templatePath = persisted<string | undefined>(
+		undefined,
+		`last-template-${untrack(() => projectId)}`,
+	);
+	const templateEnabled = persisted(false, `enable-template-${untrack(() => projectId)}`);
 
 	async function getDefaultBody(commits: Commit[]): Promise<string> {
 		if ($templateEnabled && $templatePath) {

--- a/apps/desktop/src/components/history/SnapshotCard.svelte
+++ b/apps/desktop/src/components/history/SnapshotCard.svelte
@@ -9,6 +9,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { Button, Icon, ScrollableContainer, type IconName } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import { untrack } from "svelte";
 	import type { Snapshot, SnapshotDetails } from "$lib/history/types";
 
 	interface Props {
@@ -172,10 +173,10 @@
 		}
 	}
 
-	const isRestoreSnapshot = entry.details?.operation === "RestoreFromSnapshot";
-	const error = entry.details?.trailers.find((t) => t.key === "error")?.value;
+	const isRestoreSnapshot = untrack(() => entry.details?.operation === "RestoreFromSnapshot");
+	const error = untrack(() => entry.details?.trailers.find((t) => t.key === "error")?.value);
 
-	const operation = mapOperation(entry.details);
+	const operation = mapOperation(untrack(() => entry.details));
 
 	const modeService = inject(MODE_SERVICE);
 	const mode = $derived(modeService.mode(projectId));

--- a/apps/desktop/src/components/irc/IrcCommit.svelte
+++ b/apps/desktop/src/components/irc/IrcCommit.svelte
@@ -4,6 +4,7 @@
 	import FileListProvider from "$components/files/FileListProvider.svelte";
 	import AppScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
 	import { createCommitSelection } from "$lib/selection/key";
+	import { untrack } from "svelte";
 	import type { UnifiedDiff } from "$lib/hunks/diff";
 	import type { SharedCommitPayload } from "$lib/irc/sharedStack";
 
@@ -14,7 +15,7 @@
 
 	const { projectId, commit }: Props = $props();
 
-	const selectionId = createCommitSelection({ commitId: commit.commitId });
+	const selectionId = createCommitSelection({ commitId: untrack(() => commit).commitId });
 	const changes = $derived(commit.commit.files.map((f) => f.change));
 
 	let selectedIndex: number = $state(0);

--- a/apps/desktop/src/components/irc/IrcMessages.svelte
+++ b/apps/desktop/src/components/irc/IrcMessages.svelte
@@ -13,7 +13,7 @@
 		Avatar,
 		Markdown,
 	} from "@gitbutler/ui";
-	import { onDestroy } from "svelte";
+	import { onDestroy, untrack } from "svelte";
 	import type { Reaction, StoredMessage } from "$lib/irc/ircEndpoints";
 
 	function avatarUrl(sender: string): string {
@@ -94,7 +94,7 @@
 	const grouped = $derived(groupConsecutive(messages));
 
 	// True when there is no more history to load — banner is shown only then.
-	let reachedTop = $state(!onLoadMore);
+	let reachedTop = $state(!untrack(() => onLoadMore));
 
 	async function handleLoadMore() {
 		const hasMore = await onLoadMore?.();
@@ -211,6 +211,7 @@
 	{@const reactions = groupReactions(msg.msgid ? (messageReactions[msg.msgid] ?? []) : [])}
 	{@const displayContent = msg.content.trim() ? msg.content : "\u00a0"}
 	<div
+		role="listitem"
 		class="message-row"
 		class:active={activeMessageId === msg.msgid}
 		onpointerenter={(e) => {
@@ -325,6 +326,8 @@
 	</VirtualList>
 	{#if activeMsg}
 		<div
+			role="toolbar"
+			tabindex="-1"
 			class="floating-actions"
 			style={actionsStyle}
 			bind:this={actionsEl}

--- a/apps/desktop/src/components/projectSettings/AIPromptSelect.svelte
+++ b/apps/desktop/src/components/projectSettings/AIPromptSelect.svelte
@@ -2,7 +2,7 @@
 	import { PROMPT_SERVICE } from "$lib/ai/aiPromptService";
 	import { inject } from "@gitbutler/core/context";
 	import { Select, SelectItem } from "@gitbutler/ui";
-	import { onMount } from "svelte";
+	import { onMount, untrack } from "svelte";
 	import type { Prompts, UserPrompt } from "$lib/ai/types";
 	import type { Persisted } from "@gitbutler/shared/persisted";
 
@@ -18,12 +18,12 @@
 	let prompts: Prompts;
 	let selectedPromptId = $state<Persisted<string | undefined>>();
 
-	if (promptUse === "commits") {
+	if (untrack(() => promptUse) === "commits") {
 		prompts = promptService.commitPrompts;
-		selectedPromptId = promptService.selectedCommitPromptId(projectId);
+		selectedPromptId = promptService.selectedCommitPromptId(untrack(() => projectId));
 	} else {
 		prompts = promptService.branchPrompts;
-		selectedPromptId = promptService.selectedBranchPromptId(projectId);
+		selectedPromptId = promptService.selectedBranchPromptId(untrack(() => projectId));
 	}
 
 	let userPrompts = prompts.userPrompts;

--- a/apps/desktop/src/components/rules/RuleEditor.svelte
+++ b/apps/desktop/src/components/rules/RuleEditor.svelte
@@ -18,6 +18,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { Button, chipToasts, Icon, Select, SelectItem, Spacer } from "@gitbutler/ui";
 	import { isDefined } from "@gitbutler/ui/utils/typeguards";
+	import { untrack } from "svelte";
 
 	type Props = {
 		projectId: string;
@@ -43,8 +44,10 @@
 	const [create, creatingRule] = rulesService.createWorkspaceRule;
 	const [update, updatingRule] = rulesService.updateWorkspaceRule;
 
-	let stackTargetSelected = $state<StackTarget | undefined>(initialStackTarget);
-	let draftRuleFilterInitialValues = $state<Partial<RuleFilterMap>>(initialFilterValues);
+	let stackTargetSelected = $state<StackTarget | undefined>(untrack(() => initialStackTarget));
+	let draftRuleFilterInitialValues = $state<Partial<RuleFilterMap>>(
+		untrack(() => initialFilterValues),
+	);
 	const ruleFilterTypes = $derived(typedKeys(draftRuleFilterInitialValues));
 	const encodedStackTarget = $derived(
 		stackTargetSelected && encodeStackTarget(stackTargetSelected),

--- a/apps/desktop/src/components/rules/RuleFiltersEditor.svelte
+++ b/apps/desktop/src/components/rules/RuleFiltersEditor.svelte
@@ -13,6 +13,7 @@
 	} from "$lib/rules/rule";
 	import { typedKeys } from "$lib/utils/object";
 	import { Button, Select, SelectItem, Textbox, FileStatusBadge } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { FileStatus } from "@gitbutler/ui/components/file/types";
 
 	const FILE_STATUS_OPTIONS: FileStatus[] = ["addition", "modification", "deletion", "rename"];
@@ -29,14 +30,18 @@
 	let addFilterButton = $state<HTMLDivElement>();
 	let newFilterContextMenu = $state<NewRuleMenu>();
 
-	let pathRegex = $state<string | undefined>(initialFilterValues.pathMatchesRegex ?? undefined);
+	let pathRegex = $state<string | undefined>(
+		untrack(() => initialFilterValues.pathMatchesRegex ?? undefined),
+	);
 	let contentRegex = $state<string | undefined>(
-		initialFilterValues.contentMatchesRegex ?? undefined,
+		untrack(() => initialFilterValues.contentMatchesRegex ?? undefined),
 	);
 	let treeChangeType = $state<FileStatus | undefined>(
-		initialFilterValues.fileChangeType ?? undefined,
+		untrack(() => initialFilterValues.fileChangeType ?? undefined),
 	);
-	let semanticType = $state<SemanticType | undefined>(initialFilterValues.semanticType?.type);
+	let semanticType = $state<SemanticType | undefined>(
+		untrack(() => initialFilterValues.semanticType?.type),
+	);
 
 	const ruleFilterTypes = $derived(typedKeys(initialFilterValues));
 	const hasClaudeSession = $derived(ruleFilterTypes.includes("claudeCodeSessionId"));

--- a/apps/desktop/src/components/rules/RulesList.svelte
+++ b/apps/desktop/src/components/rules/RulesList.svelte
@@ -14,6 +14,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { Badge, Button, chipToasts, Link, SkeletonBone } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
+	import { untrack } from "svelte";
 	import { slide } from "svelte/transition";
 
 	type Props = {
@@ -33,7 +34,7 @@
 	let editorInitialFilterValues = $state<Partial<RuleFilterMap>>({});
 
 	// Read initial collapsed state from persisted storage, default to false (open) if not found
-	const drawerPersistId = `rules-drawer-${projectId}`;
+	const drawerPersistId = `rules-drawer-${untrack(() => projectId)}`;
 	let drawer = $state<Drawer>();
 
 	const rules = $derived(rulesService.workspaceRules(projectId));

--- a/apps/desktop/src/components/settings/AIPromptEdit.svelte
+++ b/apps/desktop/src/components/settings/AIPromptEdit.svelte
@@ -3,6 +3,7 @@
 	import { PROMPT_SERVICE } from "$lib/ai/aiPromptService";
 	import { inject } from "@gitbutler/core/context";
 	import { Button } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import { get } from "svelte/store";
 	import type { Prompts, UserPrompt } from "$lib/ai/types";
 
@@ -16,7 +17,7 @@
 
 	let prompts = $state<Prompts>();
 
-	if (promptUse === "commits") {
+	if (untrack(() => promptUse) === "commits") {
 		prompts = promptService.commitPrompts;
 	} else {
 		prompts = promptService.branchPrompts;

--- a/apps/desktop/src/components/shared/Drawer.svelte
+++ b/apps/desktop/src/components/shared/Drawer.svelte
@@ -7,6 +7,7 @@
 	import { persistWithExpiration } from "@gitbutler/shared/persisted";
 	import { Icon } from "@gitbutler/ui";
 	import { pxToRem } from "@gitbutler/ui/utils/pxToRem";
+	import { untrack } from "svelte";
 	import { writable, type Writable } from "svelte/store";
 	import type { ComponentProps, Snippet } from "svelte";
 
@@ -72,9 +73,13 @@
 	const zoom = $derived($userSettings.zoom);
 
 	let containerDiv = $state<HTMLDivElement>();
-	let internalCollapsed: Writable<boolean | undefined> = persistId
-		? persistWithExpiration<boolean>(defaultCollapsed, persistId, 1440)
-		: writable(defaultCollapsed);
+	let internalCollapsed: Writable<boolean | undefined> = untrack(() => persistId)
+		? persistWithExpiration<boolean>(
+				untrack(() => defaultCollapsed),
+				untrack(() => persistId)!,
+				1440,
+			)
+		: writable(untrack(() => defaultCollapsed));
 
 	const isCollapsed = $derived($internalCollapsed);
 

--- a/apps/desktop/src/components/shared/DropzoneOverlay.svelte
+++ b/apps/desktop/src/components/shared/DropzoneOverlay.svelte
@@ -2,6 +2,7 @@
 	import { injectOptional } from "@gitbutler/core/context";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { pxToRem } from "@gitbutler/ui/utils/pxToRem";
+	import { untrack } from "svelte";
 
 	interface Props {
 		hovered: boolean;
@@ -20,10 +21,10 @@
 	let defaultPadding = 4;
 	const dragStateService = injectOptional(DRAG_STATE_SERVICE, undefined);
 
-	const extraPaddingTop = extraPaddings?.top ?? 0;
-	const extraPaddingRight = extraPaddings?.right ?? 0;
-	const extraPaddingBottom = extraPaddings?.bottom ?? 0;
-	const extraPaddingLeft = extraPaddings?.left ?? 0;
+	const extraPaddingTop = untrack(() => extraPaddings?.top ?? 0);
+	const extraPaddingRight = untrack(() => extraPaddings?.right ?? 0);
+	const extraPaddingBottom = untrack(() => extraPaddings?.bottom ?? 0);
+	const extraPaddingLeft = untrack(() => extraPaddings?.left ?? 0);
 
 	$effect(() => {
 		if (activated && hovered && label && dragStateService) {

--- a/apps/desktop/src/components/shared/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/shared/ProjectSwitcher.svelte
@@ -5,13 +5,14 @@
 	import { projectPath } from "$lib/routes/routes.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import { Button, OptionsGroup, Select, SelectItem } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	const { projectId }: { projectId?: string } = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectsQuery = $derived(projectsService.projects());
 
-	let selectedId = $state<string | undefined>(projectId);
+	let selectedId = $state<string | undefined>(untrack(() => projectId));
 
 	const mappedProjects = $derived(
 		projectsQuery.response?.map((project) => ({

--- a/apps/desktop/src/components/shared/Tabs.svelte
+++ b/apps/desktop/src/components/shared/Tabs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext } from "svelte";
+	import { setContext, untrack } from "svelte";
 	import { writable } from "svelte/store";
 	import type { TabContext } from "$lib/utils/tabs";
 	import type { Snippet } from "svelte";
@@ -11,7 +11,7 @@
 
 	const { children, defaultSelected }: Props = $props();
 
-	let selectedIndex = writable(defaultSelected);
+	let selectedIndex = writable(untrack(() => defaultSelected));
 
 	const context: TabContext = {
 		selectedIndex,

--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -28,6 +28,7 @@
 	import { AsyncButton, Button, Modal, TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
+	import { untrack } from "svelte";
 	import type { BranchFilterOption, SidebarEntrySubject } from "$lib/branches/branchListing";
 	type Props = {
 		projectId: string;
@@ -57,7 +58,7 @@
 	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
 	const selectedOption = persisted<BranchFilterOption>(
 		"all",
-		`branches-selectedOption-${projectId}`,
+		`branches-selectedOption-${untrack(() => projectId)}`,
 	);
 
 	let selection = $state<BranchesSelection>({ type: "target" });

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -31,7 +31,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { ChipToastContainer } from "@gitbutler/ui";
 	import { FOCUS_MANAGER } from "@gitbutler/ui/focus/focusManager";
-	import { type Snippet } from "svelte";
+	import { untrack, type Snippet } from "svelte";
 	import type { LayoutData } from "./$types";
 
 	const { data, children }: { data: LayoutData; children: Snippet } = $props();
@@ -41,8 +41,8 @@
 	// BOOTSTRAP & INIT
 	// =============================================================================
 
-	const { backend } = data;
-	initDependencies(data);
+	const { backend } = untrack(() => data);
+	initDependencies(untrack(() => data));
 
 	new MessageQueueProcessor();
 

--- a/apps/web/src/lib/components/OrganizationProfile.svelte
+++ b/apps/web/src/lib/components/OrganizationProfile.svelte
@@ -8,6 +8,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { ORGANIZATION_SERVICE } from "@gitbutler/shared/organizations/organizationService";
 	import { Button, Modal } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	import type { ExtendedOrganization, OrganizationMember } from "$lib/owner/types";
 
@@ -27,7 +28,7 @@
 	// Get owner service to refresh organization data
 	const ownerService = inject(OWNER_SERVICE);
 
-	let patchStacksStore = $state(organizationService.getPatchStacks(ownerSlug));
+	let patchStacksStore = $state(organizationService.getPatchStacks(untrack(() => ownerSlug)));
 	let patchStacks = $derived($patchStacksStore);
 	let patchStacksData = $derived(patchStacks.status === "found" ? patchStacks.value || [] : []);
 

--- a/apps/web/src/lib/components/UserProfile.svelte
+++ b/apps/web/src/lib/components/UserProfile.svelte
@@ -5,6 +5,7 @@
 	import { inject } from "@gitbutler/core/context";
 
 	import { AsyncButton, Button, Markdown, chipToasts } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import { get } from "svelte/store";
 	import type { ExtendedUser } from "$lib/owner/types";
 
@@ -58,7 +59,7 @@
 		}
 	}
 
-	let patchStacksStore = $state(userService.getPatchStacks(ownerSlug));
+	let patchStacksStore = $state(userService.getPatchStacks(untrack(() => ownerSlug)));
 	let patchStacks = $derived($patchStacksStore);
 	let patchStacksData = $derived(patchStacks.status === "found" ? patchStacks.value || [] : []);
 

--- a/apps/web/src/lib/components/auth/OAuthButtons.svelte
+++ b/apps/web/src/lib/components/auth/OAuthButtons.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from "svelte";
 	import { env } from "$env/dynamic/public";
 
 	interface Props {
@@ -7,7 +8,7 @@
 
 	let { mode = "signin" }: Props = $props();
 
-	const actionText = mode === "signup" ? "Sign up" : "Sign in";
+	const actionText = untrack(() => mode) === "signup" ? "Sign up" : "Sign in";
 </script>
 
 <div class="auth-form__social">

--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -225,12 +225,6 @@
 		transform: translateY(-4px);
 	}
 
-	.download-options {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-	}
-
 	.download-link {
 		color: var(--text-1);
 		font-size: 16px;

--- a/apps/web/src/lib/components/projects/OrganizationProjects.svelte
+++ b/apps/web/src/lib/components/projects/OrganizationProjects.svelte
@@ -5,6 +5,7 @@
 	import { ORGANIZATION_SERVICE } from "@gitbutler/shared/organizations/organizationService";
 	import { getOrganizationBySlug } from "@gitbutler/shared/organizations/organizationsPreview.svelte";
 	import { APP_STATE } from "@gitbutler/shared/redux/store.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		slug: string;
@@ -15,7 +16,11 @@
 
 	const { slug }: Props = $props();
 
-	const organization = getOrganizationBySlug(appState, organizationService, slug);
+	const organization = getOrganizationBySlug(
+		appState,
+		organizationService,
+		untrack(() => slug),
+	);
 </script>
 
 <Loading loadable={organization.current}>

--- a/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
+++ b/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
@@ -6,6 +6,7 @@
 	import { WEB_ROUTES_SERVICE } from "@gitbutler/shared/routing/webRoutes.svelte";
 	import dayjs from "dayjs";
 	import relativeTime from "dayjs/plugin/relativeTime";
+	import { untrack } from "svelte";
 
 	dayjs.extend(relativeTime);
 	type Props = {
@@ -18,7 +19,7 @@
 
 	const routes = inject(WEB_ROUTES_SERVICE);
 
-	const project = getProjectByRepositoryId(projectId);
+	const project = getProjectByRepositoryId(untrack(() => projectId));
 	const projectRoute = $featureShowProjectPage ? routes.projectPath : routes.projectReviewPath;
 </script>
 

--- a/apps/web/src/lib/components/review/ReviewInfo.svelte
+++ b/apps/web/src/lib/components/review/ReviewInfo.svelte
@@ -15,6 +15,7 @@
 	import { APP_STATE } from "@gitbutler/shared/redux/store.svelte";
 	import { AvatarGroup, Icon } from "@gitbutler/ui";
 	import { copyToClipboard } from "@gitbutler/ui/utils/clipboard";
+	import { untrack } from "svelte";
 
 	const NO_REVIEWERS = "Not reviewed yet";
 	const NO_CONTRIBUTORS = "No contributors";
@@ -42,7 +43,7 @@
 	const approvers = $derived(getPatchApproversWithAvatars(patchCommit));
 	const rejectors = $derived(getPatchRejectorsWithAvatars(patchCommit));
 
-	const commitShortSha = patchCommit.commitSha.substring(0, 7);
+	const commitShortSha = untrack(() => patchCommit).commitSha.substring(0, 7);
 </script>
 
 <InfoFlexRow>

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
@@ -13,6 +13,7 @@
 	} from "@gitbutler/shared/routing/webRoutes.svelte";
 
 	import { AsyncButton, Button, Markdown, Modal, chipToasts } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 
 	interface Props {
 		data: ProjectParameters;
@@ -32,7 +33,7 @@
 	let projectData = $state<any>(null);
 
 	// Create a promise for the project data
-	const projectSlug = `${data.ownerSlug}/${data.projectSlug}`;
+	const projectSlug = untrack(() => `${data.ownerSlug}/${data.projectSlug}`);
 	const projectPromise = projectService.getProjectBySlug(projectSlug).then((result) => {
 		if (result) {
 			projectData = result;

--- a/apps/web/src/routes/(home)/sections/FeatureUpdates.svelte
+++ b/apps/web/src/routes/(home)/sections/FeatureUpdates.svelte
@@ -187,6 +187,8 @@
 		<div class="video-content">
 			<div class="video-carousel__container">
 				<div
+					role="region"
+					aria-label="Video carousel"
 					class="video-carousel__scroll"
 					bind:this={carousel}
 					ontouchstart={handleTouchStart}

--- a/apps/web/src/routes/cli/sections/ScriptSwitcher.svelte
+++ b/apps/web/src/routes/cli/sections/ScriptSwitcher.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { untrack } from "svelte";
+
 	interface Props {
 		scriptsData: Record<string, any>;
 		onScriptChange?: (scriptId: string) => void;
@@ -13,7 +15,7 @@
 		scriptProgress = 0,
 	}: Props = $props();
 
-	const scripts = Object.values(scriptsData);
+	const scripts = Object.values(untrack(() => scriptsData));
 
 	function handleScriptSelect(scriptId: string) {
 		onScriptChange?.(scriptId);

--- a/apps/web/src/routes/downloads/+page.svelte
+++ b/apps/web/src/routes/downloads/+page.svelte
@@ -2,6 +2,7 @@
 	import Footer from "$lib/components/marketing/Footer.svelte";
 	import Header from "$lib/components/marketing/Header.svelte";
 	import ReleaseCard from "$lib/components/marketing/ReleaseCard.svelte";
+	import { untrack } from "svelte";
 	import Markdown from "svelte-exmarkdown";
 	import type { Release } from "$lib/types/releases";
 	import type { LatestReleaseBuilds } from "$lib/utils/releaseUtils";
@@ -17,7 +18,7 @@
 
 	const { data }: Props = $props();
 
-	const { latestRelease, latestReleaseBuilds } = data;
+	const { latestRelease, latestReleaseBuilds } = untrack(() => data);
 
 	let linuxArch = $state<"x86-64" | "ARM64">("x86-64");
 </script>

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -3,6 +3,7 @@
 	import Header from "$lib/components/marketing/Header.svelte";
 	import ReleaseDownloadLinks from "$lib/components/marketing/ReleaseDownloadLinks.svelte";
 	import { Icon } from "@gitbutler/ui";
+	import { untrack } from "svelte";
 	import type { Release } from "$lib/types/releases";
 	import type { LatestReleaseBuilds } from "$lib/utils/releaseUtils";
 
@@ -16,7 +17,7 @@
 
 	const { data }: Props = $props();
 
-	const { latestNightly, latestNightlyBuilds, otherNightlies } = data;
+	const { latestNightly, latestNightlyBuilds, otherNightlies } = untrack(() => data);
 
 	let linuxArch = $state<"x86-64" | "ARM64">("x86-64");
 	let expandedRelease: string | null = $state(null);

--- a/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
+++ b/packages/ui/src/lib/components/IntegrationSeriesRow.svelte
@@ -34,7 +34,7 @@
 		branchShouldBeDeletedMap,
 	}: Props = $props();
 
-	const allSeriesAreIntegrated = series.every((branch) => branch.status === "integrated");
+	const allSeriesAreIntegrated = $derived(series.every((branch) => branch.status === "integrated"));
 </script>
 
 {#snippet stackBranch({ name, status }: Branch, isLast: boolean)}

--- a/packages/ui/src/lib/components/Modal.svelte
+++ b/packages/ui/src/lib/components/Modal.svelte
@@ -37,7 +37,7 @@
 	import { focusable } from "$lib/focus/focusable";
 	import { portal } from "$lib/utils/portal";
 	import { pxToRem } from "$lib/utils/pxToRem";
-	import { onDestroy } from "svelte";
+	import { onDestroy, untrack } from "svelte";
 	import type { Snippet } from "svelte";
 
 	const {
@@ -58,7 +58,7 @@
 	}: ModalProps = $props();
 
 	let open = $state(false);
-	let item = $state<T>(defaultItem as any);
+	let item = $state<T>(untrack(() => defaultItem) as any);
 	let isClosing = $state(false);
 	let closingPromise: Promise<void> | undefined = undefined;
 	let formEl: HTMLFormElement | undefined = $state();

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { focusable } from "$lib/focus/focusable";
 	import { pxToRem } from "$lib/utils/pxToRem";
+	import { untrack } from "svelte";
 	import type { HTMLTextareaAttributes } from "svelte/elements";
 
 	interface Props extends HTMLTextareaAttributes {
@@ -104,7 +105,7 @@
 	);
 
 	// Initialize with approximate minHeight to prevent initial scroll flash
-	let measureElHeight = $state(fontSize * lineHeight * minRows + 24);
+	let measureElHeight = $state(untrack(() => fontSize * lineHeight * minRows) + 24);
 
 	// Ensure measureElHeight never goes below minHeight
 	$effect(() => {

--- a/packages/ui/src/lib/components/Tooltip.svelte
+++ b/packages/ui/src/lib/components/Tooltip.svelte
@@ -14,7 +14,7 @@
 	import { tooltip } from "$lib/utils/tooltipPosition";
 	import { flyScale } from "$lib/utils/transitions";
 	import { injectOptional } from "@gitbutler/core/context";
-	import { type Snippet } from "svelte";
+	import { untrack, type Snippet } from "svelte";
 
 	interface Props {
 		text?: string;
@@ -44,7 +44,7 @@
 	const draggingService = injectOptional(DRAG_STATE_SERVICE, undefined);
 	const isDragging = $derived(draggingService?.isDragging);
 	let targetEl: HTMLElement | undefined = $state();
-	let position = $state(requestedPosition);
+	let position = $state(untrack(() => requestedPosition));
 	let show = $state(false);
 	let timeoutId: undefined | ReturnType<typeof setTimeout> = $state();
 	let isInstant = $state(false);

--- a/packages/ui/src/lib/components/chipToast/ChipToast.svelte
+++ b/packages/ui/src/lib/components/chipToast/ChipToast.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from "$components/Icon.svelte";
 	import { type IconName } from "$lib/icons/names";
+	import { untrack } from "svelte";
 	import { fly, fade } from "svelte/transition";
 	import type { ChipToastType, ChipToastButtonConfig } from "$components/chipToast/chipToastTypes";
 
@@ -30,7 +31,7 @@
 		}
 	}
 
-	const icon = getEmojiForType(type);
+	const icon = getEmojiForType(untrack(() => type));
 
 	function handleDismiss() {
 		onDismiss?.();

--- a/packages/ui/src/lib/components/scroll/Scrollbar.svelte
+++ b/packages/ui/src/lib/components/scroll/Scrollbar.svelte
@@ -3,6 +3,8 @@
 </script>
 
 <script lang="ts">
+	import { untrack } from "svelte";
+
 	interface Props {
 		viewport: HTMLElement;
 		initiallyVisible?: boolean;
@@ -66,12 +68,12 @@
 
 	const vert = $derived(!horz);
 
-	let wholeHeight = $state(viewport?.scrollHeight ?? 0);
-	let wholeWidth = $state(viewport?.scrollWidth ?? 0);
-	let scrollTop = $state(viewport?.scrollTop ?? 0);
-	let scrollLeft = $state(viewport?.scrollLeft ?? 0);
-	let trackHeight = $state(viewport?.offsetHeight ?? 0);
-	let trackWidth = $state(viewport?.offsetWidth ?? 0);
+	let wholeHeight = $state(untrack(() => viewport?.scrollHeight ?? 0));
+	let wholeWidth = $state(untrack(() => viewport?.scrollWidth ?? 0));
+	let scrollTop = $state(untrack(() => viewport?.scrollTop ?? 0));
+	let scrollLeft = $state(untrack(() => viewport?.scrollLeft ?? 0));
+	let trackHeight = $state(untrack(() => viewport?.offsetHeight ?? 0));
+	let trackWidth = $state(untrack(() => viewport?.offsetWidth ?? 0));
 
 	const thumbHeight = $derived(wholeHeight > 0 ? (trackHeight / wholeHeight) * trackHeight : 0);
 	const thumbWidth = $derived(wholeWidth > 0 ? (trackWidth / wholeWidth) * trackWidth : 0);

--- a/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
+++ b/packages/ui/src/lib/components/segmentControl/SegmentControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext } from "svelte";
+	import { setContext, untrack } from "svelte";
 	import { writable } from "svelte/store";
 	import type { SegmentContext } from "$components/segmentControl/segmentTypes";
 	import type { Snippet } from "svelte";
@@ -23,7 +23,7 @@
 	}: SegmentProps = $props();
 
 	const registeredSegments: string[] = [];
-	const selectedSegmentId = writable<string | undefined>(selected);
+	const selectedSegmentId = writable<string | undefined>(untrack(() => selected));
 
 	// Sync external selected prop to internal store
 	$effect(() => {

--- a/packages/ui/src/lib/components/select/Select.svelte
+++ b/packages/ui/src/lib/components/select/Select.svelte
@@ -52,7 +52,7 @@
 	import { portal } from "$lib/utils/portal";
 	import { pxToRem } from "$lib/utils/pxToRem";
 	import { resizeObserver } from "$lib/utils/resizeObserver";
-	import { type Snippet } from "svelte";
+	import { untrack, type Snippet } from "svelte";
 
 	const {
 		id,
@@ -133,11 +133,11 @@
 			highlightedIndex = undefined;
 		}
 	});
-	let maxHeightState = $state(maxHeight);
+	let maxHeightState = $state(untrack(() => maxHeight));
 	let listOpen = $state(false);
 	let inputBoundingRect = $state<DOMRect>();
 	let optionsGroupBoundingRect = $state<DOMRect>();
-	let computedVerticalAlign = $state<"top" | "bottom">(popupVerticalAlign);
+	let computedVerticalAlign = $state<"top" | "bottom">(untrack(() => popupVerticalAlign));
 
 	const maxBottomPadding = 20;
 

--- a/packages/ui/tests/HardWrapPluginTestWrapper.svelte
+++ b/packages/ui/tests/HardWrapPluginTestWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import RichTextEditor from "$lib/richText/RichTextEditor.svelte";
 	import HardWrapPlugin from "$lib/richText/plugins/HardWrapPlugin.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		maxLength?: number;
@@ -13,7 +14,7 @@
 	let editor = $state<RichTextEditor>();
 	let paragraphCountDisplay = $state(0);
 	let textContentDisplay = $state("");
-	let value = $state(initialText);
+	let value = $state(untrack(() => initialText));
 
 	// Update display values from the editor
 	async function updateDisplayValues() {

--- a/packages/ui/tests/IndentPluginTestWrapper.svelte
+++ b/packages/ui/tests/IndentPluginTestWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import RichTextEditor from "$lib/richText/RichTextEditor.svelte";
 	import IndentPlugin from "$lib/richText/plugins/IndentPlugin.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		initialText?: string;
@@ -11,7 +12,7 @@
 	let editor = $state<RichTextEditor>();
 	let paragraphCountDisplay = $state(0);
 	let textContentDisplay = $state("");
-	let value = $state(initialText);
+	let value = $state(untrack(() => initialText));
 
 	// Update display values from the editor
 	async function updateDisplayValues() {

--- a/packages/ui/tests/InlineCodeTestWrapper.svelte
+++ b/packages/ui/tests/InlineCodeTestWrapper.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import RichTextEditor from "$lib/richText/RichTextEditor.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		initialText?: string;
@@ -10,7 +11,7 @@
 	let editor = $state<RichTextEditor>();
 	let textContentDisplay = $state("");
 	let inlineCodeCountDisplay = $state(0);
-	let value = $state(initialText);
+	let value = $state(untrack(() => initialText));
 
 	async function updateDisplayValues() {
 		if (!editor) return;

--- a/packages/ui/tests/VirtualListTestWrapper.svelte
+++ b/packages/ui/tests/VirtualListTestWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import VirtualList from "$components/VirtualList.svelte";
 	import AsyncContent from "$lib/helpers/AsyncContent.svelte";
+	import { untrack } from "svelte";
 
 	type Props = {
 		defaultHeight: number;
@@ -56,7 +57,7 @@
 		return 30; // short message
 	}
 
-	let items = $state(Array.from({ length: itemCount }, (_, i) => `Item ${i + 1}`));
+	let items = $state(Array.from({ length: untrack(() => itemCount) }, (_, i) => `Item ${i + 1}`));
 	let container = $state<HTMLDivElement>();
 	let loadMoreCallCount = $state(0);
 	let virtualList = $state<VirtualList<any>>();


### PR DESCRIPTION
Wrap reactive prop references in untrack() across 51 component files
where initial-value-only capture is intentional. Uses $derived instead
of untrack in IntegrationSeriesRow where reactivity is desired. Also
fixes a11y warnings in IrcMessages and removes unused CSS in Footer.