### PR TITLE
Show loading state when uncommitting changes

### DIFF
--- a/apps/desktop/src/components/commit/CommitView.svelte
+++ b/apps/desktop/src/components/commit/CommitView.svelte
@@ -13,7 +13,7 @@
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { showToast } from "$lib/notifications/toasts";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject, injectOptional } from "@gitbutler/core/context";
 	import { Button, TestId } from "@gitbutler/ui";
@@ -125,12 +125,20 @@
 
 	async function handleUncommit() {
 		if (!branchName) return;
-		await stackService.uncommit({
+		const targetStackId = ensureValue(stackId);
+		await withStackBusy(
+			uiState,
 			projectId,
-			stackId: ensureValue(stackId),
-			branchName,
-			commitId: commitKey.commitId,
-		});
+			{ commitId: commitKey.commitId, stackIds: [targetStackId] },
+			async () => {
+				await stackService.uncommit({
+					projectId,
+					stackId: targetStackId,
+					branchName,
+					commitId: commitKey.commitId,
+				});
+			},
+		);
 	}
 
 	function canEdit() {

--- a/apps/desktop/src/components/shared/ChangedFilesContextMenu.svelte
+++ b/apps/desktop/src/components/shared/ChangedFilesContextMenu.svelte
@@ -18,7 +18,7 @@
 	import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
 	import { SETTINGS } from "$lib/settings/userSettings";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import {
 		ContextMenu,
@@ -158,25 +158,27 @@
 	}
 
 	async function uncommitChanges(stackId: string, commitId: string, changes: TreeChange[]) {
-		const { workspace } = await stackService.uncommitChanges({
-			projectId,
-			stackId,
-			commitId,
-			changes: changesToDiffSpec(changes),
-			dryRun: false,
+		await withStackBusy(uiState, projectId, { commitId, stackIds: [stackId] }, async () => {
+			const { workspace } = await stackService.uncommitChanges({
+				projectId,
+				stackId,
+				commitId,
+				changes: changesToDiffSpec(changes),
+				dryRun: false,
+			});
+			const newCommitId = workspace.replacedCommits[commitId];
+			const branchName = uiState.lane(stackId).selection.current?.branchName;
+			const selectedFiles = changes.map((change) => ({ ...selectionId, path: change.path }));
+
+			// Unselect the uncommitted files
+			idSelection.removeMany(selectedFiles);
+
+			if (newCommitId && branchName) {
+				const previewOpen = uiState.lane(stackId).selection.current?.previewOpen ?? false;
+				// Update the selection to the new commit
+				uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId, previewOpen });
+			}
 		});
-		const newCommitId = workspace.replacedCommits[commitId];
-		const branchName = uiState.lane(stackId).selection.current?.branchName;
-		const selectedFiles = changes.map((change) => ({ ...selectionId, path: change.path }));
-
-		// Unselect the uncommitted files
-		idSelection.removeMany(selectedFiles);
-
-		if (newCommitId && branchName) {
-			const previewOpen = uiState.lane(stackId).selection.current?.previewOpen ?? false;
-			// Update the selection to the new commit
-			uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId, previewOpen });
-		}
 		contextMenu.close();
 	}
 

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -36,6 +36,7 @@
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 
 	import { combineResults } from "$lib/state/helpers";
+	import { UI_STATE, withStackBusy } from "$lib/state/uiState.svelte";
 	import { ensureValue } from "$lib/utils/validation";
 	import { inject } from "@gitbutler/core/context";
 	import { TestId } from "@gitbutler/ui";
@@ -63,6 +64,7 @@
 	const settingsService = inject(SETTINGS_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);
+	const uiState = inject(UI_STATE);
 
 	const projectId = $derived(controller.projectId);
 	const stackId = $derived(controller.stackId);
@@ -100,11 +102,14 @@
 	}
 
 	async function handleUncommit(commitId: string) {
-		await stackService.uncommit({
-			projectId,
-			stackId: ensureValue(stackId),
-			branchName,
-			commitId,
+		const targetStackId = ensureValue(stackId);
+		await withStackBusy(uiState, projectId, { commitId, stackIds: [targetStackId] }, async () => {
+			await stackService.uncommit({
+				projectId,
+				stackId: targetStackId,
+				branchName,
+				commitId,
+			});
 		});
 	}
 

--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -12,7 +12,7 @@ import {
 import { HOOKS_SERVICE } from "$lib/git/hooksService";
 import { showToast } from "$lib/notifications/toasts";
 import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
-import { UI_STATE, type UiState } from "$lib/state/uiState.svelte";
+import { UI_STATE, withStackBusy, type UiState } from "$lib/state/uiState.svelte";
 import { inject } from "@gitbutler/core/context";
 import { untrack } from "svelte";
 import type { DropzoneHandler } from "$lib/dragging/handler";
@@ -206,18 +206,25 @@ export class UncommitDzHandler implements DropzoneHandler {
 					const stackId = data.stackId;
 					const commitId = data.selectionId.commitId;
 					if (stackId && commitId) {
-						const changes = changesToDiffSpec(await data.treeChanges());
-						const { workspace } = await this.stackService.uncommitChanges({
-							projectId: this.projectId,
-							stackId,
-							commitId,
-							changes,
-							assignTo: this.assignTo,
-							dryRun: false,
-						});
+						await withStackBusy(
+							this.uiState,
+							this.projectId,
+							{ commitId, stackIds: [stackId] },
+							async () => {
+								const changes = changesToDiffSpec(await data.treeChanges());
+								const { workspace } = await this.stackService.uncommitChanges({
+									projectId: this.projectId,
+									stackId,
+									commitId,
+									changes,
+									assignTo: this.assignTo,
+									dryRun: false,
+								});
 
-						// Update the project state to point to the new commit if needed.
-						updateUiState(this.uiState, stackId, commitId, workspace.replacedCommits);
+								// Update the project state to point to the new commit if needed.
+								updateUiState(this.uiState, stackId, commitId, workspace.replacedCommits);
+							},
+						);
 					} else {
 						throw new Error("Change drop data must specify the source stackId");
 					}
@@ -237,30 +244,40 @@ export class UncommitDzHandler implements DropzoneHandler {
 			const previousPathBytes =
 				data.change.status.type === "Rename" ? data.change.status.subject.previousPathBytes : null;
 
-			const { workspace } = await this.stackService.uncommitChanges({
-				projectId: this.projectId,
-				stackId: data.stackId,
-				commitId: data.commitId,
-				changes: [
-					{
-						previousPathBytes,
-						pathBytes: data.change.pathBytes,
-						hunkHeaders: [
+			const sourceStackId = data.stackId;
+			const sourceCommitId = data.commitId;
+
+			await withStackBusy(
+				this.uiState,
+				this.projectId,
+				{ commitId: sourceCommitId, stackIds: [sourceStackId] },
+				async () => {
+					const { workspace } = await this.stackService.uncommitChanges({
+						projectId: this.projectId,
+						stackId: sourceStackId,
+						commitId: sourceCommitId,
+						changes: [
 							{
-								oldStart: data.hunk.oldStart,
-								oldLines: data.hunk.oldLines,
-								newStart: data.hunk.newStart,
-								newLines: data.hunk.newLines,
+								previousPathBytes,
+								pathBytes: data.change.pathBytes,
+								hunkHeaders: [
+									{
+										oldStart: data.hunk.oldStart,
+										oldLines: data.hunk.oldLines,
+										newStart: data.hunk.newStart,
+										newLines: data.hunk.newLines,
+									},
+								],
 							},
 						],
-					},
-				],
-				assignTo: this.assignTo,
-				dryRun: false,
-			});
+						assignTo: this.assignTo,
+						dryRun: false,
+					});
 
-			// Update the project state to point to the new commit if needed.
-			updateUiState(this.uiState, data.stackId, data.commitId, workspace.replacedCommits);
+					// Update the project state to point to the new commit if needed.
+					updateUiState(this.uiState, sourceStackId, sourceCommitId, workspace.replacedCommits);
+				},
+			);
 
 			return;
 		}
@@ -433,20 +450,6 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 				},
 			);
 		}
-	}
-}
-
-export async function withStackBusy(
-	uiState: UiState,
-	projectId: string,
-	opts: { commitId?: string; stackIds?: string[] },
-	fn: () => Promise<void>,
-) {
-	uiState.project(projectId).stackBusy.set({ commitId: opts.commitId, stackIds: opts.stackIds });
-	try {
-		await fn();
-	} finally {
-		uiState.project(projectId).stackBusy.set(undefined);
 	}
 }
 

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -1,8 +1,8 @@
-import { CommitDropData, withStackBusy } from "$lib/dragging/dropHandlers/commitDropHandler";
+import { CommitDropData } from "$lib/dragging/dropHandlers/commitDropHandler";
+import { withStackBusy, type UiState } from "$lib/state/uiState.svelte";
 import { InjectionToken } from "@gitbutler/core/context";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { StackService } from "$lib/stacks/stackService.svelte";
-import type { UiState } from "$lib/state/uiState.svelte";
 import type { StackOrder } from "@gitbutler/but-sdk";
 
 export class ReorderCommitDzHandler implements DropzoneHandler {

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -396,3 +396,22 @@ export type WritableReactive<T> = {
 export type WritableReactiveStore<T extends DefaultConfig> = {
 	[K in keyof T]: WritableReactive<T[K]>;
 };
+
+/**
+ * Sets the `stackBusy` state while running `fn`, and clears it afterwards.
+ * Used to show a busy spinner on commits and block interaction on affected
+ * stacks during operations like squash, move, uncommit, etc.
+ */
+export async function withStackBusy(
+	uiState: UiState,
+	projectId: string,
+	opts: { commitId?: string; stackIds?: string[] },
+	fn: () => Promise<void>,
+) {
+	uiState.project(projectId).stackBusy.set({ commitId: opts.commitId, stackIds: opts.stackIds });
+	try {
+		await fn();
+	} finally {
+		uiState.project(projectId).stackBusy.set(undefined);
+	}
+}


### PR DESCRIPTION
Add withStackBusy wrapping around uncommit and uncommitChanges flows to
display a loading/busy state while uncommitting. This change ensures the
UI indicates activity when uncommitting from CommitView,
BranchCommitList, ChangedFilesContextMenu, and various drag/drop
handlers, and also centralizes update logic (selection updates and
uiState updates) to occur inside the busy wrapper.