### PR TITLE
fix(but): print normalized name after creating branch

### DIFF
--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use bstr::ByteSlice;
 use but_api::json::HexHash;
 use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use colored::Colorize;
@@ -120,7 +121,7 @@ pub fn new(
         })
     };
 
-    but_api::legacy::stack::create_reference_with_perm(
+    let (_, normalized_branch_name) = but_api::legacy::stack::create_reference_with_perm(
         ctx,
         but_api::legacy::stack::create_reference::Request {
             new_name: branch_name.clone(),
@@ -129,13 +130,23 @@ pub fn new(
         guard.write_permission(),
     )?;
 
+    let normalized_branch_name = normalized_branch_name.shorten();
     if let Some(out) = out.for_human() {
+        if normalized_branch_name != branch_name {
+            writeln!(
+                out,
+                "Branch name normalized: {} -> {}",
+                branch_name.dimmed(),
+                normalized_branch_name.to_str_lossy().yellow(),
+            )?;
+        }
+
         if let Some(anchor_name) = anchor_display {
             writeln!(
                 out,
                 "{} {} stacked on {}",
                 "✓ Created branch".green(),
-                branch_name.yellow(),
+                normalized_branch_name.to_str_lossy().yellow(),
                 anchor_name.dimmed()
             )?;
         } else {
@@ -143,14 +154,14 @@ pub fn new(
                 out,
                 "{} {}",
                 "✓ Created branch".green(),
-                branch_name.yellow()
+                normalized_branch_name.to_str_lossy().yellow()
             )?;
         }
     } else if let Some(out) = out.for_shell() {
-        writeln!(out, "{branch_name}")?;
+        writeln!(out, "{}", normalized_branch_name.to_str_lossy())?;
     } else if let Some(out) = out.for_json() {
         let value = json::BranchNewOutput {
-            branch: branch_name.clone(),
+            branch: normalized_branch_name.to_str_lossy().into(),
             anchor: anchor_for_json,
         };
         out.write_value(value)?;

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -34,6 +34,55 @@ fn outputs_branch_name() -> anyhow::Result<()> {
 }
 
 #[test]
+fn creates_branch_with_normalized_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&[])?;
+
+    env.but("branch new trailing-hyphen-stripped-")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Branch name normalized: trailing-hyphen-stripped- -> trailing-hyphen-stripped
+✓ Created branch trailing-hyphen-stripped
+
+"#]]);
+
+    env.but("show trailing-hyphen-stripped")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Branch: trailing-hyphen-stripped
+
+No commits on this branch.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn json_outputs_normalized_branch_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&[])?;
+
+    env.but("--json branch new trailing-hyphen-stripped-")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "branch": "trailing-hyphen-stripped"
+}
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn with_json_output() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"


### PR DESCRIPTION
`but branch new` always created the new branch with a normalized name, but the name reported to users was the original non-normalized input, making it a li'l bit confusing.

Also took the opportunity to notify the user that the branch name was normalized.

Before:

<img width="352" height="43" alt="before" src="https://github.com/user-attachments/assets/cad34206-5188-4922-85aa-362e94bdac24" />

After:
<img width="496" height="86" alt="after" src="https://github.com/user-attachments/assets/464c1834-901b-4a5e-9857-7411502ba620" />

## TODO
Tests probably need revising as I realized that trailing dashes are actually fine by Git, it's just GitButler that strips them away for some reason. I think this is wrong.
