### PR TITLE
Follow but-api conventions in `assign_hunk`

### DIFF
--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -3,6 +3,7 @@ use but_core::{sync::RepoExclusive, ui::TreeChange};
 use but_ctx::Context;
 use but_hunk_assignment::{HunkAssignmentRequest, WorktreeChanges};
 use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use gix::prelude::ObjectIdExt;
 use tracing::instrument;
 
@@ -178,14 +179,30 @@ pub fn assign_hunk(
     ctx: &mut Context,
     assignments: Vec<HunkAssignmentRequest>,
 ) -> anyhow::Result<()> {
-    let context_lines = ctx.settings.context_lines;
-    let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
-    but_hunk_assignment::assign(
-        db.hunk_assignments_mut()?,
-        &repo,
-        &ws,
-        assignments,
-        context_lines,
-    )?;
+    let mut guard = ctx.exclusive_worktree_access();
+
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::MoveHunk),
+        guard.read_permission(),
+    )
+    .ok();
+
+    {
+        let context_lines = ctx.settings.context_lines;
+        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
+        but_hunk_assignment::assign(
+            db.hunk_assignments_mut()?,
+            &repo,
+            &ws,
+            assignments,
+            context_lines,
+        )?;
+    }
+
+    if let Some(snapshot) = maybe_oplog_entry {
+        snapshot.commit(ctx, guard.write_permission()).ok();
+    }
+
     Ok(())
 }

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -235,6 +235,8 @@ pub fn assign_hunk_with_perm(
     assignments: Vec<HunkAssignmentRequest>,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    // this oplog entry is currently a noop (i.e. restoring it does nothing) but we do wanna
+    // support it in the future so leaving it here for consistency
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveHunk),

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -168,41 +168,83 @@ pub fn changes_in_worktree_with_perm(
     })
 }
 
-/// Persists `assignments` for the current workspace.
+/// Persists `assignments` for the current workspace without creating an oplog
+/// entry.
 ///
-/// `assignments` is applied against the current workspace state and stored in
-/// the hunk-assignment database. For lower-level implementation details, see
+/// This acquires exclusive worktree access from `ctx` before writing
+/// assignments.
+///
+/// See [`assign_hunk_only_with_perm()`] for details.
+#[but_api]
+#[instrument(skip_all, err(Debug))]
+pub fn assign_hunk_only(
+    ctx: &mut Context,
+    assignments: Vec<HunkAssignmentRequest>,
+) -> anyhow::Result<()> {
+    let mut guard = ctx.exclusive_worktree_access();
+    assign_hunk_only_with_perm(ctx, assignments, guard.write_permission())
+}
+
+/// Persists `assignments` under caller-held exclusive repository access without
+/// creating an oplog entry.
+///
+/// For lower-level implementation details, see
 /// [`but_hunk_assignment::assign()`].
+pub fn assign_hunk_only_with_perm(
+    ctx: &mut Context,
+    assignments: Vec<HunkAssignmentRequest>,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<()> {
+    let context_lines = ctx.settings.context_lines;
+    let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    but_hunk_assignment::assign(
+        db.hunk_assignments_mut()?,
+        &repo,
+        &ws,
+        assignments,
+        context_lines,
+    )?;
+    Ok(())
+}
+
+/// Persists `assignments` for the current workspace and records an oplog
+/// snapshot on success.
+///
+/// This acquires exclusive worktree access from `ctx` before writing
+/// assignments.
+///
+/// See [`assign_hunk_with_perm()`] for details.
 #[but_api(napi)]
-#[instrument(err(Debug))]
+#[instrument(skip_all, err(Debug))]
 pub fn assign_hunk(
     ctx: &mut Context,
     assignments: Vec<HunkAssignmentRequest>,
 ) -> anyhow::Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
+    assign_hunk_with_perm(ctx, assignments, guard.write_permission())
+}
 
+/// Persists `assignments` under caller-held exclusive repository access and
+/// records an oplog snapshot on success.
+///
+/// It behaves like [`assign_hunk_only_with_perm()`], but first prepares a
+/// best-effort `MoveHunk` oplog snapshot and commits the snapshot only if the
+/// assignment succeeds.
+pub fn assign_hunk_with_perm(
+    ctx: &mut Context,
+    assignments: Vec<HunkAssignmentRequest>,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<()> {
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveHunk),
-        guard.read_permission(),
+        perm.read_permission(),
     )
     .ok();
 
-    {
-        let context_lines = ctx.settings.context_lines;
-        let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(guard.read_permission())?;
-        but_hunk_assignment::assign(
-            db.hunk_assignments_mut()?,
-            &repo,
-            &ws,
-            assignments,
-            context_lines,
-        )?;
+    let res = assign_hunk_only_with_perm(ctx, assignments, perm);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx, perm).ok();
     }
-
-    if let Some(snapshot) = maybe_oplog_entry {
-        snapshot.commit(ctx, guard.write_permission()).ok();
-    }
-
-    Ok(())
+    res
 }


### PR DESCRIPTION
I noticed that `but_api::diff::assign_hunk` didn't create a snapshot and didn't follow the convention of having `_only`, `_with_perm`, and `_only_with_perm` variants. This should fix that.

There seem to be some bugs happening in `but undo` (see https://discord.com/channels/1060193121130000425/1442962582444183593/1491124718584070346) so couldn't actually test the snapshotting.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13215
- <kbd>&nbsp;1&nbsp;</kbd> #13214 👈 
<!-- GitButler Footer Boundary Bottom -->