### PR TITLE
fix(but): fix `but` detection with symlink trick on Linux

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -55,7 +55,7 @@ use crate::{
         },
     },
     tui::{CrosstermTerminalGuard, HeadlessTerminalGuard, TerminalGuard},
-    utils::{DebugAsType, OutputChannel},
+    utils::{DebugAsType, OutputChannel, binary_path::current_exe_for_but_exec},
 };
 
 use super::{
@@ -1948,7 +1948,7 @@ impl App {
             return Ok(());
         };
 
-        let binary_path = std::env::current_exe().unwrap_or_default();
+        let binary_path = current_exe_for_but_exec()?;
         let args = shell_words::split(input)?.into_iter().map(OsString::from);
 
         let mut cmd = Command::new(binary_path);

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -49,6 +49,8 @@ use crate::{
 mod id;
 pub use id::{CliId, IdMap};
 
+pub use utils::binary_path::is_executed_as_but;
+
 mod alias;
 /// A place for all command implementations.
 pub(crate) mod command;

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -7,7 +7,7 @@ use command_group::AsyncCommandGroup;
 
 use crate::{
     args::Args,
-    utils::{Confirm, ConfirmDefault, OutputChannel},
+    utils::{Confirm, ConfirmDefault, OutputChannel, binary_path::current_exe_for_but_exec},
 };
 
 #[derive(Default)]
@@ -324,20 +324,17 @@ fn spawn_background_sync(
     operations: SyncOperations,
     silent: bool,
 ) {
-    #[cfg(windows)]
-    let binary_path = std::env::current_exe().unwrap();
-    #[cfg(unix)]
-    // std::env::current_exe() resolves symlinks on many UNIX implementations, which breaks the
-    // builtin-but behavior that relies on being able to tell that a `but` symlink was used to start
-    // `gitbutler-tauri`. Getting the actual OS argument used to invoke the program circumvents this
-    // issue.
-    //
-    // It would in theory be possible to just fork the current process, instead of fork-exec like we
-    // currently do here. But that would split the implementation across UNIX and Windows (which
-    // does not have fork), and I'm also uncertain how the Tokio runtime would behave with a fork.
-    let binary_path = std::env::args_os().next().unwrap();
-
-    let mut cmd = tokio::process::Command::new(binary_path);
+    let mut cmd = {
+        match current_exe_for_but_exec() {
+            Ok(but_path) => tokio::process::Command::new(but_path),
+            Err(e) => {
+                tracing::error!(error = %e, "failed to resolve but binary path");
+                // We don't want to cause a crash just because we can't spawn background sync, so we fail
+                // silently instead
+                return;
+            }
+        }
+    };
     cmd.arg("-C")
         .arg(&args.current_dir)
         .arg("refresh-remote-data");

--- a/crates/but/src/utils/binary_path.rs
+++ b/crates/but/src/utils/binary_path.rs
@@ -1,0 +1,67 @@
+//! Helpers for resolving binary paths.
+use std::path::{Path, PathBuf};
+
+/// Resolve the path to the current executable, assuming it's `but`, such that it can be executed.
+///
+/// # Linux
+/// Under Linux, the `/proc/self/exe` magic symlink is maintained by the kernel to point to the
+/// executable. The kernel keeps the executable's inode alive even if the file has been moved
+/// or deleted, and therefore this symlink can be executed as long as the process is running.
+///
+/// Resolving the symlink with [`std::env::current_exe`] fully resolves `/proc/self/exe` to the
+/// executable it points to. Executing that fails if the binary has been removed. This is the case
+/// when emitting metrics for the `update install` command. The executable first renames itself
+/// (causing `/proc/self/exe` to point to the new location) and then removes itself once the new
+/// version is successfully installed (causing `/proc/self/exe` to point to a non-existing binary).
+///
+/// As [`std::env::current_exe`] resolves the symlink, it also means that the `but ->
+/// gitbutler-tauri` symlink trick to execute the CLI via the primary `gitbutler-tauri` executable
+/// fails, as it's executed with the fully resolved path.
+///
+/// Note that both of the above issues could _probably_ be addressed by using argv[0] as the path,
+/// but as we are always guaranteed to have `/proc/self/exe` we might as well use it.
+///
+/// # Windows and macOS
+/// Under macOS and Windows, there's no equivalent to Linux's /proc/self/exe, so we
+/// can't easily refer to the "current process' program" like we can there.
+///
+/// On macOS, std::env::current_exe() is implemented with _NSGetExecutablePath, which provides the
+/// path the executable was launched with. In the `update install` case, metrics will then be
+/// emitted with the _new_ version rather than the one that actually ran the command. The only way
+/// around this is to emit metrics before cleaning up the old version, but that does not seem
+/// worthwhile at the moment.
+///
+/// On Windows, current_exe() is implemented with GetModuleFileNameW, which also
+/// returns the path with which the executable was launched, and so has the same
+/// problem. Although at the time of writing, `update install` is not implemented
+/// for Windows.
+pub fn current_exe_for_but_exec() -> std::io::Result<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        Ok("/proc/self/exe".into())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::env::current_exe()
+    }
+}
+
+/// Determine if this program was executed with the intention of running the `but` CLI, handling the
+/// case where this may be `gitbutler-tauri` invoked via symlink.
+pub fn is_executed_as_but() -> anyhow::Result<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        Ok(std::env::args_os().next().is_some_and(|exec_path| {
+            // Assumption: We never self-exec the GUI itself
+            exec_path == "/proc/self/exe"
+                || Path::new(&exec_path)
+                    .file_stem()
+                    .is_some_and(|stem| stem == "but")
+        }))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let current_exe = std::env::current_exe()?;
+        Ok(current_exe.file_stem().is_some_and(|stem| stem == "but"))
+    }
+}

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     args::{Subcommands, config, metrics::CommandName},
-    utils::ResultMetricsExt,
+    utils::{ResultMetricsExt, binary_path},
 };
 
 pub(super) mod types {
@@ -429,41 +429,7 @@ impl<T> ResultMetricsExt for anyhow::Result<T> {
             return self.map(|_| ());
         };
 
-        let binary_path = {
-            #[cfg(target_os = "linux")]
-            {
-                // Under Linux, the /proc/self/exe magic symlink is maintained by the kernel to
-                // point to the executable. The kernel keeps the executable's inode alive even if
-                // the file has been moved or deleted, and therefore this symlink can be executed
-                // as long as the process is running.
-                //
-                // Resolving the symlink with std::env::current_exe() and executing that fails if
-                // the binary has been removed, which is the case when emitting metrics for the
-                // `update install` command (the executable removes itself at the end of the
-                // command).
-                std::path::PathBuf::from("/proc/self/exe")
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                // Under macOS and Windows, there's no equivalent to Linux's /proc/self/exe, so we
-                // can't easily refer to the "current process' program" like we can there.
-                //
-                // On macOS, std::env::current_exe() is implemented with _NSGetExecutablePath,
-                // which provides the path the executable was launched with, so in the `but update
-                // install` case, metrics will actually be emitted with the _new_ version rather
-                // than the one that actually ran the command. The only way around this is to emit
-                // metrics before cleaning up the old version, but that does not seem worthwhile at
-                // the moment.
-                //
-                // On Windows, current_exe() is implemented with GetModuleFileNameW, which also
-                // returns the path with which the executable was launched, and so has the same
-                // problem. Although at the time of writing, `update install` is not implemented
-                // for Windows.
-                std::env::current_exe()?
-            }
-        };
-
-        tokio::process::Command::new(binary_path)
+        tokio::process::Command::new(binary_path::current_exe_for_but_exec()?)
             .arg("metrics")
             .arg("--command-name")
             .arg(v.get_name())

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -21,6 +21,8 @@ pub use metrics::types::OneshotMetricsContext;
 pub mod detect_agent;
 pub mod time;
 
+pub(crate) mod binary_path;
+
 /// Utilities attached to `anyhow::Result<impl serde::Serialize>`.
 pub trait ResultJsonExt {
     /// Write this value as pretty `JSON` to stdout if `json` is `true`.

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -54,14 +54,7 @@ fn main() -> anyhow::Result<()> {
         .build()?;
     #[cfg(feature = "builtin-but")]
     {
-        // Note: We use std::env::args_os() instead of std::env::current_exe() as the latter
-        // resolves symlinks on many UNIX implementations, which makes it unsuitable for the `but`
-        // symlink trick.
-        if std::env::args_os().next().is_some_and(|exec_path| {
-            std::path::Path::new(&exec_path)
-                .file_stem()
-                .is_some_and(|stem| stem == "but")
-        }) {
+        if but::is_executed_as_but()? {
             gitbutler_repo_actions::askpass::disable();
             return runtime.block_on(but::handle_args(std::env::args_os()));
         }


### PR DESCRIPTION
It broke horribly for metrics emission and TUI command invocation because of the deep link fix in 85c5c82b001b5564a44d0c83f840ca834b450a78

Currently making a nightly dry run to see if this works as it should in published form.