### PR TITLE
Forge: Set review to auto-merge

### DIFF
--- a/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/StackedPullRequestCard.svelte
@@ -7,6 +7,7 @@
 	import { inject } from "@gitbutler/core/context";
 	import { AsyncButton, TestId } from "@gitbutler/ui";
 
+	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import type { MergeMethod } from "$lib/forge/interface/types";
 
 	interface Props {
@@ -26,6 +27,7 @@
 	// TODO: Make these props so we don't need `!`.
 	const repoService = $derived(forge.current.repoService);
 	const prService = $derived(forge.current.prService);
+	const checksService = $derived(forge.current.checks);
 
 	const branchQuery = $derived(stackService.branchByName(projectId, stackId, branchName));
 	const branch = $derived(branchQuery.response);
@@ -34,6 +36,8 @@
 	const isPushed = $derived(branchDetails?.pushStatus !== "completelyUnpushed");
 	const prQuery = $derived(branch?.prNumber ? prService?.get(branch?.prNumber) : undefined);
 	const pr = $derived(prQuery?.response);
+
+	const checksQuery = $derived(checksService?.get(branchName));
 
 	const parentQuery = $derived(stackService.branchParentByName(projectId, stackId, branchName));
 	const parent = $derived(parentQuery.response);
@@ -86,6 +90,11 @@
 			baseBranchService.refreshBaseBranch(projectId),
 		]);
 	}
+
+	async function handleEnableAutoMerge() {
+		if (!pr) return;
+		await prService?.setAutoMerge(projectId, pr.number, true);
+	}
 </script>
 
 <PullRequestCard
@@ -101,10 +110,15 @@
 >
 	{#snippet button({ pr, mergeStatus, reopenStatus, setDraft })}
 		{#if pr.state === "open"}
+			{@const checks = checksQuery?.response}
 			{#if pr.draft}
 				<AsyncButton wide kind="outline" action={() => setDraft(false)}
 					>Ready for review</AsyncButton
 				>
+			{:else if isDefined(checks) && !(checks.completed && checks.success)}
+				<AsyncButton wide style="gray" kind="outline" action={handleEnableAutoMerge}>
+					Enable auto-merge
+				</AsyncButton>
 			{:else}
 				<MergeButton
 					wide

--- a/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
@@ -106,6 +106,10 @@ export class GitHubPrService implements ForgePrService {
 		await this.api.endpoints.updatePr.mutate({ number, update });
 	}
 
+	async setAutoMerge(projectId: string, reviewId: number, enable: boolean) {
+		await this.backendApi.endpoints.setAutoMerge.mutate({ projectId, reviewId, enable });
+	}
+
 	async setDraft(projectId: string, reviewId: number, draft: boolean) {
 		await this.backendApi.endpoints.setDraft.mutate({ projectId, reviewId, draft });
 	}

--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -99,6 +99,10 @@ export class GitLabPrService implements ForgePrService {
 		await this.api.endpoints.updatePr.mutate({ number, update });
 	}
 
+	async setAutoMerge(projectId: string, reviewId: number, enable: boolean) {
+		await this.backendApi.endpoints.setAutoMergeMR.mutate({ projectId, reviewId, enable });
+	}
+
 	async setDraft(projectId: string, reviewId: number, draft: boolean) {
 		await this.backendApi.endpoints.setDraftMR.mutate({ projectId, reviewId, draft });
 	}

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -38,5 +38,6 @@ export interface ForgePrService {
 		prNumber: number,
 		details: { description?: string; state?: "open" | "closed"; targetBase?: string },
 	): Promise<void>;
+	setAutoMerge(projectId: string, prNumber: number, enable: boolean): Promise<void>;
 	setDraft(projectId: string, prNumber: number, draft: boolean): Promise<void>;
 }


### PR DESCRIPTION
Add a button to the PR card to enable the auto-merge if there are checks
and they haven’t finished.


![Screenshot 2026-04-08 at 17.21.16.png](https://app.staging.gitbutler.com/uploads/d02fe617-b7e6-4063-8afb-9d731037d370)

### TODOs
- [ ] Ability to toggle on and off
- [ ] Ensure this is not janky (loading the checks info should be a bit faster)
- [ ] Get some design vetting 