### PR TITLE
Fix flaky pre_push_resolves_relative_core_hooks_path_against_workdir test

### DIFF
--- a/crates/gitbutler-repo/src/hooks.rs
+++ b/crates/gitbutler-repo/src/hooks.rs
@@ -185,14 +185,6 @@ pub fn pre_push(
     .spawn()?;
 
     {
-        // Wait for the child process to be ready before writing to stdin.
-        // Check if the process has already exited unexpectedly.
-        if let Some(status) = child.try_wait()? {
-            // Process already exited, don't write to stdin.
-            let error = format!("pre-push hook exited early with status: {status}");
-            return Ok(HookResult::Failure(ErrorData { error }));
-        }
-
         let remote_commit = repo
             .try_find_reference(&remote_tracking_branch.to_string())?
             .map(|mut reference| reference.peel_to_id().map(|id| id.detach()))
@@ -203,10 +195,16 @@ pub fn pre_push(
         let local_tracking_branch_deduced =
             format!("refs/heads/{}", remote_tracking_branch.branch());
         let stdin = child.stdin.as_mut().expect("configured");
-        stdin.write_all(
-            format!("{local_tracking_branch_deduced} {local_commit} {remote_tracking_branch} {remote_commit}\n")
-                .as_bytes(),
-        )?;
+        let refspec = format!(
+            "{local_tracking_branch_deduced} {local_commit} {remote_tracking_branch} {remote_commit}\n"
+        );
+        // Hooks may exit before reading stdin if they don't need the refspec info.
+        // The actual success/failure is determined by the exit code via wait_with_output() below.
+        if let Err(err) = stdin.write_all(refspec.as_bytes())
+            && err.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(err.into());
+        }
     }
 
     let output = child.wait_with_output()?;


### PR DESCRIPTION
The test was flaky because pre_push() had a try_wait() check that treated
any early hook exit — including successful ones — as a failure. Hooks that
don't read stdin (like the test's `echo ran > file` script) can exit with
code 0 before try_wait() is called, causing the function to return
HookResult::Failure("pre-push hook exited early with status: exit
status: 0") instead of HookResult::Success.

The try_wait() guard was also redundant: its only purpose was to avoid
writing to a dead process's stdin, but that race exists regardless (the
hook can exit between try_wait() returning None and write_all() being
called). The real success/failure signal is the exit code, which
wait_with_output() at the end already captures correctly.

Fix by removing the try_wait() check and only ignoring BrokenPipe errors
on stdin.write_all(). Broken pipe means the hook exited before reading
stdin, which is valid for hooks that don't need the refspec info. All
other write errors are still propagated, so a hook that genuinely can't
receive data won't silently swallow the failure. The exit code from
wait_with_output() remains the sole arbiter of hook success.