### PR TITLE
API: graphy squash

### DIFF
--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -5,7 +5,7 @@ use crate::{commit::types::CommitDiscardResult, json::HexHash};
 
 use super::types::{
     CommitCreateResult, CommitInsertBlankResult, CommitMoveResult, CommitRewordResult,
-    MoveChangesResult,
+    CommitSquashResult, MoveChangesResult,
 };
 
 /// UI type for a move changes between commits result.
@@ -129,6 +129,43 @@ but_schemars::register_sdk_type!(UICommitRewordResult);
 impl From<CommitRewordResult> for UICommitRewordResult {
     fn from(value: CommitRewordResult) -> Self {
         let CommitRewordResult {
+            new_commit,
+            replaced_commits,
+        } = value;
+
+        Self {
+            new_commit: new_commit.into(),
+            replaced_commits: replaced_commits
+                .into_iter()
+                .map(|(old, new)| (old.into(), new.into()))
+                .collect(),
+        }
+    }
+}
+
+/// UI type for squashing commits.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct UICommitSquashResult {
+    /// The new commit ID after squashing.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub new_commit: HexHash,
+    /// Commits that have been replaced as a side-effect of the squash.
+    /// Maps `oldId -> newId`.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(with = "std::collections::BTreeMap<String, String>")
+    )]
+    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(UICommitSquashResult);
+
+impl From<CommitSquashResult> for UICommitSquashResult {
+    fn from(value: CommitSquashResult) -> Self {
+        let CommitSquashResult {
             new_commit,
             replaced_commits,
         } = value;

--- a/crates/but-api/src/commit/mod.rs
+++ b/crates/but-api/src/commit/mod.rs
@@ -22,6 +22,9 @@ pub mod move_commit;
 /// Functions for rewording commits.
 pub mod reword;
 
+/// Functions for squashing commits.
+pub mod squash;
+
 /// Shared result and selector types for commit APIs.
 pub mod types;
 

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -1,0 +1,108 @@
+use but_api_macros::but_api;
+use but_core::sync::RepoExclusive;
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use tracing::instrument;
+
+use super::types::CommitSquashResult;
+
+/// Squash `subject_commit_id` into `target_commit_id`.
+///
+/// This acquires exclusive worktree access from `ctx` before rewriting the
+/// commits.
+///
+/// For details, see [`commit_squash_only_with_perm()`].
+#[but_api(crate::commit::json::UICommitSquashResult)]
+#[instrument(err(Debug))]
+pub fn commit_squash_only(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    target_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitSquashResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_squash_only_with_perm(
+        ctx,
+        subject_commit_id,
+        target_commit_id,
+        guard.write_permission(),
+    )
+}
+
+/// Squash `subject_commit_id` into `target_commit_id` under caller-held
+/// exclusive repository access.
+///
+/// This materializes the squash rebase and returns the resulting squashed
+/// commit ID together with rewritten commit mappings. This variant does not
+/// create an oplog entry. For lower-level implementation details, see
+/// [`but_workspace::commit::squash_commits()`].
+pub fn commit_squash_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    target_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitSquashResult> {
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+
+    let outcome =
+        but_workspace::commit::squash_commits(editor, subject_commit_id, target_commit_id)?;
+
+    let materialized = outcome.rebase.materialize()?;
+    let new_commit = materialized.lookup_pick(outcome.commit_selector)?;
+
+    Ok(CommitSquashResult {
+        new_commit,
+        replaced_commits: materialized.history.commit_mappings(),
+    })
+}
+
+/// Squash `subject_commit_id` into `target_commit_id` and record an oplog
+/// snapshot on success.
+///
+/// This acquires exclusive worktree access from `ctx` before rewriting the
+/// commits.
+///
+/// For details, see [`commit_squash_with_perm()`].
+#[but_api(napi, crate::commit::json::UICommitSquashResult)]
+#[instrument(err(Debug))]
+pub fn commit_squash(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    target_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitSquashResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_squash_with_perm(
+        ctx,
+        subject_commit_id,
+        target_commit_id,
+        guard.write_permission(),
+    )
+}
+
+/// Squash `subject_commit_id` into `target_commit_id` under caller-held
+/// exclusive repository access and record an oplog snapshot on success.
+///
+/// It prepares a best-effort `SquashCommit` oplog snapshot, performs the
+/// squash, and commits the snapshot only if the operation succeeds. For
+/// lower-level implementation details, see
+/// [`but_workspace::commit::squash_commits()`].
+pub fn commit_squash_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    target_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitSquashResult> {
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::SquashCommit),
+        perm.read_permission(),
+    )
+    .ok();
+
+    let res = commit_squash_only_with_perm(ctx, subject_commit_id, target_commit_id, perm);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx, perm).ok();
+    };
+    res
+}

--- a/crates/but-api/src/commit/types.rs
+++ b/crates/but-api/src/commit/types.rs
@@ -26,6 +26,14 @@ pub struct CommitRewordResult {
     pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
 }
 
+/// Outcome of squashing one commit into another.
+pub struct CommitSquashResult {
+    /// The ID of the newly created squashed commit.
+    pub new_commit: gix::ObjectId,
+    /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
+    pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+}
+
 /// Outcome of moving a commit.
 pub struct CommitMoveResult {
     /// Commits that were replaced by this operation. Maps `old_id -> new_id`.

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -1,9 +1,14 @@
-use anyhow::bail;
+use std::collections::BTreeMap;
+
+use anyhow::{Context as _, bail};
 use bstr::BString;
 use but_core::{ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use colored::Colorize;
-use gitbutler_branch_actions::squash_commits_with_perm;
+use gitbutler_oplog::{
+    OplogExt,
+    entry::{OperationKind, SnapshotDetails},
+};
 use gix::ObjectId;
 
 use super::undo::stack_id_by_commit_id;
@@ -274,44 +279,78 @@ fn squash_commits_internal(
         None
     };
 
-    // Perform the squash using the API - it can handle multiple source commits
-    let new_commit_oid =
-        squash_commits_with_perm(ctx, target_stack, source_oids.clone(), target_oid, perm)?;
+    // Keep the complete multi-rewrite sequence atomic: if any step fails,
+    // restore the pre-squash snapshot so we don't leave partial rewrites.
+    let snapshot = ctx.create_snapshot(SnapshotDetails::new(OperationKind::SquashCommit), perm)?;
+    let squash_result: anyhow::Result<ObjectId> = (|| {
+        // Perform the squash by folding sources into the current target one by one.
+        // We process from bottom to top so each next source remains adjacent to the
+        // rewritten target commit.
+        let mut new_commit_oid = target_oid;
+        let mut rewritten_commits = BTreeMap::<ObjectId, ObjectId>::new();
+        for source_oid in source_oids.iter().rev() {
+            let mut remapped_source_oid = *source_oid;
+            while let Some(next_oid) = rewritten_commits.get(&remapped_source_oid) {
+                remapped_source_oid = *next_oid;
+            }
 
-    // Determine the final message and apply if needed
-    let final_commit_oid = if let Some(user_summary) = ai {
-        // Use AI to generate the commit message
-        let ai_message = ai::generate_commit_message_from_multiple_messages(
-            out,
-            source_messages.unwrap_or_default(),
-            destination_message.unwrap_or_default(),
-            user_summary,
-        )?;
-        but_api::commit::reword::commit_reword_only_with_perm(
-            ctx,
-            new_commit_oid,
-            BString::from(ai_message),
-            perm,
-        )?
-        .new_commit
-    } else if let Some(msg) = custom_message {
-        but_api::commit::reword::commit_reword_only_with_perm(
-            ctx,
-            new_commit_oid,
-            BString::from(msg),
-            perm,
-        )?
-        .new_commit
-    } else if let Some(target_msg) = target_message {
-        but_api::commit::reword::commit_reword_only_with_perm(
-            ctx,
-            new_commit_oid,
-            BString::from(target_msg),
-            perm,
-        )?
-        .new_commit
-    } else {
-        new_commit_oid
+            let squash_result = but_api::commit::squash::commit_squash_only_with_perm(
+                ctx,
+                remapped_source_oid,
+                new_commit_oid,
+                perm,
+            )?;
+            rewritten_commits.extend(squash_result.replaced_commits.iter().map(|(k, v)| (*k, *v)));
+            new_commit_oid = squash_result.new_commit;
+        }
+
+        // Determine the final message and apply if needed.
+        let final_commit_oid = if let Some(user_summary) = ai {
+            // Use AI to generate the commit message.
+            let ai_message = ai::generate_commit_message_from_multiple_messages(
+                out,
+                source_messages.unwrap_or_default(),
+                destination_message.unwrap_or_default(),
+                user_summary,
+            )?;
+            but_api::commit::reword::commit_reword_only_with_perm(
+                ctx,
+                new_commit_oid,
+                BString::from(ai_message),
+                perm,
+            )?
+            .new_commit
+        } else if let Some(msg) = custom_message {
+            but_api::commit::reword::commit_reword_only_with_perm(
+                ctx,
+                new_commit_oid,
+                BString::from(msg),
+                perm,
+            )?
+            .new_commit
+        } else if let Some(target_msg) = target_message {
+            but_api::commit::reword::commit_reword_only_with_perm(
+                ctx,
+                new_commit_oid,
+                BString::from(target_msg),
+                perm,
+            )?
+            .new_commit
+        } else {
+            new_commit_oid
+        };
+
+        Ok(final_commit_oid)
+    })();
+
+    let final_commit_oid = match squash_result {
+        Ok(final_commit_oid) => final_commit_oid,
+        Err(err) => {
+            ctx.restore_snapshot(snapshot, perm).with_context(|| {
+                format!("Failed to restore snapshot {snapshot} after squash failure")
+            })?;
+            return Err(err);
+        }
     };
 
     // Output message based on context

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -144,6 +144,17 @@ export declare function commitMoveChangesBetween(projectId: string, sourceCommit
 export declare function commitReword(projectId: string, commitId: string, message: string): Promise<UICommitRewordResult>
 
 /**
+ * Squash `subject_commit_id` into `target_commit_id` and record an oplog
+ * snapshot on success.
+ *
+ * This acquires exclusive worktree access from `ctx` before rewriting the
+ * commits.
+ *
+ * For details, see [`commit_squash_with_perm()`].
+ */
+export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string): Promise<UICommitSquashResult>
+
+/**
  * Extract `changes` from `commit_id` and record the rewrite in the oplog.
  *
  * This acquires exclusive worktree access from `ctx` before extracting the
@@ -1367,6 +1378,17 @@ export type UICommitRewordResult = {
   newCommit: string;
   /**
    * Commits that have been replaced as a side-effect of the reword.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** UI type for squashing commits. */
+export type UICommitSquashResult = {
+  /** The new commit ID after squashing. */
+  newCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the squash.
    * Maps `oldId -> newId`.
    */
   replacedCommits: Record<string, string>;

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -596,6 +596,7 @@ export { commitInsertBlank }
 export { commitMove }
 export { commitMoveChangesBetween }
 export { commitReword }
+export { commitSquash }
 export { commitUncommitChanges }
 export { forgeProvider }
 export { getReview }


### PR DESCRIPTION
Use the new squash command that's backed by graph operations in the CLI.

- Add an API to the but-api crate
- Add a binding for the API in question
- Use the new API in the but CLI