### PR TITLE
Fix forge_provider ACL permission

### DIFF
--- a/crates/gitbutler-tauri/permissions/default.toml
+++ b/crates/gitbutler-tauri/permissions/default.toml
@@ -74,6 +74,7 @@ commands.allow = [
   "fetch_from_remotes",
   "find_files",
   "forge_branch_chat",
+  "forge_provider",
   "forget_github_account",
   "forget_gitlab_account",
   "get_anonymous_graph_path",


### PR DESCRIPTION
## Summary

Add forge_provider to the Tauri ACL commands.allow list in
permissions/default.toml. The command was exposed via #[but_api(napi)]
and called unconditionally by the frontend (branchEndpoints.ts) to
determine the forge type, but was never added to the permissions when
the ACL system was introduced. Every call fails with "Command
forge_provider not allowed by ACL", meaning users on v0.19.8 cannot
see any forge integration (PR status, reviews, etc.).