### PR TITLE
Fix bugs and improve error handling found via PostHog and Sentry analysis

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -84,6 +84,7 @@
 	const commits = $derived(allCommits?.response);
 	const branchType = $derived(commits?.at(0)?.state.type || "LocalOnly");
 	const isConflicted = $derived(commits?.some((commit) => commit.hasConflicts) ?? false);
+	const hasCommits = $derived((commits?.length ?? 0) > 0);
 
 	let aiConfigurationValid = $state(false);
 
@@ -246,7 +247,7 @@
 						label="Generate branch name"
 						icon="edit-ai"
 						testId={TestId.BranchHeaderContextMenu_GenerateBranchName}
-						disabled={isReadOnly}
+						disabled={isReadOnly || !hasCommits}
 						onclick={() => {
 							generateBranchName(stackId, branchName);
 							close();

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -99,7 +99,7 @@ export function parseQueryError(error: unknown): QueryError {
 export function emitQueryError(error: unknown) {
 	const { name, message, code } = parseQueryError(error);
 	posthog.capture(QUERY_ERROR_EVENT_NAME, {
-		erro_title: name,
+		error_title: name,
 		error_message: message,
 		error_code: code,
 	});

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -90,7 +90,7 @@ export function shouldOfferToIgnoreError(title: string): boolean {
 	return isGitHubOrgAuthError(title);
 }
 
-export function shouldIgnoreThistError(title: string): boolean {
+export function shouldIgnoreThisError(title: string): boolean {
 	if (isGitHubOrgAuthError(title)) {
 		return getSwallowGitHubOrgAuthErrors();
 	}

--- a/apps/desktop/src/lib/error/showError.ts
+++ b/apps/desktop/src/lib/error/showError.ts
@@ -4,7 +4,7 @@ import {
 	isBundlingError,
 	isGitHubOrgAuthError,
 	parseError,
-	shouldIgnoreThistError,
+	shouldIgnoreThisError,
 } from "$lib/error/parser";
 import { showToast, type Toast } from "$lib/notifications/toasts";
 
@@ -22,7 +22,7 @@ export function showError(title: string, error: unknown, extraAction?: ExtraActi
 	}
 	const commonErrorTitle = getTitleFromCommonErrorMessage(message);
 	const actualTitle = name || commonErrorTitle || title;
-	const shouldIgnoreThisSpecificError = shouldIgnoreThistError(actualTitle);
+	const shouldIgnoreThisSpecificError = shouldIgnoreThisError(actualTitle);
 
 	if (!ignored && !shouldIgnoreThisSpecificError) {
 		const offerToIgnore = isGitHubOrgAuthError(actualTitle);

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -22,8 +22,25 @@ export const toastStore: Writable<Toast[]> = writable([]);
 
 let idCounter = 0;
 
+const TOAST_CAPTURE_LIMIT = 60;
+const TOAST_CAPTURE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const toastCaptureTimestamps: number[] = [];
+
+function shouldCaptureToast(): boolean {
+	const now = Date.now();
+	const cutoff = now - TOAST_CAPTURE_WINDOW_MS;
+	while (toastCaptureTimestamps.length > 0 && toastCaptureTimestamps[0]! <= cutoff) {
+		toastCaptureTimestamps.shift();
+	}
+	if (toastCaptureTimestamps.length >= TOAST_CAPTURE_LIMIT) {
+		return false;
+	}
+	toastCaptureTimestamps.push(now);
+	return true;
+}
+
 export function showToast(toast: Toast) {
-	if (toast.error) {
+	if (toast.error && shouldCaptureToast()) {
 		posthog.capture("toast:show_error", {
 			error_test_id: toast.testId,
 			error_title: toast.title,
@@ -31,7 +48,7 @@ export function showToast(toast: Toast) {
 		});
 	}
 
-	if (toast.style === "warning") {
+	if (toast.style === "warning" && shouldCaptureToast()) {
 		posthog.capture("toast:show_warning", {
 			warning_test_id: toast.testId,
 			warning_title: toast.title,

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -230,7 +230,7 @@ export class UncommittedService {
 				if (assignment.hunkHeader !== null) {
 					const hunkDiff = this.findHunkDiff(changeDiff, assignment.hunkHeader);
 					if (!hunkDiff) {
-						throw new Error("Hunk not found while commiting");
+						throw new Error("Hunk not found while committing");
 					}
 
 					if (lines.length === 0) {

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -78,24 +78,18 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 		queryArg: unknown,
 		options?: { transform?: T; forceRefetch?: boolean },
 	) {
-		// const startTime = Date.now();
 		const dispatch = getDispatch();
-		const result = await dispatch(
+		const result = dispatch(
 			initiate(queryArg, {
 				subscribe: false,
 				forceRefetch: options?.forceRefetch,
 			}),
 		);
-		const { data, error } = result;
-		if (result.error) {
-			// track({ failure: true, startTime, error });
-			throw error;
-		}
-		// track({ failure: false, startTime });
+		const data = await result.unwrap();
 		if (options?.transform && data) {
 			return options.transform(data, queryArg);
 		}
-		return result.data;
+		return data;
 	}
 
 	function useQuery<T extends TransformerFn>(

--- a/apps/desktop/src/lib/utils/ratelimit.ts
+++ b/apps/desktop/src/lib/utils/ratelimit.ts
@@ -1,3 +1,5 @@
+import { SilentError } from "$lib/error/error";
+
 type RateLimitedFunction<T extends (...args: any[]) => any> = (
 	...args: Parameters<T>
 ) => ReturnType<T> | void;
@@ -29,7 +31,7 @@ export function rateLimit<T extends (...args: any[]) => any>(params: {
 			timestamps.push(now);
 			return fn(...args);
 		} else {
-			throw new Error(`Rate limit for ${name} exceeded, ${limit} / ${windowMs}ms.`);
+			throw new SilentError(`Rate limit for ${name} exceeded, ${limit} / ${windowMs}ms.`);
 		}
 	};
 }

--- a/packages/shared/src/lib/network/httpClient.ts
+++ b/packages/shared/src/lib/network/httpClient.ts
@@ -110,6 +110,8 @@ export class HttpClient {
 async function parseResponseJSON(response: Response) {
 	if (response.status === 204 || response.status === 205) {
 		return null;
+	} else if (response.status === 401) {
+		throw new ApiError("Login token expired. Please log in to GitButler again.", response);
 	} else if (response.status >= 400) {
 		throw new ApiError(`HTTP Error ${response.statusText}: ${await response.text()}`, response);
 	} else {


### PR DESCRIPTION
Used Claude to systematically explore PostHog toast error events and
cross-reference with Sentry stack traces to identify and fix several
issues:

- Fix `erro_title`, `commiting`, and `shouldIgnoreThistError` typos
  that were polluting analytics and error handling
- Disable AI branch name generation when branch has no commits,
  preventing errors users were hitting on empty branches
- Rate limit toast error/warning PostHog captures to 60 per hour
  to reduce analytics noise while preserving signal
- Return actionable "please log in again" message for 401 API errors
  instead of opaque HTTP error text
- Use SilentError for Octokit rate limiter so internal throttling
  doesn't surface unnecessary toast errors to users
- Use RTK Query unwrap() in fetch wrapper to fix widespread
  "Cannot read properties of undefined (reading 'type')" TypeError,
  root-caused via Sentry sourcemaps to the fetch wrapper returning
  unresolved QuerySubState instead of guaranteed data