### PR TITLE
replace the `log` crate with `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,9 +1026,9 @@ name = "but-askpass"
 version = "0.0.0"
 dependencies = [
  "but-core",
- "log",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4300,7 +4300,6 @@ dependencies = [
  "gitbutler-project",
  "gitbutler-watcher",
  "gix",
- "log",
  "notify-rust",
  "open",
  "opener",

--- a/crates/but-askpass/Cargo.toml
+++ b/crates/but-askpass/Cargo.toml
@@ -14,7 +14,7 @@ but-core.workspace = true
 
 serde.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-log = "^0.4"
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/but-askpass/src/lib.rs
+++ b/crates/but-askpass/src/lib.rs
@@ -139,7 +139,7 @@ impl AskpassBroker {
         if let Some(request) = pending_requests.remove(&id) {
             request.sender.send(response).ok();
         } else {
-            log::warn!("received response for unknown askpass request: {id}");
+            tracing::warn!("received response for unknown askpass request: {id}");
         }
     }
 }

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -70,7 +70,6 @@ serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 
 parking_lot.workspace = true
-log = "^0.4"
 # The features here optimize for performance.
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
 tracing.workspace = true

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -129,9 +129,9 @@ fn main() -> anyhow::Result<()> {
                 file_name: Some("ui-logs".to_string()),
             }))
             .level(if tauri_debug_logging {
-                log::LevelFilter::Debug
+                tauri_plugin_log::log::LevelFilter::Debug
             } else {
-                log::LevelFilter::Error
+                tauri_plugin_log::log::LevelFilter::Error
             });
 
         let builder = tauri::Builder::default()

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
 	"bundle": {
 		"active": false,
 		"category": "DeveloperTool",
-		"copyright": "Copyright © 2023-2025 GitButler. All rights reserved.",
+		"copyright": "Copyright © 2023-2026 GitButler. All rights reserved.",
 		"createUpdaterArtifacts": "v1Compatible",
 		"targets": ["app", "dmg", "appimage", "deb", "rpm", "msi"],
 		"icon": [


### PR DESCRIPTION
Just because `log` is less powerful and `tracing` proved itself to be very useful.
While `log` is still in the dependency tree, at least we now have one way of logging.
