### PR TITLE
Fix CIChecksBadge click not refetching when polling has stopped

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -198,8 +198,15 @@
 	tooltip={checksTagInfo.tooltip}
 	reversedDirection
 	onclick={(e) => {
-		checksService?.fetch(branchName, { forceRefetch: true });
 		e.stopPropagation();
+		if (!enabled) return;
+		// Re-add to polling list so that if new checks are discovered, polling resumes.
+		if (isDone) {
+			projectState.branchesToPoll.add(branchName);
+			loadedOnce = false;
+			elapsedMs = 0;
+		}
+		checksQuery?.result.refetch();
 	}}
 >
 	<span data-pr-text={checksTagInfo.reducedText} class="truncate">

--- a/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
@@ -1,7 +1,7 @@
 import type { ChecksStatus } from "$lib/forge/interface/types";
-import type { QueryOptions, ReactiveQuery } from "$lib/state/butlerModule";
+import type { QueryExtensions, QueryOptions, ReactiveQuery } from "$lib/state/butlerModule";
 
 export interface ChecksService {
-	get(branch: string, options?: QueryOptions): ReactiveQuery<ChecksStatus | null>;
+	get(branch: string, options?: QueryOptions): ReactiveQuery<ChecksStatus | null, QueryExtensions>;
 	fetch(branch: string, options?: QueryOptions): Promise<ChecksStatus | null>;
 }


### PR DESCRIPTION
Replace the standalone fetch (subscribe: false) with the query's own
refetch method so the subscription reliably picks up new data. When
polling has already stopped, re-add the branch to the poll list and
reset elapsed state so polling can resume if checks are still running.