### PR TITLE
Move `Context::cache` to `DbHandle::cache` and give `DbHandle` cache semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "but-project-handle",
  "but-settings",
  "but-testsupport",
+ "but-utils",
  "git2",
  "gitbutler-project",
  "gix",
@@ -1171,6 +1172,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "bitflags 2.11.0",
+ "but-utils",
  "chrono",
  "insta",
  "libc",
@@ -1212,11 +1214,11 @@ dependencies = [
  "anyhow",
  "but-db",
  "but-forge-storage",
- "but-fs",
  "but-github",
  "but-gitlab",
  "but-path",
  "but-schemars",
+ "but-utils",
  "chrono",
  "git-url-parse",
  "schemars 1.2.1",
@@ -1231,20 +1233,9 @@ name = "but-forge-storage"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "but-fs",
+ "but-utils",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "but-fs"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "gix",
- "serde",
- "toml 0.9.12+spec-1.1.0",
- "walkdir",
 ]
 
 [[package]]
@@ -1422,11 +1413,11 @@ dependencies = [
  "bstr",
  "but-core",
  "but-db",
- "but-fs",
  "but-graph",
  "but-meta",
  "but-serde",
  "but-testsupport",
+ "but-utils",
  "gitbutler-reference",
  "gix",
  "hex",
@@ -1617,8 +1608,8 @@ name = "but-settings"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "but-fs",
  "but-path",
+ "but-utils",
  "notify",
  "serde",
  "serde_json",
@@ -1732,6 +1723,17 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+]
+
+[[package]]
+name = "but-utils"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "gix",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -4104,10 +4106,10 @@ dependencies = [
  "bstr",
  "but-core",
  "but-ctx",
- "but-fs",
  "but-schemars",
  "but-serde",
  "but-testsupport",
+ "but-utils",
  "but-workspace",
  "gix",
  "schemars 1.2.1",
@@ -4124,11 +4126,11 @@ dependencies = [
  "anyhow",
  "but-core",
  "but-ctx",
- "but-fs",
  "but-meta",
  "but-oxidize",
  "but-serde",
  "but-testsupport",
+ "but-utils",
  "git2",
  "gitbutler-branch",
  "gitbutler-cherry-pick",
@@ -4152,12 +4154,12 @@ dependencies = [
  "but-core",
  "but-error",
  "but-forge",
- "but-fs",
  "but-path",
  "but-project-handle",
  "but-schemars",
  "but-serde",
  "but-testsupport",
+ "but-utils",
  "gix",
  "insta",
  "resolve-path",
@@ -4339,9 +4341,9 @@ name = "gitbutler-user"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "but-fs",
  "but-path",
  "but-secret",
+ "but-utils",
  "keyring",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,6 @@ dependencies = [
  "anyhow",
  "bstr",
  "but-core",
- "but-db",
  "but-gerrit",
  "but-graph",
  "but-meta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ members = [
     ##
     # Mostly supporting legacy code.
     # In big parts replaced by other crates.
-    "crates/but-fs",      # 📄filesystem utilities 👉we should be using `but-db` instead.
+    "crates/but-utils",   # 📄filesystem and general utilities; formerly `but-fs`.
     "crates/but-oxidize", # 📄Utilities to help translate between `git2` and `gix`. 👉Shouldn't be needed once `git2` is gone.
 
     ##
@@ -181,7 +181,7 @@ but-project-handle = { path = "crates/but-project-handle" }
 but-forge-storage = { path = "crates/but-forge-storage" }
 but-settings = { path = "crates/but-settings" }
 but-oxidize = { path = "crates/but-oxidize" }
-but-fs = { path = "crates/but-fs" }
+but-utils = { path = "crates/but-utils" }
 but-forge = { path = "crates/but-forge" }
 but-oplog = { path = "crates/but-oplog" }
 but-llm = { path = "crates/but-llm" }

--- a/crates/but-action/src/action.rs
+++ b/crates/but-action/src/action.rs
@@ -146,9 +146,9 @@ impl ButlerAction {
     }
 }
 
-pub(crate) fn persist_action(ctx: &mut Context, action: ButlerAction) -> anyhow::Result<()> {
+pub(crate) fn persist_action(ctx: &Context, action: ButlerAction) -> anyhow::Result<()> {
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .butler_actions_mut()
         .insert(action.try_into()?)
         .map_err(|e| anyhow::anyhow!("Failed to persist action: {e}"))?;
@@ -158,7 +158,7 @@ pub(crate) fn persist_action(ctx: &mut Context, action: ButlerAction) -> anyhow:
 pub fn list_actions(ctx: &Context, offset: i64, limit: i64) -> anyhow::Result<ActionListing> {
     let (total, actions) = ctx
         .db
-        .get()?
+        .get_cache()?
         .butler_actions()
         .list(offset, limit)
         .map_err(|e| anyhow::anyhow!("Failed to list actions: {e}"))?;

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -79,7 +79,7 @@ pub fn commit(
         output_commits,
         None,
     )
-    .persist(&mut ctx)
+    .persist(&ctx)
     .ok();
 
     Ok(new_commit_id.map(|id| (id, message)))

--- a/crates/but-action/src/workflow.rs
+++ b/crates/but-action/src/workflow.rs
@@ -202,9 +202,9 @@ impl Workflow {
         }
     }
 
-    pub(crate) fn persist(self, ctx: &mut Context) -> anyhow::Result<()> {
+    pub(crate) fn persist(self, ctx: &Context) -> anyhow::Result<()> {
         ctx.db
-            .get_mut()?
+            .get_cache_mut()?
             .workflows_mut()
             .insert(self.try_into()?)
             .map_err(|e| anyhow::anyhow!("Failed to persist workflow: {e}"))?;
@@ -215,7 +215,7 @@ impl Workflow {
 pub fn list_workflows(ctx: &Context, offset: i64, limit: i64) -> anyhow::Result<WorkflowList> {
     let (total, workflows) = ctx
         .db
-        .get()?
+        .get_cache()?
         .workflows()
         .list(offset, limit)
         .map_err(|e| anyhow::anyhow!("Failed to list workflows: {e}"))?;

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -247,7 +247,7 @@ fn move_branch_impl_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::move_branch(editor, subject_branch, target_branch)?;
@@ -312,7 +312,7 @@ fn tear_off_branch_impl_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<MoveBranchResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let but_workspace::branch::move_branch::Outcome { rebase, ws_meta } =
         but_workspace::branch::tear_off_branch(editor, subject_branch, None)?;

--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -38,7 +38,7 @@ pub(crate) fn commit_amend_only_impl(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let but_workspace::commit::CommitAmendOutcome {

--- a/crates/but-api/src/commit/create.rs
+++ b/crates/but-api/src/commit/create.rs
@@ -50,7 +50,7 @@ pub(crate) fn commit_create_only_impl(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitCreateResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let but_workspace::commit::CommitCreateOutcome {

--- a/crates/but-api/src/commit/insert_blank.rs
+++ b/crates/but-api/src/commit/insert_blank.rs
@@ -30,7 +30,7 @@ pub(crate) fn commit_insert_blank_only_impl(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitInsertBlankResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let (outcome, blank_commit_selector) =

--- a/crates/but-api/src/commit/move_changes.rs
+++ b/crates/but-api/src/commit/move_changes.rs
@@ -45,7 +45,7 @@ pub fn commit_move_changes_between_only_with_perm(
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let outcome = but_workspace::commit::move_changes_between_commits(

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -46,7 +46,7 @@ pub fn commit_move_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let rebase = but_workspace::commit::move_commit(editor, subject_commit_id, relative_to, side)?;

--- a/crates/but-api/src/commit/reword.rs
+++ b/crates/but-api/src/commit/reword.rs
@@ -39,7 +39,7 @@ pub fn commit_reword_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitRewordResult> {
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _, _cache) = ctx.workspace_mut_and_db_and_cache_with_perm(perm)?;
+    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let (outcome, edited_commit_selector) =

--- a/crates/but-api/src/commit/uncommit.rs
+++ b/crates/but-api/src/commit/uncommit.rs
@@ -49,7 +49,7 @@ pub fn commit_uncommit_changes_only_with_perm(
 ) -> anyhow::Result<MoveChangesResult> {
     let context_lines = ctx.settings.context_lines;
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, mut db, _cache) = ctx.workspace_mut_and_db_mut_and_cache_with_perm(perm)?;
+    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
 
     let before_assignments = if assign_to.is_some() {
         let (assignments, _) = but_hunk_assignment::assignments_with_fallback(

--- a/crates/but-api/src/legacy/claude.rs
+++ b/crates/but-api/src/legacy/claude.rs
@@ -109,7 +109,7 @@ pub fn claude_list_permission_requests(
 #[but_api]
 #[instrument(err(Debug))]
 pub fn claude_update_permission_request(
-    ctx: &mut but_ctx::Context,
+    ctx: &but_ctx::Context,
     request_id: String,
     decision: but_claude::PermissionDecision,
     use_wildcard: bool,
@@ -125,8 +125,8 @@ pub fn claude_answer_ask_user_question(
     answers: std::collections::HashMap<String, String>,
 ) -> Result<bool> {
     let project = legacy_project(project_id)?;
-    let mut ctx = Context::new_from_legacy_project(project.clone())?;
-    but_claude::db::set_ask_user_question_answers_by_stack(&mut ctx, stack_id, answers)
+    let ctx = Context::new_from_legacy_project(project.clone())?;
+    but_claude::db::set_ask_user_question_answers_by_stack(&ctx, stack_id, answers)
 }
 
 #[derive(Deserialize)]

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -163,7 +163,7 @@ pub fn set_review_template(ctx: &but_ctx::Context, template_path: Option<String>
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn list_reviews(
-    ctx: &mut Context,
+    ctx: &Context,
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::ForgeReview>> {
     let (storage, forge_repo_info, preferred_forge_user) = {
@@ -177,7 +177,7 @@ pub fn list_reviews(
         )
     };
 
-    let db = &mut *ctx.db.get_mut()?;
+    let db = &mut *ctx.db.get_cache_mut()?;
 
     but_forge::list_forge_reviews_with_cache(
         preferred_forge_user,
@@ -190,7 +190,7 @@ pub fn list_reviews(
 
 #[but_api(napi)]
 #[instrument(err(Debug))]
-pub fn get_review(ctx: &mut Context, review_id: usize) -> Result<but_forge::ForgeReview> {
+pub fn get_review(ctx: &Context, review_id: usize) -> Result<but_forge::ForgeReview> {
     let (storage, forge_repo_info, preferred_forge_user) = {
         let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
         let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url)
@@ -203,7 +203,7 @@ pub fn get_review(ctx: &mut Context, review_id: usize) -> Result<but_forge::Forg
         )
     };
 
-    let db = &mut *ctx.db.get_mut()?;
+    let db = &mut *ctx.db.get_cache_mut()?;
     but_forge::get_forge_review(
         &preferred_forge_user,
         &forge_repo_info,
@@ -216,7 +216,7 @@ pub fn get_review(ctx: &mut Context, review_id: usize) -> Result<but_forge::Forg
 #[but_api(napi)]
 #[instrument(skip(ctx), err(Debug))]
 pub fn list_ci_checks_and_update_cache(
-    ctx: &mut Context,
+    ctx: &Context,
     reference: String,
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::CiCheck>> {
@@ -230,7 +230,7 @@ pub fn list_ci_checks_and_update_cache(
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
-    let db = &mut *ctx.db.get_mut()?;
+    let db = &mut *ctx.db.get_cache_mut()?;
 
     but_forge::ci_checks_for_ref_with_cache(
         preferred_forge_user,
@@ -428,7 +428,7 @@ pub async fn list_reviews_for_branch(
 /// part of any applied stack.
 #[but_api(napi)]
 #[instrument(err(Debug))]
-pub fn warm_ci_checks_cache(ctx: &mut Context) -> Result<()> {
+pub fn warm_ci_checks_cache(ctx: &Context) -> Result<()> {
     // Get all stacks
     let stacks = crate::legacy::workspace::stacks(ctx, None)?;
 
@@ -459,7 +459,7 @@ pub fn warm_ci_checks_cache(ctx: &mut Context) -> Result<()> {
     }
 
     // Clean up stale CI check entries from the database
-    let db = &mut *ctx.db.get_mut()?;
+    let db = &mut *ctx.db.get_cache_mut()?;
     let all_cached_refs = db.ci_checks().list_all_references()?;
 
     // Delete CI checks for references that are no longer in applied stacks

--- a/crates/but-api/src/legacy/rules.rs
+++ b/crates/but-api/src/legacy/rules.rs
@@ -23,7 +23,7 @@ pub fn create_workspace_rule(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn delete_workspace_rule(ctx: &mut Context, rule_id: String) -> Result<()> {
+pub fn delete_workspace_rule(ctx: &Context, rule_id: String) -> Result<()> {
     delete_rule(ctx, &rule_id)
 }
 
@@ -39,7 +39,7 @@ pub fn update_workspace_rule(
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn list_workspace_rules(ctx: &mut Context) -> Result<Vec<WorkspaceRule>> {
+pub fn list_workspace_rules(ctx: &Context) -> Result<Vec<WorkspaceRule>> {
     let in_workspace = crate::legacy::workspace::stacks_v3_from_ctx(
         ctx,
         but_workspace::legacy::StacksFilter::InWorkspace,

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -613,9 +613,9 @@ async fn resolve_review_map(
         }
         acc
     });
-    let mut ctx = ctx;
+    let ctx = ctx;
     let mut resolved_reviews = HashMap::new();
-    let db = &mut *ctx.db.get_mut()?;
+    let db = &mut *ctx.db.get_cache_mut()?;
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
     for (key, pr_number) in reviews.drain() {
         if let Ok(resolved) = but_forge::get_forge_review(

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -210,7 +210,7 @@ pub fn stack_details(
     }?;
     let repo = ctx.repo.get()?;
     let gerrit_mode = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
-    let db = ctx.db.get()?;
+    let db = ctx.db.get_cache()?;
     if gerrit_mode {
         for branch in details.branch_details.iter_mut() {
             handle_gerrit(branch, &repo, &db)?;
@@ -306,7 +306,7 @@ pub fn branch_details(
         but_workspace::branch_details(&repo, ref_name.as_ref(), &meta)
     }?;
     let repo = ctx.repo.get()?;
-    let db = ctx.db.get()?;
+    let db = ctx.db.get_cache()?;
     let gerrit_mode = ctx
         .repo
         .get()?

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -140,7 +140,7 @@ pub fn cherry_apply(
     let mut rebase = Rebase::new(&repo, stack.merge_base(ctx)?, None)?;
     rebase.steps(steps)?;
     rebase.rebase_noops(false);
-    let output = rebase.rebase(&*ctx.cache.get_cache()?)?;
+    let output = rebase.rebase()?;
     stack.set_heads_from_rebase_output(ctx, output.references)?;
 
     {

--- a/crates/but-claude/src/db.rs
+++ b/crates/but-claude/src/db.rs
@@ -5,13 +5,13 @@ use uuid::Uuid;
 use crate::{ClaudePermissionRequest, ClaudeSession};
 
 /// Creates a new ClaudeSession with the session_id provided and saves it to the database.
-pub fn save_new_session(ctx: &mut Context, id: Uuid) -> anyhow::Result<ClaudeSession> {
+pub fn save_new_session(ctx: &Context, id: Uuid) -> anyhow::Result<ClaudeSession> {
     save_new_session_with_gui_flag(ctx, id, false)
 }
 
 /// Creates a new ClaudeSession with the session_id provided and saves it to the database.
 pub fn save_new_session_with_gui_flag(
-    ctx: &mut Context,
+    ctx: &Context,
     id: Uuid,
     in_gui: bool,
 ) -> anyhow::Result<ClaudeSession> {
@@ -27,18 +27,14 @@ pub fn save_new_session_with_gui_flag(
         denied_permissions: vec![],
     };
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .claude_mut()
         .insert_session(session.clone().try_into()?)?;
     Ok(session)
 }
 
 /// Adds a session ID to the list of session IDs for a given session.
-pub fn add_session_id(
-    ctx: &mut Context,
-    session_id: Uuid,
-    new_session_id: Uuid,
-) -> anyhow::Result<()> {
+pub fn add_session_id(ctx: &Context, session_id: Uuid, new_session_id: Uuid) -> anyhow::Result<()> {
     if let Some(mut session) = get_session_by_id(ctx, session_id)?
         && !session.session_ids.contains(&new_session_id)
     {
@@ -48,11 +44,11 @@ pub fn add_session_id(
         let json = serde_json::to_string(&session.session_ids)?;
 
         ctx.db
-            .get_mut()?
+            .get_cache_mut()?
             .claude_mut()
             .update_session_ids(&session_id.to_string(), &json)?;
         ctx.db
-            .get_mut()?
+            .get_cache_mut()?
             .claude_mut()
             .update_session_current_id(&session_id.to_string(), &new_session_id.to_string())?;
     }
@@ -60,9 +56,9 @@ pub fn add_session_id(
 }
 
 /// Updates the current session ID for a given session in the database.
-pub fn set_session_in_gui(ctx: &mut Context, session_id: Uuid, in_gui: bool) -> anyhow::Result<()> {
+pub fn set_session_in_gui(ctx: &Context, session_id: Uuid, in_gui: bool) -> anyhow::Result<()> {
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .claude_mut()
         .update_session_in_gui(&session_id.to_string(), in_gui)?;
     Ok(())
@@ -70,18 +66,17 @@ pub fn set_session_in_gui(ctx: &mut Context, session_id: Uuid, in_gui: bool) -> 
 
 /// Updates the permissions for a given session in the database.
 pub fn update_session_permissions(
-    ctx: &mut Context,
+    ctx: &Context,
     session_id: Uuid,
     approved_permissions: &[crate::Permission],
     denied_permissions: &[crate::Permission],
 ) -> anyhow::Result<()> {
     let approved_json = serde_json::to_string(approved_permissions)?;
     let denied_json = serde_json::to_string(denied_permissions)?;
-    ctx.db.get_mut()?.claude_mut().update_session_permissions(
-        &session_id.to_string(),
-        &approved_json,
-        &denied_json,
-    )?;
+    ctx.db
+        .get_cache_mut()?
+        .claude_mut()
+        .update_session_permissions(&session_id.to_string(), &approved_json, &denied_json)?;
     Ok(())
 }
 
@@ -89,7 +84,7 @@ pub fn update_session_permissions(
 pub fn get_session_by_id(ctx: &Context, session_id: Uuid) -> anyhow::Result<Option<ClaudeSession>> {
     let session = ctx
         .db
-        .get()?
+        .get_cache()?
         .claude()
         .get_session(&session_id.to_string())?;
     match session {
@@ -104,7 +99,7 @@ pub fn get_session_by_current_id(
 ) -> anyhow::Result<Option<ClaudeSession>> {
     let session = ctx
         .db
-        .get()?
+        .get_cache()?
         .claude()
         .get_session_by_current_id(&current_id.to_string())?;
     match session {
@@ -114,12 +109,9 @@ pub fn get_session_by_current_id(
 }
 
 /// Deletes a Claude session and all associated messages from the database. This is what we want to use when we want to delete a session completely.
-pub fn delete_session_and_messages_by_id(
-    ctx: &mut Context,
-    session_id: Uuid,
-) -> anyhow::Result<()> {
+pub fn delete_session_and_messages_by_id(ctx: &Context, session_id: Uuid) -> anyhow::Result<()> {
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .claude_mut()
         .delete_session_and_messages(&session_id.to_string())?;
     Ok(())
@@ -127,7 +119,7 @@ pub fn delete_session_and_messages_by_id(
 
 /// Creates a new ClaudeMessage with the provided session_id and payload, and saves it to the database.
 pub fn save_new_message(
-    ctx: &mut Context,
+    ctx: &Context,
     session_id: Uuid,
     payload: crate::MessagePayload,
 ) -> anyhow::Result<crate::ClaudeMessage> {
@@ -138,7 +130,7 @@ pub fn save_new_message(
         payload,
     };
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .claude_mut()
         .insert_message(message.clone().try_into()?)?;
     Ok(message)
@@ -152,7 +144,7 @@ pub fn list_messages_by_session(
 ) -> anyhow::Result<Vec<crate::ClaudeMessage>> {
     let messages = ctx
         .db
-        .get()?
+        .get_cache()?
         .claude()
         .list_messages_by_session(&session_id.to_string())?;
     messages
@@ -169,7 +161,7 @@ pub fn get_user_message(
 ) -> anyhow::Result<Option<crate::ClaudeMessage>> {
     let message = ctx
         .db
-        .get()?
+        .get_cache()?
         .claude()
         .get_message_of_type(MessagePayloadDbType::User.to_string(), offset)?;
 
@@ -189,7 +181,7 @@ pub fn list_all_permission_requests(
 /// Update permission request decision.
 /// This sends the decision to the waiting in-memory request.
 pub fn update_permission_request(
-    _ctx: &mut Context,
+    _ctx: &Context,
     id: &str,
     decision: crate::PermissionDecision,
     use_wildcard: bool,
@@ -211,7 +203,7 @@ pub fn list_pending_ask_user_question_requests(
 /// Updates the answers for an AskUserQuestion request.
 /// This sends the answers to the waiting in-memory request.
 pub fn set_ask_user_question_answers(
-    _ctx: &mut Context,
+    _ctx: &Context,
     id: &str,
     answers: std::collections::HashMap<String, String>,
 ) -> anyhow::Result<()> {
@@ -220,7 +212,7 @@ pub fn set_ask_user_question_answers(
 
 /// Alias for set_ask_user_question_answers for API compatibility.
 pub fn answer_ask_user_question(
-    ctx: &mut Context,
+    ctx: &Context,
     id: &str,
     answers: std::collections::HashMap<String, String>,
 ) -> anyhow::Result<()> {
@@ -230,7 +222,7 @@ pub fn answer_ask_user_question(
 /// Updates the answers for the pending AskUserQuestion request for a specific stack.
 /// Returns true if an update was made, false if no pending request was found for the stack.
 pub fn set_ask_user_question_answers_by_stack(
-    _ctx: &mut Context,
+    _ctx: &Context,
     stack_id: but_core::ref_metadata::StackId,
     answers: std::collections::HashMap<String, String>,
 ) -> anyhow::Result<bool> {

--- a/crates/but-claude/src/hooks/file_lock.rs
+++ b/crates/but-claude/src/hooks/file_lock.rs
@@ -2,12 +2,12 @@ use but_ctx::Context;
 use uuid::Uuid;
 
 pub(crate) fn obtain_or_insert(
-    ctx: &mut Context,
+    ctx: &Context,
     session_id: Uuid,
     file_path: String,
 ) -> anyhow::Result<()> {
     let owner = session_id.to_string();
-    let mut db = ctx.db.get_mut()?;
+    let mut db = ctx.db.get_cache_mut()?;
     let mut locks_mut = db.file_write_locks_mut();
     let max_wait_time = std::time::Duration::from_secs(30);
     let start = std::time::Instant::now();
@@ -42,9 +42,9 @@ pub(crate) fn obtain_or_insert(
 
 /// If file_path is provided, it will clear the lock for that file.
 /// Otherwise, it will clear all locks for the session_id.
-pub fn clear(ctx: &mut Context, session_id: Uuid, file_path: Option<String>) -> anyhow::Result<()> {
+pub fn clear(ctx: &Context, session_id: Uuid, file_path: Option<String>) -> anyhow::Result<()> {
     let owner = session_id.to_string();
-    let mut db = ctx.db.get_mut()?;
+    let mut db = ctx.db.get_cache_mut()?;
     let mut trans = db.transaction()?;
 
     let locks = trans.file_write_locks().list()?;

--- a/crates/but-claude/src/hooks/mod.rs
+++ b/crates/but-claude/src/hooks/mod.rs
@@ -90,13 +90,13 @@ pub fn handle_stop(ctx: Context, read: impl std::io::Read) -> anyhow::Result<Cla
 /// `maybe_unused_session_id` is the session ID that was passed to the hook, and it should always be the same as the
 /// one that is stored. The code behaves like that's not the case, but we just go with it.
 pub fn handle_session_stop(
-    mut ctx: Context,
+    ctx: Context,
     maybe_unused_session_id: Uuid,
     transcript_path: &str,
     skip_gui_check: bool,
 ) -> anyhow::Result<ClaudeHookOutput> {
     let session_id =
-        stable_session_id(&mut ctx, maybe_unused_session_id)?.unwrap_or(maybe_unused_session_id);
+        stable_session_id(&ctx, maybe_unused_session_id)?.unwrap_or(maybe_unused_session_id);
 
     // ClearLocksGuard ensures all file locks for this session are cleared on drop,
     // including early returns (no changes, GUI check, auto-commit disabled).
@@ -126,7 +126,7 @@ pub fn handle_session_stop(
     let summary = transcript.summary().unwrap_or_default();
     let prompt = transcript.prompt().unwrap_or_default();
 
-    if !skip_gui_check && should_exit_early(&mut defer.ctx, maybe_unused_session_id)? {
+    if !skip_gui_check && should_exit_early(&defer.ctx, maybe_unused_session_id)? {
         return Ok(ClaudeHookOutput {
             do_continue: true,
             stop_reason: "Session running in GUI, skipping hook".to_string(),
@@ -244,7 +244,7 @@ pub fn handle_session_stop(
                 }),
             );
 
-            crate::db::save_new_message(&mut defer.ctx, session_id, commit_message)?;
+            crate::db::save_new_message(&defer.ctx, session_id, commit_message)?;
         }
     }
 
@@ -334,16 +334,16 @@ pub struct ClaudePreToolUseInput {
 }
 
 pub fn handle_pre_tool_call(
-    mut ctx: Context,
+    ctx: Context,
     read: impl std::io::Read,
 ) -> anyhow::Result<ClaudeHookOutput> {
     let input: ClaudePreToolUseInput = serde_json::from_reader(read)
         .map_err(|e| anyhow::anyhow!("Failed to parse input JSON: {e}"))?;
 
     let session_id = input.session_id;
-    let session_id = stable_session_id(&mut ctx, session_id)?.unwrap_or(session_id);
+    let session_id = stable_session_id(&ctx, session_id)?.unwrap_or(session_id);
 
-    if should_exit_early(&mut ctx, session_id)? {
+    if should_exit_early(&ctx, session_id)? {
         return Ok(ClaudeHookOutput {
             do_continue: true,
             stop_reason: "Session running in GUI, skipping hook".to_string(),
@@ -351,7 +351,7 @@ pub fn handle_pre_tool_call(
         });
     }
 
-    file_lock::obtain_or_insert(&mut ctx, session_id, input.tool_input.file_path)?;
+    file_lock::obtain_or_insert(&ctx, session_id, input.tool_input.file_path)?;
 
     Ok(ClaudeHookOutput {
         do_continue: true,
@@ -367,9 +367,9 @@ pub fn lock_file_for_tool_call(
     session_id: Uuid,
     file_path: &str,
 ) -> anyhow::Result<ClaudeHookOutput> {
-    let mut ctx: Context = sync_ctx.into_thread_local();
-    let resolved_session_id = stable_session_id(&mut ctx, session_id)?.unwrap_or(session_id);
-    file_lock::obtain_or_insert(&mut ctx, resolved_session_id, file_path.to_string())?;
+    let ctx: Context = sync_ctx.into_thread_local();
+    let resolved_session_id = stable_session_id(&ctx, session_id)?.unwrap_or(session_id);
+    file_lock::obtain_or_insert(&ctx, resolved_session_id, file_path.to_string())?;
 
     Ok(ClaudeHookOutput {
         do_continue: true,
@@ -395,7 +395,7 @@ pub fn handle_post_tool_call(
 }
 
 pub fn assign_hunks_post_tool_call(
-    mut ctx: Context,
+    ctx: Context,
     session_id: Uuid,
     file_path: &str,
     structured_patch: &[StructuredPatch],
@@ -403,7 +403,7 @@ pub fn assign_hunks_post_tool_call(
 ) -> anyhow::Result<ClaudeHookOutput> {
     let hook_headers: Vec<HunkHeader> = structured_patch.iter().map(|p| p.into()).collect();
 
-    let resolved_session_id = stable_session_id(&mut ctx, session_id)?.unwrap_or(session_id);
+    let resolved_session_id = stable_session_id(&ctx, session_id)?.unwrap_or(session_id);
 
     // ClearLocksGuard ensures the file lock is cleared on drop, including early returns.
     let mut defer = ClearLocksGuard {
@@ -412,7 +412,7 @@ pub fn assign_hunks_post_tool_call(
         file_path: Some(file_path.to_string()),
     };
 
-    if !skip_gui_check && should_exit_early(&mut defer.ctx, session_id)? {
+    if !skip_gui_check && should_exit_early(&defer.ctx, session_id)? {
         return Ok(ClaudeHookOutput {
             do_continue: true,
             stop_reason: "Session running in GUI, skipping hook".to_string(),
@@ -496,7 +496,7 @@ pub fn assign_hunks_post_tool_call(
 
 /// Get the stable session ID for a given session ID, if one is saved.
 /// This hinges on the assumption that the stored session ID can be different, but I don't see how it would be.
-fn stable_session_id(ctx: &mut Context, current_id: Uuid) -> Result<Option<Uuid>> {
+fn stable_session_id(ctx: &Context, current_id: Uuid) -> Result<Option<Uuid>> {
     Ok(crate::db::get_session_by_current_id(ctx, current_id)?.map(|session| session.id))
 }
 
@@ -567,7 +567,7 @@ pub(crate) struct ClearLocksGuard {
 
 impl Drop for ClearLocksGuard {
     fn drop(&mut self) {
-        file_lock::clear(&mut self.ctx, self.session_id, self.file_path.clone()).ok();
+        file_lock::clear(&self.ctx, self.session_id, self.file_path.clone()).ok();
     }
 }
 
@@ -608,7 +608,7 @@ fn list_stacks(ctx: &Context) -> anyhow::Result<Vec<StackEntry>> {
 }
 
 /// Returns true if the session has `is_gui` set to true, and `GUTBUTLER_IN_GUI` is unset
-fn should_exit_early(ctx: &mut Context, current_id: Uuid) -> anyhow::Result<bool> {
+fn should_exit_early(ctx: &Context, current_id: Uuid) -> anyhow::Result<bool> {
     let in_gui = std::env::var("GITBUTLER_IN_GUI").is_ok_and(|v| v == "1");
     if in_gui {
         return Ok(false);

--- a/crates/but-claude/src/session.rs
+++ b/crates/but-claude/src/session.rs
@@ -307,8 +307,8 @@ impl Claudes {
         // Persist the current session ID to the database so hooks can map current_session_id
         // back to our stable original_session_id.
         {
-            let mut ctx = sync_ctx.clone().into_thread_local();
-            if let Err(e) = db::add_session_id(&mut ctx, original_session_id, current_session_id) {
+            let ctx = sync_ctx.clone().into_thread_local();
+            if let Err(e) = db::add_session_id(&ctx, original_session_id, current_session_id) {
                 tracing::error!(
                     original_session_id = %original_session_id,
                     current_session_id = %current_session_id,
@@ -332,7 +332,7 @@ impl Claudes {
         let system_prompt_append = {
             let mut ctx = sync_ctx.clone().into_thread_local();
             let guard = ctx.exclusive_worktree_access();
-            let branch_info = format_branch_info(&mut ctx, stack_id, guard.read_permission());
+            let branch_info = format_branch_info(&ctx, stack_id, guard.read_permission());
             format!("{}\n\n{}", system_prompt(), branch_info)
         };
         let sdk_system_prompt =
@@ -905,7 +905,7 @@ Uncommitted changes (assigned to this stack):
 }
 
 /// Formats branch information for the system prompt
-fn format_branch_info(ctx: &mut Context, stack_id: StackId, perm: &RepoShared) -> String {
+fn format_branch_info(ctx: &Context, stack_id: StackId, perm: &RepoShared) -> String {
     let mut output = String::from(
         "<branch-info>\n\
         This repository uses GitButler for branch management. While git shows you are on\n\
@@ -991,7 +991,7 @@ fn append_stack_branches_info(output: &mut String, stack_id: StackId, ctx: &Cont
 fn append_assigned_files_info(
     output: &mut String,
     stack_id: StackId,
-    ctx: &mut Context,
+    ctx: &Context,
     perm: &RepoShared,
 ) -> anyhow::Result<()> {
     let context_lines = ctx.settings.context_lines;

--- a/crates/but-ctx/Cargo.toml
+++ b/crates/but-ctx/Cargo.toml
@@ -24,6 +24,7 @@ but-meta = { workspace = true, features = ["legacy"] }
 but-db.workspace = true
 but-graph.workspace = true
 but-project-handle.workspace = true
+but-utils.workspace = true
 
 # Optional so `but-ctx` can stay decoupled from legacy project storage by default.
 gitbutler-project = { workspace = true, optional = true }

--- a/crates/but-ctx/src/legacy.rs
+++ b/crates/but-ctx/src/legacy.rs
@@ -4,7 +4,7 @@ use tracing::instrument;
 
 use crate::{
     CacheMode, Context, LegacyProjectId, ProjectHandleOrLegacyProjectId, RepoOpenMode,
-    ThreadSafeContext, app_settings, new_ondemand_app_cache, new_ondemand_cache, new_ondemand_db,
+    ThreadSafeContext, app_settings, new_ondemand_app_cache, new_ondemand_db,
     new_ondemand_git2_repo, new_ondemand_repo, open_repo,
 };
 
@@ -59,7 +59,6 @@ impl Context {
             repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
             db: new_ondemand_db(project_data_dir.clone()),
-            cache: new_ondemand_cache(project_data_dir, cache_mode),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
             app_cache_dir,
             workspace: Default::default(),

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -123,8 +123,6 @@ pub struct Context {
     /// An open handle to the database. It's initialized lazily upon first access.
     /// It is also what makes this type non-Clone, which is fair.
     pub db: OnDemand<but_db::DbHandle>,
-    /// An open handle to the project-local cache, initialized lazily on first access and only fallible if it's already borrowed.
-    pub cache: OnDemandCache<but_db::CacheHandle>,
     /// An open handle to the cache, initialized lazily on first access and only fallible if it's already borrowed.
     pub app_cache: OnDemandCache<but_db::AppCacheHandle>,
     /// The legacy implementation, for all the old code.
@@ -159,7 +157,7 @@ pub struct ThreadSafeContext {
 }
 
 impl From<ThreadSafeContext> for Context {
-    #[allow(
+    #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must initialize it."
     )]
@@ -185,7 +183,6 @@ impl From<ThreadSafeContext> for Context {
             repo: ondemand,
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
             db: new_ondemand_db(project_data_dir.clone()),
-            cache: new_ondemand_cache(project_data_dir.clone(), cache_mode),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
             gitdir,
             project_data_dir,
@@ -276,7 +273,7 @@ impl Context {
 
     /// Just like [`Context::new()`], but allows controlling how the repository
     /// sources configuration via `repo_open_mode`.
-    #[allow(
+    #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must initialize it."
     )]
@@ -301,7 +298,6 @@ impl Context {
                 repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
                 db: new_ondemand_db(project_data_dir.clone()),
-                cache: new_ondemand_cache(project_data_dir, CacheMode::Disk),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone(), CacheMode::Disk),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -327,7 +323,6 @@ impl Context {
                 repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
                 db: new_ondemand_db(project_data_dir.clone()),
-                cache: new_ondemand_cache(project_data_dir, cache_mode),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -411,10 +406,6 @@ impl Context {
         Self::from_repo_with_legacy_support(repo, repo_open_mode)
     }
 
-    #[allow(
-        deprecated,
-        reason = "Context owns the deprecated boundary cache and must initialize it."
-    )]
     fn from_repo_with_legacy_support(
         repo: gix::Repository,
         repo_open_mode: RepoOpenMode,
@@ -422,7 +413,7 @@ impl Context {
         Self::from_repo_with_legacy_support_and_channel(repo, repo_open_mode, AppChannel::new())
     }
 
-    #[allow(
+    #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must initialize it."
     )]
@@ -454,7 +445,6 @@ impl Context {
                 repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
                 db: new_ondemand_db(project_data_dir.clone()),
-                cache: new_ondemand_cache(project_data_dir, cache_mode),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -475,7 +465,6 @@ impl Context {
                 repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
                 git2_repo: new_ondemand_git2_repo(gitdir.clone()),
                 db: new_ondemand_db(project_data_dir.clone()),
-                cache: new_ondemand_cache(project_data_dir, cache_mode),
                 app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
                 app_cache_dir,
                 workspace: Default::default(),
@@ -488,7 +477,7 @@ impl Context {
     ///
     /// Particularly useful in testing, which might start off with just a Git repository.
     /// **Note that it does not have support for legacy projects to encourage single-branch compatible code.**
-    #[allow(
+    #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must initialize it."
     )]
@@ -516,7 +505,6 @@ impl Context {
             repo: new_ondemand_repo(gitdir.clone(), repo_open_mode),
             git2_repo: new_ondemand_git2_repo(gitdir.clone()),
             db: new_ondemand_db(project_data_dir.clone()),
-            cache: new_ondemand_cache(project_data_dir, cache_mode),
             app_cache: new_ondemand_app_cache(app_cache_dir.clone(), cache_mode),
             app_cache_dir,
             workspace: Default::default(),
@@ -530,13 +518,12 @@ impl Context {
         self
     }
 
-    /// Use in-memory caches instead of project/app cache files.
+    /// Use an in-memory application cache instead of cache files on disk.
     ///
     /// This is useful for read-only contexts so cache access doesn't create SQLite files on disk.
     /// Prefer calling it before the first cache access.
     pub fn with_memory_cache(mut self) -> Self {
         self.cache_mode = CacheMode::Memory;
-        self.cache = new_ondemand_cache(self.project_data_dir.clone(), self.cache_mode);
         self.app_cache = new_ondemand_app_cache(self.app_cache_dir.clone(), self.cache_mode);
         self
     }
@@ -564,34 +551,6 @@ impl Context {
         let mut guard = self.exclusive_worktree_access();
         let (repo, ws, db) = self.workspace_mut_and_db_mut_with_perm(guard.write_permission())?;
         Ok((guard, repo, ws, db))
-    }
-
-    /// Create a cached workspace as seen from the current HEAD for editing, and return it,
-    /// along with `(&repo, &mut ws, &mut db, &cache)`.
-    /// `perm` ensures exclusive process-wide access to the repository.
-    /// Once the repository is changed, the cached workspace should be updated.
-    ///
-    /// # IMPORTANT
-    /// * if the workspace was changed, write the new workspace back into `&mut ws`.
-    #[instrument(
-        name = "Context::workspace_mut_and_db_mut_and_cache",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_mut_and_db_mut_and_cache(
-        &mut self,
-    ) -> anyhow::Result<(
-        RepoExclusiveGuard,
-        cell::Ref<'_, gix::Repository>,
-        cell::RefMut<'_, but_graph::projection::Workspace>,
-        cell::RefMut<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let mut guard = self.exclusive_worktree_access();
-        let (repo, ws, db, cache) =
-            self.workspace_mut_and_db_mut_and_cache_with_perm(guard.write_permission())?;
-        Ok((guard, repo, ws, db, cache))
     }
 
     /// Create a cached workspace as seen from the current HEAD for editing, and return it,
@@ -631,48 +590,6 @@ impl Context {
             .unwrap_or_else(|_| unreachable!("just set the value"));
         let db = self.db.get_mut()?;
         Ok((repo, ws, db))
-    }
-
-    /// Create a cached workspace as seen from the current HEAD for editing, and return it,
-    /// along with `(&repo, &mut ws, &mut db, &cache)`.
-    /// `perm` ensures exclusive process-wide access to the repository.
-    /// Once the repository is changed, the cached workspace should be updated.
-    ///
-    /// # IMPORTANT
-    /// * if the workspace was changed, write it back into `&mut ws`.
-    /// * Keep the guard alive like `let (_guard, …) = …`!
-    #[instrument(
-        name = "Context::workspace_mut_and_db_mut_and_cache_with_perm",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_mut_and_db_mut_and_cache_with_perm(
-        &mut self,
-        _perm: &mut RepoExclusive,
-    ) -> anyhow::Result<(
-        cell::Ref<'_, gix::Repository>,
-        cell::RefMut<'_, but_graph::projection::Workspace>,
-        cell::RefMut<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let cache = self.cache.get_cache()?;
-        let repo = self.repo.get()?;
-        if let Ok(cached) =
-            cell::RefMut::filter_map(self.workspace.try_borrow_mut()?, |opt| opt.as_mut())
-        {
-            let db = self.db.get_mut()?;
-            return Ok((repo, cached, db, cache));
-        }
-        let ws = self.workspace_from_head()?;
-        {
-            let mut value = self.workspace.try_borrow_mut()?;
-            *value = Some(ws);
-        }
-        let ws = cell::RefMut::filter_map(self.workspace.borrow_mut(), |opt| opt.as_mut())
-            .unwrap_or_else(|_| unreachable!("just set the value"));
-        let db = self.db.get_mut()?;
-        Ok((repo, ws, db, cache))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
@@ -756,35 +673,6 @@ impl Context {
         Ok((guard, repo, ws, db))
     }
 
-    /// Create a new cached workspace as seen from the current HEAD for *writing* and return it,
-    /// along with `(guard, &repo, &mut ws, &db, &cache)`.
-    /// The `db` and `cache` are read-only.
-    /// The guard is for exclusive access to the repository.
-    ///
-    /// # IMPORTANT
-    /// * if the workspace was changed, write it back into `&mut ws`.
-    /// * Keep the guard alive like `let (_guard, …) = …`!
-    #[instrument(
-        name = "Context::workspace_mut_and_db_and_cache",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_mut_and_db_and_cache(
-        &mut self,
-    ) -> anyhow::Result<(
-        RepoExclusiveGuard,
-        cell::Ref<'_, gix::Repository>,
-        cell::RefMut<'_, but_graph::projection::Workspace>,
-        cell::Ref<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let mut guard = self.exclusive_worktree_access();
-        let (repo, ws, db, cache) =
-            self.workspace_mut_and_db_and_cache_with_perm(guard.write_permission())?;
-        Ok((guard, repo, ws, db, cache))
-    }
-
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
     /// along with `(&repo, &mut ws, &db)`, given a read-`perm`ission.
     /// The `db` is read-only.
@@ -819,32 +707,6 @@ impl Context {
         Ok((self.repo.get()?, ws, self.db.get()?))
     }
 
-    /// Create a new cached workspace as seen from the current HEAD for *writing* and return it,
-    /// along with `(&repo, &mut ws, &db, &cache)`, given a write-`perm`ission.
-    /// The `db` and `cache` are read-only.
-    ///
-    /// # IMPORTANT
-    /// * if the workspace was changed, write it back into `&mut ws`.
-    #[instrument(
-        name = "Context::workspace_mut_and_db_and_cache_with_perm",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_mut_and_db_and_cache_with_perm(
-        &self,
-        perm: &RepoExclusive,
-    ) -> anyhow::Result<(
-        cell::Ref<'_, gix::Repository>,
-        cell::RefMut<'_, but_graph::projection::Workspace>,
-        cell::Ref<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let (repo, ws, db) = self.workspace_mut_and_db_with_perm(perm)?;
-        let cache = self.cache.get_cache()?;
-        Ok((repo, ws, db, cache))
-    }
-
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
     /// along with `(guard, &repo, &ws, &db)`.
     /// The `db` is read-only.
@@ -865,34 +727,6 @@ impl Context {
         let guard = self.shared_worktree_access();
         let (repo, ws, db) = self.workspace_and_db_with_perm(guard.read_permission())?;
         Ok((guard, repo, ws, db))
-    }
-
-    /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(guard, &repo, &ws, &db, &cache)`.
-    /// The `db` and `cache` are read-only.
-    /// The guard is for shared access to the repository.
-    ///
-    /// # IMPORTANT
-    /// * Keep the guard alive like `let (_guard, …) = …`!
-    #[instrument(
-        name = "Context::workspace_and_db_and_cache",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_and_db_and_cache(
-        &self,
-    ) -> anyhow::Result<(
-        RepoSharedGuard,
-        cell::Ref<'_, gix::Repository>,
-        cell::Ref<'_, but_graph::projection::Workspace>,
-        cell::Ref<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let guard = self.shared_worktree_access();
-        let (repo, ws, db, cache) =
-            self.workspace_and_db_and_cache_with_perm(guard.read_permission())?;
-        Ok((guard, repo, ws, db, cache))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
@@ -923,29 +757,6 @@ impl Context {
         let ws = cell::Ref::filter_map(self.workspace.borrow(), |opt| opt.as_ref())
             .unwrap_or_else(|_| unreachable!("just set the value"));
         Ok((self.repo.get()?, ws, self.db.get()?))
-    }
-
-    /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(&repo, &ws, &db, &cache)`, given a read-`perm`ission.
-    /// The `db` and `cache` are read-only.
-    #[instrument(
-        name = "Context::workspace_and_db_and_cache_with_perm",
-        level = "debug",
-        skip_all
-    )]
-    #[expect(clippy::type_complexity)]
-    pub fn workspace_and_db_and_cache_with_perm(
-        &self,
-        perm: &RepoShared,
-    ) -> anyhow::Result<(
-        cell::Ref<'_, gix::Repository>,
-        cell::Ref<'_, but_graph::projection::Workspace>,
-        cell::Ref<'_, but_db::DbHandle>,
-        cell::Ref<'_, but_db::CacheHandle>,
-    )> {
-        let (repo, ws, db) = self.workspace_and_db_with_perm(perm)?;
-        let cache = self.cache.get_cache()?;
-        Ok((repo, ws, db, cache))
     }
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::projection::Workspace> {
@@ -1018,7 +829,7 @@ impl Context {
     }
 
     /// Take all copyable values and place them in an instance that can pass across thread boundaries.
-    #[allow(
+    #[expect(
         deprecated,
         reason = "Context owns the deprecated boundary cache and must move it out internally."
     )]
@@ -1030,7 +841,6 @@ impl Context {
             mut repo,
             git2_repo: _,
             db: _,
-            cache: _,
             app_cache: _,
             app_cache_dir,
             cache_mode,
@@ -1158,17 +968,6 @@ fn new_ondemand_git2_repo(gitdir: PathBuf) -> OnDemand<git2::Repository> {
 #[instrument(level = "trace")]
 fn new_ondemand_db(project_data_dir: PathBuf) -> OnDemand<but_db::DbHandle> {
     OnDemand::new(move || but_db::DbHandle::new_in_directory(project_data_dir.clone()))
-}
-
-#[instrument(level = "trace")]
-fn new_ondemand_cache(
-    project_data_dir: PathBuf,
-    cache_mode: CacheMode,
-) -> OnDemandCache<but_db::CacheHandle> {
-    OnDemandCache::new(move || match cache_mode {
-        CacheMode::Disk => but_db::CacheHandle::new_in_directory(project_data_dir.clone()),
-        CacheMode::Memory => but_db::CacheHandle::new_at_path(":memory:"),
-    })
 }
 
 #[instrument(level = "trace")]

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -122,7 +122,8 @@ pub struct Context {
     pub git2_repo: OnDemand<git2::Repository>,
     /// An open handle to the database. It's initialized lazily upon first access.
     /// It is also what makes this type non-Clone, which is fair.
-    pub db: OnDemand<but_db::DbHandle>,
+    /// It sports interior mutability, which works as it's `Sync` naturally.
+    pub db: OnDemandCache<but_db::DbHandle>,
     /// An open handle to the cache, initialized lazily on first access and only fallible if it's already borrowed.
     pub app_cache: OnDemandCache<but_db::AppCacheHandle>,
     /// The legacy implementation, for all the old code.
@@ -578,7 +579,7 @@ impl Context {
         if let Ok(cached) =
             cell::RefMut::filter_map(self.workspace.try_borrow_mut()?, |opt| opt.as_mut())
         {
-            let db = self.db.get_mut()?;
+            let db = self.db.get_cache_mut()?;
             return Ok((repo, cached, db));
         }
         let ws = self.workspace_from_head()?;
@@ -588,7 +589,7 @@ impl Context {
         }
         let ws = cell::RefMut::filter_map(self.workspace.borrow_mut(), |opt| opt.as_mut())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        let db = self.db.get_mut()?;
+        let db = self.db.get_cache_mut()?;
         Ok((repo, ws, db))
     }
 
@@ -603,7 +604,7 @@ impl Context {
     #[instrument(name = "Context::workspace_and_db_mut", level = "debug", skip_all)]
     #[expect(clippy::type_complexity)]
     pub fn workspace_and_db_mut(
-        &mut self,
+        &self,
     ) -> anyhow::Result<(
         RepoSharedGuard,
         cell::Ref<'_, gix::Repository>,
@@ -629,7 +630,7 @@ impl Context {
         skip_all
     )]
     pub fn workspace_and_db_mut_with_perm(
-        &mut self,
+        &self,
         _perm: &RepoShared,
     ) -> anyhow::Result<(
         cell::Ref<'_, gix::Repository>,
@@ -638,7 +639,7 @@ impl Context {
     )> {
         if let Ok(cached) = cell::Ref::filter_map(self.workspace.try_borrow()?, |opt| opt.as_ref())
         {
-            return Ok((self.repo.get()?, cached, self.db.get_mut()?));
+            return Ok((self.repo.get()?, cached, self.db.get_cache_mut()?));
         }
         let ws = self.workspace_from_head()?;
         {
@@ -647,7 +648,7 @@ impl Context {
         }
         let ws = cell::Ref::filter_map(self.workspace.borrow(), |opt| opt.as_ref())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        Ok((self.repo.get()?, ws, self.db.get_mut()?))
+        Ok((self.repo.get()?, ws, self.db.get_cache_mut()?))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *writing* and return it,
@@ -695,7 +696,7 @@ impl Context {
         if let Ok(cached) =
             cell::RefMut::filter_map(self.workspace.try_borrow_mut()?, |opt| opt.as_mut())
         {
-            return Ok((self.repo.get()?, cached, self.db.get()?));
+            return Ok((self.repo.get()?, cached, self.db.get_cache()?));
         }
         let ws = self.workspace_from_head()?;
         {
@@ -704,7 +705,7 @@ impl Context {
         }
         let ws = cell::RefMut::filter_map(self.workspace.borrow_mut(), |opt| opt.as_mut())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        Ok((self.repo.get()?, ws, self.db.get()?))
+        Ok((self.repo.get()?, ws, self.db.get_cache()?))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
@@ -747,7 +748,7 @@ impl Context {
     )> {
         if let Ok(cached) = cell::Ref::filter_map(self.workspace.try_borrow()?, |opt| opt.as_ref())
         {
-            return Ok((self.repo.get()?, cached, self.db.get()?));
+            return Ok((self.repo.get()?, cached, self.db.get_cache()?));
         }
         let ws = self.workspace_from_head()?;
         {
@@ -756,7 +757,7 @@ impl Context {
         }
         let ws = cell::Ref::filter_map(self.workspace.borrow(), |opt| opt.as_ref())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        Ok((self.repo.get()?, ws, self.db.get()?))
+        Ok((self.repo.get()?, ws, self.db.get_cache()?))
     }
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::projection::Workspace> {
@@ -966,8 +967,10 @@ fn new_ondemand_git2_repo(gitdir: PathBuf) -> OnDemand<git2::Repository> {
 }
 
 #[instrument(level = "trace")]
-fn new_ondemand_db(project_data_dir: PathBuf) -> OnDemand<but_db::DbHandle> {
-    OnDemand::new(move || but_db::DbHandle::new_in_directory(project_data_dir.clone()))
+fn new_ondemand_db(project_data_dir: PathBuf) -> OnDemandCache<but_db::DbHandle> {
+    OnDemandCache::new_fallible(move || {
+        but_db::DbHandle::new_in_directory(project_data_dir.clone())
+    })
 }
 
 #[instrument(level = "trace")]

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -119,7 +119,9 @@ pub struct Context {
     pub git2_repo: OnDemand<git2::Repository>,
     /// An open handle to the database. It's initialized lazily upon first access.
     /// It is also what makes this type non-Clone, which is fair.
-    /// It sports interior mutability, which works as it's `Sync` naturally.
+    /// Note that the underlying ref-cell will still yield an error if the `db` is mutably borrowed more than once,
+    /// which now is a real risk as the Rust borrow-check doesn't apply anymore to the parent context
+    /// (which now may be read-only).
     pub db: OnDemandCache<but_db::DbHandle>,
     /// An open handle to the cache, initialized lazily on first access and only fallible if it's already borrowed.
     pub app_cache: OnDemandCache<but_db::AppCacheHandle>,
@@ -520,7 +522,7 @@ impl Context {
     ///
     /// This is useful for read-only contexts so cache access doesn't create SQLite files on disk.
     /// Prefer calling it before the first cache access.
-    pub fn with_memory_cache(mut self) -> Self {
+    pub fn with_memory_app_cache(mut self) -> Self {
         self.cache_mode = CacheMode::Memory;
         self.app_cache = new_ondemand_app_cache(self.app_cache_dir.clone(), self.cache_mode);
         self

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -15,6 +15,7 @@ use but_core::{
 };
 use but_path::AppChannel;
 use but_settings::AppSettings;
+use but_utils::OnDemandCache;
 use tracing::instrument;
 
 /// Legacy types that shouldn't be used.
@@ -34,12 +35,8 @@ mod project_handle;
 /// Once `gitbutler-project` is dissolved, these types are expected to merge back into `but-ctx`.
 /// Thus, use it through this crate only to simplify dependencies.
 pub use but_project_handle::{ProjectHandle, ProjectHandleOrLegacyProjectId};
-
-mod ondemand;
-pub use ondemand::OnDemand;
-
-mod ondemand_cache;
-use crate::ondemand_cache::OnDemandCache;
+/// Convenience export as most crates out there refer to `but-ctx`.
+pub use but_utils::OnDemand;
 
 /// A context specific to a repository, along with commonly used information to make higher-level functions
 /// more convenient to implement.

--- a/crates/but-ctx/src/ondemand_cache.rs
+++ b/crates/but-ctx/src/ondemand_cache.rs
@@ -4,13 +4,15 @@ use std::{cell, cell::RefCell, rc::Rc};
 ///
 /// This structure trades compile-time safety for being able to 'hide' that caches are actually changed as they allow accessing
 /// cached data mutably on a *shared* borrow.
-/// Caches must also infallibly initialize to ensure that applications always work even without a cache, or an empty cache. To facilitate
+/// Caches *may* also infallibly initialize to ensure that applications always work even without a cache, or an empty cache. To facilitate
 /// this, the consuming code will always get to work with a cache, and should choose to ignore errors where possible - in the worst case,
-/// it can recalculate the cached data.
+/// it can recalculate the cached data. Use [`OnDemandCache::new()`] for that.
+///
+/// If only interior mutability is needed, without guaranteed cache creation, use [`OnDemandCache::new_fallible()`].
 ///
 /// Otherwise, equivalent to [`OnDemand`](crate::OnDemand)
 pub struct OnDemandCache<T> {
-    init: Rc<dyn Fn() -> T + 'static>,
+    init: Rc<dyn Fn() -> anyhow::Result<T> + 'static>,
     value: cell::RefCell<Option<T>>,
 }
 
@@ -30,6 +32,12 @@ where
 impl<T> OnDemandCache<T> {
     /// Create a new instance that can instantiate its value via `init` when needed.
     pub fn new(init: impl Fn() -> T + 'static) -> Self {
+        Self::new_fallible(move || Ok(init()))
+    }
+
+    /// Create a new instance that can instantiate its value via `init` when needed,
+    /// allowing initialization to fail.
+    pub fn new_fallible(init: impl Fn() -> anyhow::Result<T> + 'static) -> Self {
         OnDemandCache {
             init: Rc::new(init),
             value: RefCell::new(None),
@@ -40,13 +48,13 @@ impl<T> OnDemandCache<T> {
 /// Access
 impl<T> OnDemandCache<T> {
     /// Get a shared reference to the cached value or initialise it.
-    pub fn get_cache(&self) -> Result<cell::Ref<'_, T>, BorrowError> {
+    pub fn get_cache(&self) -> anyhow::Result<cell::Ref<'_, T>> {
         if let Ok(cached) = cell::Ref::filter_map(self.value.try_borrow()?, |opt| opt.as_ref()) {
             return Ok(cached);
         }
         {
             let mut value = self.value.try_borrow_mut()?;
-            *value = Some((self.init)());
+            *value = Some((self.init)()?);
         }
         Ok(
             cell::Ref::filter_map(self.value.borrow(), |opt| opt.as_ref())
@@ -55,7 +63,7 @@ impl<T> OnDemandCache<T> {
     }
 
     /// Get an exclusive references to the cached value or fallibly initialise it.
-    pub fn get_cache_mut(&self) -> Result<cell::RefMut<'_, T>, BorrowError> {
+    pub fn get_cache_mut(&self) -> anyhow::Result<cell::RefMut<'_, T>> {
         if let Ok(cached) =
             cell::RefMut::filter_map(self.value.try_borrow_mut()?, |opt| opt.as_mut())
         {
@@ -63,7 +71,7 @@ impl<T> OnDemandCache<T> {
         }
         {
             let mut value = self.value.try_borrow_mut()?;
-            *value = Some((self.init)());
+            *value = Some((self.init)()?);
         }
         Ok(
             cell::RefMut::filter_map(self.value.borrow_mut(), |opt| opt.as_mut())
@@ -71,49 +79,6 @@ impl<T> OnDemandCache<T> {
         )
     }
 }
-
-mod error {
-    use std::{cell, fmt::Formatter};
-
-    pub enum BorrowError {
-        Shared(cell::BorrowError),
-        Exclusive(cell::BorrowMutError),
-    }
-
-    impl From<cell::BorrowError> for BorrowError {
-        fn from(value: cell::BorrowError) -> Self {
-            Self::Shared(value)
-        }
-    }
-
-    impl From<cell::BorrowMutError> for BorrowError {
-        fn from(value: cell::BorrowMutError) -> Self {
-            Self::Exclusive(value)
-        }
-    }
-
-    impl std::fmt::Display for BorrowError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            match self {
-                BorrowError::Shared(e) => std::fmt::Display::fmt(&e, f),
-                BorrowError::Exclusive(e) => std::fmt::Display::fmt(&e, f),
-            }
-        }
-    }
-
-    impl std::fmt::Debug for BorrowError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            match self {
-                BorrowError::Shared(e) => std::fmt::Debug::fmt(&e, f),
-                BorrowError::Exclusive(e) => std::fmt::Debug::fmt(&e, f),
-            }
-        }
-    }
-
-    impl std::error::Error for BorrowError {}
-}
-use error::BorrowError;
-
 #[cfg(test)]
 mod tests {
     use crate::OnDemand;

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -70,11 +70,6 @@ fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
         ctx.project_data_dir().join("but.sqlite").exists(),
         "database should be created in configured project-data directory"
     );
-    let _cache = ctx.cache.get_cache()?;
-    assert!(
-        ctx.project_data_dir().join("but_cache.sqlite").exists(),
-        "project cache should be created in configured project-data directory"
-    );
     Ok(())
 }
 
@@ -88,14 +83,6 @@ fn sync_context_preserves_project_data_dir() -> anyhow::Result<()> {
     let sync = ctx.to_sync();
     let restored = sync.into_thread_local();
     assert_eq!(ctx.project_data_dir(), restored.project_data_dir());
-    let _cache = restored.cache.get_cache()?;
-    assert!(
-        restored
-            .project_data_dir()
-            .join("but_cache.sqlite")
-            .exists(),
-        "thread-local restoration should still initialize the project cache in the project data dir"
-    );
     Ok(())
 }
 
@@ -123,21 +110,6 @@ fn discover_with_app_channel_uses_requested_project_data_dir() -> anyhow::Result
     assert_eq!(
         dev_ctx.project_data_dir(),
         dev_ctx.gitdir.join("gitbutler-dev")
-    );
-    Ok(())
-}
-
-#[test]
-fn memory_cache_does_not_create_project_cache_file() -> anyhow::Result<()> {
-    let repo_dir = TempDir::new()?;
-    gix::init(repo_dir.path())?;
-    let repo = open_repo(repo_dir.path())?;
-    let ctx = Context::from_repo(repo)?.with_memory_cache();
-
-    let _cache = ctx.cache.get_cache()?;
-    assert!(
-        !ctx.project_data_dir().join("but_cache.sqlite").exists(),
-        "project cache should remain in-memory"
     );
     Ok(())
 }

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -65,7 +65,7 @@ fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
     let ctx = Context::from_repo(repo)?;
     assert_eq!(ctx.project_data_dir(), ctx.gitdir.join("gitbutler-custom"));
 
-    let _db = ctx.db.get()?;
+    let _db = ctx.db.get_cache()?;
     assert!(
         ctx.project_data_dir().join("but.sqlite").exists(),
         "database should be created in configured project-data directory"

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -65,10 +65,22 @@ fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
     let ctx = Context::from_repo(repo)?;
     assert_eq!(ctx.project_data_dir(), ctx.gitdir.join("gitbutler-custom"));
 
-    let _db = ctx.db.get_cache()?;
+    let db = ctx.db.get_cache()?;
     assert!(
         ctx.project_data_dir().join("but.sqlite").exists(),
         "database should be created in configured project-data directory"
+    );
+
+    let project_cache_path = ctx.project_data_dir().join("but_cache.sqlite");
+    assert!(
+        !project_cache_path.exists(),
+        "cache database isn't present initially"
+    );
+
+    let _cache = db.cache.get()?;
+    assert!(
+        project_cache_path.exists(),
+        "cache database should be created after first access alongside the main database in configured project-data directory"
     );
     Ok(())
 }

--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -20,6 +20,7 @@ bitflags.workspace = true
 serde.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["serde"] }
+but-utils.workspace = true
 # other things
 tracing.workspace = true
 backoff.workspace = true

--- a/crates/but-db/src/handle.rs
+++ b/crates/but-db/src/handle.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
 
+use but_utils::OnDemand;
 use tracing::instrument;
 
-use crate::{DbHandle, migration, migration::improve_concurrency};
+use crate::{CacheHandle, DbHandle, migration, migration::improve_concurrency};
 
 const FILE_NAME: &str = "but.sqlite";
 
@@ -36,13 +37,22 @@ impl DbHandle {
         let mut conn = rusqlite::Connection::open(&path)?;
         improve_concurrency(&conn)?;
         run_migrations(&mut conn)?;
-        Ok(DbHandle { conn, path })
+        let cache = cache_for_db_path(&path);
+        Ok(DbHandle { conn, path, cache })
     }
 
     /// Return the path to the standard database file.
     pub fn db_file_path(db_dir: impl AsRef<Path>) -> PathBuf {
         db_dir.as_ref().join(FILE_NAME)
     }
+}
+
+fn cache_for_db_path(path: &Path) -> OnDemand<CacheHandle> {
+    if path == Path::new(":memory:") {
+        return OnDemand::new(|| Ok(CacheHandle::new_at_path(":memory:")));
+    }
+    let cache_dir = path.parent().map(Path::to_path_buf).unwrap_or_default();
+    OnDemand::new(move || Ok(CacheHandle::new_in_directory(cache_dir.clone())))
 }
 
 fn run_migrations(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -206,7 +206,8 @@ pub struct DbHandle {
     conn: rusqlite::Connection,
     /// The path at which the connection was opened, mainly for debugging.
     path: PathBuf,
-    /// A lazily opened project-local cache, in-memory of this instance is, or in the same directory as this instance.
+    /// A lazily opened project-local cache. It is in-memory of the parent instance is in-memory,
+    /// or in the same directory as the parent instance.
     pub cache: OnDemand<CacheHandle>,
 }
 

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -55,6 +55,7 @@
 //! ```
 #![expect(clippy::inconsistent_digit_grouping)]
 #![deny(missing_docs)]
+use but_utils::OnDemand;
 use rusqlite::ErrorCode;
 use std::path::PathBuf;
 
@@ -205,6 +206,8 @@ pub struct DbHandle {
     conn: rusqlite::Connection,
     /// The path at which the connection was opened, mainly for debugging.
     path: PathBuf,
+    /// A lazily opened project-local cache, in-memory of this instance is, or in the same directory as this instance.
+    pub cache: OnDemand<CacheHandle>,
 }
 
 /// A wrapper for a [`rusqlite::Transaction`] to allow ORM handles to be created more easily,

--- a/crates/but-forge-storage/Cargo.toml
+++ b/crates/but-forge-storage/Cargo.toml
@@ -14,7 +14,7 @@ description = "Store and retrieve information about forges"
 doctest = false
 
 [dependencies]
-but-fs = { workspace = true, features = ["legacy"] }
+but-utils = { workspace = true, features = ["legacy"] }
 
 serde.workspace = true
 anyhow.workspace = true

--- a/crates/but-forge-storage/src/storage.rs
+++ b/crates/but-forge-storage/src/storage.rs
@@ -6,13 +6,13 @@ const FORGE_SETTINGS_FILE: &str = "forge_settings.json";
 
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
-    inner: but_fs::Storage,
+    inner: but_utils::Storage,
 }
 
 impl Storage {
     pub fn from_path(path: impl Into<PathBuf>) -> Self {
         Storage {
-            inner: but_fs::Storage::new(path),
+            inner: but_utils::Storage::new(path),
         }
     }
 

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -20,7 +20,7 @@ export-schema = [
 doctest = false
 
 [dependencies]
-but-fs.workspace = true
+but-utils.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
 but-forge-storage.workspace = true

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use anyhow::{Context as _, Error, Result};
-use but_fs::list_files;
 use but_github::CredentialCheckResult;
 use but_gitlab::GitLabProjectId;
+use but_utils::list_files;
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 

--- a/crates/but-gerrit/src/lib.rs
+++ b/crates/but-gerrit/src/lib.rs
@@ -147,13 +147,13 @@ fn with_change_id_trailer(msg: BString, change_id: ChangeId) -> BString {
 }
 
 pub fn record_push_metadata(
-    ctx: &mut Context,
+    ctx: &Context,
     candidate_ids: Vec<gix::ObjectId>,
     push_output: PushOutput,
 ) -> anyhow::Result<()> {
     let repo = ctx.repo.get()?;
     let mappings = mappings(&repo, candidate_ids, push_output)?;
-    let mut db = ctx.db.get_mut()?;
+    let mut db = ctx.db.get_cache_mut()?;
     let mut trans = db.transaction()?;
 
     for mapping in mappings {

--- a/crates/but-gerrit/tests/gerrit/main.rs
+++ b/crates/but-gerrit/tests/gerrit/main.rs
@@ -28,10 +28,10 @@ fn record_push_metadata_fallback_url() -> anyhow::Result<()> {
         .expect("gb header are set")
         .change_id
         .expect("commit has change id");
-    let mut ctx = but_ctx::Context::from_repo(repo)?;
-    record_push_metadata(&mut ctx, candidate_ids, push_output)?;
+    let ctx = but_ctx::Context::from_repo(repo)?;
+    record_push_metadata(&ctx, candidate_ids, push_output)?;
 
-    let db = ctx.db.get_mut()?;
+    let db = ctx.db.get_cache_mut()?;
     let db = db.gerrit_metadata();
     let meta = db
         .get(&change_id.to_string())?

--- a/crates/but-meta/Cargo.toml
+++ b/crates/but-meta/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 [features]
 legacy = [
     "dep:but-db",
-    "dep:but-fs",
+    "dep:but-utils",
     "dep:but-serde",
     "dep:but-graph",
     "dep:gitbutler-reference",
@@ -33,7 +33,7 @@ but-core.workspace = true
 but-db = { workspace = true, optional = true }
 but-serde = { workspace = true, optional = true }
 but-graph = { workspace = true, optional = true }
-but-fs = { workspace = true, optional = true }
+but-utils = { workspace = true, optional = true }
 
 gitbutler-reference = {workspace = true, optional = true}
 

--- a/crates/but-meta/src/legacy/storage.rs
+++ b/crates/but-meta/src/legacy/storage.rs
@@ -216,7 +216,7 @@ fn write_toml(path: &Path, data: &VirtualBranches) -> anyhow::Result<TomlFileSta
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    but_fs::write(path, content.as_bytes())?;
+    but_utils::write(path, content.as_bytes())?;
     // Read from a single file descriptor so mtime/hash come from the same file instance.
     let (bytes, metadata) = read_file_bytes_and_metadata(path)?;
     let mtime_ns = file_mtime_ns(&metadata)?;

--- a/crates/but-rebase/Cargo.toml
+++ b/crates/but-rebase/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 
 [dependencies]
 but-core.workspace = true
-but-db.workspace = true
 but-gerrit.workspace = true
 but-graph.workspace = true
 

--- a/crates/but-rebase/src/lib.rs
+++ b/crates/but-rebase/src/lib.rs
@@ -141,10 +141,7 @@ impl<'repo> Rebase<'repo> {
     ///
     /// **However, note that it will also make all input commits sequential, so the caller must assure
     /// these actually form a 'line'.**
-    // TODO: use the `cache` in all places where a ChangeID would be generated, and pick the cached
-    //       version if available. The idea is that the 'virtual' one from the cache gets persisted
-    //       when needed.
-    pub fn rebase(&mut self, _cache: &but_db::CacheHandle) -> Result<RebaseOutput> {
+    pub fn rebase(&mut self) -> Result<RebaseOutput> {
         if self.steps.is_empty() {
             return Err(anyhow!("No rebase steps provided"));
         }

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -5,8 +5,7 @@ use but_testsupport::visualize_commit_graph;
 use gix::prelude::ObjectIdExt;
 
 use crate::utils::{
-    assure_nonconflicting, conflicted, fixture_writable, four_commits_writable, test_cache,
-    visualize_tree,
+    assure_nonconflicting, conflicted, fixture_writable, four_commits_writable, visualize_tree,
 };
 
 mod error_handling;
@@ -73,7 +72,6 @@ mod commit {
 #[test]
 fn single_stack_journey() -> Result<()> {
     let (repo, commits, _tmp) = four_commits_writable()?;
-    let cache = test_cache();
     let mut builder = Rebase::new(&repo, commits.base, None)?;
     let out = builder
         .steps([
@@ -87,7 +85,7 @@ fn single_stack_journey() -> Result<()> {
             },
             RebaseStep::Reference(but_core::Reference::Virtual("anchor".into())),
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @"
     * 120e3a9 (HEAD -> main) c
     * a96434e b
@@ -142,7 +140,7 @@ fn single_stack_journey() -> Result<()> {
     assure_nonconflicting(&repo, &out)?;
 
     assert_eq!(
-        builder.rebase(&cache).unwrap_err().to_string(),
+        builder.rebase().unwrap_err().to_string(),
         "No rebase steps provided",
         "The builder (and its base) can be reused, but it needs new steps"
     );
@@ -152,7 +150,6 @@ fn single_stack_journey() -> Result<()> {
 #[test]
 fn amended_commit() -> Result<()> {
     let (repo, _tmp, _meta) = fixture_writable("three-branches-merged")?;
-    let cache = test_cache();
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -181,7 +178,7 @@ fn amended_commit() -> Result<()> {
                 new_message: Some("Merge branches 'A', 'B' and 'C' - rewritten".into()),
             },
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     // Note how the `C` isn't visible anymore as we don't rewrite reference here.
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
     *-.   6a38e67 Merge branches 'A', 'B' and 'C' - rewritten
@@ -226,7 +223,6 @@ fn amended_commit() -> Result<()> {
 #[test]
 fn reorder_merge_in_reverse() -> Result<()> {
     let (repo, _tmp, _meta) = fixture_writable("merge-in-the-middle")?;
-    let cache = test_cache();
     insta::assert_snapshot!(visualize_commit_graph(&repo, "with-inner-merge")?, @r"
     * e8ee978 (HEAD -> with-inner-merge) on top of inner merge
     *   2fc288c Merge branch 'B' into with-inner-merge
@@ -257,7 +253,7 @@ fn reorder_merge_in_reverse() -> Result<()> {
                 new_message: Some("was dd59d2 below merge".into()),
             },
         ])?
-        .rebase(&cache)
+        .rebase()
         .expect("the first parent of a merge is replaced unconditionally");
     // Note that we don't rewrite references here.
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
@@ -305,7 +301,6 @@ fn reorder_merge_in_reverse() -> Result<()> {
 #[test]
 fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     let (repo, _tmp, _meta) = fixture_writable("three-branches-merged")?;
-    let cache = test_cache();
     insta::assert_snapshot!(visualize_commit_graph(&repo, "@")?, @r"
     *-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
     |\ \  
@@ -342,7 +337,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
                 new_message: Some("Re-merge branches 'A', 'B' and 'C'".into()),
             },
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     insta::assert_debug_snapshot!(out, @"
     RebaseOutput {
         top_commit: Sha1(b811bdb2d96bfc96bf54030ce094edea09fc8db0),
@@ -482,7 +477,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
             commit_id: repo.rev_parse_single("C~2")?.into(),
             new_message: Some("picked on top of conflicted base".into()),
         }])?
-        .rebase(&cache)?;
+        .rebase()?;
 
     // The base doesn't have new file, and we pick that up from the base of `base` of
     // the previous conflict. `our` side then is the original our.
@@ -512,7 +507,6 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
 fn reversible_conflicts() -> anyhow::Result<()> {
     // If conflicts are created one way, putting them back the other way auto-resolves them.
     let (repo, _tmp, _meta) = fixture_writable("three-branches-merged")?;
-    let cache = test_cache();
 
     let mut builder = Rebase::new(&repo, repo.rev_parse_single("base")?.detach(), None)?;
     // Re-order commits with conflict, and trigger a re-merge.
@@ -535,7 +529,7 @@ fn reversible_conflicts() -> anyhow::Result<()> {
                 new_message: Some("Re-merge branches 'A', 'B' and 'C'".into()),
             },
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     assert_eq!(
         conflicted(&repo, &out),
         [false, false, true, false],
@@ -563,7 +557,7 @@ fn reversible_conflicts() -> anyhow::Result<()> {
                     new_message: Some("Re-merge branches 'A', 'B' and 'C'".into()),
                 },
             ])?
-            .rebase(&cache)?;
+            .rebase()?;
 
         assert_eq!(
             conflicted(&repo, &out),
@@ -582,7 +576,7 @@ fn reversible_conflicts() -> anyhow::Result<()> {
                 commit_id: repo.rev_parse_single("C")?.into(),
                 new_message: Some("C~1".into()),
             }])?
-            .rebase(&cache)?;
+            .rebase()?;
         assert_eq!(conflicted(&repo, &out), [false]);
         // The conflicting commit is 1-10, 21-30, and now it is putting 21-30 on top again.
         // Important is that it uses the real tree of the base.
@@ -633,7 +627,7 @@ fn reversible_conflicts() -> anyhow::Result<()> {
                 new_message: Some("Re-merge branches 'A', 'B' and 'C'".into()),
             },
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     assert_eq!(
         conflicted(&repo, &out),
         [false, false, false, false],
@@ -651,7 +645,6 @@ fn reversible_conflicts() -> anyhow::Result<()> {
 #[test]
 fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
     let (repo, commits, _tmp) = four_commits_writable()?;
-    let cache = test_cache();
     let mut builder = Rebase::new(&repo, None, None)?;
     let out = builder
         .steps([
@@ -664,7 +657,7 @@ fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
                 new_message: Some("reworded base after squash".into()),
             },
         ])?
-        .rebase(&cache)?;
+        .rebase()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @"* e380582 reworded base after squash");
     insta::assert_debug_snapshot!(out, @"
     RebaseOutput {
@@ -743,10 +736,6 @@ pub mod utils {
                 .join("should-never-be-written.toml"),
         )?;
         Ok((repo, tmp, std::mem::ManuallyDrop::new(meta)))
-    }
-
-    pub fn test_cache() -> but_db::CacheHandle {
-        but_db::CacheHandle::new_at_path(":memory:")
     }
 
     #[derive(Debug)]

--- a/crates/but-rules/src/db.rs
+++ b/crates/but-rules/src/db.rs
@@ -32,7 +32,7 @@ impl TryFrom<crate::WorkspaceRule> for but_db::WorkspaceRule {
 pub fn workspace_rules(ctx: &Context) -> Result<Vec<crate::WorkspaceRule>> {
     let rules = ctx
         .db
-        .get()?
+        .get_cache()?
         .workspace_rules()
         .list()?
         .into_iter()

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -201,15 +201,15 @@ pub fn create_rule(
     };
 
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .workspace_rules_mut()
         .insert(rule.clone().try_into()?)?;
     process_rules(ctx, perm).ok(); // Reevaluate rules after creating
     Ok(rule)
 }
 
-pub fn delete_rule(ctx: &mut Context, id: &str) -> anyhow::Result<()> {
-    ctx.db.get_mut()?.workspace_rules_mut().delete(id)?;
+pub fn delete_rule(ctx: &Context, id: &str) -> anyhow::Result<()> {
+    ctx.db.get_cache_mut()?.workspace_rules_mut().delete(id)?;
     Ok(())
 }
 
@@ -248,7 +248,7 @@ pub fn update_rule(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceRule> {
     let mut rule: WorkspaceRule = {
-        let db = ctx.db.get_mut()?;
+        let db = ctx.db.get_cache_mut()?;
         db.workspace_rules()
             .get(&req.id)?
             .ok_or_else(|| anyhow::anyhow!("Rule with ID {} not found", req.id))?
@@ -269,7 +269,7 @@ pub fn update_rule(
     }
 
     ctx.db
-        .get_mut()?
+        .get_cache_mut()?
         .workspace_rules_mut()
         .update(&req.id, rule.clone().try_into()?)?;
     process_rules(ctx, perm).ok(); // Reevaluate rules after updating
@@ -280,7 +280,7 @@ pub fn update_rule(
 pub fn get_rule(ctx: &Context, id: &str) -> anyhow::Result<WorkspaceRule> {
     let rule = ctx
         .db
-        .get()?
+        .get_cache()?
         .workspace_rules()
         .get(id)?
         .ok_or_else(|| anyhow::anyhow!("Rule with ID {id} not found"))?
@@ -292,7 +292,7 @@ pub fn get_rule(ctx: &Context, id: &str) -> anyhow::Result<WorkspaceRule> {
 pub fn list_rules(ctx: &Context) -> anyhow::Result<Vec<WorkspaceRule>> {
     let rules = ctx
         .db
-        .get()?
+        .get_cache()?
         .workspace_rules()
         .list()?
         .into_iter()

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -484,7 +484,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                 let mut active = extra.active_projects.lock().await;
                 let activated = active
                     .set_active(
-                        &mut ctx,
+                        &ctx,
                         &app,
                         app_settings.clone(),
                         #[cfg(feature = "irc")]

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -41,7 +41,7 @@ impl ActiveProjects {
 
     pub fn set_active(
         &mut self,
-        ctx: &mut Context,
+        ctx: &Context,
         claude: &Claude,
         app_settings_sync: AppSettingsWithDiskSync,
         #[cfg(feature = "irc")] working_files_broadcast: WorkingFilesBroadcast,
@@ -123,7 +123,7 @@ impl ActiveProjects {
 
         // Set up database watcher for database changes
         let db_watcher = {
-            let db = &mut *ctx.db.get_mut()?;
+            let db = &mut *ctx.db.get_cache_mut()?;
             but_db::poll::watch_in_background(db, {
                 let broadcaster = claude.broadcaster.clone();
                 let project_id = ctx.legacy_project.id.clone();
@@ -195,7 +195,7 @@ pub async fn set_project_active(
     let mut ctx: Context = params.id.try_into()?;
     but_api::legacy::projects::prepare_project_for_activation(&mut ctx)?;
     active_projects.set_active(
-        &mut ctx,
+        &ctx,
         claude,
         app_settings_sync,
         #[cfg(feature = "irc")]

--- a/crates/but-settings/Cargo.toml
+++ b/crates/but-settings/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 but-path.workspace = true
-but-fs.workspace = true
+but-utils.workspace = true
 
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/but-settings/src/legacy_settings.rs
+++ b/crates/but-settings/src/legacy_settings.rs
@@ -92,7 +92,7 @@ fn maybe_persist_overrides(config_path: &Path, legacy_overrides: serde_json::Val
     if let Some(diff_obj) = diff.as_object()
         && !diff_obj.is_empty()
     {
-        but_fs::write(
+        but_utils::write(
             config_path,
             serde_json_lenient::to_string_pretty(&customizations_with_overrides)?,
         )?;

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -22,7 +22,7 @@ impl AppSettings {
     pub fn load(config_path: &Path, customization: Option<serde_json::Value>) -> Result<Self> {
         // If the file on config_path does not exist, create it empty
         if !config_path.exists() {
-            but_fs::create_dirs_then_write(config_path, "{}\n")?;
+            but_utils::create_dirs_then_write(config_path, "{}\n")?;
         }
 
         // merge customizations from disk into the defaults to get a complete set of settings.
@@ -78,7 +78,7 @@ impl AppSettings {
         // Merge the new customizations into the existing ones
         // TODO: This will nuke any comments in the file
         merge_json_value(diff, &mut customizations);
-        but_fs::write(config_path, to_string_pretty(&customizations)?)?;
+        but_utils::write(config_path, to_string_pretty(&customizations)?)?;
         Ok(())
     }
 }

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -60,7 +60,7 @@ pub mod assignment {
     use crate::command::{context_from_args, debug_print};
 
     pub fn hunk_assignments(args: &crate::Args, use_json: bool) -> anyhow::Result<()> {
-        let mut ctx = context_from_args(args)?;
+        let ctx = context_from_args(args)?;
         let context_lines = ctx.settings.context_lines;
         let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
         let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
@@ -84,7 +84,7 @@ pub mod assignment {
         use_json: bool,
         assignment: HunkAssignmentRequest,
     ) -> anyhow::Result<()> {
-        let mut ctx = context_from_args(args)?;
+        let ctx = context_from_args(args)?;
         let context_lines = ctx.settings.context_lines;
         let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
         but_hunk_assignment::assign(
@@ -376,7 +376,7 @@ pub async fn watch(args: &super::Args, watch_mode: Option<&str>) -> anyhow::Resu
 }
 pub fn watch_db(args: &super::Args) -> anyhow::Result<()> {
     let ctx = context_from_args(args)?;
-    let db = ctx.db.get()?;
+    let db = ctx.db.get_cache()?;
     let rx = db.poll_changes(
         ItemKind::Actions | ItemKind::Assignments | ItemKind::Workflows,
         std::time::Duration::from_millis(500),

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -246,14 +246,14 @@ impl Sandbox {
         )
     }
 
-    /// Return a context configured to interact with this repository.
+    /// Return a fully isolated context configured to interact with this repository.
     ///
     /// ### Not for plumbing
     ///
     /// This feature is only meant for higher-level Client or API tests. Plumbing crates must not use the [`but_ctx::Context`].
     #[cfg(feature = "sandbox-but-api")]
     pub fn context(&self) -> anyhow::Result<but_ctx::Context> {
-        but_ctx::Context::from_repo(self.open_repo()?)
+        but_ctx::Context::from_repo(self.open_repo()?).map(but_ctx::Context::with_memory_app_cache)
     }
 
     /// Return the graph at `HEAD`, along with the `(graph, repo, meta)` repository and metadata used to create it.

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1484,7 +1484,7 @@ impl ToolResult for Result<ProjectStatus, anyhow::Error> {
 }
 
 pub fn get_project_status(
-    ctx: &mut Context,
+    ctx: &Context,
     filter_changes: Option<Vec<BString>>,
 ) -> anyhow::Result<ProjectStatus> {
     let stacks = stacks(ctx)?;
@@ -1505,7 +1505,7 @@ pub fn get_project_status(
 }
 
 pub fn get_filtered_changes(
-    ctx: &mut Context,
+    ctx: &Context,
     filter_changes: Option<Vec<BString>>,
 ) -> Result<Vec<FileChange>, anyhow::Error> {
     let context_lines = ctx.settings.context_lines;

--- a/crates/but-utils/Cargo.toml
+++ b/crates/but-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "but-fs"
+name = "but-utils"
 version = "0.0.0"
 edition.workspace = true
 authors.workspace = true

--- a/crates/but-utils/src/lib.rs
+++ b/crates/but-utils/src/lib.rs
@@ -9,6 +9,12 @@ use gix::tempfile::{AutoRemove, ContainingDirectory, create_dir::Retries};
 use serde::de::DeserializeOwned;
 use walkdir::WalkDir;
 
+mod on_demand;
+mod on_demand_cache;
+
+pub use on_demand::OnDemand;
+pub use on_demand_cache::OnDemandCache;
+
 #[cfg(feature = "legacy")]
 mod legacy {
     use std::{

--- a/crates/but-utils/src/on_demand.rs
+++ b/crates/but-utils/src/on_demand.rs
@@ -1,10 +1,10 @@
-use std::{cell, cell::RefCell, rc::Rc};
+use std::{cell, cell::RefCell, sync::Arc};
 
-/// A utility to keep a cached value and initialize it on the fly.
+/// A utility to keep a cached value and initialize it on demand.
 ///
 /// Note that despite interior mutability, the structure is made to *not bypass* Rust's borrow-checker.
 pub struct OnDemand<T> {
-    init: Rc<dyn Fn() -> anyhow::Result<T> + 'static>,
+    init: Arc<dyn Fn() -> anyhow::Result<T> + Send + Sync + 'static>,
     value: cell::RefCell<Option<T>>,
 }
 
@@ -20,21 +20,16 @@ where
     }
 }
 
-/// Lifecycle
 impl<T> OnDemand<T> {
     /// Create a new instance that can instantiate its value via `init` when needed.
-    pub fn new(init: impl Fn() -> anyhow::Result<T> + 'static) -> Self {
+    pub fn new(init: impl Fn() -> anyhow::Result<T> + Send + Sync + 'static) -> Self {
         OnDemand {
-            init: Rc::new(init),
+            init: Arc::new(init),
             value: RefCell::new(None),
         }
     }
-}
 
-/// Access
-impl<T> OnDemand<T> {
     /// Get a shared reference to the cached value or fallibly initialize it.
-    /// There can be multiple of these reference at the same time as long as there is no mutable one.
     pub fn get(&self) -> anyhow::Result<cell::Ref<'_, T>> {
         if let Ok(cached) = cell::Ref::filter_map(self.value.try_borrow()?, |opt| opt.as_ref()) {
             return Ok(cached);
@@ -49,8 +44,7 @@ impl<T> OnDemand<T> {
         )
     }
 
-    /// Get an exclusive references to the cached value or fallibly initialize it.
-    /// This can only happen if there are no other shared or mutable references.
+    /// Get an exclusive reference to the cached value or fallibly initialize it.
     pub fn get_mut(&mut self) -> anyhow::Result<cell::RefMut<'_, T>> {
         if let Ok(cached) =
             cell::RefMut::filter_map(self.value.try_borrow_mut()?, |opt| opt.as_mut())
@@ -68,28 +62,23 @@ impl<T> OnDemand<T> {
     }
 
     /// Return the existing value if there is one, without automatically initializing it.
-    /// There can be multiple of these reference at the same time as long as there is no mutable one.
     pub fn get_opt(&self) -> cell::Ref<'_, Option<T>> {
         self.value.borrow()
     }
 
     /// Take the existing value out of the cache if there is one.
-    ///
-    /// On next access, the cache will be re-initialised.
-    /// This can only happen if there are no other shared or mutable references.
     pub fn take(&mut self) -> Option<T> {
         self.value.borrow_mut().take()
     }
 
     /// Assign `value` and return a reference to it, dropping the previous cached value if it existed.
-    /// This can only happen if there are no other shared or mutable references.
-    // TODO: make this private and replace it with `Context` constructors or `with_*` post-construction modifiers.
     pub fn assign(&mut self, value: T) -> cell::RefMut<'_, T> {
         self.value = RefCell::new(Some(value));
         cell::RefMut::filter_map(self.value.borrow_mut(), |opt| opt.as_mut())
             .unwrap_or_else(|_| unreachable!("just set with a new value"))
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::OnDemand;
@@ -109,7 +98,6 @@ mod tests {
         }
 
         assert_eq!(*v.get_mut()?, 52);
-
         assert_eq!(*v.get()?, 52);
 
         {

--- a/crates/but-utils/src/on_demand_cache.rs
+++ b/crates/but-utils/src/on_demand_cache.rs
@@ -79,26 +79,26 @@ impl<T> OnDemandCache<T> {
         )
     }
 }
+
 #[cfg(test)]
 mod tests {
-    use crate::OnDemand;
+    use crate::OnDemandCache;
 
     #[test]
-    fn on_demand_journey() -> anyhow::Result<()> {
-        let mut v = OnDemand::new(|| Ok(42usize));
-        let vr = *v.get()?;
-        assert_eq!(vr, 42);
-        assert_eq!(*v.get()?, 42, "double read-only borrow is fine");
+    fn on_demand_cache_journey() -> anyhow::Result<()> {
+        let v = OnDemandCache::new(|| 42usize);
+        assert_eq!(*v.get_cache()?, 42);
+        assert_eq!(*v.get_cache()?, 42, "double read-only borrow is fine");
 
         {
-            let mut vr = v.get_mut()?;
+            let mut vr = v.get_cache_mut()?;
             assert_eq!(*vr, 42);
             *vr = 52;
             assert_eq!(*vr, 52);
         }
 
-        assert_eq!(*v.get_mut()?, 52);
-        assert_eq!(*v.get()?, 52);
+        assert_eq!(*v.get_cache_mut()?, 52);
+        assert_eq!(*v.get_cache()?, 52);
         Ok(())
     }
 }

--- a/crates/but-workspace/src/legacy/commit_engine/mod.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/mod.rs
@@ -307,8 +307,7 @@ pub fn create_commit_and_update_refs(
                         commit_id,
                         new_message: None,
                     }])?;
-                    let cache = ctx.cache.get_cache()?;
-                    match builder.rebase(&cache) {
+                    match builder.rebase() {
                         Ok(mut outcome) => {
                             if commit_id != workspace_tip {
                                 let Some(rewritten_old) =
@@ -336,8 +335,7 @@ pub fn create_commit_and_update_refs(
                         }
                     }
                 } else {
-                    let cache = ctx.cache.get_cache()?;
-                    match builder.rebase(&cache) {
+                    match builder.rebase() {
                         Ok(rebase) => rebase,
                         Err(err) => {
                             return if let Some(conflicts) =

--- a/crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/move_between_commits.rs
@@ -105,8 +105,7 @@ pub fn move_changes_between_commits(
     let mut rebase = Rebase::new(&repo, source_stack.merge_base(ctx)?, None)?;
     rebase.steps(source_stack_steps.clone())?;
     rebase.rebase_noops(false);
-    let cache = ctx.cache.get_cache()?;
-    let source_stack_result = rebase.rebase(&cache)?;
+    let source_stack_result = rebase.rebase()?;
 
     let source_stack_mapping = rebase_mapping_with_overrides(
         &source_stack_result,
@@ -161,8 +160,7 @@ pub fn move_changes_between_commits(
         let mut rebase = Rebase::new(&repo, source_stack.merge_base(ctx)?, None)?;
         rebase.steps(source_stack_steps.clone())?;
         rebase.rebase_noops(false);
-        let cache = ctx.cache.get_cache()?;
-        let result = rebase.rebase(&cache)?;
+        let result = rebase.rebase()?;
 
         // Create the output mapping
         let mut output_commit_mapping = source_stack_mapping.clone();
@@ -204,8 +202,7 @@ pub fn move_changes_between_commits(
         let mut rebase = Rebase::new(&repo, destination_stack.merge_base(ctx)?, None)?;
         rebase.steps(destination_stack_steps.clone())?;
         rebase.rebase_noops(false);
-        let cache = ctx.cache.get_cache()?;
-        let result = rebase.rebase(&cache)?;
+        let result = rebase.rebase()?;
         let (mut source_stack, mut destination_stack) = (source_stack, destination_stack);
 
         let output_commit_mapping = source_stack_mapping

--- a/crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/remove_changes_from_commit_in_stack.rs
@@ -53,11 +53,10 @@ pub fn remove_changes_from_commit_in_stack(
 
     let result = {
         let repo = ctx.repo.get()?;
-        let cache = ctx.cache.get_cache()?;
         let mut rebase = Rebase::new(&repo, base, None)?;
         rebase.steps(steps)?;
         rebase.rebase_noops(false);
-        rebase.rebase(&cache)?
+        rebase.rebase()?
     };
     let commit_mapping =
         rebase_mapping_with_overrides(&result, [(source_commit_id, rewritten_source_commit)]);

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_branch.rs
@@ -109,11 +109,10 @@ pub fn split_branch(
 
     let result = {
         let repo = ctx.repo.get()?;
-        let cache = ctx.cache.get_cache()?;
         let mut rebase = Rebase::new(&repo, merge_base, None)?;
         rebase.steps(steps)?;
         rebase.rebase_noops(false);
-        rebase.rebase(&cache)?
+        rebase.rebase()?
     };
 
     let new_branch_full_name: gix::refs::FullName = new_branch_ref_name.try_into()?;
@@ -220,8 +219,7 @@ pub fn split_into_dependent_branch(
     let mut source_rebase = Rebase::new(&repo, merge_base, None)?;
     source_rebase.steps(steps)?;
     source_rebase.rebase_noops(false);
-    let cache = ctx.cache.get_cache()?;
-    let source_result = source_rebase.rebase(&cache)?;
+    let source_result = source_rebase.rebase()?;
     let new_head = repo.find_commit(source_result.top_commit)?;
 
     let mut source_stack = source_stack;
@@ -270,11 +268,10 @@ fn filter_file_changes_in_branch(
 
     let source_result = {
         let repo = ctx.repo.get()?;
-        let cache = ctx.cache.get_cache()?;
         let mut source_rebase = Rebase::new(&repo, merge_base, None)?;
         source_rebase.steps(source_steps)?;
         source_rebase.rebase_noops(false);
-        source_rebase.rebase(&cache)?
+        source_rebase.rebase()?
     };
 
     let mut source_stack = source_stack;

--- a/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
+++ b/crates/but-workspace/src/legacy/tree_manipulation/split_commit.rs
@@ -43,11 +43,10 @@ pub fn split_commit(
     let base = source_stack.merge_base(ctx)?;
     let result = {
         let repo = ctx.repo.get()?;
-        let cache = ctx.cache.get_cache()?;
         let mut rebase = Rebase::new(&repo, base, None)?;
         rebase.steps(steps)?;
         rebase.rebase_noops(false);
-        rebase.rebase(&cache)?
+        rebase.rebase()?
     };
 
     let commit_mapping = result

--- a/crates/but-worktrees/src/integrate.rs
+++ b/crates/but-worktrees/src/integrate.rs
@@ -201,7 +201,7 @@ fn worktree_integration_inner(
     let mut rebase = Rebase::new(&repo, stack.merge_base(ctx)?, None)?;
     rebase.steps(steps)?;
     rebase.rebase_noops(false);
-    let output = rebase.rebase(&*ctx.cache.get_cache()?)?;
+    let output = rebase.rebase()?;
 
     // Does the new stack tip conflict with any of the other stacks.
     let tip_tree = repo.find_commit(output.top_commit)?.tree_id()?;

--- a/crates/but/src/command/legacy/clean.rs
+++ b/crates/but/src/command/legacy/clean.rs
@@ -208,7 +208,7 @@ fn find_empty_branches(
 }
 
 /// Returns the set of stack IDs that have at least one worktree change assigned to them.
-fn stacks_with_assigned_changes(ctx: &mut but_ctx::Context) -> anyhow::Result<HashSet<StackId>> {
+fn stacks_with_assigned_changes(ctx: &but_ctx::Context) -> anyhow::Result<HashSet<StackId>> {
     let context_lines = ctx.settings.context_lines;
     let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
     let changes = but_core::diff::ui::worktree_changes(&repo)?.changes;

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -1085,7 +1085,7 @@ fn extract_commit_title(commit: Option<&Commit>) -> Option<&str> {
 /// Get a mapping from branch names to their associated reviews.
 #[instrument(skip(ctx))]
 pub fn get_review_map(
-    ctx: &mut Context,
+    ctx: &Context,
     cache_config: Option<but_forge::CacheConfig>,
 ) -> anyhow::Result<std::collections::HashMap<String, Vec<but_forge::ForgeReview>>> {
     let reviews = but_api::legacy::forge::list_reviews(ctx, cache_config).unwrap_or_default();

--- a/crates/but/src/command/legacy/mcp_internal/mod.rs
+++ b/crates/but/src/command/legacy/mcp_internal/mod.rs
@@ -25,8 +25,8 @@ pub mod commit;
 pub mod stack;
 
 pub fn project_status(project_dir: &Path) -> anyhow::Result<but_tools::workspace::ProjectStatus> {
-    let mut ctx = Context::open(project_dir)?;
-    but_tools::workspace::get_project_status(&mut ctx, None)
+    let ctx = Context::open(project_dir)?;
+    but_tools::workspace::get_project_status(&ctx, None)
 }
 
 pub(crate) async fn start(app_settings: AppSettings) -> Result<()> {

--- a/crates/but/src/command/legacy/rub/assign.rs
+++ b/crates/but/src/command/legacy/rub/assign.rs
@@ -4,7 +4,7 @@ use but_ctx::Context;
 use but_hunk_assignment::{HunkAssignmentRequest, HunkAssignmentTarget};
 
 pub(crate) fn do_assignments(
-    ctx: &mut Context,
+    ctx: &Context,
     reqs: Vec<HunkAssignmentRequest>,
 ) -> anyhow::Result<()> {
     let context_lines = ctx.settings.context_lines;

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -674,7 +674,7 @@ fn print_worktree_status(
 }
 
 fn ci_map(
-    ctx: &mut Context,
+    ctx: &Context,
     cache_config: &but_forge::CacheConfig,
     stack_details: &[StackEntry],
 ) -> Result<BTreeMap<String, Vec<but_forge::CiCheck>>, anyhow::Error> {

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -340,7 +340,7 @@ pub(super) fn create_branch_legacy(ctx: &mut Context) -> anyhow::Result<String> 
     Ok(new_name)
 }
 
-pub(super) fn has_unassigned_changes(ctx: &mut Context) -> anyhow::Result<bool> {
+pub(super) fn has_unassigned_changes(ctx: &Context) -> anyhow::Result<bool> {
     let context_lines = ctx.settings.context_lines;
 
     let (_guard, repo, ws, mut db) = ctx.workspace_and_db_mut()?;
@@ -359,7 +359,7 @@ pub(super) fn has_unassigned_changes(ctx: &mut Context) -> anyhow::Result<bool> 
 }
 
 pub(super) fn assigned_file_count_for_stack(
-    ctx: &mut Context,
+    ctx: &Context,
     stack_id: StackId,
 ) -> anyhow::Result<usize> {
     let context_lines = ctx.settings.context_lines;

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -551,7 +551,7 @@ impl IdMap {
     /// # NOTE: claims a read-only workspace lock!
     /// TODO(ctx|ai): Use a `ws` directly instead of creating a whole new RefInfo uncached.
     pub fn new_from_context(
-        ctx: &mut Context,
+        ctx: &Context,
         assignments: Option<Vec<HunkAssignment>>,
         perm: &RepoShared,
     ) -> anyhow::Result<Self> {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -329,7 +329,7 @@ impl BranchManager<'_> {
             let mut rebase = but_rebase::Rebase::new(&repo, default_target.sha, None)?;
             rebase.steps(steps)?;
             rebase.rebase_noops(true);
-            let output = rebase.rebase(&*self.ctx.cache.get_cache()?)?;
+            let output = rebase.rebase()?;
             stack.set_stack_head(&mut vb_state, &repo, output.top_commit)?;
 
             stack.set_heads_from_rebase_output(self.ctx, output.references)?;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -163,7 +163,7 @@ pub fn integrate_branch_with_steps(
     let mut rebase = Rebase::new(&repo, merge_base, None)?;
     rebase.steps(new_rebase_steps)?;
     rebase.rebase_noops(false);
-    let result = rebase.rebase(&*ctx.cache.get_cache()?)?;
+    let result = rebase.rebase()?;
 
     source_stack.set_stack_head(&mut vb_state, &repo, result.top_commit)?;
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;

--- a/crates/gitbutler-branch-actions/src/move_branch.rs
+++ b/crates/gitbutler-branch-actions/src/move_branch.rs
@@ -74,7 +74,7 @@ pub(crate) fn move_branch(
             let mut src_rebase = Rebase::new(&repo, source_merge_base, None)?;
             src_rebase.steps(remaining_steps)?;
             src_rebase.rebase_noops(false);
-            Some(src_rebase.rebase(&*ctx.cache.get_cache()?)?)
+            Some(src_rebase.rebase()?)
         } else {
             None
         };
@@ -90,7 +90,7 @@ pub(crate) fn move_branch(
         let mut dst_rebase = Rebase::new(&repo, dest_merge_base, None)?;
         dst_rebase.steps(new_dest_steps)?;
         dst_rebase.rebase_noops(false);
-        let dest_output = dst_rebase.rebase(&*ctx.cache.get_cache()?)?;
+        let dest_output = dst_rebase.rebase()?;
 
         // Conflict check — bail before any state is written.
         if let Some(ref src_out) = source_output {
@@ -200,7 +200,7 @@ pub(crate) fn tear_off_branch(
     let mut new_stack_rebase = Rebase::new(&repo, source_merge_base, None)?;
     new_stack_rebase.steps(subject_branch_steps)?;
     new_stack_rebase.rebase_noops(false);
-    let new_stack_rebase_output = new_stack_rebase.rebase(&*ctx.cache.get_cache()?)?;
+    let new_stack_rebase_output = new_stack_rebase.rebase()?;
 
     let subject_branch_reference_spec = new_stack_rebase_output
         .clone()
@@ -261,7 +261,7 @@ fn extract_and_rebase_source_branch(
         let mut source_stack_rebase = Rebase::new(repository, source_merge_base, None)?;
         source_stack_rebase.steps(new_source_steps)?;
         source_stack_rebase.rebase_noops(false);
-        let source_rebase_result = source_stack_rebase.rebase(&*ctx.cache.get_cache()?)?;
+        let source_rebase_result = source_stack_rebase.rebase()?;
         let new_source_head = repository.find_commit(source_rebase_result.top_commit)?;
 
         source_stack.remove_branch(ctx, subject_branch_name)?;

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -158,7 +158,7 @@ fn rebase_without_commit(
     let mut rebase = but_rebase::Rebase::new(repo, Some(merge_base), None)?;
     rebase.rebase_noops(false);
     rebase.steps(steps)?;
-    rebase.rebase(&*ctx.cache.get_cache()?)
+    rebase.rebase()
 }
 
 /// Rebase `stack` with `subject_commit_oid` inserted at the top, writing only to the ODB.
@@ -186,7 +186,7 @@ fn rebase_with_commit_at_top(
     let mut rebase = but_rebase::Rebase::new(repo, Some(merge_base), None)?;
     rebase.rebase_noops(false);
     rebase.steps(steps)?;
-    rebase.rebase(&*ctx.cache.get_cache()?)
+    rebase.rebase()
 }
 
 /// Remove the commit from the source stack.

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -57,7 +57,7 @@ pub fn reorder_stack(
     let mut builder = but_rebase::Rebase::new(&repo, Some(merge_base), None)?;
     let builder = builder.steps(steps)?;
     builder.rebase_noops(false);
-    let output = builder.rebase(&*ctx.cache.get_cache()?)?;
+    let output = builder.rebase()?;
 
     // Ensure the stack head is set to the new oid after rebasing
     stack.set_stack_head(&mut state, &repo, output.top_commit)?;

--- a/crates/gitbutler-branch-actions/src/squash.rs
+++ b/crates/gitbutler-branch-actions/src/squash.rs
@@ -246,7 +246,7 @@ fn do_squash_commits(
         let mut builder = but_rebase::Rebase::new(&repo, Some(merge_base), None)?;
         let builder = builder.steps(steps)?;
         builder.rebase_noops(false);
-        let output = builder.rebase(&*ctx.cache.get_cache()?)?;
+        let output = builder.rebase()?;
 
         stack.set_stack_head(&mut vb_state, &repo, output.top_commit)?;
 

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -46,7 +46,7 @@ pub(crate) fn undo_commit(
     let mut rebase = but_rebase::Rebase::new(&repo, Some(merge_base), None)?;
     rebase.rebase_noops(false);
     rebase.steps(steps)?;
-    let output = rebase.rebase(&*ctx.cache.get_cache()?)?;
+    let output = rebase.rebase()?;
 
     stack.set_stack_head(&mut vb_state, &repo, output.top_commit)?;
 

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -307,7 +307,7 @@ fn get_stack_status(
         let mut rebase = but_rebase::Rebase::new(gix_repo, Some(rebase_base), None)?;
         rebase.rebase_noops(false);
         rebase.steps(steps)?;
-        let output = rebase.rebase(&*ctx.cache.get_cache()?)?;
+        let output = rebase.rebase()?;
         let new_head_oid = output.top_commit;
 
         let any_conflicted = output.commit_mapping.iter().any(|(_base, _old, new)| {
@@ -660,7 +660,7 @@ pub(crate) fn resolve_upstream_integration(
             let mut rebase = but_rebase::Rebase::new(&repo, Some(new_target_id), None)?;
             rebase.steps(steps)?;
             rebase.rebase_noops(false);
-            let outcome = rebase.rebase(&*ctx.cache.get_cache()?)?;
+            let outcome = rebase.rebase()?;
             Ok(outcome.top_commit)
         }
     }
@@ -775,7 +775,7 @@ fn compute_resolutions(
                         but_rebase::Rebase::new(context.gix_repo, Some(lower_bound), None)?;
                     rebase.rebase_noops(false);
                     rebase.steps(steps)?;
-                    let output = rebase.rebase(&*context.ctx.cache.get_cache()?)?;
+                    let output = rebase.rebase()?;
                     let new_head = output.top_commit;
 
                     Ok((

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -205,7 +205,7 @@ pub(crate) fn update_commit_message(
         let mut rebase = but_rebase::Rebase::new(&repo, Some(merge_base), None)?;
         rebase.rebase_noops(false);
         rebase.steps(steps)?;
-        rebase.rebase(&*ctx.cache.get_cache()?)?
+        rebase.rebase()?
     };
 
     stack.set_stack_head(&mut vb_state, &repo, output.top_commit)?;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -76,7 +76,7 @@ pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> 
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(root.join(repo_name).as_path())?;
-    Ok(Context::from_repo(repo)?)
+    Context::from_repo(repo)
 }
 
 fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/driverless.rs
@@ -76,7 +76,7 @@ pub fn read_only_context(script_name: &str, repo_name: &str) -> Result<Context> 
     )
     .map_err(anyhow::Error::from_boxed)?;
     let repo = open_repo(root.join(repo_name).as_path())?;
-    Ok(Context::from_repo(repo)?.with_memory_cache())
+    Ok(Context::from_repo(repo)?)
 }
 
 fn seed_fixture(repo: &gix::Repository, script_name: &str, repo_name: &str) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
@@ -32,7 +32,8 @@ pub fn hook_case() -> Result<HookCase> {
         &project,
         AppSettings::default(),
         RepoOpenMode::Isolated,
-    )?;
+    )?
+    .with_memory_app_cache();
     Ok(HookCase {
         ctx,
         _app_data_dir: app_data_dir,

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
@@ -22,7 +22,8 @@ fn twice() {
             AppSettings::default(),
             but_ctx::RepoOpenMode::Isolated,
         )
-        .expect("can create context");
+        .expect("can create context")
+        .with_memory_app_cache();
 
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
@@ -46,7 +47,8 @@ fn twice() {
             AppSettings::default(),
             but_ctx::RepoOpenMode::Isolated,
         )
-        .expect("can create context");
+        .expect("can create context")
+        .with_memory_app_cache();
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
             &ctx,

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -222,7 +222,8 @@ impl Test {
             settings,
             RepoOpenMode::Isolated,
         )
-        .expect("can create context");
+        .expect("can create context")
+        .with_memory_app_cache();
         Self {
             repo: test_project,
             project_id: project.id,

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 but-serde = { workspace = true, features = ["legacy"] }
 but-workspace = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
-but-fs.workspace = true
+but-utils.workspace = true
 but-ctx.workspace = true
 but-schemars.workspace = true
 

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -50,7 +50,7 @@ pub fn write_edit_mode_metadata(
 ) -> Result<()> {
     let serialized_edit_mode_metadata =
         toml::to_string(edit_mode_metadata).context("Failed to serialize edit mode metadata")?;
-    but_fs::write(
+    but_utils::write(
         edit_mode_metadata_path(ctx).as_path(),
         serialized_edit_mode_metadata,
     )

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -14,7 +14,7 @@ but-meta.workspace = true
 but-serde = { workspace = true, features = ["legacy"]}
 but-core.workspace = true
 but-oxidize.workspace = true
-but-fs.workspace = true
+but-utils.workspace = true
 but-ctx = { workspace = true }
 
 gitbutler-branch.workspace = true

--- a/crates/gitbutler-oplog/src/reflog.rs
+++ b/crates/gitbutler-oplog/src/reflog.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use but_fs::write;
+use but_utils::write;
 use gitbutler_repo::{GITBUTLER_COMMIT_AUTHOR_EMAIL, GITBUTLER_COMMIT_AUTHOR_NAME};
 use gitbutler_stack::VirtualBranchesHandle;
 use gix::{config::tree::Key, date::parse::TimeBuf};

--- a/crates/gitbutler-oplog/src/state.rs
+++ b/crates/gitbutler-oplog/src/state.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use but_fs::read_toml_file_or_default;
+use but_utils::read_toml_file_or_default;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::OPLOG_FILE_NAME;
@@ -84,6 +84,6 @@ impl OplogHandle {
 
     fn write_file(&self, mut oplog: Oplog) -> Result<()> {
         oplog.modified_at = SystemTime::now();
-        but_fs::write(&self.file_path, toml::to_string(&oplog)?)
+        but_utils::write(&self.file_path, toml::to_string(&oplog)?)
     }
 }

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -17,7 +17,7 @@ but-error.workspace = true
 but-path.workspace = true
 but-serde = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
-but-fs = { workspace = true, features = ["legacy"] }
+but-utils = { workspace = true, features = ["legacy"] }
 but-forge.workspace = true
 but-project-handle = { workspace = true, features = ["legacy"] }
 but-schemars = { workspace = true, optional = true }

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -11,7 +11,7 @@ const PROJECTS_FILE: &str = "projects.json";
 
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
-    inner: but_fs::Storage,
+    inner: but_utils::Storage,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -122,7 +122,7 @@ fn default_false() -> bool {
 impl Storage {
     pub fn from_path(path: impl Into<PathBuf>) -> Self {
         Storage {
-            inner: but_fs::Storage::new(path),
+            inner: but_utils::Storage::new(path),
         }
     }
 

--- a/crates/gitbutler-repo/tests/repo/credentials.rs
+++ b/crates/gitbutler-repo/tests/repo/credentials.rs
@@ -36,7 +36,8 @@ impl TestCase<'_> {
             AppSettings::default(),
             RepoOpenMode::Isolated,
         )
-        .expect("can create context");
+        .expect("can create context")
+        .with_memory_app_cache();
 
         #[expect(deprecated, reason = "transport/auth compatibility coverage")]
         let git2_repo = &*ctx.git2_repo.get().unwrap();

--- a/crates/gitbutler-repo/tests/repo/read_file_from_workspace_security.rs
+++ b/crates/gitbutler-repo/tests/repo/read_file_from_workspace_security.rs
@@ -17,6 +17,7 @@ fn context_for_repo(workdir: &Path) -> Context {
         RepoOpenMode::Isolated,
     )
     .expect("can create context")
+    .with_memory_app_cache()
 }
 
 #[test]

--- a/crates/gitbutler-repo/tests/repo/remotes.rs
+++ b/crates/gitbutler-repo/tests/repo/remotes.rs
@@ -22,7 +22,8 @@ fn ctx() -> TestCtx {
             AppSettings::default(),
             RepoOpenMode::Isolated,
         )
-        .expect("can create context"),
+        .expect("can create context")
+        .with_memory_app_cache(),
         _tmp: tmp,
     }
 }

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -185,7 +185,7 @@ pub(crate) mod state {
                 watch_mode,
             )?;
 
-            let db = ctx.db.get()?;
+            let db = ctx.db.get_cache()?;
             let db_watcher = but_db::poll::watch_in_background(&db, {
                 let app_handle = self.app_handle.clone();
                 let project_id = ctx.legacy_project.id.clone();

--- a/crates/gitbutler-user/Cargo.toml
+++ b/crates/gitbutler-user/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 but-secret.workspace = true
-but-fs = { workspace = true, features = ["legacy"] }
+but-utils = { workspace = true, features = ["legacy"] }
 but-path.workspace = true
 
 anyhow.workspace = true

--- a/crates/gitbutler-user/src/storage.rs
+++ b/crates/gitbutler-user/src/storage.rs
@@ -8,13 +8,13 @@ const USER_FILE: &str = "user.json";
 
 #[derive(Debug, Clone)]
 pub(crate) struct Storage {
-    inner: but_fs::Storage,
+    inner: but_utils::Storage,
 }
 
 impl Storage {
     pub fn from_path(path: impl Into<PathBuf>) -> Storage {
         Storage {
-            inner: but_fs::Storage::new(path),
+            inner: but_utils::Storage::new(path),
         }
     }
 


### PR DESCRIPTION
A `db` field with `cache` semantics means that

* `&Context` can be used to obtain a mutable handle
    - existing usages of code that reconciles-on-query can now be changed to `&Context`,
      which effectively reserves `&mut Context` for actual repository changes.
* `db.cache.get_mut()` can be used to get a separate per-repository cache.
    - separting these may one day not be necessary anymore, but at least for now we expect
      `db` to always be readable and persisted, whereas `CacheHandle` may be in memory.

## Out of Scope

While I contemplated with using cache-style migrations also for `db` which means it could be
opened in memory and users will be able to use GitButler on any filesystem, I think doing this
right needs better UX. For instance, projects that can't persist their metadata should help the
user to set `gitbutler[.channel].storagePath` to a wriable location.
Leaving the current behaviour of failing hard adds implementation pressure if it is a common problem.

## Tasks

* [x] refackiew
* [ ] address auto-review
