### PR TITLE
feat(tui): use non-legacy rub by default

### DIFF
--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -193,7 +193,6 @@ fn register_detail_key_binds(key_binds: &mut KeyBinds) {
         message: Message::EnterNormalMode,
         hide_from_hotbar: true,
     });
-
     register_quit_key_binds(key_binds, Vec::from([ModeDiscriminant::Details]));
 }
 
@@ -462,6 +461,15 @@ fn register_rub_but_api_mode_key_binds(key_binds: &mut KeyBinds) {
         modes: Vec::from([ModeDiscriminant::RubButApi]),
         message: Message::EnterNormalMode,
         hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "back",
+        chord_display: "r",
+        key_matcher: press().code(KeyCode::Char('r')),
+        modes: Vec::from([ModeDiscriminant::RubButApi]),
+        message: Message::EnterNormalMode,
+        hide_from_hotbar: true,
     });
 }
 

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -273,18 +273,18 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
         key_matcher: press().code(KeyCode::Char('r')),
         modes: Vec::from([ModeDiscriminant::Normal]),
         message: Message::Rub(RubMessage::Start {
-            using_but_api: false,
+            using_but_api: true,
         }),
         hide_from_hotbar: false,
     });
 
     key_binds.register(StaticKeyBind {
-        short_description: "rub (but-api)",
+        short_description: "rub (legacy)",
         chord_display: "shift+r",
         key_matcher: press().shift().code(KeyCode::Char('R')),
         modes: Vec::from([ModeDiscriminant::Normal]),
         message: Message::Rub(RubMessage::Start {
-            using_but_api: true,
+            using_but_api: false,
         }),
         hide_from_hotbar: true,
     });

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2533,8 +2533,8 @@ impl App {
             "  {}  ",
             match self.mode {
                 Mode::Normal => "normal",
-                Mode::Rub(..) => "rub",
-                Mode::RubButApi(..) => "rub (api)",
+                Mode::Rub(..) => "rub (legacy)",
+                Mode::RubButApi(..) => "rub",
                 Mode::InlineReword(..) => "reword",
                 Mode::Command(..) => "command",
                 Mode::Commit(..) => "commit",

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -2446,14 +2446,7 @@ impl App {
 
         let display = match source {
             RubSource::CliId(source) => {
-                match rub_api::rub_operation_display(source, target)
-                    .unwrap_or(rub_api::RubOperationDisplay::Supported("invalid"))
-                {
-                    rub_api::RubOperationDisplay::Supported(display) => Cow::Borrowed(display),
-                    rub_api::RubOperationDisplay::NotSupported(_, discriminant) => {
-                        Cow::Owned(format!("{discriminant:?}"))
-                    }
-                }
+                Cow::Borrowed(rub_api::rub_operation_display(source, target).unwrap_or("invalid"))
             }
             RubSource::CommittedHunk(hunk) => Cow::Borrowed(
                 rub_from_detail_view::rub_operation_display(hunk, target).unwrap_or("invalid"),

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Context as _;
 use but_api::commit::types::{
-    CommitCreateResult, CommitMoveResult, CommitSquashResult, MoveChangesResult,
+    CommitCreateResult, CommitMoveResult, CommitSquashResult, CommitUndoResult, MoveChangesResult,
 };
 use but_core::{DiffSpec, diff::tree_changes, ref_metadata::StackId};
 use but_ctx::Context;
@@ -267,9 +267,9 @@ fn execute_unassigned_to_stack(
 fn execute_undo_commit(
     ctx: &mut Context,
     operation: &UndoCommitOperation,
-) -> anyhow::Result<MoveChangesResult> {
-    let changes = changes_for_commit(ctx, operation.oid)?;
-    but_api::commit::uncommit::commit_uncommit_changes(ctx, operation.oid, changes, None)
+) -> anyhow::Result<CommitUndoResult> {
+    let UndoCommitOperation { oid } = operation;
+    but_api::commit::undo::commit_undo(ctx, *oid)
 }
 
 /// Executes `SquashCommits` by squashing source into target.
@@ -445,19 +445,6 @@ fn stack_id_for_branch_name(
     Ok(ws
         .find_segment_and_stack_by_refname(target_branch_full_name.as_ref())
         .and_then(|(stack, _segment)| stack.id))
-}
-
-/// Computes diff specs for all changes in `commit_oid` relative to its first parent.
-fn changes_for_commit(ctx: &Context, commit_oid: gix::ObjectId) -> anyhow::Result<Vec<DiffSpec>> {
-    let repo = ctx.repo.get()?;
-    let source_commit = repo.find_commit(commit_oid)?;
-    let source_commit_parent_id = source_commit.parent_ids().next().context("no parents")?;
-
-    let tree_changes = tree_changes(&repo, Some(source_commit_parent_id.detach()), commit_oid)?;
-    Ok(tree_changes
-        .into_iter()
-        .map(DiffSpec::from)
-        .collect::<Vec<_>>())
 }
 
 /// Computes diff specs for changes to `path` in `commit_oid` relative to its first parent.

--- a/crates/but/src/command/legacy/status/tui/rub_api.rs
+++ b/crates/but/src/command/legacy/status/tui/rub_api.rs
@@ -4,7 +4,9 @@
 //! `RubOperationDiscriminants`, and `route_operation`.
 
 use anyhow::Context as _;
-use but_api::commit::types::{CommitCreateResult, CommitMoveResult, MoveChangesResult};
+use but_api::commit::types::{
+    CommitCreateResult, CommitMoveResult, CommitSquashResult, MoveChangesResult,
+};
 use but_core::{DiffSpec, diff::tree_changes, ref_metadata::StackId};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignmentRequest;
@@ -19,56 +21,44 @@ use crate::{
             BranchToUnassignedOperation, CommittedFileToBranchOperation,
             CommittedFileToCommitOperation, CommittedFileToUnassignedOperation,
             MoveCommitToBranchOperation, RubOperation, RubOperationDiscriminants,
-            StackToBranchOperation, StackToStackOperation, StackToUnassignedOperation,
-            UnassignUncommittedOperation, UnassignedToBranchOperation, UnassignedToCommitOperation,
-            UnassignedToStackOperation, UncommittedToBranchOperation, UncommittedToCommitOperation,
-            UncommittedToStackOperation, UndoCommitOperation, route_operation,
+            SquashCommitsOperation, StackToBranchOperation, StackToStackOperation,
+            StackToUnassignedOperation, UnassignUncommittedOperation, UnassignedToBranchOperation,
+            UnassignedToCommitOperation, UnassignedToStackOperation, UncommittedToBranchOperation,
+            UncommittedToCommitOperation, UncommittedToStackOperation, UndoCommitOperation,
+            route_operation,
         },
         status::tui::SelectAfterReload,
     },
 };
 
-/// Describes whether a routed rub operation is currently available in the rub-api implementation.
-pub(super) enum RubOperationDisplay {
-    /// The operation is available and should be shown with the provided label.
-    Supported(&'static str),
-    /// The operation isn't available and should show an explanation label plus its discriminant.
-    NotSupported(#[expect(dead_code)] &'static str, RubOperationDiscriminants),
-}
-
 /// Returns a human-facing operation descriptor for the source/target pair.
-pub(super) fn rub_operation_display(source: &CliId, target: &CliId) -> Option<RubOperationDisplay> {
+pub(super) fn rub_operation_display(source: &CliId, target: &CliId) -> Option<&'static str> {
     if source == target {
-        return Some(RubOperationDisplay::Supported("noop"));
+        return Some("noop");
     }
 
     let operation = route_operation(source, target)?;
-    let discriminant = RubOperationDiscriminants::from(&operation);
     Some(match operation {
-        RubOperation::UnassignUncommitted(..) => RubOperationDisplay::Supported("unassign hunks"),
-        RubOperation::UncommittedToCommit(..) => RubOperationDisplay::Supported("amend"),
-        RubOperation::UncommittedToBranch(..) => RubOperationDisplay::Supported("assign hunks"),
-        RubOperation::UncommittedToStack(..) => RubOperationDisplay::Supported("assign hunks"),
-        RubOperation::StackToUnassigned(..) => RubOperationDisplay::Supported("unassign hunks"),
-        RubOperation::StackToStack(..) => RubOperationDisplay::Supported("reassign hunks"),
-        RubOperation::StackToBranch(..) => RubOperationDisplay::Supported("reassign hunks"),
-        RubOperation::UnassignedToCommit(..) => RubOperationDisplay::Supported("amend"),
-        RubOperation::UnassignedToBranch(..) => RubOperationDisplay::Supported("assign hunks"),
-        RubOperation::UnassignedToStack(..) => RubOperationDisplay::Supported("assign hunks"),
-        RubOperation::UndoCommit(..) => RubOperationDisplay::Supported("undo commit"),
-        RubOperation::SquashCommits(..) => {
-            RubOperationDisplay::NotSupported("squash", discriminant)
-        }
-        RubOperation::MoveCommitToBranch(..) => RubOperationDisplay::Supported("move commit"),
-        RubOperation::BranchToUnassigned(..) => RubOperationDisplay::Supported("unassign hunks"),
-        RubOperation::BranchToStack(..) => RubOperationDisplay::Supported("reassign hunks"),
-        RubOperation::BranchToCommit(..) => RubOperationDisplay::Supported("amend"),
-        RubOperation::BranchToBranch(..) => RubOperationDisplay::Supported("reassign hunks"),
-        RubOperation::CommittedFileToBranch(..) => RubOperationDisplay::Supported("uncommit file"),
-        RubOperation::CommittedFileToCommit(..) => RubOperationDisplay::Supported("move file"),
-        RubOperation::CommittedFileToUnassigned(..) => {
-            RubOperationDisplay::Supported("uncommit file")
-        }
+        RubOperation::UnassignUncommitted(..) => "unassign hunks",
+        RubOperation::UncommittedToCommit(..) => "amend",
+        RubOperation::UncommittedToBranch(..) => "assign hunks",
+        RubOperation::UncommittedToStack(..) => "assign hunks",
+        RubOperation::StackToUnassigned(..) => "unassign hunks",
+        RubOperation::StackToStack(..) => "reassign hunks",
+        RubOperation::StackToBranch(..) => "reassign hunks",
+        RubOperation::UnassignedToCommit(..) => "amend",
+        RubOperation::UnassignedToBranch(..) => "assign hunks",
+        RubOperation::UnassignedToStack(..) => "assign hunks",
+        RubOperation::UndoCommit(..) => "undo commit",
+        RubOperation::SquashCommits(..) => "squash",
+        RubOperation::MoveCommitToBranch(..) => "move commit",
+        RubOperation::BranchToUnassigned(..) => "unassign hunks",
+        RubOperation::BranchToStack(..) => "reassign hunks",
+        RubOperation::BranchToCommit(..) => "amend",
+        RubOperation::BranchToBranch(..) => "reassign hunks",
+        RubOperation::CommittedFileToBranch(..) => "uncommit file",
+        RubOperation::CommittedFileToCommit(..) => "move file",
+        RubOperation::CommittedFileToUnassigned(..) => "uncommit file",
     })
 }
 
@@ -122,7 +112,10 @@ pub(super) fn perform_operation(
             execute_undo_commit(ctx, operation)?;
             SelectAfterReload::Unassigned
         }
-        RubOperation::SquashCommits(_operation) => return Ok(None),
+        RubOperation::SquashCommits(operation) => {
+            let result = execute_squash_commits(ctx, operation)?;
+            SelectAfterReload::Commit(result.new_commit)
+        }
         RubOperation::MoveCommitToBranch(operation) => {
             execute_move_commit_to_branch(ctx, operation)?;
             SelectAfterReload::Branch(operation.name.to_string())
@@ -277,6 +270,18 @@ fn execute_undo_commit(
 ) -> anyhow::Result<MoveChangesResult> {
     let changes = changes_for_commit(ctx, operation.oid)?;
     but_api::commit::uncommit::commit_uncommit_changes(ctx, operation.oid, changes, None)
+}
+
+/// Executes `SquashCommits` by squashing source into target.
+fn execute_squash_commits(
+    ctx: &mut Context,
+    operation: &SquashCommitsOperation,
+) -> anyhow::Result<CommitSquashResult> {
+    let SquashCommitsOperation {
+        source,
+        destination,
+    } = operation;
+    but_api::commit::squash::commit_squash(ctx, *source, *destination)
 }
 
 /// Executes `MoveCommitToBranch` and returns the exact commit-move API result.
@@ -496,7 +501,7 @@ impl std::error::Error for OperationNotSupported {}
 mod tests {
     use bstr::BString;
 
-    use super::{RubOperationDisplay, rub_operation_display};
+    use super::rub_operation_display;
     use crate::CliId;
 
     /// Converts a hex object id into `gix::ObjectId` for test setup.
@@ -516,10 +521,7 @@ mod tests {
             id: "c0".into(),
         };
 
-        assert!(matches!(
-            rub_operation_display(&source, &target),
-            Some(RubOperationDisplay::Supported("amend"))
-        ));
+        assert_eq!(rub_operation_display(&source, &target).unwrap(), "amend");
     }
 
     #[test]
@@ -535,9 +537,9 @@ mod tests {
             stack_id: None,
         };
 
-        assert!(matches!(
-            rub_operation_display(&source, &target),
-            Some(RubOperationDisplay::Supported("uncommit file"))
-        ));
+        assert_eq!(
+            rub_operation_display(&source, &target).unwrap(),
+            "uncommit file"
+        );
     }
 }

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -14,7 +14,7 @@ fn commit_mode_enter_and_escape() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -37,7 +37,7 @@ fn commit_confirm_on_source_is_noop() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -92,7 +92,7 @@ fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -135,7 +135,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     let mut tui = test_tui(env);
 
-    tui.env.file("multi-hunk.txt", &base);
+    tui.env().file("multi-hunk.txt", &base);
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -162,7 +162,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
         .collect::<Vec<_>>()
         .join("\n")
         + "\n";
-    tui.env.file("multi-hunk.txt", changed);
+    tui.env().file("multi-hunk.txt", changed);
 
     tui.input_then_render(None);
     tui.input_then_render(std::array::repeat::<_, 20>(KeyCode::Up));
@@ -180,7 +180,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
             .assert_current_line_eq(str!["┊●   [..] commit from tui test[..]"]);
     });
 
-    let status = tui.env.invoke_git("status --porcelain");
+    let status = tui.env().invoke_git("status --porcelain");
     assert_eq!(
         status, "",
         "expected all zz changes to be committed, but worktree still has:\n{status}"
@@ -194,7 +194,7 @@ fn commit_mode_shows_commit_above_on_commit_rows() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -216,7 +216,7 @@ fn commit_mode_can_toggle_commit_target_insert_side() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -251,7 +251,7 @@ fn commit_to_commit_above_creates_commit_visible_in_tui() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -288,7 +288,7 @@ fn commit_to_commit_below_creates_commit_visible_in_tui() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -321,7 +321,7 @@ fn commit_mode_from_staged_changes_stays_within_current_stack() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -371,7 +371,7 @@ fn staged_source_commit_cannot_be_forced_to_other_stack_target() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -11,7 +11,7 @@ fn discard_prompt_can_be_cancelled() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -34,7 +34,7 @@ fn discard_unassigned_confirm_yes_discards_changes() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -47,7 +47,7 @@ fn discard_unassigned_confirm_yes_discards_changes() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    let status = tui.env.invoke_git("status --porcelain");
+    let status = tui.env().invoke_git("status --porcelain");
     assert_eq!(status, "");
 
     tui.input_then_render(None)
@@ -63,7 +63,7 @@ fn discard_unassigned_cancel_keeps_changes() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -76,7 +76,7 @@ fn discard_unassigned_cancel_keeps_changes() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    let status = tui.env.invoke_git("status --porcelain");
+    let status = tui.env().invoke_git("status --porcelain");
     assert!(
         status.contains("test.txt"),
         "expected unassigned changes to remain, got: {status:?}"
@@ -105,7 +105,7 @@ fn discard_commit_confirm_yes_removes_commit() {
     tui.input_then_render('y');
     tui.input_then_render(None);
 
-    let log = tui.env.invoke_git("log --oneline");
+    let log = tui.env().invoke_git("log --oneline");
     assert!(
         !log.contains("add A"),
         "expected discarded commit to be removed from history, got:\n{log}"
@@ -124,7 +124,7 @@ fn discard_stack_confirm_yes_discards_staged_changes() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -153,7 +153,7 @@ fn discard_stack_confirm_yes_discards_staged_changes() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
-    let status = tui.env.invoke_git("status --porcelain");
+    let status = tui.env().invoke_git("status --porcelain");
     assert_eq!(status, "");
 
     tui.input_then_render(None)
@@ -169,7 +169,7 @@ fn discard_stack_cancel_keeps_staged_changes() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -197,7 +197,7 @@ fn discard_stack_cancel_keeps_staged_changes() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["┊  ╭┄[..] [staged to A]"]);
 
-    let status = tui.env.invoke_git("status --porcelain");
+    let status = tui.env().invoke_git("status --porcelain");
     assert!(
         status.contains("test.txt"),
         "expected staged changes to remain, got: {status:?}"
@@ -234,7 +234,7 @@ fn discard_branch_confirm_yes_removes_branch() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
-    let branches = tui.env.invoke_git("branch --list");
+    let branches = tui.env().invoke_git("branch --list");
     assert!(
         !branches.contains("c-branch-1"),
         "expected branch c-branch-1 to be removed, got: {branches:?}"
@@ -270,7 +270,7 @@ fn discard_branch_cancel_keeps_branch() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["┊╭┄br [c-branch-1] (no commits)"]);
 
-    let branches = tui.env.invoke_git("branch --list");
+    let branches = tui.env().invoke_git("branch --list");
     assert!(
         branches.contains("c-branch-1"),
         "expected branch c-branch-1 to remain, got: {branches:?}"

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -450,7 +450,7 @@ fn esc_leaves_rub_mode() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -472,7 +472,7 @@ fn mode_toggle_key_r_enters_and_leaves_rub_mode() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊   vo A test.txt"]);
@@ -494,7 +494,7 @@ fn mode_toggle_key_c_enters_and_leaves_commit_mode() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render('c')
         .assert_rendered_term_svg_eq(file![
@@ -554,7 +554,7 @@ fn rubbing() {
         .assert_rendered_term_svg_eq(file!["snapshots/rubbing_001.svg"])
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file!["snapshots/rubbing_002.svg"])
@@ -580,7 +580,7 @@ fn rubbing() {
 
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str![
-            "┊●   << amend commit >> [..] (no commit message) (no changes)"
+            "┊●   << amend >> [..] (no commit message) (no changes)"
         ]);
 
     tui.input_then_render(KeyCode::Enter);

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -90,8 +90,7 @@ fn move_commit_above_other_commit_reorders_tui() {
     tui.input_then_render(KeyCode::Enter)
         .assert_current_line_eq(str!["┊●   [..] add A"]);
 
-    let env = tui.env;
-    let mut tui = test_tui(env);
+    tui = tui.recreate();
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file![
             "snapshots/move_commit_above_other_commit_reorders_tui_final.svg"
@@ -132,8 +131,7 @@ fn move_commit_below_other_commit_reorders_tui() {
     tui.input_then_render(KeyCode::Enter)
         .assert_current_line_eq(str!["┊●   [..] add A"]);
 
-    let env = tui.env;
-    let mut tui = test_tui(env);
+    tui = tui.recreate();
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file![
             "snapshots/move_commit_below_other_commit_reorders_tui_final.svg"
@@ -165,8 +163,7 @@ fn move_branch_onto_other_branch_reorders_stacks() {
     tui.input_then_render(KeyCode::Enter)
         .assert_current_line_eq(str!["┊├┄[..] [A]"]);
 
-    let env = tui.env;
-    let mut tui = test_tui(env);
+    tui = tui.recreate();
     tui.input_then_render(None)
         .assert_rendered_term_svg_eq(file![
             "snapshots/move_branch_onto_other_branch_reorders_stacks_final.svg"
@@ -200,8 +197,7 @@ fn move_branch_to_merge_base_tears_off_branch() {
     tui.input_then_render(KeyCode::Enter)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    let env = tui.env;
-    let mut tui = test_tui(env);
+    tui = tui.recreate();
     tui.render_with_messages(
         None,
         Vec::from([Message::EnterNormalMode, Message::Reload(None)]),

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -15,7 +15,7 @@ fn rub_api_unassigned_to_commit() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -32,7 +32,7 @@ fn rub_api_unassigned_to_commit() {
     tui.input_then_render([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   vo A test.txt"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
@@ -59,7 +59,7 @@ fn rub_api_unassigned_to_branch_operation() {
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -74,7 +74,7 @@ fn rub_api_unassign_uncommitted_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -82,7 +82,7 @@ fn rub_api_unassign_uncommitted_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊   [..] A test.txt"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> [..] A test.txt"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -97,7 +97,7 @@ fn rub_api_uncommitted_to_branch_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -105,7 +105,7 @@ fn rub_api_uncommitted_to_branch_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊   [..] A test.txt"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> [..] A test.txt"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -120,7 +120,7 @@ fn rub_api_uncommitted_to_commit_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -128,7 +128,7 @@ fn rub_api_uncommitted_to_commit_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊   [..] A test.txt"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> [..] A test.txt"]);
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
@@ -149,7 +149,7 @@ fn rub_api_branch_to_unassigned_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄[..] [A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊╭┄<< source >> << noop >> [..] [A]"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -170,7 +170,7 @@ fn rub_api_branch_to_commit_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄[..] [A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊╭┄<< source >> << noop >> [..] [A]"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -191,7 +191,7 @@ fn rub_api_branch_to_branch_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄[..] [A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊╭┄<< source >> << noop >> [..] [A]"]);
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
@@ -212,7 +212,7 @@ fn rub_api_move_commit_to_branch_operation() {
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   [..] add A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊●   << source >> << noop >> [..] add A"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -233,7 +233,7 @@ fn rub_api_undo_commit_operation() {
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   [..] add A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊●   << source >> << noop >> [..] add A"]);
 
     tui.input_then_render([KeyCode::Up, KeyCode::Up])
@@ -254,11 +254,11 @@ fn rub_api_squash_commits_operation() {
     tui.input_then_render([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   [..] add A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊●   << source >> << noop >> [..] add A"]);
 
     tui.input_then_render([KeyCode::Down, KeyCode::Down, KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊●   << SquashCommits >> d3e2ba3 add B"]);
+        .assert_current_line_eq(str!["┊●   << squash >> [..] add B"]);
 }
 
 // Tests RubOperation::CommittedFileToCommit.
@@ -281,7 +281,7 @@ fn rub_api_committed_file_to_commit_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊│     [..] A A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊│     << source >> << noop >> [..] A A"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -308,7 +308,7 @@ fn rub_api_committed_file_to_branch_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊│     [..] A A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊│     << source >> << noop >> [..] A A"]);
 
     tui.input_then_render([KeyCode::Up, KeyCode::Up])
@@ -335,7 +335,7 @@ fn rub_api_committed_file_to_unassigned_operation() {
     tui.input_then_render(KeyCode::Down)
         .assert_current_line_eq(str!["┊│     [..] A A"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊│     << source >> << noop >> [..] A A"]);
 
     tui.input_then_render([KeyCode::Up, KeyCode::Up, KeyCode::Up])
@@ -350,8 +350,8 @@ fn rub_api_unassigned_to_stack_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("a.txt", "content");
-    tui.env.file("z.txt", "content");
+    tui.env().file("a.txt", "content");
+    tui.env().file("z.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -371,7 +371,7 @@ fn rub_api_unassigned_to_stack_operation() {
     tui.input_then_render([KeyCode::Up, KeyCode::Up, KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unstaged changes]"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -386,8 +386,8 @@ fn rub_api_uncommitted_to_stack_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("a.txt", "content");
-    tui.env.file("z.txt", "content");
+    tui.env().file("a.txt", "content");
+    tui.env().file("z.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -407,7 +407,7 @@ fn rub_api_uncommitted_to_stack_operation() {
     tui.input_then_render([KeyCode::Up, KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   [..] A z.txt"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> [..] A z.txt"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -422,7 +422,7 @@ fn rub_api_branch_to_stack_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("a.txt", "content");
+    tui.env().file("a.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -439,7 +439,7 @@ fn rub_api_branch_to_stack_operation() {
     tui.input_then_render(KeyCode::Enter)
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊╭┄<< source >> << noop >> g0 [A]"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -454,7 +454,7 @@ fn rub_api_stack_to_unassigned_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -477,7 +477,7 @@ fn rub_api_stack_to_unassigned_operation() {
     tui.input_then_render(KeyCode::Up)
         .assert_current_line_eq(str!["┊  ╭┄[..] [staged to A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊  ╭┄<< source >> << noop >> [..] [staged to A]"]);
 
     tui.input_then_render(KeyCode::Up)
@@ -492,7 +492,7 @@ fn rub_api_stack_to_branch_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("test.txt", "content");
+    tui.env().file("test.txt", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -515,7 +515,7 @@ fn rub_api_stack_to_branch_operation() {
     tui.input_then_render(KeyCode::Up)
         .assert_current_line_eq(str!["┊  ╭┄[..] [staged to A]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊  ╭┄<< source >> << noop >> [..] [staged to A]"]);
 
     tui.input_then_render(KeyCode::Down)
@@ -530,8 +530,8 @@ fn rub_api_stack_to_stack_operation() {
 
     let mut tui = test_tui(env);
 
-    tui.env.file("A", "content");
-    tui.env.file("B", "content");
+    tui.env().file("A", "content");
+    tui.env().file("B", "content");
 
     tui.input_then_render(None)
         .assert_current_line_eq(str!["╭┄zz [unstaged changes]"]);
@@ -574,7 +574,7 @@ fn rub_api_stack_to_stack_operation() {
     tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('K')))
         .assert_current_line_eq(str!["┊  ╭┄[..] [staged to B]"]);
 
-    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('R')))
+    tui.input_then_render('r')
         .assert_current_line_eq(str!["┊  ╭┄<< source >> << noop >> [..] [staged to B]"]);
 
     tui.input_then_render([KeyCode::Up, KeyCode::Up])

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -24,10 +24,12 @@ use crate::{
 pub(super) struct TestTui {
     pub(super) app: App,
     terminal: Terminal<TestBackend>,
-    pub(super) env: Sandbox,
+    env: Option<Sandbox>,
     out: OutputChannel,
     mode: OperatingMode,
     async_runtime: tokio::runtime::Runtime,
+    width: u16,
+    height: u16,
 }
 
 pub(super) fn test_tui(env: Sandbox) -> TestTui {
@@ -75,14 +77,22 @@ pub(super) fn test_tui_with_size(env: Sandbox, width: u16, height: u16) -> TestT
     TestTui {
         app,
         terminal,
-        env,
+        env: Some(env),
         out,
         mode,
         async_runtime,
+        width,
+        height,
     }
 }
 
 impl TestTui {
+    #[track_caller]
+    pub(super) fn env(&self) -> &Sandbox {
+        self.env.as_ref().unwrap()
+    }
+
+    #[track_caller]
     pub(super) fn input_then_render<E>(&mut self, event: E) -> TestTuiInputThenRenderResult<'_>
     where
         E: EventPolling,
@@ -90,6 +100,7 @@ impl TestTui {
         self.render_with_messages(event, Vec::from([Message::Reload(None)]))
     }
 
+    #[track_caller]
     pub(super) fn render_with_messages<E>(
         &mut self,
         event: E,
@@ -98,7 +109,7 @@ impl TestTui {
     where
         E: EventPolling,
     {
-        let mut ctx = self.env.context().expect("failed to create context");
+        let mut ctx = self.env().context().expect("failed to create context");
         let mut other_messages = Vec::new();
 
         with_var("GIT_AUTHOR_DATE", Some("2000-01-01T00:00:00Z"), || {
@@ -119,6 +130,54 @@ impl TestTui {
         });
 
         TestTuiInputThenRenderResult(self)
+    }
+
+    #[track_caller]
+    pub(super) fn recreate(mut self) -> Self {
+        let env = self.env.take().expect(
+            "env already removed?! This shouldn't happen, only TestTui::recreate removes the env",
+        );
+        self = test_tui_with_size(env, self.width, self.height);
+        self
+    }
+}
+
+impl Drop for TestTui {
+    fn drop(&mut self) {
+        use colored::Colorize;
+
+        if self.env.is_none() {
+            // `TestTui::recreate` was called, in which case we'll print the state of the new tui
+            // when that is dropped
+            return;
+        }
+
+        // Print the state of the terminal backend on test failures. If the test succeeds then
+        // cargo discards the test output. This makes it easier to debug test failures because so
+        // much of it depends on getting the cursor on the right line.
+
+        let render_result = self.input_then_render(None);
+        let selected_row = render_result.selected_row() as usize;
+
+        eprintln!("\nCurrent terminal state:");
+
+        for (idx, line) in render_result.output().lines().enumerate() {
+            let line = line.trim_matches('"');
+            if idx == selected_row {
+                colored::control::set_override(true);
+                eprintln!(
+                    "\"{}\"",
+                    line.on_custom_color(colored::CustomColor {
+                        r: 69,
+                        g: 71,
+                        b: 90
+                    })
+                );
+                colored::control::unset_override();
+            } else {
+                eprintln!("\"{line}\"");
+            }
+        }
     }
 }
 
@@ -141,7 +200,7 @@ pub(super) struct TestTuiInputThenRenderResult<'a>(&'a mut TestTui);
 impl TestTuiInputThenRenderResult<'_> {
     #[track_caller]
     pub(super) fn assert_rendered_contains(self, expected: &str) -> Self {
-        let output = self.0.terminal.backend().to_string();
+        let output = self.output();
         assert!(
             output.contains(expected),
             "expected rendered output to contain {expected:?}, got:\n{output}"
@@ -150,21 +209,31 @@ impl TestTuiInputThenRenderResult<'_> {
         self
     }
 
-    #[track_caller]
-    pub(super) fn assert_current_line_eq(self, expected: impl snapbox::IntoData) -> Self {
+    pub(super) fn output(&self) -> String {
+        self.0.terminal.backend().to_string()
+    }
+
+    fn selected_row(&self) -> u16 {
         let backend = self.0.terminal.backend();
         let buffer = backend.buffer();
         let area = *buffer.area();
         let selected_bg = *super::super::CURSOR_BG;
 
-        let selected_row = (area.y..area.y.saturating_add(area.height))
+        (area.y..area.y.saturating_add(area.height))
             .find(|&y| {
                 (area.x..area.x.saturating_add(area.width))
                     .any(|x| buffer[(x, y)].bg == selected_bg)
             })
-            .unwrap_or_else(|| {
-                panic!("failed to find selected row in rendered output:\n{backend}")
-            });
+            .unwrap_or_else(|| panic!("failed to find selected row in rendered output:\n{backend}"))
+    }
+
+    #[track_caller]
+    pub(super) fn assert_current_line_eq(self, expected: impl snapbox::IntoData) -> Self {
+        let backend = self.0.terminal.backend();
+        let buffer = backend.buffer();
+        let area = *buffer.area();
+
+        let selected_row = self.selected_row();
 
         let mut line = String::new();
         for x in area.x..area.x.saturating_add(area.width) {


### PR DESCRIPTION
The TUI currently has two rub modes:

- `r` which uses the same implementation as `but rub`
- `shift+r` which uses a new implementation that doesn't use legacy APIs.

All the operations performed by the latter are now non-legacy so in the interest of dog fooding this swaps the key binds so `r` is new version and `shift+r` is the old one. I've been using this for about a week and it seems to be working well.