### PR TITLE
tui: show slow messages in debug builds

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -7,7 +7,7 @@ use std::{
     process::Command,
     rc::Rc,
     sync::{Arc, LazyLock, mpsc::Receiver},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
@@ -556,6 +556,9 @@ impl App {
         T: TerminalGuard,
         anyhow::Error: From<<T::Backend as Backend>::Error>,
     {
+        let start = Instant::now();
+        let discriminant = MessageDiscriminant::from(&msg);
+
         self.should_render = true;
         let terminal_area: Rect = terminal_guard.terminal_mut().size()?.into();
         let visible_height = self.status_viewport_height(terminal_area);
@@ -773,6 +776,20 @@ impl App {
         }
 
         self.ensure_cursor_visible(visible_height);
+
+        if cfg!(feature = "tui-profiling") && !cfg!(test) {
+            let elapsed_ms = start.elapsed().as_millis();
+            if !matches!(
+                discriminant,
+                MessageDiscriminant::Reload | MessageDiscriminant::Command
+            ) && elapsed_ms > 60
+            {
+                self.toasts.insert(
+                    ToastKind::Debug,
+                    format!("Slow message: {discriminant:?} {elapsed_ms:?} ms"),
+                );
+            }
+        }
 
         Ok(())
     }
@@ -2934,7 +2951,8 @@ fn event_to_messages(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, strum::EnumDiscriminants)]
+#[strum_discriminants(name(MessageDiscriminant))]
 enum Message {
     // Lifecycle
     JustRender,


### PR DESCRIPTION
If TUI is compiled with `feature = tui-profiling` we now show a toast if a message was slow to handle. Should help me sluggish things more clear.