### PR TITLE
fix: align "part N of M" with <kbd> labels in stacked PR footers

### DIFF
--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -138,13 +138,13 @@ function clearFooter(body: string | undefined) {
 function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
 	const stackLength = allPrNumbers.length;
 	const stackIndex = allPrNumbers.findIndex((number) => number === forPrNumber);
-	const nth = stackLength - stackIndex;
+	const nth = stackIndex + 1;
 	let footer = "";
 	footer += STACKING_FOOTER_BOUNDARY_TOP + "\n";
 	footer += "---\n";
 	footer += `This is **part ${nth} of ${stackLength} in a stack** made with GitButler:\n`;
-	allPrNumbers.forEach((prNumber, i) => {
-		const current = i === stackIndex;
+	[...allPrNumbers].reverse().forEach((prNumber, i) => {
+		const current = prNumber === forPrNumber;
 		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> ${symbol}${prNumber} ${current ? "👈 " : ""}\n`;
 	});
 	footer += STACKING_FOOTER_BOUNDARY_BOTTOM;

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1559,6 +1559,7 @@ mod tests {
 
         assert!(pr_100_line.contains("👈"));
         assert!(pr_100_line.contains("<kbd>&nbsp;1&nbsp;</kbd>"));
+        assert!(footer.contains("part 1 of 3 in a stack"));
     }
 
     #[test]
@@ -1571,6 +1572,7 @@ mod tests {
 
         assert!(pr_102_line.contains("👈"));
         assert!(pr_102_line.contains("<kbd>&nbsp;3&nbsp;</kbd>"));
+        assert!(footer.contains("part 3 of 3 in a stack"));
     }
 
     #[test]

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1238,7 +1238,7 @@ fn generate_footer(for_pr_number: i64, all_pr_numbers: &[i64], symbol: &str) -> 
         .iter()
         .position(|&n| n == for_pr_number)
         .unwrap_or(0);
-    let nth = stack_length - stack_index;
+    let nth = stack_index + 1;
 
     let mut footer = String::new();
     footer.push_str(STACKING_FOOTER_BOUNDARY_TOP);
@@ -1600,7 +1600,7 @@ mod tests {
         let all_prs: Vec<i64> = (1..=10).collect();
         let footer = generate_footer(5, &all_prs, "#");
 
-        assert!(footer.contains("part 6 of 10 in a stack"));
+        assert!(footer.contains("part 5 of 10 in a stack"));
 
         // Verify all PRs are listed
         for pr in &all_prs {


### PR DESCRIPTION
This bug may also exist on the Desktop version of the app, but I haven't tested that yet.

## 🧢 Changes

- Change `nth = stack_length - stack_index` to `nth = stack_index + 1` in `generate_footer` (Rust)
- Apply same fix in TypeScript mirror (`prFooter.ts`), plus reverse iteration order to list top-first (matching Rust)
- Update test expectation in `test_generate_footer_large_stack`

## ☕️ Reasoning

The `<kbd>` labels number the stack with 1 = base and highest = top, but the "part N of M" text used the opposite convention. This made the base PR say "part 3 of 3" while its `<kbd>` label said 1.

## 🎫 Affected issues

Fixes: #13362