### PR TITLE
dist: add metrics notice to rpm and deb packages

### DIFF
--- a/crates/gitbutler-tauri/deb-postinstall.sh
+++ b/crates/gitbutler-tauri/deb-postinstall.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Postinstall script for the deb package.
+
+# Print metrics notice on fresh install
+if [ "$1" = "configure" ] && [ -z "$2" ]; then
+  echo ""
+  echo "GitButler uses metrics to help us improve our product."
+  echo "You can configure metrics collection either in the GUI or via 'but config metrics'."
+  echo "Privacy policy: https://gitbutler.com/privacy"
+  echo ""
+fi

--- a/crates/gitbutler-tauri/rpm-postinstall.sh
+++ b/crates/gitbutler-tauri/rpm-postinstall.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Postinstall script for the rpm package.
+
+set -eu
+
 # Create a 'but' symlink so the CLI is available as /usr/bin/but.
 #
 # Ideally this symlink would be a proper tracked file in the RPM (like VS Code
@@ -36,4 +40,13 @@ else
     # Path exists but is not a symlink
     echo "Error: $SYMLINK already exists and is not a symlink" >&2
     exit 1
+fi
+
+# Print metrics notice on fresh install
+if [ "${1:-}" = "1" ]; then
+  echo ""
+  echo "GitButler uses metrics to help us improve our product."
+  echo "You can configure metrics collection either in the GUI or via 'but config metrics'."
+  echo "Privacy policy: https://gitbutler.com/privacy"
+  echo ""
 fi

--- a/crates/gitbutler-tauri/rpm-preremove.sh
+++ b/crates/gitbutler-tauri/rpm-preremove.sh
@@ -8,6 +8,8 @@
 # We only remove the symlink on a full uninstall; during an upgrade the
 # postinstall script of the new package will recreate/update it.
 
+set -eu
+
 # Skip removal during upgrades
 if [ "${1:-0}" -ge 1 ]; then
     exit 0

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
 			},
 			"deb": {
 				"depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"],
+				"postInstallScript": "deb-postinstall.sh",
 				"files": {
 					"/usr/share/metainfo/com.gitbutler.gitbutler.metainfo.xml": "com.gitbutler.gitbutler.metainfo.xml"
 				}


### PR DESCRIPTION
This makes you aware of the metrics collection even if you don't go through the first-time GUI setup. Without this notice, jumping straight into the `but` cli leaves you completely unaware that metrics are being sent.