### PR TITLE
Show 'Needs review' and 'Has conflicts' states in CI checks badge

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -85,19 +85,27 @@
 		}
 
 		if (checks) {
-			// GitHub only returns check runs that have actually been created.
-			// When required checks haven't reported yet, the API may return
-			// all existing checks as passed while the PR is still unmergeable.
-			if (checks.completed && checks.success) {
-				if (mergeableState === "blocked") {
-					return {
-						style: "warning",
-						icon: "warning",
-						text: "Blocked",
-						reducedText: "Blocked",
-						tooltip: "Some required checks have not reported yet.",
-					};
-				}
+			// When checks pass but the PR is blocked, it's typically because
+			// review approval is still required — not a CI issue.
+			if (checks.completed && checks.success && mergeableState === "blocked") {
+				return {
+					style: "warning",
+					icon: "eye",
+					text: "Needs review",
+					reducedText: "Needs review",
+					tooltip: "Checks passed but the PR still needs approval.",
+				};
+			}
+
+			// Merge conflicts can prevent checks from running at all.
+			if (mergeableState === "dirty") {
+				return {
+					style: "danger",
+					icon: "warning",
+					text: "Has conflicts",
+					reducedText: "Conflicts",
+					tooltip: "The PR has merge conflicts that need to be resolved.",
+				};
 			}
 
 			const style = checks.completed ? (checks.success ? "safe" : "danger") : "warning";
@@ -175,13 +183,7 @@
 			prUpdatedAtChangedTime !== undefined &&
 			Date.now() - prUpdatedAtChangedTime < STALE_GRACE_PERIOD_MS;
 		const checksCompleted = checksQuery?.response?.completed || checksQuery?.response === null;
-		// Don't stop polling if checks appear passed but the PR is blocked
-		// (some required checks may not have been created yet).
-		const blocked =
-			checksQuery?.response?.completed &&
-			checksQuery?.response?.success &&
-			mergeableState === "blocked";
-		shouldStop = !withinGracePeriod && checksCompleted && !blocked;
+		shouldStop = !withinGracePeriod && checksCompleted;
 
 		if (!isDone && loadedOnce && !loading && shouldStop) {
 			projectState.branchesToPoll.remove(branchName);


### PR DESCRIPTION
The CI checks badge previously showed a generic "Blocked" state whenever `mergeableState` was `blocked` and all checks passed. This was misleading because `blocked` usually means the PR needs review approval, not that checks are missing.

This replaces the generic state with two specific ones:
- **Needs review** (eye icon) — checks passed but the PR still needs approval
- **Has conflicts** (warning icon) — the PR has merge conflicts, which may prevent checks from running

Also simplifies the polling logic to stop when checks complete, rather than continuing to poll indefinitely when the PR is blocked for non-check reasons.

<img width="356" height="130" alt="image" src="https://github.com/user-attachments/assets/c42e699d-aa1b-492d-92bf-38a1bf1043c8" />
