### PR TITLE
Skip commit/file reaction queries when IRC is disabled

### DIFF
--- a/apps/desktop/src/components/diff/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/diff/UnifiedDiffView.svelte
@@ -20,6 +20,7 @@
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { type SelectionId } from "$lib/selection/key";
 	import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { UI_STATE } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
@@ -92,8 +93,13 @@
 	const assignments = $derived(uncommittedService.assignmentsByPath(stackId || null, change.path));
 
 	const ircApiService = inject(IRC_API_SERVICE);
+	const settingsService = inject(SETTINGS_SERVICE);
+	const settingsStore = settingsService.appSettings;
+	const ircEnabled = $derived(
+		($settingsStore?.featureFlags?.irc && $settingsStore?.irc?.connection?.enabled) ?? false,
+	);
 	const fileReactionsQuery = $derived(
-		ircApiService.fileMessageReactions({ filePath: change.path }),
+		ircEnabled ? ircApiService.fileMessageReactions({ filePath: change.path }) : undefined,
 	);
 	const fileReactions = $derived(fileReactionsQuery?.response ?? {});
 

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -31,6 +31,7 @@
 	import { DEFAULT_FORGE_FACTORY } from "$lib/forge/forgeFactory.svelte";
 	import { IRC_API_SERVICE } from "$lib/irc/ircApiService";
 	import { createCommitSelection } from "$lib/selection/key";
+	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { getStackContext } from "$lib/stacks/stackController.svelte";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
@@ -59,13 +60,19 @@
 	const stackService = inject(STACK_SERVICE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const ircApiService = inject(IRC_API_SERVICE);
+	const settingsService = inject(SETTINGS_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
 
 	const projectId = $derived(controller.projectId);
 	const stackId = $derived(controller.stackId);
 
-	const commitReactionsQuery = $derived(ircApiService.commitReactions());
+	const settingsStore = settingsService.appSettings;
+	const ircEnabled = $derived(
+		($settingsStore?.featureFlags?.irc && $settingsStore?.irc?.connection?.enabled) ?? false,
+	);
+
+	const commitReactionsQuery = $derived(ircEnabled ? ircApiService.commitReactions() : undefined);
 	const commitReactions = $derived(commitReactionsQuery?.response ?? {});
 
 	const exclusiveAction = $derived(controller.exclusiveAction);


### PR DESCRIPTION
Gate irc_get_all_commit_reactions and irc_get_file_message_reactions
behind featureFlags.irc && irc.connection.enabled in BranchCommitList
and UnifiedDiffView.