### PR TITLE
oplog: use AutoResolution tree in non-v3 restore to prevent conflict dirs leaking to disk

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -11,6 +11,7 @@ use but_workspace::{
     legacy::stack_ext::StackExt,
 };
 use gitbutler_branch::{self, BranchCreateRequest, dedup};
+use gitbutler_cherry_pick::GixRepositoryExt as _;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_oplog::SnapshotExt;
 use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
@@ -281,7 +282,10 @@ impl BranchManager<'_> {
             .context(format!("failed to find merge base commit {merge_base}"))?
             .tree_id()?
             .detach();
-        let branch_tree_id = stack.tree(self.ctx)?;
+        let branch_head_commit = repo.find_commit(stack_head)?;
+        let branch_tree_id = repo
+            .find_real_tree(&branch_head_commit, Default::default())?
+            .detach();
 
         let mut unapplied_stacks = vec![];
 

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -13,7 +13,7 @@ use but_ctx::{
 };
 use but_meta::virtual_branches_legacy_types;
 use but_oxidize::{ObjectIdExt as _, OidExt};
-use gitbutler_cherry_pick::RepositoryExtLite;
+use gitbutler_cherry_pick::{GixRepositoryExt as _, RepositoryExtLite};
 use gitbutler_repo::{SignaturePurpose, commit_without_signature_gix, signature_gix};
 use gitbutler_stack::{VirtualBranchesHandle, VirtualBranchesState};
 use gix::objs::Write as _;
@@ -792,8 +792,13 @@ fn tree_from_applied_vbranches(
     let applied_branch_trees: Vec<_> = vbs_from_toml
         .list_stacks_in_workspace()?
         .iter()
-        .flat_map(|b| b.tree(ctx))
-        .collect();
+        .map(|b| {
+            let head_oid = b.head_oid(ctx)?;
+            let commit = repo.find_commit(head_oid)?;
+            repo.find_real_tree(&commit, Default::default())
+                .map(|id| id.detach())
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let mut workdir_tree_id = target_tree_id;
     let base_tree_id = target_tree_id;


### PR DESCRIPTION
Symptom: switching away from the GitButler workspace caused severe UI lag
(18+ seconds). Application logs showed `changes_in_worktree` spending 3.5 s
of CPU time scanning hundreds of large binary files inside
`.conflict-base-0/`, `.conflict-side-0/`, `.conflict-side-1/`, and
`.auto-resolution/` directories in the working tree, while holding an
exclusive repo lock for the entire duration and blocking all other
operations.

Root cause: those directories are GitButler-internal tree keys stored as
subtrees *inside* conflicted commit objects. They are a git-object concept
and should never appear on disk. They leaked to disk transiently during
oplog snapshot restore (with `cv3 = false`) via this chain:

1. `apply_branch` rebases the incoming branch onto the target. When a
   commit conflicts during rebase, `but_rebase::Rebase` creates a
   conflicted commit whose raw `.tree()` contains `.conflict-*`
   subtrees at the top level. The stack ref is updated to point at
   this conflicted commit.

2. `restore_snapshot` is called to undo the apply. In the non-v3 path,
   `tree_from_applied_vbranches` reconstructs the working-directory tree.
   It called `b.tree(ctx)` which calls `Stack::tree()`:

   ```
   repo.find_commit(self.head_oid(ctx)?)?.tree()  // raw, not AutoResolution
   ```

   `head_oid` reads the *current* git ref, which still points at the
   conflicted commit because branch refs are not restored until *after*
   the checkout. The raw tree is octopus-merged into the workspace tree,
   producing a result that includes the `.conflict-*` directories at
   the top level.

3. `git2::Repository::checkout_tree` materialises that merged tree to
   disk, creating the conflict directories. `remove_untracked(true)`
   does not remove them because they are present in the target tree.

**Fix:** replace `b.tree(ctx)` with `find_real_tree(&commit, Default::default())`
(AutoResolution) in `tree_from_applied_vbranches`. This is consistent with
every other site in the codebase that works with potentially-conflicted
commits — `remerged_workspace_tree_v2`, `WorkspaceState::create`,
`from_new_merge_with_tips`, etc. For non-conflicted commits `find_real_tree`
is a no-op.

Also switches the iterator from `flat_map` to `map(...).collect::<Result<_>>()?`
so errors propagate instead of silently dropping branch trees.