### PR TITLE
Jump between first commit in branch in rub mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -336,7 +336,7 @@ impl Cursor {
         Some(Self(idx))
     }
 
-    /// Moves the cursor to the next selectable jump-target line after the current cursor position.
+    /// Moves the cursor to the first selectable row in the next section.
     #[must_use]
     pub(super) fn move_next_section(
         self,
@@ -348,19 +348,23 @@ impl Cursor {
             return None;
         }
 
-        let (idx, _) = lines
-            .iter()
-            .enumerate()
-            .skip(self.0 + 1)
-            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))?;
-        Some(Self(idx))
+        let mut next_section_start = find_next_section_start(lines, mode, self.0)?;
+        loop {
+            if let Some(idx) =
+                first_selectable_in_section(lines, mode, show_files, next_section_start)
+            {
+                return Some(Self(idx));
+            }
+
+            next_section_start = find_next_section_start(lines, mode, next_section_start)?;
+        }
     }
 
-    /// Moves the cursor to the previous selectable jump-target line.
+    /// Moves the cursor to the first selectable row in the previous section.
     ///
-    /// If the cursor is inside a section (for example, on a file or commit row), this jumps to the
-    /// current section header first. If the cursor is already on a section header, this jumps to the
-    /// previous section header.
+    /// If the cursor is inside a section, this jumps to that section's first selectable row first.
+    /// If the cursor is already on that row, this jumps to the previous section's first selectable
+    /// row.
     #[must_use]
     pub(super) fn move_previous_section(
         self,
@@ -372,23 +376,89 @@ impl Cursor {
             return None;
         }
 
-        let current_line_is_section_header = lines
-            .get(self.0)
-            .is_some_and(|line| is_section_header(line, mode));
-        let search_end = if current_line_is_section_header {
-            self.0
-        } else {
-            self.0 + 1
-        };
+        let current_section_start = find_section_start_at_or_before(lines, mode, self.0)?;
 
-        let (target_idx, _) = lines
-            .iter()
-            .enumerate()
-            .take(search_end)
-            .rev()
-            .find(|(_, line)| is_jump_target_in_mode(line, mode, show_files))?;
-        Some(Self(target_idx))
+        if let Some(current_section_first_selectable) =
+            first_selectable_in_section(lines, mode, show_files, current_section_start)
+            && self.0 != current_section_first_selectable
+        {
+            return Some(Self(current_section_first_selectable));
+        }
+
+        let mut search_end = current_section_start;
+        while let Some(previous_section_start) =
+            find_previous_section_start(lines, mode, search_end)
+        {
+            if let Some(idx) =
+                first_selectable_in_section(lines, mode, show_files, previous_section_start)
+            {
+                return Some(Self(idx));
+            }
+
+            search_end = previous_section_start;
+        }
+
+        None
     }
+}
+
+/// Finds the start index of the nearest section at or before `idx`.
+fn find_section_start_at_or_before(
+    lines: &[StatusOutputLine],
+    mode: &Mode,
+    idx: usize,
+) -> Option<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .take(idx + 1)
+        .rev()
+        .find(|(_, line)| is_section_header(line, mode))
+        .map(|(idx, _)| idx)
+}
+
+/// Finds the next section start after `idx`.
+fn find_next_section_start(lines: &[StatusOutputLine], mode: &Mode, idx: usize) -> Option<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .skip(idx + 1)
+        .find(|(_, line)| is_section_header(line, mode))
+        .map(|(idx, _)| idx)
+}
+
+/// Finds the previous section start before `search_end`.
+fn find_previous_section_start(
+    lines: &[StatusOutputLine],
+    mode: &Mode,
+    search_end: usize,
+) -> Option<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .take(search_end)
+        .rev()
+        .find(|(_, line)| is_section_header(line, mode))
+        .map(|(idx, _)| idx)
+}
+
+/// Finds the first selectable line in the section starting at `section_start`.
+fn first_selectable_in_section(
+    lines: &[StatusOutputLine],
+    mode: &Mode,
+    show_files: FilesStatusFlag,
+    section_start: usize,
+) -> Option<usize> {
+    let next_section_start =
+        find_next_section_start(lines, mode, section_start).unwrap_or(lines.len());
+
+    lines
+        .iter()
+        .enumerate()
+        .skip(section_start)
+        .take(next_section_start.saturating_sub(section_start))
+        .find(|(_, line)| is_selectable_in_mode(line, mode, show_files))
+        .map(|(idx, _)| idx)
 }
 
 /// Returns true if a line marks the boundary of a commit list within a branch section.
@@ -440,15 +510,6 @@ fn is_section_header(line: &StatusOutputLine, mode: &Mode) -> bool {
             )
         }
     }
-}
-
-/// Returns true if a line is selectable and is a jump target in the given mode.
-fn is_jump_target_in_mode(
-    line: &StatusOutputLine,
-    mode: &Mode,
-    show_files: FilesStatusFlag,
-) -> bool {
-    is_selectable_in_mode(line, mode, show_files) && is_section_header(line, mode)
 }
 
 pub(super) fn is_selectable_in_mode(

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -1259,108 +1259,69 @@ fn move_previous_section_can_jump_from_merge_base_line() {
 }
 
 #[test]
-fn move_next_section_in_rub_mode_skips_unavailable_sections() {
-    let allowed = Arc::new(CliId::Branch {
+fn move_next_section_in_rub_mode_jumps_to_first_selectable_in_next_section() {
+    let branch_a = Arc::new(CliId::Branch {
         name: "main".into(),
         id: "b0".into(),
         stack_id: None,
     });
-    let blocked = Arc::new(CliId::Branch {
-        name: "feature".into(),
+    let branch_b = Arc::new(CliId::Branch {
+        name: "release".into(),
         id: "b1".into(),
         stack_id: None,
     });
+    let commit_a = commit_cli_id("1111111111111111111111111111111111111111", "c0");
+    let commit_b = commit_cli_id("2222222222222222222222222222222222222222", "c1");
     let lines = vec![
-        line(StatusOutputLineData::Branch {
-            cli_id: blocked.clone(),
+        line(StatusOutputLineData::Branch { cli_id: branch_a }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_a.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
         }),
-        line(StatusOutputLineData::UnassignedChanges { cli_id: blocked }),
-        line(StatusOutputLineData::StagedChanges {
-            cli_id: allowed.clone(),
+        line(StatusOutputLineData::Branch { cli_id: branch_b }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_b.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
         }),
     ];
     let mode = Mode::Rub(RubMode {
         source: RubSource::CliId(unassigned("source")),
-        available_targets: vec![allowed],
+        available_targets: vec![commit_a, commit_b],
         _unlock_details: None,
     });
 
-    let mut cursor = Cursor(0);
+    let mut cursor = Cursor(1);
     if let Some(new_cursor) = cursor.move_next_section(&lines, &mode, FilesStatusFlag::All) {
         cursor = new_cursor;
     }
 
-    assert_eq!(cursor, Cursor(2));
+    assert_eq!(cursor, Cursor(3));
 }
 
 #[test]
-fn move_previous_section_in_rub_mode_moves_to_current_available_section_header() {
-    let allowed = Arc::new(CliId::Branch {
+fn move_previous_section_in_rub_mode_moves_to_first_selectable_in_current_section() {
+    let branch = Arc::new(CliId::Branch {
         name: "main".into(),
         id: "b0".into(),
         stack_id: None,
     });
-    let blocked = Arc::new(CliId::Branch {
-        name: "feature".into(),
-        id: "b1".into(),
-        stack_id: None,
-    });
-    let lines = vec![
-        line(StatusOutputLineData::UnassignedChanges {
-            cli_id: allowed.clone(),
-        }),
-        line(StatusOutputLineData::StagedChanges { cli_id: blocked }),
-        line(StatusOutputLineData::StagedChanges {
-            cli_id: allowed.clone(),
-        }),
-        line(StatusOutputLineData::StagedFile {
-            cli_id: allowed.clone(),
-        }),
-    ];
-    let mode = Mode::Rub(RubMode {
-        source: RubSource::CliId(unassigned("source")),
-        available_targets: vec![allowed],
-        _unlock_details: None,
-    });
-
-    let mut cursor = Cursor(3);
-    if let Some(new_cursor) = cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All) {
-        cursor = new_cursor;
-    }
-
-    assert_eq!(cursor, Cursor(2));
-}
-
-#[test]
-fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_previous_available_section()
- {
-    let allowed_a = Arc::new(CliId::Branch {
-        name: "main".into(),
-        id: "b0".into(),
-        stack_id: None,
-    });
-    let allowed_b = Arc::new(CliId::Branch {
-        name: "release".into(),
-        id: "b2".into(),
-        stack_id: None,
-    });
-    let blocked = Arc::new(CliId::Branch {
-        name: "feature".into(),
-        id: "b1".into(),
-        stack_id: None,
-    });
+    let commit = commit_cli_id("1111111111111111111111111111111111111111", "c0");
     let lines = vec![
         line(StatusOutputLineData::Branch {
-            cli_id: allowed_a.clone(),
+            cli_id: branch.clone(),
         }),
-        line(StatusOutputLineData::StagedChanges {
-            cli_id: allowed_b.clone(),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
         }),
-        line(StatusOutputLineData::UnassignedChanges { cli_id: blocked }),
+        line(StatusOutputLineData::StagedFile { cli_id: branch }),
     ];
     let mode = Mode::Rub(RubMode {
         source: RubSource::CliId(unassigned("source")),
-        available_targets: vec![allowed_a, allowed_b],
+        available_targets: vec![commit],
         _unlock_details: None,
     });
 
@@ -1370,6 +1331,101 @@ fn move_previous_section_in_rub_mode_from_unavailable_section_header_goes_to_pre
     }
 
     assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn move_previous_section_in_rub_mode_from_first_selectable_goes_to_previous_section_first_selectable()
+ {
+    let branch_a = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let branch_b = Arc::new(CliId::Branch {
+        name: "release".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let blocked = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b2".into(),
+        stack_id: None,
+    });
+    let commit_a = commit_cli_id("1111111111111111111111111111111111111111", "c0");
+    let commit_b = commit_cli_id("2222222222222222222222222222222222222222", "c1");
+    let lines = vec![
+        line(StatusOutputLineData::Branch { cli_id: branch_a }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_a.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+        line(StatusOutputLineData::Branch { cli_id: blocked }),
+        line(StatusOutputLineData::Branch { cli_id: branch_b }),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_b.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+    ];
+    let mode = Mode::Rub(RubMode {
+        source: RubSource::CliId(unassigned("source")),
+        available_targets: vec![commit_a, commit_b],
+        _unlock_details: None,
+    });
+
+    let mut cursor = Cursor(4);
+    if let Some(new_cursor) = cursor.move_previous_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+
+    assert_eq!(cursor, Cursor(1));
+}
+
+#[test]
+fn move_next_section_in_rub_mode_skips_sections_without_selectable_targets() {
+    let allowed_branch = Arc::new(CliId::Branch {
+        name: "main".into(),
+        id: "b0".into(),
+        stack_id: None,
+    });
+    let blocked_branch = Arc::new(CliId::Branch {
+        name: "feature".into(),
+        id: "b1".into(),
+        stack_id: None,
+    });
+    let blocked_commit = commit_cli_id("1111111111111111111111111111111111111111", "c0");
+    let allowed_commit = commit_cli_id("2222222222222222222222222222222222222222", "c1");
+    let lines = vec![
+        line(StatusOutputLineData::Branch {
+            cli_id: blocked_branch,
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: blocked_commit,
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+        line(StatusOutputLineData::Branch {
+            cli_id: allowed_branch,
+        }),
+        line(StatusOutputLineData::Commit {
+            cli_id: allowed_commit.clone(),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+    ];
+    let mode = Mode::Rub(RubMode {
+        source: RubSource::CliId(unassigned("source")),
+        available_targets: vec![allowed_commit],
+        _unlock_details: None,
+    });
+
+    let mut cursor = Cursor(0);
+    if let Some(new_cursor) = cursor.move_next_section(&lines, &mode, FilesStatusFlag::All) {
+        cursor = new_cursor;
+    }
+
+    assert_eq!(cursor, Cursor(3));
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -512,6 +512,72 @@ fn mode_toggle_key_r_enters_and_leaves_rub_mode() {
 }
 
 #[test]
+fn rub_mode_shift_j_lands_on_first_selectable_in_next_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   vo A test.txt"]);
+
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add A"]);
+}
+
+#[test]
+fn rub_mode_shift_j_can_jump_between_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   vo A test.txt"]);
+
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add A"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add B"]);
+}
+
+#[test]
+fn rub_mode_shift_k_jumps_to_first_selectable_in_previous_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks").unwrap();
+    env.setup_metadata(&["A", "B"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   vo A test.txt"]);
+
+    tui.input_then_render('r')
+        .assert_current_line_eq(str!["┊   << source >> << noop >> vo A test.txt"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add A"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('J')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add B"]);
+
+    tui.input_then_render((KeyModifiers::SHIFT, KeyCode::Char('K')))
+        .assert_current_line_eq(str!["┊●   << amend >> [..] add A"]);
+}
+
+#[test]
 fn mode_toggle_key_c_enters_and_leaves_commit_mode() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();


### PR DESCRIPTION
In the TUI you can press shift+j/k to jump between branches to get around quickly. However in rub mode you cannot select branches so shift+j/k didn't do anything. I found that annoying. So this changes it so in rub mode shift+j/k jumps to the first commit in a branch.