### PR TITLE
Fix flaky commitActions e2e test by preventing dropzone expansion during drag

### DIFF
--- a/apps/desktop/src/components/views/StackPanel.svelte
+++ b/apps/desktop/src/components/views/StackPanel.svelte
@@ -235,11 +235,8 @@
 
 		&.dropzone-activated {
 			& .assigned-changes-empty {
-				padding: 20px 8px 20px;
 				background-color: var(--bg-1);
-				transition:
-					background-color var(--transition-fast),
-					padding var(--transition-fast);
+				transition: background-color var(--transition-fast);
 			}
 
 			& .assigned-changes-empty__text {


### PR DESCRIPTION
## Summary

- Fix flaky `commitActions` e2e test ("should be able to amend a file to a commit") that consistently fails on CI but passes locally
- The "Drop files to stage or commit directly" dropzone container was expanding its padding on drag activation, pushing the commit list down and causing `elementFromPoint()` to resolve to the branch card instead of the target commit dropzone
- Removed the padding expansion on `dropzone-activated` so the layout stays stable during drag

## Test plan

- [x] Verify the `commitActions` e2e test passes consistently on CI
- [x] Visually confirm the dropzone area still highlights on drag activation (background color change preserved, only padding expansion removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)