### PR TITLE
When sorting, avoid allocations

### DIFF
--- a/crates/but-claude/src/prompt_templates.rs
+++ b/crates/but-claude/src/prompt_templates.rs
@@ -113,7 +113,7 @@ pub fn list_templates(project_data_dir: &Path) -> Result<Vec<PromptTemplate>> {
     }
 
     let mut out = out.into_values().collect::<Vec<_>>();
-    out.sort_by_key(|a| a.file_name.clone());
+    out.sort_by(|a, b| a.file_name.cmp(&b.file_name));
 
     Ok(out)
 }

--- a/crates/but-meta/src/legacy/storage.rs
+++ b/crates/but-meta/src/legacy/storage.rs
@@ -306,7 +306,7 @@ fn legacy_to_snapshot(
     let last_pushed_base_sha = vb.last_pushed_base.map(|oid| oid.to_string());
 
     let mut stacks: Vec<_> = vb.branches.iter().collect();
-    stacks.sort_by_key(|(sid, stack)| (stack.order, sid.to_string()));
+    stacks.sort_by_key(|(sid, stack)| (stack.order, **sid));
 
     let mut out_stacks = Vec::with_capacity(stacks.len());
     let mut out_heads = Vec::new();
@@ -376,7 +376,7 @@ fn legacy_to_snapshot(
     }
 
     let mut out_targets: Vec<_> = vb.branch_targets.iter().collect();
-    out_targets.sort_by_key(|(sid, _)| sid.to_string());
+    out_targets.sort_by_key(|(sid, _)| **sid);
     let branch_targets = out_targets
         .into_iter()
         .map(|(stack_id, target)| {

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -360,7 +360,7 @@ pub fn visualize_disk_tree_skip_dot_git(root: &Path) -> anyhow::Result<termtree:
         });
 
         let mut entries: Vec<_> = std::fs::read_dir(p)?.filter_map(|e| e.ok()).collect();
-        entries.sort_by_key(|e| e.file_name());
+        entries.sort_by_cached_key(|e| e.file_name());
         for entry in entries {
             let md = entry.metadata()?;
             if md.is_dir() && entry.file_name() != ".git" {

--- a/crates/but-ts/src/main.rs
+++ b/crates/but-ts/src/main.rs
@@ -200,7 +200,7 @@ fn collect_all_schemas(
     }
 
     // Order output types by name
-    types.sort_by_cached_key(|t| t.name.to_string());
+    types.sort_by(|a, b| a.name.cmp(&b.name));
 
     Ok(types
         .into_iter()

--- a/crates/but-workspace/src/legacy/commit_engine/refs.rs
+++ b/crates/but-workspace/src/legacy/commit_engine/refs.rs
@@ -27,7 +27,7 @@ pub fn rewrite(
         .values_mut()
         .filter(|stack| stack.in_workspace)
         .collect();
-    stacks_ordered.sort_by_key(|a| a.name());
+    stacks_ordered.sort_by_cached_key(|a| a.name());
     for (old, new) in changed_commits {
         let mut already_updated_refs = Vec::<BString>::new();
         for stack in &mut stacks_ordered {
@@ -112,6 +112,6 @@ pub fn rewrite(
     repo.edit_references(ref_edits)?;
     // Due to the way these are processed, they aren't stable.
     // Make tests reproducible, hoping that soon we don't need hashmaps in the backend anymore.
-    updated_refs.sort_by_key(|a| a.reference.to_string());
+    updated_refs.sort_by_cached_key(|a| a.reference.to_string());
     Ok(())
 }

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -137,7 +137,7 @@ impl Storage {
                     })
                     .collect();
 
-                all_projects.sort_by_key(|p| p.title.to_lowercase());
+                all_projects.sort_by_cached_key(|p| p.title.to_lowercase());
                 Ok(all_projects)
             }
             None => Ok(vec![]),


### PR DESCRIPTION
This is a follow-up to this review comment: https://github.com/gitbutlerapp/gitbutler/pull/13349#pullrequestreview-4125809422

It's notable that I don't think it matters in any of these cases, but maybe it's good
to see the `cached_key` version more in the codebase for it to be repeated.
