### PR TITLE
Shell command mode for TUI

### DIFF
--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -231,7 +231,7 @@ impl Details {
                 RewordMessage::InlineStart | RewordMessage::InlineInput(_) => false,
             },
             Message::Command(command_message) => match command_message {
-                CommandMessage::Start | CommandMessage::Input(_) => false,
+                CommandMessage::Start(_) | CommandMessage::Input(_) => false,
                 CommandMessage::Confirm => true,
             },
             Message::Files(files_message) => match files_message {

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -9,7 +9,7 @@ use crate::command::legacy::status::tui::{
     mode::ModeDiscriminant,
 };
 
-use super::{CommitMessage, DetailsMessage, FilesMessage, MoveMessage};
+use super::{CommandModeKind, CommitMessage, DetailsMessage, FilesMessage, MoveMessage};
 
 pub(super) fn default_key_binds() -> KeyBinds {
     let mut key_binds = KeyBinds::new();
@@ -177,7 +177,16 @@ fn register_detail_key_binds(key_binds: &mut KeyBinds) {
         chord_display: ":",
         key_matcher: press().code(KeyCode::Char(':')),
         modes: Vec::from([ModeDiscriminant::Details]),
-        message: Message::Command(CommandMessage::Start),
+        message: Message::Command(CommandMessage::Start(CommandModeKind::But)),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "shell command",
+        chord_display: "!",
+        key_matcher: press().code(KeyCode::Char('!')),
+        modes: Vec::from([ModeDiscriminant::Details]),
+        message: Message::Command(CommandMessage::Start(CommandModeKind::Shell)),
         hide_from_hotbar: false,
     });
 
@@ -411,7 +420,16 @@ fn register_normal_mode_key_binds(key_binds: &mut KeyBinds) {
         chord_display: ":",
         key_matcher: press().code(KeyCode::Char(':')),
         modes: Vec::from([ModeDiscriminant::Normal]),
-        message: Message::Command(CommandMessage::Start),
+        message: Message::Command(CommandMessage::Start(CommandModeKind::But)),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(StaticKeyBind {
+        short_description: "shell command",
+        chord_display: "!",
+        key_matcher: press().code(KeyCode::Char('!')),
+        modes: Vec::from([ModeDiscriminant::Normal]),
+        message: Message::Command(CommandMessage::Start(CommandModeKind::Shell)),
         hide_from_hotbar: false,
     });
 

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -48,8 +48,9 @@ use crate::{
                 key_bind::{KeyBinds, confirm_key_binds, default_key_binds},
                 message_on_drop::MessageOnDrop,
                 mode::{
-                    CommandMode, CommitMode, CommitSource, InlineRewordMode, Mode, MoveMode,
-                    MoveSource, RubMode, RubSource, StackCommitSource, UnassignedCommitSource,
+                    CommandMode, CommandModeKind, CommitMode, CommitSource, InlineRewordMode, Mode,
+                    MoveMode, MoveSource, RubMode, RubSource, StackCommitSource,
+                    UnassignedCommitSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -651,7 +652,7 @@ impl App {
                 }
             },
             Message::Command(command_message) => match command_message {
-                CommandMessage::Start => self.handle_enter_command_mode(),
+                CommandMessage::Start(kind) => self.handle_enter_command_mode(kind),
                 CommandMessage::Input(ev) => self.handle_command_input(ev),
                 CommandMessage::Confirm => {
                     self.handle_run_command(terminal_guard, out, messages)?
@@ -2001,18 +2002,19 @@ impl App {
         Ok(())
     }
 
-    fn handle_enter_command_mode(&mut self) {
+    fn handle_enter_command_mode(&mut self, kind: CommandModeKind) {
         let mut textarea = TextArea::default();
         textarea.set_cursor_line_style(Style::default());
         textarea.move_cursor(CursorMove::End);
 
         self.mode = Mode::Command(CommandMode {
             textarea: Box::new(textarea),
+            kind,
         });
     }
 
     fn handle_command_input(&mut self, ev: Event) {
-        if let Mode::Command(CommandMode { textarea }) = &mut self.mode {
+        if let Mode::Command(CommandMode { textarea, .. }) = &mut self.mode {
             textarea.input(ev);
         }
     }
@@ -2027,7 +2029,7 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
-        let Mode::Command(CommandMode { textarea }) = &self.mode else {
+        let Mode::Command(CommandMode { textarea, kind }) = &self.mode else {
             messages.push(Message::EnterNormalMode);
             return Ok(());
         };
@@ -2036,18 +2038,31 @@ impl App {
             return Ok(());
         };
 
-        let binary_path = current_exe_for_but_exec()?;
-        let args = shell_words::split(input)?.into_iter().map(OsString::from);
-
-        let mut cmd = Command::new(binary_path);
-        cmd.args(args);
-
         let _suspend_guard = terminal_guard.suspend()?;
+
+        let mut cmd = match kind {
+            CommandModeKind::But => {
+                let binary_path = current_exe_for_but_exec()?;
+                let args = shell_words::split(input)?.into_iter().map(OsString::from);
+                let mut cmd = Command::new(binary_path);
+                cmd.args(args);
+                cmd
+            }
+            CommandModeKind::Shell => {
+                let mut args = shell_words::split(input)?.into_iter().map(OsString::from);
+                let Some(binary) = args.next() else {
+                    messages.push(Message::EnterNormalMode);
+                    return Ok(());
+                };
+                let mut cmd = Command::new(binary);
+                cmd.args(args);
+                cmd
+            }
+        };
+
         let status = cmd.spawn()?.wait()?;
 
         self.prompt_to_continue(out)?;
-
-        drop(_suspend_guard);
 
         if status.success() {
             messages.extend([Message::EnterNormalMode, Message::Reload(None)]);
@@ -2057,6 +2072,8 @@ impl App {
                 format_exit_status(status)
             )));
         }
+
+        drop(_suspend_guard);
 
         Ok(())
     }
@@ -2614,12 +2631,24 @@ impl App {
 
                 frame.render_widget(line, layout[2]);
             }
-            Mode::Command(CommandMode { textarea }) => {
-                let command_layout =
-                    Layout::horizontal([Constraint::Length(4), Constraint::Min(1)])
-                        .split(layout[2]);
+            Mode::Command(CommandMode { textarea, kind }) => {
+                let command_layout = Layout::horizontal([
+                    match kind {
+                        CommandModeKind::But => Constraint::Length(4),
+                        CommandModeKind::Shell => Constraint::Length(2),
+                    },
+                    Constraint::Min(1),
+                ])
+                .split(layout[2]);
 
-                frame.render_widget("but ", command_layout[0]);
+                match kind {
+                    CommandModeKind::But => {
+                        frame.render_widget("but ", command_layout[0]);
+                    }
+                    CommandModeKind::Shell => {
+                        frame.render_widget("$ ", command_layout[0]);
+                    }
+                }
                 frame.render_widget(&**textarea, command_layout[1]);
             }
         }
@@ -2905,7 +2934,7 @@ enum RewordMessage {
 
 #[derive(Debug, Clone)]
 enum CommandMessage {
-    Start,
+    Start(CommandModeKind),
     Input(Event),
     Confirm,
 }

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -34,7 +34,9 @@ impl Mode {
             Mode::Commit(_) => Color::Green,
             Mode::Rub(_) => Color::Blue,
             Mode::InlineReword(_) => Color::Magenta,
-            Mode::Command(_) => Color::Yellow,
+            Mode::Command(CommandMode { kind, .. }) => match kind {
+                CommandModeKind::But | CommandModeKind::Shell => Color::Yellow,
+            },
             Mode::Move(..) => Color::Cyan,
             Mode::Details => Color::Rgb(255, 165, 0), // orange
         }
@@ -114,6 +116,13 @@ impl InlineRewordMode {
 #[derive(Debug)]
 pub(super) struct CommandMode {
     pub(super) textarea: Box<TextArea<'static>>,
+    pub(super) kind: CommandModeKind,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(super) enum CommandModeKind {
+    But,
+    Shell,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Currently you can press `:` to run any but command. This is useful for things the TUI doesn't yet support and convenient because you don't have to close and re-open the TUI.

I often find myself wanting to run non-but commands though. So this adds support for pressing `!` to run any shell command. For me that'll mostly be `cargo fmt`.