### PR TITLE
Add hidden `but remote` subcommand for local and remote browser access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "but-rules",
  "but-secret",
  "but-serde",
+ "but-server",
  "but-settings",
  "but-testsupport",
  "but-tools",
@@ -1583,6 +1584,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "but-api",
  "but-claude",
  "but-ctx",
@@ -1592,17 +1594,25 @@ dependencies = [
  "but-path",
  "but-secret",
  "but-settings",
+ "clap",
+ "colored",
  "futures-util",
  "gitbutler-repo-actions",
+ "gitbutler-user",
  "gitbutler-watcher",
+ "mime_guess",
+ "reqwest 0.12.28",
+ "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -2227,9 +2237,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -9033,6 +9046,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "axum",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13168,6 +13216,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ but-fs = { path = "crates/but-fs" }
 but-forge = { path = "crates/but-forge" }
 but-oplog = { path = "crates/but-oplog" }
 but-llm = { path = "crates/but-llm" }
+but-server = { path = "crates/but-server" }
 
 gitbutler-git = { path = "crates/gitbutler-git" }
 gitbutler-watcher = { path = "crates/gitbutler-watcher" }
@@ -256,10 +257,13 @@ reqwest = { version = "0.12.28", default-features = false, features = [
     "rustls-tls",
     "json",
 ] }
+rust-embed = { version = "8", features = ["axum"] }
+mime_guess = "2"
 chrono = { version = "0.4.42", default-features = false, features = ["std"] }
 hex = "0.4.3"
 md5 = "0.8.0"
 sha2 = "0.10"
+base64 = "0.22"
 bitflags = "2.9.4"
 notify = "8.2.0"
 snapbox = "0.6.23"

--- a/apps/desktop/src/app.html
+++ b/apps/desktop/src/app.html
@@ -2,7 +2,8 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 		%sveltekit.head%
 	</head>
 

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -183,13 +183,18 @@ async function webRelaunch(): Promise<void> {
  */
 async function webInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {
 	try {
-		const response = await fetch(`http://${getWebUrl()}/${command}`, {
+		const response = await fetch(`${getApiBaseUrl()}/${command}`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
+			credentials: "include",
 			body: JSON.stringify(params),
 		});
+		if (response.status === 401) {
+			window.location.href = `${getApiBaseUrl()}/auth/login`;
+			throw new Error("Authentication required");
+		}
 		const out: ServerResonse<T> = await response.json();
 		if (out.type === "success") {
 			return out.subject;
@@ -259,7 +264,7 @@ class WebListener {
 		this.handlers.push(handler);
 		this.count++;
 		if (!this.socket) {
-			this.socket = new ReconnectingWebSocket(`ws://${getWebUrl()}/ws`);
+			this.socket = new ReconnectingWebSocket(getWsUrl());
 			this.socket.addEventListener("message", (event) => {
 				const data: { name: string; payload: any } = JSON.parse(event.data);
 				for (const handler of this.handlers) {
@@ -284,10 +289,52 @@ class WebListener {
 	}
 }
 
-function getWebUrl(): string {
-	const host = getCookie("butlerHost") || import.meta.env.VITE_BUTLER_HOST || "localhost";
-	const port = getCookie("butlerPort") || import.meta.env.VITE_BUTLER_PORT || "6978";
-	return `${host}:${port}`;
+/**
+ * Returns the base URL for API calls (without trailing slash).
+ *
+ * Resolution order:
+ * 1. `VITE_BUTLER_API_BASE_URL` — build-time env var (e.g. `http://localhost:6978`)
+ * 2. Cookies (`butlerHost`, `butlerPort`) — runtime overrides used by e2e tests
+ *    to direct each parallel worker to its own but-server instance.
+ * 3. `VITE_BUTLER_HOST` + `VITE_BUTLER_PORT` — legacy host/port env vars
+ * 4. `` — empty string (same origin, no prefix). When running with `--tunnel`,
+ *    the server auto-sets `--base-path=/api` so `VITE_BUTLER_API_BASE_URL`
+ *    should be set to `/api` if needed.
+ */
+export function getApiBaseUrl(): string {
+	const base = import.meta.env.VITE_BUTLER_API_BASE_URL;
+	if (base) return base.replace(/\/$/, "");
+
+	const cookieHost = getCookie("butlerHost");
+	const cookiePort = getCookie("butlerPort");
+	const host = cookieHost || import.meta.env.VITE_BUTLER_HOST;
+	const port = cookiePort || import.meta.env.VITE_BUTLER_PORT;
+	if (host && port) {
+		const protocol = "http";
+		return `${protocol}://${host}:${port}`;
+	}
+
+	return "";
+}
+
+/**
+ * Returns the WebSocket URL for the event stream.
+ * Derived from `getApiBaseUrl()` — replaces http(s) with ws(s) and
+ * appends `/ws` after any base path (e.g. `/api`), keeping the same host.
+ */
+function getWsUrl(): string {
+	const base = getApiBaseUrl();
+	// Empty string or relative URL (e.g. /api) — use window.location.host
+	if (!base || base.startsWith("/")) {
+		const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+		return `${wsProtocol}//${window.location.host}${base}/ws`;
+	}
+	// Absolute URL (e.g. http://localhost:6978 or https://tunnel.com/api) —
+	// keep any path component from the base and append /ws.
+	const url = new URL(base);
+	const wsProtocol = url.protocol === "https:" ? "wss:" : "ws:";
+	const basePath = url.pathname.replace(/\/$/, "");
+	return `${wsProtocol}//${url.host}${basePath}/ws`;
 }
 
 type EventName = string;

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -122,7 +122,10 @@ export function initDependencies(args: {
 
 	const secretsService = new RustSecretService(backend);
 	const tokenMemoryService = new TokenMemoryService();
-	const httpClient = new HttpClient(window.fetch, PUBLIC_API_BASE_URL, tokenMemoryService.token);
+	const runtimeApiUrl =
+		document.querySelector<HTMLMetaElement>('meta[name="gitbutler-api-url"]')?.content ||
+		PUBLIC_API_BASE_URL;
+	const httpClient = new HttpClient(window.fetch, runtimeApiUrl, tokenMemoryService.token);
 
 	// ============================================================================
 	// FORGE CLIENTS & INTEGRATIONS

--- a/apps/desktop/src/styles/styles.css
+++ b/apps/desktop/src/styles/styles.css
@@ -9,7 +9,8 @@
 
 body {
 	width: 100vw;
-	height: 100vh;
+	height: 100dvh;
+	padding-bottom: env(safe-area-inset-bottom);
 	overflow-y: hidden;
 	background-color: var(--bg-2);
 	color: var(--text-1);

--- a/apps/desktop/static/favicon.svg
+++ b/apps/desktop/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2332_18209)">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H12C14.2091 0 16 1.79086 16 4V12C16 14.2091 14.2091 16 12 16H4C1.79086 16 0 14.2091 0 12V4Z" fill="#98EFEB"/>
+<path d="M3 13V3L7.99215 7.37879L13 3V13L7.99215 8.63636L3 13Z" fill="#0A0A0A"/>
+</g>
+<defs>
+<clipPath id="clip0_2332_18209">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [features]
 irc = ["dep:but-irc"]
+embedded-frontend = ["dep:rust-embed", "dep:mime_guess"]
 
 [dependencies]
 but-api = { workspace = true, features = ["path-bytes", "legacy"] }
@@ -28,21 +29,30 @@ but-settings.workspace = true
 but-feedback.workspace = true
 but-secret.workspace = true
 but-ctx = { workspace = true, features = ["legacy"] }
+gitbutler-user.workspace = true
 gitbutler-watcher.workspace = true
 gitbutler-repo-actions.workspace = true
 
+reqwest.workspace = true
+sha2.workspace = true
+base64.workspace = true
+rust-embed = { workspace = true, optional = true }
+mime_guess = { workspace = true, optional = true }
 serde.workspace = true
 axum = { version = "0.8.8", features = ["ws"] }
 futures-util = { version = "0.3", default-features = false, features = [
     "sink",
     "std",
 ] }
-tower-http = { version = "0.6.8", features = ["cors"] }
+tower-http = { version = "0.6.8", features = ["cors", "compression-full"] }
 tower = { version = "0.5.3" }
 tokio = { workspace = true, features = ["full"] }
+clap.workspace = true
+colored = "3.0.0"
 anyhow.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+url.workspace = true
 
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/but-server/build.rs
+++ b/crates/but-server/build.rs
@@ -1,0 +1,89 @@
+use std::path::Path;
+
+fn main() {
+    // When the embedded-frontend feature is active, rust-embed requires the
+    // dist directory to exist at compile time. Fail with clear instructions
+    // rather than writing placeholder files into the source tree.
+    if std::env::var("CARGO_FEATURE_EMBEDDED_FRONTEND").is_ok() {
+        let dist = Path::new("../../apps/desktop/build");
+        if !dist.exists() {
+            // Create an empty directory so rust-embed can compile. The embedded
+            // server will serve no frontend assets until `pnpm build` is run:
+            //
+            //   VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api \
+            //   pnpm --filter @gitbutler/desktop build
+            //
+            // This allows `cargo check --workspace` to succeed without a prior
+            // frontend build (e.g. in CI steps that only lint Rust code).
+            let _ = std::fs::create_dir_all(dist);
+            println!(
+                "cargo:warning=Frontend assets not found at apps/desktop/build/. \
+                      The embedded server will have no UI until you run `pnpm build`."
+            );
+            println!("cargo:rustc-env=EMBEDDED_FRONTEND_HASH=0");
+            // Always watch the dist directory so Cargo reruns this script once
+            // `pnpm build` creates it and populates it with assets.
+            println!("cargo:rerun-if-changed=../../apps/desktop/build");
+            return;
+        }
+
+        // Emit rerun-if-changed for every file in dist so this build script
+        // is re-run whenever `pnpm build` updates any asset.
+        emit_rerun_if_changed_recursive(dist);
+
+        // Compute a hash of the entire dist tree and emit it as a rustc-env
+        // variable. When the hash changes, Cargo recompiles the crate, which
+        // causes rust-embed to re-embed the updated files.
+        let hash = dir_hash(dist);
+        println!("cargo:rustc-env=EMBEDDED_FRONTEND_HASH={hash}");
+    }
+}
+
+/// A fast, order-independent hash of every file path + contents under `dir`.
+fn dir_hash(dir: &Path) -> u64 {
+    use std::collections::BTreeMap;
+    use std::hash::Hash as _;
+
+    // Collect path → contents into a sorted map so the hash is stable
+    // regardless of directory traversal order.
+    let mut files: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    collect_files(dir, dir, &mut files);
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    files.hash(&mut hasher);
+    std::hash::Hasher::finish(&hasher)
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut std::collections::BTreeMap<String, Vec<u8>>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, out);
+        } else {
+            let key = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            let contents = std::fs::read(&path).unwrap_or_default();
+            out.insert(key, contents);
+        }
+    }
+}
+
+fn emit_rerun_if_changed_recursive(dir: &Path) {
+    println!("cargo:rerun-if-changed={}", dir.display());
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                emit_rerun_if_changed_recursive(&path);
+            } else {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+}

--- a/crates/but-server/src/auth.rs
+++ b/crates/but-server/src/auth.rs
@@ -1,0 +1,637 @@
+//! Authentication for remote access to but-server.
+//!
+//! When the server is configured with a remote origin (via `--tunnel` or
+//! `--remote-origin`), all non-localhost requests must be authenticated.
+//! Authentication is performed by validating the user's GitButler access
+//! token against the GitButler API and checking that the authenticated
+//! user matches the local owner.
+
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Redirect, Response},
+};
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+/// How long to cache a validated token before re-checking with the API.
+const TOKEN_CACHE_TTL: Duration = Duration::from_secs(300);
+
+const COOKIE_NAME: &str = "butler_token";
+
+/// Partial user response from the GitButler API `/api/login/whoami` endpoint.
+#[derive(Debug, Deserialize)]
+struct ApiUser {
+    id: u64,
+}
+
+/// Response from `POST /api/login/token`.
+#[derive(Debug, Deserialize)]
+struct LoginTokenResponse {
+    /// The full URL to redirect the user's browser to for login.
+    url: String,
+}
+
+/// A cached token validation result.
+struct CachedValidation {
+    token: String,
+    user_id: u64,
+    validated_at: std::time::Instant,
+}
+
+/// Shared authentication state.
+pub struct AuthState {
+    owner_id: u64,
+    http: reqwest::Client,
+    cache: RwLock<Option<CachedValidation>>,
+    /// Base path prefix for auth routes, e.g. "/api" when `--base-path=/api`.
+    base_path: String,
+    /// GitButler API base URL, e.g. "https://app.gitbutler.com".
+    api_url: String,
+}
+
+impl AuthState {
+    /// Create a new auth state for the given local owner user ID, base path, and API URL.
+    pub fn new(owner_id: u64, base_path: impl Into<String>, api_url: impl Into<String>) -> Self {
+        Self {
+            owner_id,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .connect_timeout(Duration::from_secs(5))
+                .build()
+                .expect("failed to build reqwest client"),
+            cache: RwLock::new(None),
+            base_path: base_path.into(),
+            api_url: api_url.into(),
+        }
+    }
+
+    /// Validate an access token against the GitButler API.
+    /// Returns `true` if the token belongs to the local owner.
+    pub async fn validate_token(&self, token: &str) -> Result<bool, reqwest::Error> {
+        // Check cache first.
+        {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.as_ref()
+                && cached.token == token
+                && cached.validated_at.elapsed() < TOKEN_CACHE_TTL
+            {
+                return Ok(cached.user_id == self.owner_id);
+            }
+        }
+
+        // Call the GitButler API.
+        let url = format!("{}/api/login/whoami", self.api_url);
+        let resp = self
+            .http
+            .get(&url)
+            .header("X-Auth-Token", token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Ok(false);
+        }
+
+        let user: ApiUser = resp.json().await?;
+
+        // Update cache.
+        {
+            let mut cache = self.cache.write().await;
+            *cache = Some(CachedValidation {
+                token: token.to_string(),
+                user_id: user.id,
+                validated_at: std::time::Instant::now(),
+            });
+        }
+
+        Ok(user.id == self.owner_id)
+    }
+
+    /// Get the gitbutler.com login URL for the user to visit.
+    async fn login_url(&self) -> anyhow::Result<String> {
+        let url = format!("{}/api/login/token", self.api_url);
+        let resp: LoginTokenResponse = self
+            .http
+            .post(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp.url)
+    }
+}
+
+/// Extract the auth token from the request (cookie or header).
+fn extract_token(req: &axum::extract::Request<Body>) -> Option<String> {
+    // Check X-Auth-Token header first.
+    if let Some(val) = req.headers().get("X-Auth-Token") {
+        return val.to_str().ok().map(|s| s.to_string());
+    }
+
+    // Check cookie.
+    if let Some(cookie_header) = req.headers().get(header::COOKIE)
+        && let Ok(cookies) = cookie_header.to_str()
+    {
+        for cookie in cookies.split(';') {
+            let cookie = cookie.trim();
+            if let Some(value) = cookie.strip_prefix(&format!("{COOKIE_NAME}=")) {
+                return Some(percent_decode_cookie_value(value));
+            }
+        }
+    }
+
+    None
+}
+
+/// Middleware that enforces authentication for remote requests.
+///
+/// Skips auth for:
+/// - `--local` mode: `auth_state` is `None` when no tunnel/remote-origin is
+///   configured, so the whole middleware is a no-op.
+/// - Exactly `/auth/login` and `/auth/callback` (public by necessity; logout
+///   requires auth so an unauthenticated caller cannot force a session clear)
+pub async fn auth_middleware(
+    State(auth): State<Option<Arc<AuthState>>>,
+    req: axum::extract::Request<Body>,
+    next: Next,
+) -> Response {
+    // Bypass all authentication when explicitly opted in.
+    if crate::allow_anyone() {
+        return next.run(req).await;
+    }
+
+    let auth = match auth {
+        Some(auth) => auth,
+        // No remote origin configured — server is in --local mode, no auth needed.
+        None => return next.run(req).await,
+    };
+
+    // Only the login and callback routes are public — everything else, including
+    // logout, requires authentication. A wildcard /auth/* exemption would
+    // silently make any future endpoint under that prefix unauthenticated.
+    let path = req.uri().path();
+    let public_suffixes = ["/auth/login", "/auth/callback"];
+    let is_public = public_suffixes.iter().any(|suffix| {
+        path == *suffix
+            || (!auth.base_path.is_empty() && path == format!("{}{}", auth.base_path, suffix))
+    });
+    if is_public {
+        return next.run(req).await;
+    }
+
+    // Check for a valid token.
+    match extract_token(&req) {
+        Some(token) => match auth.validate_token(&token).await {
+            Ok(true) => next.run(req).await,
+            Ok(false) => {
+                tracing::warn!("Remote auth: token valid but user is not the owner");
+                StatusCode::FORBIDDEN.into_response()
+            }
+            Err(e) => {
+                tracing::error!("Remote auth: failed to validate token: {e}");
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        },
+        None => {
+            // No token — redirect browsers to login, return 401 for API calls.
+            if accepts_html(&req) {
+                let login_path = format!("{}/auth/login", auth.base_path);
+                Redirect::temporary(&login_path).into_response()
+            } else {
+                StatusCode::UNAUTHORIZED.into_response()
+            }
+        }
+    }
+}
+
+fn accepts_html(req: &axum::extract::Request<Body>) -> bool {
+    req.headers()
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.contains("text/html"))
+}
+
+// --- Auth route handlers ---
+
+/// `GET /auth/login` — Serves the login page, or redirects to `/` if already authenticated.
+///
+/// Opens gitbutler.com in a new tab and shows a field to paste the access
+/// token that gitbutler.com displays after login.
+///
+/// With `SameSite=Strict` cookies, clicking the tunnel URL from an external
+/// source (email, chat) won't include the cookie on the initial navigation, so
+/// the auth middleware redirects here. But when the user navigates *within* the
+/// site to `/auth/login` (e.g. from a bookmark), the cookie is included —
+/// in that case we redirect straight to `/` instead of showing the login form.
+pub async fn login(
+    State(auth): State<Option<Arc<AuthState>>>,
+    req: axum::extract::Request<Body>,
+) -> Response {
+    let auth = match auth {
+        Some(auth) => auth,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    // Already authenticated — redirect to the app instead of showing the form.
+    if let Some(token) = extract_token(&req)
+        && matches!(auth.validate_token(&token).await, Ok(true))
+    {
+        return Redirect::temporary("/").into_response();
+    }
+
+    let login_url = match auth.login_url().await {
+        Ok(url) => url,
+        Err(e) => {
+            tracing::error!("Failed to get login URL: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let base_path = &auth.base_path;
+    // The script body is kept in a separate function so its SHA-256 hash can
+    // be computed once at startup and included in the Content-Security-Policy.
+    // Dynamic data (login_url) is passed via a <meta> tag instead of being
+    // inlined in the script, keeping the script content stable across requests.
+    let script = login_page_script(base_path);
+    let login_url_escaped = crate::html_escape(&login_url);
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>GitButler | Log in</title>
+  <meta name="gb-login-url" content="{login_url_escaped}">
+  <style>
+    :root {{
+      --bg-1: #fff;
+      --bg-2: #f3f2f1;
+      --border-2: #cac6c3;
+      --text-1: #1c1917;
+      --text-2: #7c716a;
+      --text-danger: #dc2626;
+      --fill-pop: #25b1b1;
+      --fill-pop-hover: #1d8a8a;
+      --radius-s: 0.25rem;
+      --radius-xl: 20px;
+      --font: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+      --font-accent: "But Head", Georgia, serif;
+      --transition-fast: 0.05s ease;
+    }}
+    @media (prefers-color-scheme: dark) {{
+      :root {{
+        --bg-1: #272321;
+        --bg-2: #1c1917;
+        --border-2: #4f4844;
+        --text-1: #f3f2f1;
+        --text-2: #aaa29d;
+        --fill-pop: #1d8a8a;
+        --fill-pop-hover: #25b1b1;
+      }}
+    }}
+    *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    body {{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100dvh;
+      padding-bottom: env(safe-area-inset-bottom);
+      background: var(--bg-2);
+      font-family: var(--font);
+      color: var(--text-1);
+    }}
+    .service-form {{
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      max-width: 540px;
+      padding: 50px 60px 40px;
+      border-radius: var(--radius-xl);
+      background: var(--bg-1);
+    }}
+    h1 {{
+      font-family: var(--font-accent);
+      font-size: 2.625rem;
+      font-weight: 400;
+      line-height: 110%;
+      margin-bottom: 16px;
+    }}
+    .warning {{
+      font-size: 12px;
+      line-height: 1.5;
+      color: #a46204;
+      background: #fef7ee;
+      border: 1px solid #f0bc73;
+      border-radius: var(--radius-s);
+      padding: 8px 12px;
+      margin-bottom: 16px;
+    }}
+    @media (prefers-color-scheme: dark) {{
+      .warning {{ color: #f0bc73; background: #a46204; border-color: #f0bc73; }}
+    }}
+    .content {{
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }}
+    p {{ font-size: 13px; line-height: 1.5; color: var(--text-2); }}
+    a {{ color: var(--text-1); text-decoration: underline; transition: color var(--transition-fast); }}
+    a:hover {{ color: var(--text-2); }}
+    input {{
+      width: 100%;
+      padding: 7px 10px;
+      border: 1px solid var(--border-2);
+      border-radius: var(--radius-s);
+      background: var(--bg-1);
+      color: var(--text-1);
+      font-family: var(--font);
+      font-size: 13px;
+      outline: none;
+      transition: border-color var(--transition-fast);
+      margin-top: 8px;
+    }}
+    input::placeholder {{ color: var(--text-2); }}
+    input:hover, input:focus {{ border-color: var(--text-2); }}
+    .actions {{
+      display: flex;
+      gap: 8px;
+      margin-top: 8px;
+    }}
+    button {{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border: 1px solid var(--border-2);
+      border-radius: var(--radius-s);
+      background: transparent;
+      color: var(--text-1);
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background var(--transition-fast), border-color var(--transition-fast);
+    }}
+    button:hover {{ background: var(--bg-2); }}
+    button.primary {{
+      background: var(--fill-pop);
+      border-color: var(--fill-pop);
+      color: #fff;
+    }}
+    button.primary:hover {{ background: var(--fill-pop-hover); border-color: var(--fill-pop-hover); }}
+    button:disabled {{ opacity: 0.5; cursor: not-allowed; }}
+    @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
+    .spinner {{
+      display: none;
+      width: 12px; height: 12px;
+      border: 1.5px solid currentColor;
+      border-top-color: transparent;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+    }}
+    button.loading .btn-label {{ display: none; }}
+    button.loading .spinner {{ display: block; }}
+    .error {{
+      font-size: 12px;
+      color: var(--text-danger);
+      display: none;
+    }}
+    .footer {{
+      display: flex;
+      justify-content: space-between;
+      margin-top: 40px;
+      font-size: 12px;
+      color: var(--text-2);
+    }}
+    .footer a {{ color: var(--text-2); }}
+    .footer a:hover {{ color: var(--text-1); }}
+    @media (max-width: 600px) {{
+      .service-form {{ padding: 30px 20px 20px; border-radius: 0; }}
+      .footer {{ flex-direction: column; gap: 8px; margin-top: 24px; }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="service-form">
+    <h1>Log in to GitButler</h1>
+    <div class="warning">
+      ⚠ This is an experimental feature — use at your own risk.
+    </div>
+    <div class="content">
+      <p>
+        <a href="{login_url_escaped}" target="_blank" rel="noopener noreferrer" id="loginLink">Open gitbutler.com to sign in</a>
+        — then paste the access token shown on that page below.
+      </p>
+      <div>
+        <input id="token" type="password" placeholder="Paste your access token here" />
+        <p class="error" id="error">Invalid token or wrong account. Please try again.</p>
+      </div>
+      <div class="actions">
+        <button class="primary" id="submitBtn"><span class="btn-label">Submit</span><span class="spinner"></span></button>
+      </div>
+    </div>
+    <div class="footer">
+      <p></p>
+      <p>Need help? <a href="https://docs.gitbutler.com" target="_blank" rel="noopener noreferrer">docs.gitbutler.com</a></p>
+    </div>
+  </div>
+  <script>{script}</script>
+</body>
+</html>"#
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/html")
+        .body(Body::from(html))
+        .unwrap()
+}
+
+#[derive(Deserialize)]
+pub struct TokenSubmission {
+    token: String,
+}
+
+/// `POST /auth/callback` — Validates a pasted access token and sets the session cookie.
+pub async fn callback(
+    State(auth): State<Option<Arc<AuthState>>>,
+    axum::Json(body): axum::Json<TokenSubmission>,
+) -> Response {
+    let auth = match auth {
+        Some(auth) => auth,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    match auth.validate_token(&body.token).await {
+        Ok(true) => {
+            let remote_origin = crate::allowed_remote_origin().unwrap_or_default();
+            let secure = remote_origin.starts_with("https://");
+            let encoded_token = percent_encode_cookie_value(&body.token);
+            let mut attrs = vec![
+                format!("{COOKIE_NAME}={encoded_token}"),
+                "HttpOnly".to_string(),
+                "SameSite=Strict".to_string(),
+                "Path=/".to_string(),
+            ];
+            if secure {
+                attrs.push("Secure".to_string());
+            }
+            let cookie = attrs.join("; ");
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::SET_COOKIE, cookie)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"ok":true}"#))
+                .unwrap()
+        }
+        Ok(false) => Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"ok":false,"error":"not the owner"}"#))
+            .unwrap(),
+        Err(e) => {
+            tracing::error!("Token validation failed: {e}");
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"ok":false,"error":"validation error"}"#))
+                .unwrap()
+        }
+    }
+}
+
+/// `POST /auth/logout` — Clears the auth cookie and invalidates the token cache.
+///
+/// Using POST (rather than GET) means browsers won't trigger logout via link
+/// prefetch, `<img>` tags, or cross-site navigations, and our middleware will
+/// require an `Origin` header matching the server's own origin.
+pub async fn logout(State(auth): State<Option<Arc<AuthState>>>) -> Response {
+    // Clear the cached token so a re-presented token is re-validated against
+    // the API rather than served from the in-memory cache.
+    if let Some(auth) = auth {
+        *auth.cache.write().await = None;
+    }
+
+    let remote_origin = crate::allowed_remote_origin().unwrap_or_default();
+    let secure = remote_origin.starts_with("https://");
+    let mut attrs = vec![
+        format!("{COOKIE_NAME}="),
+        "HttpOnly".to_string(),
+        "SameSite=Strict".to_string(),
+        "Path=/".to_string(),
+        "Max-Age=0".to_string(),
+    ];
+    if secure {
+        attrs.push("Secure".to_string());
+    }
+    let cookie = attrs.join("; ");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::SET_COOKIE, cookie)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"ok":true}"#))
+        .unwrap()
+}
+
+/// Decodes a percent-encoded cookie value back to its original string.
+fn percent_decode_cookie_value(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (
+                char::from(bytes[i + 1]).to_digit(16),
+                char::from(bytes[i + 2]).to_digit(16),
+            )
+        {
+            out.push(((hi << 4) | lo) as u8);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| value.to_string())
+}
+
+/// Percent-encodes characters that are not allowed in cookie values per RFC 6265.
+///
+/// Cookie values must not contain whitespace, double-quotes, commas, semicolons,
+/// or backslashes. GitButler tokens are typically base64url/JWT-like and rarely
+/// need encoding, but we encode defensively.
+fn percent_encode_cookie_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        // cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+        // Everything else gets percent-encoded.
+        if matches!(byte, 0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E) {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(
+                char::from_digit((byte >> 4) as u32, 16)
+                    .unwrap()
+                    .to_ascii_uppercase(),
+            );
+            out.push(
+                char::from_digit((byte & 0xF) as u32, 16)
+                    .unwrap()
+                    .to_ascii_uppercase(),
+            );
+        }
+    }
+    out
+}
+
+/// Returns the static JavaScript body for the login page.
+///
+/// The login URL is intentionally NOT embedded here — it is passed via a
+/// `<meta name="gb-login-url">` tag so that the script content stays stable
+/// across requests and its SHA-256 hash can be pre-computed for the CSP.
+///
+/// Only `base_path` is baked in; it is fixed at server startup.
+pub fn login_page_script(base_path: &str) -> String {
+    format!(
+        r#"
+    const loginUrl = document.querySelector('meta[name="gb-login-url"]').getAttribute('content');
+    document.getElementById('loginLink').href = loginUrl;
+    async function submit() {{
+      const token = document.getElementById('token').value.trim();
+      if (!token) return;
+      const btn = document.getElementById('submitBtn');
+      btn.disabled = true;
+      btn.classList.add('loading');
+      try {{
+        const r = await fetch('{base_path}/auth/callback', {{
+          method: 'POST',
+          headers: {{ 'Content-Type': 'application/json' }},
+          body: JSON.stringify({{ token }}),
+          credentials: 'include',
+        }});
+        const data = await r.json();
+        if (data.ok) {{
+          window.location.href = '/';
+        }} else {{
+          document.getElementById('error').style.display = 'block';
+        }}
+      }} catch (_) {{
+        document.getElementById('error').style.display = 'block';
+      }} finally {{
+        btn.disabled = false;
+        btn.classList.remove('loading');
+      }}
+    }}
+    document.getElementById('submitBtn').addEventListener('click', submit);
+    document.getElementById('token').addEventListener('keydown', e => {{
+      if (e.key === 'Enter') submit();
+    }});"#
+    )
+}

--- a/crates/but-server/src/frontend.rs
+++ b/crates/but-server/src/frontend.rs
@@ -1,0 +1,155 @@
+//! Embedded frontend assets for `--features embedded-frontend`.
+//!
+//! Build the frontend first (from the repo root):
+//!
+//! ```sh
+//! VITE_BUILD_TARGET=web VITE_BUTLER_API_BASE_URL=/api \
+//!   pnpm --filter @gitbutler/desktop build
+//! ```
+//!
+//! `VITE_BUILD_TARGET=web` switches the backend adapter from Tauri to the HTTP
+//! client, so the bundle works in a regular browser. `VITE_BUTLER_API_BASE_URL=/api`
+//! tells the frontend to prefix all API calls with `/api`, matching the server's
+//! default base path in any remote-access mode.
+//!
+//! Then run with the feature enabled:
+//!
+//! ```sh
+//! cargo run -p but-server --features embedded-frontend
+//! ```
+
+use axum::{body::Body, http::StatusCode, response::Response};
+use rust_embed::RustEmbed;
+
+/// Returns `'sha256-<base64>'` hashes for every inline `<script>` block in
+/// the embedded `index.html`. Used to populate `script-src` in the CSP without
+/// resorting to `'unsafe-inline'`.
+pub fn inline_script_hashes() -> Vec<String> {
+    let html = match Assets::get("index.html") {
+        Some(f) => f.data,
+        None => return vec![],
+    };
+    let html = match std::str::from_utf8(&html) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    extract_inline_script_hashes(html)
+}
+
+fn extract_inline_script_hashes(html: &str) -> Vec<String> {
+    let mut hashes = Vec::new();
+    let mut pos = 0;
+    while let Some(tag_start) = html[pos..].find("<script") {
+        let abs = pos + tag_start + "<script".len();
+        // Find end of opening tag
+        let Some(tag_close) = html[abs..].find('>') else {
+            break;
+        };
+        let attrs = &html[abs..abs + tag_close];
+        let body_start = abs + tag_close + 1;
+        let Some(close) = html[body_start..].find("</script>") else {
+            break;
+        };
+        // Only hash inline scripts — skip those with a src attribute
+        if !attrs.contains("src=") {
+            let body = &html[body_start..body_start + close];
+            hashes.push(crate::sha256_csp_hash(body.as_bytes()));
+        }
+        pos = body_start + close + "</script>".len();
+    }
+    hashes
+}
+
+/// Forces recompilation when the frontend build changes so rust-embed
+/// picks up new assets. Value is set by build.rs.
+const _: &str = env!("EMBEDDED_FRONTEND_HASH");
+
+#[derive(RustEmbed)]
+#[folder = "../../apps/desktop/build/"]
+struct Assets;
+
+/// Axum fallback handler — serves embedded static files with SPA fallback.
+///
+/// Any path not matched by but-server's API routes is handled here:
+/// - Known files are served with the correct Content-Type.
+/// - Unknown paths fall back to `index.html` for client-side routing.
+/// - `index.html` has a `<meta name="gitbutler-api-url">` tag injected so the
+///   frontend can use the correct API URL at runtime instead of the build-time
+///   default baked into the bundle.
+pub async fn serve(uri: axum::http::Uri, api_url: String, api_base: String) -> Response<Body> {
+    let path = uri.path().trim_start_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    if path == "index.html" {
+        serve_index(&api_url, &api_base)
+    } else {
+        serve_path(path, &api_url, &api_base)
+    }
+}
+
+/// Serves `index.html` with two meta tags injected into `<head>`:
+/// - `gitbutler-api-url`: the GitButler web API base URL (e.g. https://app.gitbutler.com)
+///   used by the frontend's HttpClient for auth and user API calls.
+/// - `gitbutler-server-base`: the local server's API base path (e.g. `/api` or empty string)
+///   used by webInvoke to reach but-server endpoints at runtime.
+fn serve_index(api_url: &str, api_base: &str) -> Response<Body> {
+    let file = match Assets::get("index.html") {
+        Some(f) => f,
+        None => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "text/plain")
+                .body(Body::from("index.html not found in embedded assets"))
+                .unwrap();
+        }
+    };
+    let html = match std::str::from_utf8(&file.data) {
+        Ok(s) => s,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(axum::http::header::CONTENT_TYPE, "text/plain")
+                .body(Body::from("index.html is not valid UTF-8"))
+                .unwrap();
+        }
+    };
+    let metas = format!(
+        "<meta name=\"gitbutler-api-url\" content=\"{}\">\
+         <meta name=\"gitbutler-server-base\" content=\"{}\">",
+        crate::html_escape(api_url),
+        crate::html_escape(api_base),
+    );
+    let injected = if let Some(pos) = html.find("</head>") {
+        format!(
+            "{}{}</head>{}",
+            &html[..pos],
+            metas,
+            &html[pos + "</head>".len()..]
+        )
+    } else {
+        // No </head> found — prepend the meta tags.
+        format!("{metas}{html}")
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(injected))
+        .unwrap()
+}
+
+fn serve_path(path: &str, api_url: &str, api_base: &str) -> Response<Body> {
+    match Assets::get(path) {
+        Some(file) => {
+            let mime = mime_guess::from_path(path)
+                .first_or_octet_stream()
+                .to_string();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(axum::http::header::CONTENT_TYPE, mime)
+                .body(Body::from(file.data))
+                .unwrap()
+        }
+        // SPA fallback — serve index.html so the client-side router can handle it.
+        None => serve_index(api_url, api_base),
+    }
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1,5 +1,7 @@
 use std::{convert::Infallible, future::Future, net::SocketAddr, sync::Arc};
 
+use colored::Colorize as _;
+
 use axum::{
     Json, Router,
     body::Body,
@@ -10,7 +12,7 @@ use axum::{
     http::StatusCode,
     middleware::{self, Next},
     response::IntoResponse,
-    routing::{MethodRouter, any, post},
+    routing::{MethodRouter, any, get, post},
 };
 use but_api::{commit, diff, github, gitlab, json, legacy, platform};
 use but_claude::{Broadcaster, Claude};
@@ -23,14 +25,28 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::Mutex;
 use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{self, CorsLayer};
 
+mod auth;
+#[cfg(feature = "embedded-frontend")]
+mod frontend;
 #[cfg(feature = "irc")]
 mod irc;
 #[cfg(feature = "irc")]
 mod irc_lifecycle;
 mod projects;
+mod tunnel;
 use crate::projects::ActiveProjects;
+
+/// Escapes a string for safe embedding in an HTML attribute value.
+pub(crate) fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
 #[cfg(feature = "irc")]
 use but_irc::WorkingFilesBroadcast;
 
@@ -52,6 +68,8 @@ pub(crate) struct Request {
 pub(crate) struct Extra {
     active_projects: Arc<Mutex<ActiveProjects>>,
     archival: Arc<but_feedback::Archival>,
+    /// When set, restricts project switching to only this project.
+    pinned_project: Option<but_ctx::ProjectHandleOrLegacyProjectId>,
 }
 
 #[derive(Clone)]
@@ -111,26 +129,172 @@ fn cmd_result_to_json(res: anyhow::Result<serde_json::Value>) -> Json<serde_json
 
 /// Check if an origin byte string is from localhost.
 ///
-/// Matches `http://localhost` optionally followed by `:<port>`.
-fn is_localhost_origin(origin: &[u8]) -> bool {
-    origin
-        .strip_prefix(b"http://localhost")
-        .is_some_and(|rest| rest.first().is_none_or(|b| *b == b':'))
+/// Matches `http(s)://localhost`, `http(s)://127.0.0.1`, and
+/// `http(s)://[::1]`, each optionally followed by `:<port>`.
+pub(crate) fn is_localhost_origin(origin: &[u8]) -> bool {
+    for prefix in [
+        b"http://localhost".as_slice(),
+        b"https://localhost".as_slice(),
+        b"http://127.0.0.1".as_slice(),
+        b"https://127.0.0.1".as_slice(),
+        b"http://[::1]".as_slice(),
+        b"https://[::1]".as_slice(),
+    ] {
+        if let Some(rest) = origin.strip_prefix(prefix)
+            && rest.first().is_none_or(|b| *b == b':')
+        {
+            return true;
+        }
+    }
+    false
 }
 
-/// Middleware to ensure all connections are from localhost only
+/// Check if a `Host` header value is a localhost address.
+///
+/// Matches `localhost`, `127.0.0.1`, and `[::1]`, each optionally followed
+/// by `:<port>`. Used to defend against DNS rebinding: browsers always set
+/// `Host` to the *domain name* being requested (not the resolved IP), so a
+/// rebinding attack using `evil.com` will have `Host: evil.com:PORT` and be
+/// rejected here.
+fn is_localhost_host(host: &[u8]) -> bool {
+    for prefix in [
+        b"localhost".as_slice(),
+        b"127.0.0.1".as_slice(),
+        b"[::1]".as_slice(),
+    ] {
+        if let Some(rest) = host.strip_prefix(prefix)
+            && rest.first().is_none_or(|b| *b == b':')
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Configuration for the but-server, populated from CLI args.
+#[derive(Debug, Default)]
+pub struct Config {
+    /// Port to listen on. `but-server` defaults to 6978; `but remote` defaults to 8080.
+    pub port: Option<u16>,
+    /// Address to bind to. Defaults to 127.0.0.1. Override with --bind-addr if needed
+    /// (e.g. 0.0.0.0 in a container environment).
+    pub bind_addr: Option<String>,
+    /// Spawn a Cloudflare quick tunnel and use its URL as the allowed remote origin.
+    pub tunnel: bool,
+    /// Named tunnel mode: cloudflared tunnel name (or UUID) to run.
+    /// Must be paired with `origin`. Requires `cloudflared tunnel login`
+    /// and `cloudflared tunnel route dns <name> <hostname>` to have been run already.
+    pub named_tunnel: Option<String>,
+    /// The public hostname routed to `named_tunnel` (e.g. `but.example.com`).
+    /// Used as the CORS allowed-origin and display URL. Must be set when `named_tunnel` is set.
+    pub origin: Option<String>,
+    /// Prefix all API routes with this path (e.g. `/api`).
+    pub base_path: Option<String>,
+    /// Disable authentication entirely. DANGEROUS — only use on trusted networks.
+    pub allow_anyone: bool,
+    /// Use the staging GitButler API (<https://app.staging.gitbutler.com>) instead of production.
+    pub dev: bool,
+    /// If set, auto-activate this directory's project on startup and prevent switching to others.
+    pub project_path: Option<std::path::PathBuf>,
+    /// Show cloudflared output on stderr. Enabled by `-v` in the CLI.
+    pub verbose: bool,
+}
+
+static TUNNEL_ORIGIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+static ALLOW_ANYONE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Return the allowed remote origin (set from tunnel or --remote-origin arg).
+fn allowed_remote_origin() -> Option<&'static str> {
+    TUNNEL_ORIGIN.get().map(String::as_str)
+}
+
+/// Whether authentication is disabled via --dangerously-allow-anyone.
+pub(crate) fn allow_anyone() -> bool {
+    ALLOW_ANYONE.get().copied().unwrap_or(false)
+}
+
+/// Check if an origin matches the configured remote origin.
+fn is_allowed_remote_origin(origin: &[u8]) -> bool {
+    allowed_remote_origin().is_some_and(|allowed| origin == allowed.as_bytes())
+}
+
+/// Middleware to ensure all connections are from localhost only,
+/// unless remote access is enabled via tunnel or `--remote-origin`.
+///
+/// For mutating methods (POST, PUT, DELETE, PATCH), `Origin` is required to be
+/// present and must match localhost or the configured remote origin. Modern
+/// browsers always send `Origin` on mutating requests, so this reliably blocks
+/// all cross-site state-changing requests without needing CSRF tokens.
+///
+/// For safe methods (GET, HEAD, OPTIONS), `Origin` is checked only when present
+/// since browsers omit it on direct navigation and same-origin safe requests.
 async fn localhost_only_middleware(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     req: axum::extract::Request<Body>,
     next: Next,
 ) -> Result<impl IntoResponse, StatusCode> {
-    // Check if the connection is from localhost (127.0.0.1 or ::1)
-    if addr.ip().is_loopback() {
-        Ok(next.run(req).await)
-    } else {
-        tracing::warn!("Rejected non-localhost connection from: {}", addr);
-        Err(StatusCode::FORBIDDEN)
+    let is_mutating = matches!(
+        req.method(),
+        &axum::http::Method::POST
+            | &axum::http::Method::PUT
+            | &axum::http::Method::DELETE
+            | &axum::http::Method::PATCH
+    );
+
+    match req.headers().get(axum::http::header::ORIGIN) {
+        Some(origin) => {
+            let origin_bytes = origin.as_bytes();
+            if !is_localhost_origin(origin_bytes) && !is_allowed_remote_origin(origin_bytes) {
+                tracing::warn!(
+                    "Rejected request with disallowed Origin: {}",
+                    String::from_utf8_lossy(origin_bytes)
+                );
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+        None if is_mutating && allowed_remote_origin().is_some() => {
+            // In remote-access mode, browsers always send Origin on mutating
+            // requests. A missing Origin on POST/PUT/DELETE/PATCH means a
+            // non-browser client — reject to prevent cross-site attacks via
+            // the tunnel. In local-only mode the loopback + Host checks below
+            // are sufficient, so programmatic clients (curl, Playwright, etc.)
+            // can POST without Origin.
+            tracing::warn!("Rejected mutating request with no Origin header");
+            return Err(StatusCode::FORBIDDEN);
+        }
+        None => {} // Safe method, no Origin — direct navigation or same-origin GET; allow.
     }
+
+    // When a remote origin is configured, cloudflared connects from localhost
+    // too (it's a local process), so the IP check still passes. Skip it only
+    // for explicit reverse-proxy setups where the proxy may be on another host.
+    if allowed_remote_origin().is_some() {
+        return Ok(next.run(req).await);
+    }
+    // Local-only mode: require a loopback address AND a localhost Host header.
+    //
+    // The Host header check defends against DNS rebinding: an attacker can
+    // change their domain's DNS to 127.0.0.1, making the browser treat it as
+    // same-origin (no Origin header sent). The TCP connection still comes from
+    // loopback, so the IP check passes. But the browser always sets Host to the
+    // *domain name* being requested (e.g. "evil.com:8080"), not the resolved IP,
+    // so checking Host catches the attack.
+    //
+    // This only applies to --local mode. Tunnel mode has authentication instead.
+    if !addr.ip().is_loopback() {
+        tracing::warn!("Rejected non-localhost connection from: {}", addr);
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if let Some(host) = req.headers().get(axum::http::header::HOST)
+        && !is_localhost_host(host.as_bytes())
+    {
+        tracing::warn!(
+            "Rejected DNS-rebinding attempt: Host header was {}",
+            String::from_utf8_lossy(host.as_bytes())
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+    Ok(next.run(req).await)
 }
 
 #[cfg(feature = "irc")]
@@ -150,14 +314,92 @@ fn effective_irc(
     }
 }
 
-pub async fn run() -> anyhow::Result<()> {
+pub async fn run(config: Config) -> anyhow::Result<()> {
     but_api::panic_capture::install_panic_hook();
+
+    if config.allow_anyone {
+        let remote = config.tunnel || config.named_tunnel.is_some();
+        anyhow::ensure!(
+            !remote,
+            "--dangerously-allow-anyone cannot be used with a tunnel: \
+             it would expose the server to the internet without any authentication"
+        );
+        ALLOW_ANYONE.set(true).ok();
+        eprintln!("WARNING: --dangerously-allow-anyone is set — authentication is disabled");
+    }
+
+    let api_url = if config.dev {
+        "https://app.staging.gitbutler.com"
+    } else {
+        "https://app.gitbutler.com"
+    }
+    .to_owned();
+
+    let port: u16 = config
+        .port
+        .or_else(|| std::env::var("BUTLER_PORT").ok()?.parse().ok())
+        .unwrap_or(6978);
+
+    // Spawn cloudflared (quick or named tunnel).
+    // The child process must stay alive for the tunnel to remain open.
+    let _tunnel_child = if let (Some(name), Some(origin)) = (&config.named_tunnel, &config.origin) {
+        println!(
+            "{} {}",
+            "Starting named cloudflare tunnel on port".dimmed(),
+            port.to_string().dimmed()
+        );
+        let mode = tunnel::Mode::Named {
+            name,
+            hostname: origin,
+        };
+        Some(mode)
+    } else if config.tunnel {
+        println!(
+            "{} {}",
+            "Starting cloudflare tunnel on port".dimmed(),
+            port.to_string().dimmed()
+        );
+        Some(tunnel::Mode::Quick)
+    } else {
+        None
+    };
+    let _tunnel_child = if let Some(mode) = _tunnel_child {
+        let (url, child) = tunnel::start(mode, port, config.verbose).await?;
+        println!("{} {}", "Tunnel:".bold(), url.cyan().underline());
+        TUNNEL_ORIGIN
+            .set(url.trim_end_matches('/').to_string())
+            .ok();
+        Some(child)
+    } else {
+        None
+    };
+
+    // CORS wildcards are forbidden when credentials are allowed, so always list explicitly.
+    // `baggage` and `sentry-trace` are injected by Sentry's performance monitoring into
+    // outgoing fetch requests; without them the browser blocks the preflight.
+    let allowed_headers: cors::AllowHeaders = vec![
+        axum::http::header::CONTENT_TYPE,
+        axum::http::header::AUTHORIZATION,
+        axum::http::HeaderName::from_static("x-auth-token"),
+        axum::http::HeaderName::from_static("baggage"),
+        axum::http::HeaderName::from_static("sentry-trace"),
+    ]
+    .into();
+    let allowed_methods: cors::AllowMethods = vec![
+        axum::http::Method::GET,
+        axum::http::Method::POST,
+        axum::http::Method::PUT,
+        axum::http::Method::DELETE,
+        axum::http::Method::OPTIONS,
+    ]
+    .into();
     let cors = CorsLayer::new()
-        .allow_methods(cors::Any)
+        .allow_methods(allowed_methods)
         .allow_origin(cors::AllowOrigin::predicate(|origin, _parts| {
-            is_localhost_origin(origin.as_bytes())
+            is_localhost_origin(origin.as_bytes()) || is_allowed_remote_origin(origin.as_bytes())
         }))
-        .allow_headers(cors::Any);
+        .allow_headers(allowed_headers)
+        .allow_credentials(true);
 
     let config_dir = but_path::app_config_dir().unwrap();
     let app_data_dir = but_path::app_data_dir().unwrap();
@@ -167,9 +409,10 @@ pub async fn run() -> anyhow::Result<()> {
         cache_dir: app_data_dir.join("cache").clone(),
         logs_dir: app_data_dir.join("logs").clone(),
     });
-    let extra = Extra {
+    let mut extra = Extra {
         active_projects: Arc::new(Mutex::new(ActiveProjects::new())),
         archival,
+        pinned_project: None,
     };
     #[cfg_attr(not(feature = "irc"), allow(unused_mut))]
     let mut app_settings =
@@ -231,6 +474,89 @@ pub async fn run() -> anyhow::Result<()> {
     let irc_manager_for_shutdown = irc_manager.clone();
     #[cfg(feature = "irc")]
     let working_files_broadcast = WorkingFilesBroadcast::new(irc_manager.clone());
+
+    // If a project path was provided, auto-activate that project and pin it.
+    if let Some(ref project_path) = config.project_path {
+        match but_ctx::Context::discover(project_path) {
+            Ok(mut ctx) => {
+                but_api::legacy::projects::prepare_project_for_activation(&mut ctx).ok();
+                let project_id = ctx.legacy_project.id.clone();
+                let mut active = extra.active_projects.lock().await;
+                let activated = active
+                    .set_active(
+                        &mut ctx,
+                        &app,
+                        app_settings.clone(),
+                        #[cfg(feature = "irc")]
+                        working_files_broadcast.clone(),
+                    )
+                    .is_ok();
+                drop(active);
+                if activated {
+                    extra.pinned_project = Some(project_id);
+                } else {
+                    tracing::warn!(
+                        "Failed to activate project at {}; project switching will not be locked",
+                        project_path.display()
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Could not discover project at {}: {err}",
+                    project_path.display()
+                );
+            }
+        }
+    }
+
+    // Compute base path early — needed for both auth redirects and route nesting.
+    // In any remote-access mode default to /api so the embedded frontend (which
+    // fetches from the same origin without a prefix) and API routes don't clash.
+    let remote_access = config.tunnel || config.named_tunnel.is_some();
+    let default_base = if remote_access { "/api" } else { "" };
+    let mut api_base = config
+        .base_path
+        .as_deref()
+        .unwrap_or(default_base)
+        .trim_end_matches('/')
+        .to_string();
+    // Ensure the base path starts with '/' when non-empty so Router::nest doesn't panic.
+    if !api_base.is_empty() && !api_base.starts_with('/') {
+        api_base.insert(0, '/');
+    }
+
+    // Set up remote auth when a remote origin is configured (via --tunnel or --remote-origin)
+    // AND authentication is not explicitly bypassed via --dangerously-allow-anyone.
+    // Fail fast if no local user is found — remote access without auth would be a security hole.
+    // `None` here means exactly one thing: no remote origin is configured (or allow_anyone is set,
+    // in which case auth_middleware's allow_anyone() check fires before inspecting this value).
+    let auth_state: Option<Arc<auth::AuthState>> =
+        if !config.allow_anyone && allowed_remote_origin().is_some() {
+            match gitbutler_user::get_user() {
+                Ok(Some(user)) => {
+                    tracing::info!(
+                        "Remote access enabled for user {} (id={}) via {}",
+                        user.name.as_deref().unwrap_or("?"),
+                        user.id,
+                        api_url,
+                    );
+                    Some(Arc::new(auth::AuthState::new(user.id, &api_base, &api_url)))
+                }
+                Ok(None) => {
+                    anyhow::bail!(
+                        "Remote access is enabled but no local GitButler user is logged in.\n\
+                     Open the GitButler desktop app and log in, then retry."
+                    );
+                }
+                Err(e) => {
+                    anyhow::bail!("Failed to read local user for remote auth: {e}");
+                }
+            }
+        } else {
+            None
+        };
+
     let state = AppState {
         app,
         extra,
@@ -735,6 +1061,24 @@ pub async fn run() -> anyhow::Result<()> {
             post(irc::irc_stop_working_files_broadcast),
         );
 
+    // Auth routes (only functional when remote access is enabled).
+    // When the frontend is embedded, GET / is handled by the frontend fallback
+    // instead of the plain-HTML root handler.
+    let auth_state_for_routes = auth_state.clone();
+    let app = app
+        .route(
+            "/auth/login",
+            get(auth::login).with_state(auth_state_for_routes.clone()),
+        )
+        .route(
+            "/auth/callback",
+            post(auth::callback).with_state(auth_state_for_routes.clone()),
+        )
+        .route(
+            "/auth/logout",
+            post(auth::logout).with_state(auth_state_for_routes.clone()),
+        );
+
     // Catch-all for commands that need special handling (app, extra, app_settings_sync)
     let app = app
         .route("/{command}", post(post_handle_command_with_path))
@@ -750,26 +1094,104 @@ pub async fn run() -> anyhow::Result<()> {
                 tokio::task::spawn(next.run(req)).await.unwrap()
             },
         ))
+        .with_state(state);
+
+    // Optionally nest all API routes under a configurable base path.
+    // e.g. --base-path=/api makes all endpoints available at /api/...
+    // The embedded frontend fallback is attached to the outermost router so
+    // that it handles / regardless of where the API lives.
+    let app: Router = if api_base.is_empty() {
+        app
+    } else {
+        Router::new().nest(&api_base, app)
+    };
+
+    // When the frontend is embedded, serve static files as a fallback for
+    // all routes not handled by the API. This makes but-server self-contained
+    // with no need for a separate frontend dev server or Caddy.
+    // The api_url is injected into index.html via a <meta> tag so the frontend
+    // can use the correct API URL at runtime.
+    #[cfg(feature = "embedded-frontend")]
+    let app = {
+        let api_url_for_frontend = api_url.clone();
+        let api_base_for_frontend = api_base.clone();
+        app.fallback(move |uri| {
+            frontend::serve(
+                uri,
+                api_url_for_frontend.clone(),
+                api_base_for_frontend.clone(),
+            )
+        })
+    };
+
+    // Security layers are applied to the outermost router so they cover
+    // *every* HTTP entrypoint — API routes, the embedded-frontend fallback,
+    // and static assets alike.
+    //
+    // Ordering (outermost → innermost, i.e. request hits them top-to-bottom):
+    //
+    //   CORS  →  localhost_only  →  auth  →  handler
+    //
+    // CORS must be outermost of the three so browser OPTIONS preflight
+    // requests (which carry no cookies) get proper `Access-Control-*`
+    // headers *before* auth can reject them with 401.
+    let app = app
         .layer(
             ServiceBuilder::new()
                 // Middleware to ensure only localhost connections are accepted.
-                //
-                // NOTE: `ServiceBuilder` runs middlewares top to bottom:
-                // - `localhost_only_middleware` will receive the request first and performs the
-                //    security checks.
-                // - Then `cors`
-                // - Then our `route_layer` middleware
-                // - Then the axum router calls the handler and produces a response
-                // - `cors` receives the response
-                // - `localhost_only_middleware` receives the response
-                // - And finally the response is sent to the client
                 .layer(middleware::from_fn(localhost_only_middleware))
-                .layer(cors),
+                // Auth middleware — validates remote tokens when a remote origin is configured.
+                .layer(middleware::from_fn_with_state(
+                    auth_state,
+                    auth::auth_middleware,
+                )),
         )
-        .with_state(state);
+        .layer(cors);
 
-    let port = std::env::var("BUTLER_PORT").unwrap_or("6978".into());
-    let host = std::env::var("BUTLER_HOST").unwrap_or("127.0.0.1".into());
+    // Collect SHA-256 hashes of every inline <script> in the embedded frontend
+    // plus the auth login page script. These replace 'unsafe-inline' in the CSP.
+    let script_hashes = {
+        let login_hash = sha256_csp_hash(auth::login_page_script(&api_base).as_bytes());
+        #[cfg(not(feature = "embedded-frontend"))]
+        let hashes = vec![login_hash];
+        #[cfg(feature = "embedded-frontend")]
+        let hashes = std::iter::once(login_hash)
+            .chain(frontend::inline_script_hashes())
+            .collect::<Vec<_>>();
+        hashes
+    };
+
+    // Add Content-Security-Policy header to all responses.
+    // Adapted from crates/gitbutler-tauri/tauri.conf.json — Tauri-specific
+    // schemes (tauri://, asset:, ipc:) are dropped; connect-src includes the
+    // remote origin's WebSocket when remote access is configured.
+    let csp = build_csp(allowed_remote_origin(), port, &script_hashes);
+    let csp_value = axum::http::HeaderValue::from_str(&csp).expect("CSP is valid header value");
+    let app = app
+        .layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request<Body>, next: Next| {
+                let csp_value = csp_value.clone();
+                async move {
+                    let mut response = next.run(req).await;
+                    response
+                        .headers_mut()
+                        .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp_value);
+                    response
+                }
+            },
+        ))
+        .layer(CompressionLayer::new());
+
+    // Always bind to loopback by default. Cloudflared (quick or named tunnel) connects
+    // from localhost so 127.0.0.1 is sufficient. Users who need a different address
+    // (e.g. a container environment) can pass --bind-addr explicitly.
+    let default_host = "127.0.0.1";
+    let host_env = std::env::var("BUTLER_HOST").ok();
+    let host = config
+        .bind_addr
+        .as_deref()
+        .or(host_env.as_deref())
+        .unwrap_or(default_host);
     let url = format!("{host}:{port}");
     let listener = match tokio::net::TcpListener::bind(&url).await {
         Ok(listener) => listener,
@@ -784,7 +1206,13 @@ pub async fn run() -> anyhow::Result<()> {
             anyhow::bail!("Failed to bind to {url}: {e}");
         }
     };
-    println!("Running at {url}");
+    if !config.tunnel && config.named_tunnel.is_none() {
+        println!(
+            "{} {}",
+            "Local:".bold(),
+            format!("http://localhost:{port}").cyan().underline()
+        );
+    }
     let server = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -798,14 +1226,86 @@ pub async fn run() -> anyhow::Result<()> {
                 tracing::info!("Shutdown signal received, closing IRC connections…");
                 irc_manager_for_shutdown.shutdown().await;
             }
+            // Kill the cloudflared tunnel process if one was started.
+            if let Some(mut child) = _tunnel_child {
+                let _ = child.kill().await;
+            }
             // The settings file watcher (spawn_blocking with infinite loop) and
             // other background tasks prevent the tokio runtime from exiting
-            // cleanly. Since we've already sent QUIT to IRC servers, it's safe
-            // to terminate immediately.
+            // cleanly. It's safe to terminate immediately.
             std::process::exit(0);
         }
     }
     Ok(())
+}
+
+/// Compute a `'sha256-<base64>'` CSP hash for a script body.
+pub(crate) fn sha256_csp_hash(data: &[u8]) -> String {
+    use base64::Engine as _;
+    use sha2::Digest as _;
+    let hash = sha2::Sha256::digest(data);
+    format!(
+        "'sha256-{}'",
+        base64::engine::general_purpose::STANDARD.encode(hash)
+    )
+}
+
+/// Build a Content-Security-Policy header value.
+///
+/// Mirrors `crates/gitbutler-tauri/tauri.conf.json` with Tauri-specific
+/// schemes removed. Always allows WebSocket connections to the server's own
+/// loopback address (needed in local mode, where `'self'` does not cover the
+/// `ws://` scheme). In remote-access mode the wss form of the tunnel origin is
+/// added as well.
+fn build_csp(remote_origin: Option<&str>, port: u16, script_hashes: &[String]) -> String {
+    // Always allow WebSocket to the loopback addresses on this port.
+    // `'self'` covers http/https but not the ws/wss scheme change, so without
+    // these entries the browser will block /ws in local mode.
+    let mut ws_origins = format!(" ws://localhost:{port} ws://127.0.0.1:{port} ws://[::1]:{port}");
+
+    // In remote-access mode also allow the wss form of the tunnel origin
+    // (https://foo.com → wss://foo.com).
+    if let Some(origin) = remote_origin {
+        let wss = origin
+            .replacen("https://", "wss://", 1)
+            .replacen("http://", "ws://", 1);
+        ws_origins.push(' ');
+        ws_origins.push_str(&wss);
+    }
+
+    [
+        "default-src 'self'",
+        "img-src 'self' data: blob: \
+             https://avatars.githubusercontent.com \
+             https://*.gitbutler.com \
+             https://gitbutler-public.s3.amazonaws.com \
+             https://*.gravatar.com \
+             https://io.wp.com https://i0.wp.com https://i1.wp.com \
+             https://i2.wp.com https://i3.wp.com \
+             https://github.com \
+             https://*.googleusercontent.com \
+             https://*.giphy.com/",
+        &format!(
+            "connect-src 'self'{ws_origins} \
+             https://eu.posthog.com https://eu.i.posthog.com \
+             https://eu-assets.i.posthog.com \
+             https://app.gitbutler.com \
+             https://app.staging.gitbutler.com \
+             https://o4504644069687296.ingest.sentry.io \
+             https://github.com https://api.github.com \
+             https://api.openai.com https://api.anthropic.com \
+             https://*.gitlab.com https://gitlab.com \
+             wss://irc.gitbutler.com:8097 data:"
+        ),
+        &format!(
+            "script-src 'self' 'wasm-unsafe-eval' {} \
+             https://eu.posthog.com https://eu.i.posthog.com \
+             https://eu-assets.i.posthog.com",
+            script_hashes.join(" ")
+        ),
+        "style-src 'self' 'unsafe-inline'",
+    ]
+    .join("; ")
 }
 
 /// Handler that extracts the command from the URL path.
@@ -844,7 +1344,7 @@ async fn handle_ws_request(
     let origin = headers
         .get(axum::http::header::ORIGIN)
         .ok_or(StatusCode::FORBIDDEN)?;
-    if !is_localhost_origin(origin.as_bytes()) {
+    if !is_localhost_origin(origin.as_bytes()) && !is_allowed_remote_origin(origin.as_bytes()) {
         tracing::warn!("Rejected WebSocket connection from origin: {origin:?}");
         return Err(StatusCode::FORBIDDEN);
     }
@@ -1251,6 +1751,75 @@ fn deserialize_json<T: serde::de::DeserializeOwned>(value: serde_json::Value) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn localhost_origin_accepts_valid() {
+        // Basic schemes
+        assert!(is_localhost_origin(b"http://localhost"));
+        assert!(is_localhost_origin(b"https://localhost"));
+        assert!(is_localhost_origin(b"http://127.0.0.1"));
+        assert!(is_localhost_origin(b"https://127.0.0.1"));
+        assert!(is_localhost_origin(b"http://[::1]"));
+        assert!(is_localhost_origin(b"https://[::1]"));
+
+        // With port
+        assert!(is_localhost_origin(b"http://localhost:3000"));
+        assert!(is_localhost_origin(b"https://127.0.0.1:8080"));
+        assert!(is_localhost_origin(b"http://[::1]:6978"));
+    }
+
+    #[test]
+    fn localhost_origin_rejects_invalid() {
+        // Missing scheme
+        assert!(!is_localhost_origin(b"localhost"));
+        assert!(!is_localhost_origin(b"localhost:3000"));
+
+        // DNS rebinding — hostname that starts with "localhost" but isn't
+        assert!(!is_localhost_origin(b"http://localhost.evil.com"));
+        assert!(!is_localhost_origin(b"http://localhost.evil.com:8080"));
+
+        // IP prefix attacks
+        assert!(!is_localhost_origin(b"http://127.0.0.10"));
+        assert!(!is_localhost_origin(b"http://127.0.0.1.evil.com"));
+
+        // Other hosts
+        assert!(!is_localhost_origin(b"http://evil.com"));
+        assert!(!is_localhost_origin(b"https://192.168.1.1"));
+
+        // Empty
+        assert!(!is_localhost_origin(b""));
+    }
+
+    #[test]
+    fn localhost_host_accepts_valid() {
+        // Bare hostnames
+        assert!(is_localhost_host(b"localhost"));
+        assert!(is_localhost_host(b"127.0.0.1"));
+        assert!(is_localhost_host(b"[::1]"));
+
+        // With port
+        assert!(is_localhost_host(b"localhost:8080"));
+        assert!(is_localhost_host(b"127.0.0.1:3000"));
+        assert!(is_localhost_host(b"[::1]:6978"));
+    }
+
+    #[test]
+    fn localhost_host_rejects_invalid() {
+        // DNS rebinding — must not match hostnames that merely start with "localhost"
+        assert!(!is_localhost_host(b"localhost.evil.com"));
+        assert!(!is_localhost_host(b"localhost.evil.com:8080"));
+
+        // IP prefix attacks
+        assert!(!is_localhost_host(b"127.0.0.10"));
+        assert!(!is_localhost_host(b"127.0.0.1.evil.com"));
+
+        // Other hosts
+        assert!(!is_localhost_host(b"evil.com"));
+        assert!(!is_localhost_host(b"192.168.1.1"));
+
+        // Empty
+        assert!(!is_localhost_host(b""));
+    }
 
     #[test]
     fn claude_get_session_details_params_deserialize_uuid_string() {

--- a/crates/but-server/src/main.rs
+++ b/crates/but-server/src/main.rs
@@ -1,3 +1,47 @@
+use but_server::Config;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "but-server", about = "GitButler remote access server")]
+struct Args {
+    /// Port to listen on.
+    #[arg(long, default_value = "6978")]
+    port: u16,
+
+    /// Address to bind to. Defaults to 127.0.0.1. Override if needed (e.g. 0.0.0.0 in a container).
+    #[arg(long)]
+    bind_addr: Option<String>,
+
+    /// Serve on localhost only without opening a tunnel. No authentication required.
+    #[arg(long)]
+    local: bool,
+
+    /// Spawn a Cloudflare quick tunnel and use its URL as the allowed remote origin.
+    #[arg(long)]
+    tunnel: bool,
+
+    /// Cloudflare named tunnel name or UUID to run (e.g. `mytunnel`). Must be paired with --origin.
+    #[arg(long, requires = "origin")]
+    named_tunnel: Option<String>,
+
+    /// Public hostname routed to --named-tunnel (e.g. `but.example.com`).
+    /// Used as the CORS allowed-origin and display URL. Required when --named-tunnel is set.
+    #[arg(long)]
+    origin: Option<String>,
+
+    /// Prefix all API routes with this path (e.g. /api).
+    #[arg(long)]
+    base_path: Option<String>,
+
+    /// Disable authentication entirely. DANGEROUS — only use on trusted networks.
+    #[arg(long)]
+    dangerously_allow_anyone: bool,
+
+    /// Use the staging GitButler API (app.staging.gitbutler.com) instead of production.
+    #[arg(long)]
+    dev: bool,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     trace::init()?;
@@ -13,7 +57,21 @@ async fn main() -> anyhow::Result<()> {
     // the websocket. As the askpass broker historically hasn't been initialized for but-server,
     // it does not seem worthwhile to hook that up right now.
     gitbutler_repo_actions::askpass::disable();
-    but_server::run().await
+
+    let args = Args::parse();
+    let config = Config {
+        port: Some(args.port),
+        bind_addr: args.bind_addr,
+        tunnel: !args.local && args.tunnel && args.named_tunnel.is_none(),
+        named_tunnel: args.named_tunnel,
+        origin: args.origin,
+        base_path: args.base_path,
+        allow_anyone: args.dangerously_allow_anyone,
+        dev: args.dev,
+        project_path: None,
+        verbose: true,
+    };
+    but_server::run(config).await
 }
 
 mod trace {

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -177,6 +177,17 @@ pub async fn set_project_active(
 ) -> Result<serde_json::Value> {
     let params: SetProjectActiveParams = serde_json::from_value(params).to_json_error()?;
 
+    // When a project is pinned, reject attempts to switch to a different one.
+    if extra
+        .pinned_project
+        .as_ref()
+        .is_some_and(|pinned| &params.id != pinned)
+    {
+        anyhow::bail!(
+            "Project switching is disabled: only the current directory's project is accessible"
+        );
+    }
+
     // TODO(ctx): Adding projects to a list of active projects requires some more
     //            knowledge around how many unique tabs are looking at it
 

--- a/crates/but-server/src/tunnel.rs
+++ b/crates/but-server/src/tunnel.rs
@@ -1,0 +1,333 @@
+//! Cloudflare tunnel support.
+//!
+//! Two modes are supported:
+//!
+//! * **Quick tunnel** — no account needed. `cloudflared` is spawned
+//!   with `--url` and assigns a random `trycloudflare.com` URL.  The URL is
+//!   parsed from cloudflared's stderr output and returned.
+//!
+//! * **Named tunnel** — requires a pre-configured tunnel.
+//!   `cloudflared` is invoked with `tunnel run --url ... <name>` and the URL
+//!   is the supplied hostname (known upfront, no parsing needed).  See
+//!   <https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/> for setup.
+//!
+//! Requires `cloudflared` to be installed. If it is not found a clear
+//! error message with install instructions is printed.
+
+use colored::Colorize as _;
+use tokio::io::AsyncBufReadExt as _;
+
+const TUNNEL_URL_TIMEOUT_SECS: u64 = 30;
+
+/// Which kind of cloudflare tunnel to start.
+pub enum Mode<'a> {
+    /// Quick tunnel — no account needed, random `trycloudflare.com` URL.
+    Quick,
+    /// Named tunnel — requires `cloudflared tunnel login` + `cloudflared tunnel route dns`.
+    /// Fields: `(tunnel_name, hostname)`.
+    Named { name: &'a str, hostname: &'a str },
+}
+
+/// Spawn a cloudflared tunnel pointed at `http://127.0.0.1:{port}`.
+///
+/// Waits up to 30 seconds for cloudflared to become ready, then returns the
+/// public URL and the child process. The child **must** be kept alive for the
+/// tunnel to remain open; dropping it kills the process.
+///
+/// When `verbose` is true, cloudflared's output is forwarded to stderr.
+pub async fn start(
+    mode: Mode<'_>,
+    port: u16,
+    verbose: bool,
+) -> anyhow::Result<(String, tokio::process::Child)> {
+    let local_url = format!("http://127.0.0.1:{port}");
+
+    let (mut child, url_source) = match &mode {
+        Mode::Quick => {
+            let child = spawn_cloudflared(&["tunnel", "--url", &local_url, "--no-autoupdate"])?;
+            (child, UrlSource::ParseFromOutput)
+        }
+        Mode::Named { name, hostname } => {
+            let child = spawn_cloudflared(&["tunnel", "run", "--url", &local_url, name])?;
+            (child, UrlSource::Known(normalize_origin(hostname)?))
+        }
+    };
+
+    let mut rx = merge_output(&mut child);
+
+    // Wait for cloudflared to signal readiness.
+    // For quick tunnels we parse the URL from output; for named tunnels we
+    // wait for a "connection registered" log line.
+    let url = tokio::time::timeout(
+        std::time::Duration::from_secs(TUNNEL_URL_TIMEOUT_SECS),
+        wait_for_ready(&mut rx, &url_source, verbose),
+    )
+    .await
+    .map_err(|_| {
+        let what = match url_source {
+            UrlSource::ParseFromOutput => "cloudflared tunnel URL",
+            UrlSource::Known(_) => "cloudflared to connect",
+        };
+        anyhow::anyhow!("Timed out after {TUNNEL_URL_TIMEOUT_SECS}s waiting for {what}")
+    })??;
+
+    // Keep draining cloudflared's output so its stdio pipes never fill up.
+    // Without this, the write-blocking cloudflared would stall mid-proxy.
+    tokio::spawn(async move {
+        while let Some(line) = rx.recv().await {
+            if verbose {
+                eprintln!("{line}");
+            }
+        }
+    });
+
+    Ok((url, child))
+}
+
+enum UrlSource {
+    /// Parse the tunnel URL from cloudflared's output (quick tunnel).
+    ParseFromOutput,
+    /// URL is already known (named tunnel) — just wait for connection.
+    Known(String),
+}
+
+async fn wait_for_ready(
+    rx: &mut tokio::sync::mpsc::Receiver<String>,
+    url_source: &UrlSource,
+    verbose: bool,
+) -> anyhow::Result<String> {
+    let mut seen = Vec::new();
+    while let Some(line) = rx.recv().await {
+        if verbose {
+            eprintln!("{line}");
+        }
+        match url_source {
+            UrlSource::ParseFromOutput => {
+                if let Some(url) = extract_url(&line) {
+                    return Ok(url);
+                }
+            }
+            UrlSource::Known(url) => {
+                if is_connected(&line) {
+                    return Ok(url.clone());
+                }
+            }
+        }
+        seen.push(line);
+    }
+    // Process exited before becoming ready.
+    let detail = if seen.is_empty() {
+        "(no output)".to_string()
+    } else {
+        seen.join("\n")
+    };
+    let what = match url_source {
+        UrlSource::ParseFromOutput => "reporting a tunnel URL",
+        UrlSource::Known(_) => "the tunnel was established",
+    };
+    Err(anyhow::anyhow!(
+        "cloudflared exited before {what}:\n{detail}"
+    ))
+}
+
+/// Spawn `cloudflared` with the given arguments, returning the child process.
+///
+/// Translates a "not found" OS error into a user-friendly message with install
+/// instructions; other spawn errors are returned as-is.
+fn spawn_cloudflared(args: &[&str]) -> anyhow::Result<tokio::process::Child> {
+    tokio::process::Command::new("cloudflared")
+        .args(args)
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                let install_hint = if cfg!(target_os = "macos") {
+                    "brew install cloudflared"
+                } else if cfg!(target_os = "windows") {
+                    "winget install --id Cloudflare.cloudflared"
+                } else {
+                    "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+                };
+                anyhow::anyhow!(
+                    "{}\nInstall: {}",
+                    "cloudflared is not installed.".bold(),
+                    install_hint.cyan()
+                )
+            } else {
+                anyhow::anyhow!("Failed to spawn cloudflared: {e}")
+            }
+        })
+}
+
+/// Spawn two tasks that each read one stream and forward lines to a shared channel.
+///
+/// Using `chain` would read stdout to EOF before touching stderr; this
+/// interleaves both so neither stream starves the other.
+fn merge_output(child: &mut tokio::process::Child) -> tokio::sync::mpsc::Receiver<String> {
+    let (tx, rx) = tokio::sync::mpsc::channel(64);
+
+    let stdout = child.stdout.take().expect("stdout is piped");
+    let tx_out = tx.clone();
+    tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if tx_out.send(line).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let stderr = child.stderr.take().expect("stderr is piped");
+    tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if tx.send(line).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    rx
+}
+
+/// Normalise an arbitrary hostname or URL string into a canonical `https://<host>` origin.
+///
+/// Accepts:
+/// * A bare hostname: `my-tunnel.example.com`
+/// * A URL with a scheme: `https://my-tunnel.example.com` or `http://my-tunnel.example.com`
+///
+/// Any path, query, or fragment component is stripped; the scheme is always
+/// normalised to `https://`.  Returns an error when the input cannot be parsed
+/// as a URL or contains no host component.
+///
+/// The returned string exactly matches what a browser sends in the `Origin`
+/// header (scheme + host + optional non-default port), so it is safe to use
+/// directly for CORS / origin-allow-list comparisons.
+pub fn normalize_origin(input: &str) -> anyhow::Result<String> {
+    // If the caller omitted the scheme, prepend https:// so url::Url can parse it.
+    let with_scheme;
+    let to_parse = if input.contains("://") {
+        input
+    } else {
+        with_scheme = format!("https://{input}");
+        &with_scheme
+    };
+
+    let parsed =
+        url::Url::parse(to_parse).map_err(|e| anyhow::anyhow!("invalid origin {input:?}: {e}"))?;
+
+    anyhow::ensure!(
+        matches!(parsed.scheme(), "http" | "https"),
+        "invalid origin {:?}: scheme must be http or https, got {:?}",
+        input,
+        parsed.scheme()
+    );
+
+    let host = parsed
+        .host_str()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("invalid origin {input:?}: no host component found"))?;
+
+    // Reconstruct as https://<host> (with port only when non-default).
+    let origin = match parsed.port() {
+        Some(port) => format!("https://{host}:{port}"),
+        None => format!("https://{host}"),
+    };
+    Ok(origin)
+}
+
+/// Returns `true` when a cloudflared log line confirms the tunnel is connected.
+fn is_connected(line: &str) -> bool {
+    // cloudflared emits this once the first connection to the Cloudflare edge
+    // is registered and ready to accept traffic.
+    line.contains("Registered tunnel connection")
+        || line.contains("Connection registered")
+        || line.contains("connsReady=1")
+}
+
+/// Extract a `https://*.trycloudflare.com` URL from a cloudflared log line.
+fn extract_url(line: &str) -> Option<String> {
+    let marker = ".trycloudflare.com";
+    let end = line.find(marker)? + marker.len();
+    let start = line[..end].rfind("https://")?;
+    Some(line[start..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tunnel_url_from_log_line() {
+        let line = "2024-01-01T00:00:00Z INF |  https://example-words-here.trycloudflare.com  |";
+        assert_eq!(
+            extract_url(line),
+            Some("https://example-words-here.trycloudflare.com".into())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unrelated_lines() {
+        assert_eq!(extract_url("INFO starting tunnel"), None);
+    }
+
+    #[test]
+    fn detects_registered_connection() {
+        assert!(is_connected(
+            "2024-01-01T00:00:00Z INF Registered tunnel connection connIndex=0"
+        ));
+        assert!(is_connected("INF connsReady=1"));
+        assert!(!is_connected("INF Starting tunnel tunnelID=abc"));
+    }
+
+    #[test]
+    fn normalize_origin_cases() {
+        // Bare hostname — scheme is inferred as https.
+        assert_eq!(
+            normalize_origin("my-tunnel.example.com").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // https:// is preserved as-is.
+        assert_eq!(
+            normalize_origin("https://my-tunnel.example.com").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // http:// is accepted and normalised to https.
+        assert_eq!(
+            normalize_origin("http://my-tunnel.example.com").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // Path, query, and fragment are stripped.
+        assert_eq!(
+            normalize_origin("https://my-tunnel.example.com/path?q=1#frag").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // Query without a path is also stripped.
+        assert_eq!(
+            normalize_origin("https://my-tunnel.example.com?q=1").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // Trailing slash is stripped.
+        assert_eq!(
+            normalize_origin("https://my-tunnel.example.com/").unwrap(),
+            "https://my-tunnel.example.com"
+        );
+        // Non-default port is preserved (browsers include it in the Origin header).
+        assert_eq!(
+            normalize_origin("https://my-tunnel.example.com:8443").unwrap(),
+            "https://my-tunnel.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn normalize_origin_rejects_invalid() {
+        // Empty string.
+        assert!(normalize_origin("").is_err());
+        // Scheme only, no host.
+        assert!(normalize_origin("https://").is_err());
+        // Non-http/https scheme.
+        assert!(normalize_origin("ftp://my-tunnel.example.com").is_err());
+    }
+}

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -10,6 +10,12 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = [
+    # Activated via `remote` or `irc` features (dev/nightly only), never imported directly in source.
+    "but-server",
+]
+
 [[bin]]
 name = "but"
 path = "src/main.rs"
@@ -44,6 +50,15 @@ legacy = [
     "dep:gitbutler-repo",
     "dep:gitbutler-repo-actions",
 ]
+## Enable IRC collaboration features (enabled for dev and nightly builds).
+irc = ["dep:but-server", "but-server/irc"]
+## Enable the `but remote` subcommand and embedded HTTP server (dev and nightly builds).
+## Brings in but-server and the embedded SvelteKit frontend.
+remote = ["dep:but-server", "embedded-frontend"]
+## Embed the SvelteKit frontend into the binary (only useful with `remote`).
+## If apps/desktop/build/ is absent at compile time the binary still builds but
+## returns 404 for frontend requests — build the frontend first to serve the UI.
+embedded-frontend = ["but-server?/embedded-frontend"]
 # Feature that enables profiling related features of the TUI.
 tui-profiling = []
 
@@ -68,6 +83,7 @@ but-llm.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.
+but-server = { workspace = true, optional = true }
 but-action = { workspace = true, optional = true }
 # Still uses `gitbutler-stack`, but otherwise it is non-legacy.
 but-hunk-assignment.workspace = true

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1129,6 +1129,74 @@ pub enum Subcommands {
     #[clap(verbatim_doc_comment)]
     Skill(skill::Platform),
 
+    /// Serve the GitButler UI over HTTP.
+    ///
+    /// Starts the embedded GitButler frontend and API on a local port.
+    /// By default opens a Cloudflare quick tunnel so you can access it
+    /// from any device. All non-localhost requests require a valid
+    /// GitButler token. Pass `--local` to skip the tunnel and bind to
+    /// localhost only (no auth required).
+    ///
+    /// Requires `cloudflared` to be installed. If it is missing, a one-line
+    /// install hint is printed.
+    ///
+    /// ## Examples
+    ///
+    /// ```text
+    /// but remote
+    /// ```
+    ///
+    /// Localhost only (no tunnel, no auth):
+    ///
+    /// ```text
+    /// but remote --local
+    /// ```
+    ///
+    /// Use a pre-configured named tunnel:
+    ///
+    /// ```text
+    /// but remote --named-tunnel gitbutler --origin git.example.com
+    /// ```
+    ///
+    /// Set up a named tunnel once (requires a Cloudflare account and a domain):
+    ///
+    /// ```text
+    /// cloudflared tunnel login
+    /// cloudflared tunnel create gitbutler
+    /// cloudflared tunnel route dns gitbutler git.example.com
+    /// ```
+    #[cfg(all(feature = "legacy", feature = "remote"))]
+    #[clap(verbatim_doc_comment, hide = true)]
+    Remote {
+        /// Port to listen on.
+        #[clap(long, default_value = "8080")]
+        port: u16,
+        /// Address to bind to. Defaults to 127.0.0.1. Override if needed (e.g. 0.0.0.0 in a container).
+        #[clap(long)]
+        bind_addr: Option<String>,
+        /// Serve on localhost only without opening a tunnel. No authentication required.
+        #[clap(long)]
+        local: bool,
+        /// Cloudflare named tunnel name or UUID (e.g. `gitbutler`).
+        ///
+        /// Must be paired with `--origin`. Runs `cloudflared tunnel run --url ... <name>`
+        /// which connects your pre-configured named tunnel to the local server.
+        /// Requires `cloudflared tunnel login` and `cloudflared tunnel route dns` to have
+        /// been run already.
+        #[clap(long, requires = "origin")]
+        named_tunnel: Option<String>,
+        /// Public hostname routed to `--named-tunnel` (e.g. `git.example.com`).
+        /// Used as the CORS allowed-origin and display URL. Required when --named-tunnel is set.
+        #[clap(long)]
+        origin: Option<String>,
+        /// Disable authentication entirely. DANGEROUS — only use on trusted networks.
+        #[clap(long)]
+        dangerously_allow_anyone: bool,
+        /// Use the staging GitButler API (app.staging.gitbutler.com) instead of production.
+        #[clap(long)]
+        dev: bool,
+    },
+
     /// Show help information grouped by category.
     ///
     /// Displays all available commands organized into functional categories

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -245,6 +245,30 @@ async fn match_subcommand(
         Subcommands::Update(update_args::Platform { cmd }) => {
             command::update::handle(cmd, out, &app_settings).emit_metrics(metrics_ctx)
         }
+        #[cfg(all(feature = "legacy", feature = "remote"))]
+        Subcommands::Remote {
+            port,
+            bind_addr,
+            local,
+            named_tunnel,
+            origin,
+            dangerously_allow_anyone,
+            dev,
+        } => {
+            but_server::run(but_server::Config {
+                port: Some(port),
+                bind_addr,
+                tunnel: !local && named_tunnel.is_none(),
+                named_tunnel,
+                origin,
+                base_path: Some("/api".into()),
+                allow_anyone: dangerously_allow_anyone,
+                dev,
+                project_path: Some(args.current_dir.clone()),
+                verbose: args.trace > 0,
+            })
+            .await
+        }
         Subcommands::Help => {
             command::help::print_grouped(out)?;
             Ok(())

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -218,6 +218,8 @@ impl Subcommands {
             Subcommands::Edit { .. } => Edit,
             #[cfg(feature = "legacy")]
             Subcommands::Clean { .. } => Clean,
+            #[cfg(all(feature = "legacy", feature = "remote"))]
+            Subcommands::Remote { .. } => Unknown,
             Subcommands::Onboarding | Subcommands::EvalHook => Unknown,
         }
     }

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -96,10 +96,12 @@ workspace = true
 [features]
 default = ["custom-protocol", "devtools", "opener"]
 ## Enable IRC-based real-time collaboration features.
-irc = ["dep:but-irc"]
+irc = ["dep:but-irc", "but?/irc"]
+## Enable the `but remote` subcommand (dev and nightly builds only).
+remote = ["but?/remote"]
 #! ## Build- and package-related Options
 ## If enabled, we will pretend to be `but` when the binary filename is `but`.
-builtin-but = ["dep:but", "but-action/builtin-but"]
+builtin-but = ["dep:but", "but-action/builtin-but", "but/embedded-frontend"]
 ## A very specific utility flag to make clear that the 'but' binary is managed by a package manager.
 packaged-but-distribution = ["but?/packaged-but-distribution"]
 ## Disable the auto-updater in the frontend.

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -14,6 +14,12 @@ cargo build --release -p gitbutler-git
 if [ "${OS:-}" == "windows" ] || [ "${OS:-}" == "linux" ]; then
   # NOTE: Should run either if the builtin-but feature is *not* selected in `release.sh` (case for Windows), OR if we
   # need the standalone CLI for separate publishing (case for Linux)
-  cargo build --release -p but
+  # remote brings in but-server and the embedded frontend; excluded from release builds.
+  BUT_FEATURES=""
+  if [ "${CHANNEL:-}" != "release" ]; then
+    BUT_FEATURES="--features irc,remote"
+  fi
+  # shellcheck disable=SC2086
+  cargo build --release -p but $BUT_FEATURES
 fi
 bash ./crates/gitbutler-tauri/inject-git-binaries.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"dev:lite": "turbo watch --filter @gitbutler/lite dev",
 		"dev:desktop": "cross-env CARGO_TARGET_DIR=\"$PNPM_SCRIPT_SRC_DIR/target/tauri\" pnpm dev:desktop-with-env",
 		"dev:desktop-http": "cross-env VITE_BUTLER_PORT=6978 VITE_BUTLER_HOST=localhost VITE_BUILD_TARGET=web turbo watch dev --filter=...@gitbutler/desktop",
-		"dev:desktop-with-env": "cargo build -p but && cargo build -p gitbutler-git && pnpm tauri dev --features irc",
+		"dev:desktop-with-env": "cargo build -p but --features irc && cargo build -p gitbutler-git && pnpm tauri dev --features irc",
 		"dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
 		"package": "turbo run package",
 		"ui:playwright:install:unit": "turbo run --filter @gitbutler/ui playwright:install:unit",


### PR DESCRIPTION
## Summary

Adds a `but remote` subcommand that serves the embedded GitButler UI and API over HTTP.
The subcommand is available in dev and nightly builds only, gated behind the `remote` Cargo
feature. Release builds exclude `but-server` and the embedded frontend entirely.

- **`but remote`** (default) — opens a Cloudflare quick tunnel; all requests require a valid GitButler token
- **`but remote --local`** — binds to localhost only, no tunnel, no auth required
- **`but remote --name <tunnel> --hostname <host>`** — uses a pre-configured Cloudflare named tunnel with a custom domain
- **`but remote --remote-origin <url>`** — uses an existing reverse proxy / static origin instead of spawning cloudflared
- **`--dangerously-allow-anyone`** — disables auth entirely (LAN/dev use)

```sh
$ cd ~/my-repo
$ but remote
Starting cloudflare tunnel on port 8080
Tunnel: https://example-words-here.trycloudflare.com
```

```sh
$ cd ~/my-repo
$ but remote --local
Local: http://localhost:8080
```

## Security

- **DNS rebinding**: `--local` mode validates the `Host` header is `localhost`, `127.0.0.1`, or `[::1]`
- **Token auth**: validated against `app.gitbutler.com`; session cookie is `SameSite=Strict`
- **CORS**: explicit header/method allowlist, `allow_credentials(true)`, origin-locked in tunnel mode
- **CSRF**: `SameSite=Strict` cookie + Origin header required on all mutating requests (POST/PUT/DELETE/PATCH); requests without an Origin header are rejected with 403
- **Auth allowlist**: only `/auth/login` and `/auth/callback` are public; all other routes (including `/auth/logout`) require a valid session
- **Logout**: `POST /auth/logout` — using POST prevents CSRF-driven session termination
- **Login redirect**: `GET /auth/login` redirects to `/` when a valid session already exists, avoiding a login-page flash when following direct links
- **CSP**: header with per-script SHA-256 hashes on all responses
- **Compression**: response compression via `tower-http` `CompressionLayer`
- Fails fast if remote access is configured but no local GitButler user is logged in

## Auth / Login page

- Login flow: redirects to `app.gitbutler.com`, user pastes token back
- Async submit button with loading spinner
- `--dangerously-allow-anyone` flag bypasses auth for LAN/dev use

## Other

- Project is pinned to CWD on startup — `set_project_active` rejects other project IDs
- Mobile safe area: `viewport-fit=cover` + `env(safe-area-inset-bottom)` + `100dvh`
- Friendly error with install hint when `cloudflared` is missing
- `BUTLER_PORT` / `BUTLER_HOST` env vars preserved as fallbacks
- Remote origin normalised via `url::Url` (scheme + host + optional port only, path/query/fragment stripped)

## Test plan

- [ ] `cargo build -p but` builds cleanly
- [ ] `but remote --local` starts server, prints `Local: http://localhost:8080`, frontend loads to current repo
- [ ] `but remote` starts cloudflared, prints `Tunnel: https://….trycloudflare.com`, login required
- [ ] Visiting the tunnel URL on another device prompts login
- [ ] `--dangerously-allow-anyone` skips login
- [ ] Running in a repo auto-opens that project; switching projects is blocked
- [ ] Starting without a logged-in user (and no `--dangerously-allow-anyone`) exits with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)