### PR TITLE
lite: file watcher invalidates diffs

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -6,50 +6,63 @@ import type {
 } from "#electron/ipc.ts";
 import { queryOptions } from "@tanstack/react-query";
 
+export enum QueryKey {
+	BranchDetails = "branchDetails",
+	BranchDiff = "branchDiff",
+	ChangesInWorktree = "changesInWorktree",
+	CommitDetailsWithLineStats = "commitDetailsWithLineStats",
+	HeadInfo = "headInfo",
+	Branches = "branches",
+	Projects = "projects",
+	TreeChangeDiffs = "treeChangeDiffs",
+}
+
 export const branchDetailsQueryOptions = (params: BranchDetailsParams) =>
 	queryOptions({
-		queryKey: ["branchDetails", params],
+		queryKey: [QueryKey.BranchDetails, params],
 		queryFn: () => window.lite.branchDetails(params),
 	});
 
 export const branchDiffQueryOptions = (params: BranchDiffParams) =>
 	queryOptions({
-		queryKey: ["branchDiff", params],
+		queryKey: [QueryKey.BranchDiff, params],
 		queryFn: () => window.lite.branchDiff(params),
 	});
 
 export const changesInWorktreeQueryOptions = (projectId: string) =>
 	queryOptions({
-		queryKey: ["changesInWorktree", projectId],
+		queryKey: [QueryKey.ChangesInWorktree, projectId],
 		queryFn: () => window.lite.changesInWorktree(projectId),
 	});
 
 export const commitDetailsWithLineStatsQueryOptions = (params: CommitDetailsWithLineStatsParams) =>
 	queryOptions({
-		queryKey: ["commitDetailsWithLineStats", params],
+		queryKey: [QueryKey.CommitDetailsWithLineStats, params],
 		queryFn: () => window.lite.commitDetailsWithLineStats(params),
 	});
 
 export const headInfoQueryOptions = (projectId: string) =>
 	queryOptions({
-		queryKey: ["headInfo", projectId],
+		queryKey: [QueryKey.HeadInfo, projectId],
 		queryFn: () => window.lite.headInfo(projectId),
 	});
 
 export const listBranchesQueryOptions = (projectId: string) =>
 	queryOptions({
-		queryKey: ["branches", projectId],
+		queryKey: [QueryKey.Branches, projectId],
 		queryFn: () => window.lite.listBranches(projectId, null),
 	});
 
 export const listProjectsQueryOptions = () =>
 	queryOptions({
-		queryKey: ["projects"],
+		queryKey: [QueryKey.Projects],
 		queryFn: () => window.lite.listProjects(),
 	});
 
-export const treeChangeDiffsQueryOptions = (params: TreeChangeDiffParams) =>
-	queryOptions({
-		queryKey: ["treeChangeDiffs", params],
-		queryFn: () => window.lite.treeChangeDiffs(params),
+export const treeChangeDiffsQueryOptions = (params: TreeChangeDiffParams) => {
+	const { projectId, change } = params;
+	return queryOptions({
+		queryKey: [QueryKey.TreeChangeDiffs, projectId, change],
+		queryFn: () => window.lite.treeChangeDiffs({ projectId, change }),
 	});
+};

--- a/apps/lite/ui/src/watcher.ts
+++ b/apps/lite/ui/src/watcher.ts
@@ -1,4 +1,4 @@
-import { changesInWorktreeQueryOptions } from "#ui/api/queries.ts";
+import { changesInWorktreeQueryOptions, QueryKey } from "#ui/api/queries.ts";
 import { WatcherEvent } from "@gitbutler/but-sdk";
 import { QueryClient } from "@tanstack/react-query";
 
@@ -14,6 +14,7 @@ export function handleWatcher(event: WatcherEvent, projectId: string, client: Qu
 				changesInWorktreeQueryOptions(projectId).queryKey,
 				() => workspaceChanges,
 			);
+			void client.invalidateQueries({ queryKey: [QueryKey.TreeChangeDiffs, projectId] });
 			break;
 	}
 }


### PR DESCRIPTION
The watcher events invalidate the diff queries in order to update the changes as soon as they are changed.

### Some notes on this
I don't think it's too bad to invalidate every diff query whenever the file watcher emits. We don't know which files changed whenever we emit, and we usually are looking at one file diff whenever that happens.

There is some room for optimization in which we'd know exactly which files were changed and we only invalidate the queries for that. This is fine for now.