### PR TITLE
ci: add minimal workflow for building gitbutler-lite

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -1,0 +1,58 @@
+name: "Lite"
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+env:
+  RUST_BACKTRACE: full
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-15 # [macOs, ARM64]
+          - platform: ubuntu-22.04 # [linux, x64]
+          - platform: windows-latest # [windows, x64]
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_PROFILE_RELEASE_LTO: fat
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: s
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install pkg-config libxss-dev libdbus-1-dev
+      - uses: ./.github/actions/init-env-node
+      - name: Set version
+        working-directory: apps/lite
+        run: pnpm version "0.0.${{ github.run_number }}" --no-git-tag-version
+      - name: Build
+        env:
+          CHANNEL: nightly
+          VERSION: "0.0.${{ github.run_number }}"
+        run: |
+          pnpm --filter @gitbutler/but-sdk build
+          pnpm --filter @gitbutler/lite bundle
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        name: Upload artifacts
+        with:
+          name: gitbutler-lite-${{ github.run_number }}-${{ matrix.platform }}
+          path: apps/lite/release/
+          if-no-files-found: error
+          retention-days: 7

--- a/apps/lite/.gitignore
+++ b/apps/lite/.gitignore
@@ -1,0 +1,1 @@
+release/

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "@gitbutler/lite",
+	"productName": "gitbutler-lite",
+	"homepage": "https://gitbutler.com",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
@@ -32,6 +34,31 @@
 		],
 		"mac": {
 			"target": "dmg"
+		},
+		"linux": {
+			"target": [
+				"deb",
+				"appimage"
+			],
+			"maintainer": "GitButler <gitbutler@gitbutler.com>"
+		},
+		"win": {
+			"target": [
+				"portable"
+			]
+		},
+		"deb": {
+			"packageName": "gitbutler-lite",
+			"artifactName": "${productName}-${version}-${arch}.${ext}",
+			"depends": [
+				"libnotify4",
+				"libxtst6",
+				"libnss3",
+				"libxss1"
+			]
+		},
+		"appImage": {
+			"artifactName": "${productName}-${version}-${arch}.${ext}"
 		}
 	},
 	"dependencies": {
@@ -46,7 +73,6 @@
 		"@tanstack/react-query-devtools": "^5.91.3",
 		"@tanstack/react-router": "^1.167.4",
 		"effect": "^3.20.0",
-		"electron": "^41.1.0",
 		"electron-devtools-installer": "^4.0.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
@@ -61,6 +87,7 @@
 		"@typescript/native-preview": "7.0.0-dev.20260311.1",
 		"@vitejs/plugin-react": "^5.2.0",
 		"babel-plugin-react-compiler": "^1.0.0",
+		"electron": "^41.1.0",
 		"concurrently": "^9.2.1",
 		"cross-env": "^10.1.0",
 		"electron-builder": "^26.8.1",

--- a/apps/lite/ui/vite.config.ts
+++ b/apps/lite/ui/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
 			},
 		}),
 	],
+	base: "./",
 	build: {
 		outDir: "../dist/ui",
 		emptyOutDir: true,

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -20,7 +20,7 @@
 			],
 			"project": ["electron/src/**!", "ui/src/**!"],
 			"includeEntryExports": true,
-			"ignoreDependencies": ["@tanstack/eslint-plugin-query"],
+			"ignoreDependencies": ["@tanstack/eslint-plugin-query", "electron"],
 		},
 	},
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,9 +431,6 @@ importers:
       effect:
         specifier: ^3.20.0
         version: 3.20.0
-      electron:
-        specifier: ^41.1.0
-        version: 41.1.0
       electron-devtools-installer:
         specifier: ^4.0.0
         version: 4.0.0
@@ -477,6 +474,9 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      electron:
+        specifier: ^41.1.0
+        version: 41.1.0
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.7.0)


### PR DESCRIPTION
## 🧢 Changes
Minimal workflow for building distributions of gitbutler-lite across macOS (aarch64 only), Linux (x86-64 only) and Windows (x86-64 only). The artifacts are uploaded to the workflow run's artifact store only, they're not distributed elsewhere at this time.

I haven't tried the Windows build yet but... it builds at least.

## Important
This is _very_ minimal and not production ready. It's just to get a starting point. Things that aren't fixed/checked yet include:

* CSP
* Preventing navigation to the Internet
* Signing of executables
  - On macOS, you may get `"gitbutler-lite" is damaged`, in which case you can run `xattr -c <path/to/application.app>` to explicitly mark it as safe.
  - DO NOT DO THIS unless you are a dev on this project, it won't be necessary once we start signing the app
* Reloading the app doesn't work (you get a blank screen as assets refuse to load)
* [Bitwarden's Desktop client](https://github.com/bitwarden/clients) has a very similar setup with Napi and electron-builder that we can draw inspiration from