### PR TITLE
Don't hide the TUI subcommand

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1155,7 +1155,7 @@ pub enum Subcommands {
     EvalHook,
 
     /// Show an interactive TUI.
-    #[clap(verbatim_doc_comment, hide = true)]
+    #[clap(verbatim_doc_comment)]
     #[cfg(feature = "legacy")]
     Tui {
         /// Show debug pane with selected-line metadata.


### PR DESCRIPTION
I think the TUI is in a decent enough state where we don't need to hide the subcommand. It was also mentioned in the latest release notes.