### PR TITLE
fix(ui): adjust CtaButton color vars for pop state dark mode

### DIFF
--- a/apps/web/src/routes/(home)/components/CtaButton.svelte
+++ b/apps/web/src/routes/(home)/components/CtaButton.svelte
@@ -127,7 +127,7 @@
 		border: 1px solid color-mix(in srgb, var(--fill-pop-bg) 50%, transparent);
 		border-radius: var(--radius-xl);
 		background-color: var(--chip-pop-bg);
-		color: var(--fill-pop-fg);
+		color: var(--clr-pop-30);
 		transition:
 			transform 0.15s ease-out,
 			color 0.15s ease,
@@ -140,6 +140,10 @@
 			background-color: hsl(from var(--chip-pop-bg) h s calc(l - 5));
 			box-shadow: 0 12px 26px color-mix(in srgb, var(--fill-pop-bg) 30%, transparent);
 		}
+	}
+
+	:global(.dark) .download-btn {
+		color: var(--clr-pop-80);
 	}
 
 	.download-btn.mobile {


### PR DESCRIPTION
A fix for this:

<img width="733" height="419" alt="image" src="https://github.com/user-attachments/assets/b42f3296-4e9b-43be-aa84-f9387850b705" />