### PR TITLE
Upgrade `gix` for better commit message trailer parsing support/better diff slider processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4430,7 +4430,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4448,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4472,13 +4472,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "kstring",
  "serde",
  "smallvec",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-error",
 ]
@@ -4497,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "gix-blame"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4506,7 +4506,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-error",
 ]
@@ -4524,19 +4524,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4590,7 +4590,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4627,7 +4627,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-traverse",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4646,7 +4646,7 @@ dependencies = [
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4655,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "dunce",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
 ]
@@ -4677,13 +4677,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4708,7 +4708,7 @@ dependencies = [
  "gix-packetline",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4730,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4764,12 +4764,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "serde",
  "unicode-bom",
 ]
@@ -4777,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "hashbrown 0.15.5",
  "memchr",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff-01"
 version = "0.1.8"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "hashbrown 0.15.5",
 ]
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4822,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4844,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4860,7 +4860,7 @@ dependencies = [
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
@@ -4869,7 +4869,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4882,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4902,7 +4902,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4922,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4944,11 +4944,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "thiserror 2.0.18",
 ]
 
@@ -4967,10 +4967,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -5004,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -5018,7 +5018,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5088,7 +5088,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
  "nonempty",
  "serde",
 ]
@@ -5096,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.2",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "filetime",
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5186,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "crc",
@@ -5215,7 +5215,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "tracing",
 ]
@@ -5223,7 +5223,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5242,7 +5242,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
@@ -5270,7 +5270,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5290,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
 ]
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5316,7 +5316,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=8f091d108cd75371be2ed9de6e81f785cda53d92#8f091d108cd75371be2ed9de6e81f785cda53d92"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
 dependencies = [
  "gix-attributes",
  "gix-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,10 +212,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "8f091d108cd75371be2ed9de6e81f785cda53d92", default-features = false, features = [
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "c261237f64c9032e72998a3bbf7ca9abf08c83b8", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "8f091d108cd75371be2ed9de6e81f785cda53d92" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "c261237f64c9032e72998a3bbf7ca9abf08c83b8" }
 
 
 insta = { version = "1.45.1", features = ["json"] }

--- a/crates/gitbutler-repo/src/commit_message.rs
+++ b/crates/gitbutler-repo/src/commit_message.rs
@@ -43,7 +43,7 @@ impl CommitMessage {
                 .map(|body_ref| {
                     body_ref
                         .trailers()
-                        .map(|trailer| (trailer.token.to_owned(), trailer.value.to_owned()))
+                        .map(|trailer| (trailer.token.to_owned(), trailer.value.into_owned()))
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default(),


### PR DESCRIPTION
Relevant for https://github.com/gitbutlerapp/gitbutler/pull/13247, https://github.com/gitbutlerapp/gitbutler/pull/13048, https://github.com/gitbutlerapp/gitbutler/pull/12948.

* [x] wait for https://github.com/GitoxideLabs/gitoxide/pull/2514 
* [x] ~~wait for https://github.com/GitoxideLabs/gitoxide/pull/2513~~ - do not wait for it, as it might cause use to require more changes, possibly, also the conflict-handling doesn't have to block on it.