### PR TITLE
update `gix` for once again fast hidden-traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.81.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -4441,7 +4441,7 @@ dependencies = [
  "gix-status",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4471,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4483,13 +4483,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "kstring",
  "serde",
  "smallvec",
@@ -4500,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-error",
 ]
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "gix-blame"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4517,7 +4517,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-traverse",
  "gix-worktree",
  "smallvec",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-error",
 ]
@@ -4535,19 +4535,19 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.37.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4601,7 +4601,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-url",
  "serde",
  "thiserror 2.0.18",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4637,7 +4637,7 @@ dependencies = [
  "gix-path 0.11.2",
  "gix-pathspec",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-traverse",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4656,7 +4656,7 @@ dependencies = [
  "gix-object",
  "gix-path 0.11.2",
  "gix-pathspec",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-utils",
  "gix-worktree",
  "thiserror 2.0.18",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "dunce",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.2.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
 ]
@@ -4687,13 +4687,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4718,7 +4718,7 @@ dependencies = [
  "gix-packetline",
  "gix-path 0.11.2",
  "gix-quote",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-utils",
  "smallvec",
  "thiserror 2.0.18",
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4752,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.23.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4764,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -4774,12 +4774,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path 0.11.2",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "serde",
  "unicode-bom",
 ]
@@ -4787,17 +4787,17 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "memchr",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4825,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.14.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4863,7 +4863,7 @@ dependencies = [
  "gix-revision",
  "gix-revwalk",
  "gix-tempfile",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-worktree",
  "nonempty",
  "thiserror 2.0.18",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.78.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -4947,11 +4947,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.21.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "thiserror 2.0.18",
 ]
 
@@ -4970,10 +4970,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.11.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-validate 0.11.0",
  "thiserror 2.0.18",
 ]
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -5021,7 +5021,7 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "gix-transport",
  "gix-utils",
  "maybe-async",
@@ -5034,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5044,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-error",
@@ -5080,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -5091,7 +5091,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8)",
+ "gix-trace 0.1.18 (git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be)",
  "nonempty",
  "serde",
 ]
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -5114,7 +5114,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.13.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "gix-path 0.11.2",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "filetime",
@@ -5161,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-config",
@@ -5175,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "21.0.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -5189,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "crc",
@@ -5218,7 +5218,7 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 [[package]]
 name = "gix-trace"
 version = "0.1.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "tracing",
 ]
@@ -5226,7 +5226,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.55.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5245,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bitflags 2.11.0",
  "gix-commitgraph",
@@ -5261,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-path 0.11.2",
@@ -5273,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5293,7 +5293,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
 ]
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=2a5db88d0330b0d125de4b6f3819f17a7f76f4b8#2a5db88d0330b0d125de4b6f3819f17a7f76f4b8"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=172bd22b8241aba9187fc6e5134e3f454053c2be#172bd22b8241aba9187fc6e5134e3f454053c2be"
 dependencies = [
  "gix-attributes",
  "gix-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,10 @@ backoff = "0.4.0"
 bstr = "1.12.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "2a5db88d0330b0d125de4b6f3819f17a7f76f4b8", default-features = false, features = [
+gix = { version = "0.81.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "172bd22b8241aba9187fc6e5134e3f454053c2be", default-features = false, features = [
     "sha1",
 ] }
-gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "2a5db88d0330b0d125de4b6f3819f17a7f76f4b8" }
+gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "172bd22b8241aba9187fc6e5134e3f454053c2be" }
 
 
 insta = { version = "1.45.1", features = ["json"] }

--- a/crates/gitbutler-repo/src/traversal.rs
+++ b/crates/gitbutler-repo/src/traversal.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use gix::{
+    prelude::ObjectIdExt,
     revision::plumbing::{graph, merge_base::Flags},
     revwalk::Graph,
 };
@@ -11,21 +12,23 @@ use gix::{
 ///
 /// The returned commits are ordered from `from` backwards along the first-parent chain, excluding
 /// the first commit that is reachable from `stop_before` by ancestry.
-///
-/// This matches the semantics of a first-parent walk with `stop_before` hidden, but avoids the
-/// up-front hidden-side graph painting that makes `with_hidden(stop_before)` expensive in large
-/// repositories.
 pub fn first_parent_commit_ids_until(
     repo: &gix::Repository,
     from: gix::ObjectId,
     stop_before: gix::ObjectId,
 ) -> Result<Vec<gix::ObjectId>> {
-    let cache = repo.commit_graph_if_enabled()?;
-    let mut graph = repo.revision_graph(cache.as_ref());
-    first_parent_commit_ids_until_with_graph(repo, from, stop_before, &mut graph)
+    from.attach(repo)
+        .ancestors()
+        .first_parent_only()
+        .with_hidden(Some(stop_before))
+        .all()?
+        .map(|info| Ok(info?.id))
+        .collect()
 }
 
 /// Like [`first_parent_commit_ids_until()`], but reuses `graph` across repeated ancestry queries.
+///
+/// The implementation is `merge_base` based.
 pub fn first_parent_commit_ids_until_with_graph(
     repo: &gix::Repository,
     from: gix::ObjectId,
@@ -59,8 +62,7 @@ pub fn first_parent_commit_ids_until_with_graph(
 
 /// Return commits reachable from `from` that are not reachable from `stop_before`.
 ///
-/// This matches the semantics of walking `from` with `stop_before` hidden, but avoids
-/// the up-front hidden-side graph painting done by `with_hidden(stop_before)`.
+/// This matches the semantics of walking `from` with `stop_before` hidden.
 ///
 /// Reuse `graph` across repeated ancestry queries for better performance.
 pub fn commit_ids_excluding_reachable_from_with_graph(


### PR DESCRIPTION
This PR also re-adds the traversal in one spot that is safe.

### gix upgrade fixes

* [x] bad performance of `with_hidden()` for ancestor traversal
* [x] Git-like Myers hunks post-processing for less spurious conflicts