### PR TITLE
Decrease time to first render

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -172,6 +172,8 @@ where
     anyhow::Error: From<<T::Backend as Backend>::Error>,
     E: EventPolling + Copy,
 {
+    render(app, terminal_guard)?;
+
     loop {
         if app
             .options


### PR DESCRIPTION
Currently we run one update loop before doing the first render. That includes waiting 30 ms for input. This improves that by doing a render immediately before updating.