### PR TITLE
fix(gitbutler-git): avoid tampering with existing SSH configuration

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -195,8 +195,7 @@ where
     envs.insert("SSH_ASKPASS".into(), askpath_path.display().to_string());
     envs.insert("SSH_ASKPASS_REQUIRE".into(), "force".into());
 
-    let git_ssh_command = resolve_git_ssh_command(&harness_env, &envs);
-    envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
+    ensure_git_ssh_is_configured(&harness_env, &mut envs);
 
     let cwd = match harness_env {
         HarnessEnv::Repo(p) | HarnessEnv::Global(p) => p,
@@ -295,10 +294,7 @@ where
     E: GitExecutor,
 {
     let mut envs = envs.unwrap_or_default();
-    envs.insert(
-        "GIT_SSH_COMMAND".into(),
-        resolve_git_ssh_command(&harness_env, &envs),
-    );
+    ensure_git_ssh_is_configured(&harness_env, &mut envs);
 
     let cwd = match harness_env {
         HarnessEnv::Repo(p) | HarnessEnv::Global(p) => p,
@@ -310,24 +306,50 @@ where
         .map_err(Error::<E>::Exec)
 }
 
-fn resolve_git_ssh_command<P>(harness_env: &HarnessEnv<P>, envs: &HashMap<String, String>) -> String
+/// Ensures that the SSH command for Git is configured via one of GIT_SSH one GIT_SSH_COMMAND in
+/// `envs`, or core.sshCommand in the Git-config. `envs` may be mutated as part of this.
+///
+/// Resolution order is `envs` -> environment variables -> Git config.
+///
+/// If no configuration is encountered in any of these locations, we add our own default
+/// configuration for `ssh` to GIT_SSH_COMMAND. This should be the case hit by the vast majority of
+/// users, and it is tuned for what we believe is a good balance between security and convenience.
+///
+/// Note that we never add any options to existing configuration. If the user has made explicit
+/// choices about how SSH should behave, we respect those choices.
+fn ensure_git_ssh_is_configured<P>(harness_env: &HarnessEnv<P>, envs: &mut HashMap<String, String>)
 where
     P: AsRef<Path>,
 {
-    let base_ssh_command = match envs
-        .get("GIT_SSH_COMMAND")
-        .cloned()
-        .or_else(|| envs.get("GIT_SSH").cloned())
-        .or_else(|| std::env::var("GIT_SSH_COMMAND").ok())
-        .or_else(|| std::env::var("GIT_SSH").ok())
-    {
-        Some(v) => v,
-        None => get_core_sshcommand(harness_env)
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| "ssh".into()),
-    };
+    if envs.get("GIT_SSH").is_some() || envs.get("GIT_SSH_COMMAND").is_some() {
+        return;
+    }
 
+    // Note: GIT_SSH_COMMAND takes precedence over GIT_SSH so there is no reason to try to resolve
+    // both.
+    //
+    // Minor correctness issue: Neither GIT_SSH_COMMAND nor GIT_SSH are required to be unicode.
+    // It's entirely possible to have non-unicode byte sequences in paths, for example. This should
+    // be rewritten to use `std::env::var_os()` and the executor should be tweaked to let `envs`
+    // contain raw binary strings. This is however exceedingly unlikely to be a problem in practice
+    // so we'll keep it like this for now.
+    if let Ok(git_ssh_command) = std::env::var("GIT_SSH_COMMAND") {
+        envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
+        return;
+    }
+
+    if let Ok(git_ssh) = std::env::var("GIT_SSH") {
+        envs.insert("GIT_SSH".into(), git_ssh);
+        return;
+    }
+
+    if get_core_sshcommand(harness_env).ok().is_some() {
+        // If there is an SSH command configured in Git config, we don't want to override it with
+        // environment variables. Git will pick up on it automatically.
+        return;
+    }
+
+    // There is nothing preconfigured - we apply our own defaults.
     let additional_options = {
         // In test environments, we don't want to pollute the user's known hosts file.
         // So, we just use /dev/null instead.
@@ -341,9 +363,10 @@ where
         }
     };
 
-    format!(
-        "{base_ssh_command} -o StrictHostKeyChecking=accept-new -o KbdInteractiveAuthentication=no{additional_options}"
-    )
+    let git_ssh_command = format!(
+        "ssh -o StrictHostKeyChecking=accept-new -o KbdInteractiveAuthentication=no{additional_options}"
+    );
+    envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
 }
 
 fn get_core_sshcommand<P>(harness_env: &HarnessEnv<P>) -> anyhow::Result<Option<String>>

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -75,7 +75,6 @@ async fn execute_with_auth_harness<P, F, Fut, E>(
     harness_env: HarnessEnv<P>,
     executor: &E,
     args: &[&str],
-    envs: Option<HashMap<String, String>>,
     on_prompt: Option<F>,
 ) -> Result<(usize, String, String), Error<E>>
 where
@@ -84,6 +83,9 @@ where
     F: FnMut(String) -> Fut,
     Fut: std::future::Future<Output = Option<String>>,
 {
+    let mut envs = HashMap::new();
+    ensure_git_ssh_is_configured(&harness_env, &mut envs);
+
     if let Some(on_prompt) = on_prompt {
         execute_with_indirect_askpass(harness_env, executor, args, envs, on_prompt).await
     } else {
@@ -92,12 +94,12 @@ where
 }
 
 /// Askpass-aware execution of Git commands, allowing the GUI to communicate with the askpass
-/// process over a pipe.
+/// process over a pipe or socket.
 async fn execute_with_indirect_askpass<P, F, Fut, E>(
     harness_env: HarnessEnv<P>,
     executor: &E,
     args: &[&str],
-    envs: Option<HashMap<String, String>>,
+    mut envs: HashMap<String, String>,
     mut on_prompt: F,
 ) -> Result<(usize, String, String), Error<E>>
 where
@@ -170,7 +172,6 @@ where
         .map(char::from)
         .collect::<String>();
 
-    let mut envs = envs.unwrap_or_default();
     envs.insert("GITBUTLER_ASKPASS_PIPE".into(), sock_server.to_string());
     envs.insert("GITBUTLER_ASKPASS_SECRET".into(), secret.clone());
 
@@ -194,8 +195,6 @@ where
     // See the OpenSSH client manual for more info.
     envs.insert("SSH_ASKPASS".into(), askpath_path.display().to_string());
     envs.insert("SSH_ASKPASS_REQUIRE".into(), "force".into());
-
-    ensure_git_ssh_is_configured(&harness_env, &mut envs);
 
     let cwd = match harness_env {
         HarnessEnv::Repo(p) | HarnessEnv::Global(p) => p,
@@ -287,15 +286,12 @@ async fn execute_direct<P, E>(
     harness_env: HarnessEnv<P>,
     executor: &E,
     args: &[&str],
-    envs: Option<HashMap<String, String>>,
+    envs: HashMap<String, String>,
 ) -> Result<(usize, String, String), Error<E>>
 where
     P: AsRef<Path>,
     E: GitExecutor,
 {
-    let mut envs = envs.unwrap_or_default();
-    ensure_git_ssh_is_configured(&harness_env, &mut envs);
-
     let cwd = match harness_env {
         HarnessEnv::Repo(p) | HarnessEnv::Global(p) => p,
     };
@@ -306,25 +302,24 @@ where
         .map_err(Error::<E>::Exec)
 }
 
-/// Ensures that the SSH command for Git is configured via one of GIT_SSH one GIT_SSH_COMMAND in
-/// `envs`, or core.sshCommand in the Git-config. `envs` may be mutated as part of this.
+/// Ensures that the SSH command for Git is configured via one of GIT_SSH or GIT_SSH_COMMAND in
+/// `envs`, or core.sshCommand in the Git-config. `envs` may be modified with the aforementioned
+/// environment variables if they are found in the environment.
 ///
-/// Resolution order is `envs` -> environment variables -> Git config.
+/// Resolution order reflects Git in that we first look for environment variables, and if those are
+/// not found we consider Git config.
 ///
 /// If no configuration is encountered in any of these locations, we add our own default
 /// configuration for `ssh` to GIT_SSH_COMMAND. This should be the case hit by the vast majority of
 /// users, and it is tuned for what we believe is a good balance between security and convenience.
 ///
 /// Note that we never add any options to existing configuration. If the user has made explicit
-/// choices about how SSH should behave, we respect those choices.
+/// choices about how SSH should behave, we respect those choices and leave it to the user to deal
+/// with the consequences.
 fn ensure_git_ssh_is_configured<P>(harness_env: &HarnessEnv<P>, envs: &mut HashMap<String, String>)
 where
     P: AsRef<Path>,
 {
-    if envs.get("GIT_SSH").is_some() || envs.get("GIT_SSH_COMMAND").is_some() {
-        return;
-    }
-
     // Note: GIT_SSH_COMMAND takes precedence over GIT_SSH so there is no reason to try to resolve
     // both.
     //
@@ -411,14 +406,8 @@ where
     args.push(remote);
     args.push(&refspec);
 
-    let (status, stdout, stderr) = execute_with_auth_harness(
-        HarnessEnv::Repo(repo_path),
-        &executor,
-        &args,
-        None,
-        on_prompt,
-    )
-    .await?;
+    let (status, stdout, stderr) =
+        execute_with_auth_harness(HarnessEnv::Repo(repo_path), &executor, &args, on_prompt).await?;
 
     if status == 0 {
         Ok(())
@@ -492,14 +481,8 @@ where
         args.push(opt.as_str());
     }
 
-    let (status, stdout, stderr) = execute_with_auth_harness(
-        HarnessEnv::Repo(repo_path),
-        &executor,
-        &args,
-        None,
-        on_prompt,
-    )
-    .await?;
+    let (status, stdout, stderr) =
+        execute_with_auth_harness(HarnessEnv::Repo(repo_path), &executor, &args, on_prompt).await?;
 
     if status == 0 {
         return Ok(stderr);
@@ -565,14 +548,9 @@ where
     let target_dir_str = target_dir.to_string_lossy();
     let args = vec!["clone", "--", repository_url, &target_dir_str];
 
-    let (status, stdout, stderr) = execute_with_auth_harness(
-        HarnessEnv::Global(work_dir),
-        &executor,
-        &args,
-        None,
-        on_prompt,
-    )
-    .await?;
+    let (status, stdout, stderr) =
+        execute_with_auth_harness(HarnessEnv::Global(work_dir), &executor, &args, on_prompt)
+            .await?;
 
     if status == 0 {
         Ok(())

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -83,8 +83,7 @@ where
     F: FnMut(String) -> Fut,
     Fut: std::future::Future<Output = Option<String>>,
 {
-    let mut envs = HashMap::new();
-    ensure_git_ssh_is_configured(&harness_env, &mut envs);
+    let envs = new_env_with_git_ssh_configured(&harness_env);
 
     if let Some(on_prompt) = on_prompt {
         execute_with_indirect_askpass(harness_env, executor, args, envs, on_prompt).await
@@ -302,27 +301,25 @@ where
         .map_err(Error::<E>::Exec)
 }
 
-/// Ensures that the SSH command for Git is configured via one of GIT_SSH or GIT_SSH_COMMAND in
-/// `envs`, or core.sshCommand in the Git-config. `envs` may be modified with the aforementioned
-/// environment variables if they are found in the environment.
+/// Create an environment variable mapping that is guaranteed to have the Git SSH command configured
+/// in either GIT_SSH_COMMAND or GIT_SSH.
 ///
-/// Resolution order reflects Git in that we first look for environment variables, and if those are
-/// not found we consider Git config.
+/// Resolution order reflects Git: GIT_SSH_COMMAND -> core.sshCommand -> GIT_SSH
+/// See https://github.com/git/git/blob/60f07c4f5c5f81c8a994d9e06b31a4a3a1679864/connect.c#L1382-L1397
 ///
-/// If no configuration is encountered in any of these locations, we add our own default
-/// configuration for `ssh` to GIT_SSH_COMMAND. This should be the case hit by the vast majority of
+/// If no configuration is encountered in any of these locations, we set our own default
+/// configuration for `ssh` in GIT_SSH_COMMAND. This should be the case hit by the vast majority of
 /// users, and it is tuned for what we believe is a good balance between security and convenience.
 ///
 /// Note that we never add any options to existing configuration. If the user has made explicit
 /// choices about how SSH should behave, we respect those choices and leave it to the user to deal
 /// with the consequences.
-fn ensure_git_ssh_is_configured<P>(harness_env: &HarnessEnv<P>, envs: &mut HashMap<String, String>)
+fn new_env_with_git_ssh_configured<P>(harness_env: &HarnessEnv<P>) -> HashMap<String, String>
 where
     P: AsRef<Path>,
 {
-    // Note: GIT_SSH_COMMAND takes precedence over GIT_SSH so there is no reason to try to resolve
-    // both.
-    //
+    let mut envs = HashMap::new();
+
     // Minor correctness issue: Neither GIT_SSH_COMMAND nor GIT_SSH are required to be unicode.
     // It's entirely possible to have non-unicode byte sequences in paths, for example. This should
     // be rewritten to use `std::env::var_os()` and the executor should be tweaked to let `envs`
@@ -330,18 +327,19 @@ where
     // so we'll keep it like this for now.
     if let Ok(git_ssh_command) = std::env::var("GIT_SSH_COMMAND") {
         envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
-        return;
+        return envs;
+    }
+
+    if let Ok(Some(git_ssh_command)) = get_core_sshcommand(harness_env) {
+        // This move is a NOOP in most practical applications, but we do it for the simplicity of
+        // the GIT_SSH/GIT_SSH_COMMAND-is-configured invariant.
+        envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
+        return envs;
     }
 
     if let Ok(git_ssh) = std::env::var("GIT_SSH") {
         envs.insert("GIT_SSH".into(), git_ssh);
-        return;
-    }
-
-    if get_core_sshcommand(harness_env).ok().is_some() {
-        // If there is an SSH command configured in Git config, we don't want to override it with
-        // environment variables. Git will pick up on it automatically.
-        return;
+        return envs;
     }
 
     // There is nothing preconfigured - we apply our own defaults.
@@ -362,6 +360,7 @@ where
         "ssh -o StrictHostKeyChecking=accept-new -o KbdInteractiveAuthentication=no{additional_options}"
     );
     envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
+    envs
 }
 
 fn get_core_sshcommand<P>(harness_env: &HarnessEnv<P>) -> anyhow::Result<Option<String>>

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -325,14 +325,7 @@ where
     // be rewritten to use `std::env::var_os()` and the executor should be tweaked to let `envs`
     // contain raw binary strings. This is however exceedingly unlikely to be a problem in practice
     // so we'll keep it like this for now.
-    if let Ok(git_ssh_command) = std::env::var("GIT_SSH_COMMAND") {
-        envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
-        return envs;
-    }
-
-    if let Ok(Some(git_ssh_command)) = get_core_sshcommand(harness_env) {
-        // This move is a NOOP in most practical applications, but we do it for the simplicity of
-        // the GIT_SSH/GIT_SSH_COMMAND-is-configured invariant.
+    if let Ok(Some(git_ssh_command)) = get_git_ssh_command(harness_env) {
         envs.insert("GIT_SSH_COMMAND".into(), git_ssh_command);
         return envs;
     }
@@ -363,7 +356,12 @@ where
     envs
 }
 
-fn get_core_sshcommand<P>(harness_env: &HarnessEnv<P>) -> anyhow::Result<Option<String>>
+/// Gets GIT_SSH_COMMAND from env first, config second.
+///
+/// Correctness issue: If the command is not valid UTF8, this function returns Ok(None). When the
+/// executor is updated to be able to handle binary strings for envs, this should be rewritten
+/// accordingly.
+fn get_git_ssh_command<P>(harness_env: &HarnessEnv<P>) -> anyhow::Result<Option<String>>
 where
     P: AsRef<Path>,
 {
@@ -371,10 +369,10 @@ where
         HarnessEnv::Repo(repo_path) => Ok(gix::open(repo_path.as_ref())?
             .config_snapshot()
             .trusted_program(gix::config::tree::Core::SSH_COMMAND)
-            .map(|program| program.to_string_lossy().into_owned())),
+            .and_then(|program| program.to_str().map(String::from))),
         HarnessEnv::Global(_) => Ok(gix::config::File::from_globals()?
             .string(gix::config::tree::Core::SSH_COMMAND)
-            .map(|program| program.to_str_lossy().into_owned())),
+            .and_then(|program| program.to_str().ok().map(String::from))),
     }
 }
 


### PR DESCRIPTION
Historically, we have unconditionally 1) promoted GIT_SSH to GIT_SSH_COMMAND, and 2) appended OpenSSH-specific options to the command.

The GIT_SSH->GIT_SSH_COMMAND promotion caused issues with escaping of GIT_SSH, as GIT_SSH is explicitly a _program_ (path or just a name to be looked up on PATH), while GIT_SSH_COMMAND is an arbitrary shell command. So, for example, unescaped whitespace in GIT_SSH is fine but causes GIT_SSH_COMMAND to break.

The appending of OpenSSH-specific options causes alternative clients (such as plink.exe on Windows) to break.

To resolve these issues, we take a more conservative approach and only apply our own preferred defaults for OpenSSH if we cannot find any configuration for the SSH behavior in the current environment.

Replaces https://github.com/gitbutlerapp/gitbutler/pull/13239

Fixes https://github.com/gitbutlerapp/gitbutler/issues/13088