### PR TITLE
Skip commit/file reaction queries when IRC is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "but-rules",
  "but-secret",
  "but-serde",
+ "but-server",
  "but-settings",
  "but-testsupport",
  "but-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ but-fs = { path = "crates/but-fs" }
 but-forge = { path = "crates/but-forge" }
 but-oplog = { path = "crates/but-oplog" }
 but-llm = { path = "crates/but-llm" }
+but-server = { path = "crates/but-server" }
 
 gitbutler-git = { path = "crates/gitbutler-git" }
 gitbutler-watcher = { path = "crates/gitbutler-watcher" }

--- a/apps/desktop/src/components/diff/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/diff/UnifiedDiffView.svelte
@@ -20,6 +20,7 @@
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { type SelectionId } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
@@ -92,8 +93,13 @@
 	const assignments = $derived(uncommittedService.assignmentsByPath(stackId || null, change.path));
 
 	const ircApiService = inject(IRC_API_SERVICE);
+	const settingsService = inject(SETTINGS_SERVICE);
+	const settingsStore = settingsService.appSettings;
+	const ircEnabled = $derived(
+		($settingsStore?.featureFlags?.irc && $settingsStore?.irc?.connection?.enabled) ?? false,
+	);
 	const fileReactionsQuery = $derived(
-		ircApiService.fileMessageReactions({ filePath: change.path }),
+		ircEnabled ? ircApiService.fileMessageReactions({ filePath: change.path }) : undefined,
 	);
 	const fileReactions = $derived(fileReactionsQuery?.response ?? {});
 

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -31,6 +31,7 @@
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { createCommitSelection } from "$lib/selection/key";
+	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
@@ -59,13 +60,19 @@
 	const stackService = inject(STACK_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const ircApiService = inject(IRC_API_SERVICE);
+	const settingsService = inject(SETTINGS_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
 
 	const projectId = $derived(controller.projectId);
 	const stackId = $derived(controller.stackId);
 
-	const commitReactionsQuery = $derived(ircApiService.commitReactions());
+	const settingsStore = settingsService.appSettings;
+	const ircEnabled = $derived(
+		($settingsStore?.featureFlags?.irc && $settingsStore?.irc?.connection?.enabled) ?? false,
+	);
+
+	const commitReactionsQuery = $derived(ircEnabled ? ircApiService.commitReactions() : undefined);
 	const commitReactions = $derived(commitReactionsQuery?.response ?? {});
 
 	const exclusiveAction = $derived(controller.exclusiveAction);

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -10,6 +10,12 @@ readme = "../../README.md"
 publish = false
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = [
+    # Only referenced via the optional `irc` feature flag
+    "but-server",
+]
+
 [[bin]]
 name = "but"
 path = "src/main.rs"
@@ -24,6 +30,7 @@ legacy = [
     "but-workspace/legacy",
     "but-api/legacy",
     "but-ctx/legacy",
+    "dep:but-server",
     "dep:but-action",
     "dep:but-claude",
     "dep:but-cursor",
@@ -44,6 +51,8 @@ legacy = [
     "dep:gitbutler-repo",
     "dep:gitbutler-repo-actions",
 ]
+## Enable IRC collaboration features (enabled for dev and nightly builds).
+irc = ["but-server?/irc"]
 # Feature that enables profiling related features of the TUI.
 tui-profiling = []
 
@@ -68,6 +77,7 @@ but-llm.workspace = true
 
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.
+but-server = { workspace = true, optional = true }
 but-action = { workspace = true, optional = true }
 # Still uses `gitbutler-stack`, but otherwise it is non-legacy.
 but-hunk-assignment.workspace = true

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -96,7 +96,7 @@ workspace = true
 [features]
 default = ["custom-protocol", "devtools", "opener"]
 ## Enable IRC-based real-time collaboration features.
-irc = ["dep:but-irc"]
+irc = ["dep:but-irc", "but?/irc"]
 #! ## Build- and package-related Options
 ## If enabled, we will pretend to be `but` when the binary filename is `but`.
 builtin-but = ["dep:but", "but-action/builtin-but"]

--- a/crates/gitbutler-tauri/tauri-before-build-command.sh
+++ b/crates/gitbutler-tauri/tauri-before-build-command.sh
@@ -14,6 +14,11 @@ cargo build --release -p gitbutler-git
 if [ "${OS:-}" == "windows" ] || [ "${OS:-}" == "linux" ]; then
   # NOTE: Should run either if the builtin-but feature is *not* selected in `release.sh` (case for Windows), OR if we
   # need the standalone CLI for separate publishing (case for Linux)
-  cargo build --release -p but
+  BUT_FEATURES=""
+  if [ "${CHANNEL:-}" != "release" ]; then
+    BUT_FEATURES="--features irc"
+  fi
+  # shellcheck disable=SC2086
+  cargo build --release -p but $BUT_FEATURES
 fi
 bash ./crates/gitbutler-tauri/inject-git-binaries.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"dev:lite": "turbo watch --filter @gitbutler/lite dev",
 		"dev:desktop": "cross-env CARGO_TARGET_DIR=\"$PNPM_SCRIPT_SRC_DIR/target/tauri\" pnpm dev:desktop-with-env",
 		"dev:desktop-http": "cross-env VITE_BUTLER_PORT=6978 VITE_BUTLER_HOST=localhost VITE_BUILD_TARGET=web turbo watch dev --filter=...@gitbutler/desktop",
-		"dev:desktop-with-env": "cargo build -p but && cargo build -p gitbutler-git && pnpm tauri dev --features irc",
+		"dev:desktop-with-env": "cargo build -p but --features irc && cargo build -p gitbutler-git && pnpm tauri dev --features irc",
 		"dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
 		"package": "turbo run package",
 		"ui:playwright:install:unit": "turbo run --filter @gitbutler/ui playwright:install:unit",


### PR DESCRIPTION
Gate irc_get_all_commit_reactions and irc_get_file_message_reactions
behind featureFlags.irc && irc.connection.enabled in BranchCommitList
and UnifiedDiffView. Also fix feature flag checks to use optional
chaining consistently.