### PR TITLE
Improvements to login flow

### DIFF
--- a/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
+++ b/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
@@ -14,7 +14,7 @@
 
 	const userService = inject(USER_SERVICE);
 	const incomingUser = $derived(userService.incomingUserLogin);
-	const incomingUserEmail = $derived($incomingUser?.email ?? "");
+	const incomingUserEmail = $derived($incomingUser?.email);
 	const incomingUserName = $derived(
 		$incomingUser?.login ?? $incomingUser?.name ?? incomingUserEmail ?? "unknown",
 	);
@@ -44,7 +44,7 @@
 	const avatarSize = "3.25rem";
 </script>
 
-<ModalHeader type="info">Confirm login attempt</ModalHeader>
+<ModalHeader type="info">Confirm login attempt of {incomingUserName}</ModalHeader>
 <div class="modal-content">
 	{#await getUserAvatarURL()}
 		<SkeletonBone width={avatarSize} height={avatarSize} radius="100%" />
@@ -53,9 +53,9 @@
 	{/await}
 
 	<p class="text-13 text-body clr-text-2">
-		A new login attempt has been detected for the user
-		<span class="text-bold clr-text-1">{incomingUserName}</span>. Would you like to accept this
-		login?
+		A new login attempt has been detected for the user with email
+		<span class="text-bold clr-text-1">{incomingUserEmail ?? "-unknown-"}</span>. Would you like to
+		accept this login?
 	</p>
 </div>
 <ModalFooter>

--- a/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
+++ b/apps/desktop/src/components/onboarding/LoginConfirmationModalContent.svelte
@@ -44,7 +44,7 @@
 	const avatarSize = "3.25rem";
 </script>
 
-<ModalHeader type="info">Confirm login attempt of {incomingUserName}</ModalHeader>
+<ModalHeader type="info">Confirm login attempt for {incomingUserName}</ModalHeader>
 <div class="modal-content">
 	{#await getUserAvatarURL()}
 		<SkeletonBone width={avatarSize} height={avatarSize} radius="100%" />

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -89,8 +89,8 @@ export class UserService {
 			if (currentUser) {
 				// Error out if we're trying to set a token when we've already logged in.
 				showError(
-					"Error: Attempting to login before loggin out first",
-					"There's already an account logged in, please log out before attempting to login to another account.",
+					"Error: Attempting to log in before logging out first",
+					"There's already an account logged in, please log out before attempting to log in to another account.",
 				);
 				return;
 			}

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -85,6 +85,16 @@ export class UserService {
 
 	async setUserAccessToken(token: string, bypassConfirmationToast = false) {
 		try {
+			const currentUser = await this.refresh();
+			if (currentUser) {
+				// Error out if we're trying to set a token when we've already logged in.
+				showError(
+					"Error: Attempting to login before loggin out first",
+					"There's already an account logged in, please log out before attempting to login to another account.",
+				);
+				return;
+			}
+
 			const user = await this.httpClient.get<User>("login/whoami", {
 				headers: {
 					"X-Auth-Token": token,


### PR DESCRIPTION
- Display the email of the user being logged in in the confirmation
  modal.
- Don’t allow for login substitution, error out if there’s already an
  account present when attempting to login.
  
###  Visuals

This error toast is displayed when:
1. Clicked the button to 'Open client' after a successful login in the browser.
2. And already having an authenticated account in the client.

The intention is to prevent replacing the account loggedin with another one. The user should logout before loging into another account.
<img width="480" height="171" alt="Screenshot 2026-04-13 at 09 38 04" src="https://github.com/user-attachments/assets/afd17317-4b20-4a82-a36b-6cb77da8fd70" />

We display the user name and the user **email**, that way we make it harder to confuse which account is being logged in
<img width="369" height="196" alt="Screenshot 2026-04-13 at 09 48 03" src="https://github.com/user-attachments/assets/e607c46a-1265-4547-bba3-9ef666adbb30" />
