### PR TITLE
add-kitty-terminal

### DIFF
--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -78,6 +78,7 @@
 		{ identifier: "alacritty-mac", displayName: "Alacritty", platform: "macos" },
 		{ identifier: "wezterm-mac", displayName: "WezTerm", platform: "macos" },
 		{ identifier: "hyper", displayName: "Hyper", platform: "macos" },
+		{ identifier: "kitty", displayName: "Kitty", platform: "macos" },
 		// Windows
 		{ identifier: "wt", displayName: "Windows Terminal", platform: "windows" },
 		{ identifier: "powershell", displayName: "PowerShell", platform: "windows" },
@@ -91,6 +92,7 @@
 		{ identifier: "warp", displayName: "Warp", platform: "linux" },
 		{ identifier: "hyper", displayName: "Hyper", platform: "linux" },
 		{ identifier: "wezterm", displayName: "WezTerm", platform: "linux" },
+		{ identifier: "kitty", displayName: "Kitty", platform: "linux" },
 	];
 
 	const terminalOptions = allTerminalOptions.filter((t) => t.platform === platformName);

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -216,8 +216,10 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
                 .status()
                 .context("Failed to run 'open -Ra' to check application availability")?;
             if !status.success() {
-                return Err(anyhow::anyhow!("'{app_name}' was not found.")
-                    .context(but_error::Code::DefaultTerminalNotFound));
+                return Err(anyhow::anyhow!(
+                    "'{app_name}' was not found - `open -Ra {app_name}` failed."
+                )
+                .context(but_error::Code::DefaultTerminalNotFound));
             }
             Ok(())
         }

--- a/crates/but-api/src/legacy/open.rs
+++ b/crates/but-api/src/legacy/open.rs
@@ -118,6 +118,7 @@ pub fn open_url(url: String) -> Result<()> {
 /// - `alacritty-mac` - Alacritty
 /// - `wezterm-mac` - WezTerm
 /// - `hyper` - Hyper
+/// - `kitty` - Kitty
 ///
 /// **Windows:**
 /// - `wt` - Windows Terminal
@@ -133,6 +134,7 @@ pub fn open_url(url: String) -> Result<()> {
 /// - `warp` - Warp
 /// - `hyper` - Hyper
 /// - `wezterm` - WezTerm
+/// - `kitty` - Kitty
 ///
 /// # Errors
 /// Returns an error if:
@@ -245,6 +247,7 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
                     .arg(&path);
                 run_terminal_command(cmd, "Alacritty", &path)?;
             }
+            "kitty" => open_with_path("kitty", Some("Kitty"))?,
             // WezTerm does not support `open -a WezTerm <path>`. Their docs state you have to use their CLI.
             // https://wezterm.org/config/launch.html#specifying-the-current-working-directory
             "wezterm-mac" => {
@@ -271,15 +274,18 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
         // a vague launch failure (which could be confused with path issues).
         let binary_found = which::which(binary).is_ok();
         if !binary_found {
-            return Err(anyhow::anyhow!("'{binary}' was not found.")
-                .context(but_error::Code::DefaultTerminalNotFound));
+            return Err(anyhow::anyhow!(
+                "'{binary}' was not found. Make sure it is installed and available on your PATH."
+            )
+            .context(but_error::Code::DefaultTerminalNotFound));
         }
 
         match terminal_id.as_str() {
             // Terminals that inherit parent process CWD (no explicit flags needed).
             // Note: `binary` is used instead of the terminal ID because some terminals
             // have a different binary name (e.g. "warp" launches "warp-terminal").
-            "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "ghostty" | "warp" => {
+            "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "ghostty" | "warp"
+            | "kitty" => {
                 let mut cmd = Command::new(binary);
                 cmd.current_dir(&path);
                 spawn_and_reap(cmd, binary, &path)?;


### PR DESCRIPTION
## 🧢 Changes

- Adds Kitty to supported terminals on MacOS
- Adds Kitty to supported terminals on Linux.

## ☕️ Reasoning

The "Open in terminal" feature already implements a bunch of terminals, but we are not supporting the Kitty terminal. This is a oversight.

Windows is not supported by Kitty, so not in scope.

Related to https://github.com/gitbutlerapp/gitbutler/pull/11878

## 🎫 Affected issues

Fixes: #13067

## 📌 Todos
- [x] Test Kitty on MacOS
- Works
- [x] Test Kitty on Linux
- [x] Squash commits into single commit

For testing the changes, you can download Kitty as instructed on [their website](https://sw.kovidgoyal.net/kitty/binary/)
`curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin`

Then select your terminal in the GB settings and try the Open in Terminal command