### PR TITLE
Simplify undo

### DIFF
--- a/crates/but-api/src/commit/undo.rs
+++ b/crates/but-api/src/commit/undo.rs
@@ -1,9 +1,9 @@
 use crate::WorkspaceState;
 use anyhow::Context as _;
 use but_api_macros::but_api;
-use but_core::{DiffSpec, DryRun, sync::RepoExclusive};
+use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
-use but_rebase::graph_rebase::{Editor, LookupStep as _};
+use but_rebase::graph_rebase::Editor;
 use tracing::instrument;
 
 use crate::commit::types::CommitUndoResult;
@@ -80,48 +80,12 @@ pub fn commit_undo_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitUndoResult> {
-    let context_lines = ctx.settings.context_lines;
-
-    let changes = {
-        let repo = ctx.repo.get()?;
-        let commit = repo.find_commit(subject_commit_id)?;
-
-        let mut parent_ids = commit.parent_ids();
-        let first_parent = parent_ids.next().map(|id| id.detach());
-
-        // TODO: do we want to handle this?
-        anyhow::ensure!(
-            parent_ids.next().is_none(),
-            "expected {} to have at most one parent",
-            subject_commit_id.to_hex()
-        );
-
-        let changes = but_core::diff::tree_changes(&repo, first_parent, subject_commit_id)?;
-        changes.into_iter().map(DiffSpec::from).collect::<Vec<_>>()
-    };
-
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
-    let final_rebase = if changes.is_empty() {
-        but_workspace::commit::discard_commit(editor, subject_commit_id)
-            .with_context(|| format!("failed to discard {}", subject_commit_id.to_hex()))?
-    } else {
-        let but_workspace::commit::UncommitChangesOutcome {
-            rebase,
-            commit_selector,
-        } = but_workspace::commit::uncommit_changes(
-            editor,
-            subject_commit_id,
-            changes,
-            context_lines,
-        )?;
-        let new_commit = rebase.lookup_pick(commit_selector)?;
-        let editor = rebase.into_editor();
-        but_workspace::commit::discard_commit(editor, new_commit)
-            .with_context(|| format!("failed to discard {}", subject_commit_id.to_hex()))?
-    };
+    let final_rebase = but_workspace::commit::discard_commit(editor, subject_commit_id)
+        .with_context(|| format!("failed to discard {}", subject_commit_id.to_hex()))?;
 
     let workspace = if dry_run.into() {
         WorkspaceState::from_rebase_preview(&final_rebase, final_rebase.history.commit_mappings())?


### PR DESCRIPTION
The previously operation would first remove all the contents of the commit and then drop it. This works out to be the same as just dropping the commit.

IE, If I had the commits `A -> B -> C` and I want to drop `C`

In the first operation, we write `B’` to equal `A`’s tree. 
Then, we rebase C on top of `B’` to get `C’` with the 3wm `C’ = C - B + B'`.
After that we then drop `B’` and rebase `C’` directly on top of `C'’`. This means that `C’’ = C’ - B’ + A`.

Expanding this we see: `C’’ = (C - B + B’) - B’ + A` => `C’' = (C - B + A) - A + A)` => `C'’ = C - B + A`.


If I instead just drop `B` directly, we just rewrite `C` on top of `A`, we do that with the 3wm `C’ = C - B + A`. Which is the same as the other version.