### PR TITLE
[codex] Improve error for refs outside workspace and adopt existing ones

### DIFF
--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -155,6 +155,12 @@ pub(super) mod function {
             .and_then(|ws_ref| meta.workspace_opt(ws_ref).transpose())
             .transpose()?;
         let ref_name = ref_name.borrow();
+        let existing_ref_target_id = repo
+            .try_find_reference(ref_name)?
+            .map(|mut reference| reference.peel_to_id().map(|id| id.detach()))
+            .transpose()?;
+        let existing_ref_target_in_workspace = existing_ref_target_id
+            .filter(|id| workspace.find_owner_indexes_by_commit_id(*id).is_some());
 
         let (check_if_id_in_workspace, ref_target_id, instruction): (
             _,
@@ -170,18 +176,35 @@ pub(super) mod function {
                     {
                         return Ok(Cow::Borrowed(workspace));
                     }
-                    let base = ws_base.with_context(|| {
-                        format!(
-                            "workspace at {} is missing a base",
-                            workspace.ref_name_display()
+                    if let Some(existing_ref_target_id) = existing_ref_target_in_workspace {
+                        let instruction = existing_ws_meta
+                            .as_ref()
+                            .map(|_| {
+                                instruction_by_named_anchor_for_commit(
+                                    workspace,
+                                    existing_ref_target_id,
+                                )
+                            })
+                            .transpose()?;
+                        (
+                            true, // expect the target id to be in the workspace
+                            existing_ref_target_id,
+                            instruction,
                         )
-                    })?;
-                    (
-                        // do not validate, as the base is expectedly outside of workspace
-                        false,
-                        base,
-                        Some(Instruction::Independent),
-                    )
+                    } else {
+                        let base = ws_base.with_context(|| {
+                            format!(
+                                "workspace at {} is missing a base",
+                                workspace.ref_name_display()
+                            )
+                        })?;
+                        (
+                            // do not validate, as the base is expectedly outside of workspace
+                            false,
+                            base,
+                            Some(Instruction::Independent),
+                        )
+                    }
                 }
                 Some(Anchor::AtCommit {
                     commit_id,
@@ -269,11 +292,6 @@ pub(super) mod function {
             workspace.try_find_owner_indexes_by_commit_id(ref_target_id)?;
         }
 
-        let existing_ref_target_id = repo
-            .try_find_reference(ref_name)?
-            .map(|mut reference| reference.peel_to_id().map(|id| id.detach()))
-            .transpose()?;
-
         let graph_with_new_ref = {
             // Always update the metadata, this may help disambiguating.
             let mut branch_md = meta.branch(ref_name)?;
@@ -304,8 +322,10 @@ pub(super) mod function {
         let has_new_ref_as_standalone_segment = updated_workspace
             .find_segment_and_stack_by_refname(ref_name)
             .is_some();
+        let existing_ref_is_in_workspace = existing_ref_target_in_workspace.is_some();
         if !has_new_ref_as_standalone_segment {
             if existing_ref_target_id.is_some()
+                && !existing_ref_is_in_workspace
                 && !workspace.refname_is_segment(ref_name)
                 && workspace.ref_name() != Some(ref_name)
             {

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -269,6 +269,11 @@ pub(super) mod function {
             workspace.try_find_owner_indexes_by_commit_id(ref_target_id)?;
         }
 
+        let existing_ref_target_id = repo
+            .try_find_reference(ref_name)?
+            .map(|mut reference| reference.peel_to_id().map(|id| id.detach()))
+            .transpose()?;
+
         let graph_with_new_ref = {
             // Always update the metadata, this may help disambiguating.
             let mut branch_md = meta.branch(ref_name)?;
@@ -300,6 +305,15 @@ pub(super) mod function {
             .find_segment_and_stack_by_refname(ref_name)
             .is_some();
         if !has_new_ref_as_standalone_segment {
+            if existing_ref_target_id.is_some()
+                && !workspace.refname_is_segment(ref_name)
+                && workspace.ref_name() != Some(ref_name)
+            {
+                bail!(
+                    "Reference '{}' already exists and is outside the workspace",
+                    ref_name.shorten()
+                )
+            }
             // TODO: this should probably be easier to understand for the UI, with error codes maybe?
             bail!(
                 "Reference '{}' cannot be created as segment at {ref_target_id}",

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -8,6 +8,7 @@ use but_core::{
 use but_graph::init::Options;
 use but_testsupport::{graph_workspace, id_at, id_by_rev, visualize_commit_graph_all};
 use but_workspace::branch::create_reference::{Anchor, Position::*};
+use gix::refs::transaction::PreviousValue;
 
 use crate::{
     ref_info::with_workspace_commit::utils::{
@@ -1631,6 +1632,50 @@ fn journey_with_commits() -> anyhow::Result<()> {
         │   └── ·12995d7
         └── 📙:2:two-below-main
             └── ·3d57fc1
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn existing_git_ref_inside_workspace_is_adopted() -> anyhow::Result<()> {
+    let (_tmp, repo, mut meta) = named_writable_scenario("single-branch-4-commits")?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, Options::limited())?;
+    let ws = graph.into_workspace()?;
+
+    let test_ref = r("refs/heads/created-with-git");
+    let target_id = id_by_rev(&repo, ":/A1").detach();
+    repo.reference(
+        test_ref,
+        target_id,
+        PreviousValue::Any,
+        "manual branch created with git",
+    )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 05240ea (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 43f9472 (A) A2
+    * 6fdab32 (created-with-git) A1
+    * bce0c5e (origin/main, main) M2
+    * 3183e43 M1
+    ");
+
+    let ws = but_workspace::branch::create_reference(
+        test_ref,
+        None,
+        &repo,
+        &ws,
+        &mut meta,
+        stack_id_for_name,
+        None,
+    )?;
+
+    insta::assert_snapshot!(graph_workspace(&ws), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+    └── ≡:4:A on bce0c5e {632}
+        ├── :4:A
+        │   └── ·43f9472 (🏘️)
+        └── 📙:3:created-with-git
+            └── ·6fdab32 (🏘️)
     ");
 
     Ok(())

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -1190,8 +1190,8 @@ mod with_workspace {
         .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "Reference 'extra' cannot be created as segment at 3183e43ff482a2c4c8ff531d595453b64f58d90b",
-            "The simulation catches the issue first, note how it wants to create it at the base"
+            "Reference 'extra' already exists and is outside the workspace",
+            "Existing refs outside the workspace should fail explicitly instead of surfacing the generic segment error"
         );
         assert!(
             meta.branch(outside_ref.as_ref())?.is_default(),


### PR DESCRIPTION
## Summary
- improve `create_reference` so an existing ref outside the workspace fails with an explicit error instead of the generic segment-creation error
- add a regression test covering that exact case
- existing refs within the workspace are adopted automatically.

## Tasks

* [x] refackview

## Why
The reported failure mode in issue #13104 surfaced a cryptic error when the branch already existed in Git but was outside the GitButler workspace.

## Validation
- `cargo test -p but-workspace create_reference -- --nocapture`
- `cargo fmt --check --all`

## Notes
- This draft PR was created by Codex.
- Byron still needs to review this change before it is ready to merge.
