### PR TITLE
Per-branch hunk assignment: absorb routing, reconciliation validation, partitioning

### DIFF
--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -16,7 +16,7 @@ use but_hunk_dependency::ui::{
     hunk_dependencies_for_workspace_changes_by_worktree_dir,
 };
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
-use but_workspace::ui::StackDetails;
+use but_workspace::ui::{BranchDetails, StackDetails};
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -367,6 +367,21 @@ fn find_top_most_lock<'a>(
     None
 }
 
+/// Resolve the target branch in stack details: match `branch_ref` if set, otherwise use the topmost branch.
+fn find_target_branch<'a>(
+    stack_details: &'a StackDetails,
+    branch_ref: Option<&gix::refs::FullName>,
+) -> Option<&'a BranchDetails> {
+    branch_ref
+        .and_then(|branch_ref| {
+            stack_details
+                .branch_details
+                .iter()
+                .find(|b| &b.reference == branch_ref)
+        })
+        .or_else(|| stack_details.branch_details.first())
+}
+
 /// Determine the target commit for an assignment based on dependencies and assignments
 fn determine_target_commit(
     ctx: &mut Context,
@@ -395,20 +410,17 @@ fn determine_target_commit(
 
     // Priority 2: Use the assignment's stack ID if available
     if let Some(stack_id) = assignment.stack_id {
-        // We need to find the topmost commit in this stack
-        let stack_details = crate::legacy::workspace::stack_details(ctx, Some(stack_id))?;
+        let branch_ref = assignment.branch_ref_bytes.as_ref();
 
-        // Find the topmost commit in the first branch
-        if let Some(branch) = stack_details.branch_details.first()
+        let stack_details = crate::legacy::workspace::stack_details(ctx, Some(stack_id))?;
+        if let Some(branch) = find_target_branch(&stack_details, branch_ref)
             && let Some(commit) = branch.commits.first()
         {
             return Ok((stack_id, commit.id, AbsorptionReason::StackAssignment));
         }
 
-        // If there are no commits in the stack, create a blank commit first
-        let branch = stack_details
-            .branch_details
-            .first()
+        // If there are no commits in the target branch, create a blank commit first
+        let branch = find_target_branch(&stack_details, branch_ref)
             .ok_or_else(|| anyhow::anyhow!("Stack has no branches"))?;
         commit_insert_blank_only_impl(
             ctx,
@@ -417,9 +429,9 @@ fn determine_target_commit(
             perm,
         )?;
 
-        // Now fetch the stack details again to get the newly created commit
+        // Fetch again to get the newly created commit
         let stack_details = crate::legacy::workspace::stack_details(ctx, Some(stack_id))?;
-        if let Some(branch) = stack_details.branch_details.first()
+        if let Some(branch) = find_target_branch(&stack_details, branch_ref)
             && let Some(commit) = branch.commits.first()
         {
             return Ok((stack_id, commit.id, AbsorptionReason::StackAssignment));

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -421,11 +421,7 @@ pub fn assign(
     requests: Vec<HunkAssignmentRequest>,
     context_lines: u32,
 ) -> Result<()> {
-    let identifiable_stacks = workspace
-        .stacks
-        .iter()
-        .filter_map(|s| s.id)
-        .collect::<Vec<_>>();
+    let (identifiable_stacks, branches_by_stack) = workspace_stack_and_branch_info(workspace);
 
     let worktree_changes: Vec<but_core::TreeChange> =
         but_core::diff::worktree_changes(repo)?.changes;
@@ -444,6 +440,7 @@ pub fn assign(
         &worktree_assignments,
         &persisted_assignments,
         &identifiable_stacks,
+        &branches_by_stack,
         MultipleOverlapping::SetMostLines,
         true,
     );
@@ -453,6 +450,7 @@ pub fn assign(
         &with_worktree,
         &requests_to_assignments(requests),
         &identifiable_stacks,
+        &branches_by_stack,
         MultipleOverlapping::SetMostLines,
         true,
     );
@@ -530,22 +528,39 @@ fn reconcile_with_worktree(
     workspace: &but_graph::projection::Workspace,
     worktree_assignments: &[HunkAssignment],
 ) -> Result<Vec<HunkAssignment>> {
-    let identifiable_stacks = workspace
-        .stacks
-        .iter()
-        .filter_map(|s| s.id)
-        .collect::<Vec<_>>();
+    let (identifiable_stacks, branches_by_stack) = workspace_stack_and_branch_info(workspace);
 
     let persisted_assignments = state::assignments(db)?;
     let with_worktree = reconcile::assignments(
         worktree_assignments,
         &persisted_assignments,
         &identifiable_stacks,
+        &branches_by_stack,
         MultipleOverlapping::SetMostLines,
         true,
     );
 
     Ok(with_worktree)
+}
+
+/// Collect applied stack IDs and a mapping of stack→branches from the workspace for reconciliation.
+fn workspace_stack_and_branch_info(
+    workspace: &but_graph::projection::Workspace,
+) -> (Vec<StackId>, HashMap<StackId, Vec<gix::refs::FullName>>) {
+    let mut stack_ids = Vec::new();
+    let mut branches_by_stack = HashMap::new();
+    for stack in &workspace.stacks {
+        if let Some(id) = stack.id {
+            stack_ids.push(id);
+            let branch_refs: Vec<gix::refs::FullName> = stack
+                .segments
+                .iter()
+                .filter_map(|s| s.ref_name().map(|r| r.to_owned()))
+                .collect();
+            branches_by_stack.insert(id, branch_refs);
+        }
+    }
+    (stack_ids, branches_by_stack)
 }
 
 /// For assignments that have a `stack_id` but no `branch_ref_bytes`, auto-populate `branch_ref_bytes`
@@ -909,6 +924,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -930,6 +946,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -948,6 +965,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -969,6 +987,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -990,6 +1009,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetNone,
             true,
         );
@@ -1008,6 +1028,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             false,
         );
@@ -1172,6 +1193,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -1216,6 +1238,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -1229,6 +1252,8 @@ mod tests {
 
     #[test]
     fn test_reconcile_preserves_branch_ref_bytes() {
+        let feature_ref = gix::refs::FullName::try_from("refs/heads/feature".to_string()).unwrap();
+        let branches = HashMap::from([(stack_id_seq(1), vec![feature_ref])]);
         let previous_assignments = vec![
             HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1))
                 .with_branch_ref_bytes(Some("refs/heads/feature")),
@@ -1239,6 +1264,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &branches,
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -1265,6 +1291,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             true,
         );
@@ -1294,6 +1321,7 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetNone,
             true,
         );
@@ -1321,11 +1349,46 @@ mod tests {
             &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
+            &HashMap::new(),
             MultipleOverlapping::SetMostLines,
             false,
         );
         assert_eq!(result.len(), 1);
         // With update_unassigned=false, worktree hunk has no stack_id, so it should NOT adopt from previous
         assert_eq!(result[0].branch_ref_bytes, None);
+    }
+
+    #[test]
+    fn test_reconcile_clears_stale_branch_ref_bytes() {
+        // When a branch is deleted from the workspace but the stack remains,
+        // branch_ref_bytes should be cleared while stack_id is preserved.
+        let previous_assignments = vec![
+            HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1))
+                .with_branch_ref_bytes(Some("refs/heads/deleted-branch")),
+        ];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, None, None)];
+        let applied_stacks = vec![stack_id_seq(1)];
+        // The stack exists but only has a different branch — "deleted-branch" is gone
+        let other_ref =
+            gix::refs::FullName::try_from("refs/heads/other-branch".to_string()).unwrap();
+        let branches = HashMap::from([(stack_id_seq(1), vec![other_ref])]);
+        let result = reconcile::assignments(
+            &worktree_assignments,
+            &previous_assignments,
+            &applied_stacks,
+            &branches,
+            MultipleOverlapping::SetMostLines,
+            true,
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].stack_id,
+            Some(stack_id_seq(1)),
+            "stack_id should be preserved when stack is still applied"
+        );
+        assert_eq!(
+            result[0].branch_ref_bytes, None,
+            "branch_ref_bytes should be cleared when branch is no longer in workspace"
+        );
     }
 }

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, collections::HashMap};
 
 use but_core::ref_metadata::StackId;
 use itertools::Itertools;
@@ -12,7 +12,13 @@ pub enum MultipleOverlapping {
 }
 
 impl HunkAssignment {
-    fn set_from(&mut self, other: &Self, applied_stack_ids: &[StackId], update_unassigned: bool) {
+    fn set_from(
+        &mut self,
+        other: &Self,
+        applied_stack_ids: &[StackId],
+        branches_by_stack: &HashMap<StackId, Vec<gix::refs::FullName>>,
+        update_unassigned: bool,
+    ) {
         // Always set the path from the other assignment
         self.path = other.path.clone();
         // Override the id only if the other assignment has an id
@@ -47,6 +53,17 @@ impl HunkAssignment {
         {
             self.stack_id = None;
         }
+        // If branch_ref_bytes is set, ensure it belongs to the assignment's own stack.
+        // A branch that moved to a different stack should not retain its old association.
+        if let Some(branch_ref) = &self.branch_ref_bytes {
+            let is_valid = self
+                .stack_id
+                .and_then(|sid| branches_by_stack.get(&sid))
+                .is_some_and(|branches| branches.contains(branch_ref));
+            if !is_valid {
+                self.branch_ref_bytes = None;
+            }
+        }
         // Invariant: if stack_id was cleared, branch_ref_bytes must also be cleared
         if self.stack_id.is_none() {
             self.branch_ref_bytes = None;
@@ -58,6 +75,7 @@ pub(crate) fn assignments(
     new: &[HunkAssignment],
     old: &[HunkAssignment],
     applied_stack_ids: &[StackId],
+    branches_by_stack: &HashMap<StackId, Vec<gix::refs::FullName>>,
     multiple_overlapping_resolution: MultipleOverlapping,
     update_unassigned: bool,
 ) -> Vec<HunkAssignment> {
@@ -74,7 +92,12 @@ pub(crate) fn assignments(
                 // No intersection - do nothing, the None assignment is kept
             }
             Ordering::Equal => {
-                new_assignment.set_from(intersecting[0], applied_stack_ids, update_unassigned);
+                new_assignment.set_from(
+                    intersecting[0],
+                    applied_stack_ids,
+                    branches_by_stack,
+                    update_unassigned,
+                );
             }
             Ordering::Greater => {
                 // Pick the hunk with the most lines to adopt the assignment info from.
@@ -82,7 +105,12 @@ pub(crate) fn assignments(
                     .iter()
                     .max_by_key(|h| h.hunk_header.as_ref().map(|h| h.new_lines));
                 if let Some(other) = biggest_hunk {
-                    new_assignment.set_from(other, applied_stack_ids, update_unassigned);
+                    new_assignment.set_from(
+                        other,
+                        applied_stack_ids,
+                        branches_by_stack,
+                        update_unassigned,
+                    );
                 }
 
                 // If requested, reset stack_id to none on multiple overlapping

--- a/crates/but/src/id/uncommitted_info.rs
+++ b/crates/but/src/id/uncommitted_info.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashSet, btree_map::Entry};
 
 use bstr::BString;
-use but_core::ref_metadata::StackId;
 use but_hunk_assignment::HunkAssignment;
 use nonempty::NonEmpty;
 
@@ -9,17 +8,24 @@ use crate::id::id_usage::UintId;
 
 /// Information about uncommitted files.
 pub(crate) struct UncommittedInfo {
-    /// Uncommitted hunks partitioned by stack assignment and filename.
+    /// Uncommitted hunks partitioned by branch assignment and filename.
     pub(crate) partitioned_hunks: Vec<NonEmpty<HunkAssignment>>,
     pub(crate) uncommitted_short_filenames: HashSet<BString>,
 }
 
+/// A key that groups hunks by their assignment target and file path.
+/// Uses `branch_ref_bytes` as the primary discriminator, falling back
+/// to `stack_id` (as string bytes) when no branch ref is available.
+/// This ensures hunks assigned to different stacks but with no branch
+/// ref don't collapse into the same bucket.
+type PartitionKey = (Option<BString>, BString);
+
 impl UncommittedInfo {
-    /// Partitions hunk assignments by stack assignment and filename.
+    /// Partitions hunk assignments by branch assignment and filename.
     pub(crate) fn from_hunk_assignments(
         hunk_assignments: Vec<HunkAssignment>,
     ) -> anyhow::Result<Self> {
-        let mut uncommitted_hunks: BTreeMap<(Option<StackId>, BString), NonEmpty<HunkAssignment>> =
+        let mut uncommitted_hunks: BTreeMap<PartitionKey, NonEmpty<HunkAssignment>> =
             BTreeMap::new();
         let mut uncommitted_short_filenames = HashSet::new();
         for assignment in hunk_assignments {
@@ -28,10 +34,14 @@ impl UncommittedInfo {
             {
                 uncommitted_short_filenames.insert(assignment.path_bytes.clone());
             }
-            // Rust does not let us borrow a tuple from 2 separate fields, so
-            // we have to clone the parts of the key even though we technically
-            // might not need it.
-            let key = (assignment.stack_id, assignment.path_bytes.clone());
+            // Use branch_ref_bytes as the primary grouping key, falling back to
+            // stack_id when branch_ref_bytes is None to prevent cross-stack collapse.
+            let assignment_key = assignment
+                .branch_ref_bytes
+                .as_ref()
+                .map(|r| BString::from(r.as_bstr()))
+                .or_else(|| assignment.stack_id.map(|id| BString::from(id.to_string())));
+            let key = (assignment_key, assignment.path_bytes.clone());
             match uncommitted_hunks.entry(key) {
                 Entry::Vacant(vacant_entry) => {
                     vacant_entry.insert(NonEmpty::new(assignment));


### PR DESCRIPTION
## Summary

Phase 2 of per-branch hunk assignments. Makes consumers branch-aware:

- **Absorb routing**: When `branch_ref_bytes` targets a specific branch within a stack, the absorb flow finds that branch and routes to its topmost commit instead of always using the first branch. Falls back gracefully when no specific branch is targeted.
- **Reconciliation validation**: Stale branch refs (from deleted/archived branches) are now cleared during reconciliation, while the stack assignment is preserved. New `applied_branch_refs` parameter validates branch existence.
- **Hunk partitioning**: Uncommitted hunks are now grouped by `(branch_ref_bytes, path)` instead of `(stack_id, path)`, laying the groundwork for per-branch CLI display.

All changes are backward-compatible — existing behavior is preserved when `branch_ref_bytes` is `None`.

## Context

Follows PR #13203 which added the `branch_ref_bytes` field. This PR makes key consumers actually use it.

## Test plan

- [x] `cargo test -p but-hunk-assignment` — 19 tests pass (1 new for stale branch ref clearing)
- [x] `cargo test -p but -p but-db -p but-api` — all pass
- [x] `cargo fmt` and `cargo clippy --all-targets` clean