### PR TITLE
upgrade `gix` with patched and vendored `imara-diff`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4432,7 +4432,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4450,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4474,13 +4474,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "kstring",
  "serde",
  "smallvec",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-error",
 ]
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "gix-blame"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4508,7 +4508,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-error",
 ]
@@ -4526,19 +4526,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4592,7 +4592,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4622,23 +4622,23 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
+ "gix-imara-diff-01",
  "gix-index",
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-traverse",
  "gix-worktree",
- "imara-diff 0.1.8",
- "imara-diff 0.2.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4648,7 +4648,7 @@ dependencies = [
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "dunce",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
 ]
@@ -4679,13 +4679,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4710,7 +4710,7 @@ dependencies = [
  "gix-packetline",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4766,20 +4766,37 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "serde",
  "unicode-bom",
 ]
 
 [[package]]
+name = "gix-imara-diff"
+version = "0.2.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
+name = "gix-imara-diff-01"
+version = "0.1.8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "gix-index"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4807,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4817,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4829,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4837,6 +4854,7 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff-01",
  "gix-index",
  "gix-object",
  "gix-path 0.11.2",
@@ -4844,9 +4862,8 @@ dependencies = [
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-worktree",
- "imara-diff 0.1.8",
  "nonempty",
  "thiserror 2.0.18",
 ]
@@ -4854,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4867,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4887,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4907,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4929,11 +4946,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "thiserror 2.0.18",
 ]
 
@@ -4952,10 +4969,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
@@ -4963,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4977,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4989,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -5003,7 +5020,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -5016,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5026,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5047,7 +5064,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5062,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5073,7 +5090,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
  "nonempty",
  "serde",
 ]
@@ -5081,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5096,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.2",
@@ -5108,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5121,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "filetime",
@@ -5143,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5157,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5171,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "crc",
@@ -5200,7 +5217,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "tracing",
 ]
@@ -5208,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5227,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5243,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
@@ -5255,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5275,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
 ]
@@ -5283,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5301,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5318,7 +5335,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=e51c40bd5c206305197bd635014f51930b5d8fc2#e51c40bd5c206305197bd635014f51930b5d8fc2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5934,25 +5951,6 @@ dependencies = [
  "num-traits",
  "png 0.18.1",
  "tiff",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
-dependencies = [
- "hashbrown 0.15.5",
- "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,10 +212,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "e51c40bd5c206305197bd635014f51930b5d8fc2", default-features = false, features = [
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "8f091d108cd75371be2ed9de6e81f785cda53d92", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "e51c40bd5c206305197bd635014f51930b5d8fc2" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "8f091d108cd75371be2ed9de6e81f785cda53d92" }
 
 ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
 insta = { version = "1.45.1", features = ["json"] }
@@ -336,7 +336,8 @@ incremental = false
 # Assure that `gix` is always fast so debug builds aren't unnecessarily slow.
 [profile.dev.package]
 foldhash = { opt-level = 3 }
-imara-diff = { opt-level = 3 }
+gix-imara-diff = { opt-level = 3 }
+gix-imara-diff-01 = { opt-level = 3 }
 but-graph = { opt-level = 3 }
 gix = { opt-level = 3 }
 gix-diff = { opt-level = 3 }


### PR DESCRIPTION
This addresses a DoS issue when creating diffs that could lead to exponential (or quadratic) compute time for diffs.

`imara-diff` is now vendoered as it's hard to time-sensitive patches released. As it's quite stable as well, it seems like useful move, particularly as it's fuzzed through `gitoxide` as well (and the reason the DoS was discovered).
