### PR TITLE
Fix broken CI on master: trigger lint-node on e2e/playwright changes

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -44,6 +44,7 @@ jobs:
               - *workflows
               - 'apps/**'
               - 'packages/**'
+              - 'e2e/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
             ui:

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -1,5 +1,11 @@
 import { setConfig } from "./config.ts";
-import { BUT_SERVER, BUT_SERVER_PORT, BUT_TESTING, DESKTOP_PORT, GIT_CONFIG_GLOBAL } from "./env.ts";
+import {
+	BUT_SERVER,
+	BUT_SERVER_PORT,
+	BUT_TESTING,
+	DESKTOP_PORT,
+	GIT_CONFIG_GLOBAL,
+} from "./env.ts";
 import { type BrowserContext } from "@playwright/test";
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
@@ -100,21 +106,18 @@ class GitButlerManager implements GitButler {
 			const shutdownTimeoutMs = 5000;
 			let settled = false;
 
-			const finish = () => {
+			function finish() {
 				if (settled) return;
 				settled = true;
 				clearTimeout(forceKillTimer);
 				resolve();
-			};
+			}
 
 			this.butServerProcess.once("close", finish);
 
 			const forceKillTimer = setTimeout(() => {
 				if (settled) return;
-				log(
-					`but-server did not stop after ${shutdownTimeoutMs}ms, sending SIGKILL...`,
-					colors.red,
-				);
+				log(`but-server did not stop after ${shutdownTimeoutMs}ms, sending SIGKILL...`, colors.red);
 				try {
 					this.butServerProcess.kill("SIGKILL");
 				} catch {


### PR DESCRIPTION
Add `e2e/**` to the `node` paths filter so that changes to files like
`e2e/playwright/src/setup.ts` trigger `lint-node` in CI. This fixes
broken CI on master where a formatting issue in that file went undetected
because the job wasn't triggered for changes outside `apps/**` and `packages/**`.