### PR TITLE
edit-mode: upon enter, modify commit consistently

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -96,10 +96,22 @@ fn find_or_create_base_commit(
 
     let base_tree = repo.find_real_tree(&commit, ConflictedTreeKey::Ours)?;
 
+    let concrete_commit = gix::objs::Commit::try_from(commit.decode()?)?;
+    let extra_headers: Vec<(BString, BString)> = Headers::try_from_commit(&concrete_commit)
+        .map(|commit_headers| {
+            let headers = Headers {
+                conflicted: None,
+                ..commit_headers
+            };
+            (&headers).into()
+        })
+        .unwrap_or_default();
+    let message = but_core::commit::strip_conflict_markers(concrete_commit.message.as_ref());
     let commit = gix::objs::Commit {
         tree: base_tree.into(),
-        extra_headers: Vec::new(),
-        ..gix::objs::Commit::try_from(commit.decode()?)?
+        extra_headers,
+        message,
+        ..concrete_commit
     };
     Ok(repo.write_object(&commit)?.detach())
 }
@@ -271,22 +283,11 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
     let new_commit_oid = if decoded_head_commit.tree() == tree_id {
         head_commit.id
     } else {
-        let mut commit = gix::objs::Commit::try_from(decoded_head_commit.clone())?;
-        let extra_headers: Vec<(BString, BString)> = Headers::try_from_commit(&commit)
-            .map(|commit_headers| {
-                let headers = Headers {
-                    conflicted: None,
-                    ..commit_headers
-                };
-                (&headers).into()
-            })
-            .unwrap_or_default();
-        commit.message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
+        let commit = gix::objs::Commit::try_from(decoded_head_commit.clone())?;
         but_rebase::commit::create(
             repo,
             gix::objs::Commit {
                 tree: tree_id,
-                extra_headers,
                 ..commit
             },
             but_rebase::commit::DateMode::CommitterUpdateAuthorKeep,

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -362,7 +362,22 @@ fn enter_edit_mode_checks_out_conflicted_commit() -> Result<()> {
     );
     insta::assert_debug_snapshot!(
         repo.head_commit()?.message()?.summary(),
-        @r#""[conflict] Changes to make millions""#
+        @r#""Changes to make millions""#
+    );
+    insta::assert_debug_snapshot!(
+        repo.head_commit()?.decode()?.extra_headers,
+        @r#"
+    [
+        (
+            "gitbutler-headers-version",
+            "2",
+        ),
+        (
+            "change-id",
+            "00000000-0000-0000-0000-000000000001",
+        ),
+    ]
+    "#
     );
 
     insta::assert_snapshot!(


### PR DESCRIPTION
Why I'm not automerging: need a product decision (whether going with what's in this PR, the "alternative design choice" described below, or something else).

This is a follow-up from https://github.com/gitbutlerapp/gitbutler/pull/13247#discussion_r3084451232 (that link is what's provided by GitHub but it doesn't work as it links to a resolved comment; it's a comment on `crates/gitbutler-edit-mode/src/lib.rs`). The problem description by chatgpt-codex-connector is correct, and upon investigation, the problem is a bit more than described. This PR fixes everything I've seen in my investigation. 

---

There are currently some bugs and inconsistencies with how edit mode is
entered. In particular:
 - all extra headers are cleared (not only the one that represents
   conflicts)
 - the conflict marker in the commit message title is not cleared, even
   though (as stated in the previous bullet point) the conflict extra
   header is cleared

Therefore, preserve all other extra headers, and clear the conflict
marker in the commit message title. This allows us to remove the
corresponding code that is run upon exiting edit mode, so remove that
too.

An alternative design choice would be:
 1) not clear any extra headers or conflict markers in the commit
    message title upon entering edit mode
 2) clear the conflict extra header and the conflict marker in the
    commit message title upon exiting edit mode

This is closer to the status quo, in which we do 2) but not 1). But I
think this is less user-friendly, as the user cannot see exactly what
commit is going to be committed.