### PR TITLE
Make `but status` 5x faster in some scenarios

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -167,8 +167,8 @@ pub fn list_reviews(
     cache_config: Option<but_forge::CacheConfig>,
 ) -> Result<Vec<but_forge::ForgeReview>> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let remote_url = gitbutler_branch_actions::base::get_base_branch_remote_url(ctx)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url);
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -100,6 +100,12 @@ pub fn get_base_branch_data(ctx: &Context) -> Result<BaseBranch> {
     Ok(base)
 }
 
+#[instrument(skip(ctx), err(Debug))]
+pub fn get_base_branch_remote_url(ctx: &Context) -> Result<String> {
+    let target = default_target(&ctx.project_data_dir())?;
+    remote_url_of_target_to_base_branch(ctx, &target)
+}
+
 /// Restore the default target metadata if it is missing in the currently configured storage
 /// location while an existing `gitbutler/workspace` ref already proves the repository was
 /// initialized before.
@@ -395,22 +401,7 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         None => target.remote_url.clone(),
     };
 
-    // Fallback to the remote URL of the branch if the target remote URL is empty
-    let remote_url = if target.remote_url.is_empty() {
-        let remote = repo.find_remote(target.branch.remote()).context(format!(
-            "failed to find remote for branch {}",
-            target.branch.fullname()
-        ))?;
-        remote
-            .url(gix::remote::Direction::Fetch)
-            .map(|url| url.to_bstring().to_string())
-            .context(format!(
-                "failed to get remote url for {}",
-                target.branch.fullname()
-            ))?
-    } else {
-        target.remote_url.clone()
-    };
+    let remote_url = remote_url_of_target_to_base_branch(ctx, target)?;
 
     let branch_name = target.branch.fullname();
     let remote_name = target.branch.remote().to_string();
@@ -443,6 +434,29 @@ pub(crate) fn target_to_base_branch(ctx: &Context, target: &Target) -> Result<Ba
         short_name,
     };
     Ok(base)
+}
+
+fn remote_url_of_target_to_base_branch(ctx: &Context, target: &Target) -> Result<String> {
+    let repo = &*ctx.repo.get()?;
+
+    // Fallback to the remote URL of the branch if the target remote URL is empty
+    let remote_url = if target.remote_url.is_empty() {
+        let remote = repo.find_remote(target.branch.remote()).context(format!(
+            "failed to find remote for branch {}",
+            target.branch.fullname()
+        ))?;
+        remote
+            .url(gix::remote::Direction::Fetch)
+            .map(|url| url.to_bstring().to_string())
+            .context(format!(
+                "failed to get remote url for {}",
+                target.branch.fullname()
+            ))?
+    } else {
+        target.remote_url.clone()
+    };
+
+    Ok(remote_url)
 }
 
 fn default_target(base_path: &Path) -> Result<Target> {

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -4,21 +4,45 @@ mod commands;
 mod traversal {
     use anyhow::Result;
 
-    /// Return first-parent ancestors from `from` until `stop_before`, excluding `stop_before`.
+    /// Return commits on `from`'s first-parent chain, stopping before the first
+    /// commit that is reachable from `stop_before`.
+    ///
+    /// The returned commits are ordered from `from` backwards along the first-parent chain, excluding
+    /// the first commit that is reachable from `stop_before` by ancestry.
+    ///
+    /// This matches the semantics of a first-parent walk with `stop_before` hidden, but avoids the
+    /// up-front hidden-side graph painting that makes `with_hidden(stop_before)` expensive in large
+    /// repositories.
     pub fn first_parent_commit_ids_until(
         repo: &gix::Repository,
         from: gix::ObjectId,
         stop_before: gix::ObjectId,
     ) -> Result<Vec<gix::ObjectId>> {
-        use gix::prelude::ObjectIdExt as _;
+        let cache = repo.commit_graph_if_enabled()?;
+        let mut graph = repo.revision_graph(cache.as_ref());
+        let mut commit_ids = Vec::new();
+        let mut current = Some(from);
 
-        from.attach(repo)
-            .ancestors()
-            .first_parent_only()
-            .with_hidden(Some(stop_before))
-            .all()?
-            .map(|info| Ok(info?.id))
-            .collect()
+        while let Some(commit_id) = current {
+            let reaches_hidden_history =
+                match repo.merge_base_with_graph(commit_id, stop_before, &mut graph) {
+                    Ok(merge_base) => merge_base.detach() == commit_id,
+                    Err(gix::repository::merge_base_with_graph::Error::NotFound { .. }) => false,
+                    Err(err) => return Err(err.into()),
+                };
+            if reaches_hidden_history {
+                break;
+            }
+
+            commit_ids.push(commit_id);
+            current = repo
+                .find_commit(commit_id)?
+                .parent_ids()
+                .next()
+                .map(|parent_id| parent_id.detach());
+        }
+
+        Ok(commit_ids)
     }
 }
 pub use traversal::first_parent_commit_ids_until;


### PR DESCRIPTION
I noticed that `but status` would occasionally be slow especially if you hadn't pulled in a while.

With the openclaw repo (which moves insanely quickly):

```
hyperfine --warmup 2 "./target/release/but -C /Users/davidpdrsn/code/openclaw status"
Benchmark 1: ./target/release/but -C /Users/davidpdrsn/code/openclaw status
  Time (mean ± σ):     455.4 ms ±   1.2 ms    [User: 443.3 ms, System: 162.3 ms]
  Range (min … max):   453.5 ms … 457.3 ms    10 runs
```

In the same repo `git status` takes ~30 ms.

I ran a flamegraph and found most of the time was spent in [`gitbutler_branch_actions::base::target_to_base_branch`](https://github.com/gitbutlerapp/gitbutler/blob/b5f62abf1dc5257570755cc8cd755eb5ea58b653/crates/gitbutler-branch-actions/src/base.rs#L344) which was called twice:

1. Once as part of [`but_api::legacy::forge::list_reviews`](https://github.com/gitbutlerapp/gitbutler/blob/b5f62abf1dc5257570755cc8cd755eb5ea58b653/crates/but-api/src/legacy/forge.rs#L170) to get the remote url of the target branch.
2. And again via [`but_api::legacy::virtual_branches::get_base_branch_data`](https://github.com/gitbutlerapp/gitbutler/blob/b5f62abf1dc5257570755cc8cd755eb5ea58b653/crates/but/src/command/legacy/status/mod.rs#L321) to get various upstream data such as how far behind you are.

## `list_reviews`

For 1 (getting the remote url) we're calling `target_to_base_branch` just to get a single field. We don't even look at all the commits it traverses. The first commit addresses that by making a dedicated helper just to get the remote url. This gave a 2x speed up.

## `get_base_branch_data`

For 2 the real culprit was [`first_parent_commit_ids_until`](https://github.com/gitbutlerapp/gitbutler/blob/b5f62abf1dc5257570755cc8cd755eb5ea58b653/crates/gitbutler-repo/src/lib.rs#L8) which is called three times from `target_to_base_branch`:

- For finding `upstream_commits` which is used for the `(upstream) ⏫ 2 new commits` line
- `diverged_ahead` and `diverged_behind` both of which aren't used by `but status`

After a bunch of back and forth with codex about what a "hidden walk" is I think I've come up with a faster version of `first_parent_commit_ids_until` that behaves the same. The main issue was `.with_hidden(Some(stop_before))` which appears to do perform a ton of extra work including decompressing commits. The flamegraph looked like this:

<img width="1075" height="502" alt="image" src="https://github.com/user-attachments/assets/d5db40f9-7b23-48ce-8669-3abd810ee612" />

That was fixed in the second commit and gave another 3x speed up.

## The result

After both of these changes `but status` is down to 90 ms in openclaw:

```
hyperfine --warmup 2 "./target/release/but -C /Users/davidpdrsn/code/openclaw status"
Benchmark 1: ./target/release/but -C /Users/davidpdrsn/code/openclaw status
  Time (mean ± σ):      89.3 ms ±   2.0 ms    [User: 71.8 ms, System: 174.0 ms]
  Range (min … max):    87.1 ms …  98.4 ms    32 runs
```

This also impacts the TUI since it runs `but status` before starting and again after each operation.