### PR TITLE
Speed up playwright and blackbox workflow

### DIFF
--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -5,7 +5,20 @@ on:
       - master
   pull_request:
     paths-ignore:
+      - "*.md"
+      - ".cargo/**"
+      - ".claude/**"
+      - ".vscode/**"
+      - ".oxlintrc.json"
+      - "deny.toml"
+      - "scripts/**"
       - "apps/web/**"
+      - "apps/lite/**"
+      - "crates/but/**"
+      - "crates/but-clap/**"
+      - "crates/but-debugging/**"
+      - "crates/but-installer/**"
+      - "crates/but-testing/**"
   workflow_dispatch:
     inputs:
       sha:
@@ -21,7 +34,7 @@ jobs:
       contents: read
       packages: read
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:c0ab58bb5f1cd99beb36861f460895be77515f4dd252df736c27c117a8e04a92
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -36,10 +49,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.sha }}
-      # TODO: put these into the docker image
-      - name: Install Webdriver dependencies
-        run: apt update && apt install -y webkit2gtk-driver ffmpeg xvfb
-        if: ${{ github.ref != 'refs/heads/master' }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -47,18 +56,30 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Setup node environment
         uses: ./.github/actions/init-env-node
-      - name: Build CLI
-        run: cargo build -p gitbutler-cli
-      - name: Build SvelteKit
-        run: pnpm build:desktop -- --mode development
-      - name: Build Tauri
-        run: pnpm build:test
-      - name: Install tauri-driver
+        if: ${{ github.ref != 'refs/heads/master' }}
+      - name: Build CLI, SvelteKit, and tauri-driver
         if: ${{ github.ref != 'refs/heads/master' }}
         run: |
+          cargo build -p gitbutler-cli &
+          cargo_pid=$!
+          pnpm build:desktop -- --mode development &
+          pnpm_pid=$!
+          td_pid=""
           if [ ! -e "$HOME/.cargo/bin/tauri-driver" ]; then
-            cargo install tauri-driver
+            cargo install tauri-driver &
+            td_pid=$!
           fi
+          status=0
+          wait "$cargo_pid" || status=1
+          wait "$pnpm_pid" || status=1
+          [ -n "$td_pid" ] && { wait "$td_pid" || status=1; }
+          exit "$status"
+      - name: Build Tauri
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: pnpm build:test
+      - name: Build CLI (cache warming)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: cargo build -p gitbutler-cli
 
       # Run it through `xvfb-run` to have a fake display server which allows our
       # application to run headless without any changes to the code

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -4,6 +4,21 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - "*.md"
+      - ".cargo/**"
+      - ".claude/**"
+      - ".vscode/**"
+      - ".oxlintrc.json"
+      - "deny.toml"
+      - "scripts/**"
+      - "apps/web/**"
+      - "apps/lite/**"
+      - "crates/gitbutler-cli/**"
+      - "crates/but/**"
+      - "crates/but-clap/**"
+      - "crates/but-debugging/**"
+      - "crates/but-installer/**"
   workflow_dispatch:
     inputs:
       sha:
@@ -19,7 +34,7 @@ jobs:
       contents: read
       packages: read
     container:
-      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:3eaeae1b07072796a53dc1e7585cdc1f462d0b11d10ecd3685c6fa8082d647dd
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:c0ab58bb5f1cd99beb36861f460895be77515f4dd252df736c27c117a8e04a92
     timeout-minutes: 60
     env:
       DESKTOP_PORT: 3000
@@ -61,25 +76,33 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
-      - run: cd e2e && pnpm exec playwright install --with-deps
-        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' && github.ref != 'refs/heads/master' }}
-      - run: apt-get update && apt-get install -y libnss3
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && github.ref != 'refs/heads/master' }}
-        name: Install missing deps after cache hit
-      - name: Build gitbutler-git
-        run: cargo build -p gitbutler-git
-      - name: Build but-server
-        run: cargo build -p but-server
-      - name: Build but-testing
-        run: cargo build -p but-testing
-      - name: Build SvelteKit
-        run: pnpm build:desktop
+      - name: Build Rust binaries, SvelteKit, and install Playwright
         if: ${{ github.ref != 'refs/heads/master' }}
+        env:
+          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+        run: |
+          cargo build -p gitbutler-git -p but-server -p but-testing &
+          cargo_pid=$!
+          pnpm build:desktop &
+          pnpm_pid=$!
+          pw_pid=""
+          if [ "$PLAYWRIGHT_CACHE_HIT" != "true" ]; then
+            (apt-get update && cd e2e && pnpm exec playwright install chromium webkit) &
+            pw_pid=$!
+          fi
+          status=0
+          wait "$cargo_pid" || status=1
+          wait "$pnpm_pid" || status=1
+          [ -n "$pw_pid" ] && { wait "$pw_pid" || status=1; }
+          exit "$status"
+      - name: Build Rust binaries
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: cargo build -p gitbutler-git -p but-server -p but-testing
       - name: Run Playwright tests
         run: pnpm exec turbo run test:e2e:playwright
         if: ${{ github.ref != 'refs/heads/master' }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: ${{ !cancelled() }}
+        if: failure()
         with:
           name: playwright-report
           path: |


### PR DESCRIPTION
Parallelize independent build steps (Rust, SvelteKit, Playwright
install, tauri-driver) so they run concurrently instead of sequentially.

Skip node setup, SvelteKit, and test steps on master pushes since those
runs only exist to warm the Rust cache.

Add paths-ignore to both workflows so PRs that only touch docs, scripts,
config files, or unrelated crates (CLI, TUI, debugging tools) skip
the e2e jobs entirely.

Install only chromium and webkit (no Firefox) and run apt-get update
before Playwright install to avoid stale package index 404s.

Upload artifacts only on failure instead of on every non-cancelled run.