### PR TITLE
but-graph: detect force-push need when remote tip is owned by an upper stack segment

### DIFF
--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -9,7 +9,7 @@ use but_core::ref_metadata::{
     self, StackId,
     StackKind::{Applied, AppliedAndUnapplied},
 };
-use gix::refs::Category;
+use gix::{ObjectId, refs::Category};
 use itertools::Itertools;
 use petgraph::{
     Direction,
@@ -386,7 +386,7 @@ impl Graph {
         target_ref: Option<&TargetRef>,
         target_commit: Option<&TargetCommit>,
         additional: impl IntoIterator<Item = SegmentIndex>,
-    ) -> Option<(gix::ObjectId, SegmentIndex)> {
+    ) -> Option<(ObjectId, SegmentIndex)> {
         // It's important to not start from the tip, but instead find paths to the merge-base from each stack individually.
         // Otherwise, we may end up with a short path to a segment that isn't actually reachable by all stacks.
         let (tips, actual_tip) = match tip {
@@ -834,23 +834,26 @@ impl WorkspaceState {
     /// - commits that are purely remote (never existed locally or pre-rebase versions), and
     /// - non-integrated commits from upper stack segments that are still on the
     ///   remote (the "branch split" case — a previously combined push left the
-    ///   remote pointing at commits that now belong to a higher branch).
+    ///   remote pointing at commits that now belong to branch above it).
     fn add_commits_on_remote(&mut self, graph: &Graph) {
         for stack in &mut self.stacks {
             let mut above_commit_ids = HashSet::new();
             for seg_idx in 0..stack.segments.len() {
                 let Some(rsidx) = stack.segments[seg_idx].remote_tracking_branch_segment_id else {
                     // Still accumulate this segment's commits for lower segments.
-                    for commit in &stack.segments[seg_idx].commits {
-                        above_commit_ids.insert(commit.id);
-                    }
+                    above_commit_ids.extend(stack.segments[seg_idx].commits.iter().map(|c| c.id));
                     continue;
                 };
 
-                // All-parents walk: collect commits from fully-remote segments.
+                // All-parents walk: collect commits from *fully*-remote segments.
                 // Stop at segments that contain non-remote commits or that belong
-                // to another remote-branch (unless we started empty, which signals
-                // ambiguous ownership).
+                // to another remote-branch, unless this segment is empty and
+                // the first reachable remote commits can't be uniquely attributed.
+                // This happens if multiple remote tracking branches point to the same commit,
+                // which is when ours might be empty because it was traversed after the one which
+                // then gets to own the commit.
+                // So `may_take_from_first_remote` allows us to pretend that these commits
+                // belong to our remote (which they do as well from a pure graph perspective).
                 let mut may_take_from_first_remote = graph[rsidx].commits.is_empty();
                 let mut remote_commits = Vec::new();
                 graph.visit_all_segments_including_start_until(
@@ -879,18 +882,10 @@ impl WorkspaceState {
                 );
 
                 // First-parent walk: detect non-integrated commits from upper
-                // stack segments that are still on the remote (branch-split case).
+                // stack segments that are still reachable by the remote tracking branch.
                 if !above_commit_ids.is_empty() {
                     let mut seen: HashSet<_> = remote_commits.iter().map(|c| c.id).collect();
                     let mut extra = Vec::new();
-                    for commit in &graph[rsidx].commits {
-                        if above_commit_ids.contains(&commit.id)
-                            && !commit.flags.contains(CommitFlags::Integrated)
-                            && seen.insert(commit.id)
-                        {
-                            extra.push(StackCommit::from_graph_commit(commit));
-                        }
-                    }
                     graph.visit_segments_downward_along_first_parent_exclude_start(rsidx, |s| {
                         if s.ref_name()
                             .is_some_and(|rn| rn.category() == Some(Category::RemoteBranch))
@@ -913,9 +908,7 @@ impl WorkspaceState {
                 stack.segments[seg_idx].commits_on_remote = remote_commits;
 
                 // Accumulate this segment's commits for lower segments.
-                for commit in &stack.segments[seg_idx].commits {
-                    above_commit_ids.insert(commit.id);
-                }
+                above_commit_ids.extend(stack.segments[seg_idx].commits.iter().map(|c| c.id));
             }
         }
     }

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeSet, HashSet, VecDeque},
 };
 
 use anyhow::Context;
@@ -363,6 +363,7 @@ impl Graph {
 
         ws.prune_archived_segments();
         ws.mark_remote_reachability(self)?;
+        ws.add_commits_on_remote(self);
         ws.truncate_single_stack_to_match_base();
         Ok(ws)
     }
@@ -769,7 +770,6 @@ impl WorkspaceState {
             })
             .collect();
         for (remote_tracking_ref_name, remote_sidx) in remote_refs {
-            let mut remote_commits = Vec::new();
             let mut may_take_commits_from_first_remote = graph[remote_sidx].commits.is_empty();
             graph.visit_all_segments_including_start_until(remote_sidx, Direction::Outgoing, |s| {
                 let prune = !s.commits.iter().all(|c| c.flags.is_remote())
@@ -822,32 +822,102 @@ impl WorkspaceState {
                         // keep looking - other stacks can repeat the segment!
                         continue;
                     }
-                } else {
-                    for commit in &s.commits {
-                        remote_commits.push(StackCommit::from_graph_commit(commit));
-                    }
                 }
                 prune
             });
-
-            // Have to keep looking for matching segments, they can be mentioned multiple times.
-            let mut found_segment = false;
-            for local_segment_with_this_remote in self.stacks.iter_mut().flat_map(|stack| {
-                stack.segments.iter_mut().filter_map(|s| {
-                    (s.remote_tracking_ref_name.as_ref() == Some(&remote_tracking_ref_name))
-                        .then_some(s)
-                })
-            }) {
-                found_segment = true;
-                local_segment_with_this_remote.commits_on_remote = remote_commits.clone();
-            }
-            if !found_segment {
-                tracing::error!(
-                    "BUG: Couldn't find local segment with remote tracking ref '{remote_tracking_ref_name}' - remote commits for it seem to be missing",
-                );
-            }
         }
         Ok(())
+    }
+
+    /// For each local segment that has a remote tracking branch, walk the remote
+    /// side and collect commits that exist on the remote but not locally:
+    /// - commits that are purely remote (never existed locally or pre-rebase versions), and
+    /// - non-integrated commits from upper stack segments that are still on the
+    ///   remote (the "branch split" case — a previously combined push left the
+    ///   remote pointing at commits that now belong to a higher branch).
+    fn add_commits_on_remote(&mut self, graph: &Graph) {
+        for stack in &mut self.stacks {
+            let mut above_commit_ids = HashSet::new();
+            for seg_idx in 0..stack.segments.len() {
+                let Some(rsidx) = stack.segments[seg_idx].remote_tracking_branch_segment_id else {
+                    // Still accumulate this segment's commits for lower segments.
+                    for commit in &stack.segments[seg_idx].commits {
+                        above_commit_ids.insert(commit.id);
+                    }
+                    continue;
+                };
+
+                // All-parents walk: collect commits from fully-remote segments.
+                // Stop at segments that contain non-remote commits or that belong
+                // to another remote-branch (unless we started empty, which signals
+                // ambiguous ownership).
+                let mut may_take_from_first_remote = graph[rsidx].commits.is_empty();
+                let mut remote_commits = Vec::new();
+                graph.visit_all_segments_including_start_until(
+                    rsidx,
+                    Direction::Outgoing,
+                    |segment| {
+                        if !segment.commits.iter().all(|c| c.flags.is_remote()) {
+                            return true;
+                        }
+                        if segment.id != rsidx
+                            && segment
+                                .ref_name()
+                                .is_some_and(|rn| rn.category() == Some(Category::RemoteBranch))
+                        {
+                            if may_take_from_first_remote {
+                                may_take_from_first_remote = false;
+                            } else {
+                                return true;
+                            }
+                        }
+                        for commit in &segment.commits {
+                            remote_commits.push(StackCommit::from_graph_commit(commit));
+                        }
+                        false
+                    },
+                );
+
+                // First-parent walk: detect non-integrated commits from upper
+                // stack segments that are still on the remote (branch-split case).
+                if !above_commit_ids.is_empty() {
+                    let mut seen: HashSet<_> = remote_commits.iter().map(|c| c.id).collect();
+                    let mut extra = Vec::new();
+                    for commit in &graph[rsidx].commits {
+                        if above_commit_ids.contains(&commit.id)
+                            && !commit.flags.contains(CommitFlags::Integrated)
+                            && seen.insert(commit.id)
+                        {
+                            extra.push(StackCommit::from_graph_commit(commit));
+                        }
+                    }
+                    graph.visit_segments_downward_along_first_parent_exclude_start(rsidx, |s| {
+                        if s.ref_name()
+                            .is_some_and(|rn| rn.category() == Some(Category::RemoteBranch))
+                        {
+                            return true;
+                        }
+                        for commit in &s.commits {
+                            if above_commit_ids.contains(&commit.id)
+                                && !commit.flags.contains(CommitFlags::Integrated)
+                                && seen.insert(commit.id)
+                            {
+                                extra.push(StackCommit::from_graph_commit(commit));
+                            }
+                        }
+                        false
+                    });
+                    remote_commits.extend(extra);
+                }
+
+                stack.segments[seg_idx].commits_on_remote = remote_commits;
+
+                // Accumulate this segment's commits for lower segments.
+                for commit in &stack.segments[seg_idx].commits {
+                    above_commit_ids.insert(commit.id);
+                }
+            }
+        }
     }
 
     /// If there is a single stack and the base happens to be itself (which happens if the stack is directly integrated/inline with the target),

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1156,6 +1156,20 @@ EOF
     create_workspace_commit_once D
   )
 
+  git init "stacked-bottom-remote-still-points-at-now-split-top"
+  (cd "stacked-bottom-remote-still-points-at-now-split-top"
+    echo init>file && git add file && git commit -m "init"
+    setup_target_to_match_main
+    git checkout -b bottom && echo B >>file && git commit -am "B"
+    git checkout -b top && echo T >>file && git commit -am "T"
+    # origin/bottom previously pointed at the combined push (T), but the
+    # branches were since split locally so that bottom now contains only B
+    # and top contains T on top of bottom. Force-push is required to clear
+    # T from origin/bottom.
+    setup_remote_tracking top bottom "cp"
+    create_workspace_commit_once top
+  )
+
   git init special-branches
   (cd special-branches
     commit init

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1158,10 +1158,12 @@ EOF
 
   git init "stacked-bottom-remote-still-points-at-now-split-top"
   (cd "stacked-bottom-remote-still-points-at-now-split-top"
-    echo init>file && git add file && git commit -m "init"
+    commit init
     setup_target_to_match_main
-    git checkout -b bottom && echo B >>file && git commit -am "B"
-    git checkout -b top && echo T >>file && git commit -am "T"
+    git checkout -b bottom
+        commit "B"
+    git checkout -b top
+        commit "T"
     # origin/bottom previously pointed at the combined push (T), but the
     # branches were since split locally so that bottom now contains only B
     # and top contains T on top of bottom. Force-push is required to clear

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -4116,24 +4116,24 @@ fn stacked_bottom_remote_still_points_at_now_split_top() -> anyhow::Result<()> {
     // local stack is now split so that bottom holds only B and top holds T on
     // top of bottom. To remove T from origin/bottom we'd need to force-push,
     // so bottom must report `commits_on_remote` containing T.
-    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * c64d2cd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 6fd3c8b (origin/bottom, top) T
-    * 0d42e6d (bottom) B
-    * 281456a (origin/main, main) init
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 5c66c47 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * bfbff44 (origin/bottom, top) T
+    * 7fdb58d (bottom) B
+    * fafd9d0 (origin/main, main) init
     ");
 
     add_stack_with_segments(&mut meta, 0, "top", StackState::InWorkspace, &["bottom"]);
 
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
-    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 281456a
-    └── ≡📙:3:top on 281456a {0}
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+    └── ≡📙:3:top on fafd9d0 {0}
         ├── 📙:3:top
-        │   └── ❄6fd3c8b (🏘️)
+        │   └── ❄bfbff44 (🏘️)
         └── 📙:4:bottom <> origin/bottom →:5:⇣1
-            ├── 🟣6fd3c8b (🏘️)
-            └── ❄️0d42e6d (🏘️)
+            ├── 🟣bfbff44 (🏘️)
+            └── ❄️7fdb58d (🏘️)
     ");
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -4109,6 +4109,36 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
 }
 
 #[test]
+fn stacked_bottom_remote_still_points_at_now_split_top() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("ws/stacked-bottom-remote-still-points-at-now-split-top")?;
+    // origin/bottom still points at T (the previously combined push), but the
+    // local stack is now split so that bottom holds only B and top holds T on
+    // top of bottom. To remove T from origin/bottom we'd need to force-push,
+    // so bottom must report `commits_on_remote` containing T.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * c64d2cd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 6fd3c8b (origin/bottom, top) T
+    * 0d42e6d (bottom) B
+    * 281456a (origin/main, main) init
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "top", StackState::InWorkspace, &["bottom"]);
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_workspace(&graph.into_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 281456a
+    └── ≡📙:3:top on 281456a {0}
+        ├── 📙:3:top
+        │   └── ❄6fd3c8b (🏘️)
+        └── 📙:4:bottom <> origin/bottom →:5:⇣1
+            ├── 🟣6fd3c8b (🏘️)
+            └── ❄️0d42e6d (🏘️)
+    ");
+    Ok(())
+}
+
+#[test]
 fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -> anyhow::Result<()>
 {
     let (repo, mut meta) = read_only_in_memory_scenario(

--- a/crates/but-workspace/tests/fixtures/scenario/shared.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/shared.sh
@@ -69,7 +69,7 @@ function create_workspace_commit_once() {
 
   git checkout -b gitbutler/workspace
   if [ $# == 1 ] || [ $# == 0 ]; then
-    git commit --allow-empty -m "$workspace_commit_subject"
+    commit "$workspace_commit_subject"
   else
     git merge --no-ff -m "$workspace_commit_subject" "${@}"
   fi
@@ -90,7 +90,7 @@ function create_workspace_commit_aggressively() {
 
   git checkout -b gitbutler/workspace main
   if [ $# == 1 ] || [ $# == 0 ]; then
-    git commit --allow-empty -m "$workspace_commit_subject"
+    commit "$workspace_commit_subject"
   else
     git merge --no-ff --strategy octopus -m "$workspace_commit_subject" "${@}"
   fi

--- a/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
@@ -5,6 +5,7 @@
 # another 4 lines to the top of the file.
 # Large numbers are used make fuzzy-patch application harder.
 set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
 
 git init
 seq 10 >file
@@ -12,4 +13,4 @@ git add . && git commit -m init && git tag first-commit
 
 { seq 4; seq 10; } >file && git commit -am "insert 5 lines to the top" && git branch feat1
 
-git commit -m $'GitButler Workspace Commit\n\njust a fake - only the subject matters right now' --allow-empty
+commit $'GitButler Workspace Commit\n\njust a fake - only the subject matters right now'

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -251,6 +251,22 @@ cp -R two-dependent-branches-rebased-with-remotes two-dependent-branches-rebased
   git branch base-of-A origin/A
 )
 
+git init stacked-bottom-remote-still-points-at-now-split-top
+(cd stacked-bottom-remote-still-points-at-now-split-top
+  git commit -m "init" --allow-empty
+  setup_target_to_match_main
+  git checkout -b bottom
+  git commit -m "B" --allow-empty
+  git checkout -b top
+  git commit -m "T" --allow-empty
+  # origin/bottom previously pointed at the combined push (T), but the
+  # branches were since split locally so that bottom now contains only B
+  # and top contains T on top of bottom. Force-push is required to clear
+  # T from origin/bottom.
+  setup_remote_tracking top bottom 'cp'
+  create_workspace_commit_once top
+)
+
 git init two-branches-one-advanced-ws-commit-on-top-of-stack
 (cd two-branches-one-advanced-ws-commit-on-top-of-stack
   git commit -m "init" --allow-empty

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -57,48 +57,48 @@ git clone remote empty-workspace-with-branch-below
 git clone remote target-ahead-remote-rewritten
 (cd target-ahead-remote-rewritten
   git checkout -b origin/main
-  git commit -m "target ahead" --allow-empty
+  commit "target ahead"
 
   git checkout -b A main
-  git commit --allow-empty -m "shared local/remote"
+  commit "shared local/remote"
 
   (git checkout -b new-origin
     # a remote commit that looks like a local commit by message
-    git commit --allow-empty -m "shared by name"
-    git commit --allow-empty -m "unique remote"
+    commit "shared by name"
+    commit "unique remote"
     setup_remote_tracking new-origin A 'move'
   )
   git checkout A
 
-  git commit --allow-empty -m "unique local"
+  commit "unique local"
   # a local commit that looks like a remote commit by message
-  git commit --allow-empty -m "shared by name"
-  git commit --allow-empty -m "unique local tip"
+  commit "shared by name"
+  commit "unique local tip"
 
   create_workspace_commit_once A
 )
 
 git init disjoint
 (cd disjoint
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git checkout --orphan disjoint
-  git commit -m "disjoint init" --allow-empty
+  commit "disjoint init"
 )
 
 git init two-branches-one-advanced-one-parent-ws-commit
 (cd two-branches-one-advanced-one-parent-ws-commit
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git checkout -b lane main
 
   git branch advanced-lane-2
   git checkout -b advanced-lane
-  git commit -m "change" --allow-empty
+  commit "change"
 
   git checkout advanced-lane-2
-  git commit -m "change 2" --allow-empty
+  commit "change 2"
 
   create_workspace_commit_once advanced-lane-2 advanced-lane
 )
@@ -106,11 +106,11 @@ git init two-branches-one-advanced-one-parent-ws-commit
 # TTB = target-tracking-branch
 git init two-branches-one-advanced-two-parent-ws-commit-diverged-ttb
 (cd two-branches-one-advanced-two-parent-ws-commit-diverged-ttb
-  git commit -m "init" --allow-empty
+  commit "init"
   git checkout -b lane main
 
   git checkout -b advanced-lane
-  git commit -m "change" --allow-empty
+  commit "change"
 
   create_workspace_commit_aggressively advanced-lane lane
   # swap trees - Git puts 'lane' first for some reason, but we really need the other way to reproduce a bug!
@@ -118,7 +118,7 @@ git init two-branches-one-advanced-two-parent-ws-commit-diverged-ttb
   echo "${commit_swapped_parents}" >.git/refs/heads/gitbutler/workspace
 
   git checkout --orphan disjoint-target-tracking
-  git commit -m "disjoint remote target" --allow-empty
+  commit "disjoint remote target"
 
   mkdir -p .git/refs/remotes/origin
   setup_remote_tracking disjoint-target-tracking main 'move'
@@ -128,12 +128,12 @@ git init two-branches-one-advanced-two-parent-ws-commit-diverged-ttb
 
 git init two-branches-one-advanced-two-parent-ws-commit
 (cd two-branches-one-advanced-two-parent-ws-commit
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git checkout -b lane main
 
   git checkout -b advanced-lane
-  git commit -m "change" --allow-empty
+  commit "change"
 
   create_workspace_commit_aggressively lane advanced-lane
 )
@@ -151,12 +151,12 @@ cp -R two-branches-one-advanced-two-parent-ws-commit-advanced-fully-pushed two-b
 
 git init three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-dependent
 (cd three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-dependent
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git checkout -b lane main
 
   git checkout -b advanced-lane
-  git commit -m "change" --allow-empty
+  commit "change"
   # This works without an official remote setup as we go by name as fallback.
   remote_tracking_caught_up advanced-lane
   git branch dependent
@@ -167,7 +167,7 @@ git init three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-depen
 
 git init two-dependent-branches-first-merge-no-ff
 (cd two-dependent-branches-first-merge-no-ff
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git checkout -b A
@@ -189,7 +189,7 @@ git init two-dependent-branches-first-merge-no-ff
 
 git init two-dependent-branches-first-merge-no-ff-second-merge-into-first-on-remote
 (cd two-dependent-branches-first-merge-no-ff-second-merge-into-first-on-remote
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git checkout -b A
@@ -217,27 +217,27 @@ git init two-dependent-branches-first-merge-no-ff-second-merge-into-first-on-rem
 
 git init two-dependent-branches-rebased-with-remotes
 (cd two-dependent-branches-rebased-with-remotes
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git branch A
   git checkout A
-  git commit -m "change in A" --allow-empty
+  commit "change in A"
   git branch future-remote-A
 
   # create remotes with the same structure as the branches before,
   # just as if the local branches were rebased.
   # This is the state that was pushed, i.e. just two commits.
   git checkout -b future-remote-B
-  git commit -m "change in B" --allow-empty
+  commit "change in B"
 
   # this emulates someone adding another commit in the lower level
   # of a stack after push.
   # The tick makes it more realistic, indicating that the rebased commits are newer.
   git checkout A && tick_committer
-  git commit -m "change after push" --allow-empty
+  commit "change after push"
 
   git checkout -b B-on-A
-  git commit -m "change in B" --allow-empty
+  commit "change in B"
 
   create_workspace_commit_once B-on-A
 
@@ -253,12 +253,12 @@ cp -R two-dependent-branches-rebased-with-remotes two-dependent-branches-rebased
 
 git init stacked-bottom-remote-still-points-at-now-split-top
 (cd stacked-bottom-remote-still-points-at-now-split-top
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git checkout -b bottom
-  git commit -m "B" --allow-empty
+  commit "B"
   git checkout -b top
-  git commit -m "T" --allow-empty
+  commit "T"
   # origin/bottom previously pointed at the combined push (T), but the
   # branches were since split locally so that bottom now contains only B
   # and top contains T on top of bottom. Force-push is required to clear
@@ -269,27 +269,27 @@ git init stacked-bottom-remote-still-points-at-now-split-top
 
 git init two-branches-one-advanced-ws-commit-on-top-of-stack
 (cd two-branches-one-advanced-ws-commit-on-top-of-stack
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
   git checkout -b lane main
 
   git checkout -b advanced-lane
-  git commit -m "change" --allow-empty
+  commit "change"
 
   create_workspace_commit_once lane advanced-lane
 )
 
 git init two-dependent-branches-with-one-commit-with-remotes
 (cd two-dependent-branches-with-one-commit-with-remotes
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git checkout -b lane
-  git commit -m "change" --allow-empty
+  commit "change"
   remote_tracking_caught_up lane
 
   git checkout -b on-top-of-lane
-  git commit -m "change on top" --allow-empty
+  commit "change on top"
   remote_tracking_caught_up on-top-of-lane
 
   create_workspace_commit_once on-top-of-lane
@@ -297,7 +297,7 @@ git init two-dependent-branches-with-one-commit-with-remotes
 
 git init multiple-dependent-branches-per-stack-without-commit
 (cd multiple-dependent-branches-per-stack-without-commit
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git branch lane-segment-01
@@ -308,29 +308,29 @@ git init multiple-dependent-branches-per-stack-without-commit
   git branch lane-2-segment-02
 
   git checkout -b lane
-  git commit -m "change" --allow-empty
+  commit "change"
 
   create_workspace_commit_once lane lane-2
 )
 
 git init two-dependent-branches-with-interesting-remote-setup
 (cd two-dependent-branches-with-interesting-remote-setup
-  git commit -m "init" --allow-empty
+  commit "init"
   setup_target_to_match_main
 
   git checkout -b integrated
-  git commit -m "integrated in target" --allow-empty
-  git commit -m "other integrated" --allow-empty
+  commit "integrated in target"
+  commit "other integrated"
 
   git checkout -b soon-A-remote
-  git commit -m "shared by name" --allow-empty
+  commit "shared by name"
   setup_remote_tracking soon-A-remote A "move"
 
   git checkout -b soon-main-remote integrated
-  git commit -m "another unrelated" --allow-empty
+  commit "another unrelated"
 
   git checkout -b A
-  git commit -m "shared by name" --allow-empty
+  commit "shared by name"
 
   setup_remote_tracking soon-main-remote main "move"
   create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -365,6 +365,74 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
 }
 
 #[test]
+fn stacked_bottom_remote_still_points_at_now_split_top() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("stacked-bottom-remote-still-points-at-now-split-top")?;
+    // origin/bottom still points at the previously-pushed combined commit (T),
+    // but the local stack has been split so `bottom` now contains only B and
+    // `top` contains T on top of bottom. To remove T from origin/bottom we'd
+    // need to force-push, so bottom must report `UnpushedCommitsRequiringForce`.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"
+    * 5c66c47 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * bfbff44 (origin/bottom, top) T
+    * 7fdb58d (bottom) B
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "top", StackState::InWorkspace, &["bottom"]);
+
+    let opts = standard_options();
+    let info = head_info(&repo, &meta, opts)?;
+    let bottom = info
+        .stacks
+        .first()
+        .and_then(|s| {
+            s.segments.iter().find(|seg| {
+                seg.ref_info
+                    .as_ref()
+                    .is_some_and(|ri| ri.ref_name.as_bstr() == "refs/heads/bottom")
+            })
+        })
+        .expect("bottom segment present");
+    assert_eq!(
+        bottom.push_status,
+        but_workspace::ui::PushStatus::UnpushedCommitsRequiringForce,
+        "bottom needs a force-push because origin/bottom is at T (now owned by top)"
+    );
+    let remote_ids: Vec<_> = bottom
+        .commits_on_remote
+        .iter()
+        .map(|c| c.id.to_hex().to_string())
+        .collect();
+    assert_eq!(
+        remote_ids.len(),
+        1,
+        "bottom's commits_on_remote contains exactly T, which would be lost on force-push"
+    );
+    assert!(
+        remote_ids[0].starts_with("bfbff44"),
+        "expected T (bfbff44...) in commits_on_remote, got: {remote_ids:?}"
+    );
+
+    // The `top` segment is unaffected: origin/bottom is unrelated to it, and
+    // there's no remote tracking ref configured for `top` itself.
+    let top = info.stacks[0]
+        .segments
+        .iter()
+        .find(|seg| {
+            seg.ref_info
+                .as_ref()
+                .is_some_and(|ri| ri.ref_name.as_bstr() == "refs/heads/top")
+        })
+        .expect("top segment present");
+    assert_eq!(
+        top.push_status,
+        but_workspace::ui::PushStatus::CompletelyUnpushed
+    );
+    Ok(())
+}
+
+#[test]
 fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario(
         "two-dependent-branches-rebased-explicit-remote-in-extra-segment",


### PR DESCRIPTION
What we are fixing
------------------
When a stack contains two dependent branches (`top` on `bottom`) and a
previous combined push left `origin/bottom` pointing at the top
commit (`T`), splitting the stack locally so that `bottom` only
contains `B` again left GitButler reporting `bottom` as
`NothingToPush`. In reality the lower branch must be force-pushed to
remove `T` from `origin/bottom`, otherwise the remote keeps a commit
that locally now belongs to `top`.

How it was discovered
---------------------
The bug surfaced as a user report: with two stacked branches of one
commit each where the lower one had previously been pushed in its
combined form, GitButler thought both branches were already pushed.
Reproducing it against a small repo showed that
`but_workspace::ui::PushStatus` resolved to `NothingToPush` for the
lower branch even though `origin/bottom` was strictly ahead of the
local tip and divergent from where a fast-forward push would land.

Tracing the projection showed that
`Workspace::mark_remote_reachability` only sets stack-segment flags
for the local owners of those commits — it never adds them to the
matching local segment's `commits_on_remote`. Because
`PushStatus::derive_from_commits` keys force-push detection off
`commits_on_remote.is_empty()`, the lower branch silently degraded to
`NothingToPush`.

How the fix works
-----------------
The fix extracts `commits_on_remote` population into a new
`add_commits_on_remote` method that iterates stacks by segment index.
It performs two walks from each remote tracking branch:

  1. An all-parents walk that collects commits from fully-remote
     segments (the existing behavior, now isolated from the flag-
     setting logic). It stops at segments containing non-remote
     commits or belonging to another remote branch.

  2. A first-parent walk that detects non-integrated commits from
     upper stack segments still on the remote — the "branch split"
     case. The first-parent restriction avoids attributing merge-
     parent commits from sibling branches.

The set of upper-segment commit IDs (`above_commit_ids`) is
maintained cumulatively across the segment loop so each commit ID is
inserted at most once.

How it is tested
----------------
Two tests cover the new behavior:

  * `but-graph` snapshot test
    `stacked_bottom_remote_still_points_at_now_split_top` asserts the
    workspace projection: `bottom`'s `commits_on_remote` contains `T`
    (rendered as `🟣` with `⇣1`) while `top` is unaffected.

  * `but-workspace` API-level test of the same name asserts that
    `bottom`'s `push_status` is `UnpushedCommitsRequiringForce` with
    exactly the `T` commit in `commits_on_remote`, while `top`
    remains `CompletelyUnpushed`.

Both tests load a new fixture
`stacked-bottom-remote-still-points-at-now-split-top` added to the
respective scenarios scripts.
