### PR TITLE
Show "Blocked" when PR has missing required checks

### DIFF
--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -270,6 +270,7 @@
 										{projectId}
 										branchName={pr.sourceBranch}
 										prUpdatedAt={pr.updatedAt}
+										mergeableState={pr.mergeableState}
 										isFork={pr.fork}
 										isMerged={pr.merged}
 									/>

--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -11,6 +11,7 @@
 		projectId: string;
 		branchName: string;
 		prUpdatedAt?: string;
+		mergeableState?: string;
 		hasChecks?: boolean;
 		isFork?: boolean;
 		isMerged?: boolean;
@@ -29,6 +30,7 @@
 		projectId,
 		branchName,
 		prUpdatedAt,
+		mergeableState,
 		isFork,
 		isMerged,
 		hasChecks = $bindable(),
@@ -83,6 +85,21 @@
 		}
 
 		if (checks) {
+			// GitHub only returns check runs that have actually been created.
+			// When required checks haven't reported yet, the API may return
+			// all existing checks as passed while the PR is still unmergeable.
+			if (checks.completed && checks.success) {
+				if (mergeableState === "blocked") {
+					return {
+						style: "warning",
+						icon: "warning",
+						text: "Blocked",
+						reducedText: "Blocked",
+						tooltip: "Some required checks have not reported yet.",
+					};
+				}
+			}
+
 			const style = checks.completed ? (checks.success ? "safe" : "danger") : "warning";
 			// Keep the terminal icon stable during background re-fetches
 			const icon = checks.completed ? (checks.success ? "tick" : "danger") : "spinner";
@@ -158,7 +175,13 @@
 			prUpdatedAtChangedTime !== undefined &&
 			Date.now() - prUpdatedAtChangedTime < STALE_GRACE_PERIOD_MS;
 		const checksCompleted = checksQuery?.response?.completed || checksQuery?.response === null;
-		shouldStop = !withinGracePeriod && checksCompleted;
+		// Don't stop polling if checks appear passed but the PR is blocked
+		// (some required checks may not have been created yet).
+		const blocked =
+			checksQuery?.response?.completed &&
+			checksQuery?.response?.success &&
+			mergeableState === "blocked";
+		shouldStop = !withinGracePeriod && checksCompleted && !blocked;
 
 		if (!isDone && loadedOnce && !loading && shouldStop) {
 			projectState.branchesToPoll.remove(branchName);


### PR DESCRIPTION
## Summary

GitHub only returns check runs that have actually been created. When required checks haven't reported yet, the API may show all checks as passed while the PR is still unmergeable.

This PR detects when check results all pass but the PR's `mergeableState` is `blocked`, and shows a "Blocked" warning instead of a false green checkmark. It also keeps polling in this state since new check runs may still appear.

## Test plan

- [ ] Create a PR with branch protection requiring a check that doesn't exist yet — verify "Blocked" is shown instead of green
- [ ] Create a PR where all required checks pass and `mergeableState` is `clean` — verify normal green checkmark
- [ ] Verify polling continues when state is "Blocked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)