### PR TITLE
fix: scope absorb plan and lock indicators to visible assignments

### DIFF
--- a/apps/desktop/src/components/files/FileListItems.svelte
+++ b/apps/desktop/src/components/files/FileListItems.svelte
@@ -84,7 +84,7 @@
 
 	const filePaths = $derived(controller.changes.map((change) => change.path));
 	const fileDependenciesQuery = $derived(
-		showLockedIndicator ? dependencyService.filesDependencies(projectId, filePaths) : null,
+		showLockedIndicator ? dependencyService.filesDependencies(projectId, filePaths, stackId) : null,
 	);
 	const fileDependencies = $derived(fileDependenciesQuery?.result.data || []);
 </script>

--- a/apps/desktop/src/lib/dependencies/dependencyService.svelte.ts
+++ b/apps/desktop/src/lib/dependencies/dependencyService.svelte.ts
@@ -1,5 +1,6 @@
 import {
 	aggregateFileDependencies,
+	filterDependenciesByAssignments,
 	type FileDependencies,
 	type HunkDependencies,
 } from "$lib/hunks/dependencies";
@@ -37,16 +38,17 @@ export default class DependencyService {
 		);
 	}
 
-	filesDependencies(projectId: string, filePaths: string[]) {
+	filesDependencies(projectId: string, filePaths: string[], stackId?: string) {
 		return this.worktreeService.worktreeChanges.useQuery(
 			{ projectId },
 			{
-				transform: ({ dependencies }) => {
+				transform: ({ dependencies, hunkAssignments }) => {
 					if (!dependencies) {
 						return [];
 					}
 
-					const e = toEntityAdapter(dependencies);
+					const filtered = filterDependenciesByAssignments(dependencies, hunkAssignments, stackId);
+					const e = toEntityAdapter(filtered);
 					return fileDependencySelectors.selectByIds(e.fileDependencies, filePaths);
 				},
 			},

--- a/apps/desktop/src/lib/hunks/dependencies.test.ts
+++ b/apps/desktop/src/lib/hunks/dependencies.test.ts
@@ -1,0 +1,146 @@
+import { filterDependenciesByAssignments } from "$lib/hunks/dependencies";
+import { describe, expect, test } from "vitest";
+import type { HunkDependencies } from "$lib/hunks/dependencies";
+import type { HunkAssignment } from "$lib/hunks/hunk";
+
+function makeDeps(
+	entries: Array<{ path: string; newStart: number; newLines: number }>,
+): HunkDependencies {
+	return {
+		diffs: entries.map(({ path, newStart, newLines }) => [
+			path,
+			{ oldStart: 1, oldLines: 1, newStart, newLines, diff: "" },
+			[{ target: { type: "stack", subject: "stack-1" }, commitId: "abc" }],
+		]),
+		errors: [],
+	};
+}
+
+function makeAssignment(
+	path: string,
+	stackId: string | null,
+	newStart: number,
+	newLines: number,
+): HunkAssignment {
+	return {
+		id: null,
+		path,
+		pathBytes: [],
+		stackId,
+		hunkHeader: { oldStart: 1, oldLines: 1, newStart, newLines },
+		lineNumsAdded: null,
+		lineNumsRemoved: null,
+	};
+}
+
+describe("filterDependenciesByAssignments", () => {
+	describe("unassigned view (stackId = undefined)", () => {
+		test("keeps dependency overlapping an unassigned hunk", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("a.ts", null, 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(1);
+		});
+
+		test("drops dependency overlapping a stack-assigned hunk", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("a.ts", "stack-1", 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(0);
+		});
+
+		test("keeps only the entry overlapping the unassigned hunk when mixed", () => {
+			const deps = makeDeps([
+				{ path: "a.ts", newStart: 10, newLines: 5 }, // overlaps unassigned hunk
+				{ path: "a.ts", newStart: 50, newLines: 5 }, // overlaps stack-assigned hunk
+			]);
+			const assignments = [
+				makeAssignment("a.ts", null, 10, 5),
+				makeAssignment("a.ts", "stack-1", 50, 5),
+			];
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(1);
+			expect(result.diffs[0]![1].newStart).toBe(10);
+		});
+	});
+
+	describe("stack lane view (stackId = 'stack-1')", () => {
+		test("keeps dependency overlapping a hunk assigned to this stack", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("a.ts", "stack-1", 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, "stack-1");
+			expect(result.diffs).toHaveLength(1);
+		});
+
+		test("drops dependency overlapping an unassigned hunk", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("a.ts", null, 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, "stack-1");
+			expect(result.diffs).toHaveLength(0);
+		});
+
+		test("drops dependency overlapping a hunk from a different stack", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("a.ts", "stack-2", 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, "stack-1");
+			expect(result.diffs).toHaveLength(0);
+		});
+	});
+
+	describe("range overlap", () => {
+		test("overlapping ranges match", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]); // [10, 15)
+			const assignments = [makeAssignment("a.ts", null, 12, 5)]; // [12, 17)
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(1);
+		});
+
+		test("adjacent but non-overlapping ranges do not match", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]); // [10, 15)
+			const assignments = [makeAssignment("a.ts", null, 15, 5)]; // [15, 20)
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(0);
+		});
+
+		test("0-line dependency hunk treated as single-line point", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 0 }]); // treated as [10, 11)
+			const assignments = [makeAssignment("a.ts", null, 10, 5)]; // [10, 15)
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(1);
+		});
+
+		test("0-line assignment hunk treated as single-line point", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]); // [10, 15)
+			const assignments = [makeAssignment("a.ts", null, 10, 0)]; // treated as [10, 11)
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(1);
+		});
+
+		test("no match when dependency is entirely before assignment", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 5, newLines: 3 }]); // [5, 8)
+			const assignments = [makeAssignment("a.ts", null, 10, 5)]; // [10, 15)
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(0);
+		});
+	});
+
+	describe("path matching", () => {
+		test("only matches entries with the same path", () => {
+			const deps = makeDeps([{ path: "a.ts", newStart: 10, newLines: 5 }]);
+			const assignments = [makeAssignment("b.ts", null, 10, 5)];
+			const result = filterDependenciesByAssignments(deps, assignments, undefined);
+			expect(result.diffs).toHaveLength(0);
+		});
+	});
+
+	describe("preserves errors", () => {
+		test("errors field is passed through unchanged", () => {
+			const deps: HunkDependencies = {
+				diffs: [],
+				errors: [{ errorMessage: "oops", stackId: "s", commitId: "c", path: "a.ts" }],
+			};
+			const result = filterDependenciesByAssignments(deps, [], undefined);
+			expect(result.errors).toEqual(deps.errors);
+		});
+	});
+});

--- a/apps/desktop/src/lib/hunks/dependencies.ts
+++ b/apps/desktop/src/lib/hunks/dependencies.ts
@@ -1,4 +1,4 @@
-import type { DiffHunk } from "$lib/hunks/hunk";
+import type { DiffHunk, HunkAssignment } from "$lib/hunks/hunk";
 
 export type DependencyError = {
 	description: string;
@@ -92,6 +92,48 @@ export type FileDependencies = {
 	 */
 	dependencies: HunkLocks[];
 };
+/**
+ * Check whether two line ranges overlap.
+ * Ranges are `[start, start + lines)` (1-based start, length in lines).
+ * A range with 0 lines (pure insertion/deletion) is treated as a point at `start`.
+ */
+function rangesOverlap(startA: number, linesA: number, startB: number, linesB: number): boolean {
+	const endA = startA + Math.max(linesA, 1);
+	const endB = startB + Math.max(linesB, 1);
+	return startA < endB && startB < endA;
+}
+
+/**
+ * Filters dependency entries to only those whose hunk ranges overlap with
+ * assignments visible in the current view.
+ *
+ * When `stackId` is provided, includes only dependencies overlapping assignments
+ * assigned to that stack (matching the stack lane's visible hunks).
+ * When `stackId` is undefined, includes only dependencies overlapping
+ * unassigned assignments (matching the unassigned lane).
+ */
+export function filterDependenciesByAssignments(
+	dependencies: HunkDependencies,
+	assignments: HunkAssignment[],
+	stackId: string | undefined,
+): HunkDependencies {
+	const filtered = dependencies.diffs.filter(([depPath, depHunk]) => {
+		return assignments.some(
+			(a) =>
+				a.path === depPath &&
+				a.hunkHeader !== null &&
+				a.stackId === (stackId ?? null) &&
+				rangesOverlap(
+					depHunk.newStart,
+					depHunk.newLines,
+					a.hunkHeader.newStart,
+					a.hunkHeader.newLines,
+				),
+		);
+	});
+	return { diffs: filtered, errors: dependencies.errors };
+}
+
 /**
  * Aggregates file dependencies from a collection of hunk dependencies.
  *

--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -177,18 +177,19 @@ pub fn absorption_plan_with_perm(
             let all_assignments = worktree_changes.assignments;
             let dependencies = worktree_changes.dependencies;
 
-            // Filter assignments to just this stack
+            // Include hunks that are unassigned or assigned to the acting stack,
+            // so that dependency locks can route unassigned hunks correctly.
             let stack_assignments: Vec<_> = all_assignments
                 .iter()
                 .filter(|a| {
-                    a.stack_id == assigned_stack_id
-                        && changes.iter().any(|c| c.path_bytes == a.path_bytes)
+                    changes.iter().any(|c| c.path_bytes == a.path_bytes)
+                        && (a.stack_id.is_none() || a.stack_id == assigned_stack_id)
                 })
                 .cloned()
                 .collect();
 
             if stack_assignments.is_empty() {
-                anyhow::bail!("No uncommitted changes assigned to stack: {assigned_stack_id:?}");
+                anyhow::bail!("No uncommitted changes found for the selected files");
             }
 
             (stack_assignments, dependencies)


### PR DESCRIPTION
## Summary

- **Backend (`absorb.rs`):** The `TreeChanges` absorption target was filtering assignments by stack ID, which excluded unassigned hunks (`stack_id = None`). Without those hunks, dependency-lock routing (Priority 1) never fired and they fell through to the default-stack fallback instead of the correct commit. Fixed to include hunks that are unassigned or assigned to the acting stack — excluding only hunks assigned to a different stack.

- **Frontend (`dependencies.ts`):** The lock icon on files in the worktree list was computed from all dependency entries regardless of which hunks were visible in the current lane. A file could show locked in the unassigned lane due to dependencies on its stack-assigned hunks, and vice versa. Fixed by cross-referencing dependency hunk ranges (via `rangesOverlap`) with the assignments visible in the current lane before computing lock indicators: unassigned assignments when no `stackId`, stack-assigned when `stackId` is present.

- **Tests (`dependencies.test.ts`):** 13 Vitest unit tests covering stack vs unassigned filtering, range overlap edge cases, 0-line hunk handling, path matching, and error passthrough.

## Test plan

- [ ] In the unassigned lane, a file with no unassigned hunks that have dependency locks no longer shows a lock icon
- [ ] In a stack lane, a file only shows locked if its stack-assigned hunks have dependency locks
- [ ] Right-clicking a file in the unassigned lane and choosing "Absorb" routes hunks via dependency locks where applicable
- [ ] `cargo test -p but -- absorb` passes (9 tests)
- [ ] `pnpm vitest run src/lib/hunks/dependencies.test.ts` passes (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)