### PR TITLE
Use native file dialog instead of browser built-in for directory picking

### DIFF
--- a/apps/desktop/src/components/onboarding/Welcome.svelte
+++ b/apps/desktop/src/components/onboarding/Welcome.svelte
@@ -13,6 +13,8 @@
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const posthog = inject(POSTHOG_WRAPPER);
+	const serverCapabilitiesQuery = $derived(projectsService.serverCapabilities());
+	const canAddProjects = $derived(serverCapabilitiesQuery.response?.canAddProjects ?? true);
 
 	let newProjectLoading = $state(false);
 	let directoryInputElement = $state<HTMLInputElement | undefined>();
@@ -49,20 +51,22 @@
 				bind:this={directoryInputElement}
 				data-testid="test-directory-path"
 			/>
-			<WelcomeAction
-				title="Add local project"
-				loading={newProjectLoading}
-				onclick={onNewProject}
-				dimMessage
-				testId={TestId.WelcomePageAddLocalProjectButton}
-			>
-				{#snippet icon()}
-					{@html newProjectSvg}
-				{/snippet}
-				{#snippet message()}
-					Should be a valid git repository
-				{/snippet}
-			</WelcomeAction>
+			{#if canAddProjects}
+				<WelcomeAction
+					title="Add local project"
+					loading={newProjectLoading}
+					onclick={onNewProject}
+					dimMessage
+					testId={TestId.WelcomePageAddLocalProjectButton}
+				>
+					{#snippet icon()}
+						{@html newProjectSvg}
+					{/snippet}
+					{#snippet message()}
+						Should be a valid git repository
+					{/snippet}
+				</WelcomeAction>
+			{/if}
 			<WelcomeAction title="Clone repository" onclick={onCloneProject} dimMessage>
 				{#snippet icon()}
 					{@html cloneRepoSvg}

--- a/apps/desktop/src/components/shared/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/shared/ProjectSwitcher.svelte
@@ -11,6 +11,8 @@
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectsQuery = $derived(projectsService.projects());
+	const serverCapabilitiesQuery = $derived(projectsService.serverCapabilities());
+	const canAddProjects = $derived(serverCapabilitiesQuery.response?.canAddProjects ?? true);
 
 	let selectedId = $state<string | undefined>(untrack(() => projectId));
 
@@ -43,26 +45,28 @@
 		{/snippet}
 
 		<OptionsGroup>
-			<SelectItem
-				icon="plus"
-				loading={newProjectLoading}
-				onClick={async () => {
-					newProjectLoading = true;
-					try {
-						const outcome = await projectsService.addProject();
-						if (!outcome) {
-							// User cancelled the project creation
+			{#if canAddProjects}
+				<SelectItem
+					icon="plus"
+					loading={newProjectLoading}
+					onClick={async () => {
+						newProjectLoading = true;
+						try {
+							const outcome = await projectsService.addProject();
+							if (!outcome) {
+								// User cancelled the project creation
+								newProjectLoading = false;
+								return;
+							}
+							handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
+						} finally {
 							newProjectLoading = false;
-							return;
 						}
-						handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
-					} finally {
-						newProjectLoading = false;
-					}
-				}}
-			>
-				Add local repository
-			</SelectItem>
+					}}
+				>
+					Add local repository
+				</SelectItem>
+			{/if}
 			<SelectItem
 				icon="clone"
 				loading={cloneProjectLoading}

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -29,6 +29,8 @@
 	const { createAiStack } = useCreateAiStack(reactive(() => projectId));
 
 	const projectsService = inject(PROJECTS_SERVICE);
+	const serverCapabilitiesQuery = $derived(projectsService.serverCapabilities());
+	const canAddProjects = $derived(serverCapabilitiesQuery.response?.canAddProjects ?? true);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const settingsService = inject(SETTINGS_SERVICE);
 	const modeService = inject(MODE_SERVICE);
@@ -176,28 +178,30 @@
 				{/snippet}
 
 				<OptionsGroup>
-					<SelectItem
-						icon="plus"
-						testId={TestId.ChromeHeaderProjectSelectorAddLocalProject}
-						loading={newProjectLoading}
-						onClick={async () => {
-							newProjectLoading = true;
-							try {
-								const outcome = await projectsService.addProject();
-								if (!outcome) {
-									// User cancelled the project creation
-									newProjectLoading = false;
-									return;
-								}
+					{#if canAddProjects}
+						<SelectItem
+							icon="plus"
+							testId={TestId.ChromeHeaderProjectSelectorAddLocalProject}
+							loading={newProjectLoading}
+							onClick={async () => {
+								newProjectLoading = true;
+								try {
+									const outcome = await projectsService.addProject();
+									if (!outcome) {
+										// User cancelled the project creation
+										newProjectLoading = false;
+										return;
+									}
 
-								handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
-							} finally {
-								newProjectLoading = false;
-							}
-						}}
-					>
-						Add local repository
-					</SelectItem>
+									handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
+								} finally {
+									newProjectLoading = false;
+								}
+							}}
+						>
+							Add local repository
+						</SelectItem>
+					{/if}
 					<SelectItem
 						icon="clone"
 						onClick={() => {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -114,16 +114,22 @@ async function webDocumentDir(): Promise<string> {
 async function webFilePicker<T extends OpenDialogOptions>(
 	options?: T,
 ): Promise<OpenDialogReturn<T>> {
+	// For directory picks, delegate to the backend's native OS dialog which
+	// returns an absolute path. The browser's <input> file picker cannot
+	// provide absolute paths, making it useless for "add project".
+	if (options?.directory) {
+		const result: { path: string | null } = await webInvoke("pick_directory");
+		if (result.path) {
+			return result.path as OpenDialogReturn<T>;
+		}
+		return null as OpenDialogReturn<T>;
+	}
+
 	const fileInput = document.createElement("input");
-	const projectPath = getCookie("PROJECT_PATH") || "";
 	fileInput.type = "file";
 
 	if (options?.multiple) {
 		fileInput.multiple = true;
-	}
-
-	if (options?.directory) {
-		fileInput.webkitdirectory = true; // This is a web-specific feature for directory selection
 	}
 
 	const promise = new Promise<OpenDialogReturn<T>>((resolve) => {
@@ -131,15 +137,6 @@ async function webFilePicker<T extends OpenDialogOptions>(
 			const files = fileInput.files;
 			if (!files || files.length === 0) {
 				resolve(null);
-				return;
-			}
-
-			if (options?.directory) {
-				const file = files[0]!;
-				const filePath = file.webkitRelativePath || file.name;
-				const dirPath = filePath.split("/").slice(0, -1).join("/");
-				const absolute = projectPath + "/" + dirPath;
-				resolve(absolute as OpenDialogReturn<T>);
 				return;
 			}
 

--- a/apps/desktop/src/lib/project/projectEndpoints.ts
+++ b/apps/desktop/src/lib/project/projectEndpoints.ts
@@ -9,9 +9,17 @@ export type ProjectInfo = {
 	headsup?: string;
 };
 
+export type ServerCapabilities = {
+	isRemote: boolean;
+	canAddProjects: boolean;
+};
+
 export function buildProjectEndpoints(build: BackendEndpointBuilder) {
 	return {
-		// ── Projects ────────────────────────────────────────────────
+		serverCapabilities: build.query<ServerCapabilities, void>({
+			extraOptions: { command: "server_capabilities" },
+			query: () => undefined,
+		}),
 		listProjects: build.query<Project[], void>({
 			extraOptions: { command: "list_projects" },
 			query: () => undefined,
@@ -58,8 +66,6 @@ export function buildProjectEndpoints(build: BackendEndpointBuilder) {
 			query: (args) => args,
 			providesTags: (_result, _error, args) => providesItem(ReduxTag.ProjectGerrit, args.projectId),
 		}),
-
-		// ── Oplog ───────────────────────────────────────────────────
 		oplogDiffWorktrees: build.query<TreeChanges, { projectId: string; snapshotId: string }>({
 			extraOptions: { command: "oplog_diff_worktrees" },
 			query: (args) => args,

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -28,6 +28,15 @@ export class ProjectsService {
 		return this.backendApi.endpoints.listProjects.useQuery();
 	}
 
+	/**
+	 * Capabilities that vary by how the backend was launched (local Tauri app
+	 * vs. but-server running behind a tunnel). Used to hide UI entry points
+	 * that require the user to be on the same machine as the backend.
+	 */
+	serverCapabilities() {
+		return this.backendApi.endpoints.serverCapabilities.useQuery();
+	}
+
 	getProject(projectId: string, noValidation?: boolean) {
 		return this.backendApi.endpoints.project.useQuery({ projectId, noValidation });
 	}
@@ -112,6 +121,15 @@ export class ProjectsService {
 	}
 
 	async addProject(path?: string) {
+		const capabilities = await this.backendApi.endpoints.serverCapabilities.fetch();
+		if (!capabilities?.canAddProjects) {
+			showToast({
+				style: "info",
+				title: "Adding projects is disabled",
+				message: "Projects can only be added when GitButler runs on your local machine.",
+			});
+			return;
+		}
 		if (!path) {
 			path = await this.getValidPath();
 			if (!path) return;

--- a/crates/but-api/src/platform.rs
+++ b/crates/but-api/src/platform.rs
@@ -1,6 +1,23 @@
 use anyhow::Result;
 use but_api_macros::but_api;
 
+/// Capabilities that vary by how the backend was launched.
+///
+/// Consumed by the frontend to conditionally show or hide affordances that
+/// only work when the user is on the same machine as the server (e.g. adding
+/// a local project requires a real filesystem path).
+#[derive(Debug, serde::Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCapabilities {
+    /// True when the server is reachable from outside localhost (e.g. a
+    /// tunnel is active). False in the Tauri desktop app and when
+    /// but-server is running locally.
+    pub is_remote: bool,
+    /// Whether the user can add a local project via a filesystem path.
+    pub can_add_projects: bool,
+}
+
 /// Get the build type of the current GitButler build.
 #[but_api]
 pub fn build_type() -> Result<String> {

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -68,8 +68,6 @@ pub(crate) struct Request {
 pub(crate) struct Extra {
     active_projects: Arc<Mutex<ActiveProjects>>,
     archival: Arc<but_feedback::Archival>,
-    /// When set, restricts project switching to only this project.
-    pinned_project: Option<but_ctx::ProjectHandleOrLegacyProjectId>,
 }
 
 #[derive(Clone)]
@@ -117,6 +115,179 @@ where
         let res = f(params).await;
         cmd_result_to_json(res)
     })
+}
+
+/// Like `but_post`, but rejects the request when the server is running in
+/// remote mode (tunnel active). Used for commands that only make sense when
+/// the user is on the same machine as the server, e.g. adding a project from
+/// a local filesystem path.
+fn local_only_post<F, S>(f: F) -> MethodRouter<S, Infallible>
+where
+    F: Fn(serde_json::Value) -> anyhow::Result<serde_json::Value> + Copy + Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
+{
+    post(move |Json(params)| async move {
+        let res = if is_remote() {
+            Err(anyhow::anyhow!(
+                "This action is disabled when but-server is running in remote mode"
+            ))
+        } else {
+            tokio::task::spawn_blocking(move || f(params))
+                .await
+                .unwrap_or_else(|e| Err(anyhow::anyhow!("handler task panicked: {e}")))
+        };
+        cmd_result_to_json(res)
+    })
+}
+
+/// Reports capabilities that depend on how but-server was launched, so the
+/// frontend can hide affordances that would fail on the backend (e.g. "Add
+/// project" when the server is behind a tunnel and the user's filesystem is
+/// not reachable).
+fn server_capabilities(_params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    let remote = is_remote();
+    Ok(serde_json::to_value(
+        but_api::platform::ServerCapabilities {
+            is_remote: remote,
+            can_add_projects: !remote,
+        },
+    )?)
+}
+
+/// Opens a native directory picker on the machine running but-server.
+/// Only available in local mode — remote clients cannot trigger a dialog on
+/// the server's display.
+///
+/// `rfd` cannot be used here because but-server is a headless process without
+/// an NSApplication run loop, so on macOS it would panic trying to show a
+/// dialog off the main thread. Instead we shell out to `osascript` (macOS) or
+/// `zenity`/`kdialog` (Linux) which work from any thread and any process.
+async fn pick_directory(_params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    if is_remote() {
+        anyhow::bail!("Native file picker is not available in remote mode");
+    }
+    let path = tokio::task::spawn_blocking(native_pick_directory).await??;
+    match path {
+        Some(p) => Ok(json!({ "path": p })),
+        None => Ok(json!({ "path": null })),
+    }
+}
+
+/// Shell out to a platform-native directory picker.
+fn native_pick_directory() -> anyhow::Result<Option<String>> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(
+                r#"set theFolder to choose folder with prompt "Select a Git repository"
+return POSIX path of theFolder"#,
+            )
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            // osascript exits with code 1 and "User canceled" on cancel
+            if stderr.contains("User canceled") || stderr.contains("(-128)") {
+                return Ok(None);
+            }
+            anyhow::bail!(
+                "osascript directory picker failed (exit {:?}): {}",
+                output.status.code(),
+                if stderr.is_empty() {
+                    "unknown error"
+                } else {
+                    &stderr
+                }
+            );
+        }
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() {
+            return Ok(None);
+        }
+        // osascript returns paths with a trailing slash — strip it
+        Ok(Some(path.trim_end_matches('/').to_string()))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Try zenity first, fall back to kdialog
+        let output = std::process::Command::new("zenity")
+            .args([
+                "--file-selection",
+                "--directory",
+                "--title=Select a Git repository",
+            ])
+            .output()
+            .or_else(|_| {
+                std::process::Command::new("kdialog")
+                    .args([
+                        "--getexistingdirectory",
+                        ".",
+                        "--title",
+                        "Select a Git repository",
+                    ])
+                    .output()
+            })?;
+        if !output.status.success() {
+            // zenity exits 1 on cancel, kdialog exits 1 on cancel
+            let code = output.status.code().unwrap_or(-1);
+            if code == 1 {
+                return Ok(None);
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "directory picker failed (exit {code}): {}",
+                if stderr.is_empty() {
+                    "unknown error"
+                } else {
+                    &stderr
+                }
+            );
+        }
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(path))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Use the modern IFileOpenDialog via PowerShell (STA is required for
+        // any Windows Forms/COM dialog). FolderBrowserDialog is directory-only.
+        // The script outputs the selected path on OK, or empty string on cancel.
+        // A non-zero exit means PowerShell itself failed (e.g. Add-Type error).
+        let output = std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-STA",
+                "-Command",
+                r#"Add-Type -AssemblyName System.Windows.Forms; $f = New-Object System.Windows.Forms.FolderBrowserDialog; $f.Description = 'Select a Git repository'; $f.UseDescriptionForTitle = $true; if ($f.ShowDialog() -eq 'OK') { $f.SelectedPath } else { '' }"#,
+            ])
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            anyhow::bail!(
+                "PowerShell directory picker failed (exit {:?}): {}",
+                output.status.code(),
+                if stderr.is_empty() {
+                    "unknown error"
+                } else {
+                    &stderr
+                }
+            );
+        }
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(path))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        anyhow::bail!("Native file picker is not supported on this platform")
+    }
 }
 
 fn cmd_result_to_json(res: anyhow::Result<serde_json::Value>) -> Json<serde_json::Value> {
@@ -194,7 +365,7 @@ pub struct Config {
     pub base_path: Option<String>,
     /// Disable authentication entirely. DANGEROUS — only use on trusted networks.
     pub allow_anyone: bool,
-    /// If set, auto-activate this directory's project on startup and prevent switching to others.
+    /// If set, auto-activate this directory's project on startup.
     pub project_path: Option<std::path::PathBuf>,
     /// Show cloudflared output on stderr. Enabled by `-v` in the CLI.
     pub verbose: bool,
@@ -211,6 +382,15 @@ fn allowed_remote_origin() -> Option<&'static str> {
 /// Whether authentication is disabled via --dangerously-allow-anyone.
 pub(crate) fn allow_anyone() -> bool {
     ALLOW_ANYONE.get().copied().unwrap_or(false)
+}
+
+/// Whether but-server is reachable from outside localhost (a tunnel is active).
+///
+/// Used to gate features that only make sense when the user is on the same
+/// machine as the server — notably adding projects, which needs a filesystem
+/// path the user can actually pick from their own machine.
+pub(crate) fn is_remote() -> bool {
+    allowed_remote_origin().is_some()
 }
 
 /// Check if an origin matches the configured remote origin.
@@ -404,10 +584,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         cache_dir: app_data_dir.join("cache").clone(),
         logs_dir: app_data_dir.join("logs").clone(),
     });
-    let mut extra = Extra {
+    let extra = Extra {
         active_projects: Arc::new(Mutex::new(ActiveProjects::new())),
         archival,
-        pinned_project: None,
     };
     #[cfg_attr(not(feature = "irc"), allow(unused_mut))]
     let mut app_settings =
@@ -470,14 +649,13 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     #[cfg(feature = "irc")]
     let working_files_broadcast = WorkingFilesBroadcast::new(irc_manager.clone());
 
-    // If a project path was provided, auto-activate that project and pin it.
+    // If a project path was provided, auto-activate that project.
     if let Some(ref project_path) = config.project_path {
         match but_ctx::Context::discover(project_path) {
             Ok(mut ctx) => {
                 but_api::legacy::projects::prepare_project_for_activation(&mut ctx).ok();
-                let project_id = ctx.legacy_project.id.clone();
                 let mut active = extra.active_projects.lock().await;
-                let activated = active
+                if active
                     .set_active(
                         &ctx,
                         &app,
@@ -485,15 +663,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                         #[cfg(feature = "irc")]
                         working_files_broadcast.clone(),
                     )
-                    .is_ok();
-                drop(active);
-                if activated {
-                    extra.pinned_project = Some(project_id);
-                } else {
-                    tracing::warn!(
-                        "Failed to activate project at {}; project switching will not be locked",
-                        project_path.display()
-                    );
+                    .is_err()
+                {
+                    tracing::warn!("Failed to activate project at {}", project_path.display());
                 }
             }
             Err(err) => {
@@ -563,6 +735,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     };
 
     let app = Router::new()
+        .route("/server_capabilities", but_post(server_capabilities))
+        .route("/pick_directory", but_post_async(pick_directory))
         .route(
             "/git_remote_branches",
             but_post(legacy::git::git_remote_branches_cmd),
@@ -699,10 +873,13 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             "/update_project",
             but_post(legacy::projects::update_project_cmd),
         )
-        .route("/add_project", but_post(legacy::projects::add_project_cmd))
+        .route(
+            "/add_project",
+            local_only_post(legacy::projects::add_project_cmd),
+        )
         .route(
             "/add_project_best_effort",
-            but_post(legacy::projects::add_project_best_effort_cmd),
+            local_only_post(legacy::projects::add_project_best_effort_cmd),
         )
         .route("/get_project", but_post(legacy::projects::get_project_cmd))
         .route(

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -177,17 +177,6 @@ pub async fn set_project_active(
 ) -> Result<serde_json::Value> {
     let params: SetProjectActiveParams = serde_json::from_value(params).to_json_error()?;
 
-    // When a project is pinned, reject attempts to switch to a different one.
-    if extra
-        .pinned_project
-        .as_ref()
-        .is_some_and(|pinned| &params.id != pinned)
-    {
-        anyhow::bail!(
-            "Project switching is disabled: only the current directory's project is accessible"
-        );
-    }
-
     // TODO(ctx): Adding projects to a list of active projects requires some more
     //            knowledge around how many unique tabs are looking at it
 

--- a/crates/gitbutler-tauri/permissions/default.toml
+++ b/crates/gitbutler-tauri/permissions/default.toml
@@ -179,6 +179,7 @@ commands.allow = [
   "secret_delete_global",
   "secret_get_global",
   "secret_set_global",
+  "server_capabilities",
   "set_base_branch",
   "set_gb_config",
   "set_project_active",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -454,6 +454,7 @@ fn main() -> anyhow::Result<()> {
                 askpass::submit_prompt_response,
                 menu::menu_item_set_enabled,
                 projects::list_projects,
+                projects::server_capabilities,
                 projects::set_project_active,
                 projects::open_project_in_window,
                 zip::get_logs_archive_path,

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -22,6 +22,17 @@ pub fn list_projects(
     but_api::legacy::projects::list_projects(open_projects).map_err(Into::into)
 }
 
+/// Reports capabilities that vary by how the backend was launched.
+/// In the Tauri app these are always "local-mode" values — the user is
+/// by definition on the same machine.
+#[tauri::command(async)]
+pub fn server_capabilities() -> Result<but_api::platform::ServerCapabilities, json::Error> {
+    Ok(but_api::platform::ServerCapabilities {
+        is_remote: false,
+        can_add_projects: true,
+    })
+}
+
 /// Additional information to help the user interface communicate what happened with the project.
 #[derive(Debug, serde::Serialize)]
 pub struct ProjectInfo {

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -116,3 +116,21 @@ export async function textEditorFillByTestId(page: Page, testId: TestIdValues, v
 export async function sleep(ms: number): Promise<void> {
 	return await new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Mock the backend's native directory picker to return a specific path.
+ *
+ * The web frontend calls `POST /pick_directory` to open a native OS file dialog.
+ * In e2e tests we intercept this request and return the desired path directly.
+ * Must be called before the action that triggers the picker.
+ */
+export async function mockPickDirectory(page: Page, directoryPath: string): Promise<void> {
+	await page.unroute("**/pick_directory");
+	await page.route("**/pick_directory", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ type: "success", subject: { path: directoryPath } }),
+		});
+	});
+}

--- a/e2e/playwright/tests/addingAProject.spec.ts
+++ b/e2e/playwright/tests/addingAProject.spec.ts
@@ -1,5 +1,5 @@
 import { getBaseURL, startGitButler, type GitButler } from "../src/setup.ts";
-import { clickByTestId, getByTestId, waitForTestId } from "../src/util.ts";
+import { clickByTestId, getByTestId, mockPickDirectory, waitForTestId } from "../src/util.ts";
 import { expect, test } from "@playwright/test";
 
 let gitbutler: GitButler;
@@ -29,11 +29,8 @@ test("should handle gracefully adding an existing project", async ({ page, conte
 	// Open the project selector
 	await clickByTestId(page, "chrome-header-project-selector");
 	// Click the add local project button
-	const fileChooserPromise = page.waitForEvent("filechooser");
+	await mockPickDirectory(page, projectPath);
 	await clickByTestId(page, "chrome-header-project-selector-add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
 
 	// Should display the "project already exists" modal
 	await waitForTestId(page, "add-project-already-exists-modal");
@@ -64,11 +61,8 @@ test("should handle gracefully adding bare repo", async ({ page, context }, test
 	clickByTestId(page, "analytics-continue");
 
 	// Add a local project
-	const fileChooserPromise = page.waitForEvent("filechooser");
-	clickByTestId(page, "add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
+	await mockPickDirectory(page, projectPath);
+	await clickByTestId(page, "add-local-project");
 
 	await waitForTestId(page, "add-project-bare-repo-modal");
 });
@@ -89,11 +83,8 @@ test("should handle gracefully adding a non-git directory", async ({ page, conte
 	clickByTestId(page, "analytics-continue");
 
 	// Add a local project
-	const fileChooserPromise = page.waitForEvent("filechooser");
-	clickByTestId(page, "add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
+	await mockPickDirectory(page, projectPath);
+	await clickByTestId(page, "add-local-project");
 
 	await waitForTestId(page, "add-project-not-a-git-repo-modal");
 });
@@ -119,11 +110,8 @@ test("should handle adding a project with extra commit and uncommitted changes o
 	clickByTestId(page, "analytics-continue");
 
 	// Click the add local project button
-	const fileChooserPromise = page.waitForEvent("filechooser");
-	clickByTestId(page, "add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
+	await mockPickDirectory(page, projectPath);
+	await clickByTestId(page, "add-local-project");
 
 	clickByTestId(page, "set-base-branch");
 

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -5,6 +5,7 @@ import {
 	clickByTestId,
 	fillByTestId,
 	getByTestId,
+	mockPickDirectory,
 	sleep,
 	textEditorFillByTestId,
 	waitForTestId,
@@ -37,11 +38,8 @@ test("should start the application and be able to commit", async ({ page, contex
 	clickByTestId(page, "analytics-continue");
 
 	// Add a local project
-	const fileChooserPromise = page.waitForEvent("filechooser");
-	clickByTestId(page, "add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
+	await mockPickDirectory(page, projectPath);
+	await clickByTestId(page, "add-local-project");
 
 	// Should see the set target page
 	await waitForTestId(page, "project-setup-page");
@@ -108,11 +106,8 @@ test("no author setup - should start the application and be able to commit", asy
 	clickByTestId(page, "analytics-continue");
 
 	// Add a local project
-	const fileChooserPromise = page.waitForEvent("filechooser");
-	clickByTestId(page, "add-local-project");
-
-	const fileChooser = await fileChooserPromise;
-	await fileChooser.setFiles(projectPath);
+	await mockPickDirectory(page, projectPath);
+	await clickByTestId(page, "add-local-project");
 
 	// Should see the set target page
 	await waitForTestId(page, "project-setup-page");


### PR DESCRIPTION
The browser file picker cannot return absolute paths, making it impossible
to add a project when using GitButler via but-server in a browser.

- /pick_directory shells out to the native OS folder picker (osascript on
  macOS, zenity/kdialog on Linux, FolderBrowserDialog via PowerShell -STA
  on Windows) and returns an absolute path. Distinguishes user cancellation
  from real errors on all platforms.

- /add_project and /add_project_best_effort are gated behind local_only_post,
  which rejects requests when a tunnel is active.

- /server_capabilities (and a matching Tauri command) reports
  { isRemote, canAddProjects } so the frontend can hide the "Add local
  repository" affordances when the backend is not local. ServerCapabilities
  is defined in but-api/src/platform.rs and shared by both backends.

- E2e Playwright tests use mockPickDirectory (page.route interception)
  instead of the browser filechooser event.