### PR TITLE
Fix edit mode navigation race and stale conflict state on save

### DIFF
--- a/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte
+++ b/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	/**
+	 * Test harness that mirrors the conflict-tracking $effect from
+	 * EditCommitPanel. It reads conflicted files via fileService and
+	 * maintains a reactive conflictStates map, exactly like the real
+	 * component does.
+	 */
+	import { getConflictState } from "$lib/files/conflictEntryPresence";
+	import { SvelteMap } from "svelte/reactivity";
+	import type { ConflictState } from "$lib/files/conflictEntryPresence";
+	import type { FileService } from "$lib/files/fileService";
+	import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+
+	type FileEntry = {
+		path: string;
+		conflictEntryPresence?: ConflictEntryPresence;
+	};
+
+	type Props = {
+		files: FileEntry[];
+		uncommittedResponse: unknown;
+		fileService: FileService;
+		projectId: string;
+	};
+
+	const { files, uncommittedResponse, fileService, projectId }: Props = $props();
+
+	const conflictStates = new SvelteMap<string, ConflictState>();
+
+	$effect(() => {
+		void uncommittedResponse;
+
+		for (const file of files) {
+			if (!file.conflictEntryPresence) continue;
+			const presence = file.conflictEntryPresence;
+			const path = file.path;
+			fileService.readFromWorkspace(path, projectId).then((result) => {
+				conflictStates.set(path, getConflictState(presence, result.data.content));
+			});
+		}
+	});
+</script>
+
+{#each files as file (file.path)}
+	<div
+		data-testid="file-{file.path}"
+		data-conflict-state={conflictStates.get(file.path) ?? "unknown"}
+	>
+		{file.path}: {conflictStates.get(file.path) ?? "unknown"}
+	</div>
+{/each}

--- a/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte.test.ts
+++ b/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte.test.ts
@@ -1,0 +1,219 @@
+import ConflictStatesHarness from "$components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte";
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { describe, expect, test, vi } from "vitest";
+import type { FileService } from "$lib/files/fileService";
+import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+
+const BOTH_SIDES: ConflictEntryPresence = { ancestor: true, ours: true, theirs: true };
+
+function conflictContent() {
+	return "before\n<<<<<<< ours\nour change\n=======\ntheir change\n>>>>>>> theirs\nafter\n";
+}
+
+function resolvedContent() {
+	return "before\nour change\ntheir change\nafter\n";
+}
+
+function createFileService(contentByPath: Record<string, string>): FileService {
+	return {
+		readFromWorkspace: vi.fn(async (path: string) => ({
+			data: { content: contentByPath[path] ?? "" },
+			isLarge: false,
+		})),
+	} as unknown as FileService;
+}
+
+/** Wait for all pending promises and Svelte reactivity to settle. */
+async function settle() {
+	await tick();
+	await new Promise((r) => setTimeout(r, 0));
+	await tick();
+}
+
+describe("conflict state tracking", () => {
+	test("initially reads all conflicted files and sets their state", async () => {
+		const fileService = createFileService({
+			"a.txt": conflictContent(),
+			"b.txt": resolvedContent(),
+		});
+
+		render(ConflictStatesHarness, {
+			props: {
+				files: [
+					{ path: "a.txt", conflictEntryPresence: BOTH_SIDES },
+					{ path: "b.txt", conflictEntryPresence: BOTH_SIDES },
+					{ path: "c.txt" }, // no conflict presence — should not be read
+				],
+				uncommittedResponse: [],
+				fileService,
+				projectId: "proj",
+			},
+		});
+
+		await settle();
+
+		expect(screen.getByTestId("file-a.txt")).toHaveAttribute("data-conflict-state", "conflicted");
+		expect(screen.getByTestId("file-b.txt")).toHaveAttribute("data-conflict-state", "resolved");
+		expect(screen.getByTestId("file-c.txt")).toHaveAttribute("data-conflict-state", "unknown");
+
+		// Should only read conflicted files, not c.txt
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(2);
+		expect(fileService.readFromWorkspace).toHaveBeenCalledWith("a.txt", "proj");
+		expect(fileService.readFromWorkspace).toHaveBeenCalledWith("b.txt", "proj");
+	});
+
+	test("re-reads conflicted files when uncommittedResponse changes", async () => {
+		const contents: Record<string, string> = {
+			"a.txt": conflictContent(),
+		};
+
+		const fileService = createFileService(contents);
+
+		const { rerender } = render(ConflictStatesHarness, {
+			props: {
+				files: [{ path: "a.txt", conflictEntryPresence: BOTH_SIDES }],
+				uncommittedResponse: [{ path: "a.txt" }],
+				fileService,
+				projectId: "proj",
+			},
+		});
+
+		await settle();
+		expect(screen.getByTestId("file-a.txt")).toHaveAttribute("data-conflict-state", "conflicted");
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(1);
+
+		// Simulate the user resolving the conflict on disk.
+		// The file watcher would update uncommittedResponse with a new array reference.
+		contents["a.txt"] = resolvedContent();
+		await rerender({
+			files: [{ path: "a.txt", conflictEntryPresence: BOTH_SIDES }],
+			uncommittedResponse: [{ path: "a.txt" }], // new array reference
+			fileService,
+			projectId: "proj",
+		});
+
+		await settle();
+		expect(screen.getByTestId("file-a.txt")).toHaveAttribute("data-conflict-state", "resolved");
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(2);
+	});
+
+	test("does not re-read when only non-conflicted files change", async () => {
+		const fileService = createFileService({
+			"conflict.txt": conflictContent(),
+		});
+
+		const { rerender } = render(ConflictStatesHarness, {
+			props: {
+				files: [
+					{ path: "conflict.txt", conflictEntryPresence: BOTH_SIDES },
+					{ path: "normal.txt" },
+				],
+				uncommittedResponse: [{ path: "conflict.txt" }],
+				fileService,
+				projectId: "proj",
+			},
+		});
+
+		await settle();
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(1);
+
+		// A non-conflicted file is added — uncommittedResponse changes but
+		// the conflicted file set is the same. The effect re-runs but only
+		// reads conflicted files.
+		await rerender({
+			files: [
+				{ path: "conflict.txt", conflictEntryPresence: BOTH_SIDES },
+				{ path: "normal.txt" },
+				{ path: "new-normal.txt" },
+			],
+			uncommittedResponse: [{ path: "conflict.txt" }, { path: "new-normal.txt" }],
+			fileService,
+			projectId: "proj",
+		});
+
+		await settle();
+		// Should re-read conflict.txt (effect re-ran) but never read normal files
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(2);
+		expect(fileService.readFromWorkspace).toHaveBeenNthCalledWith(1, "conflict.txt", "proj");
+		expect(fileService.readFromWorkspace).toHaveBeenNthCalledWith(2, "conflict.txt", "proj");
+	});
+
+	test("skips non-conflicted files on re-read", async () => {
+		const contents: Record<string, string> = {
+			"conflict.txt": conflictContent(),
+		};
+		const fileService = createFileService(contents);
+
+		const { rerender } = render(ConflictStatesHarness, {
+			props: {
+				files: [
+					{ path: "conflict.txt", conflictEntryPresence: BOTH_SIDES },
+					{ path: "normal.txt" },
+				],
+				uncommittedResponse: [{ path: "conflict.txt" }, { path: "normal.txt" }],
+				fileService,
+				projectId: "proj",
+			},
+		});
+
+		await settle();
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(1);
+		expect(fileService.readFromWorkspace).toHaveBeenCalledWith("conflict.txt", "proj");
+
+		// Trigger re-read via new response reference
+		contents["conflict.txt"] = resolvedContent();
+		await rerender({
+			files: [{ path: "conflict.txt", conflictEntryPresence: BOTH_SIDES }, { path: "normal.txt" }],
+			uncommittedResponse: [{ path: "conflict.txt" }, { path: "normal.txt" }],
+			fileService,
+			projectId: "proj",
+		});
+
+		await settle();
+		// Should only have read conflict.txt again, never normal.txt
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(2);
+		expect(fileService.readFromWorkspace).toHaveBeenNthCalledWith(2, "conflict.txt", "proj");
+	});
+
+	test("updates state from conflicted to resolved when file is fixed", async () => {
+		const contents: Record<string, string> = {
+			"a.txt": conflictContent(),
+			"b.txt": conflictContent(),
+		};
+		const fileService = createFileService(contents);
+
+		const { rerender } = render(ConflictStatesHarness, {
+			props: {
+				files: [
+					{ path: "a.txt", conflictEntryPresence: BOTH_SIDES },
+					{ path: "b.txt", conflictEntryPresence: BOTH_SIDES },
+				],
+				uncommittedResponse: [],
+				fileService,
+				projectId: "proj",
+			},
+		});
+
+		await settle();
+		expect(screen.getByTestId("file-a.txt")).toHaveAttribute("data-conflict-state", "conflicted");
+		expect(screen.getByTestId("file-b.txt")).toHaveAttribute("data-conflict-state", "conflicted");
+
+		// Resolve only a.txt, leave b.txt conflicted
+		contents["a.txt"] = resolvedContent();
+
+		await rerender({
+			files: [
+				{ path: "a.txt", conflictEntryPresence: BOTH_SIDES },
+				{ path: "b.txt", conflictEntryPresence: BOTH_SIDES },
+			],
+			uncommittedResponse: [{ path: "a.txt" }], // new reference triggers re-read
+			fileService,
+			projectId: "proj",
+		});
+
+		await settle();
+		expect(screen.getByTestId("file-a.txt")).toHaveAttribute("data-conflict-state", "resolved");
+		expect(screen.getByTestId("file-b.txt")).toHaveAttribute("data-conflict-state", "conflicted");
+	});
+});

--- a/apps/desktop/src/components/workspace/EditCommitPanel.svelte
+++ b/apps/desktop/src/components/workspace/EditCommitPanel.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-	import { goto } from "$app/navigation";
 	import ScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
 	import ChangedFilesContextMenu from "$components/shared/ChangedFilesContextMenu.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import EditModeFileListItem from "$components/workspace/EditModeFileListItem.svelte";
 	import { getEditorUri, URL_SERVICE } from "$lib/backend/url";
 	import { splitMessage } from "$lib/commits/commitMessage";
-	import { conflictEntryHint } from "$lib/files/conflictEntryPresence";
+	import { hasUnresolvedConflictsOnDisk } from "$lib/files/conflictCheck";
+	import { conflictEntryHint, getConflictState } from "$lib/files/conflictEntryPresence";
+	import { FILE_SERVICE } from "$lib/files/fileService";
 	import { computeChangeStatus } from "$lib/files/fileStatus";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { vscodePath } from "$lib/project/project";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
-	import { workspacePath } from "$lib/routes/routes.svelte";
 	import { createCommitSelection } from "$lib/selection/key";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
@@ -19,7 +19,8 @@
 	import { inject } from "@gitbutler/core/context";
 
 	import { AsyncButton, Avatar, Badge, Button, InfoButton, Modal, TestId } from "@gitbutler/ui";
-	import { SvelteSet } from "svelte/reactivity";
+	import { SvelteMap, SvelteSet } from "svelte/reactivity";
+	import type { ConflictState } from "$lib/files/conflictEntryPresence";
 	import type { EditModeMetadata, TreeChange } from "@gitbutler/but-sdk";
 	import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
 	import type { FileStatus } from "@gitbutler/ui/components/file/types";
@@ -39,6 +40,7 @@
 	const modeService = inject(MODE_SERVICE);
 	const userSettings = inject(SETTINGS);
 	const urlService = inject(URL_SERVICE);
+	const fileService = inject(FILE_SERVICE);
 
 	const initialFiles = $derived(modeService.initialEditModeState({ projectId }));
 	const uncommittedFiles = $derived(modeService.changesSinceInitialEditState({ projectId }));
@@ -123,23 +125,43 @@
 	const conflictedFiles = $derived(files.filter((file) => file.conflicted));
 
 	let manuallyResolvedFiles = new SvelteSet<string>();
-	let stillConflictedPaths = new SvelteSet<string>();
-	const hasUnresolvedConflicts = $derived(stillConflictedPaths.size > 0);
+
+	// Per-file conflict state, updated by re-reading file content from disk.
+	// Re-reads when uncommittedFiles changes (driven by the file watcher).
+	const conflictStates = new SvelteMap<string, ConflictState>();
+
+	$effect(() => {
+		// Subscribe to uncommittedFiles so we re-read when files change on disk.
+		void uncommittedFiles.response;
+
+		for (const file of files) {
+			if (!file.conflictEntryPresence) continue;
+			const presence = file.conflictEntryPresence;
+			const path = file.path;
+			fileService.readFromWorkspace(path, projectId).then((result) => {
+				conflictStates.set(path, getConflictState(presence, result.data.content));
+			});
+		}
+	});
 
 	async function abort(force: boolean) {
 		if (loading) return;
 		await abortEdit({ projectId, force });
-		goto(workspacePath(projectId));
+		// Force-refresh the mode cache so the edit route's $effect sees
+		// the updated mode immediately and navigates to workspace.
+		// Without this, the cache relies on async tag invalidation which
+		// can be delayed, leaving us stuck on the edit page.
+		await modeService.fetchMode(projectId);
 	}
 
 	async function save() {
 		if (loading) return;
 		await saveEdit({ projectId });
-		goto(workspacePath(projectId));
+		await modeService.fetchMode(projectId);
 	}
 
 	async function handleSave() {
-		if (hasUnresolvedConflicts) {
+		if (await hasUnresolvedConflictsOnDisk(files, manuallyResolvedFiles, fileService, projectId)) {
 			confirmSaveModal?.show();
 			return;
 		}
@@ -252,12 +274,12 @@
 						>
 							{#each files as file (file.path)}
 								<EditModeFileListItem
-									{projectId}
 									filePath={file.path}
 									pathFirst={$userSettings.pathFirst}
 									fileStatus={file.status}
 									conflictHint={file.conflictHint}
 									conflictEntryPresence={file.conflictEntryPresence}
+									conflictState={conflictStates.get(file.path) ?? "unknown"}
 									manuallyResolved={manuallyResolvedFiles.has(file.path)}
 									onresolveclick={file.conflicted
 										? () => manuallyResolvedFiles.add(file.path)
@@ -266,13 +288,6 @@
 										const treeChange = getTreeChangeForFile(file);
 										if (treeChange) {
 											contextMenu?.open(e, { changes: [treeChange] });
-										}
-									}}
-									onconflictchange={(conflicted) => {
-										if (conflicted) {
-											stillConflictedPaths.add(file.path);
-										} else {
-											stillConflictedPaths.delete(file.path);
 										}
 									}}
 								/>

--- a/apps/desktop/src/components/workspace/EditModeFileListItem.svelte
+++ b/apps/desktop/src/components/workspace/EditModeFileListItem.svelte
@@ -1,68 +1,36 @@
 <script lang="ts">
-	import { getConflictState } from "$lib/files/conflictEntryPresence";
-	import { FILE_SERVICE } from "$lib/files/fileService";
-	import { inject } from "@gitbutler/core/context";
 	import { FileListItem } from "@gitbutler/ui";
-	import { isDefined } from "@gitbutler/ui/utils/typeguards";
-	import type { FileInfo } from "$lib/files/file";
+	import type { ConflictState } from "$lib/files/conflictEntryPresence";
 	import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
 	import type { FileStatus } from "@gitbutler/ui/components/file/types";
 
 	type Props = {
-		projectId: string;
 		filePath: string;
 		pathFirst: boolean;
 		fileStatus?: FileStatus;
 		conflictHint?: string;
 		conflictEntryPresence?: ConflictEntryPresence;
+		conflictState: ConflictState;
 		manuallyResolved: boolean;
 		onresolveclick?: () => void;
 		oncontextmenu?: (e: MouseEvent) => void;
-		onconflictchange?: (conflicted: boolean) => void;
 	};
 
 	const {
-		projectId,
 		filePath,
 		pathFirst,
 		fileStatus,
 		conflictHint,
 		conflictEntryPresence,
+		conflictState,
 		manuallyResolved,
 		onresolveclick,
 		oncontextmenu,
-		onconflictchange,
 	}: Props = $props();
-
-	const fileService = inject(FILE_SERVICE);
-
-	let workspaceFile = $state<{ data: FileInfo; isLarge: boolean } | undefined>(undefined);
-
-	$effect(() => {
-		if (conflictEntryPresence) {
-			fileService.readFromWorkspace(filePath, projectId).then((result) => {
-				workspaceFile = result;
-			});
-		}
-	});
-
-	const conflictState = $derived.by(() => {
-		if (!conflictEntryPresence) return "unknown";
-		if (!isDefined(workspaceFile?.data.content)) return "unknown";
-		return getConflictState(conflictEntryPresence, workspaceFile.data.content);
-	});
 
 	const conflicted = $derived(
 		conflictEntryPresence !== undefined && conflictState === "conflicted" && !manuallyResolved,
 	);
-
-	$effect(() => {
-		onconflictchange?.(conflicted);
-
-		return () => {
-			onconflictchange?.(false);
-		};
-	});
 </script>
 
 <div class="file">

--- a/apps/desktop/src/lib/files/conflictCheck.test.ts
+++ b/apps/desktop/src/lib/files/conflictCheck.test.ts
@@ -1,0 +1,77 @@
+import { hasUnresolvedConflictsOnDisk } from "$lib/files/conflictCheck";
+import { describe, expect, test, vi } from "vitest";
+import type { FileService } from "$lib/files/fileService";
+import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+
+const BOTH_SIDES_PRESENT: ConflictEntryPresence = {
+	ancestor: true,
+	ours: true,
+	theirs: true,
+};
+
+const OURS_DELETED: ConflictEntryPresence = {
+	ancestor: true,
+	ours: false,
+	theirs: true,
+};
+
+function mockFileService(contentByPath: Record<string, string>): FileService {
+	return {
+		readFromWorkspace: vi.fn(async (path: string) => ({
+			data: { content: contentByPath[path] ?? "" },
+			isLarge: false,
+		})),
+	} as unknown as FileService;
+}
+
+describe("hasUnresolvedConflictsOnDisk", () => {
+	test("skips manually resolved files", async () => {
+		const files = [
+			{
+				path: "a.txt",
+				conflictEntryPresence: BOTH_SIDES_PRESENT,
+			},
+		];
+		const fileService = mockFileService({
+			"a.txt": "<<<<<<< still has markers\n=======\n>>>>>>> but manually resolved\n",
+		});
+		const manuallyResolved = new Set(["a.txt"]);
+
+		const result = await hasUnresolvedConflictsOnDisk(files, manuallyResolved, fileService, "proj");
+
+		expect(result).toBe(false);
+		expect(fileService.readFromWorkspace).not.toHaveBeenCalled();
+	});
+
+	test("returns true for delete/modify conflicts even without markers", async () => {
+		const files = [
+			{
+				path: "deleted.txt",
+				conflictEntryPresence: OURS_DELETED,
+			},
+		];
+		const fileService = mockFileService({
+			"deleted.txt": "clean content\n",
+		});
+
+		const result = await hasUnresolvedConflictsOnDisk(files, new Set(), fileService, "proj");
+
+		expect(result).toBe(true);
+	});
+
+	test("short-circuits on first conflicted file", async () => {
+		const files = [
+			{ path: "a.txt", conflictEntryPresence: BOTH_SIDES_PRESENT },
+			{ path: "b.txt", conflictEntryPresence: BOTH_SIDES_PRESENT },
+		];
+		const fileService = mockFileService({
+			"a.txt": "<<<<<<< conflict\n=======\n>>>>>>>\n",
+			"b.txt": "resolved\n",
+		});
+
+		const result = await hasUnresolvedConflictsOnDisk(files, new Set(), fileService, "proj");
+
+		expect(result).toBe(true);
+		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/lib/files/conflictCheck.ts
+++ b/apps/desktop/src/lib/files/conflictCheck.ts
@@ -1,0 +1,31 @@
+import { getConflictState } from "$lib/files/conflictEntryPresence";
+import type { FileService } from "$lib/files/fileService";
+import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+
+interface ConflictFile {
+	path: string;
+	conflictEntryPresence?: ConflictEntryPresence;
+}
+
+/**
+ * Re-reads conflicted files from disk to check whether conflicts are
+ * truly unresolved. The reactive UI state can lag behind actual file
+ * contents, so this gives an authoritative answer at call time.
+ */
+export async function hasUnresolvedConflictsOnDisk(
+	files: ConflictFile[],
+	manuallyResolved: ReadonlySet<string>,
+	fileService: FileService,
+	projectId: string,
+): Promise<boolean> {
+	for (const file of files) {
+		if (!file.conflictEntryPresence) continue;
+		if (manuallyResolved.has(file.path)) continue;
+		const result = await fileService.readFromWorkspace(file.path, projectId);
+		const state = getConflictState(file.conflictEntryPresence, result.data.content);
+		if (state === "conflicted") {
+			return true;
+		}
+	}
+	return false;
+}

--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -41,6 +41,14 @@ export class ModeService {
 		);
 	}
 
+	/**
+	 * Force-fetch the current mode, bypassing the cache. This updates the
+	 * cache so that reactive subscribers see the new value immediately.
+	 */
+	async fetchMode(projectId: string) {
+		return await this.backendApi.endpoints.headAndMode.fetch({ projectId }, { forceRefetch: true });
+	}
+
 	head(projectId: string) {
 		return this.backendApi.endpoints.headSha.useQuery(
 			{ projectId },

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -33,7 +33,6 @@
 
 	$effect(() => {
 		if (mode.response?.type === "Edit") {
-			// That was causing an incorrect linting error when project.id was accessed inside the reactive block
 			gotoEdit();
 		}
 	});


### PR DESCRIPTION
## Summary

Two related issues were causing e2e edit-mode conflict tests to fail.

### Navigation bounce-back after save/abort

After `saveEdit`/`abortEdit`, `EditCommitPanel` called `goto(workspacePath)` (added in PR #13301). This navigated to the workspace route **before** RTK Query's async tag invalidation had updated the mode cache. The workspace route's `$effect` still saw `mode="Edit"` and redirected back to `/edit`, creating a bounce loop.

**Fix:** Replace `goto(workspacePath)` with `modeService.fetchMode()` — a force-refetch that updates the mode cache synchronously. The edit route's existing `$effect` then sees the fresh `"OpenWorkspace"` value and navigates without bouncing.

### Stale conflict state at save time

After resolving conflicts by editing the file on disk, `EditModeFileListItem` never re-read the file content, so `hasUnresolvedConflicts` remained `true` and the confirmation modal appeared unexpectedly.

**Fix:**

- Lift conflict file reading from `EditModeFileListItem` into `EditCommitPanel` via a reactive `$effect` that re-reads when `uncommittedFiles` changes, keeping the UI indicators up to date.
- Make `handleSave` re-read conflicted files from disk at click time for an authoritative check (extracted into a testable `hasUnresolvedConflictsOnDisk` function in `conflictCheck.ts`).
- `EditModeFileListItem` becomes a purely presentational component — it receives `conflictState` as a prop instead of reading files itself.

## Test plan

- [x] Unit tests for `hasUnresolvedConflictsOnDisk` (manually resolved files, delete/modify conflicts, short-circuiting)
- [x] Integration tests via `ConflictStatesHarness.svelte` verifying reactive conflict state updates, selectivity (only conflicted files are read), and state transitions from conflicted → resolved
- [x] Verified tests fail without the fix (4/5 integration tests fail when the `$effect` is removed)
- [x] e2e playwright tests pass without modal click-through workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)