### PR TITLE
Fix rubbing commits with no message

### DIFF
--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -118,12 +118,25 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata>(
     let direction = determine_reorder_direction(&workspace, &repo, &subject, &target)?;
 
     let mut combined_message = Vec::new();
-    combined_message.extend_from_slice(subject.message.as_ref());
-    if !combined_message.ends_with(b"\n") {
-        combined_message.push(b'\n');
+    match (subject.message.is_empty(), target.message.is_empty()) {
+        (true, true) => {
+            // both messages are empty, leave combined message as empty
+        }
+        (true, false) => {
+            combined_message.extend_from_slice(target.message.as_ref());
+        }
+        (false, true) => {
+            combined_message.extend_from_slice(subject.message.as_ref());
+        }
+        (false, false) => {
+            combined_message.extend_from_slice(subject.message.as_ref());
+            if !combined_message.ends_with(b"\n") {
+                combined_message.push(b'\n');
+            }
+            combined_message.push(b'\n');
+            combined_message.extend_from_slice(target.message.as_ref());
+        }
     }
-    combined_message.push(b'\n');
-    combined_message.extend_from_slice(target.message.as_ref());
 
     let (replace_selector, dropped_selector, mut commit_to_replace, top_tree_id) = match direction {
         ReorderDirection::MoveSubjectAboveTarget => (

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -1430,6 +1430,98 @@ Squashed [..] → [..]
 }
 
 #[test]
+fn rub_commit_without_message_to_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("one.txt", "one.txt contents");
+    env.but("commit -m 'add one.txt'").assert().success();
+
+    env.but("status --no-hint")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   aec35ac add one.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+"#]]);
+
+    env.but("commit empty --after aec35ac").assert().success();
+
+    env.but("status --no-hint")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   5e5c05a (no commit message) (no changes)
+┊●   aec35ac add one.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+"#]]);
+
+    env.but("rub 5e5c05a aec35ac").assert().success();
+
+    env.but("status --no-hint")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   aec35ac add one.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn rub_commit_to_commit_without_message() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+    env.setup_metadata(&["A"])?;
+
+    env.file("one.txt", "one.txt contents");
+    env.but("commit -m 'add one.txt'").assert().success();
+    env.but("commit empty --after aec35ac").assert().success();
+
+    env.but("rub aec35ac 5e5c05a").assert().success();
+
+    let status = status_json(&env)?;
+    let branch = status["stacks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().unwrap().iter())
+        .find(|branch| branch["name"].as_str().unwrap() == "A")
+        .unwrap();
+    let commit_messages = branch["commits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|commit| commit["message"].as_str().unwrap().trim_end_matches('\n'))
+        .collect::<Vec<_>>();
+
+    assert_eq!(commit_messages, vec!["add one.txt", "add A"]);
+
+    Ok(())
+}
+
+#[test]
 fn rub_matrix_commit_to_branch_smoke() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks")?;
     env.setup_metadata(&["A", "B"])?;


### PR DESCRIPTION
Rubbing two commits where one of them had an empty message would result in extra new lines in the final message. This fixes that so if either message is empty we only keep the non empty one.