### PR TITLE
Navigate explicitly after save/abort in edit mode

### DIFF
--- a/apps/desktop/src/components/workspace/EditCommitPanel.svelte
+++ b/apps/desktop/src/components/workspace/EditCommitPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from "$app/navigation";
 	import ScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
 	import ChangedFilesContextMenu from "$components/shared/ChangedFilesContextMenu.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
@@ -10,6 +11,7 @@
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { vscodePath } from "$lib/project/project";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
+	import { workspacePath } from "$lib/routes/routes.svelte";
 	import { createCommitSelection } from "$lib/selection/key";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
@@ -127,11 +129,13 @@
 	async function abort(force: boolean) {
 		if (loading) return;
 		await abortEdit({ projectId, force });
+		goto(workspacePath(projectId));
 	}
 
 	async function save() {
 		if (loading) return;
 		await saveEdit({ projectId });
+		goto(workspacePath(projectId));
 	}
 
 	async function handleSave() {


### PR DESCRIPTION
After saveEdit or abortEdit completes, navigate directly to the project
root instead of relying solely on the mode query's reactive chain. The
$effect in the edit route remains as a fallback for external mode changes.

This fixes a flaky e2e test where the workspace-view never appeared
because the mode refetch (triggered by RTK Query cache invalidation)
could be delayed under CI load, leaving the edit route's $effect waiting
indefinitely for mode.response to change.