### PR TITLE
updade `gix` for more Git-like diffs + rustc upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2187,7 +2187,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2933,7 +2933,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4431,7 +4431,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4473,13 +4473,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "kstring",
  "serde",
  "smallvec",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-error",
 ]
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "gix-blame"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4507,7 +4507,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-error",
 ]
@@ -4525,19 +4525,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4591,7 +4591,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4600,7 +4600,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4622,13 +4622,12 @@ dependencies = [
  "gix-fs",
  "gix-hash",
  "gix-imara-diff",
- "gix-imara-diff-01",
  "gix-index",
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-traverse",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4637,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4647,7 +4646,7 @@ dependencies = [
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4656,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "dunce",
@@ -4670,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
 ]
@@ -4678,13 +4677,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4698,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4709,7 +4708,7 @@ dependencies = [
  "gix-packetline",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4718,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4731,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4743,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4755,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4765,12 +4764,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "serde",
  "unicode-bom",
 ]
@@ -4778,24 +4777,17 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
+ "bstr",
  "hashbrown 0.16.1",
  "memchr",
 ]
 
 [[package]]
-name = "gix-imara-diff-01"
-version = "0.1.8"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
 name = "gix-index"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4823,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4833,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4845,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4853,7 +4845,7 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
- "gix-imara-diff-01",
+ "gix-imara-diff",
  "gix-index",
  "gix-object",
  "gix-path 0.11.2",
@@ -4861,7 +4853,7 @@ dependencies = [
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
@@ -4870,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4883,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4903,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4923,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4945,11 +4937,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "thiserror 2.0.18",
 ]
 
@@ -4968,10 +4960,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
@@ -4979,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4993,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -5005,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -5019,7 +5011,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -5032,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5042,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5063,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5078,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5089,7 +5081,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
  "nonempty",
  "serde",
 ]
@@ -5097,7 +5089,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5112,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.2",
@@ -5124,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5137,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "filetime",
@@ -5159,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5173,7 +5165,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5187,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "crc",
@@ -5216,7 +5208,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "tracing",
 ]
@@ -5224,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5243,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5259,7 +5251,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
@@ -5271,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5291,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
 ]
@@ -5299,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5317,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5334,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=c261237f64c9032e72998a3bbf7ca9abf08c83b8#c261237f64c9032e72998a3bbf7ca9abf08c83b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -6142,7 +6134,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6217,7 +6209,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7123,7 +7115,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7667,7 +7659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8436,7 +8428,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9148,7 +9140,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9161,7 +9153,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9219,7 +9211,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10759,7 +10751,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10789,7 +10781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12231,7 +12223,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,10 +212,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "c261237f64c9032e72998a3bbf7ca9abf08c83b8", default-features = false, features = [
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "2a5db88d0330b0d125de4b6f3819f17a7f76f4b8", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "c261237f64c9032e72998a3bbf7ca9abf08c83b8" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "2a5db88d0330b0d125de4b6f3819f17a7f76f4b8" }
 
 
 insta = { version = "1.45.1", features = ["json"] }

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -200,13 +200,16 @@ impl UnifiedPatch {
                     }
                 }
                 let input = prep.interned_input();
-                let uni_diff = gix::diff::blob::UnifiedDiff::new(
+                let diff = gix::diff::blob::diff_with_slider_heuristics(algorithm, &input);
+                let (lines_added, lines_removed) = compute_line_changes(&diff);
+                let hunks = gix::diff::blob::UnifiedDiff::new(
+                    &diff,
                     &input,
                     ConsumeBinaryHunk::new(ProduceDiffHunk::default(), "\n"),
                     ContextSize::symmetrical(context_lines),
-                );
-                let hunks = gix::diff::blob::diff(algorithm, &input, uni_diff)?.hunks;
-                let (lines_added, lines_removed) = compute_line_changes(&hunks);
+                )
+                .consume()?
+                .hunks;
                 UnifiedPatch::Patch {
                     is_result_of_binary_to_text_conversion: prep.old_or_new_is_derived,
                     hunks,
@@ -262,19 +265,8 @@ fn detect_and_convert_to_utf8(content: BString) -> BString {
     decoded.into_owned().into()
 }
 
-fn compute_line_changes(hunks: &Vec<DiffHunk>) -> (u32, u32) {
-    let mut lines_added = 0;
-    let mut lines_removed = 0;
-    for hunk in hunks {
-        hunk.diff.lines().for_each(|line| {
-            if line.starts_with(b"+") {
-                lines_added += 1;
-            } else if line.starts_with(b"-") {
-                lines_removed += 1;
-            }
-        });
-    }
-    (lines_added, lines_removed)
+fn compute_line_changes(diff: &gix::diff::blob::Diff) -> (u32, u32) {
+    (diff.count_additions(), diff.count_removals())
 }
 
 /// Produce a filter from `repo` and `state` using `mode` that is able to perform diffs of `state`.

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -6,7 +6,7 @@ use but_hunk_assignment::{HunkAssignmentRequest, HunkAssignmentTarget};
 use but_llm::LLMProvider;
 use but_workspace::legacy::StacksFilter;
 use gix::diff::blob::{
-    Algorithm, UnifiedDiff,
+    Algorithm, InternedInput, UnifiedDiff,
     unified_diff::{ConsumeBinaryHunk, ContextSize},
 };
 use serde::{Deserialize, Serialize};
@@ -59,19 +59,15 @@ impl gix::diff::blob::unified_diff::ConsumeBinaryHunkDelegate for ProduceDiffHun
 
 impl Edit {
     fn generate_headers(&self) -> anyhow::Result<Vec<but_core::HunkHeader>> {
-        let interner = gix::diff::blob::intern::InternedInput::new(
-            self.old_string.as_bytes(),
-            self.new_string.as_bytes(),
-        );
-        let headers = gix::diff::blob::diff(
-            Algorithm::Myers,
+        let interner = InternedInput::new(self.old_string.as_bytes(), self.new_string.as_bytes());
+        let diff = gix::diff::blob::diff_with_slider_heuristics(Algorithm::Myers, &interner);
+        let headers = UnifiedDiff::new(
+            &diff,
             &interner,
-            UnifiedDiff::new(
-                &interner,
-                ConsumeBinaryHunk::new(ProduceDiffHunk::default(), "\n"),
-                ContextSize::symmetrical(0), // Zero context lines is fine since the hunk will be reconciled later with but_hunk_assignment::assignments_with_fallback
-            ),
-        )?
+            ConsumeBinaryHunk::new(ProduceDiffHunk::default(), "\n"),
+            ContextSize::symmetrical(0), // Zero context lines is fine since the hunk will be reconciled later with but_hunk_assignment::assignments_with_fallback
+        )
+        .consume()?
         .headers;
         Ok(headers)
     }

--- a/crates/but-hunk-dependency/src/ranges/paths.rs
+++ b/crates/but-hunk-dependency/src/ranges/paths.rs
@@ -31,10 +31,7 @@ impl PathRanges {
 
         for incoming_hunk in &incoming_hunks {
             let mut incoming_hunk_line_shift = incoming_hunk.net_lines()?;
-            loop {
-                let Some(existing_hunk_range) = existing_hunk_ranges_iter.next() else {
-                    break;
-                };
+            while let Some(existing_hunk_range) = existing_hunk_ranges_iter.next() {
                 let ReceiveResult {
                     above,
                     incoming_line_shift_change,

--- a/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
@@ -273,10 +273,9 @@ mod util {
         stack_ids: impl Iterator<Item = impl ToString>,
         mut to_simplify: String,
     ) -> String {
-        let mut count = 1;
-        for stack_id in stack_ids {
+        for (count, stack_id) in stack_ids.enumerate() {
+            let count = count + 1;
             to_simplify = to_simplify.replace(&stack_id.to_string(), &format!("stack_{count}"));
-            count += 1;
         }
         to_simplify
     }

--- a/crates/but-irc/src/lifecycle.rs
+++ b/crates/but-irc/src/lifecycle.rs
@@ -755,13 +755,12 @@ fn try_buffer_history_message(
         // Skip join/part/quit from history replay — they're noise in the chat timeline.
         IrcEvent::UserJoined { batch, .. }
         | IrcEvent::UserParted { batch, .. }
-        | IrcEvent::UserQuit { batch, .. } => {
+        | IrcEvent::UserQuit { batch, .. }
             if batch
                 .as_ref()
-                .is_some_and(|b| history_batch_channels.contains_key(b.as_str()))
-            {
-                return true;
-            }
+                .is_some_and(|b| history_batch_channels.contains_key(b.as_str())) =>
+        {
+            return true;
         }
         IrcEvent::NickChanged {
             old_nick,
@@ -799,23 +798,21 @@ fn try_buffer_history_message(
             }
         }
         // Typing indicators from history are stale — silently discard them.
-        IrcEvent::Typing { batch, .. } => {
+        IrcEvent::Typing { batch, .. }
             if batch
                 .as_ref()
-                .is_some_and(|b| history_batch_channels.contains_key(b.as_str()))
-            {
-                return true;
-            }
+                .is_some_and(|b| history_batch_channels.contains_key(b.as_str())) =>
+        {
+            return true;
         }
         // TAGMSG reactions from history: let them fall through to
         // process_event_for_store so reactions get indexed.
-        IrcEvent::TagReaction { batch, .. } => {
+        IrcEvent::TagReaction { batch, .. }
             if batch
                 .as_ref()
-                .is_some_and(|b| history_batch_channels.contains_key(b.as_str()))
-            {
-                return false;
-            }
+                .is_some_and(|b| history_batch_channels.contains_key(b.as_str())) =>
+        {
+            return false;
         }
         _ => {}
     }
@@ -1554,41 +1551,39 @@ pub async fn process_event_for_store(
             emoji,
             remove,
             ..
-        } => {
-            if !msgid.is_empty() {
+        } if !msgid.is_empty() => {
+            if *remove {
+                manager
+                    .remove_message_reaction(connection_id, msgid, from, emoji)
+                    .await;
+            } else {
+                manager
+                    .store_message_reaction(connection_id, msgid, from, emoji)
+                    .await;
+            }
+            emitter.emit(
+                &format!("irc:{}:message-reaction", connection_id),
+                json!({ "msgId": msgid }),
+            );
+            // Derive commit-reaction index if the reacted-to message is a shared-commit.
+            if let Some(target_data) = manager
+                .find_message_data_by_msgid(connection_id, msgid)
+                .await
+                && let Some(commit_id) = try_extract_shared_commit_id(&target_data)
+            {
                 if *remove {
                     manager
-                        .remove_message_reaction(connection_id, msgid, from, emoji)
+                        .remove_reaction(connection_id, &commit_id, from, emoji)
                         .await;
                 } else {
                     manager
-                        .store_message_reaction(connection_id, msgid, from, emoji)
+                        .store_reaction(connection_id, &commit_id, from, emoji)
                         .await;
                 }
                 emitter.emit(
-                    &format!("irc:{}:message-reaction", connection_id),
-                    json!({ "msgId": msgid }),
+                    &format!("irc:{}:commit-reaction", connection_id),
+                    json!({ "commitId": commit_id }),
                 );
-                // Derive commit-reaction index if the reacted-to message is a shared-commit.
-                if let Some(target_data) = manager
-                    .find_message_data_by_msgid(connection_id, msgid)
-                    .await
-                    && let Some(commit_id) = try_extract_shared_commit_id(&target_data)
-                {
-                    if *remove {
-                        manager
-                            .remove_reaction(connection_id, &commit_id, from, emoji)
-                            .await;
-                    } else {
-                        manager
-                            .store_reaction(connection_id, &commit_id, from, emoji)
-                            .await;
-                    }
-                    emitter.emit(
-                        &format!("irc:{}:commit-reaction", connection_id),
-                        json!({ "commitId": commit_id }),
-                    );
-                }
             }
         }
         IrcEvent::Raw { command, params } => {

--- a/crates/but-llm/src/anthropic.rs
+++ b/crates/but-llm/src/anthropic.rs
@@ -799,9 +799,9 @@ async fn tool_calling_stream(
                                 }
                             }
                         }
-                        "message_stop" => {
+                        "message_stop"
                             // Check if we have tool calls to return
-                            if !tool_calls.is_empty() {
+                            if !tool_calls.is_empty() => {
                                 let calls: Vec<ToolCall> = tool_calls.values().cloned().collect();
                                 let text = if response_text.is_empty() {
                                     None
@@ -810,7 +810,6 @@ async fn tool_calling_stream(
                                 };
                                 return Ok((Some(calls), text));
                             }
-                        }
                         _ => {}
                     }
                 }

--- a/crates/but-workspace/src/legacy/commit_engine/refs.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/refs.rs
@@ -112,6 +112,6 @@ pub fn rewrite(
     repo.edit_references(ref_edits)?;
     // Due to the way these are processed, they aren't stable.
     // Make tests reproducible, hoping that soon we don't need hashmaps in the backend anymore.
-    updated_refs.sort_by(|a, b| a.reference.to_string().cmp(&b.reference.to_string()));
+    updated_refs.sort_by_key(|a| a.reference.to_string());
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -706,7 +706,7 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     "#);
 
     let specs = to_change_specs_all_hunks(&repo, wt_changes)?;
-    let dropped = discard_workspace_changes(&repo, specs.into_iter(), CONTEXT_LINES)?;
+    let dropped = discard_workspace_changes(&repo, specs, CONTEXT_LINES)?;
     assert!(dropped.is_empty());
 
     // Only the data is undone; the executable bit change can be undone in the next discard,

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -157,7 +157,7 @@ pub fn list(
     }
 
     // Sort all branches by last commit date (most recent first)
-    branches.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    branches.sort_by_key(|branch| std::cmp::Reverse(branch.updated_at));
 
     // Limit branches unless --all flag is set
     let (branches_to_show, more_count) = if all {

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -639,7 +639,7 @@ fn show_branch_summary(out: &mut dyn std::fmt::Write, commits: &[BranchCommitInf
 
         // Show top changed files
         let mut files_vec: Vec<_> = file_changes.iter().collect();
-        files_vec.sort_by(|a, b| (b.1.0 + b.1.1).cmp(&(a.1.0 + a.1.1)));
+        files_vec.sort_by_key(|file| std::cmp::Reverse(file.1.0 + file.1.1));
 
         writeln!(out)?;
         writeln!(out, "  {}:", "Files changed".dimmed())?;

--- a/crates/but/src/tui/editor.rs
+++ b/crates/but/src/tui/editor.rs
@@ -583,10 +583,8 @@ impl EditorApp {
         match ev {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 KeyCode::Esc => self.active_menu = None,
-                KeyCode::Up => {
-                    if self.menu_item_index > 0 {
-                        self.menu_item_index -= 1;
-                    }
+                KeyCode::Up if self.menu_item_index > 0 => {
+                    self.menu_item_index -= 1;
                 }
                 KeyCode::Down => {
                     if let Some(mi) = self.active_menu {

--- a/crates/but/src/utils/output_channel.rs
+++ b/crates/but/src/utils/output_channel.rs
@@ -364,20 +364,17 @@ impl InputOutputChannel<'_> {
                     }
                     KeyEditAction::Ignore => {}
                 },
-                Event::Paste(text) => {
-                    if !text.is_empty() {
-                        line.push_str(&text);
-                        match echo {
-                            InputEcho::Visible => {
-                                self.out.stdout.write_all(text.as_bytes())?;
-                                self.out.stdout.flush()?;
-                            }
-                            InputEcho::Hidden => {
-                                let placeholders =
-                                    PLACEHOLDER_FOR_SECRET.repeat(text.chars().count());
-                                self.out.stdout.write_all(placeholders.as_bytes())?;
-                                self.out.stdout.flush()?;
-                            }
+                Event::Paste(text) if !text.is_empty() => {
+                    line.push_str(&text);
+                    match echo {
+                        InputEcho::Visible => {
+                            self.out.stdout.write_all(text.as_bytes())?;
+                            self.out.stdout.flush()?;
+                        }
+                        InputEcho::Hidden => {
+                            let placeholders = PLACEHOLDER_FOR_SECRET.repeat(text.chars().count());
+                            self.out.stdout.write_all(placeholders.as_bytes())?;
+                            self.out.stdout.flush()?;
                         }
                     }
                 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # IMPORTANT: This should match CI so it won't download the toolchain all the time.
-channel = "1.94"
+channel = "1.95"
 components = [
     "rustfmt",
     "clippy",


### PR DESCRIPTION
This is achieved by having similar (~95% compatible) hunk postprocessing which slides hunks around.

Also related to possible issues [with conflicts](https://github.com/GitoxideLabs/gitoxide/issues/2475) where Git sees none.

### Tasks

* [x] gix upgrade
* [x] Rust upgrade to 1.95
