### PR TITLE
Fix e2e playwright test infrastructure for parallel test runs

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
-const AMOUNT_OF_WORKERS = process.env.CI ? 1 : 4;
+const AMOUNT_OF_WORKERS = process.env.CI ? 2 : 4;
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/e2e/playwright/src/env.ts
+++ b/e2e/playwright/src/env.ts
@@ -7,5 +7,7 @@ export const BUT_SERVER_PORT = process.env.BUTLER_PORT || "6978";
 export const DESKTOP_PORT = process.env.DESKTOP_PORT || "3000";
 export const BUT_TESTING =
 	process.env.BUT_TESTING || path.join(ROOT, "target", "debug", "but-testing");
+export const BUT_SERVER =
+	process.env.BUT_SERVER || path.join(ROOT, "target", "debug", "but-server");
 export const GIT_CONFIG_GLOBAL =
 	process.env.GIT_CONFIG_GLOBAL || path.join(E2E_DIR, "fixtures", ".gitconfig");

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -1,5 +1,5 @@
 import { setConfig } from "./config.ts";
-import { BUT_SERVER_PORT, BUT_TESTING, DESKTOP_PORT, GIT_CONFIG_GLOBAL } from "./env.ts";
+import { BUT_SERVER, BUT_SERVER_PORT, BUT_TESTING, DESKTOP_PORT, GIT_CONFIG_GLOBAL } from "./env.ts";
 import { type BrowserContext } from "@playwright/test";
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
@@ -91,7 +91,46 @@ class GitButlerManager implements GitButler {
 
 	async destroy() {
 		log("Stopping GitButler...");
-		this.butServerProcess.kill("SIGTERM");
+		await new Promise<void>((resolve) => {
+			if (this.butServerProcess.exitCode !== null || this.butServerProcess.signalCode !== null) {
+				resolve();
+				return;
+			}
+
+			const shutdownTimeoutMs = 5000;
+			let settled = false;
+
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(forceKillTimer);
+				resolve();
+			};
+
+			this.butServerProcess.once("close", finish);
+
+			const forceKillTimer = setTimeout(() => {
+				if (settled) return;
+				log(
+					`but-server did not stop after ${shutdownTimeoutMs}ms, sending SIGKILL...`,
+					colors.red,
+				);
+				try {
+					this.butServerProcess.kill("SIGKILL");
+				} catch {
+					finish();
+				}
+			}, shutdownTimeoutMs);
+
+			try {
+				const killed = this.butServerProcess.kill("SIGTERM");
+				if (!killed) {
+					finish();
+				}
+			} catch {
+				finish();
+			}
+		});
 	}
 
 	pathInWorkdir(...filePathSegments: string[]): string {
@@ -120,9 +159,9 @@ class GitButlerManager implements GitButler {
 }
 
 function createButServerProcess(rootDir: string, serverEnv: Record<string, string>): ChildProcess {
-	const child = spawn("cargo", ["run", "-p", "but-server"], {
+	const child = spawn(BUT_SERVER, ["--port", serverEnv.BUTLER_PORT], {
 		cwd: rootDir,
-		stdio: "pipe",
+		stdio: ["ignore", "pipe", "pipe"],
 		env: {
 			...process.env,
 			...serverEnv,


### PR DESCRIPTION
Three bugs prevented the tests from running reliably with multiple workers:

- `destroy()` sent SIGTERM but returned immediately, causing the next
  test in the same worker to attempt binding the same port before the
  previous but-server had released it. Now awaits the 'close' event,
  with a guard for processes that already exited.

- All 4 workers started but-server on port 6978 because the port was
  passed as BUTLER_PORT in the environment, but but-server reads it
  from --port (with a hardcoded default of 6978). Fixed by spawning
  the pre-built binary directly with --port <worker-port> instead of
  `cargo run`, which also eliminates file-lock contention when workers
  compile concurrently.

- After all tests passed, worker processes would hang indefinitely
  because stdio: "pipe" created an open writable stdin handle that
  libuv kept alive. Changed to stdio: ["ignore", "pipe", "pipe"].