### PR TITLE
Amend selected commit in TUI

### DIFF
--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -201,6 +201,7 @@ impl Details {
             | Message::ShrinkDetails
             | Message::RegisterMessageOnDrop(_)
             | Message::WithOneFrameDelay(_)
+            | Message::Amend
             | Message::EnterNormalMode => false,
 
             Message::MoveCursorUp

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -371,6 +371,15 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
     });
 
     key_binds.register(StaticKeyBind {
+        short_description: "amend",
+        chord_display: "a",
+        key_matcher: press().code(KeyCode::Char('a')),
+        modes: Vec::from([ModeDiscriminant::Normal]),
+        message: Message::Amend,
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
         short_description: "files",
         chord_display: "f",
         key_matcher: press().code(KeyCode::Char('f')),

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -33,7 +33,10 @@ use crate::{
     CliId,
     command::legacy::{
         reword::get_branch_name_from_editor,
-        rub::RubOperationDiscriminants,
+        rub::{
+            RubOperation, RubOperationDiscriminants, StackToCommitOperation,
+            UnassignedToCommitOperation,
+        },
         status::{
             CommitLineContent, FileLineContent, StatusFlags, StatusOutputLine, TuiLaunchOptions,
             output::BranchLineContent,
@@ -723,6 +726,9 @@ impl App {
                         .saturating_add(DETAILS_SIZE_ADJUSTMENT_PERCENTAGE),
                     terminal_area,
                 );
+            }
+            Message::Amend => {
+                self.handle_amend(ctx)?;
             }
         }
 
@@ -2689,6 +2695,57 @@ impl App {
         let details_viewport = self.details_viewport(terminal_area);
         self.details.ensure_selection_visible(details_viewport);
     }
+
+    fn handle_amend(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
+        let Some(selection) = self
+            .cursor
+            .selected_line(&self.status_lines)
+            .and_then(|line| line.data.cli_id())
+        else {
+            return Ok(());
+        };
+
+        let CliId::Commit { commit_id, .. } = &**selection else {
+            return Ok(());
+        };
+
+        let stack_id = {
+            let (_guard, _, ws, _) = ctx.workspace_and_db()?;
+            ws.find_commit_and_containers(*commit_id)
+                .and_then(|(stack, _, _)| stack.id)
+        };
+
+        let (operation, confirm_message) = if let Some(stack_id) = stack_id
+            && operations::stack_has_assigned_changes(ctx, stack_id)?
+        {
+            (
+                RubOperation::StackToCommit(StackToCommitOperation {
+                    from: stack_id,
+                    to: *commit_id,
+                }),
+                format!(
+                    "Amend changes assigned to stack into {}?",
+                    commit_id.to_hex_with_len(7)
+                ),
+            )
+        } else {
+            (
+                RubOperation::UnassignedToCommit(UnassignedToCommitOperation { oid: *commit_id }),
+                format!("Amend unassigned into {}?", commit_id.to_hex_with_len(7)),
+            )
+        };
+
+        self.confirm = Some(Confirm::new(
+            confirm_message,
+            run_after_confirmation_msg(move |_, ctx, messages| {
+                let what_to_select = operations::rub(ctx, &operation)?;
+                messages.push(Message::Reload(what_to_select));
+                Ok(())
+            }),
+        ));
+
+        Ok(())
+    }
 }
 
 fn event_to_messages(ev: Event, key_binds: &KeyBinds, mode: &Mode, messages: &mut Vec<Message>) {
@@ -2775,6 +2832,7 @@ enum Message {
     EnterDetailsMode,
     LeaveDetailsMode,
     NewBranch,
+    Amend,
 
     // Utilities
     CopySelection,

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -565,6 +565,46 @@ fn key_b_creates_new_branch_from_selected_branch() {
 }
 
 #[test]
+fn key_a_amends_selected_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unassigned changes]"]);
+
+    tui.input_then_render([KeyCode::Down, KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊●   [..] add A"]);
+
+    tui.input_then_render('a')
+        .assert_current_line_eq(str!["┊●   [..] add A"])
+        .assert_rendered_contains("Amend unassigned into");
+
+    tui.input_then_render('y')
+        .assert_current_line_eq(str!["┊●   [..] add A"]);
+
+    let status = tui.env().invoke_git("status --porcelain");
+    assert_eq!(status, "", "expected amend to consume all worktree changes");
+}
+
+#[test]
+fn key_a_on_non_commit_selection_is_noop() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);
+
+    tui.input_then_render('a')
+        .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);
+}
+
+#[test]
 fn rubbing() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();


### PR DESCRIPTION
Pressing `a` will (after a confirmation step) amend unassigned changes into selected commit. If there are stack assignments those are amended instead.

This way you can keep the TUI open and press `a` to keep amending the same commit, which I find quite convenient.