### PR TITLE
Fix stack queries reading from HEAD instead of workspace ref during edit mode

### DIFF
--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -11,6 +11,10 @@ use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 use but_hunk_assignment::CommitAbsorption;
 use but_workspace::legacy::ui::StackEntry;
 use gitbutler_branch::BranchCreateRequest;
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 use gitbutler_stack::{Target, VirtualBranchesHandle};
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +103,10 @@ pub fn handle_changes(
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn default_target_setting_if_none(
     ctx: &Context,
     vb_state: &mut VirtualBranchesHandle,

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -134,6 +134,7 @@ fn default_target_setting_if_none(
     Ok(target)
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 fn stacks(ctx: &Context, repo: &gix::Repository) -> anyhow::Result<Vec<StackEntry>> {
     let meta = ctx.legacy_meta()?;
     but_workspace::legacy::stacks_v3(

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -85,6 +85,7 @@ pub fn commit(
     Ok(new_commit_id.map(|id| (id, message)))
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 fn stacks(ctx: &Context) -> anyhow::Result<Vec<StackEntry>> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.legacy_meta()?;

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::collections::HashMap;
 
 use anyhow::anyhow;

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -82,20 +82,28 @@ pub(crate) fn stacks_v3_from_ctx(
 ) -> anyhow::Result<Vec<but_workspace::legacy::ui::StackEntry>> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;
-    let workspace_ref = [
-        gitbutler_operating_modes::WORKSPACE_BRANCH_REF,
-        gitbutler_operating_modes::INTEGRATION_BRANCH_REF,
-    ]
-    .iter()
-    .find_map(|&name| {
-        let ref_name: &gix::refs::FullNameRef = name.try_into().ok()?;
-        repo.try_find_reference(ref_name).ok().flatten()?;
-        Some(ref_name)
-    });
-    // Prefer reading from the workspace ref rather than HEAD. During edit mode HEAD points
-    // to the edit branch, which is not part of the workspace, so querying stacks from there
-    // would produce entries without stack IDs. Fall back to HEAD when no workspace-like ref
-    // is present.
+    let workspace_ref = match repo.head() {
+        Ok(head)
+            if head.referent_name().is_some_and(|head_ref| {
+                head_ref.as_bstr() == gitbutler_operating_modes::EDIT_BRANCH_REF
+            }) =>
+        {
+            [
+                gitbutler_operating_modes::WORKSPACE_BRANCH_REF,
+                gitbutler_operating_modes::INTEGRATION_BRANCH_REF,
+            ]
+            .iter()
+            .find_map(|&name| {
+                let ref_name: &gix::refs::FullNameRef = name.try_into().ok()?;
+                repo.try_find_reference(ref_name).ok().flatten()?;
+                Some(ref_name)
+            })
+        }
+        _ => None,
+    };
+    // Only prefer a workspace-like ref during edit mode. When HEAD points at
+    // `gitbutler/edit`, querying stacks from HEAD would produce entries without stack IDs
+    // because the edit branch itself is not part of the workspace metadata.
     but_workspace::legacy::stacks_v3(&repo, &meta, filter, workspace_ref)
 }
 

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -76,6 +76,7 @@ pub fn stacks(
 }
 ///
 /// Return stack information for the repository that `ctx` refers to using legacy metadata.
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 pub(crate) fn stacks_v3_from_ctx(
     ctx: &Context,
     filter: StacksFilter,
@@ -197,6 +198,7 @@ fn remove_in_workspace_flag_below_lower_bound(
 
 #[but_api]
 #[instrument(err(Debug))]
+#[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 pub fn stack_details(
     ctx: &Context,
     stack_id: Option<StackId>,

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -82,7 +82,21 @@ pub(crate) fn stacks_v3_from_ctx(
 ) -> anyhow::Result<Vec<but_workspace::legacy::ui::StackEntry>> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;
-    but_workspace::legacy::stacks_v3(&repo, &meta, filter, None)
+    let workspace_ref = [
+        gitbutler_operating_modes::WORKSPACE_BRANCH_REF,
+        gitbutler_operating_modes::INTEGRATION_BRANCH_REF,
+    ]
+    .iter()
+    .find_map(|&name| {
+        let ref_name: &gix::refs::FullNameRef = name.try_into().ok()?;
+        repo.try_find_reference(ref_name).ok().flatten()?;
+        Some(ref_name)
+    });
+    // Prefer reading from the workspace ref rather than HEAD. During edit mode HEAD points
+    // to the edit branch, which is not part of the workspace, so querying stacks from there
+    // would produce entries without stack IDs. Fall back to HEAD when no workspace-like ref
+    // is present.
+    but_workspace::legacy::stacks_v3(&repo, &meta, filter, workspace_ref)
 }
 
 #[cfg(unix)]

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -21,7 +21,10 @@
 //!     disambiguate accurately.
 //!
 //!   - otherwise, it can be applied anywhere
-#![expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
+#![expect(
+    deprecated,
+    reason = "calls but_workspace::legacy::stacks_v3; VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 
 use anyhow::{Context as _, Result, bail};
 use but_core::{RepositoryExt, ref_metadata::StackId};

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -21,6 +21,7 @@
 //!     disambiguate accurately.
 //!
 //!   - otherwise, it can be applied anywhere
+#![expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 
 use anyhow::{Context as _, Result, bail};
 use but_core::{RepositoryExt, ref_metadata::StackId};

--- a/crates/but-cherry-apply/tests/cherry_apply/clean_to_both.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/clean_to_both.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "calls stack_details_v3")]
+
 use super::*;
 use crate::util::test_ctx;
 

--- a/crates/but-cherry-apply/tests/cherry_apply/conflicts_with_bar.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/conflicts_with_bar.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "calls stack_details_v3")]
+
 use super::*;
 use crate::util::test_ctx;
 

--- a/crates/but-cherry-apply/tests/cherry_apply/main.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/main.rs
@@ -1,4 +1,7 @@
-#![expect(deprecated, reason = "imports but_workspace::legacy::stack_details_v3")]
+#![expect(
+    deprecated,
+    reason = "imports but_workspace::legacy::stack_details_v3; VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 
 /// Tests for cherry-apply functionality
 mod util {

--- a/crates/but-cherry-apply/tests/cherry_apply/main.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/main.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "imports but_workspace::legacy::stack_details_v3")]
+
 /// Tests for cherry-apply functionality
 mod util {
     use but_cherry_apply::{CherryApplyStatus, cherry_apply, cherry_apply_status};

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -593,12 +593,14 @@ impl OutputClaudeJson for Result<ClaudeHookOutput> {
     }
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 fn stack_details(ctx: &Context, stack_id: StackId) -> anyhow::Result<StackDetails> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.legacy_meta()?;
     but_workspace::legacy::stack_details_v3(Some(stack_id), &repo, &meta)
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 fn list_stacks(ctx: &Context) -> anyhow::Result<Vec<StackEntry>> {
     let repo = ctx.repo.get()?;
     let meta = ctx.legacy_meta()?;

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -117,6 +117,7 @@ fn cursor_path_to_pathbuf(input: &str) -> PathBuf {
     }
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<CursorHookOutput> {
     let mut input: FileEditEvent = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {e}"))?;
@@ -207,6 +208,7 @@ pub async fn handle_after_edit(read: impl std::io::Read) -> anyhow::Result<Curso
     Ok(CursorHookOutput::default())
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 pub async fn handle_stop(
     nightly: bool,
     read: impl std::io::Read,

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -102,6 +102,11 @@ pub mod assignment {
 }
 
 pub mod stacks {
+    #![expect(
+        deprecated,
+        reason = "calls but_workspace::legacy::stacks_v3 and but_workspace::legacy::stack_details_v3"
+    )]
+
     use std::str::FromStr;
 
     use anyhow::Context as _;

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1742,6 +1742,7 @@ fn find_the_right_commit_id(
     commit_id
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 fn stacks(ctx: &Context) -> anyhow::Result<Vec<but_workspace::legacy::ui::StackEntry>> {
     let meta = ctx.legacy_meta()?;
     let repo = &*ctx.repo.get()?;

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -15,6 +15,10 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
 };
 use gitbutler_reference::{LocalRefname, Refname};
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 use gitbutler_stack::{PatchReferenceUpdate, VirtualBranchesHandle};
 use schemars::{JsonSchema, schema_for};
 
@@ -163,6 +167,10 @@ impl Tool for Commit {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 pub fn create_commit(
     ctx: &mut Context,
     params: CommitParameters,
@@ -297,6 +305,10 @@ impl Tool for CreateBranch {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 pub fn create_branch(
     ctx: &mut Context,
     params: CreateBranchParameters,
@@ -1521,6 +1533,10 @@ pub fn get_filtered_changes(
     Ok(file_changes)
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn entries_to_simple_stacks(
     entries: &[StackEntryNoOpt],
     ctx: &Context,
@@ -1630,6 +1646,10 @@ fn unified_diff_for_changes(
         .collect::<Result<Vec<_>, _>>()
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn changes_in_branch_inner(
     ctx: &Context,
     branch_name: String,
@@ -1649,6 +1669,10 @@ fn changes_in_branch_inner(
     but_core::diff::ui::changes_with_line_stats_in_range(&repo, start_commit_id, base_commit_id)
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn commit_and_base_from_stack(
     ctx: &Context,
     state: &VirtualBranchesHandle,

--- a/crates/but-workspace/src/legacy/commit_engine/mod.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/mod.rs
@@ -1,4 +1,8 @@
 //! The machinery used to alter and mutate commits in various ways whilst adjusting descendant commits within a [reference frame](ReferenceFrame).
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 
 use std::path::Path;
 

--- a/crates/but-workspace/src/legacy/mod.rs
+++ b/crates/but-workspace/src/legacy/mod.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::path::Path;
 
 use but_ctx::Context;

--- a/crates/but-workspace/src/legacy/mod.rs
+++ b/crates/but-workspace/src/legacy/mod.rs
@@ -14,6 +14,7 @@ pub use head::{
 
 pub mod tree_manipulation;
 // TODO: _v3 versions are specifically for the UI, so import them into `ui` instead.
+#[expect(deprecated, reason = "re-exports stacks_v3 and stack_details_v3")]
 pub use stacks::{
     local_and_remote_commits, stack_branches, stack_details_v3, stack_heads_info, stacks_v3,
 };

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -164,6 +164,9 @@ fn try_from_stack_v3(
 /// `stacks_v3_from_ctx` to anchor queries to the workspace ref (during edit mode, HEAD points
 /// elsewhere), and in tests to avoid needing multiple fixtures with different HEAD positions.
 // TODO: See if the UI can migrate to `head_info()` or a variant of it so the information is only called once.
+#[deprecated(
+    note = "Use head_info() and the returned RefInfo instead. Callers that already have a Context should prefer ctx.workspace_* helpers."
+)]
 pub fn stacks_v3(
     repo: &gix::Repository,
     meta: &impl RefMetadata,
@@ -284,6 +287,9 @@ pub fn stacks_v3(
 // TODO: StackId shouldn't be used, instead use the ref-name or stack index as universal tip identifier.
 //       It's notable that there isn't always a ref-name available right now in case the ref advanced, but maybe this is something
 //       we can pull out of the metadata information.
+#[deprecated(
+    note = "Use head_info() and the returned RefInfo instead. Callers that already have a Context should prefer ctx.workspace_* helpers."
+)]
 #[instrument(level = "debug", skip(meta), err(Debug))]
 pub fn stack_details_v3(
     stack_id: Option<StackId>,

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -160,8 +160,9 @@ fn try_from_stack_v3(
 /// Returns the list of stacks that pass `filter`, in unspecified order.
 ///
 /// Use `repo` and `meta` to read branches data
-/// Use `ref_name` to forcefully pretend the HEAD is looking at something else. Only used in testing to avoid needing
-/// multiple fixtures just with a different HEAD position.
+/// Use `ref_name_override` to read from a specific ref instead of HEAD. Used in production by
+/// `stacks_v3_from_ctx` to anchor queries to the workspace ref (during edit mode, HEAD points
+/// elsewhere), and in tests to avoid needing multiple fixtures with different HEAD positions.
 // TODO: See if the UI can migrate to `head_info()` or a variant of it so the information is only called once.
 pub fn stacks_v3(
     repo: &gix::Repository,

--- a/crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::{Result, bail};
 use but_core::{DiffSpec, RepositoryExt, sync::RepoExclusive};
 use but_ctx::Context;

--- a/crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::{Result, bail};
 use but_core::{DiffSpec, TreeChange, sync::RepoExclusive};
 use but_ctx::Context;

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use but_core::{Reference, sync::RepoExclusive};
 use but_ctx::Context;

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use but_core::sync::RepoExclusive;
 use but_ctx::Context;

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "covers calls to but_workspace::legacy::stacks_v3 and but_workspace::legacy::stack_details_v3"
+)]
+
 use std::borrow::Cow;
 
 use but_workspace::{legacy::StacksFilter, ref_info};
@@ -16,6 +21,9 @@ pub fn head_info(
     but_workspace::head_info(repo, meta, opts)
 }
 
+#[deprecated(
+    note = "Use head_info() and the returned RefInfo instead. Callers that already have a Context should prefer ctx.workspace_* helpers."
+)]
 pub fn stacks_v3(
     repo: &gix::Repository,
     meta: &but_meta::VirtualBranchesTomlMetadata,
@@ -25,6 +33,9 @@ pub fn stacks_v3(
     but_workspace::legacy::stacks_v3(repo, meta, filter, ref_name_override)
 }
 
+#[deprecated(
+    note = "Use head_info() and the returned RefInfo instead. Callers that already have a Context should prefer ctx.workspace_* helpers."
+)]
 pub fn stack_details_v3(
     stack_id: Option<gitbutler_stack::StackId>,
     repo: &gix::Repository,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "covers calls to stacks_v3 and stack_details_v3")]
+
 mod stacks {
     use but_testsupport::visualize_commit_graph_all;
     use but_workspace::legacy::StacksFilter;

--- a/crates/but-worktrees/src/integrate.rs
+++ b/crates/but-worktrees/src/integrate.rs
@@ -8,6 +8,10 @@ use but_ctx::{
 use but_rebase::{Rebase, RebaseOutput, RebaseStep};
 use but_workspace::legacy::stack_ext::StackExt;
 use gitbutler_branch_actions::update_workspace_commit;
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
 use gitbutler_workspace::branch_trees::{
     WorkspaceState, merge_workspace, move_tree_has_conflicts, update_uncommitted_changes,
@@ -89,6 +93,10 @@ struct IntegrationResult {
 
 /// Performs the workspace integration operations in memory, returning the
 /// status, and output if it's integratable
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn worktree_integration_inner(
     ctx: &mut Context,
     perm: &RepoShared,

--- a/crates/but-worktrees/tests/worktree/main.rs
+++ b/crates/but-worktrees/tests/worktree/main.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 /// Tests for worktree creation and management
 mod util {
     use but_ctx::Context;

--- a/crates/but-worktrees/tests/worktree/worktree_new.rs
+++ b/crates/but-worktrees/tests/worktree/worktree_new.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "calls stacks_v3")]
+
 use anyhow::Context as _;
 use but_meta::VirtualBranchesTomlMetadata;
 use but_workspace::legacy::{StacksFilter, stacks_v3};

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::collections::HashMap;
 
 use but_ctx::Context;

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use super::super::FileChange;
 use bstr::ByteSlice;
 use but_ctx::Context;

--- a/crates/but/src/command/legacy/mcp_internal/commit.rs
+++ b/crates/but/src/command/legacy/mcp_internal/commit.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::path::Path;
 
 use bstr::BString;

--- a/crates/but/src/command/legacy/mcp_internal/stack.rs
+++ b/crates/but/src/command/legacy/mcp_internal/stack.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::path::Path;
 
 use bstr::{BString, ByteSlice};

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -1,4 +1,8 @@
 //! Cherry-pick commits from unapplied branches into applied virtual branches.
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::fmt::Write;
 
 use but_core::{RepositoryExt, ref_metadata::StackId};

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::collections::BTreeMap;
 
 use assignment::FileAssignment;

--- a/crates/but/src/legacy/commits.rs
+++ b/crates/but/src/legacy/commits.rs
@@ -5,12 +5,14 @@ use but_workspace::{
     ui::StackDetails,
 };
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 pub fn stacks(ctx: &Context) -> anyhow::Result<Vec<StackEntry>> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;
     but_workspace::legacy::stacks_v3(&repo, &meta, StacksFilter::default(), None)
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 pub fn stack_details(ctx: &Context, stack_id: StackId) -> anyhow::Result<StackDetails> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -40,6 +40,7 @@ pub enum InteractiveIntegrationStep {
 ///
 /// This basically just lists the upstream and local commits in the display order (child to parent) and creates a `Pick` step for each.
 /// The user can then modify this in the UI.
+#[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 pub fn get_initial_integration_steps_for_branch(
     ctx: &Context,
     stack_id: Option<StackId>,

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::{Result, bail};
 use but_ctx::{Context, access::RepoExclusive};
 use but_rebase::{Rebase, RebaseStep};

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -1,4 +1,9 @@
 //! GitButler internal library containing functionality related to branches, i.e. the virtual branches implementation
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 mod actions;
 // This is our API
 pub use actions::{

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -213,6 +213,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
     }
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
 fn stacks(
     ctx: &Context,
     repo: &gix::Repository,
@@ -226,6 +227,7 @@ fn stacks(
     )
 }
 
+#[expect(deprecated, reason = "calls but_workspace::legacy::stack_details_v3")]
 fn stack_details(
     ctx: &Context,
     stack_id: Option<StackId>,
@@ -364,7 +366,7 @@ pub fn upstream_integration_statuses(
         .tree_id()?;
 
     // The working directory tree
-    #[expect(deprecated)]
+    #[expect(deprecated, reason = "calls repo.create_wd_tree")]
     let workdir_tree = repo.create_wd_tree(gitbutler_project::AUTO_TRACK_LIMIT_BYTES)?;
 
     // The target tree

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use but_core::{
     GitConfigSettings, RefMetadata, RepositoryExt,

--- a/crates/gitbutler-branch-actions/tests/branch-actions/reorder.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/reorder.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::collections::HashMap;
 
 use anyhow::Result;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/squash.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/squash.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use bstr::ByteSlice;
 use but_ctx::Context;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "calls but_workspace::legacy::stacks_v3 and but_workspace::legacy::stack_details_v3"
+)]
+
 use anyhow::Result;
 use but_ctx::{Context, RepoOpenMode};
 use but_settings::AppSettings;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use but_core::git_config::{edit_config, set_config_value};
 
 use super::*;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "calls but_workspace::legacy::stacks_v3")]
+
 use std::{fs, path, path::PathBuf, str::FromStr};
 
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId, RepoOpenMode};

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/oplog.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::{io::Write, path::Path};
 
 use bstr::ByteSlice as _;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/workspace_commit.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use gitbutler_stack::VirtualBranchesHandle;
 use tempfile::TempDir;

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -28,6 +28,10 @@ pub fn list(ctx: &Context) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    deprecated,
+    reason = "calls but_workspace::legacy::stacks_v3 and but_workspace::legacy::stack_details_v3"
+)]
 pub(crate) fn stacks(ctx: &Context) -> Result<Vec<(StackId, StackDetails)>> {
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let stacks = {

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::path::Path;
 
 use anyhow::{Context as _, Result, bail};

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -15,6 +15,10 @@ use but_meta::virtual_branches_legacy_types;
 use but_oxidize::{ObjectIdExt as _, OidExt};
 use gitbutler_cherry_pick::GixRepositoryExt as _;
 use gitbutler_repo::{SignaturePurpose, commit_without_signature_gix, signature_gix};
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 use gitbutler_stack::{VirtualBranchesHandle, VirtualBranchesState};
 use gix::objs::Write as _;
 use gix::{
@@ -423,6 +427,10 @@ fn reset_index_to_tree(ctx: &Context, tree_id: gix::ObjectId) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 pub fn prepare_snapshot(ctx: &Context, _shared_access: &RepoShared) -> Result<gix::ObjectId> {
     let repo = ctx.repo.get()?;
     let empty_tree_id = repo.empty_tree().id;
@@ -569,6 +577,10 @@ fn commit_snapshot(
     Ok(snapshot_commit_id)
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn restore_snapshot(
     ctx: &Context,
     snapshot_commit_id: gix::ObjectId,

--- a/crates/gitbutler-oplog/src/reflog.rs
+++ b/crates/gitbutler-oplog/src/reflog.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::path::Path;
 
 use anyhow::Result;

--- a/crates/gitbutler-stack/src/lib.rs
+++ b/crates/gitbutler-stack/src/lib.rs
@@ -4,6 +4,10 @@ mod state;
 mod target;
 
 pub use stack::{Stack, StackId};
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 pub use state::{VirtualBranches as VirtualBranchesState, VirtualBranchesHandle};
 pub use target::Target;
 
@@ -11,7 +15,6 @@ mod heads;
 pub use heads::add_head;
 pub use stack::PatchReferenceUpdate;
 
-#[expect(deprecated)]
 mod stack_branch;
 pub use stack::canned_branch_name;
 pub use stack_branch::{BranchCommitIds, StackBranch};

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -16,6 +16,10 @@ use gix::validate::reference::name_partial;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 use crate::{
     StackBranch, VirtualBranchesHandle,
     heads::{add_head, get_head, remove_head},
@@ -126,6 +130,10 @@ impl From<Stack> for virtual_branches_legacy_types::Stack {
 /// The first patches are in the beginning of the list and the most recent patches are at the end of the list (top of the stack)
 /// Similarly, heads that point to earlier commits are first in the order, and the last head always points to the most recent patch.
 /// If there are multiple heads that point to the same patch, the `add` and `update` operations can specify the intended order.
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 impl Stack {
     /// The name of the stack, defined as the name of the first head (branch) in the stack.
     /// The usage of this is discouraged
@@ -715,6 +723,10 @@ impl TryFrom<&Stack> for VirtualRefname {
 ///
 /// If the patch reference is a commit ID, it must be the case that the commit has no change ID associated with it.
 /// In other words, change IDs are enforced to be preferred over commit IDs when available.
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn validate_target(
     reference: gix::ObjectId,
     repo: &gix::Repository,
@@ -747,6 +759,10 @@ fn validate_target(
 ///  - unique within all stacks
 ///  - not the same as any existing local git reference (it is permitted for the name to match an existing remote reference)
 ///  - not including the `refs/heads/` prefix
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn validate_name(name: &str, state: &VirtualBranchesHandle) -> Result<()> {
     if name.starts_with("refs/heads") {
         return Err(anyhow!("Stack head name cannot start with 'refs/heads'"));
@@ -761,14 +777,26 @@ fn validate_name(name: &str, state: &VirtualBranchesHandle) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn branch_state_from_project_data_dir(project_data_dir: &Path) -> VirtualBranchesHandle {
     VirtualBranchesHandle::new(project_data_dir)
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn branch_state(ctx: &Context) -> VirtualBranchesHandle {
     branch_state_from_project_data_dir(&ctx.project_data_dir())
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn patch_reference_exists(state: &VirtualBranchesHandle, name: &str) -> Result<bool> {
     Ok(state
         .list_stacks_in_workspace()?
@@ -785,6 +813,10 @@ fn local_reference_exists(repo: &gix::Repository, name: &str) -> Result<bool> {
     Ok(repo.find_reference(name_partial(name.into())?).is_ok())
 }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 fn remote_reference_exists(
     repo: &gix::Repository,
     state: &VirtualBranchesHandle,

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use anyhow::Result;
 use bstr::{BString, ByteSlice};
 use but_ctx::Context;

--- a/crates/gitbutler-stack/src/state.rs
+++ b/crates/gitbutler-stack/src/state.rs
@@ -98,6 +98,7 @@ impl VirtualBranches {
 /// A handle to the state of virtual branches.
 ///
 /// For all operations, if the state file does not exist, it will be created.
+#[deprecated(note = "use ctx.workspace_* helpers instead of VirtualBranchesHandle")]
 pub struct VirtualBranchesHandle {
     /// The path to the file containing the virtual branches state.
     file_path: PathBuf,
@@ -113,6 +114,10 @@ pub struct VirtualBranchesHandle {
 //     }
 // }
 
+#[expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
 impl VirtualBranchesHandle {
     /// Creates a new concurrency-safe handle to the state of virtual branches.
     pub fn new<P: AsRef<Path>>(base_path: P) -> Self {

--- a/crates/gitbutler-stack/tests/stack.rs
+++ b/crates/gitbutler-stack/tests/stack.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 use std::{fs, path::Path, thread, time::Duration};
 
 use anyhow::{Context as _, Result, bail};

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -1,3 +1,8 @@
+#![expect(
+    deprecated,
+    reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+)]
+
 pub mod branch_trees;
 
 use anyhow::Result;


### PR DESCRIPTION
## Summary

- When entering edit mode, HEAD moves to the edit branch. The layout's head-change effect re-fetches stacks, but `stacks_v3_from_ctx` was reading from HEAD via `Graph::from_head()`, producing `StackEntry` objects with `id: None` (the edit branch isn't in workspace metadata). This stale data caused `stack_details` to be queried without a `stackId`, triggering "BUG(opt-stack-id): should have gotten exactly one stack" errors.
- Fixed by making `stacks_v3_from_ctx` always read from the workspace ref instead of HEAD — stacks are a workspace concept and should not depend on what HEAD happens to point at.

## Test plan

- [x] Enter edit mode, save changes, return to workspace — no "opt-stack-id" errors
- [x] Enter edit mode, abort, return to workspace — no "opt-stack-id" errors
- [x] Normal workspace operations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

#### Notes for the Reviewer

* I deprecated all remaining types and functions that would be in the way of Single Branch Mode, while at it.
* This quick-fix was scoped more narrowly to not break single-branch mode in the Svelte UI more. In general, the real fix is to not use the `stacks_v3` and `stack_details_v3` functions.