### PR TITLE
fix: resolve vite build warnings in apps/desktop

### DIFF
--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -3,7 +3,7 @@ import { getName, getVersion, getVersion as tauriGetVersion } from "@tauri-apps/
 import { invoke as invokeTauri } from "@tauri-apps/api/core";
 import { documentDir as documentDirTauri } from "@tauri-apps/api/path";
 import { join as joinPathTauri } from "@tauri-apps/api/path";
-import { getCurrentWindow, Window } from "@tauri-apps/api/window";
+import { getCurrentWindow, type Window } from "@tauri-apps/api/window";
 import {
 	writeText as tauriWriteText,
 	readText as tauriReadText,

--- a/apps/desktop/src/lib/codegen/messageQueue.svelte.ts
+++ b/apps/desktop/src/lib/codegen/messageQueue.svelte.ts
@@ -120,7 +120,7 @@ export class MessageQueueProcessor {
 		// extra recomputations when one of the message queues changes.
 		$effect(() => {
 			for (const id of queueIds) {
-				const queue = $derived(messageQueueSelectors.selectById(this.clientState.messageQueue, id));
+				const queue = messageQueueSelectors.selectById(this.clientState.messageQueue, id);
 				if (queue) {
 					$effect(() => {
 						this.handleQueue(queue);

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -1,6 +1,6 @@
 import { parseQueryError } from "$lib/error/error";
 import { InjectionToken } from "@gitbutler/core/context";
-import { PostHog, posthog, type Properties } from "posthog-js";
+import { posthog, type PostHog, type Properties } from "posthog-js";
 import type { IBackend } from "$lib/backend";
 import type { RepoInfo } from "$lib/git/gitUrl";
 import type { SettingsService } from "$lib/settings/appSettings";

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -28,8 +28,7 @@ export class WorktreeService {
 	}
 
 	worktreeData(projectId: string) {
-		const result = $derived(this.backendApi.endpoints.worktreeChanges.useQuery({ projectId }));
-		return result;
+		return this.backendApi.endpoints.worktreeChanges.useQuery({ projectId });
 	}
 
 	treeChangeByPath(projectId: string, path: string) {


### PR DESCRIPTION
- Remove unnecessary $derived wrapper in worktreeService.svelte.ts
- Remove invalid $derived inside $effect in messageQueue.svelte.ts
- Change PostHog and Window to type-only imports