### PR TITLE
migrate people into the new rebase engine

### DIFF
--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -4,7 +4,15 @@
  *
  * @module appSettings
  */
-import { persisted, persistWithExpiration } from "@gitbutler/shared/persisted";
+import {
+	getBooleanStorageItem,
+	persisted,
+	persistWithExpiration,
+	setBooleanStorageItem,
+} from "@gitbutler/shared/persisted";
+
+const USE_NEW_REBASE_ENGINE_KEY = "feature-use-new-rebase-engine";
+const USE_NEW_REBASE_ENGINE_MIGRATION_KEY = "feature-use-new-rebase-engine-default-true-migrated";
 
 export const autoSelectBranchNameFeature = persisted(false, "autoSelectBranchLaneContentsFeature");
 export const autoSelectBranchCreationFeature = persisted(false, "autoSelectBranchCreationFeature");
@@ -14,4 +22,23 @@ export type StagingBehavior = "all" | "selection" | "none";
 export const stagingBehaviorFeature = persisted<StagingBehavior>("all", "feature-staging-behavior");
 export const fModeEnabled = persisted(true, "f-mode");
 export const newlineOnEnter = persisted(false, "feature-newline-on-enter");
-export const useNewRebaseEngine = persisted(false, "feature-use-new-rebase-engine");
+export const useNewRebaseEngine = persisted(false, USE_NEW_REBASE_ENGINE_KEY);
+
+/**
+ * Migrate users into the new rebase engine once.
+ * This can always be reversed, and that decision will be respected
+ */
+export function migrateUseNewRebaseEngineDefaultToTrue(): void {
+	// Skip if migrated already.
+	if (getBooleanStorageItem(USE_NEW_REBASE_ENGINE_MIGRATION_KEY) === true) {
+		return;
+	}
+
+	// Migrate only if they haven't yet enabled it.
+	if (getBooleanStorageItem(USE_NEW_REBASE_ENGINE_KEY) !== true) {
+		useNewRebaseEngine.set(true);
+	}
+
+	// Mark as migrated.
+	setBooleanStorageItem(USE_NEW_REBASE_ENGINE_MIGRATION_KEY, true);
+}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
 	import { initDependencies } from "$lib/bootstrap/deps";
 	import { MessageQueueProcessor } from "$lib/codegen/messageQueue.svelte";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
-	import { fModeEnabled } from "$lib/config/uiFeatureFlags";
+	import { fModeEnabled, migrateUseNewRebaseEngineDefaultToTrue } from "$lib/config/uiFeatureFlags";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { createKeybind } from "$lib/shortcuts/hotkeys";
@@ -106,6 +106,11 @@
 	// IRC connections are managed by the Rust backend (irc_lifecycle.rs).
 	// The backend handles auto-connect on startup and reacts to settings changes.
 	// Frontend queries IRC state via RTKQ endpoints (ircApi.ts).
+
+	// Migrate into the new rebase engine, once.
+	$effect(() => {
+		migrateUseNewRebaseEngineDefaultToTrue();
+	});
 
 	// =============================================================================
 	// DEBUG & DEVELOPMENT TOOLS


### PR DESCRIPTION
- Toggle on the new rebase engine feature flag once. This can be still
  manually reverted.
- The toggle-migration is done on application load