### PR TITLE
Fix tokio runtime starvation deadlock in but-server

### DIFF
--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -98,7 +98,9 @@ where
     S: Clone + Send + Sync + 'static,
 {
     post(move |Json(params)| async move {
-        let res = f(params);
+        let res = tokio::task::spawn_blocking(move || f(params))
+            .await
+            .unwrap_or_else(|e| Err(anyhow::anyhow!("handler task panicked: {e}")));
         cmd_result_to_json(res)
     })
 }


### PR DESCRIPTION
Move synchronous HTTP handlers off tokio worker threads using
spawn_blocking to prevent a deadlock discovered via process sampling.

The deadlock occurs when concurrent requests hit but-server: handlers
like fetch_from_remotes block tokio workers (via thread::spawn +
join), while other handlers (changes_in_worktree, operating_mode,
set_project_active) queue up waiting for the repo RwLock. With
parking_lot's writer-priority fairness, shared readers get starved
too. Eventually all tokio workers are blocked and the runtime can
make no progress.

Diagnosed by sampling the frozen process (PID 73290) which revealed:
- 4 fetch threads parked in RepoActionsExt::fetch → Runtime::block_on
- 15 workers blocked on exclusive_repo_access → lock_exclusive_slow
- 3 workers blocked on shared_repo_access → lock_shared_slow
- The gitbutler-tauri app (PID 71428) also deadlocked waiting for
  the same flock held by the but process

The fix wraps the sync handler call in tokio::task::spawn_blocking,
moving it to tokio's blocking thread pool which grows on demand
(up to 512 threads), keeping async worker threads free.