### PR TITLE
Fix shutdown deadlock in file-monitor/BlockingPool interaction

### DIFF
--- a/crates/gitbutler-watcher/src/lib.rs
+++ b/crates/gitbutler-watcher/src/lib.rs
@@ -8,16 +8,13 @@ use anyhow::Result;
 use but_ctx::ProjectHandleOrLegacyProjectId;
 use but_settings::AppSettingsWithDiskSync;
 pub use handler::Handler;
-use tokio::{
-    sync::mpsc::{UnboundedSender, unbounded_channel},
-    task,
-};
+use tokio::{sync::mpsc::unbounded_channel, task};
 use tokio_util::sync::CancellationToken;
 
 mod events;
 
 pub use events::Change;
-use gitbutler_filemonitor::InternalEvent;
+use gitbutler_filemonitor::{FileMonitorHandle, InternalEvent};
 
 mod handler;
 
@@ -28,14 +25,17 @@ pub use gitbutler_filemonitor::WatchMode;
 pub struct WatcherHandle {
     /// The id of the project we are watching.
     project_id: ProjectHandleOrLegacyProjectId,
-    signal_flush: UnboundedSender<()>,
-    /// A way to tell the background process to stop handling events.
+    /// Must be dropped synchronously so disconnecting its command channel unblocks
+    /// `BlockingPool::shutdown` during Tokio runtime teardown.
+    file_monitor: FileMonitorHandle,
+    /// A way to tell the async event-dispatch task to stop.
     cancellation_token: CancellationToken,
 }
 
 impl Drop for WatcherHandle {
     fn drop(&mut self) {
         self.cancellation_token.cancel();
+        // file_monitor drops here, disconnecting cmd_rx and unblocking the spawn_blocking task.
     }
 }
 
@@ -46,8 +46,7 @@ impl WatcherHandle {
     }
 
     pub fn flush(&self) -> Result<()> {
-        self.signal_flush.send(())?;
-        Ok(())
+        self.file_monitor.flush()
     }
 }
 
@@ -74,9 +73,8 @@ pub fn watch_in_background(
     watch_mode: WatchMode,
 ) -> Result<WatcherHandle, anyhow::Error> {
     let (events_out, mut events_in) = unbounded_channel();
-    let (flush_tx, mut flush_rx) = unbounded_channel();
 
-    let monitor = gitbutler_filemonitor::spawn(
+    let file_monitor = gitbutler_filemonitor::spawn(
         project_id.clone(),
         worktree_path.as_ref(),
         events_out.clone(),
@@ -86,7 +84,7 @@ pub fn watch_in_background(
     let cancellation_token = CancellationToken::new();
     let handle = WatcherHandle {
         project_id: project_id.clone(),
-        signal_flush: flush_tx,
+        file_monitor,
         cancellation_token: cancellation_token.clone(),
     };
     let handle_event =
@@ -106,9 +104,6 @@ pub fn watch_in_background(
         loop {
             tokio::select! {
                 Some(event) = events_in.recv() => handle_event(event, app_settings.clone())?,
-                Some(_signal_flush) = flush_rx.recv() => {
-                    monitor.flush()?;
-                }
                 () = cancellation_token.cancelled() => {
                     tracing::debug!(%project_id, "stopped watcher");
                     break;


### PR DESCRIPTION
## Problem

When the Tokio runtime shuts down, `BlockingPool::shutdown()` blocks the main thread waiting for all `spawn_blocking` tasks to complete. The file monitor (`gitbutler_filemonitor::spawn`) runs as one such blocking task, looping indefinitely until `cmd_rx` is disconnected (i.e. until the `FileMonitorHandle` that holds `cmd_tx` is dropped).

Previously, `FileMonitorHandle` was owned by the `tokio::spawn` async event-dispatch task — not by `WatcherHandle`. The intended shutdown chain was:

```
WatcherHandle drops
  → CancellationToken fires
    → async task sees cancellation, exits loop
      → async task drops FileMonitorHandle
        → cmd_rx disconnects
          → spawn_blocking task exits
```

The flaw: Tokio's `Runtime::drop()` calls `BlockingPool::shutdown()` *before* it drops the scheduler (and thus before async tasks are cleaned up). The async task can't run to drop `FileMonitorHandle` because the scheduler hasn't been torn down yet — and the scheduler won't be torn down because the blocking pool is waiting. A classic circular dependency:

```
BlockingPool::shutdown()  [main thread, waiting]
  ← blocked on spawn_blocking file monitor task
    ← needs cmd_rx disconnect
      ← needs FileMonitorHandle drop
        ← needs async task to run
          ← needs scheduler teardown
            ← needs BlockingPool to finish first
```

## How the deadlock was found

A `gitbutler-tauri` process froze after a user navigated to a newly added project. The macOS `sample` tool showed the main thread permanently blocked in `BlockingPool::shutdown → parking_lot::Condvar::wait`. No blocking tasks appeared to be actively running, yet the pool never drained. Cross-referencing the tracing logs (`time.busy=14664s` on the `file monitor` span) confirmed the blocking task had been running for hours before the shutdown attempt.

## Fix

Move `FileMonitorHandle` from the async task into `WatcherHandle` directly. `WatcherHandle::drop` now drops it synchronously — no async scheduling required — immediately disconnecting `cmd_rx` and letting the blocking task exit. This breaks the circular dependency at the earliest possible point.

As a side effect, the `flush()` path is simplified: rather than sending a signal through an async `unbounded_channel` to the event-dispatch task (which then called `monitor.flush()`), `WatcherHandle::flush` now calls `file_monitor.flush()` directly, removing the need for the `flush_tx`/`flush_rx` pair entirely.