### PR TITLE
Add non-legacy function for undoing a commit

### DIFF
--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -1,7 +1,10 @@
 use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 
-use crate::{commit::types::CommitDiscardResult as EngineCommitDiscardResult, json::HexHash};
+use crate::{
+    commit::types::CommitDiscardResult as EngineCommitDiscardResult,
+    commit::types::CommitUndoResult as EngineCommitUndoResult, json::HexHash,
+};
 
 use super::types::{
     CommitCreateResult as EngineCommitCreateResult,
@@ -277,6 +280,42 @@ impl From<EngineCommitDiscardResult> for CommitDiscardResult {
 
         Self {
             discarded_commit: discarded_commit.into(),
+            replaced_commits: replaced_commits
+                .into_iter()
+                .map(|(old, new)| (old.into(), new.into()))
+                .collect(),
+        }
+    }
+}
+
+/// JSON transport type for undoing a commit.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct CommitUndoResult {
+    /// The ID of the commit that was undone.
+    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
+    pub undone_commit: HexHash,
+    /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(with = "std::collections::BTreeMap<String, String>")
+    )]
+    pub replaced_commits: std::collections::BTreeMap<HexHash, HexHash>,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(CommitUndoResult);
+
+impl From<EngineCommitUndoResult> for CommitUndoResult {
+    fn from(value: EngineCommitUndoResult) -> Self {
+        let EngineCommitUndoResult {
+            undone_commit,
+            replaced_commits,
+        } = value;
+
+        Self {
+            undone_commit: undone_commit.into(),
             replaced_commits: replaced_commits
                 .into_iter()
                 .map(|(old, new)| (old.into(), new.into()))

--- a/crates/but-api/src/commit/mod.rs
+++ b/crates/but-api/src/commit/mod.rs
@@ -30,3 +30,6 @@ pub mod types;
 
 /// Functions for uncommitting changes from commits.
 pub mod uncommit;
+
+/// Functions for undoing commits.
+pub mod undo;

--- a/crates/but-api/src/commit/types.rs
+++ b/crates/but-api/src/commit/types.rs
@@ -55,3 +55,11 @@ pub struct CommitDiscardResult {
     /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
     pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
 }
+
+/// Outcome of undoing a commit.
+pub struct CommitUndoResult {
+    /// The ID of the commit that was undone.
+    pub undone_commit: gix::ObjectId,
+    /// Commits that were replaced by this operation. Maps `old_id -> new_id`.
+    pub replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+}

--- a/crates/but-api/src/commit/undo.rs
+++ b/crates/but-api/src/commit/undo.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+
+use anyhow::Context as _;
+use but_api_macros::but_api;
+use but_core::{DiffSpec, sync::RepoExclusive};
+use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
+use tracing::instrument;
+
+use crate::commit::types::{CommitUndoResult, MoveChangesResult};
+
+/// Undo `subject_commit_id` using the behavior described by [`commit_undo_only_with_perm()`].
+#[but_api(napi, crate::commit::json::CommitUndoResult)]
+#[instrument(err(Debug))]
+pub fn commit_undo(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitUndoResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_undo_with_perm(ctx, subject_commit_id, guard.write_permission())
+}
+
+/// Undo `subject_commit_id` using the behavior described by [`commit_undo_only_with_perm()`].
+pub fn commit_undo_only(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+) -> anyhow::Result<CommitUndoResult> {
+    let mut guard = ctx.exclusive_worktree_access();
+    commit_undo_only_with_perm(ctx, subject_commit_id, guard.write_permission())
+}
+
+/// Undo `subject_commit_id` using the behavior described by [`commit_undo_only_with_perm()`].
+pub fn commit_undo_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitUndoResult> {
+    let details = SnapshotDetails::new(OperationKind::UndoCommit).with_trailers(vec![Trailer {
+        key: "sha".to_string(),
+        value: subject_commit_id.to_string(),
+    }]);
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        details,
+        perm.read_permission(),
+    )
+    .ok();
+
+    let res = commit_undo_only_with_perm(ctx, subject_commit_id, perm);
+    if let Some(snapshot) = maybe_oplog_entry.filter(|_| res.is_ok()) {
+        snapshot.commit(ctx, perm).ok();
+    };
+    res
+}
+
+/// Undo `subject_commit_id`, under caller-held exclusive repository access.
+///
+/// This will move the changes in the commit to be unassigned and discard the commit.
+pub fn commit_undo_only_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_id: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitUndoResult> {
+    let changes = {
+        let repo = ctx.repo.get()?;
+        let commit = repo.find_commit(subject_commit_id)?;
+
+        let mut parent_ids = commit.parent_ids();
+        let first_parent = parent_ids.next().map(|id| id.detach());
+
+        // TODO: do we want to handle this?
+        anyhow::ensure!(
+            parent_ids.next().is_none(),
+            "expected {} to have at most one parent",
+            subject_commit_id.to_hex()
+        );
+
+        let changes = but_core::diff::tree_changes(&repo, first_parent, subject_commit_id)?;
+        changes.into_iter().map(DiffSpec::from).collect::<Vec<_>>()
+    };
+
+    let (new_commit, mut replaced_commits) = if changes.is_empty() {
+        (subject_commit_id, BTreeMap::new())
+    } else {
+        let MoveChangesResult { replaced_commits } =
+            crate::commit::uncommit::commit_uncommit_changes_only_with_perm(
+                ctx,
+                subject_commit_id,
+                changes,
+                None,
+                perm,
+            )
+            .with_context(|| {
+                format!(
+                    "failed to unassign changes in {}",
+                    subject_commit_id.to_hex()
+                )
+            })?;
+
+        (
+            replaced_commits
+                .get(&subject_commit_id)
+                .copied()
+                .with_context(|| {
+                    format!(
+                        "failed to find {} in replaced commits",
+                        subject_commit_id.to_hex()
+                    )
+                })?,
+            replaced_commits,
+        )
+    };
+
+    let mut discard_result =
+        crate::commit::discard_commit::commit_discard_only_with_perm(ctx, new_commit, perm)
+            .with_context(|| format!("failed to discard {}", subject_commit_id.to_hex()))?;
+
+    replaced_commits.append(&mut discard_result.replaced_commits);
+
+    Ok(CommitUndoResult {
+        undone_commit: subject_commit_id,
+        replaced_commits,
+    })
+}

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -28,11 +28,13 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 export declare function apply(projectId: string, existingBranch: string): Promise<ApplyOutcome>
 
 /**
- * Persists `assignments` for the current workspace.
+ * Persists `assignments` for the current workspace and records an oplog
+ * snapshot on success.
  *
- * `assignments` is applied against the current workspace state and stored in
- * the hunk-assignment database. For lower-level implementation details, see
- * [`but_hunk_assignment::assign()`].
+ * This acquires exclusive worktree access from `ctx` before writing
+ * assignments.
+ *
+ * See [`assign_hunk_with_perm()`] for details.
  */
 export declare function assignHunk(projectId: string, assignments: Array<HunkAssignmentRequest>): Promise<void>
 
@@ -163,6 +165,9 @@ export declare function commitSquash(projectId: string, subjectCommitId: string,
  * See [`commit_uncommit_changes_with_perm()`] for details.
  */
 export declare function commitUncommitChanges(projectId: string, commitId: string, changes: Array<DiffSpec>, assignTo: string | null): Promise<MoveChangesResult>
+
+/** Undo `subject_commit_id` using the behavior described by [`commit_undo_only_with_perm()`]. */
+export declare function commitUndo(projectId: string, subjectCommitId: string): Promise<CommitUndoResult>
 
 /**
  * Get the forge provider name.
@@ -678,6 +683,14 @@ export type CommitState = {
   subject: string;
 } | {
   type: "Integrated";
+};
+
+/** JSON transport type for undoing a commit. */
+export type CommitUndoResult = {
+  /** The ID of the commit that was undone. */
+  undoneCommit: string;
+  /** Commits that were replaced by this operation. Maps `old_id -> new_id`. */
+  replacedCommits: Record<string, string>;
 };
 
 /** Represents what was causing a particular commit to conflict when rebased. */

--- a/packages/but-sdk/src/generated/index.js
+++ b/packages/but-sdk/src/generated/index.js
@@ -579,7 +579,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommitChanges, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
+const { absorb, absorptionPlan, apply, assignHunk, branchDetails, branchDiff, changesInWorktree, changesInWorktreeWithPerm, commitAmend, commitCreate, commitDetailsWithLineStats, commitDiscard, commitInsertBlank, commitMove, commitMoveChangesBetween, commitReword, commitSquash, commitUncommitChanges, commitUndo, forgeProvider, getReview, headInfo, listAvailableReviewTemplates, listBranches, listCiChecksAndUpdateCache, listProjectsStateless, listReviews, listReviewsForBranch, mergeReview, moveBranch, publishReview, pushStackLegacy, removeBranch, reviewTemplate, setReviewAutoMerge, setReviewDraftiness, setReviewTemplate, tearOffBranch, treeChangeDiffs, unapplyStack, updateBranchName, updateReviewFooters, warmCiChecksCache, WatcherHandle, watcherStart } = nativeBinding
 export { absorb }
 export { absorptionPlan }
 export { apply }
@@ -598,6 +598,7 @@ export { commitMoveChangesBetween }
 export { commitReword }
 export { commitSquash }
 export { commitUncommitChanges }
+export { commitUndo }
 export { forgeProvider }
 export { getReview }
 export { headInfo }


### PR DESCRIPTION
Adds `but_api::commit::undo::commit_undo` (and friends). I need this in the TUI for the non-legacy version of rub I'm cooking.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13215 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13214
<!-- GitButler Footer Boundary Bottom -->