### PR TITLE
git2 to gix (the final feasible one) - truncated to just one improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,9 +344,16 @@ gix-imara-diff = { opt-level = 3 }
 but-graph = { opt-level = 3 }
 gix = { opt-level = 3 }
 gix-diff = { opt-level = 3 }
+gix-glob = { opt-level = 3 }
+gix-attributes = { opt-level = 3 }
+gix-ignore = { opt-level = 3 }
+chardetng = { opt-level = 3 }
+gix-index = { opt-level = 3 }
+gix-odb = { opt-level = 3 }
 gix-object = { opt-level = 3 }
 gix-ref = { opt-level = 3 }
 gix-pack = { opt-level = 3 }
+gix-features = { opt-level = 3 }
 gix-hash = { opt-level = 3 }
 gix-actor = { opt-level = 3 }
 gix-config = { opt-level = 3 }

--- a/crates/but-hunk-dependency/Cargo.toml
+++ b/crates/but-hunk-dependency/Cargo.toml
@@ -18,6 +18,7 @@ but-serde.workspace = true
 but-ctx = { workspace = true }
 but-graph.workspace = true
 
+tracing.workspace = true
 anyhow.workspace = true
 itertools.workspace = true
 serde.workspace = true

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -133,6 +133,7 @@ pub use input::{InputCommit, InputDiffHunk, InputFile, InputStack};
 
 mod ranges;
 pub use ranges::{CalculationError, HunkRange, WorkspaceRanges};
+use tracing::instrument;
 
 use crate::ui::HunkLockTarget;
 
@@ -142,6 +143,7 @@ pub mod ui;
 mod utils;
 
 /// Produce one [`InputStack`] instance for each [`but_graph::projection::Stack`] for use in [`WorkspaceRanges::try_from_stacks`].
+#[instrument(skip_all, err(Debug))]
 pub fn new_stacks_to_input_stacks(
     repo: &gix::Repository,
     workspace: &but_graph::projection::Workspace,


### PR DESCRIPTION
> Probably a last step before the boundaries have to be tackled, which requires additions to `gix`.

Actually, it's already done and no more meaningful progress can be made without providing the missing primitives.

* index to tree
* checkout
* tests should be replaceable by initial setup scripts, but needs proper prompting.

Follow-up on #13093.

### Tasks

* [x] refackiew
    - LLM gets more desperate, review needs care, and that's probably it without providing missing primitives 

### For the reviewer

`tauri dev` is super slow and adding more crates to `Cargo.toml` doesn't seem to work. `tauri dev --release` doesn't bring up the GUI for me.
Turned out to be but-hunk-dependencies, which now at least show up in the traces.
I'd think that some operations are now faster in dev-mode though.

### Related

* https://github.com/gitbutlerapp/gitbutler/issues/12636
