### PR TITLE
fix(but): make `but gui` work on Linux

### DIFF
--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -1,4 +1,6 @@
 //! A version of `tauri::AppHandle::path()` for use outside `tauri`.
+#[cfg(target_os = "linux")]
+use std::process::Command;
 use std::{env, path::PathBuf};
 
 use anyhow::{Context, bail};
@@ -157,7 +159,38 @@ impl AppChannel {
 
         let mut cmd_errors = Vec::new();
 
-        for mut cmd in open::commands(url) {
+        #[cfg(target_os = "linux")]
+        let cmds = {
+            // On Linux, we don't currently want to rely on the scheme being properly registered
+            // with the Tauri app. The mechanism by which the scheme is registered relies on the
+            // bundled Desktop entry, and different desktop environments have pretty wildly
+            // different handling of such entries.
+            //
+            // Adding insult to injury, even if that desktop entry is resolved, it in turn just has
+            // an exec line with the name `gitbutler-tauri` and the URL is provided as a command
+            // line argument. Therefore, after the roundabout trip to the desktop entry via the
+            // custom scheme, we _still_ just resolve `gitbutler-tauri` from PATH.
+            //
+            // Even more annoying is that the desktop entry does not have a placeholder for the
+            // command line argument, causing some stricter environments such as KDE to just error
+            // out, while some more lenient environments simply append the URL to the exec line.
+            //
+            // For these reasons, it's way more reliable and simpler to just try to call
+            // `gitbutler-tauri` directly, completely circumventing any issues with scheme
+            // registration.
+            //
+            // As the binary is always called `gitbutler-tauri`, there's currently no way to
+            // distinguish between release, nightly and dev. We'll just have to try to launch
+            // whatever we find. This can be fixed by giving the binaries different names, but as
+            // so few users use nightly builds, it's just not worth the effort.
+            let mut cmd = Command::new("gitbutler-tauri");
+            cmd.arg(url);
+            vec![cmd]
+        };
+        #[cfg(not(target_os = "linux"))]
+        let cmds = open::commands(url);
+
+        for mut cmd in cmds {
             let cleaned_vars = clean_env_vars(&[
                 "APPDIR",
                 "GDK_PIXBUF_MODULE_FILE",

--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -3,7 +3,7 @@
 use std::process::Command;
 use std::{env, path::PathBuf};
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 
 /// The directory to store application-wide data in, like logs, **one per channel**.
 ///
@@ -136,6 +136,9 @@ impl AppChannel {
     /// Open the GitButler GUI application for `possibly_project_dir`.
     ///
     /// This uses the deeplink URL scheme registered for the specific channel.
+    ///
+    /// Note: On Linux, we don't have a good way of distinguishing between channels in the installed
+    /// binaries, so we always just resolve `gitbutler-tauri`.
     pub fn open(&self, possibly_project_dir: &std::path::Path) -> anyhow::Result<()> {
         let scheme = match self {
             AppChannel::Nightly => "but-nightly",
@@ -157,10 +160,29 @@ impl AppChannel {
             timestamp
         );
 
-        let mut cmd_errors = Vec::new();
+        let cleaned_vars: Vec<(&str, String)> = clean_env_vars(&[
+            "APPDIR",
+            "GDK_PIXBUF_MODULE_FILE",
+            "GIO_EXTRA_MODULES",
+            "GSETTINGS_SCHEMA_DIR",
+            "GST_PLUGIN_SYSTEM_PATH",
+            "GST_PLUGIN_SYSTEM_PATH_1_0",
+            "GTK_DATA_PREFIX",
+            "GTK_EXE_PREFIX",
+            "GTK_IM_MODULE_FILE",
+            "GTK_PATH",
+            "LD_LIBRARY_PATH",
+            "PATH",
+            "PERLLIB",
+            "PYTHONHOME",
+            "PYTHONPATH",
+            "QT_PLUGIN_PATH",
+            "XDG_DATA_DIRS",
+        ])
+        .collect();
 
         #[cfg(target_os = "linux")]
-        let cmds = {
+        {
             // On Linux, we don't currently want to rely on the scheme being properly registered
             // with the Tauri app. The mechanism by which the scheme is registered relies on the
             // bundled Desktop entry, and different desktop environments have pretty wildly
@@ -184,44 +206,41 @@ impl AppChannel {
             // whatever we find. This can be fixed by giving the binaries different names, but as
             // so few users use nightly builds, it's just not worth the effort.
             let mut cmd = Command::new("gitbutler-tauri");
-            cmd.arg(url);
-            vec![cmd]
-        };
-        #[cfg(not(target_os = "linux"))]
-        let cmds = open::commands(url);
-
-        for mut cmd in cmds {
-            let cleaned_vars = clean_env_vars(&[
-                "APPDIR",
-                "GDK_PIXBUF_MODULE_FILE",
-                "GIO_EXTRA_MODULES",
-                "GIO_EXTRA_MODULES",
-                "GSETTINGS_SCHEMA_DIR",
-                "GST_PLUGIN_SYSTEM_PATH",
-                "GST_PLUGIN_SYSTEM_PATH_1_0",
-                "GTK_DATA_PREFIX",
-                "GTK_EXE_PREFIX",
-                "GTK_IM_MODULE_FILE",
-                "GTK_PATH",
-                "LD_LIBRARY_PATH",
-                "PATH",
-                "PERLLIB",
-                "PYTHONHOME",
-                "PYTHONPATH",
-                "QT_PLUGIN_PATH",
-                "XDG_DATA_DIRS",
-            ]);
-
-            cmd.envs(cleaned_vars);
+            cmd.arg(&url);
             cmd.current_dir(env::temp_dir());
-            if cmd.status().is_ok() {
-                return Ok(());
-            } else {
-                cmd_errors.push(anyhow::anyhow!("Failed to execute command {cmd:?}"));
+            cmd.envs(cleaned_vars.clone());
+
+            // Unset all io to not pollute the terminal with output.
+            cmd.stdin(std::process::Stdio::null());
+            cmd.stdout(std::process::Stdio::null());
+            cmd.stderr(std::process::Stdio::null());
+
+            // We spawn this fire-and-forget style. The process will be re-parented to init when
+            // the caller exits (and that caller is typically the `but` CLI). This allows you to
+            // e.g. run `but gui` in a terminal, and then keep using that terminal.
+            //
+            // This is only necessary on cold start, i.e. when the GUI isn't already running, as
+            // then this process becomes the GUI process. If the GUI is already running, this
+            // process effectively just sends the deep link to the already running GUI and then
+            // exits.
+            cmd.spawn()?;
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let mut cmd_errors = Vec::new();
+            for mut cmd in open::commands(&url) {
+                cmd.envs(cleaned_vars.clone());
+                cmd.current_dir(env::temp_dir());
+                if cmd.status().is_ok() {
+                    return Ok(());
+                } else {
+                    cmd_errors.push(anyhow::anyhow!("Failed to execute command {cmd:?}"));
+                }
             }
-        }
-        if !cmd_errors.is_empty() {
-            bail!("Errors occurred: {cmd_errors:?}");
+            if !cmd_errors.is_empty() {
+                anyhow::bail!("Errors occurred: {cmd_errors:?}");
+            }
         }
         Ok(())
     }

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -324,7 +324,19 @@ fn spawn_background_sync(
     operations: SyncOperations,
     silent: bool,
 ) {
-    let binary_path = std::env::current_exe().unwrap_or_default();
+    #[cfg(windows)]
+    let binary_path = std::env::current_exe().unwrap();
+    #[cfg(unix)]
+    // std::env::current_exe() resolves symlinks on many UNIX implementations, which breaks the
+    // builtin-but behavior that relies on being able to tell that a `but` symlink was used to start
+    // `gitbutler-tauri`. Getting the actual OS argument used to invoke the program circumvents this
+    // issue.
+    //
+    // It would in theory be possible to just fork the current process, instead of fork-exec like we
+    // currently do here. But that would split the implementation across UNIX and Windows (which
+    // does not have fork), and I'm also uncertain how the Tokio runtime would behave with a fork.
+    let binary_path = std::env::args_os().next().unwrap();
+
     let mut cmd = tokio::process::Command::new(binary_path);
     cmd.arg("-C")
         .arg(&args.current_dir)

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -54,8 +54,14 @@ fn main() -> anyhow::Result<()> {
         .build()?;
     #[cfg(feature = "builtin-but")]
     {
-        let exe = std::env::current_exe()?;
-        if exe.file_stem().is_some_and(|stem| stem == "but") || std::env::args_os().count() > 1 {
+        // Note: We use std::env::args_os() instead of std::env::current_exe() as the latter
+        // resolves symlinks on many UNIX implementations, which makes it unsuitable for the `but`
+        // symlink trick.
+        if std::env::args_os().next().is_some_and(|exec_path| {
+            std::path::Path::new(&exec_path)
+                .file_stem()
+                .is_some_and(|stem| stem == "but")
+        }) {
             gitbutler_repo_actions::askpass::disable();
             return runtime.block_on(but::handle_args(std::env::args_os()));
         }


### PR DESCRIPTION
`but gui` works by opening a deep link using registered custom scheme handlers.

On Linux (and Windows), the deep linking in Tauri is implemented by just passing the link as a command line argument. So, in the end it resolve to something like `gitbutler-tauri 'but://open?path=...'`.

There were two problems with this.

1. The "if CLI arguments, call but CLI" gate at the start of gitbutler-tauri's main function would always invoke `but` again with the URL as an argument. So, `but` invoked gitbutler-tauri, which then invoked `but` again, which in turn errored out as `but` doesn't accept Tauri deep links as arguments. This would also happen on Windows, as [deep links are provided via CLI arguments there, too](https://v2.tauri.app/plugin/deep-linking/#desktop). I don't know how macOS does it but it's by some other mechanism.
2. We relied on the scheme being registered via Desktop entries, which on Linux will then leave it up to the desktop environment if the scheme is picked up. See comment in code for more details. 

The fix is to remove the CLI argument gate (it's sufficient to rely on the `but` symlink trick, as long as we don't resolve the symlink as we've apparently done historically), and also to directly invoke `gitbutler-tauri` with the URL instead of making the roundtrip to the Desktop entry.

There is still an issue with a cold start not actually honoring the deep link, and deep links only working when the app is up and running, but this appears to be an issue with the frontend and I'll try to resolve it
separately.

This fix _may_ also make deep linking function on Windows as there deep links are also passed via CLI arguments, but the target of this fix is currently Linux.

This PR also fixes the quirky behavior that, on Linux, running just `but` when that's a symlink to `gitbutler-tauri` would actually launch `gitbutler-tauri`.

## Fixes
Fixes #13141
Fixes #12847