### PR TITLE
API:  Remove UI* prefix

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -15,13 +15,13 @@ import type {
 	RefInfo,
 	TreeChange,
 	TreeChanges,
-	UICommitCreateResult,
-	UICommitDiscardResult,
-	UICommitInsertBlankResult,
-	UICommitMoveResult,
-	UICommitRewordResult,
-	UIMoveBranchResult,
-	UIMoveChangesResult,
+	CommitCreateResult,
+	CommitDiscardResult,
+	CommitInsertBlankResult,
+	CommitMoveResult,
+	CommitRewordResult,
+	MoveBranchResult,
+	MoveChangesResult,
 	UnifiedPatch,
 	WatcherEvent,
 	WorktreeChanges,
@@ -170,17 +170,15 @@ export interface LiteElectronApi {
 	branchDetails: (params: BranchDetailsParams) => Promise<BranchDetails>;
 	branchDiff: (params: BranchDiffParams) => Promise<TreeChanges>;
 	changesInWorktree: (projectId: string) => Promise<WorktreeChanges>;
-	commitAmend: (params: CommitAmendParams) => Promise<UICommitCreateResult>;
-	commitCreate: (params: CommitCreateParams) => Promise<UICommitCreateResult>;
-	commitDiscard: (params: CommitDiscardParams) => Promise<UICommitDiscardResult>;
+	commitAmend: (params: CommitAmendParams) => Promise<CommitCreateResult>;
+	commitCreate: (params: CommitCreateParams) => Promise<CommitCreateResult>;
+	commitDiscard: (params: CommitDiscardParams) => Promise<CommitDiscardResult>;
 	commitDetailsWithLineStats: (params: CommitDetailsWithLineStatsParams) => Promise<CommitDetails>;
-	commitInsertBlank: (params: CommitInsertBlankParams) => Promise<UICommitInsertBlankResult>;
-	commitMove: (params: CommitMoveParams) => Promise<UICommitMoveResult>;
-	commitReword: (params: CommitRewordParams) => Promise<UICommitRewordResult>;
-	commitMoveChangesBetween: (
-		params: CommitMoveChangesBetweenParams,
-	) => Promise<UIMoveChangesResult>;
-	commitUncommitChanges: (params: CommitUncommitChangesParams) => Promise<UIMoveChangesResult>;
+	commitInsertBlank: (params: CommitInsertBlankParams) => Promise<CommitInsertBlankResult>;
+	commitMove: (params: CommitMoveParams) => Promise<CommitMoveResult>;
+	commitReword: (params: CommitRewordParams) => Promise<CommitRewordResult>;
+	commitMoveChangesBetween: (params: CommitMoveChangesBetweenParams) => Promise<MoveChangesResult>;
+	commitUncommitChanges: (params: CommitUncommitChangesParams) => Promise<MoveChangesResult>;
 	getVersion: () => Promise<string>;
 	headInfo: (projectId: string) => Promise<RefInfo>;
 	listBranches: (
@@ -188,9 +186,9 @@ export interface LiteElectronApi {
 		filter: BranchListingFilter | null,
 	) => Promise<Array<BranchListing>>;
 	listProjects: () => Promise<Array<ProjectForFrontend>>;
-	moveBranch: (params: MoveBranchParams) => Promise<UIMoveBranchResult>;
+	moveBranch: (params: MoveBranchParams) => Promise<MoveBranchResult>;
 	updateBranchName: (params: UpdateBranchNameParams) => Promise<void>;
-	tearOffBranch: (params: TearOffBranchParams) => Promise<UIMoveBranchResult>;
+	tearOffBranch: (params: TearOffBranchParams) => Promise<MoveBranchResult>;
 	ping: (input: string) => Promise<string>;
 	pushStackLegacy: (params: PushStackLegacyParams) => Promise<PushResult>;
 	treeChangeDiffs: (params: TreeChangeDiffParams) => Promise<UnifiedPatch | null>;

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -10,13 +10,13 @@ import type {
 	PushResult,
 	RefInfo,
 	TreeChanges,
-	UICommitCreateResult,
-	UICommitDiscardResult,
-	UICommitInsertBlankResult,
-	UICommitMoveResult,
-	UICommitRewordResult,
-	UIMoveBranchResult,
-	UIMoveChangesResult,
+	CommitCreateResult,
+	CommitDiscardResult,
+	CommitInsertBlankResult,
+	CommitMoveResult,
+	CommitRewordResult,
+	MoveBranchResult,
+	MoveChangesResult,
 	UnifiedPatch,
 	WatcherEvent,
 	WorktreeChanges,
@@ -49,32 +49,29 @@ const api: LiteElectronApi = {
 	changesInWorktree: (projectId) =>
 		ipcRenderer.invoke("workspace:changes-in-worktree", projectId) as Promise<WorktreeChanges>,
 	commitAmend: (params) =>
-		ipcRenderer.invoke("workspace:commit-amend", params) as Promise<UICommitCreateResult>,
+		ipcRenderer.invoke("workspace:commit-amend", params) as Promise<CommitCreateResult>,
 	commitCreate: (params) =>
-		ipcRenderer.invoke("workspace:commit-create", params) as Promise<UICommitCreateResult>,
+		ipcRenderer.invoke("workspace:commit-create", params) as Promise<CommitCreateResult>,
 	commitDiscard: (params) =>
-		ipcRenderer.invoke("workspace:commit-discard", params) as Promise<UICommitDiscardResult>,
+		ipcRenderer.invoke("workspace:commit-discard", params) as Promise<CommitDiscardResult>,
 	commitDetailsWithLineStats: (params) =>
 		ipcRenderer.invoke(
 			"workspace:commit-details-with-line-stats",
 			params,
 		) as Promise<CommitDetails>,
 	commitInsertBlank: (params) =>
-		ipcRenderer.invoke(
-			"workspace:commit-insert-blank",
-			params,
-		) as Promise<UICommitInsertBlankResult>,
+		ipcRenderer.invoke("workspace:commit-insert-blank", params) as Promise<CommitInsertBlankResult>,
 	commitMove: (params) =>
-		ipcRenderer.invoke("workspace:commit-move", params) as Promise<UICommitMoveResult>,
+		ipcRenderer.invoke("workspace:commit-move", params) as Promise<CommitMoveResult>,
 	commitReword: (params) =>
-		ipcRenderer.invoke("workspace:commit-reword", params) as Promise<UICommitRewordResult>,
+		ipcRenderer.invoke("workspace:commit-reword", params) as Promise<CommitRewordResult>,
 	commitMoveChangesBetween: (params) =>
 		ipcRenderer.invoke(
 			"workspace:commit-move-changes-between",
 			params,
-		) as Promise<UIMoveChangesResult>,
+		) as Promise<MoveChangesResult>,
 	commitUncommitChanges: (params) =>
-		ipcRenderer.invoke("workspace:commit-uncommit-changes", params) as Promise<UIMoveChangesResult>,
+		ipcRenderer.invoke("workspace:commit-uncommit-changes", params) as Promise<MoveChangesResult>,
 	getVersion: () => ipcRenderer.invoke("lite:get-version") as Promise<string>,
 	headInfo: (projectId) => ipcRenderer.invoke("workspace:head-info", projectId) as Promise<RefInfo>,
 	listBranches: (projectId, filter) =>
@@ -83,11 +80,11 @@ const api: LiteElectronApi = {
 		>,
 	listProjects: () => ipcRenderer.invoke("projects:list") as Promise<Array<ProjectForFrontend>>,
 	moveBranch: (params) =>
-		ipcRenderer.invoke("workspace:move-branch", params) as Promise<UIMoveBranchResult>,
+		ipcRenderer.invoke("workspace:move-branch", params) as Promise<MoveBranchResult>,
 	updateBranchName: (params) =>
 		ipcRenderer.invoke("workspace:update-branch-name", params) as Promise<void>,
 	tearOffBranch: (params) =>
-		ipcRenderer.invoke("workspace:tear-off-branch", params) as Promise<UIMoveBranchResult>,
+		ipcRenderer.invoke("workspace:tear-off-branch", params) as Promise<MoveBranchResult>,
 	ping: (input) => ipcRenderer.invoke("lite:ping", input) as Promise<string>,
 	pushStackLegacy: (params) =>
 		ipcRenderer.invoke("workspace:push-stack-legacy", params) as Promise<PushResult>,

--- a/apps/lite/ui/src/components/RejectedChanges.tsx
+++ b/apps/lite/ui/src/components/RejectedChanges.tsx
@@ -1,4 +1,4 @@
-import type { RejectionReason, UIRejectedChange } from "@gitbutler/but-sdk";
+import type { RejectionReason, RejectedChange } from "@gitbutler/but-sdk";
 import { type ToastManagerAddOptions } from "@base-ui/react";
 import { Array, pipe } from "effect";
 import { FC } from "react";
@@ -41,7 +41,7 @@ const readableRejectionReason = (reason: RejectionReason): string => {
 };
 
 const RejectedChanges: FC<{
-	rejectedChanges: Array<UIRejectedChange>;
+	rejectedChanges: Array<RejectedChange>;
 }> = ({ rejectedChanges }) => {
 	const pathsByReason = new Map<RejectionReason, Array<string>>();
 
@@ -71,7 +71,7 @@ export const rejectedChangesToastOptions = ({
 	rejectedChanges,
 }: {
 	newCommit?: string | null;
-	rejectedChanges: Array<UIRejectedChange>;
+	rejectedChanges: Array<RejectedChange>;
 }): ToastManagerAddOptions<never> => ({
 	title: newCommit != null ? "Some changes were not committed" : "Failed to create commit",
 	description: <RejectedChanges rejectedChanges={rejectedChanges} />,

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -24,7 +24,7 @@ pub struct MoveBranchResult {
 pub mod json {
     use serde::Serialize;
 
-    use crate::{branch::MoveBranchResult, json::HexHash};
+    use crate::{branch::MoveBranchResult as InternalMoveBranchResult, json::HexHash};
 
     /// JSON sibling of [`but_workspace::branch::apply::Outcome`].
     #[derive(Debug, Serialize)]
@@ -63,8 +63,8 @@ pub mod json {
     #[derive(Debug, Serialize)]
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
-    /// UI type for moving a branch.
-    pub struct UIMoveBranchResult {
+    /// JSON transport type for moving a branch.
+    pub struct MoveBranchResult {
         /// Commits that have been replaced after transplanting a branch.
         /// Maps `oldId → newId`.
         #[cfg_attr(
@@ -74,10 +74,10 @@ pub mod json {
         pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
     }
     #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(UIMoveBranchResult);
+    but_schemars::register_sdk_type!(MoveBranchResult);
 
-    impl From<MoveBranchResult> for UIMoveBranchResult {
-        fn from(value: MoveBranchResult) -> Self {
+    impl From<InternalMoveBranchResult> for MoveBranchResult {
+        fn from(value: InternalMoveBranchResult) -> Self {
             Self {
                 replaced_commits: value
                     .replaced_commits
@@ -200,7 +200,7 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
 ///
 /// This acquires exclusive worktree access from `ctx`, moves `subject_branch`
 /// on top of `target_branch`, and records an oplog snapshot on success.
-#[but_api(napi, json::UIMoveBranchResult)]
+#[but_api(napi, json::MoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn move_branch(
     ctx: &mut but_ctx::Context,
@@ -268,7 +268,7 @@ fn move_branch_impl_with_perm(
 ///
 /// This acquires exclusive worktree access from `ctx`, tears `subject_branch`
 /// out of its current stack, and records an oplog snapshot on success.
-#[but_api(napi, json::UIMoveBranchResult)]
+#[but_api(napi, json::MoveBranchResult)]
 #[instrument(err(Debug))]
 pub fn tear_off_branch(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -12,7 +12,7 @@ use super::types::CommitCreateResult;
 ///
 /// See [`but_workspace::commit::commit_amend()`] for lower-level implementation
 /// details.
-#[but_api(crate::commit::json::UICommitCreateResult)]
+#[but_api(crate::commit::json::CommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_amend_only(
     ctx: &mut but_ctx::Context,
@@ -70,7 +70,7 @@ pub(crate) fn commit_amend_only_impl(
 /// best-effort `AmendCommit` oplog entry if the operation succeeds. For
 /// lower-level implementation details, see
 /// [`but_workspace::commit::commit_amend()`].
-#[but_api(napi, crate::commit::json::UICommitCreateResult)]
+#[but_api(napi, crate::commit::json::CommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_amend(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -17,7 +17,7 @@ use super::types::CommitCreateResult;
 /// This acquires exclusive worktree access from `ctx` before creating the
 /// commit. For lower-level implementation details, see
 /// [`but_workspace::commit::commit_create()`].
-#[but_api(crate::commit::json::UICommitCreateResult)]
+#[but_api(crate::commit::json::CommitCreateResult)]
 #[instrument(err(Debug))]
 pub fn commit_create_only(
     ctx: &mut but_ctx::Context,
@@ -91,7 +91,7 @@ pub(crate) fn commit_create_only_impl(
 /// a best-effort `CreateCommit` oplog snapshot using the same lock. For
 /// lower-level implementation details, see
 /// [`but_workspace::commit::commit_create()`].
-#[but_api(napi, crate::commit::json::UICommitCreateResult)]
+#[but_api(napi, crate::commit::json::CommitCreateResult)]
 #[instrument(skip_all, fields(relative_to, side, message), err(Debug))]
 pub fn commit_create(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -8,7 +8,7 @@ use crate::commit::types::CommitDiscardResult;
 
 /// Discard `subject_commit_id` using the behavior described by
 /// [`commit_discard_only_with_perm()`].
-#[but_api(crate::commit::json::UICommitDiscardResult)]
+#[but_api(crate::commit::json::CommitDiscardResult)]
 pub fn commit_discard_only(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
@@ -44,7 +44,7 @@ pub fn commit_discard_only_with_perm(
 
 /// Discard `subject_commit_id` using the behavior described by
 /// [`commit_discard_with_perm()`].
-#[but_api(napi, crate::commit::json::UICommitDiscardResult)]
+#[but_api(napi, crate::commit::json::CommitDiscardResult)]
 #[instrument(err(Debug))]
 pub fn commit_discard(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/insert_blank.rs
+++ b/crates/but-api/src/commit/insert_blank.rs
@@ -12,7 +12,7 @@ use super::types::CommitInsertBlankResult;
 /// Inserts a blank commit on `side` of `relative_to`.
 ///
 /// `side` chooses whether the blank commit lands before or after `relative_to`.
-#[but_api(crate::commit::json::UICommitInsertBlankResult)]
+#[but_api(crate::commit::json::CommitInsertBlankResult)]
 #[instrument(err(Debug))]
 pub fn commit_insert_blank_only(
     ctx: &mut but_ctx::Context,
@@ -50,7 +50,7 @@ pub(crate) fn commit_insert_blank_only_impl(
 /// snapshot on success.
 ///
 /// For details, see [`commit_insert_blank_with_perm()`].
-#[but_api(napi, crate::commit::json::UICommitInsertBlankResult)]
+#[but_api(napi, crate::commit::json::CommitInsertBlankResult)]
 #[instrument(err(Debug))]
 pub fn commit_insert_blank(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -1,18 +1,20 @@
 use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 
-use crate::{commit::types::CommitDiscardResult, json::HexHash};
+use crate::{commit::types::CommitDiscardResult as EngineCommitDiscardResult, json::HexHash};
 
 use super::types::{
-    CommitCreateResult, CommitInsertBlankResult, CommitMoveResult, CommitRewordResult,
-    CommitSquashResult, MoveChangesResult,
+    CommitCreateResult as EngineCommitCreateResult,
+    CommitInsertBlankResult as EngineCommitInsertBlankResult,
+    CommitMoveResult as EngineCommitMoveResult, CommitRewordResult as EngineCommitRewordResult,
+    CommitSquashResult as EngineCommitSquashResult, MoveChangesResult as EngineMoveChangesResult,
 };
 
-/// UI type for a move changes between commits result.
+/// JSON transport type for moving changes between commits.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UIMoveChangesResult {
+pub struct MoveChangesResult {
     /// Commits that have been mapped from one thing to another.
     /// Maps `oldId -> newId`.
     #[cfg_attr(
@@ -23,11 +25,11 @@ pub struct UIMoveChangesResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UIMoveChangesResult);
+but_schemars::register_sdk_type!(MoveChangesResult);
 
-impl From<MoveChangesResult> for UIMoveChangesResult {
-    fn from(value: MoveChangesResult) -> Self {
-        let MoveChangesResult { replaced_commits } = value;
+impl From<EngineMoveChangesResult> for MoveChangesResult {
+    fn from(value: EngineMoveChangesResult) -> Self {
+        let EngineMoveChangesResult { replaced_commits } = value;
 
         Self {
             replaced_commits: replaced_commits
@@ -42,7 +44,7 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UIRejectedChange {
+pub struct RejectedChange {
     /// The reason the change was rejected.
     pub reason: but_core::tree::create_tree::RejectionReason,
     /// The file path of the rejected change, potentially degenerated if it can't be represented in Unicode.
@@ -56,18 +58,18 @@ pub struct UIRejectedChange {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UIRejectedChange);
+but_schemars::register_sdk_type!(RejectedChange);
 
-/// UI type for creating a commit in the rebase graph.
+/// JSON transport type for creating a commit in the rebase graph.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitCreateResult {
+pub struct CommitCreateResult {
     /// The new commit if one was created.
     #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
     pub new_commit: Option<HexHash>,
     /// Changes that were rejected during commit creation.
-    pub rejected_changes: Vec<UIRejectedChange>,
+    pub rejected_changes: Vec<RejectedChange>,
     /// Commits that have been replaced as a side-effect of the create/amend.
     /// Maps `oldId -> newId`.
     #[cfg_attr(
@@ -78,11 +80,11 @@ pub struct UICommitCreateResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitCreateResult);
+but_schemars::register_sdk_type!(CommitCreateResult);
 
-impl From<CommitCreateResult> for UICommitCreateResult {
-    fn from(value: CommitCreateResult) -> Self {
-        let CommitCreateResult {
+impl From<EngineCommitCreateResult> for CommitCreateResult {
+    fn from(value: EngineCommitCreateResult) -> Self {
+        let EngineCommitCreateResult {
             new_commit,
             rejected_specs,
             replaced_commits,
@@ -92,7 +94,7 @@ impl From<CommitCreateResult> for UICommitCreateResult {
             new_commit: new_commit.map(Into::into),
             rejected_changes: rejected_specs
                 .into_iter()
-                .map(|(reason, diff)| UIRejectedChange {
+                .map(|(reason, diff)| RejectedChange {
                     reason,
                     path: diff.path.to_str_lossy().into(),
                     path_bytes: diff.path,
@@ -106,11 +108,11 @@ impl From<CommitCreateResult> for UICommitCreateResult {
     }
 }
 
-/// UI type for rewording a commit.
+/// JSON transport type for rewording a commit.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitRewordResult {
+pub struct CommitRewordResult {
     /// The new commit ID after rewording.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
@@ -124,11 +126,11 @@ pub struct UICommitRewordResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitRewordResult);
+but_schemars::register_sdk_type!(CommitRewordResult);
 
-impl From<CommitRewordResult> for UICommitRewordResult {
-    fn from(value: CommitRewordResult) -> Self {
-        let CommitRewordResult {
+impl From<EngineCommitRewordResult> for CommitRewordResult {
+    fn from(value: EngineCommitRewordResult) -> Self {
+        let EngineCommitRewordResult {
             new_commit,
             replaced_commits,
         } = value;
@@ -143,11 +145,11 @@ impl From<CommitRewordResult> for UICommitRewordResult {
     }
 }
 
-/// UI type for squashing commits.
+/// JSON transport type for squashing commits.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitSquashResult {
+pub struct CommitSquashResult {
     /// The new commit ID after squashing.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
@@ -161,11 +163,11 @@ pub struct UICommitSquashResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitSquashResult);
+but_schemars::register_sdk_type!(CommitSquashResult);
 
-impl From<CommitSquashResult> for UICommitSquashResult {
-    fn from(value: CommitSquashResult) -> Self {
-        let CommitSquashResult {
+impl From<EngineCommitSquashResult> for CommitSquashResult {
+    fn from(value: EngineCommitSquashResult) -> Self {
+        let EngineCommitSquashResult {
             new_commit,
             replaced_commits,
         } = value;
@@ -180,11 +182,11 @@ impl From<CommitSquashResult> for UICommitSquashResult {
     }
 }
 
-/// UI type for inserting a blank commit.
+/// JSON transport type for inserting a blank commit.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitInsertBlankResult {
+pub struct CommitInsertBlankResult {
     /// The new blank commit ID.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub new_commit: HexHash,
@@ -198,11 +200,11 @@ pub struct UICommitInsertBlankResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitInsertBlankResult);
+but_schemars::register_sdk_type!(CommitInsertBlankResult);
 
-impl From<CommitInsertBlankResult> for UICommitInsertBlankResult {
-    fn from(value: CommitInsertBlankResult) -> Self {
-        let CommitInsertBlankResult {
+impl From<EngineCommitInsertBlankResult> for CommitInsertBlankResult {
+    fn from(value: EngineCommitInsertBlankResult) -> Self {
+        let EngineCommitInsertBlankResult {
             new_commit,
             replaced_commits,
         } = value;
@@ -217,11 +219,11 @@ impl From<CommitInsertBlankResult> for UICommitInsertBlankResult {
     }
 }
 
-/// UI type for moving a commit.
+/// JSON transport type for moving a commit.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitMoveResult {
+pub struct CommitMoveResult {
     /// Commits that have been replaced as a side-effect of the move.
     /// Maps `oldId -> newId`.
     #[cfg_attr(
@@ -232,11 +234,11 @@ pub struct UICommitMoveResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitMoveResult);
+but_schemars::register_sdk_type!(CommitMoveResult);
 
-impl From<CommitMoveResult> for UICommitMoveResult {
-    fn from(value: CommitMoveResult) -> Self {
-        let CommitMoveResult { replaced_commits } = value;
+impl From<EngineCommitMoveResult> for CommitMoveResult {
+    fn from(value: EngineCommitMoveResult) -> Self {
+        let EngineCommitMoveResult { replaced_commits } = value;
 
         Self {
             replaced_commits: replaced_commits
@@ -246,11 +248,11 @@ impl From<CommitMoveResult> for UICommitMoveResult {
         }
     }
 }
-/// UI type for discarding a commit.
+/// JSON transport type for discarding a commit.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UICommitDiscardResult {
+pub struct CommitDiscardResult {
     /// The commit that was discarded as a result of this operation.
     #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
     pub discarded_commit: HexHash,
@@ -264,11 +266,11 @@ pub struct UICommitDiscardResult {
 }
 
 #[cfg(feature = "export-schema")]
-but_schemars::register_sdk_type!(UICommitDiscardResult);
+but_schemars::register_sdk_type!(CommitDiscardResult);
 
-impl From<CommitDiscardResult> for UICommitDiscardResult {
-    fn from(value: CommitDiscardResult) -> Self {
-        let CommitDiscardResult {
+impl From<EngineCommitDiscardResult> for CommitDiscardResult {
+    fn from(value: EngineCommitDiscardResult) -> Self {
+        let EngineCommitDiscardResult {
             replaced_commits,
             discarded_commit,
         } = value;

--- a/crates/but-api/src/commit/move_changes.rs
+++ b/crates/but-api/src/commit/move_changes.rs
@@ -12,7 +12,7 @@ use super::types::MoveChangesResult;
 /// changes.
 ///
 /// For details, see [`commit_move_changes_between_only_with_perm()`].
-#[but_api(crate::commit::json::UIMoveChangesResult)]
+#[but_api(crate::commit::json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_move_changes_between_only(
     ctx: &mut but_ctx::Context,
@@ -69,7 +69,7 @@ pub fn commit_move_changes_between_only_with_perm(
 /// changes.
 ///
 /// For details, see [`commit_move_changes_between_with_perm()`].
-#[but_api(napi, crate::commit::json::UIMoveChangesResult)]
+#[but_api(napi, crate::commit::json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_move_changes_between(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -15,7 +15,7 @@ use super::types::CommitMoveResult;
 /// commit.
 ///
 /// For details, see [`commit_move_only_with_perm()`].
-#[but_api(crate::commit::json::UICommitMoveResult)]
+#[but_api(crate::commit::json::CommitMoveResult)]
 pub fn commit_move_only(
     ctx: &mut but_ctx::Context,
     subject_commit_id: gix::ObjectId,
@@ -65,7 +65,7 @@ pub fn commit_move_only_with_perm(
 /// commit.
 ///
 /// For details, see [`commit_move_with_perm()`].
-#[but_api(napi, crate::commit::json::UICommitMoveResult)]
+#[but_api(napi, crate::commit::json::CommitMoveResult)]
 #[instrument(err(Debug))]
 pub fn commit_move(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/reword.rs
+++ b/crates/but-api/src/commit/reword.rs
@@ -15,7 +15,7 @@ use super::types::CommitRewordResult;
 /// `message` must be the full commit message payload: the title line, and when a
 /// body is present, `\n\n` followed by the body.
 /// See [`commit_reword_only_with_perm()`] for details.
-#[but_api(crate::commit::json::UICommitRewordResult)]
+#[but_api(crate::commit::json::CommitRewordResult)]
 #[instrument(err(Debug))]
 pub fn commit_reword_only(
     ctx: &mut but_ctx::Context,
@@ -60,7 +60,7 @@ pub fn commit_reword_only_with_perm(
 ///
 /// This acquires exclusive worktree access from `ctx` before rewriting the
 /// commit message and recording the oplog entry.
-#[but_api(napi, crate::commit::json::UICommitRewordResult)]
+#[but_api(napi, crate::commit::json::CommitRewordResult)]
 #[instrument(err(Debug))]
 pub fn commit_reword(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/squash.rs
+++ b/crates/but-api/src/commit/squash.rs
@@ -12,7 +12,7 @@ use super::types::CommitSquashResult;
 /// commits.
 ///
 /// For details, see [`commit_squash_only_with_perm()`].
-#[but_api(crate::commit::json::UICommitSquashResult)]
+#[but_api(crate::commit::json::CommitSquashResult)]
 #[instrument(err(Debug))]
 pub fn commit_squash_only(
     ctx: &mut but_ctx::Context,
@@ -64,7 +64,7 @@ pub fn commit_squash_only_with_perm(
 /// commits.
 ///
 /// For details, see [`commit_squash_with_perm()`].
-#[but_api(napi, crate::commit::json::UICommitSquashResult)]
+#[but_api(napi, crate::commit::json::CommitSquashResult)]
 #[instrument(err(Debug))]
 pub fn commit_squash(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -15,7 +15,7 @@ use super::types::MoveChangesResult;
 /// changes.
 ///
 /// See [`commit_uncommit_changes_only_with_perm()`] for details.
-#[but_api(crate::commit::json::UIMoveChangesResult)]
+#[but_api(crate::commit::json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_uncommit_changes_only(
     ctx: &mut but_ctx::Context,
@@ -114,7 +114,7 @@ pub fn commit_uncommit_changes_only_with_perm(
 /// changes.
 ///
 /// See [`commit_uncommit_changes_with_perm()`] for details.
-#[but_api(napi, crate::commit::json::UIMoveChangesResult)]
+#[but_api(napi, crate::commit::json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn commit_uncommit_changes(
     ctx: &mut but_ctx::Context,

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -23,23 +23,22 @@ use tracing::instrument;
 use crate::json::HexHash;
 
 mod json {
-    use but_workspace::legacy::MoveChangesResult;
+    use but_workspace::legacy::MoveChangesResult as LegacyMoveChangesResult;
     use serde::Serialize;
 
     use crate::json::HexHash;
 
-    /// UI type for a move changes between commits result.
+    /// JSON transport type for moving changes between commits.
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
-    /// UI type for a move changes between commits result
-    pub struct UIMoveChangesResult {
+    pub struct MoveChangesResult {
         /// Commits that have been mapped from one thing to another
         pub replaced_commits: Vec<(HexHash, HexHash)>,
     }
 
-    impl From<MoveChangesResult> for UIMoveChangesResult {
-        fn from(value: MoveChangesResult) -> Self {
-            let MoveChangesResult { replaced_commits } = value;
+    impl From<LegacyMoveChangesResult> for MoveChangesResult {
+        fn from(value: LegacyMoveChangesResult) -> Self {
+            let LegacyMoveChangesResult { replaced_commits } = value;
 
             Self {
                 replaced_commits: replaced_commits
@@ -435,7 +434,7 @@ pub fn discard_worktree_changes(
     Ok(refused)
 }
 
-#[but_api(json::UIMoveChangesResult)]
+#[but_api(json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn move_changes_between_commits(
     ctx: &mut Context,
@@ -466,7 +465,7 @@ pub fn move_changes_between_commits(
     Ok(result)
 }
 
-#[but_api(json::UIMoveChangesResult)]
+#[but_api(json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn split_branch(
     ctx: &mut Context,
@@ -510,7 +509,7 @@ pub fn split_branch(
     Ok(move_changes_result)
 }
 
-#[but_api(json::UIMoveChangesResult)]
+#[but_api(json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn split_branch_into_dependent_branch(
     ctx: &mut but_ctx::Context,
@@ -545,7 +544,7 @@ pub fn split_branch_into_dependent_branch(
 /// If `assign_to` is provided, the changes will be assigned to the stack
 /// specified.
 /// If `assign_to` is not provided, the changes will be unassigned.
-#[but_api(json::UIMoveChangesResult)]
+#[but_api(json::MoveChangesResult)]
 #[instrument(err(Debug))]
 pub fn uncommit_changes(
     ctx: &mut Context,

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -76,7 +76,7 @@ export declare function changesInWorktreeWithPerm(projectId: string): Promise<Wo
  * lower-level implementation details, see
  * [`but_workspace::commit::commit_amend()`].
  */
-export declare function commitAmend(projectId: string, commitId: string, changes: Array<DiffSpec>): Promise<UICommitCreateResult>
+export declare function commitAmend(projectId: string, commitId: string, changes: Array<DiffSpec>): Promise<CommitCreateResult>
 
 /**
  * Insert a new commit built from `changes` and record an oplog snapshot on
@@ -88,7 +88,7 @@ export declare function commitAmend(projectId: string, commitId: string, changes
  * lower-level implementation details, see
  * [`but_workspace::commit::commit_create()`].
  */
-export declare function commitCreate(projectId: string, relativeTo: RelativeTo, side: InsertSide, changes: Array<DiffSpec>, message: string): Promise<UICommitCreateResult>
+export declare function commitCreate(projectId: string, relativeTo: RelativeTo, side: InsertSide, changes: Array<DiffSpec>, message: string): Promise<CommitCreateResult>
 
 /**
  * Computes commit details for `commit_id` with line statistics enabled.
@@ -102,7 +102,7 @@ export declare function commitDetailsWithLineStats(projectId: string, commitId: 
  * Discard `subject_commit_id` using the behavior described by
  * [`commit_discard_with_perm()`].
  */
-export declare function commitDiscard(projectId: string, subjectCommitId: string): Promise<UICommitDiscardResult>
+export declare function commitDiscard(projectId: string, subjectCommitId: string): Promise<CommitDiscardResult>
 
 /**
  * Inserts a blank commit on `side` of `relative_to` and records an oplog
@@ -110,7 +110,7 @@ export declare function commitDiscard(projectId: string, subjectCommitId: string
  *
  * For details, see [`commit_insert_blank_with_perm()`].
  */
-export declare function commitInsertBlank(projectId: string, relativeTo: RelativeTo, side: InsertSide): Promise<UICommitInsertBlankResult>
+export declare function commitInsertBlank(projectId: string, relativeTo: RelativeTo, side: InsertSide): Promise<CommitInsertBlankResult>
 
 /**
  * Moves `subject_commit_id` to `side` of `relative_to` and records an oplog
@@ -121,7 +121,7 @@ export declare function commitInsertBlank(projectId: string, relativeTo: Relativ
  *
  * For details, see [`commit_move_with_perm()`].
  */
-export declare function commitMove(projectId: string, subjectCommitId: string, relativeTo: RelativeTo, side: InsertSide): Promise<UICommitMoveResult>
+export declare function commitMove(projectId: string, subjectCommitId: string, relativeTo: RelativeTo, side: InsertSide): Promise<CommitMoveResult>
 
 /**
  * Moves `changes` from `source_commit_id` to `destination_commit_id` and
@@ -132,7 +132,7 @@ export declare function commitMove(projectId: string, subjectCommitId: string, r
  *
  * For details, see [`commit_move_changes_between_with_perm()`].
  */
-export declare function commitMoveChangesBetween(projectId: string, sourceCommitId: string, destinationCommitId: string, changes: Array<DiffSpec>): Promise<UIMoveChangesResult>
+export declare function commitMoveChangesBetween(projectId: string, sourceCommitId: string, destinationCommitId: string, changes: Array<DiffSpec>): Promise<MoveChangesResult>
 
 /**
  * Reword `commit_id` to `message` using the behavior described by
@@ -141,7 +141,7 @@ export declare function commitMoveChangesBetween(projectId: string, sourceCommit
  * This acquires exclusive worktree access from `ctx` before rewriting the
  * commit message and recording the oplog entry.
  */
-export declare function commitReword(projectId: string, commitId: string, message: string): Promise<UICommitRewordResult>
+export declare function commitReword(projectId: string, commitId: string, message: string): Promise<CommitRewordResult>
 
 /**
  * Squash `subject_commit_id` into `target_commit_id` and record an oplog
@@ -152,7 +152,7 @@ export declare function commitReword(projectId: string, commitId: string, messag
  *
  * For details, see [`commit_squash_with_perm()`].
  */
-export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string): Promise<UICommitSquashResult>
+export declare function commitSquash(projectId: string, subjectCommitId: string, targetCommitId: string): Promise<CommitSquashResult>
 
 /**
  * Extract `changes` from `commit_id` and record the rewrite in the oplog.
@@ -162,7 +162,7 @@ export declare function commitSquash(projectId: string, subjectCommitId: string,
  *
  * See [`commit_uncommit_changes_with_perm()`] for details.
  */
-export declare function commitUncommitChanges(projectId: string, commitId: string, changes: Array<DiffSpec>, assignTo: string | null): Promise<UIMoveChangesResult>
+export declare function commitUncommitChanges(projectId: string, commitId: string, changes: Array<DiffSpec>, assignTo: string | null): Promise<MoveChangesResult>
 
 /**
  * Get the forge provider name.
@@ -197,7 +197,7 @@ export declare function mergeReview(projectId: string, reviewId: number): Promis
  * This acquires exclusive worktree access from `ctx`, moves `subject_branch`
  * on top of `target_branch`, and records an oplog snapshot on success.
  */
-export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string): Promise<UIMoveBranchResult>
+export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string): Promise<MoveBranchResult>
 
 export declare function publishReview(projectId: string, params: CreateForgeReviewParams): Promise<ForgeReview>
 
@@ -240,7 +240,7 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  * This acquires exclusive worktree access from `ctx`, tears `subject_branch`
  * out of its current stack, and records an oplog snapshot on success.
  */
-export declare function tearOffBranch(projectId: string, subjectBranch: string): Promise<UIMoveBranchResult>
+export declare function tearOffBranch(projectId: string, subjectBranch: string): Promise<MoveBranchResult>
 
 /**
  * Produces a unified patch for `change`.
@@ -592,6 +592,19 @@ export type CommitAbsorption = {
   reason: AbsorptionReason;
 };
 
+/** JSON transport type for creating a commit in the rebase graph. */
+export type CommitCreateResult = {
+  /** The new commit if one was created. */
+  newCommit?: string | null;
+  /** Changes that were rejected during commit creation. */
+  rejectedChanges: Array<RejectedChange>;
+  /**
+   * Commits that have been replaced as a side-effect of the create/amend.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
 /** The JSON sibling of [but_core::diff::CommitDetails]. */
 export type CommitDetails = {
   /** The commit itself. */
@@ -602,6 +615,59 @@ export type CommitDetails = {
   stats?: LineStats | null;
   /** Conflicting entries in `commit` as stored in the conflict commit metadata. */
   conflictEntries?: ConflictEntries | null;
+};
+
+/** JSON transport type for discarding a commit. */
+export type CommitDiscardResult = {
+  /** The commit that was discarded as a result of this operation. */
+  discardedCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the commit discard.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** JSON transport type for inserting a blank commit. */
+export type CommitInsertBlankResult = {
+  /** The new blank commit ID. */
+  newCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the insertion.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** JSON transport type for moving a commit. */
+export type CommitMoveResult = {
+  /**
+   * Commits that have been replaced as a side-effect of the move.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** JSON transport type for rewording a commit. */
+export type CommitRewordResult = {
+  /** The new commit ID after rewording. */
+  newCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the reword.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** JSON transport type for squashing commits. */
+export type CommitSquashResult = {
+  /** The new commit ID after squashing. */
+  newCommit: string;
+  /**
+   * Commits that have been replaced as a side-effect of the squash.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
 };
 
 /** Represents the state a commit could be in. */
@@ -988,6 +1054,24 @@ export type MetadataRefInfo = {
 
 export type ModeFlags = "ExecutableBitAdded" | "ExecutableBitRemoved" | "TypeChangeFileToLink" | "TypeChangeLinkToFile" | "TypeChange";
 
+/** JSON transport type for moving a branch. */
+export type MoveBranchResult = {
+  /**
+   * Commits that have been replaced after transplanting a branch.
+   * Maps `oldId → newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
+/** JSON transport type for moving changes between commits. */
+export type MoveChangesResult = {
+  /**
+   * Commits that have been mapped from one thing to another.
+   * Maps `oldId -> newId`.
+   */
+  replacedCommits: Record<string, string>;
+};
+
 export type OperatingMode = {
   type: "OpenWorkspace";
 } | {
@@ -1114,6 +1198,16 @@ export type RefInfo = {
   isManagedCommit: boolean;
   /** The workspace represents what `HEAD` is pointing to. */
   isEntrypoint: boolean;
+};
+
+/** A change that was rejected during commit creation, with the reason for rejection. */
+export type RejectedChange = {
+  /** The reason the change was rejected. */
+  reason: RejectionReason;
+  /** The file path of the rejected change, potentially degenerated if it can't be represented in Unicode. */
+  path: string;
+  /** `path` without degeneration, as plain bytes. */
+  pathBytes: Array<number>;
 };
 
 /** Provide a description of why a [`crate::DiffSpec`] was rejected for application to the tree of a commit. */
@@ -1326,100 +1420,6 @@ export type TreeStatus = {
     state: ChangeState;
     flags?: ModeFlags | null;
   };
-};
-
-/** UI type for creating a commit in the rebase graph. */
-export type UICommitCreateResult = {
-  /** The new commit if one was created. */
-  newCommit?: string | null;
-  /** Changes that were rejected during commit creation. */
-  rejectedChanges: Array<UIRejectedChange>;
-  /**
-   * Commits that have been replaced as a side-effect of the create/amend.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for discarding a commit. */
-export type UICommitDiscardResult = {
-  /** The commit that was discarded as a result of this operation. */
-  discardedCommit: string;
-  /**
-   * Commits that have been replaced as a side-effect of the commit discard.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for inserting a blank commit. */
-export type UICommitInsertBlankResult = {
-  /** The new blank commit ID. */
-  newCommit: string;
-  /**
-   * Commits that have been replaced as a side-effect of the insertion.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for moving a commit. */
-export type UICommitMoveResult = {
-  /**
-   * Commits that have been replaced as a side-effect of the move.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for rewording a commit. */
-export type UICommitRewordResult = {
-  /** The new commit ID after rewording. */
-  newCommit: string;
-  /**
-   * Commits that have been replaced as a side-effect of the reword.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for squashing commits. */
-export type UICommitSquashResult = {
-  /** The new commit ID after squashing. */
-  newCommit: string;
-  /**
-   * Commits that have been replaced as a side-effect of the squash.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for moving a branch. */
-export type UIMoveBranchResult = {
-  /**
-   * Commits that have been replaced after transplanting a branch.
-   * Maps `oldId → newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** UI type for a move changes between commits result. */
-export type UIMoveChangesResult = {
-  /**
-   * Commits that have been mapped from one thing to another.
-   * Maps `oldId -> newId`.
-   */
-  replacedCommits: Record<string, string>;
-};
-
-/** A change that was rejected during commit creation, with the reason for rejection. */
-export type UIRejectedChange = {
-  /** The reason the change was rejected. */
-  reason: RejectionReason;
-  /** The file path of the rejected change, potentially degenerated if it can't be represented in Unicode. */
-  path: string;
-  /** `path` without degeneration, as plain bytes. */
-  pathBytes: Array<number>;
 };
 
 /**


### PR DESCRIPTION
Remove the unnecessary prefix UI* from the exported types, as it’s not needed (nor does it make sense) anymore.