### PR TITLE
feat(but-installer): add skill install prompt

### DIFF
--- a/crates/but-installer/src/lib.rs
+++ b/crates/but-installer/src/lib.rs
@@ -11,6 +11,7 @@ mod http;
 mod install;
 mod release;
 mod shell;
+mod skill;
 pub mod ui;
 
 #[cfg(target_os = "linux")]
@@ -123,6 +124,15 @@ fn run_installation_impl(config: InstallerConfig, interactive: bool) -> Result<(
     if interactive {
         info("Checking shell configuration");
         configure_shell(&config.home_dir)?;
+
+        let but_binary = but_binary_path(&config.home_dir);
+        if skill::has_skill_install(&but_binary)
+            && ui::prompt_for_confirmation("Would you like to install the but agent skill?")
+        {
+            skill::but_skill_install_global(&but_binary);
+        } else {
+            info("Skipping skill install. If you change your mind, just run `but skill install`!");
+        }
     }
 
     ui::println_empty();

--- a/crates/but-installer/src/lib.rs
+++ b/crates/but-installer/src/lib.rs
@@ -126,12 +126,14 @@ fn run_installation_impl(config: InstallerConfig, interactive: bool) -> Result<(
         configure_shell(&config.home_dir)?;
 
         let but_binary = but_binary_path(&config.home_dir);
-        if skill::has_skill_install(&but_binary)
-            && ui::prompt_for_confirmation("Would you like to install the but agent skill?")
-        {
-            skill::but_skill_install_global(&but_binary);
-        } else {
-            info("Skipping skill install. If you change your mind, just run `but skill install`!");
+        if skill::has_skill_install(&but_binary) {
+            if ui::prompt_for_confirmation("Would you like to install the but skill files?") {
+                skill::but_skill_install_global(&but_binary);
+            } else {
+                info(
+                    "Skipping skill install. If you change your mind, just run `but skill install`!",
+                );
+            }
         }
     }
 

--- a/crates/but-installer/src/skill.rs
+++ b/crates/but-installer/src/skill.rs
@@ -1,0 +1,40 @@
+//! Functions to install the GitButler skill files
+
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use crate::ui::warn;
+
+/// Check if `but skill install` is available
+pub(crate) fn has_skill_install(but_binary: &Path) -> bool {
+    let result = Command::new(but_binary)
+        .arg("skill")
+        .arg("install")
+        .arg("--help")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    result.map(|status| status.success()).unwrap_or(false)
+}
+
+/// Install the GitButler skill files globally
+pub(crate) fn but_skill_install_global(but_binary: &Path) {
+    let status = Command::new(but_binary)
+        .arg("skill")
+        .arg("install")
+        .arg("--global")
+        .status();
+
+    match status {
+        Err(err) => warn(&format!(
+            "Something went wrong, skill files may not have been installed: {err}"
+        )),
+        Ok(status) if !status.success() => warn(&format!(
+            "`but skill install` exited non-zero, skill files may not have been installed. {status}"
+        )),
+        _ => (),
+    }
+}

--- a/crates/but-installer/src/skill.rs
+++ b/crates/but-installer/src/skill.rs
@@ -1,11 +1,12 @@
 //! Functions to install the GitButler skill files
 
 use std::{
+    io::{IsTerminal, stdin},
     path::Path,
     process::{Command, Stdio},
 };
 
-use crate::ui::warn;
+use crate::ui::{open_tty, warn};
 
 /// Check if `but skill install` is available
 pub(crate) fn has_skill_install(but_binary: &Path) -> bool {
@@ -22,10 +23,23 @@ pub(crate) fn has_skill_install(but_binary: &Path) -> bool {
 
 /// Install the GitButler skill files globally
 pub(crate) fn but_skill_install_global(but_binary: &Path) {
+    let stdin: Stdio = if stdin().is_terminal() {
+        Stdio::inherit()
+    } else {
+        match open_tty() {
+            Some(tty) => tty.into(),
+            None => {
+                warn("Could not open stdin to run `but skill install` interactively");
+                return;
+            }
+        }
+    };
+
     let status = Command::new(but_binary)
         .arg("skill")
         .arg("install")
         .arg("--global")
+        .stdin(stdin)
         .status();
 
     match status {

--- a/crates/but-installer/src/ui.rs
+++ b/crates/but-installer/src/ui.rs
@@ -16,7 +16,7 @@ use owo_colors::{OwoColorize, Stream};
 ///
 /// Returns `None` if there is no controlling terminal (e.g., in a CI environment
 /// or a detached process).
-fn open_tty() -> Option<std::fs::File> {
+pub fn open_tty() -> Option<std::fs::File> {
     std::fs::File::open("/dev/tty").ok()
 }
 


### PR DESCRIPTION
## 🧢 Changes
Adds a prompt to install the but skill files at the end of the interactive installer.

If you accept the prompt, you're dropped right into `but skill install --global`.

<img width="951" height="231" alt="accept_skill" src="https://github.com/user-attachments/assets/b3171fe6-bab3-4004-93ac-c197a918ec19" />

If you reject the prompt, you get instructions for how to "do it again".

<img width="796" height="63" alt="reject_skill" src="https://github.com/user-attachments/assets/f29d92bd-b1ab-41c4-9cd8-94898f2ef8e9" />

We never fail the install if something goes wrong installing the skill, at most we print some warnings.

## Thoughts
Having gone through adding this as a simple shim to the installed `but` binary, just invoking `<installed_bin> skill install --global`, it struck me that maybe we should take this approach for the shell config as well. Or, really, anything that requires interactivity. This would allow us to more easily provide a seamless UX across the installer and `but`, while still keeping the installer to the bare minimum.

I'll ponder it for a while. There is the obvious downside that any bugs we have in the interactive parts of the installer would not be possible to patch without making a new release (and would not be patched in older releases), so perhaps it's just not that great of an idea.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13289 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13285
<!-- GitButler Footer Boundary Bottom -->

## TODO
`but skill install` currently cannot run interactively when `curl | sh`-installing as it requires stdin to be a terminal, and in this common case stdin is a pipe. We need to also allow `/dev/tty` as a valid input, but still require that stdout is a direct terminal output.