### PR TITLE
Lite: tidy up tagged unions

### DIFF
--- a/apps/lite/ui/src/Operation.ts
+++ b/apps/lite/ui/src/Operation.ts
@@ -1,6 +1,6 @@
 import { Toast } from "@base-ui/react";
 import { useMutation } from "@tanstack/react-query";
-import { Match } from "effect";
+import { Data, Match } from "effect";
 import {
 	type AssignHunkParams,
 	type CommitAmendParams,
@@ -54,90 +54,21 @@ export type MoveBranchOperation = Omit<MoveBranchParams, "projectId">;
 /** @public */
 export type TearOffBranchOperation = Omit<TearOffBranchParams, "projectId">;
 
-export type Operation =
-	| ({ _tag: "AssignHunk" } & AssignHunkOperation)
-	| ({ _tag: "CommitAmend" } & CommitAmendOperation)
-	| ({ _tag: "CommitCreate" } & CommitCreateOperation)
-	| ({ _tag: "CommitCreateFromCommittedChanges" } & CommitCreateFromCommittedChangesOperation)
-	| ({ _tag: "CommitMove" } & CommitMoveOperation)
-	| ({ _tag: "CommitMoveChangesBetween" } & CommitMoveChangesBetweenOperation)
-	| ({ _tag: "CommitSquash" } & CommitSquashOperation)
-	| ({ _tag: "CommitUncommit" } & CommitUncommitOperation)
-	| ({ _tag: "CommitUncommitChanges" } & CommitUncommitChangesOperation)
-	| ({ _tag: "MoveBranch" } & MoveBranchOperation)
-	| ({ _tag: "TearOffBranch" } & TearOffBranchOperation);
+export type Operation = Data.TaggedEnum<{
+	AssignHunk: AssignHunkOperation;
+	CommitAmend: CommitAmendOperation;
+	CommitCreate: CommitCreateOperation;
+	CommitCreateFromCommittedChanges: CommitCreateFromCommittedChangesOperation;
+	CommitMove: CommitMoveOperation;
+	CommitMoveChangesBetween: CommitMoveChangesBetweenOperation;
+	CommitSquash: CommitSquashOperation;
+	CommitUncommit: CommitUncommitOperation;
+	CommitUncommitChanges: CommitUncommitChangesOperation;
+	MoveBranch: MoveBranchOperation;
+	TearOffBranch: TearOffBranchOperation;
+}>;
 
-/** @public */
-export const assignHunkOperation = (operation: AssignHunkOperation): Operation => ({
-	_tag: "AssignHunk",
-	...operation,
-});
-
-/** @public */
-export const commitAmendOperation = (operation: CommitAmendOperation): Operation => ({
-	_tag: "CommitAmend",
-	...operation,
-});
-
-/** @public */
-export const commitCreateOperation = (operation: CommitCreateOperation): Operation => ({
-	_tag: "CommitCreate",
-	...operation,
-});
-
-/** @public */
-export const commitCreateFromCommittedChangesOperation = (
-	operation: CommitCreateFromCommittedChangesOperation,
-): Operation => ({
-	_tag: "CommitCreateFromCommittedChanges",
-	...operation,
-});
-
-/** @public */
-export const commitMoveOperation = (operation: CommitMoveOperation): Operation => ({
-	_tag: "CommitMove",
-	...operation,
-});
-
-/** @public */
-export const commitMoveChangesBetweenOperation = (
-	operation: CommitMoveChangesBetweenOperation,
-): Operation => ({
-	_tag: "CommitMoveChangesBetween",
-	...operation,
-});
-
-/** @public */
-export const commitSquashOperation = (operation: CommitSquashOperation): Operation => ({
-	_tag: "CommitSquash",
-	...operation,
-});
-
-/** @public */
-export const commitUncommitOperation = (operation: CommitUncommitOperation): Operation => ({
-	_tag: "CommitUncommit",
-	...operation,
-});
-
-/** @public */
-export const commitUncommitChangesOperation = (
-	operation: CommitUncommitChangesOperation,
-): Operation => ({
-	_tag: "CommitUncommitChanges",
-	...operation,
-});
-
-/** @public */
-export const moveBranchOperation = (operation: MoveBranchOperation): Operation => ({
-	_tag: "MoveBranch",
-	...operation,
-});
-
-/** @public */
-export const tearOffBranchOperation = (operation: TearOffBranchOperation): Operation => ({
-	_tag: "TearOffBranch",
-	...operation,
-});
+export const Operation = Data.taggedEnum<Operation>();
 
 export const getInsertionSide = (operation: Operation): InsertSide | null =>
 	Match.value(operation).pipe(

--- a/apps/lite/ui/src/domain/FileParent.ts
+++ b/apps/lite/ui/src/domain/FileParent.ts
@@ -1,20 +1,13 @@
+import { Data } from "effect";
+
 /** @public */
 export type CommitFileParent = { commitId: string };
 /** @public */
 export type ChangesSectionFileParent = { stackId: string | null };
 
-export type FileParent =
-	| ({ _tag: "Commit" } & CommitFileParent)
-	| ({ _tag: "ChangesSection" } & ChangesSectionFileParent);
+export type FileParent = Data.TaggedEnum<{
+	Commit: CommitFileParent;
+	ChangesSection: ChangesSectionFileParent;
+}>;
 
-/** @public */
-export const commitFileParent = ({ commitId }: CommitFileParent): FileParent => ({
-	_tag: "Commit",
-	commitId,
-});
-
-/** @public */
-export const changesSectionFileParent = ({ stackId }: ChangesSectionFileParent): FileParent => ({
-	_tag: "ChangesSection",
-	stackId,
-});
+export const FileParent = Data.taggedEnum<FileParent>();

--- a/apps/lite/ui/src/routes/project/$id/branches/Selection.ts
+++ b/apps/lite/ui/src/routes/project/$id/branches/Selection.ts
@@ -1,3 +1,4 @@
+import { Data } from "effect";
 import { BranchIdentity, BranchListing } from "@gitbutler/but-sdk";
 
 /** @public */
@@ -5,38 +6,19 @@ export type BranchSelection = { branchName: BranchIdentity };
 /** @public */
 export type DetailsCommitMode = { path?: string };
 /** @public */
-export type CommitMode = { _tag: "Summary" } | ({ _tag: "Details" } & DetailsCommitMode);
+export type CommitMode = Data.TaggedEnum<{
+	Summary: {};
+	Details: DetailsCommitMode;
+}>;
 /** @public */
 export type CommitSelection = BranchSelection & { commitId: string; mode: CommitMode };
+export type Selection = Data.TaggedEnum<{
+	Branch: BranchSelection;
+	Commit: CommitSelection;
+}>;
 
-/** @public */
-export const summaryCommitMode: CommitMode = {
-	_tag: "Summary",
-};
-
-/** @public */
-export const detailsCommitMode = ({ path }: DetailsCommitMode): CommitMode => ({
-	_tag: "Details",
-	path,
-});
-
-export type Selection =
-	| ({ _tag: "Branch" } & BranchSelection)
-	| ({ _tag: "Commit" } & CommitSelection);
-
-/** @public */
-export const branchSelection = ({ branchName }: BranchSelection): Selection => ({
-	_tag: "Branch",
-	branchName,
-});
-
-/** @public */
-export const commitSelection = ({ branchName, commitId, mode }: CommitSelection): Selection => ({
-	_tag: "Commit",
-	branchName,
-	commitId,
-	mode,
-});
+export const CommitMode = Data.taggedEnum<CommitMode>();
+export const Selection = Data.taggedEnum<Selection>();
 
 export const isValidBranchSelection = (
 	selection: Selection,
@@ -50,5 +32,5 @@ export const isValidBranchSelection = (
 export const getDefaultSelection = (branches: Array<BranchListing>): Selection | null => {
 	const firstBranch = branches[0];
 	if (!firstBranch) return null;
-	return branchSelection({ branchName: firstBranch.name });
+	return Selection.Branch({ branchName: firstBranch.name });
 };

--- a/apps/lite/ui/src/routes/project/$id/branches/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/branches/route.tsx
@@ -22,7 +22,7 @@ import styles from "./route.module.css";
 import { applyBranchMutationOptions, unapplyStackMutationOptions } from "#ui/api/mutations.ts";
 import { listBranchesQueryOptions, listProjectsQueryOptions } from "#ui/api/queries.ts";
 import { CheckIcon, ArrowDownIcon, ArrowUpIcon, AddCircleIcon } from "#ui/components/icons.tsx";
-import { commitFileParent } from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { ProjectPreviewLayout } from "#ui/routes/project/$id/ProjectPreviewLayout.tsx";
 import {
 	CommitFiles,
@@ -35,19 +35,11 @@ import {
 	Patch,
 } from "#ui/routes/project/$id/shared.tsx";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
-import { fileOperationSource } from "#ui/routes/project/$id/workspace/OperationSource.ts";
 import { Route as projectRoute } from "#ui/routes/project/$id/route.tsx";
+import { OperationSource } from "#ui/routes/project/$id/workspace/OperationSource.ts";
 import uiStyles from "#ui/ui.module.css";
 import sharedStyles from "../shared.module.css";
-import {
-	branchSelection,
-	commitSelection,
-	detailsCommitMode,
-	getDefaultSelection,
-	isValidBranchSelection,
-	type Selection,
-	summaryCommitMode,
-} from "./Selection.ts";
+import { CommitMode, Selection, getDefaultSelection, isValidBranchSelection } from "./Selection.ts";
 
 const FileDiff: FC<{
 	projectId: string;
@@ -110,10 +102,10 @@ const getExpandedCommitSelection = async ({
 		commitDetailsWithLineStatsQueryOptions({ projectId, commitId }),
 	);
 
-	return commitSelection({
+	return Selection.Commit({
 		branchName,
 		commitId,
-		mode: detailsCommitMode({ path: commitDetails.changes[0]?.path }),
+		mode: CommitMode.Details({ path: commitDetails.changes[0]?.path }),
 	});
 };
 
@@ -145,8 +137,8 @@ const ShowCommit: FC<{
 							{editable ? (
 								<OperationSourceC
 									projectId={projectId}
-									source={fileOperationSource({
-										parent: commitFileParent({ commitId: commit.id }),
+									source={OperationSource.File({
+										parent: FileParent.Commit({ commitId: commit.id }),
 										path: change.path,
 									})}
 								>
@@ -319,9 +311,9 @@ const BranchRow: FC<
 		select: (selection: Selection | null) => void;
 	} & ComponentProps<"div">
 > = ({ projectId, branch, selection, select, className, ...restProps }) => {
-	const branchSelectionV =
+	const branchSelection =
 		selection?._tag === "Branch" && selection.branchName === branch.name ? selection : null;
-	const commitSelectionV =
+	const commitSelection =
 		selection?._tag === "Commit" && selection.branchName === branch.name ? selection : null;
 
 	return (
@@ -329,7 +321,7 @@ const BranchRow: FC<
 			{...restProps}
 			className={classes(
 				sharedStyles.itemRow,
-				(branchSelectionV || commitSelectionV) && sharedStyles.itemRowSelected,
+				(branchSelection || commitSelection) && sharedStyles.itemRowSelected,
 				className,
 			)}
 		>
@@ -340,7 +332,7 @@ const BranchRow: FC<
 							type="button"
 							className={styles.branchButton}
 							onClick={() => {
-								select(branchSelection({ branchName: branch.name }));
+								select(Selection.Branch({ branchName: branch.name }));
 							}}
 						>
 							{branch.name}
@@ -384,7 +376,7 @@ const CommitRow: FC<{
 }> = ({ branchName, commit, projectId, selection, select, isHighlighted }) => {
 	const [isDetailsPending, startDetailsTransition] = useTransition();
 	const queryClient = useQueryClient();
-	const commitSelectionV =
+	const commitSelection =
 		selection?._tag === "Commit" &&
 		selection.branchName === branchName &&
 		selection.commitId === commit.id
@@ -393,12 +385,12 @@ const CommitRow: FC<{
 
 	const toggleDetails = () => {
 		startDetailsTransition(async () => {
-			if (commitSelectionV?.mode._tag === "Details") {
+			if (commitSelection?.mode._tag === "Details") {
 				select(
-					commitSelection({
+					Selection.Commit({
 						branchName,
 						commitId: commit.id,
-						mode: summaryCommitMode,
+						mode: CommitMode.Summary(),
 					}),
 				);
 				return;
@@ -418,7 +410,7 @@ const CommitRow: FC<{
 		<div
 			className={classes(
 				sharedStyles.itemRow,
-				commitSelectionV && sharedStyles.itemRowSelected,
+				commitSelection && sharedStyles.itemRowSelected,
 				isHighlighted && sharedStyles.itemRowHighlighted,
 			)}
 			style={{ ...(isDetailsPending && { opacity: 0.5 }) }}
@@ -429,10 +421,10 @@ const CommitRow: FC<{
 				className={sharedStyles.commitButton}
 				onClick={() => {
 					select(
-						commitSelection({
+						Selection.Commit({
 							branchName,
 							commitId: commit.id,
-							mode: summaryCommitMode,
+							mode: CommitMode.Summary(),
 						}),
 					);
 				}}
@@ -448,19 +440,17 @@ const CommitRow: FC<{
 					className={sharedStyles.itemRowAction}
 					type="button"
 					onClick={toggleDetails}
-					aria-expanded={commitSelectionV?.mode._tag === "Details"}
+					aria-expanded={commitSelection?.mode._tag === "Details"}
 					aria-label={
-						commitSelectionV?.mode._tag === "Details" ? "Hide commit files" : "Show commit files"
+						commitSelection?.mode._tag === "Details" ? "Hide commit files" : "Show commit files"
 					}
 				>
-					<ExpandCollapseIcon isExpanded={commitSelectionV?.mode._tag === "Details"} />
+					<ExpandCollapseIcon isExpanded={commitSelection?.mode._tag === "Details"} />
 				</Tooltip.Trigger>
 				<Tooltip.Portal>
 					<Tooltip.Positioner sideOffset={8}>
 						<Tooltip.Popup className={classes(uiStyles.popup, uiStyles.tooltip)}>
-							{commitSelectionV?.mode._tag === "Details"
-								? "Hide commit files"
-								: "Show commit files"}
+							{commitSelection?.mode._tag === "Details" ? "Hide commit files" : "Show commit files"}
 						</Tooltip.Popup>
 					</Tooltip.Positioner>
 				</Tooltip.Portal>
@@ -476,7 +466,7 @@ const CommitC: FC<{
 	selection: Selection | null;
 	select: (selection: Selection | null) => void;
 }> = ({ branchName, commit, projectId, selection, select }) => {
-	const commitSelectionV =
+	const commitSelection =
 		selection?._tag === "Commit" &&
 		selection.branchName === branchName &&
 		selection.commitId === commit.id
@@ -493,15 +483,15 @@ const CommitC: FC<{
 				select={select}
 				isHighlighted={false}
 			/>
-			{commitSelectionV?.mode._tag === "Details" && (
+			{commitSelection?.mode._tag === "Details" && (
 				<Suspense fallback={<div className={sharedStyles.itemRowEmpty}>Loading commit files…</div>}>
 					<CommitFiles
 						projectId={projectId}
 						commitId={commit.id}
 						renderFile={(change) => {
 							const isSelected =
-								commitSelectionV.mode._tag === "Details" &&
-								commitSelectionV.mode.path === change.path;
+								commitSelection.mode._tag === "Details" &&
+								commitSelection.mode.path === change.path;
 							return (
 								<div
 									className={classes(
@@ -514,10 +504,10 @@ const CommitC: FC<{
 										change={change}
 										onClick={() => {
 											select(
-												commitSelection({
+												Selection.Commit({
 													branchName,
 													commitId: commit.id,
-													mode: detailsCommitMode({ path: change.path }),
+													mode: CommitMode.Details({ path: change.path }),
 												}),
 											);
 										}}

--- a/apps/lite/ui/src/routes/project/$id/state/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/state/layout.ts
@@ -1,19 +1,18 @@
+import { Data } from "effect";
+
 export type Panel = "primary" | "preview";
 
 /** @public */
 export type SplitPanelLayout = { focus: Panel };
-export type PanelLayout = { _tag: "Primary" } | ({ _tag: "Split" } & SplitPanelLayout);
+export type PanelLayout = Data.TaggedEnum<{
+	Primary: {};
+	Split: SplitPanelLayout;
+}>;
+
+export const PanelLayout = Data.taggedEnum<PanelLayout>();
 
 /** @public */
-export const primaryPanelLayout: PanelLayout = {
-	_tag: "Primary",
-};
-
-/** @public */
-export const splitPanelLayout = ({ focus }: SplitPanelLayout): PanelLayout => ({
-	_tag: "Split",
-	focus,
-});
+export const primaryPanelLayout: PanelLayout = PanelLayout.Primary();
 
 export type ProjectLayoutState = {
 	isFullscreenPreviewOpen: boolean;
@@ -22,7 +21,7 @@ export type ProjectLayoutState = {
 
 export const createInitialState = (): ProjectLayoutState => ({
 	isFullscreenPreviewOpen: false,
-	panelLayout: splitPanelLayout({ focus: "primary" }),
+	panelLayout: PanelLayout.Split({ focus: "primary" }),
 });
 
 export const initialState: ProjectLayoutState = createInitialState();
@@ -45,12 +44,12 @@ export const focusPrimary = (state: ProjectLayoutState) => {
 	state.panelLayout =
 		state.panelLayout._tag === "Primary"
 			? state.panelLayout
-			: splitPanelLayout({ focus: "primary" });
+			: PanelLayout.Split({ focus: "primary" });
 };
 
 export const focusPreview = (state: ProjectLayoutState) => {
 	if (state.isFullscreenPreviewOpen) return;
-	state.panelLayout = splitPanelLayout({ focus: "preview" });
+	state.panelLayout = PanelLayout.Split({ focus: "preview" });
 };
 
 export const openFullscreenPreview = (state: ProjectLayoutState) => {
@@ -64,7 +63,7 @@ export const toggleFullscreenPreview = (state: ProjectLayoutState) => {
 export const togglePreview = (state: ProjectLayoutState) => {
 	state.panelLayout =
 		state.panelLayout._tag === "Primary"
-			? splitPanelLayout({ focus: "primary" })
+			? PanelLayout.Split({ focus: "primary" })
 			: primaryPanelLayout;
 };
 

--- a/apps/lite/ui/src/routes/project/$id/state/workspace.ts
+++ b/apps/lite/ui/src/routes/project/$id/state/workspace.ts
@@ -1,19 +1,6 @@
-import {
-	commitItem,
-	segmentItem,
-	type CommitItem,
-	type Item,
-	type SegmentItem,
-} from "../workspace/Item.ts";
+import { Item, type CommitItem, type SegmentItem } from "../workspace/Item.ts";
 import { type OperationSource } from "../workspace/OperationSource.ts";
-import {
-	defaultWorkspaceMode,
-	moveOperationMode,
-	renameBranchWorkspaceMode,
-	rewordCommitWorkspaceMode,
-	rubOperationMode,
-	type WorkspaceMode,
-} from "../workspace/WorkspaceMode.ts";
+import { WorkspaceMode, defaultWorkspaceMode } from "../workspace/WorkspaceMode.ts";
 
 export type WorkspaceSelectionState = {
 	hunk: string | null;
@@ -54,15 +41,15 @@ const normalizeModeForSelectedItem = (mode: WorkspaceMode, item: Item | null) =>
 
 export const closeCommitFiles = (state: WorkspaceState, item: CommitItem) => {
 	state.expandedCommitId = null;
-	selectItem(state, commitItem(item));
+	selectItem(state, Item.Commit(item));
 };
 
 export const enterMoveMode = (state: WorkspaceState, source: OperationSource) => {
-	state.mode = moveOperationMode({ source });
+	state.mode = WorkspaceMode.Move({ source });
 };
 
 export const enterRubMode = (state: WorkspaceState, source: OperationSource) => {
-	state.mode = rubOperationMode({ source });
+	state.mode = WorkspaceMode.Rub({ source });
 };
 
 export const exitMode = (state: WorkspaceState) => {
@@ -71,7 +58,7 @@ export const exitMode = (state: WorkspaceState) => {
 
 export const openCommitFiles = (state: WorkspaceState, item: CommitItem) => {
 	state.expandedCommitId = item.commitId;
-	selectItem(state, commitItem(item));
+	selectItem(state, Item.Commit(item));
 };
 
 export const selectHunk = (state: WorkspaceState, hunk: string | null) => {
@@ -93,16 +80,16 @@ export const setHighlightedCommitIds = (state: WorkspaceState, commitIds: Array<
 };
 
 export const startRenameBranch = (state: WorkspaceState, item: SegmentItem) => {
-	selectItem(state, segmentItem(item));
-	state.mode = renameBranchWorkspaceMode({
+	selectItem(state, Item.Segment(item));
+	state.mode = WorkspaceMode.RenameBranch({
 		stackId: item.stackId,
 		segmentIndex: item.segmentIndex,
 	});
 };
 
 export const startRewordCommit = (state: WorkspaceState, item: CommitItem) => {
-	selectItem(state, commitItem(item));
-	state.mode = rewordCommitWorkspaceMode({ commitId: item.commitId });
+	selectItem(state, Item.Commit(item));
+	state.mode = WorkspaceMode.RewordCommit({ commitId: item.commitId });
 };
 
 export const toggleCommitFiles = (state: WorkspaceState, item: CommitItem) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Item.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Item.ts
@@ -1,4 +1,4 @@
-import { Match } from "effect";
+import { Data, Match } from "effect";
 
 /** @public */
 export type ChangesSectionItem = { stackId: string | null };
@@ -19,64 +19,19 @@ export type CommitFileItem = CommitItem & { path: string };
 /**
  * A selectable item in the primary panel.
  */
-export type Item =
-	| ({ _tag: "ChangesSection" } & ChangesSectionItem)
-	| ({ _tag: "Change" } & ChangeItem)
-	| ({ _tag: "Segment" } & SegmentItem)
-	| ({ _tag: "Commit" } & CommitItem)
-	| ({ _tag: "CommitFile" } & CommitFileItem)
-	| { _tag: "BaseCommit" };
+export type Item = Data.TaggedEnum<{
+	ChangesSection: ChangesSectionItem;
+	Change: ChangeItem;
+	Segment: SegmentItem;
+	Commit: CommitItem;
+	CommitFile: CommitFileItem;
+	BaseCommit: {};
+}>;
+
+export const Item = Data.taggedEnum<Item>();
 
 /** @public */
-export const changesSectionItem = ({ stackId }: ChangesSectionItem): Item => ({
-	_tag: "ChangesSection",
-	stackId,
-});
-
-/** @public */
-export const changeItem = ({ stackId, path }: ChangeItem): Item => ({
-	_tag: "Change",
-	stackId,
-	path,
-});
-
-/** @public */
-export const segmentItem = ({ stackId, segmentIndex, branchRef }: SegmentItem): Item => ({
-	_tag: "Segment",
-	stackId,
-	segmentIndex,
-	branchRef,
-});
-
-/** @public */
-export const commitItem = ({ stackId, segmentIndex, branchRef, commitId }: CommitItem): Item => ({
-	_tag: "Commit",
-	stackId,
-	segmentIndex,
-	branchRef,
-	commitId,
-});
-
-/** @public */
-export const commitFileItem = ({
-	stackId,
-	segmentIndex,
-	branchRef,
-	commitId,
-	path,
-}: CommitFileItem): Item => ({
-	_tag: "CommitFile",
-	stackId,
-	segmentIndex,
-	branchRef,
-	commitId,
-	path,
-});
-
-/** @public */
-export const baseCommitItem: Item = {
-	_tag: "BaseCommit",
-};
+export const baseCommitItem: Item = Item.BaseCommit();
 
 export const itemIdentityKey = (item: Item): string =>
 	Match.value(item).pipe(
@@ -98,19 +53,19 @@ export const getParentSection = (item: Item): Item | null =>
 	Match.value(item).pipe(
 		Match.tagsExhaustive({
 			Commit: (item) =>
-				segmentItem({
+				Item.Segment({
 					stackId: item.stackId,
 					segmentIndex: item.segmentIndex,
 					branchRef: item.branchRef,
 				}),
 			CommitFile: (item) =>
-				commitItem({
+				Item.Commit({
 					stackId: item.stackId,
 					segmentIndex: item.segmentIndex,
 					branchRef: item.branchRef,
 					commitId: item.commitId,
 				}),
-			Change: (item) => changesSectionItem({ stackId: item.stackId }),
+			Change: (item) => Item.ChangesSection({ stackId: item.stackId }),
 			ChangesSection: () => null,
 			BaseCommit: () => null,
 			Segment: () => null,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationMode.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationMode.tsx
@@ -1,5 +1,5 @@
 import { type Operation } from "#ui/Operation.ts";
-import { changesSectionFileParent, commitFileParent } from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { Match } from "effect";
 import { type Item } from "./Item.ts";
 import {
@@ -24,12 +24,12 @@ const rubModeOperationSourceToOperation = ({
 			ChangesSection: (target) =>
 				getCombineOperation({
 					resolvedOperationSource,
-					target: changesSectionFileParent({ stackId: target.stackId }),
+					target: FileParent.ChangesSection({ stackId: target.stackId }),
 				}),
 			Commit: (target) =>
 				getCombineOperation({
 					resolvedOperationSource,
-					target: commitFileParent({ commitId: target.commitId }),
+					target: FileParent.Commit({ commitId: target.commitId }),
 				}),
 		}),
 		Match.orElse(() => null),

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSource.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSource.ts
@@ -1,11 +1,7 @@
-import {
-	changesSectionFileParent,
-	commitFileParent,
-	type FileParent,
-} from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { type HunkHeader } from "@gitbutler/but-sdk";
-import { Match } from "effect";
-import { type Item } from "./Item.ts";
+import { Data, Match } from "effect";
+import { Item } from "./Item.ts";
 
 /** @public */
 export type ChangesSectionOperationSource = { stackId: string | null };
@@ -22,57 +18,19 @@ export type SegmentOperationSource = { branchRef: Array<number> | null };
  * The source of an operation before it has been materialized into data that can
  * be sent to the backend (`ResolvedOperationSource`).
  */
-export type OperationSource =
-	| { _tag: "BaseCommit" }
-	| ({ _tag: "ChangesSection" } & ChangesSectionOperationSource)
-	| ({ _tag: "Commit" } & CommitOperationSource)
-	| ({ _tag: "File" } & FileOperationSource)
-	| ({ _tag: "Hunk" } & HunkOperationSource)
-	| ({ _tag: "Segment" } & SegmentOperationSource);
+export type OperationSource = Data.TaggedEnum<{
+	BaseCommit: {};
+	ChangesSection: ChangesSectionOperationSource;
+	Commit: CommitOperationSource;
+	File: FileOperationSource;
+	Hunk: HunkOperationSource;
+	Segment: SegmentOperationSource;
+}>;
+
+export const OperationSource = Data.taggedEnum<OperationSource>();
 
 /** @public */
-export const baseCommitOperationSource: OperationSource = {
-	_tag: "BaseCommit",
-};
-
-/** @public */
-export const changesSectionOperationSource = ({
-	stackId,
-}: ChangesSectionOperationSource): OperationSource => ({
-	_tag: "ChangesSection",
-	stackId,
-});
-
-/** @public */
-export const commitOperationSource = ({ commitId }: CommitOperationSource): OperationSource => ({
-	_tag: "Commit",
-	commitId,
-});
-
-/** @public */
-export const fileOperationSource = ({ parent, path }: FileOperationSource): OperationSource => ({
-	_tag: "File",
-	parent,
-	path,
-});
-
-/** @public */
-export const hunkOperationSource = ({
-	parent,
-	path,
-	hunkHeader,
-}: HunkOperationSource): OperationSource => ({
-	_tag: "Hunk",
-	parent,
-	path,
-	hunkHeader,
-});
-
-/** @public */
-export const segmentOperationSource = ({ branchRef }: SegmentOperationSource): OperationSource => ({
-	_tag: "Segment",
-	branchRef,
-});
+export const baseCommitOperationSource: OperationSource = OperationSource.BaseCommit();
 
 const operationSourceIdentityKey = (operationSource: OperationSource): string =>
 	Match.value(operationSource).pipe(
@@ -94,18 +52,18 @@ export const operationSourceFromItem = (item: Item): OperationSource =>
 		Match.tagsExhaustive({
 			BaseCommit: () => baseCommitOperationSource,
 			Change: ({ stackId, path }) =>
-				fileOperationSource({
-					parent: changesSectionFileParent({ stackId }),
+				OperationSource.File({
+					parent: FileParent.ChangesSection({ stackId }),
 					path,
 				}),
-			ChangesSection: ({ stackId }) => changesSectionOperationSource({ stackId }),
-			Commit: ({ commitId }) => commitOperationSource({ commitId }),
+			ChangesSection: ({ stackId }) => OperationSource.ChangesSection({ stackId }),
+			Commit: ({ commitId }) => OperationSource.Commit({ commitId }),
 			CommitFile: ({ commitId, path }) =>
-				fileOperationSource({
-					parent: commitFileParent({ commitId }),
+				OperationSource.File({
+					parent: FileParent.Commit({ commitId }),
 					path,
 				}),
-			Segment: ({ branchRef }) => segmentOperationSource({ branchRef }),
+			Segment: ({ branchRef }) => OperationSource.Segment({ branchRef }),
 		}),
 	);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationTargets.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationTargets.tsx
@@ -3,7 +3,7 @@ import {
 	extractInstruction,
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/list-item";
 import { classes } from "#ui/classes.ts";
-import { changesSectionFileParent, commitFileParent } from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { type GetDataParams, useDroppable } from "#ui/hooks/useDroppable.ts";
 import { getInsertionSide, useRunOperation, type Operation } from "#ui/Operation.ts";
 import { projectActions } from "#ui/routes/project/$id/state/projectSlice.ts";
@@ -117,7 +117,7 @@ const dropTargetToOperation = ({
 			ChangesSection: ({ stackId }) =>
 				getCombineOperation({
 					resolvedOperationSource,
-					target: changesSectionFileParent({ stackId }),
+					target: FileParent.ChangesSection({ stackId }),
 				}),
 			Segment: ({ branchRef }) =>
 				branchRef === null
@@ -129,7 +129,7 @@ const dropTargetToOperation = ({
 			Commit: ({ commitId }) =>
 				getCombineOperation({
 					resolvedOperationSource,
-					target: commitFileParent({ commitId }),
+					target: FileParent.Commit({ commitId }),
 				}),
 			BaseCommit: () => getTearOffBranchTargetOperation(resolvedOperationSource),
 		}),
@@ -184,7 +184,7 @@ const commitDropTargetToOperation = ({
 }) => {
 	const combine = getCombineOperation({
 		resolvedOperationSource,
-		target: commitFileParent({ commitId }),
+		target: FileParent.Commit({ commitId }),
 	});
 	const insertAbove = getCommitTargetMoveOperation({
 		resolvedOperationSource,

--- a/apps/lite/ui/src/routes/project/$id/workspace/ResolvedOperationSource.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ResolvedOperationSource.ts
@@ -2,22 +2,9 @@ import {
 	changesInWorktreeQueryOptions,
 	commitDetailsWithLineStatsQueryOptions,
 } from "#ui/api/queries.ts";
-import {
-	assignHunkOperation,
-	commitAmendOperation,
-	commitCreateFromCommittedChangesOperation,
-	commitCreateOperation,
-	commitMoveChangesBetweenOperation,
-	commitMoveOperation,
-	commitSquashOperation,
-	commitUncommitChangesOperation,
-	commitUncommitOperation,
-	moveBranchOperation,
-	tearOffBranchOperation,
-	type Operation,
-} from "#ui/Operation.ts";
+import { Operation } from "#ui/Operation.ts";
 import { createDiffSpec } from "#ui/domain/DiffSpec.ts";
-import { changesSectionFileParent, type FileParent } from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { useQueryClient } from "@tanstack/react-query";
 import {
 	CommitDetails,
@@ -28,7 +15,7 @@ import {
 	type HunkHeader,
 	type TreeChange,
 } from "@gitbutler/but-sdk";
-import { Match } from "effect";
+import { Data, Match } from "effect";
 import { decodeRefName, getAssignmentsByPath } from "../shared";
 import { type OperationSource } from "./OperationSource.ts";
 
@@ -50,42 +37,18 @@ export type TreeChangesResolvedOperationSource = {
 /**
  * The source of an operation in a form that can be sent to the backend.
  */
-export type ResolvedOperationSource =
-	| { _tag: "BaseCommit" }
-	| ({ _tag: "Commit" } & CommitResolvedOperationSource)
-	| ({ _tag: "Segment" } & SegmentResolvedOperationSource)
-	| ({ _tag: "TreeChanges" } & TreeChangesResolvedOperationSource);
+export type ResolvedOperationSource = Data.TaggedEnum<{
+	BaseCommit: {};
+	Commit: CommitResolvedOperationSource;
+	Segment: SegmentResolvedOperationSource;
+	TreeChanges: TreeChangesResolvedOperationSource;
+}>;
+
+export const ResolvedOperationSource = Data.taggedEnum<ResolvedOperationSource>();
 
 /** @public */
-export const baseCommitResolvedOperationSource: ResolvedOperationSource = {
-	_tag: "BaseCommit",
-};
-
-/** @public */
-export const commitResolvedOperationSource = ({
-	commitId,
-}: CommitResolvedOperationSource): ResolvedOperationSource => ({
-	_tag: "Commit",
-	commitId,
-});
-
-/** @public */
-export const segmentResolvedOperationSource = ({
-	branchRef,
-}: SegmentResolvedOperationSource): ResolvedOperationSource => ({
-	_tag: "Segment",
-	branchRef,
-});
-
-/** @public */
-export const treeChangesResolvedOperationSource = ({
-	parent,
-	changes,
-}: TreeChangesResolvedOperationSource): ResolvedOperationSource => ({
-	_tag: "TreeChanges",
-	parent,
-	changes,
-});
+export const baseCommitResolvedOperationSource: ResolvedOperationSource =
+	ResolvedOperationSource.BaseCommit();
 
 const hunkHeadersForAssignments = (
 	assignments: Array<HunkAssignment> | undefined,
@@ -107,9 +70,9 @@ const resolveOperationSource = ({
 }) =>
 	Match.value(operationSource).pipe(
 		Match.tagsExhaustive({
-			Segment: ({ branchRef }) => segmentResolvedOperationSource({ branchRef }),
+			Segment: ({ branchRef }) => ResolvedOperationSource.Segment({ branchRef }),
 			BaseCommit: () => baseCommitResolvedOperationSource,
-			Commit: ({ commitId }) => commitResolvedOperationSource({ commitId }),
+			Commit: ({ commitId }) => ResolvedOperationSource.Commit({ commitId }),
 			ChangesSection: ({ stackId }) => {
 				if (!worktreeChanges) return null;
 
@@ -128,8 +91,8 @@ const resolveOperationSource = ({
 					},
 				);
 
-				return treeChangesResolvedOperationSource({
-					parent: changesSectionFileParent({ stackId }),
+				return ResolvedOperationSource.TreeChanges({
+					parent: FileParent.ChangesSection({ stackId }),
 					changes,
 				});
 			},
@@ -165,7 +128,7 @@ const resolveOperationSource = ({
 					}),
 				);
 
-				return treeChangesResolvedOperationSource({
+				return ResolvedOperationSource.TreeChanges({
 					parent,
 					changes: [{ change, hunkHeaders }],
 				});
@@ -189,7 +152,7 @@ const resolveOperationSource = ({
 
 				if (!change) return null;
 
-				return treeChangesResolvedOperationSource({
+				return ResolvedOperationSource.TreeChanges({
 					parent,
 					changes: [{ change, hunkHeaders: [hunkHeader] }],
 				});
@@ -237,12 +200,12 @@ export const getCombineOperation = ({
 				Match.value(target).pipe(
 					Match.tagsExhaustive({
 						ChangesSection: ({ stackId }) =>
-							commitUncommitOperation({
+							Operation.CommitUncommit({
 								commitId: sourceCommitId,
 								assignTo: stackId,
 							}),
 						Commit: ({ commitId: destinationCommitId }) =>
-							commitSquashOperation({
+							Operation.CommitSquash({
 								sourceCommitId,
 								destinationCommitId,
 							}),
@@ -259,7 +222,7 @@ export const getCombineOperation = ({
 							Match.value(target).pipe(
 								Match.tagsExhaustive({
 									ChangesSection: ({ stackId: targetStackId }) =>
-										assignHunkOperation({
+										Operation.AssignHunk({
 											assignments: sourceChanges.flatMap(({ change, hunkHeaders }) =>
 												hunkHeaders.map(
 													(hunkHeader): HunkAssignmentRequest => ({
@@ -272,7 +235,7 @@ export const getCombineOperation = ({
 											),
 										}),
 									Commit: ({ commitId }) =>
-										commitAmendOperation({
+										Operation.CommitAmend({
 											commitId,
 											changes,
 										}),
@@ -282,13 +245,13 @@ export const getCombineOperation = ({
 							Match.value(target).pipe(
 								Match.tagsExhaustive({
 									ChangesSection: ({ stackId }) =>
-										commitUncommitChangesOperation({
+										Operation.CommitUncommitChanges({
 											commitId: sourceCommitId,
 											assignTo: stackId,
 											changes,
 										}),
 									Commit: ({ commitId: destinationCommitId }) =>
-										commitMoveChangesBetweenOperation({
+										Operation.CommitMoveChangesBetween({
 											sourceCommitId,
 											destinationCommitId,
 											changes,
@@ -313,7 +276,7 @@ export const getCommitTargetMoveOperation = ({
 	Match.value(resolvedOperationSource).pipe(
 		Match.tags({
 			Commit: ({ commitId: subjectCommitId }) =>
-				commitMoveOperation({
+				Operation.CommitMove({
 					subjectCommitId,
 					relativeTo: { type: "commit", subject: commitId },
 					side,
@@ -326,14 +289,14 @@ export const getCommitTargetMoveOperation = ({
 				return Match.value(parent).pipe(
 					Match.tags({
 						ChangesSection: () =>
-							commitCreateOperation({
+							Operation.CommitCreate({
 								relativeTo: { type: "commit", subject: commitId },
 								side,
 								changes,
 								message: "",
 							}),
 						Commit: ({ commitId: sourceCommitId }) =>
-							commitCreateFromCommittedChangesOperation({
+							Operation.CommitCreateFromCommittedChanges({
 								sourceCommitId,
 								relativeTo: { type: "commit", subject: commitId },
 								side,
@@ -358,13 +321,13 @@ export const getBranchTargetOperation = ({
 		Match.tags({
 			Segment: (source) => {
 				if (source.branchRef === null) return null;
-				return moveBranchOperation({
+				return Operation.MoveBranch({
 					subjectBranch: decodeRefName(source.branchRef),
 					targetBranch: decodeRefName(branchRef),
 				});
 			},
 			Commit: ({ commitId }) =>
-				commitMoveOperation({
+				Operation.CommitMove({
 					subjectCommitId: commitId,
 					relativeTo: {
 						type: "referenceBytes",
@@ -380,14 +343,14 @@ export const getBranchTargetOperation = ({
 				return Match.value(source.parent).pipe(
 					Match.tagsExhaustive({
 						ChangesSection: () =>
-							commitCreateOperation({
+							Operation.CommitCreate({
 								relativeTo: { type: "referenceBytes", subject: branchRef },
 								side: "below",
 								changes,
 								message: "",
 							}),
 						Commit: ({ commitId: sourceCommitId }) =>
-							commitCreateFromCommittedChangesOperation({
+							Operation.CommitCreateFromCommittedChanges({
 								sourceCommitId,
 								relativeTo: { type: "referenceBytes", subject: branchRef },
 								side: "below",
@@ -406,7 +369,7 @@ export const getTearOffBranchTargetOperation = (
 	if (resolvedOperationSource._tag !== "Segment") return null;
 	if (resolvedOperationSource.branchRef === null) return null;
 
-	return tearOffBranchOperation({
+	return Operation.TearOffBranch({
 		subjectBranch: decodeRefName(resolvedOperationSource.branchRef),
 	});
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceMode.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceMode.ts
@@ -1,4 +1,4 @@
-import { Match } from "effect";
+import { Data, Match } from "effect";
 import { type OperationSource, operationSourceMatchesItem } from "./OperationSource.ts";
 import { type NavigationIndex } from "./WorkspaceModel.ts";
 
@@ -6,54 +6,24 @@ import { type NavigationIndex } from "./WorkspaceModel.ts";
 export type RubOperationMode = { source: OperationSource };
 /** @public */
 export type MoveOperationMode = { source: OperationSource };
-export type OperationMode =
-	| ({ _tag: "Rub" } & RubOperationMode)
-	| ({ _tag: "Move" } & MoveOperationMode);
 
 /** @public */
 export type RewordCommitWorkspaceMode = { commitId: string };
 /** @public */
 export type RenameBranchWorkspaceMode = { stackId: string; segmentIndex: number };
-export type WorkspaceMode =
-	| { _tag: "Default" }
-	| ({ _tag: "RewordCommit" } & RewordCommitWorkspaceMode)
-	| ({ _tag: "RenameBranch" } & RenameBranchWorkspaceMode)
-	| OperationMode;
+export type WorkspaceMode = Data.TaggedEnum<{
+	Default: {};
+	RewordCommit: RewordCommitWorkspaceMode;
+	RenameBranch: RenameBranchWorkspaceMode;
+	Rub: RubOperationMode;
+	Move: MoveOperationMode;
+}>;
+export type OperationMode = Extract<WorkspaceMode, { _tag: "Rub" | "Move" }>;
+
+export const WorkspaceMode = Data.taggedEnum<WorkspaceMode>();
 
 /** @public */
-export const rubOperationMode = ({ source }: RubOperationMode): OperationMode => ({
-	_tag: "Rub",
-	source,
-});
-
-/** @public */
-export const moveOperationMode = ({ source }: MoveOperationMode): OperationMode => ({
-	_tag: "Move",
-	source,
-});
-
-/** @public */
-export const defaultWorkspaceMode: WorkspaceMode = {
-	_tag: "Default",
-};
-
-/** @public */
-export const rewordCommitWorkspaceMode = ({
-	commitId,
-}: RewordCommitWorkspaceMode): WorkspaceMode => ({
-	_tag: "RewordCommit",
-	commitId,
-});
-
-/** @public */
-export const renameBranchWorkspaceMode = ({
-	stackId,
-	segmentIndex,
-}: RenameBranchWorkspaceMode): WorkspaceMode => ({
-	_tag: "RenameBranch",
-	stackId,
-	segmentIndex,
-});
+export const defaultWorkspaceMode: WorkspaceMode = WorkspaceMode.Default();
 
 export const getOperationMode = (mode: WorkspaceMode): OperationMode | null =>
 	mode._tag === "Rub" || mode._tag === "Move" ? mode : null;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceModel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceModel.ts
@@ -6,16 +6,7 @@ import {
 import { Segment, type HunkAssignment, type RefInfo, type TreeChange } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { type NonEmptyArray } from "effect/Array";
-import {
-	baseCommitItem,
-	changeItem,
-	changesSectionItem,
-	type Item,
-	commitItem,
-	commitFileItem,
-	itemIdentityKey,
-	segmentItem,
-} from "./Item.ts";
+import { Item, baseCommitItem, itemIdentityKey } from "./Item.ts";
 import { getRelative } from "../shared.tsx";
 
 const hasAssignmentsForPath = ({
@@ -54,10 +45,10 @@ const buildWorkspaceOutline = ({
 	expandedCommitPaths,
 }: BuildWorkspaceOutlineArgs): WorkspaceOutline => {
 	const changesSection = (stackId: string | null): WorkspaceSection => ({
-		section: changesSectionItem({ stackId }),
+		section: Item.ChangesSection({ stackId }),
 		children: changes.flatMap((change) =>
 			hasAssignmentsForPath({ assignments, stackId, path: change.path })
-				? [changeItem({ stackId, path: change.path })]
+				? [Item.Change({ stackId, path: change.path })]
 				: [],
 		),
 	});
@@ -69,12 +60,12 @@ const buildWorkspaceOutline = ({
 	): WorkspaceSection => {
 		const branchRef = segment.refName?.fullNameBytes ?? null;
 		return {
-			section: segmentItem({ stackId, segmentIndex, branchRef }),
+			section: Item.Segment({ stackId, segmentIndex, branchRef }),
 			children: segment.commits.flatMap((commit) => [
-				commitItem({ stackId, segmentIndex, branchRef, commitId: commit.id }),
+				Item.Commit({ stackId, segmentIndex, branchRef, commitId: commit.id }),
 				...(commit.id === expandedCommitId
 					? (expandedCommitPaths ?? []).map((path) =>
-							commitFileItem({
+							Item.CommitFile({
 								stackId,
 								segmentIndex,
 								branchRef,

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceShortcuts.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceShortcuts.ts
@@ -9,17 +9,12 @@ import { Match } from "effect";
 import { RefObject, useEffect, useEffectEvent } from "react";
 import {
 	baseCommitItem,
-	changeItem,
-	commitFileItem,
-	commitItem,
 	type ChangeItem,
-	changesSectionItem,
-	type ChangesSectionItem,
+	ChangesSectionItem,
 	type CommitFileItem,
 	type CommitItem,
 	getParentSection,
-	type Item,
-	segmentItem,
+	Item,
 	type SegmentItem,
 } from "./Item.ts";
 import { operationModeToOperation } from "./OperationMode.tsx";
@@ -743,7 +738,7 @@ export const useWorkspaceShortcuts = ({
 		Match.value(action).pipe(
 			Match.tags({
 				FocusPreview: () => dispatch(projectActions.focusPreview({ projectId })),
-				SelectUnassignedChanges: () => selectItem(changesSectionItem({ stackId: null })),
+				SelectUnassignedChanges: () => selectItem(Item.ChangesSection({ stackId: null })),
 				ToggleFullscreenPreview: () =>
 					dispatch(projectActions.toggleFullscreenPreview({ projectId })),
 				TogglePreview: () => dispatch(projectActions.togglePreview({ projectId })),
@@ -788,7 +783,7 @@ export const useWorkspaceShortcuts = ({
 				ToggleFiles: () =>
 					dispatch(projectActions.toggleCommitFiles({ projectId, item: selectedItem })),
 			}),
-			Match.orElse((action) => handlePrimaryPanelAction(action, commitItem(selectedItem))),
+			Match.orElse((action) => handlePrimaryPanelAction(action, Item.Commit(selectedItem))),
 		);
 
 	const handleCommitFileScopeAction = (action: CommitFileAction, selectedItem: CommitFileItem) =>
@@ -799,7 +794,7 @@ export const useWorkspaceShortcuts = ({
 				ToggleFiles: () =>
 					dispatch(projectActions.toggleCommitFiles({ projectId, item: selectedItem })),
 			}),
-			Match.orElse((action) => handlePrimaryPanelAction(action, commitFileItem(selectedItem))),
+			Match.orElse((action) => handlePrimaryPanelAction(action, Item.CommitFile(selectedItem))),
 		);
 
 	const handleBranchScopeAction = (action: BranchAction, selectedItem: SegmentItem) =>
@@ -813,7 +808,7 @@ export const useWorkspaceShortcuts = ({
 						}),
 					),
 			}),
-			Match.orElse((action) => handlePrimaryPanelAction(action, segmentItem(selectedItem))),
+			Match.orElse((action) => handlePrimaryPanelAction(action, Item.Segment(selectedItem))),
 		);
 
 	const handleDefaultScopeKeyDown = (scope: DefaultModeScope, event: KeyboardEvent) =>
@@ -835,13 +830,13 @@ export const useWorkspaceShortcuts = ({
 					const action = getAction(scope.bindings, event);
 					if (!action) return;
 					event.preventDefault();
-					handleChangesScopeAction(action, changeItem(scope.context));
+					handleChangesScopeAction(action, Item.Change(scope.context));
 				},
 				ChangesSection: (scope) => {
 					const action = getAction(scope.bindings, event);
 					if (!action) return;
 					event.preventDefault();
-					handleChangesScopeAction(action, changesSectionItem(scope.context));
+					handleChangesScopeAction(action, Item.ChangesSection(scope.context));
 				},
 				Commit: (scope) => {
 					const action = getAction(scope.bindings, event);
@@ -859,7 +854,7 @@ export const useWorkspaceShortcuts = ({
 					const action = getAction(scope.bindings, event);
 					if (!action) return;
 					event.preventDefault();
-					handlePrimaryPanelAction(action, segmentItem(scope.context));
+					handlePrimaryPanelAction(action, Item.Segment(scope.context));
 				},
 			}),
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceShortcuts.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceShortcuts.ts
@@ -38,15 +38,14 @@ type ItemSelectionAction =
 	| { _tag: "NextSection" }
 	| { _tag: "PreviousSection" };
 
-const enterMoveModeAction = { _tag: "EnterMoveMode" } as const;
-const enterRubModeAction = { _tag: "EnterRubMode" } as const;
-const nextSectionAction = { _tag: "NextSection" } as const;
-const previousSectionAction = { _tag: "PreviousSection" } as const;
-
+const enterMoveModeAction: ItemSelectionAction = { _tag: "EnterMoveMode" };
+const enterRubModeAction: ItemSelectionAction = { _tag: "EnterRubMode" };
 const moveItemSelectionAction = ({ offset }: MoveItemSelectionAction): ItemSelectionAction => ({
 	_tag: "Move",
 	offset,
 });
+const nextSectionAction: ItemSelectionAction = { _tag: "NextSection" };
+const previousSectionAction: ItemSelectionAction = { _tag: "PreviousSection" };
 
 const itemSelectionBindings: Array<ShortcutBinding<ItemSelectionAction>> = [
 	{
@@ -91,19 +90,12 @@ const itemSelectionBindings: Array<ShortcutBinding<ItemSelectionAction>> = [
 	},
 ];
 
-type PrimaryPanelAction =
-	| ItemSelectionAction
-	| { _tag: "FocusPreview" }
-	| { _tag: "SelectUnassignedChanges" }
-	| { _tag: "ToggleFullscreenPreview" }
-	| { _tag: "TogglePreview" };
+type GlobalPreviewAction = { _tag: "ToggleFullscreenPreview" } | { _tag: "TogglePreview" };
 
-const focusPreviewAction = { _tag: "FocusPreview" } as const;
-const selectUnassignedChangesAction = { _tag: "SelectUnassignedChanges" } as const;
-const toggleFullscreenPreviewAction = { _tag: "ToggleFullscreenPreview" } as const;
-const togglePreviewAction = { _tag: "TogglePreview" } as const;
+const toggleFullscreenPreviewAction: GlobalPreviewAction = { _tag: "ToggleFullscreenPreview" };
+const togglePreviewAction: GlobalPreviewAction = { _tag: "TogglePreview" };
 
-export const togglePreviewBinding: ShortcutBinding<PrimaryPanelAction> = {
+export const togglePreviewBinding: ShortcutBinding<GlobalPreviewAction> = {
 	id: "primary-panel-toggle-preview",
 	description: "Preview",
 	keys: ["p"],
@@ -111,13 +103,22 @@ export const togglePreviewBinding: ShortcutBinding<PrimaryPanelAction> = {
 	repeat: false,
 };
 
-export const toggleFullscreenPreviewBinding: ShortcutBinding<PrimaryPanelAction> = {
+export const toggleFullscreenPreviewBinding: ShortcutBinding<GlobalPreviewAction> = {
 	id: "primary-panel-toggle-fullscreen-preview",
 	description: "Fullscreen preview",
 	keys: ["d"],
 	action: toggleFullscreenPreviewAction,
 	repeat: false,
 };
+
+type PrimaryPanelAction =
+	| ItemSelectionAction
+	| { _tag: "FocusPreview" }
+	| { _tag: "SelectUnassignedChanges" }
+	| GlobalPreviewAction;
+
+const focusPreviewAction: PrimaryPanelAction = { _tag: "FocusPreview" };
+const selectUnassignedChangesAction: PrimaryPanelAction = { _tag: "SelectUnassignedChanges" };
 
 const primaryPanelBindings: Array<ShortcutBinding<PrimaryPanelAction>> = [
 	...itemSelectionBindings,
@@ -140,7 +141,8 @@ const primaryPanelBindings: Array<ShortcutBinding<PrimaryPanelAction>> = [
 ];
 
 type ChangesAction = PrimaryPanelAction | { _tag: "Absorb" };
-const absorbAction = { _tag: "Absorb" } as const;
+
+const absorbAction: ChangesAction = { _tag: "Absorb" };
 
 const changesBindings: Array<ShortcutBinding<ChangesAction>> = [
 	...primaryPanelBindings,
@@ -154,7 +156,8 @@ const changesBindings: Array<ShortcutBinding<ChangesAction>> = [
 ];
 
 type CommitToggleFilesAction = { _tag: "ToggleFiles" };
-const toggleCommitFilesAction = { _tag: "ToggleFiles" } as const;
+
+const toggleCommitFilesAction: CommitToggleFilesAction = { _tag: "ToggleFiles" };
 
 const toggleCommitFilesBinding: ShortcutBinding<CommitToggleFilesAction> = {
 	id: "commit-toggle-files",
@@ -165,7 +168,8 @@ const toggleCommitFilesBinding: ShortcutBinding<CommitToggleFilesAction> = {
 };
 
 type CommitAction = PrimaryPanelAction | CommitToggleFilesAction | { _tag: "EditMessage" };
-const editMessageAction = { _tag: "EditMessage" } as const;
+
+const editMessageAction: CommitAction = { _tag: "EditMessage" };
 
 const commitDefaultBindings: Array<ShortcutBinding<CommitAction>> = [
 	...primaryPanelBindings,
@@ -180,7 +184,8 @@ const commitDefaultBindings: Array<ShortcutBinding<CommitAction>> = [
 ];
 
 type CommitFileAction = PrimaryPanelAction | CommitToggleFilesAction | { _tag: "CloseFiles" };
-const closeFilesAction = { _tag: "CloseFiles" } as const;
+
+const closeFilesAction: CommitFileAction = { _tag: "CloseFiles" };
 
 const commitFilesBindings: Array<ShortcutBinding<CommitFileAction>> = [
 	...primaryPanelBindings,
@@ -195,7 +200,8 @@ const commitFilesBindings: Array<ShortcutBinding<CommitFileAction>> = [
 ];
 
 type BranchAction = PrimaryPanelAction | { _tag: "RenameBranch" };
-const renameBranchAction = { _tag: "RenameBranch" } as const;
+
+const renameBranchAction: BranchAction = { _tag: "RenameBranch" };
 
 const branchBindings: Array<ShortcutBinding<BranchAction>> = [
 	...primaryPanelBindings,
@@ -309,31 +315,31 @@ const segmentDefaultModeScope = ({
 const getDefaultModeScope = (selectedItem: Item): DefaultModeScope =>
 	Match.value(selectedItem).pipe(
 		Match.tagsExhaustive({
-			BaseCommit: (): DefaultModeScope =>
+			BaseCommit: () =>
 				baseCommitDefaultModeScope({
 					bindings: primaryPanelBindings,
 				}),
-			Change: (selectedItem): DefaultModeScope =>
+			Change: (selectedItem) =>
 				changeDefaultModeScope({
 					bindings: changesBindings,
 					context: selectedItem,
 				}),
-			ChangesSection: (selectedItem): DefaultModeScope =>
+			ChangesSection: (selectedItem) =>
 				changesSectionDefaultModeScope({
 					bindings: changesBindings,
 					context: selectedItem,
 				}),
-			Commit: (selectedItem): DefaultModeScope =>
+			Commit: (selectedItem) =>
 				commitDefaultModeScope({
 					bindings: commitDefaultBindings,
 					context: selectedItem,
 				}),
-			CommitFile: (selectedItem): DefaultModeScope =>
+			CommitFile: (selectedItem) =>
 				commitFileDefaultModeScope({
 					bindings: commitFilesBindings,
 					context: selectedItem,
 				}),
-			Segment: (selectedItem): DefaultModeScope =>
+			Segment: (selectedItem) =>
 				selectedItem.branchRef === null
 					? segmentDefaultModeScope({
 							bindings: primaryPanelBindings,
@@ -359,21 +365,20 @@ const getDefaultModeScopeLabel = (scope: DefaultModeScope): string =>
 		}),
 	);
 
-type HunkSelectionAction = { _tag: "Move"; offset: -1 | 1 };
-
-const closePreviewAction = { _tag: "ClosePreview" } as const;
-const focusPrimaryAction = { _tag: "FocusPrimary" } as const;
-const moveHunkSelectionAction = ({ offset }: { offset: -1 | 1 }): HunkSelectionAction => ({
-	_tag: "Move",
-	offset,
-});
+type HunkSelectionAction = { offset: -1 | 1 };
 
 type PreviewAction =
 	| { _tag: "ClosePreview" }
 	| { _tag: "FocusPrimary" }
-	| HunkSelectionAction
-	| { _tag: "ToggleFullscreenPreview" }
-	| { _tag: "TogglePreview" };
+	| ({ _tag: "Move" } & HunkSelectionAction)
+	| GlobalPreviewAction;
+
+const closePreviewAction: PreviewAction = { _tag: "ClosePreview" };
+const focusPrimaryAction: PreviewAction = { _tag: "FocusPrimary" };
+const moveHunkSelectionAction = ({ offset }: HunkSelectionAction): PreviewAction => ({
+	_tag: "Move",
+	offset,
+});
 
 export const closePreviewBinding: ShortcutBinding<PreviewAction> = {
 	id: "preview-close",
@@ -403,20 +408,8 @@ const previewBindings: Array<ShortcutBinding<PreviewAction>> = [
 		action: focusPrimaryAction,
 		repeat: false,
 	},
-	{
-		id: "preview-toggle-fullscreen-preview",
-		description: "Fullscreen preview",
-		keys: ["d"],
-		action: toggleFullscreenPreviewAction,
-		repeat: false,
-	},
-	{
-		id: "preview-toggle-preview",
-		description: "Preview",
-		keys: ["p"],
-		action: togglePreviewAction,
-		repeat: false,
-	},
+	toggleFullscreenPreviewBinding,
+	togglePreviewBinding,
 	closePreviewBinding,
 ];
 
@@ -425,21 +418,10 @@ const fullscreenPreviewBindings: Array<ShortcutBinding<PreviewAction>> = preview
 	// there's no point having the toggle preview shortcut here.
 	.filter((binding) => binding.action._tag !== "TogglePreview");
 
-type PreviewScope = {
-	_tag: "Preview";
-	bindings: Array<ShortcutBinding<PreviewAction>>;
-	context: { isFullscreen: boolean };
-};
-
-const previewScope = ({ bindings, context }: Omit<PreviewScope, "_tag">): PreviewScope => ({
-	_tag: "Preview",
-	bindings,
-	context,
-});
-
 type OperationModeAction = PrimaryPanelAction | { _tag: "Cancel" } | { _tag: "Run" };
-const runOperationModeAction = { _tag: "Run" } as const;
-const cancelOperationModeAction = { _tag: "Cancel" } as const;
+
+const runOperationModeAction: OperationModeAction = { _tag: "Run" };
+const cancelOperationModeAction: OperationModeAction = { _tag: "Cancel" };
 
 const operationModeBindings: Array<ShortcutBinding<OperationModeAction>> = [
 	...primaryPanelBindings.filter(
@@ -501,8 +483,9 @@ const getOperationModeScopeLabel = (scope: OperationModeScope): string =>
 	);
 
 type RewordCommitAction = { _tag: "Cancel" } | { _tag: "Save" };
-const saveRewordCommitAction = { _tag: "Save" } as const;
-const cancelRewordCommitAction = { _tag: "Cancel" } as const;
+
+const saveRewordCommitAction: RewordCommitAction = { _tag: "Save" };
+const cancelRewordCommitAction: RewordCommitAction = { _tag: "Cancel" };
 
 export const rewordCommitBindings: Array<ShortcutBinding<RewordCommitAction>> = [
 	{
@@ -522,8 +505,9 @@ export const rewordCommitBindings: Array<ShortcutBinding<RewordCommitAction>> = 
 ];
 
 type RenameBranchAction = { _tag: "Cancel" } | { _tag: "Save" };
-const saveRenameBranchAction = { _tag: "Save" } as const;
-const cancelRenameBranchAction = { _tag: "Cancel" } as const;
+
+const saveRenameBranchAction: RenameBranchAction = { _tag: "Save" };
+const cancelRenameBranchAction: RenameBranchAction = { _tag: "Cancel" };
 
 export const renameBranchBindings: Array<ShortcutBinding<RenameBranchAction>> = [
 	{
@@ -584,18 +568,18 @@ const getModeScope = ({
 }): ModeScope | null =>
 	Match.value(workspaceMode).pipe(
 		Match.tagsExhaustive({
-			Default: (): ModeScope | null =>
+			Default: () =>
 				selectedItem
 					? defaultModeScope({
 							scope: getDefaultModeScope(selectedItem),
 						})
 					: null,
-			Move: (): ModeScope =>
+			Move: () =>
 				moveOperationModeScope({
 					bindings: operationModeBindings,
 					context: selectedItem,
 				}),
-			RenameBranch: (workspaceMode): ModeScope | null =>
+			RenameBranch: (workspaceMode) =>
 				selectedItem?._tag === "Segment" &&
 				workspaceMode.stackId === selectedItem.stackId &&
 				workspaceMode.segmentIndex === selectedItem.segmentIndex
@@ -604,14 +588,14 @@ const getModeScope = ({
 							context: selectedItem,
 						})
 					: null,
-			RewordCommit: (workspaceMode): ModeScope | null =>
+			RewordCommit: (workspaceMode) =>
 				selectedItem?._tag === "Commit" && workspaceMode.commitId === selectedItem.commitId
 					? rewordCommitModeScope({
 							bindings: rewordCommitBindings,
 							context: selectedItem,
 						})
 					: null,
-			Rub: (): ModeScope =>
+			Rub: () =>
 				rubOperationModeScope({
 					bindings: operationModeBindings,
 					context: selectedItem,
@@ -619,7 +603,30 @@ const getModeScope = ({
 		}),
 	);
 
-type Scope = ModeScope | PreviewScope;
+type PreviewScope = {
+	bindings: Array<ShortcutBinding<PreviewAction>>;
+	context: { isFullscreen: boolean };
+};
+
+type Scope = ModeScope | ({ _tag: "Preview" } & PreviewScope);
+
+const isOperationModeScope = (scope: Scope): scope is OperationModeScope =>
+	Match.value(scope).pipe(
+		Match.tagsExhaustive({
+			Move: () => true,
+			Rub: () => true,
+			Default: () => false,
+			RenameBranch: () => false,
+			RewordCommit: () => false,
+			Preview: () => false,
+		}),
+	);
+
+const previewScope = ({ bindings, context }: PreviewScope): Scope => ({
+	_tag: "Preview",
+	bindings,
+	context,
+});
 
 export const getScope = ({
 	selectedItem,
@@ -857,23 +864,16 @@ export const useWorkspaceShortcuts = ({
 			}),
 		);
 
-	const handlePreviewSelectionAction = (action: HunkSelectionAction) =>
-		Match.value(action).pipe(
-			Match.tagsExhaustive({
-				Move: ({ offset }) => previewRef.current?.moveSelection(offset),
-			}),
-		);
-
 	const handlePreviewScopeAction = (action: PreviewAction) =>
 		Match.value(action).pipe(
-			Match.tags({
+			Match.tagsExhaustive({
 				ClosePreview: () => dispatch(projectActions.closePreview({ projectId })),
 				FocusPrimary: () => dispatch(projectActions.focusPrimary({ projectId })),
+				Move: ({ offset }) => previewRef.current?.moveSelection(offset),
 				ToggleFullscreenPreview: () =>
 					dispatch(projectActions.toggleFullscreenPreview({ projectId })),
 				TogglePreview: () => dispatch(projectActions.togglePreview({ projectId })),
 			}),
-			Match.orElse((action) => handlePreviewSelectionAction(action)),
 		);
 
 	const confirmOperationMode = (selectedItem: Item | null) => {
@@ -929,7 +929,7 @@ export const useWorkspaceShortcuts = ({
 		);
 
 	const handleScopeKeyDown = (scope: Scope, event: KeyboardEvent) =>
-		scope._tag === "Move" || scope._tag === "Rub"
+		isOperationModeScope(scope)
 			? handleOperationModeScopeKeyDown(scope, event)
 			: Match.value(scope).pipe(
 					Match.tagsExhaustive({

--- a/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
@@ -21,11 +21,7 @@ import {
 	MenuTriggerIcon,
 	PushIcon,
 } from "#ui/components/icons.tsx";
-import {
-	changesSectionFileParent,
-	commitFileParent,
-	type FileParent,
-} from "#ui/domain/FileParent.ts";
+import { FileParent } from "#ui/domain/FileParent.ts";
 import { getBranchNameByCommitId, getCommonBaseCommitId } from "#ui/domain/RefInfo.ts";
 import { ProjectPreviewLayout } from "#ui/routes/project/$id/ProjectPreviewLayout.tsx";
 import { getFocus } from "#ui/routes/project/$id/state/layout.ts";
@@ -99,16 +95,11 @@ import { Route as projectRoute } from "#ui/routes/project/$id/route.tsx";
 import { useAppDispatch, useAppSelector } from "#ui/state/hooks.ts";
 import sharedStyles from "../shared.module.css";
 import {
+	Item,
 	baseCommitItem,
-	changeItem,
-	changesSectionItem,
-	CommitFileItem,
-	commitFileItem,
-	CommitItem,
-	commitItem,
-	type Item,
-	SegmentItem,
-	segmentItem,
+	type CommitFileItem,
+	type CommitItem,
+	type SegmentItem,
 } from "./Item.ts";
 import {
 	buildNavigationIndex,
@@ -129,11 +120,7 @@ import {
 import { PositionedShortcutsBar } from "../ShortcutsBar.tsx";
 import { formatShortcutKeys, ShortcutActionBase, type ShortcutBinding } from "#ui/shortcuts.ts";
 import styles from "./route.module.css";
-import {
-	fileOperationSource,
-	hunkOperationSource,
-	operationSourceFromItem,
-} from "./OperationSource.ts";
+import { OperationSource, operationSourceFromItem } from "./OperationSource.ts";
 import {
 	getOperationMode,
 	normalizeWorkspaceMode,
@@ -298,7 +285,7 @@ const Hunk: FC<{
 		>
 			{fileParent && editable
 				? (() => {
-						const source = hunkOperationSource({
+						const source = OperationSource.Hunk({
 							parent: fileParent,
 							path: change.path,
 							hunkHeader: hunk,
@@ -486,8 +473,8 @@ const ChangesPreview: FC<{
 			) : (
 				<ul>
 					{changesWithDiffs.map(([change, diff]) => {
-						const parent = changesSectionFileParent({ stackId });
-						const source = fileOperationSource({ parent, path: change.path });
+						const parent = FileParent.ChangesSection({ stackId });
+						const source = OperationSource.File({ parent, path: change.path });
 						return (
 							<li key={change.path}>
 								<OperationSourceC
@@ -563,8 +550,8 @@ const CommitPreview: FC<{
 			) : (
 				<ul>
 					{changesWithDiffs.map(([change, diff]) => {
-						const parent = commitFileParent({ commitId });
-						const source = fileOperationSource({ parent, path: change.path });
+						const parent = FileParent.Commit({ commitId });
+						const source = OperationSource.File({ parent, path: change.path });
 						return (
 							<li key={change.path}>
 								{editable ? (
@@ -888,13 +875,13 @@ const CommitRow: FC<
 	...restProps
 }) => {
 	const dispatch = useAppDispatch();
-	const commitItemV: CommitItem = {
+	const commitItem: CommitItem = {
 		stackId,
 		segmentIndex,
 		branchRef,
 		commitId: commit.id,
 	};
-	const item = commitItem(commitItemV);
+	const item = Item.Commit(commitItem);
 	const isRewording =
 		selected !== null &&
 		workspaceMode._tag === "RewordCommit" &&
@@ -913,7 +900,7 @@ const CommitRow: FC<
 	const commitReword = useMutation(commitRewordMutationOptions);
 
 	const startEditing = () => {
-		dispatch(projectActions.startRewordCommit({ projectId, item: commitItemV }));
+		dispatch(projectActions.startRewordCommit({ projectId, item: commitItem }));
 	};
 
 	const endEditing = () => {
@@ -997,7 +984,7 @@ const CommitRow: FC<
 									className={sharedStyles.itemRowAction}
 									type="button"
 									onClick={() =>
-										dispatch(projectActions.toggleCommitFiles({ projectId, item: commitItemV }))
+										dispatch(projectActions.toggleCommitFiles({ projectId, item: commitItem }))
 									}
 									aria-expanded={isExpanded}
 									aria-label={isExpanded ? "Hide commit files" : "Show commit files"}
@@ -1045,7 +1032,7 @@ const CommitFileRow: FC<{
 	projectId: string;
 }> = ({ change, operationMode, parentCommitItem, isSelected, navigationIndex, projectId }) => {
 	const dispatch = useAppDispatch();
-	const item = commitFileItem({ ...parentCommitItem, path: change.path });
+	const item = Item.CommitFile({ ...parentCommitItem, path: change.path });
 
 	return (
 		<OperationSourceC
@@ -1101,8 +1088,8 @@ const CommitC: FC<{
 	const isHighlighted = useAppSelector((state) =>
 		selectProjectHighlightedCommitIds(state, projectId).includes(commit.id),
 	);
-	const commitItemV: CommitItem = { stackId, segmentIndex, branchRef, commitId: commit.id };
-	const item = commitItem(commitItemV);
+	const commitItem: CommitItem = { stackId, segmentIndex, branchRef, commitId: commit.id };
+	const item = Item.Commit(commitItem);
 	return (
 		<OperationSourceC
 			operationMode={operationMode}
@@ -1141,7 +1128,7 @@ const CommitC: FC<{
 							<CommitFileRow
 								change={change}
 								operationMode={operationMode}
-								parentCommitItem={commitItemV}
+								parentCommitItem={commitItem}
 								isSelected={selectedFile?.path === change.path}
 								navigationIndex={navigationIndex}
 								projectId={projectId}
@@ -1201,7 +1188,7 @@ const ChangeRow: FC<{
 	stackId,
 }) => {
 	const dispatch = useAppDispatch();
-	const item = changeItem({ stackId, path: change.path });
+	const item = Item.Change({ stackId, path: change.path });
 	return (
 		<OperationSourceC
 			operationMode={operationMode}
@@ -1301,7 +1288,7 @@ const ChangesSectionRow: FC<{
 
 	return (
 		<ItemRow
-			inert={!navigationIndexIncludes(navigationIndex, changesSectionItem({ stackId }))}
+			inert={!navigationIndexIncludes(navigationIndex, Item.ChangesSection({ stackId }))}
 			isSelected={isSelected}
 		>
 			<ContextMenu.Root>
@@ -1314,7 +1301,7 @@ const ChangesSectionRow: FC<{
 								dispatch(
 									projectActions.selectItem({
 										projectId,
-										item: changesSectionItem({ stackId }),
+										item: Item.ChangesSection({ stackId }),
 									}),
 								);
 							}}
@@ -1415,7 +1402,7 @@ const Changes: FC<{
 	const changes = worktreeChanges.changes.filter((change) => assignmentsByPath.has(change.path));
 	const isSectionSelected = isSelected || selectedPath !== null;
 
-	const item = changesSectionItem({ stackId });
+	const item = Item.ChangesSection({ stackId });
 
 	const dispatch = useAppDispatch();
 
@@ -1423,7 +1410,7 @@ const Changes: FC<{
 		dispatch(
 			projectActions.enterMoveMode({
 				projectId,
-				source: operationSourceFromItem(changesSectionItem({ stackId })),
+				source: operationSourceFromItem(Item.ChangesSection({ stackId })),
 			}),
 		);
 
@@ -1565,12 +1552,12 @@ const SegmentRow: FC<
 	const dispatch = useAppDispatch();
 	const branchName = segment.refName?.displayName ?? null;
 	const branchRef = segment.refName?.fullNameBytes ?? null;
-	const segmentItemV: SegmentItem = {
+	const segmentItem: SegmentItem = {
 		stackId,
 		segmentIndex,
 		branchRef,
 	};
-	const item = segmentItem(segmentItemV);
+	const item = Item.Segment(segmentItem);
 	const isRenaming =
 		selected !== null &&
 		workspaceMode._tag === "RenameBranch" &&
@@ -1586,7 +1573,7 @@ const SegmentRow: FC<
 
 	const startEditing = () => {
 		if (branchName === null) return;
-		dispatch(projectActions.startRenameBranch({ projectId, item: segmentItemV }));
+		dispatch(projectActions.startRenameBranch({ projectId, item: segmentItem }));
 	};
 
 	const endEditing = () => {
@@ -1615,7 +1602,7 @@ const SegmentRow: FC<
 			dispatch(
 				projectActions.selectItem({
 					projectId,
-					item: segmentItem({
+					item: Item.Segment({
 						stackId,
 						segmentIndex,
 						// TODO: ideally the API would return the new ref?


### PR DESCRIPTION
If we change our minds about using Effect's `Data.TaggedEnum` we can use agents to easily migrate away later on.