### PR TITLE
fix(but): print normalized name after branch rename

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -287,15 +287,14 @@ pub fn update_branch_name_with_perm(
     branch_name: String,
     new_name: String,
     perm: &mut RepoExclusive,
-) -> Result<()> {
+) -> Result<String> {
     gitbutler_branch_actions::stack::update_branch_name_with_perm(
         ctx,
         stack_id,
         branch_name,
         new_name,
         perm,
-    )?;
-    Ok(())
+    )
 }
 
 #[but_api]

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -3,6 +3,7 @@ use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
 use but_core::sync::RepoExclusive;
 use but_ctx::Context;
+use colored::Colorize;
 use gix::prelude::ObjectIdExt;
 
 use super::{
@@ -95,7 +96,7 @@ fn edit_branch_name(
         if let Some(sid) = stack_entry.id {
             let new_name = prepare_provided_message(message, "branch name")
                 .unwrap_or_else(|| get_branch_name_from_editor(branch_name))?;
-            but_api::legacy::stack::update_branch_name_with_perm(
+            let normalized_name = but_api::legacy::stack::update_branch_name_with_perm(
                 ctx,
                 sid,
                 branch_name.to_owned(),
@@ -103,7 +104,15 @@ fn edit_branch_name(
                 perm,
             )?;
             if let Some(out) = out.for_human() {
-                writeln!(out, "Renamed branch '{branch_name}' to '{new_name}'")?;
+                if normalized_name != new_name {
+                    writeln!(
+                        out,
+                        "New branch name normalized: {} -> {}",
+                        new_name.dimmed(),
+                        normalized_name.yellow()
+                    )?;
+                }
+                writeln!(out, "Renamed branch '{branch_name}' to '{normalized_name}'")?;
             }
             return Ok(());
         }

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -101,6 +101,36 @@ Renamed branch 'branch-to-rename-123' to 'renamed-branch'
 }
 
 #[test]
+fn reword_branch_normalizes_name() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.setup_metadata(&["A"])?;
+    env.but("branch new branch-to-rename").assert().success();
+
+    env.but("reword branch-to-rename -m trailing-hyphen-stripped-")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+New branch name normalized: trailing-hyphen-stripped- -> trailing-hyphen-stripped
+Renamed branch 'branch-to-rename' to 'trailing-hyphen-stripped'
+
+"#]]);
+
+    env.but("show trailing-hyphen-stripped")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Branch: trailing-hyphen-stripped
+
+No commits on this branch.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
 fn reword_commit_with_same_message_succeeds_as_noop() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
     insta::assert_snapshot!(env.git_log()?, @r"


### PR DESCRIPTION
`but reword <branch>` always did normalize the new branch name, but the original input was what was printed afterward. This made it seem like you had created an invalid branch name, whereas in reality the name was normalized.

This PR just makes the output consistent with reality.