### PR TITLE
Clean up top PostHog/Sentry error groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-db",
+ "but-error",
  "but-hunk-assignment",
  "but-llm",
  "but-schemars",

--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -102,9 +102,11 @@
 
 		const commits = await getAllCommits();
 		const commitMessages = commits?.map((commit) => commit.message) ?? [];
-		if (commitMessages.length === 0) {
-			throw new Error("There must be commits in the branch before you can generate a branch name");
-		}
+		// The context-menu entry is disabled via `hasCommits` when there are
+		// no commits yet. Guard defensively against a race (freshly-fetched
+		// commits may lag the reactive query) — silently no-op rather than
+		// raising an error toast.
+		if (commitMessages.length === 0) return;
 
 		const prompt = promptService.selectedBranchPrompt(projectId);
 		const newBranchName = await aiService.summarizeBranch({

--- a/apps/desktop/src/components/settings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/settings/GeneralSettings.svelte
@@ -3,8 +3,11 @@
 	import CliSymlinkSetup from "$components/settings/CliSymlinkSetup.svelte";
 	import AccessTokenSignIn from "$components/shared/AccessTokenSignIn.svelte";
 	import { BACKEND } from "$lib/backend";
+	import { getUserErrorCode } from "$lib/backend/ipc";
 	import { CLI_MANAGER } from "$lib/config/cli";
+	import { Code } from "$lib/error/knownErrors";
 	import { showError } from "$lib/error/showError";
+	import { showToast } from "$lib/notifications/toasts";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import {
@@ -320,7 +323,25 @@
 						<Button
 							style="pop"
 							icon="play"
-							onclick={async () => await instalCLI()}
+							onclick={async () => {
+								try {
+									await instalCLI();
+								} catch (err: unknown) {
+									// osascript returns a generic non-success when the
+									// user dismisses the macOS admin-privileges prompt.
+									// The backend tags that specific case with a
+									// `CliInstallCancelled` code so we can show an info
+									// toast instead of an error toast.
+									if (getUserErrorCode(err) === Code.CliInstallCancelled) {
+										showToast({
+											style: "info",
+											message: "CLI install cancelled.",
+										});
+										return;
+									}
+									throw err;
+								}
+							}}
 							loading={installingCLI.current.isLoading}
 						>
 							Install But CLI</Button

--- a/apps/desktop/src/lib/ai/macros.svelte.ts
+++ b/apps/desktop/src/lib/ai/macros.svelte.ts
@@ -1,4 +1,3 @@
-import { showError } from "$lib/error/showError";
 import { showToast } from "$lib/notifications/toasts";
 import type { PromptService } from "$lib/ai/aiPromptService";
 import type DiffInputContext from "$lib/ai/diffInputContext.svelte";
@@ -44,7 +43,14 @@ export default class AIMacros {
 		const prompt = this.promptService.selectedCommitPrompt(this.projectId);
 		const diffInput = params.diffInput ?? (await this.diffInputContext.diffInput());
 		if (!diffInput) {
-			showError("Failed to generate commit message", "No changes found");
+			// "No changes" is a benign UX state (user clicked Generate with
+			// nothing selected). Surface it as an info toast rather than an
+			// error, to avoid spamming error telemetry and to keep the tone
+			// consistent with the empty state.
+			showToast({
+				style: "info",
+				message: "Nothing to summarize yet — add or select some changes first.",
+			});
 			return;
 		}
 
@@ -92,7 +98,10 @@ export default class AIMacros {
 
 		const diffInput = await this.diffInputContext.diffInput();
 		if (!diffInput) {
-			showError("Failed to generate branch name", "No changes found");
+			showToast({
+				style: "info",
+				message: "Nothing to summarize yet — add or select some changes first.",
+			});
 			return { branchName: undefined, commitMessage: undefined };
 		}
 		const branchName = await this.generateBranchNameFromDiffInput(diffInput);

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -1,5 +1,5 @@
 import { isStr } from "@gitbutler/ui/utils/string";
-import posthog from "posthog-js";
+import type { PostHogWrapper } from "$lib/telemetry/posthog";
 
 /**
  * Error type that has both a message and a status. These errors are primarily
@@ -40,6 +40,47 @@ export class SilentError extends Error {
 const QUERY_ERROR_EVENT_NAME = "query:error";
 const DEFAULT_ERROR_NAME = "QUERY:UnknownError";
 const DEFAULT_ERROR_MESSAGE = "QUERY:An unknown error occurred";
+
+const QUERY_ERROR_CAPTURE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const QUERY_ERROR_CAPTURE_LIMIT = 200;
+const QUERY_ERROR_PER_KEY_LIMIT = 5;
+const queryErrorCaptureTimestamps: number[] = [];
+const queryErrorPerKeyTimestamps = new Map<string, number[]>();
+
+function pruneTimestamps(timestamps: number[], cutoff: number) {
+	while (timestamps.length > 0 && timestamps[0]! <= cutoff) {
+		timestamps.shift();
+	}
+}
+
+function shouldCaptureQueryError(key: string): boolean {
+	const now = Date.now();
+	const cutoff = now - QUERY_ERROR_CAPTURE_WINDOW_MS;
+
+	pruneTimestamps(queryErrorCaptureTimestamps, cutoff);
+	if (queryErrorCaptureTimestamps.length >= QUERY_ERROR_CAPTURE_LIMIT) return false;
+
+	let perKey = queryErrorPerKeyTimestamps.get(key);
+	if (perKey) {
+		pruneTimestamps(perKey, cutoff);
+		if (perKey.length === 0) {
+			// Drop the bucket so the per-key map doesn't grow without
+			// bound across long sessions where commands/error titles vary.
+			queryErrorPerKeyTimestamps.delete(key);
+			perKey = undefined;
+		} else if (perKey.length >= QUERY_ERROR_PER_KEY_LIMIT) {
+			return false;
+		}
+	}
+	if (!perKey) {
+		perKey = [];
+		queryErrorPerKeyTimestamps.set(key, perKey);
+	}
+
+	perKey.push(now);
+	queryErrorCaptureTimestamps.push(now);
+	return true;
+}
 
 interface QueryError {
 	name: string;
@@ -96,11 +137,24 @@ export function parseQueryError(error: unknown): QueryError {
 	};
 }
 
-export function emitQueryError(error: unknown) {
+export function emitQueryError(
+	posthog: PostHogWrapper | undefined,
+	error: unknown,
+	context?: { command?: string; actionName?: string },
+) {
 	const { name, message, code } = parseQueryError(error);
+	if (name === "SilentError") {
+		console.warn("SilentError suppressed from query:error telemetry", error);
+		return;
+	}
+	if (!posthog) return;
+	const key = `${context?.command ?? ""}|${name}`;
+	if (!shouldCaptureQueryError(key)) return;
 	posthog.capture(QUERY_ERROR_EVENT_NAME, {
 		error_title: name,
 		error_message: message,
 		error_code: code,
+		command: context?.command,
+		actionName: context?.actionName,
 	});
 }

--- a/apps/desktop/src/lib/error/knownErrors.ts
+++ b/apps/desktop/src/lib/error/knownErrors.ts
@@ -11,6 +11,8 @@ export enum Code {
 	GitHubTokenExpired = "errors.github.expired_token",
 	ProjectDatabaseIncompatible = "errors.projectdb.migration",
 	DefaultTerminalNotFound = "errors.terminal.not_found",
+	CliInstallCancelled = "errors.cli.install_cancelled",
+	NotInEditMode = "errors.edit_mode.not_active",
 }
 
 export const KNOWN_ERRORS: Record<string, string> = {

--- a/apps/desktop/src/lib/error/logError.ts
+++ b/apps/desktop/src/lib/error/logError.ts
@@ -1,5 +1,6 @@
 import { SilentError } from "$lib/error/error";
 import { parseError } from "$lib/error/parser";
+import { isReduxError } from "$lib/error/reduxError";
 import { showError } from "$lib/error/showError";
 import { captureException } from "@sentry/sveltekit";
 
@@ -59,19 +60,35 @@ export function logError(error: unknown, options?: LogErrorOptions) {
 	}
 
 	try {
-		captureException(error, {
-			mechanism: {
-				type: "sveltekit",
-				handled: false,
-			},
-		});
-
-		// Unwrap error if it's an unhandled promise rejection.
+		// Unwrap promise rejections first so Sentry sees the underlying reason
+		// rather than the event wrapper, and so SilentError detection works
+		// against the actual thrown value.
 		if (error instanceof PromiseRejectionEvent) {
 			error = error.reason;
 		}
 
-		if (!options?.skipToast && !(error instanceof SilentError)) {
+		// `SilentError` indicates the caller already handled (or chose to
+		// suppress) the error — skip both Sentry capture and the toast so
+		// they don't double-up on noise or surface anything unexpected.
+		const silent = error instanceof SilentError;
+
+		if (!silent) {
+			// Tauri rejections arrive as plain `{name, message, code}` objects
+			// rather than `Error` instances. Sentry can't extract a stack from
+			// those, so it buckets every variant under generic
+			// "Object captured as promise rejection" groups. Wrap them in a
+			// proper Error so Sentry groups by name + message.
+			const forSentry =
+				isReduxError(error) && !(error instanceof Error) ? reduxErrorToException(error) : error;
+			captureException(forSentry, {
+				mechanism: {
+					type: "sveltekit",
+					handled: false,
+				},
+			});
+		}
+
+		if (!options?.skipToast && !silent) {
 			showError("Unhandled exception", error);
 		}
 
@@ -82,4 +99,16 @@ export function logError(error: unknown, options?: LogErrorOptions) {
 	} catch (err: unknown) {
 		console.error("Error while trying to log error.", err);
 	}
+}
+
+function reduxErrorToException(error: { name: string; message: string; code?: string }): Error {
+	const err = new Error(error.message);
+	// Prefer the backend-provided name (e.g. "API error: (push_stack)") over
+	// the default "Error" so Sentry's title grouping matches the PostHog
+	// taxonomy we already filter by.
+	err.name = error.name || "Error";
+	if (error.code) {
+		(err as Error & { code?: string }).code = error.code;
+	}
+	return err;
 }

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -1,5 +1,6 @@
 import { goto } from "$app/navigation";
 import { showError } from "$lib/error/showError";
+import { showToast } from "$lib/notifications/toasts";
 import { handleAddProjectOutcome, type Project } from "$lib/project/project";
 import { projectPath } from "$lib/routes/routes.svelte";
 import { getCookie } from "$lib/utils/cookies";
@@ -140,22 +141,34 @@ export class ProjectsService {
 	}
 
 	validateProjectPath(path: string) {
+		// These two paths represent unsupported-configuration guidance, not
+		// runtime errors. Surface them as info toasts so they don't pollute
+		// error telemetry — they previously accounted for 53 + many events
+		// of noisy toast:show_error captures.
 		if (/^\\\\wsl.localhost/i.test(path)) {
-			const errorMsg =
-				"For WSL2 projects, install the Linux version of GitButler inside of your WSL2 distro";
-			console.error(errorMsg);
-			showError("Use the Linux version of GitButler", errorMsg);
+			const message =
+				"For WSL2 projects, install the Linux version of GitButler inside of your WSL2 distro.";
+			console.warn(message);
+			showToast({
+				style: "info",
+				title: "Use the Linux version of GitButler",
+				message,
+			});
 
 			return false;
 		}
 
 		if (/^\\\\/i.test(path)) {
-			const errorMsg =
+			const message =
 				"Using git across a network is not recommended. Either clone " +
 				"the repo locally, or use the NET USE command to map a " +
-				"network drive";
-			console.error(errorMsg);
-			showError("UNC Paths are not directly supported", errorMsg);
+				"network drive.";
+			console.warn(message);
+			showToast({
+				style: "info",
+				title: "UNC paths are not directly supported",
+				message,
+			});
 
 			return false;
 		}

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -6,6 +6,7 @@ import {
 	lineIdsToHunkHeaders,
 	orderHeaders,
 } from "$lib/hunks/hunk";
+import { showToast } from "$lib/notifications/toasts";
 import { compositeKey, partialKey, type HunkSelection } from "$lib/selection/entityAdapters";
 import {
 	uncommittedSelectors,
@@ -73,15 +74,19 @@ export class UncommittedService {
 		this.dispatch(uncommittedActions.clearHunkSelection({ stackId: stackId || null }));
 	}
 
-	async getUnifiedDiff(projectId: string, change: TreeChange): Promise<UnifiedDiff> {
-		const changeDiff = await this.diffService.fetchDiff(projectId, change);
-		if (!changeDiff) {
-			throw new Error("Failed to fetch diff");
-		}
-		return changeDiff;
+	async getUnifiedDiff(projectId: string, change: TreeChange): Promise<UnifiedDiff | null> {
+		// Real IPC / query failures now surface via RTK `unwrap()` in the
+		// underlying fetch path, so they throw and propagate as structured
+		// errors. A `null` result just means no patch data is available
+		// (e.g. binary content or an edge-case rename) — what callers do
+		// with that varies: hunk selection treats it as "no hunks to
+		// match" and may skip the path, while whole-file commits happen
+		// only when no hunks were requested or a caller explicitly falls
+		// back to that.
+		return await this.diffService.fetchDiff(projectId, change);
 	}
 
-	findHunkDiff(changeDiff: UnifiedDiff, hunk: HunkHeader): DiffHunk | undefined {
+	findHunkDiff(changeDiff: UnifiedDiff | null, hunk: HunkHeader): DiffHunk | undefined {
 		if (changeDiff?.type !== "Patch") return undefined;
 
 		const hunkDiff = changeDiff.subject.hunks.find(
@@ -97,7 +102,7 @@ export class UncommittedService {
 	/**
 	 * Check whether the given hunks represent a completely selected file.
 	 */
-	isCompletelySelectedFile(changeDiff: UnifiedDiff, hunkHeaders: HunkHeader[]): boolean {
+	isCompletelySelectedFile(changeDiff: UnifiedDiff | null, hunkHeaders: HunkHeader[]): boolean {
 		if (changeDiff?.type !== "Patch") return false;
 		const fileHunks = changeDiff.subject.hunks;
 
@@ -123,7 +128,7 @@ export class UncommittedService {
 	}
 
 	processHunkHeaders(
-		changeDiff: UnifiedDiff,
+		changeDiff: UnifiedDiff | null,
 		preprocessedHeaders: PreprocessedHunkHeader[],
 	): HunkHeader[] {
 		const finalHunkHeaders: HunkHeader[] = [];
@@ -193,6 +198,7 @@ export class UncommittedService {
 		}, {});
 
 		const worktreeChanges: DiffSpec[] = [];
+		const skippedStalePaths: string[] = [];
 		for (const [path, selection] of Object.entries(pathGroups)) {
 			const preprocessedHeaders: PreprocessedHunkHeader[] = [];
 			const change = uncommittedSelectors.treeChanges.selectById(state.treeChanges, path)!;
@@ -220,6 +226,7 @@ export class UncommittedService {
 			}
 
 			const changeDiff = await this.getUnifiedDiff(projectId, change);
+			let staleSkipped = 0;
 			for (const { lines, assignmentId } of selection) {
 				// We want to use `null` to commit from unassigned changes if new stack was created.
 				const assignment = uncommittedSelectors.hunkAssignments.selectById(
@@ -230,7 +237,13 @@ export class UncommittedService {
 				if (assignment.hunkHeader !== null) {
 					const hunkDiff = this.findHunkDiff(changeDiff, assignment.hunkHeader);
 					if (!hunkDiff) {
-						throw new Error("Hunk not found while committing");
+						// The diff has shifted since the hunk was selected (file was
+						// edited, saved, or a refresh raced the commit). Skip this
+						// stale selection rather than failing the whole commit — any
+						// still-matching hunks in the same file commit normally.
+						console.warn("Skipping stale hunk selection while committing", assignment.hunkHeader);
+						staleSkipped++;
+						continue;
 					}
 
 					if (lines.length === 0) {
@@ -254,10 +267,29 @@ export class UncommittedService {
 				}
 			}
 
+			// If the user had specific hunk selections but every one of them
+			// was stale, do NOT fall through to "commit the whole file" — that
+			// would silently commit more than the user asked for. Skip the
+			// file entirely and surface a notice so they can reselect.
+			if (preprocessedHeaders.length === 0 && staleSkipped > 0) {
+				skippedStalePaths.push(path);
+				continue;
+			}
+
 			worktreeChanges.push({
 				pathBytes: change.pathBytes,
 				previousPathBytes,
 				hunkHeaders: await this.processHunkHeaders(changeDiff, preprocessedHeaders),
+			});
+		}
+
+		if (skippedStalePaths.length > 0) {
+			const label =
+				skippedStalePaths.length === 1 ? skippedStalePaths[0] : `${skippedStalePaths.length} files`;
+			showToast({
+				style: "info",
+				title: "Some selections skipped",
+				message: `The diff for ${label} shifted since you selected it. Please reselect to commit those changes.`,
 			});
 		}
 

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -127,7 +127,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 			if (result.error) {
 				const error = result.error;
 				// track({ failure: true, startTime, error });
-				emitQueryError(error);
+				emitQueryError(posthog, error, { command, actionName });
 			}
 			if (options?.transform && data) {
 				data = options.transform(data, queryArg);

--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -202,9 +202,58 @@ function isOffline(err: any): boolean {
 	);
 }
 
+// Patterns that identify an immutable install location where the
+// auto-updater physically cannot write. We match a few concrete forms
+// rather than anything permission-flavored — "Permission denied" alone
+// is too broad and would swallow real errors.
+//
+// - "read-only file system" / "readonly filesystem": POSIX EROFS text,
+//   surfaces on Linux, macOS, and a mounted DMG.
+// - "erofs" / "os error 30": the errno symbol and its Linux numeric form.
+// - "os error 6032": a Windows ERROR_WRITE_PROTECT surface that appears in
+//   std::io::Error Debug output. We deliberately don't match the bare
+//   Windows error code 19 — on Linux errno 19 is ENODEV ("No such device"),
+//   and a bare "os error 19" match would conflate the two.
+// - "write[- ]protected": Windows "The media is write protected", plus
+//   a few translated variants that route through the same phrase.
+const READ_ONLY_FS_PATTERNS = [
+	/read-only file system/i,
+	/readonly file ?system/i,
+	/\berofs\b/i,
+	/\bos error 30\b/i,
+	/\bos error 6032\b/i,
+	/write[- ]protected/i,
+];
+
+function isReadOnlyFilesystem(err: any): boolean {
+	const message =
+		typeof err === "string"
+			? err
+			: err && typeof err === "object" && "message" in err
+				? String((err as { message: unknown }).message)
+				: "";
+	return READ_ONLY_FS_PATTERNS.some((p) => p.test(message));
+}
+
 function handleError(err: any, manual: boolean) {
 	if (!manual && isOffline(err)) return;
 	console.error(err);
+	if (isReadOnlyFilesystem(err)) {
+		// Installed into an immutable location (Homebrew Cask, Flatpak, AppImage,
+		// an un-extracted DMG). Surface as a neutral guidance toast — there's no
+		// in-app remediation, the user needs to reinstall manually.
+		showToast({
+			style: "info",
+			title: "Can't update in place",
+			message: `
+                GitButler appears to be installed in a read-only location, so
+                the auto-updater can't replace it. Please reinstall or update
+                via your package manager, or download the latest release from
+                our [downloads](https://app.gitbutler.com/downloads) page.
+            `,
+		});
+		return;
+	}
 	showToast({
 		title: "App update failed",
 		message: `

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -18,6 +18,7 @@ builtin-but = []
 but-serde.workspace = true
 but-db.workspace = true
 but-core.workspace = true
+but-error.workspace = true
 but-workspace = { workspace = true, features = ["legacy"] }
 but-hunk-assignment.workspace = true
 but-tools.workspace = true

--- a/crates/but-action/src/cli.rs
+++ b/crates/but-action/src/cli.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, anyhow, bail};
+use but_error::{Code, Context as ErrorContext};
 
 pub fn get_cli_path() -> anyhow::Result<std::path::PathBuf> {
     let cli_path = std::env::current_exe()?;
@@ -75,8 +76,25 @@ pub fn do_install_cli(mode: InstallMode) -> anyhow::Result<()> {
 
         if status.success() {
             Ok(())
+        } else if status.code() == Some(1) {
+            // osascript exits 1 when the user dismisses the admin-privileges
+            // prompt. This is a benign abort, not an error — tag it with a
+            // dedicated Code so the frontend can react based on the code
+            // rather than matching on an English message.
+            Err(
+                anyhow!("osascript exited with status 1").context(ErrorContext::new_static(
+                    Code::CliInstallCancelled,
+                    "CLI install cancelled",
+                )),
+            )
         } else {
-            Err(anyhow!("error running osascript"))
+            Err(anyhow!(
+                "osascript exited with status {}",
+                status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "unknown".into())
+            ))
         }
     } else {
         Err(anyhow!(

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -138,6 +138,15 @@ pub enum Code {
     NetworkError,
     ProjectDatabaseIncompatible,
     DefaultTerminalNotFound,
+    /// The user dismissed the macOS admin-privileges prompt when installing
+    /// the `but` CLI. Not a real failure — the frontend swaps it for a
+    /// neutral info toast.
+    CliInstallCancelled,
+    /// The GitHub access token was rejected. Currently only synthesized by
+    /// the frontend when an Octokit response message starts with
+    /// "Not Found -" — kept here so the wire-level `Code` enum is the
+    /// single source of truth for codes the desktop app may surface.
+    GitHubTokenExpired,
 }
 
 impl std::fmt::Display for Code {
@@ -159,6 +168,8 @@ impl std::fmt::Display for Code {
             Code::NetworkError => "errors.network",
             Code::ProjectDatabaseIncompatible => "errors.projectdb.migration",
             Code::DefaultTerminalNotFound => "errors.terminal.not_found",
+            Code::CliInstallCancelled => "errors.cli.install_cancelled",
+            Code::GitHubTokenExpired => "errors.github.expired_token",
         };
         f.write_str(code)
     }

--- a/crates/but-secret/src/secret.rs
+++ b/crates/but-secret/src/secret.rs
@@ -37,42 +37,59 @@ pub fn persist(handle: &str, secret: &Sensitive<String>, namespace: Namespace) -
 /// Obtain the previously [stored](persist()) secret known as `handle` from `namespace`.
 pub fn retrieve(handle: &str, namespace: Namespace) -> Result<Option<Sensitive<String>>> {
     match entry_for(handle, namespace)
-        .map_err(annotate_linux_keychain)?
+        .map_err(annotate_keychain_error)?
         .get_password()
     {
         Ok(secret) => Ok(Some(Sensitive(secret))),
         Err(keyring::Error::NoEntry) => Ok(None),
-        Err(err) => Err(annotate_linux_keychain(err.into())),
+        Err(err) => Err(annotate_keychain_error(err.into())),
     }
 }
 
-fn annotate_linux_keychain(err: anyhow::Error) -> anyhow::Error {
-    if !cfg!(target_os = "linux") {
-        return err;
+fn annotate_keychain_error(err: anyhow::Error) -> anyhow::Error {
+    let err_string = err.to_string();
+
+    if cfg!(target_os = "linux") {
+        // We could try to match on the original, but due to a lack of testing
+        // we have to blanket-catch these errors in multiple places.
+        // This is fine, except for when we might be dependent on the locale.
+        // If this is an issue, actually test this.
+        if err_string.contains(" org.freedesktop.secrets ")
+            // This is supposed to prevent the DBus-Error to trigger a popup on CI which disturbs E2E tests.
+            // Ideally, e2e could be made to auto-confirm this particular message after a timeout, maybe?
+            || (!cfg!(debug_assertions) && err_string.contains("DBus error"))
+        {
+            // Attach an explicit, stable message alongside the Code so the
+            // frontend/telemetry see a human-readable label instead of the raw
+            // DBus error string (which varies by distro/locale and leaks the
+            // i18n translation key into PostHog).
+            return err.context(but_error::Context::new_static(
+                but_error::Code::SecretKeychainNotFound,
+                "System keychain is not available",
+            ));
+        } else if err_string.contains("Secret Service: no result found") {
+            return err.context(but_error::Context::new_static(
+                but_error::Code::MissingLoginKeychain,
+                "Login keychain is missing",
+            ));
+        }
     }
 
-    // We could try to match on the original, but due to a lack of testing
-    // we have to blanket-catch these errors in multiple places.
-    // This is fine, except for when we might be dependent on the locale.
-    // If this is an issue, actually test this.
-    let err_string = err.to_string();
-    if err_string.contains(" org.freedesktop.secrets ")
-        // This is supposed to prevent the DBus-Error to trigger a popup on CI which disturbs E2E tests.
-        // Ideally, e2e could be made to auto-confirm this particular message after a timeout, maybe?
-        || (!cfg!(debug_assertions) && err_string.contains("DBus error"))
-    {
-        err.context(but_error::Code::SecretKeychainNotFound)
-    } else if err_string.contains("Secret Service: no result found") {
-        err.context(but_error::Code::MissingLoginKeychain)
-    } else {
-        err
-    }
+    // On macOS/Windows the platform-level keychain is always present, so we
+    // don't have a dedicated Code for these cases. Still attach a stable
+    // English label so PostHog can aggregate these instead of bucketing
+    // every localized platform error separately. Linux errors that didn't
+    // match a known shape fall through here too.
+    err.context(but_error::Context::new_static(
+        but_error::Code::Unknown,
+        "System keychain access failed",
+    ))
 }
 
 /// Delete the secret at `handle` permanently from `namespace`.
 pub fn delete(handle: &str, namespace: Namespace) -> Result<()> {
     match entry_for(handle, namespace)
-        .map_err(annotate_linux_keychain)?
+        .map_err(annotate_keychain_error)?
         .delete_credential()
     {
         Ok(_) => Ok(()),
@@ -80,7 +97,7 @@ pub fn delete(handle: &str, namespace: Namespace) -> Result<()> {
             // Fail silently if it doesn't exist.
             Ok(())
         }
-        Err(err) => Err(annotate_linux_keychain(err.into())),
+        Err(err) => Err(annotate_keychain_error(err.into())),
     }
 }
 

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context as _, Result};
 use but_core::{ref_metadata::StackId, ui::TreeChange};
 use but_ctx::Context;
-use gitbutler_operating_modes::{EditModeMetadata, ensure_edit_mode, ensure_open_workspace_mode};
+use gitbutler_operating_modes::{
+    EditModeMetadata, ensure_edit_mode, ensure_open_workspace_mode, in_edit_mode,
+};
 use gitbutler_oplog::{
     OplogExt,
     entry::{OperationKind, SnapshotDetails},
@@ -67,7 +69,13 @@ pub fn starting_index_state(
 pub fn changes_from_initial(ctx: &mut Context) -> Result<Vec<TreeChange>> {
     let guard = ctx.exclusive_worktree_access();
 
-    ensure_edit_mode(ctx, guard.read_permission())?;
+    // The frontend's `worktree_changes` listener may fire one last event
+    // after the workspace has already left edit mode. Treat that as "no
+    // changes" instead of an error so the listener can stay simple and
+    // PostHog/Sentry don't see a noisy benign error.
+    if !in_edit_mode(ctx, guard.read_permission())? {
+        return Ok(Vec::new());
+    }
 
     let state = crate::changes_from_initial(ctx, guard.read_permission())?;
     Ok(state.into_iter().map(|a| a.into()).collect())

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Result, anyhow, bail};
 use bstr::BString;
 use but_core::{ref_metadata::StackId, sync::RepoShared};
 use but_ctx::Context;
@@ -198,7 +198,7 @@ pub fn in_edit_mode(ctx: &Context, perm: &RepoShared) -> Result<bool> {
 pub fn ensure_edit_mode(ctx: &Context, perm: &RepoShared) -> Result<EditModeMetadata> {
     match operating_mode(ctx, perm)? {
         OperatingMode::Edit(edit_mode_metadata) => Ok(edit_mode_metadata),
-        _ => bail!("Expected to be in edit mode"),
+        _ => Err(anyhow!("Expected to be in edit mode")),
     }
 }
 

--- a/crates/gitbutler-repo/src/commands.rs
+++ b/crates/gitbutler-repo/src/commands.rs
@@ -36,6 +36,19 @@ impl FileInfo {
         Self::default()
     }
 
+    /// A placeholder for a path that points at a directory rather than a
+    /// regular file (typically a git submodule surfacing as a real
+    /// directory in the worktree). Returns empty text content so existing
+    /// text-rendering consumers can display it without error.
+    pub fn directory(path_in_worktree: &Path) -> Self {
+        FileInfo {
+            content: Some(String::new()),
+            file_name: Self::file_name_str(path_in_worktree),
+            size: Some(0),
+            mime_type: None,
+        }
+    }
+
     pub fn from_content(path_in_worktree: &Path, content: &[u8]) -> Self {
         if Self::is_binary(content) {
             FileInfo::image_or_empty(path_in_worktree, content)
@@ -295,10 +308,15 @@ impl RepoCommands for Context {
                     let content = std::fs::read_link(&path)?;
                     FileInfo::utf8_text_or_binary(&relative_path, &gix::path::into_bstr(content))
                 } else if md.is_dir() {
-                    bail!(
-                        "Path to read from at '{}' is a directory",
-                        relative_path.display(),
-                    );
+                    // Directories on disk (notably git submodules, which appear
+                    // as real directories in the worktree but are represented
+                    // as commit entries in the tree) have no readable file
+                    // content. Return a placeholder FileInfo so callers —
+                    // conflict checks, diff viewers — can handle the case
+                    // gracefully, rather than surfacing an opaque "is a
+                    // directory" toast. Note that the placeholder is shaped
+                    // identically to a real zero-byte text file.
+                    FileInfo::directory(&relative_path)
                 } else {
                     warn!(
                         ?relative_path,

--- a/crates/gitbutler-repo/tests/repo/read_file_from_workspace_security.rs
+++ b/crates/gitbutler-repo/tests/repo/read_file_from_workspace_security.rs
@@ -120,6 +120,26 @@ fn reads_deleted_file_from_head_commit() {
 }
 
 #[test]
+fn returns_empty_for_directory_path() {
+    // Directories on disk — including git submodules, which appear as real
+    // directories in the worktree but as commit entries in the tree — should
+    // not error out. Callers (conflict checks, diff viewers) depend on getting
+    // a FileInfo back rather than an exception.
+    let (repo, _tmp) = test_repository();
+    let workdir = repo.workdir().expect("workdir exists");
+    fs::create_dir(workdir.join("subdir")).expect("create directory");
+
+    let ctx = context_for_repo(workdir);
+    let info = ctx
+        .read_file_from_workspace(Path::new("subdir"))
+        .expect("directory path should be readable as empty FileInfo");
+
+    assert_eq!(info.content, Some(String::new()));
+    assert_eq!(info.size, Some(0));
+    assert_eq!(info.mime_type, None);
+}
+
+#[test]
 fn keeps_absolute_inside_worktree_behavior() {
     let (repo, _tmp) = test_repository();
     let workdir = repo.workdir().expect("workdir exists");


### PR DESCRIPTION
## Summary

Work through the highest-volume `toast:show_error` and `query:error` groups from PostHog (last 30 days, prod builds), fixing real bugs, converting benign conditions into info toasts, and tightening telemetry so future cleanups have cleaner signal.

`query:error` was ~1.6M events / 14 days — roughly 100× `toast:show_error`. Expected ~20–30× reduction without losing signal.

## Bug fixes

- **Path is a directory** — `read_file_from_workspace` now returns an empty `FileInfo` for directories via a `FileInfo::directory()` semantic constructor (`crates/gitbutler-repo/src/commands.rs`). 188 events / 14 users.
- **Hunk not found while committing** — `uncommittedService.svelte.ts` skips hunks whose diffs shifted since selection, and drops the whole file via info toast when every selection on a path went stale (previously interpreted as *commit whole file* — a latent data-loss risk). 56 events / 17 users.
- **Failed to fetch diff** — removed `throw` in `getUnifiedDiff`, widened return type to `UnifiedDiff | null`; callers already handle null via optional chaining; real IPC errors still surface via RTK `unwrap()`. 57 events / 11 users.
- **Expected to be in edit mode** — `edit_changes_from_initial` returns an empty `Vec` when not in edit mode instead of erroring. The frontend's `worktree_changes` listener routinely fires one last event after the workspace has left edit mode; treating that as "no changes" lets the listener stay simple. ~2.8k events / 350 users.
- **Previous-session fixes carried in** — RTK Query `unwrap()` in `customHooks.svelte.ts` (`TypeError: ... i.type` — 272 events / 81 users); `erro_title` PostHog typo; `commiting` typo; `shouldIgnoreThistError` typo; AI generate-branch-name disabled on empty branch.

## UX conversions (noisy but legitimate)

- **AI generate on no changes** → info toast (covers both commit-message and branch-name paths). 104 events / 48 users.
- **WSL2 / UNC path guidance** → info toast for both unsupported-path cases in `projectsService.ts`. 53 events / 37 users.
- **install_cli osascript decline** → info toast. Rust attaches a stable error code on status-1 so the frontend can match on it instead of an English substring. 32 events / 24 users.
- **App updater on read-only filesystem** → info toast with guidance. Detection covers EROFS / `os error 30`, Windows `os error 6032` (`ERROR_WRITE_PROTECT`), and `"write-protected"` / `"write protected"` phrasing (bare "Permission denied" deliberately excluded to avoid over-matching). 14 events / 5 users.

## Telemetry hardening

- **Octokit rate-limit → `SilentError`** so internal throttling no longer toasts (~76 events).
- **Keychain annotations** — renamed `annotate_linux_keychain` → `annotate_keychain_error`; attaches a stable `"System keychain access failed"` label on macOS/Windows and unmatched Linux paths too, so PostHog aggregates rather than bucketing every localized error. 23 events / 21 users.
- **401 Unauthorized** → actionable *"Login token expired. Please log in to GitButler again."* in `httpClient.ts`. 120 events / 95 users.
- **Toast PostHog captures rate-limited** to 60/hour in `toasts.ts` (caps runaway "Failed to fetch" spikes).

## `query:error` path (high-volume silent RTK Query errors)

- **`emitQueryError` now routes through `PostHogWrapper`**, adds a 60-minute rolling window with an overall 200-event cap and a 5-event cap per `(command, error_title)` pair, and skips `SilentError` (with a `console.warn` so it's still visible locally).
- **`customHooks.svelte.ts` forwards `command` + `actionName`** into the capture payload so PostHog can group by command instead of string-parsing `API error: (cmd)` out of `error_message`. Surfaces clusters like per-project `stacks` / `list_reviews` that were previously fragmented across one-user buckets with project IDs embedded in the message.
- **`erro_title` typo** confirmed fixed at all four capture sites. Deployed `1.360.2` still emits the typo because the fix rode into nightly but hasn't shipped a stable release yet; next release clears it.

## Follow-ups from review (addressed on-branch)

- **Silent whole-file commit risk** — see *Hunk not found* above; stale-skip count tracked per path, file dropped from commit with info toast when every selection was stale.
- **Directory vs. empty-file ambiguity** — `FileInfo::directory()` introduced as a semantic constructor. No dedicated marker field added: no current consumer distinguishes directories from zero-byte files, and overloading `mime_type` with `inode/directory` would confuse the `ImageDiff` renderer that uses the field for `data:` URL building. `is_directory: bool` can be added later if a consumer needs it.
- **osascript cancel string-matching** replaced with a stable error-code match.
- **RO-filesystem pattern** broadened beyond Linux/English (EROFS numeric, Windows write-protect code, write-protected phrasing).
- **Keychain annotation Linux-only** → now covers macOS/Windows + unmatched Linux too.

## Not addressed (deferred / out of scope)

- **`forge_provider` not found / ACL-blocked** (~67k events / ~5k users): feature-flag gating on call sites is a separate effort. The new rate limit already dedupes this down to ~5 events/user/hour per command.
- **Linux auto-updater "invalid updater binary format"** (178 events / 103 users): Tauri/distro issue, separate effort.
- **Single-user environment-specific loops** (`set_project_active` perm-denied, Windows `R:/` ownership, `.git/refs .lock`, etc.): not actionable code-side.
- **Disable AI-generate button when no changes**: would require reactive plumbing from selection/diff state up to the toolbar. Info-toast conversion already removes the noise.
- **Modal/inline messaging for WSL2/UNC**: UX decision for a separate design pass.

## Test plan

- [ ] `cargo clippy --all-targets --workspace` — clean
- [ ] `pnpm begood` — clean
- [ ] `cargo test -p gitbutler-repo --test repo returns_empty_for_directory_path` — passes
- [ ] Manual: open a file picker on a directory path → empty content, no error toast
- [ ] Manual: trigger AI generate on a branch with no changes → info toast, not error
- [ ] Manual: decline the `install_cli` macOS auth prompt → info toast, not error
- [ ] Manual: sign out / 401 → "Login token expired" toast, not raw 401
- [ ] Post-deploy: confirm `query:error` volume drops 20–30× and `error_title` is populated on all events

🤖 Generated with [Claude Code](https://claude.com/claude-code)