### PR TITLE
Fix dropzones freezing when data refreshes during a drag

### DIFF
--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -333,10 +333,8 @@ function setupDragHandlers(
 			element.classList.add(DRAGGING_CLASS);
 		}
 
-		// Activate dropzones
-		for (const dropzone of Array.from(opts.dropzoneRegistry.values())) {
-			dropzone.activate(opts.data);
-		}
+		// Activate dropzones (also enables auto-activation of late-registered dropzones)
+		opts.dropzoneRegistry.startDrag(opts.data);
 
 		// Create drag clone
 		clone = createClone(opts, selectedElements);
@@ -379,11 +377,6 @@ function setupDragHandlers(
 	}
 
 	function handleMouseUp(e: MouseEvent) {
-		if (opts) {
-			Array.from(opts.dropzoneRegistry.values()).forEach((dropzone) => {
-				dropzone.deactivate();
-			});
-		}
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -462,6 +455,14 @@ function setupDragHandlers(
 			currentHoveredDropzone = null;
 		}
 
+		// Deactivate all dropzones and clear drag state from the registry.
+		// This must happen in cleanup (not just mouseup) so that dropzones
+		// are properly deactivated even if the dragged element is destroyed
+		// mid-drag (e.g. due to a data refresh).
+		if (isDragging && opts) {
+			opts.dropzoneRegistry.endDrag();
+		}
+
 		// Remove listeners
 		if (isDragging) {
 			window.removeEventListener("mousemove", handleMouseMove);
@@ -475,7 +476,6 @@ function setupDragHandlers(
 		// Stop observer (also stops auto-scroll since it's in the same RAF loop)
 		stopObserver();
 
-		// Deactivate dropzones
 		selectedElements.forEach((el) => el.classList.remove(DRAGGING_CLASS));
 
 		if (clone) {

--- a/apps/desktop/src/lib/dragging/registry.ts
+++ b/apps/desktop/src/lib/dragging/registry.ts
@@ -4,26 +4,70 @@ import type { Dropzone } from "$lib/dragging/dropzone";
 export const DROPZONE_REGISTRY = new InjectionToken<DropzoneRegistry>("DropzoneRegistry");
 
 /**
- * This class was basically only created in order to facilitate injection.
+ * Registry for all active dropzones. Tracks active drag state so that
+ * dropzones created mid-drag (e.g. due to data refresh) are automatically
+ * activated, and so that all dropzones can be reliably deactivated when
+ * a drag ends — even if the dragged element is destroyed before mouseup.
  */
 export class DropzoneRegistry {
 	private map = new Map<HTMLElement, Dropzone>();
+	private activeDragData: unknown = undefined;
+	private _isDragging = false;
+
 	get(key: HTMLElement) {
 		return this.map.get(key);
 	}
+
 	set(key: HTMLElement, value: Dropzone) {
 		this.map.set(key, value);
+		// Auto-activate dropzones registered during an active drag.
+		if (this._isDragging) {
+			value.activate(this.activeDragData);
+		}
 	}
+
 	delete(key: HTMLElement) {
 		this.map.delete(key);
 	}
+
 	has(key: HTMLElement) {
 		return this.map.has(key);
 	}
+
 	values() {
 		return this.map.values();
 	}
+
 	entries() {
 		return this.map.entries();
+	}
+
+	/**
+	 * Called when a drag operation starts. Activates all registered
+	 * dropzones and stores the drag data so that late-registered
+	 * dropzones can be activated automatically.
+	 */
+	startDrag(data: unknown) {
+		this._isDragging = true;
+		this.activeDragData = data;
+		for (const dropzone of this.map.values()) {
+			dropzone.activate(data);
+		}
+	}
+
+	/**
+	 * Called when a drag operation ends (mouseup or cleanup).
+	 * Deactivates all dropzones and clears drag state.
+	 */
+	endDrag() {
+		this._isDragging = false;
+		this.activeDragData = undefined;
+		for (const dropzone of this.map.values()) {
+			dropzone.deactivate();
+		}
+	}
+
+	get isDragging() {
+		return this._isDragging;
 	}
 }


### PR DESCRIPTION
When a data refresh re-renders commit list components mid-drag, the
dragged element can be destroyed by Svelte. Previously, only mouseup
deactivated dropzones — so if the element was destroyed first, cleanup()
ran without deactivating them, leaving dropzones frozen in their
activated state. Additionally, new dropzones created by the re-render
were never activated because activation only happened at drag start.

Fix both issues by adding startDrag/endDrag lifecycle methods to
DropzoneRegistry. The registry now tracks active drag state and data,
auto-activating late-registered dropzones and ensuring endDrag is called
from cleanup() regardless of how the drag ends.