### PR TITLE
gitbutler-edit-mode: remove redundant checkout

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -137,7 +137,6 @@ fn checkout_edit_branch(ctx: &Context, commit_id: gix::ObjectId) -> Result<()> {
         EDIT_BRANCH_REF.into(),
         0,
     )?;
-    git2_repo.checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))?;
 
     // Checkout the commit as unstaged changes
     // TODO this may not be necessary if the commit is unconflicted


### PR DESCRIPTION
When entering edit mode, a redundant checkout is currently made (we set `HEAD` then check it out, then construct an index, then check out the constructed index - which overwrites the first checkout). This is not only wasteful but causes problems on platforms that prevent directories from being deleted by another process in certain conditions, like Windows.

To illustrate: if we are currently on an unconflicted commit and then enter edit mode on a conflicted commit, the filesystem will be modified like this:
 - Start: <git root>/foo/
 - After the first checkout: <git root>/.conflict-side-0/foo/ (and other directories)
 - After the second checkout: <git root>/foo/

The end user knows what's at the start and only observes what's after the second checkout, so they would expect entering edit mode to succeed even if something prevents "foo/" from being deleted (since apparently, "foo/" is never deleted). But here, the redundant checkout deletes "foo/" and causes the process of entering edit mode to fail.

Therefore, remove the redundant checkout.

I have not modified any tests, since this behavior is already covered by "enter_edit_mode_checks_out_conflicted_commit".

