### PR TITLE
Fix/floating commit box title lost

### DIFF
--- a/apps/desktop/src/components/commit/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/commit/CommitMessageEditor.svelte
@@ -245,7 +245,7 @@
 
 {#if useFloatingBox.current}
 	<FloatingCommitBox
-		title={floatingBoxHeader}
+		title={title || floatingBoxHeader}
 		onExitFloatingModeClick={() => {
 			useFloatingBox.set(false);
 		}}


### PR DESCRIPTION
Fixes #11968

The FloatingCommitBox was always displaying the static 
`floatingBoxHeader` ("Create commit") instead of the actual 
typed commit title. Changed to `title || floatingBoxHeader` 
so the typed title shows in the floating window header.
<img width="1920" height="1080" alt="Screenshot 2026-04-11 at 9 25 38 PM" src="https://github.com/user-attachments/assets/e00b6d91-0aee-4b65-92e1-c649fc0fc8b2" />
<img width="1920" height="1080" alt="Screenshot 2026-04-11 at 9 25 45 PM" src="https://github.com/user-attachments/assets/ea0991d6-7191-4a87-93e0-a4284bd33953" />
