### PR TITLE
Add and test account identifier type maps

### DIFF
--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -35,11 +35,19 @@ export function isSameGitHubAccountIdentifier(
 
 export type GitHubAccountIdentifierType = GithubAccountIdentifier["type"];
 
+type ExhaustiveGitHubMap = Record<GitHubAccountIdentifierType, true>;
+
+const exhaustiveGitHubMap: ExhaustiveGitHubMap = {
+	enterprise: true,
+	oAuthUsername: true,
+	patUsername: true,
+};
+
 function isGitHubAccountIdentifierType(text: unknown): text is GitHubAccountIdentifierType {
 	if (typeof text !== "string") {
 		return false;
 	}
-	return text === "oAuthUsername" || text === "patUsername" || text === "enterprise";
+	return exhaustiveGitHubMap[text as GitHubAccountIdentifierType] ?? false;
 }
 
 // ASCII Unit Separator, used to separate data units within a record or field.

--- a/apps/desktop/src/lib/forge/github/githubUserService.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.test.ts
@@ -1,0 +1,115 @@
+import {
+	githubAccountIdentifierToString,
+	stringToGitHubAccountIdentifier,
+} from "$lib/forge/github/githubUserService.svelte";
+import { describe, expect, test } from "vitest";
+import type { GithubAccountIdentifier } from "@gitbutler/but-sdk";
+
+const UNIT_SEP = "\u001F";
+
+describe("github account identifier serialization", () => {
+	test("serializes an oAuthUsername account", () => {
+		const account: GithubAccountIdentifier = {
+			type: "oAuthUsername",
+			info: {
+				username: "octocat",
+			},
+		};
+
+		expect(githubAccountIdentifierToString(account)).toBe(`oAuthUsername${UNIT_SEP}octocat`);
+	});
+
+	test("serializes a patUsername account", () => {
+		const account: GithubAccountIdentifier = {
+			type: "patUsername",
+			info: {
+				username: "alice",
+			},
+		};
+
+		expect(githubAccountIdentifierToString(account)).toBe(`patUsername${UNIT_SEP}alice`);
+	});
+
+	test("serializes an enterprise account", () => {
+		const account: GithubAccountIdentifier = {
+			type: "enterprise",
+			info: {
+				host: "github.example.com",
+				username: "bob",
+			},
+		};
+
+		expect(githubAccountIdentifierToString(account)).toBe(
+			`enterprise${UNIT_SEP}github.example.com${UNIT_SEP}bob`,
+		);
+	});
+});
+
+describe("github account identifier deserialization", () => {
+	test("deserializes an oAuthUsername account", () => {
+		expect(stringToGitHubAccountIdentifier(`oAuthUsername${UNIT_SEP}octocat`)).toStrictEqual({
+			type: "oAuthUsername",
+			info: {
+				username: "octocat",
+			},
+		});
+	});
+
+	test("deserializes a patUsername account", () => {
+		expect(stringToGitHubAccountIdentifier(`patUsername${UNIT_SEP}alice`)).toStrictEqual({
+			type: "patUsername",
+			info: {
+				username: "alice",
+			},
+		});
+	});
+
+	test("deserializes an enterprise account", () => {
+		expect(
+			stringToGitHubAccountIdentifier(`enterprise${UNIT_SEP}github.example.com${UNIT_SEP}bob`),
+		).toStrictEqual({
+			type: "enterprise",
+			info: {
+				host: "github.example.com",
+				username: "bob",
+			},
+		});
+	});
+
+	test("returns null for malformed or unsupported values", () => {
+		expect(stringToGitHubAccountIdentifier("patUsername")).toBeNull();
+		expect(stringToGitHubAccountIdentifier(`enterprise${UNIT_SEP}only-host`)).toBeNull();
+		expect(stringToGitHubAccountIdentifier(`selfHosted${UNIT_SEP}host${UNIT_SEP}user`)).toBeNull();
+	});
+});
+
+describe("github account identifier round-trip", () => {
+	test("round-trips supported account types", () => {
+		const accounts: GithubAccountIdentifier[] = [
+			{
+				type: "oAuthUsername",
+				info: {
+					username: "octocat",
+				},
+			},
+			{
+				type: "patUsername",
+				info: {
+					username: "alice",
+				},
+			},
+			{
+				type: "enterprise",
+				info: {
+					host: "github.example.com",
+					username: "bob",
+				},
+			},
+		];
+
+		for (const account of accounts) {
+			const serialized = githubAccountIdentifierToString(account);
+			expect(stringToGitHubAccountIdentifier(serialized)).toStrictEqual(account);
+		}
+	});
+});

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
@@ -30,11 +30,18 @@ export function isSameGitLabAccountIdentifier(
 
 export type GitLabAccountIdentifierType = GitlabAccountIdentifier["type"];
 
+type ExhaustiveGitLabMap = Record<GitLabAccountIdentifierType, true>;
+
+const exhaustiveGitLabMap: ExhaustiveGitLabMap = {
+	patUsername: true,
+	selfHosted: true,
+};
+
 function isGitLabAccountIdentifierType(text: unknown): text is GitLabAccountIdentifierType {
 	if (typeof text !== "string") {
 		return false;
 	}
-	return text === "patUsername" || text === "enterprise";
+	return exhaustiveGitLabMap[text as GitLabAccountIdentifierType] ?? false;
 }
 
 // ASCII Unit Separator, used to separate data units within a record or field.

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.test.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.test.ts
@@ -1,0 +1,89 @@
+import {
+	gitlabAccountIdentifierToString,
+	stringToGitLabAccountIdentifier,
+} from "$lib/forge/gitlab/gitlabUserService.svelte";
+import { describe, expect, test } from "vitest";
+import type { GitlabAccountIdentifier } from "@gitbutler/but-sdk";
+
+const UNIT_SEP = "\u001F";
+
+describe("gitlab account identifier serialization", () => {
+	test("serializes a patUsername account", () => {
+		const account: GitlabAccountIdentifier = {
+			type: "patUsername",
+			info: {
+				username: "octocat",
+			},
+		};
+
+		expect(gitlabAccountIdentifierToString(account)).toBe(`patUsername${UNIT_SEP}octocat`);
+	});
+
+	test("serializes a selfHosted account", () => {
+		const account: GitlabAccountIdentifier = {
+			type: "selfHosted",
+			info: {
+				host: "gitlab.example.com",
+				username: "alice",
+			},
+		};
+
+		expect(gitlabAccountIdentifierToString(account)).toBe(
+			`selfHosted${UNIT_SEP}gitlab.example.com${UNIT_SEP}alice`,
+		);
+	});
+});
+
+describe("gitlab account identifier deserialization", () => {
+	test("deserializes a patUsername account", () => {
+		expect(stringToGitLabAccountIdentifier(`patUsername${UNIT_SEP}octocat`)).toStrictEqual({
+			type: "patUsername",
+			info: {
+				username: "octocat",
+			},
+		});
+	});
+
+	test("deserializes a selfHosted account", () => {
+		expect(
+			stringToGitLabAccountIdentifier(`selfHosted${UNIT_SEP}gitlab.example.com${UNIT_SEP}alice`),
+		).toStrictEqual({
+			type: "selfHosted",
+			info: {
+				host: "gitlab.example.com",
+				username: "alice",
+			},
+		});
+	});
+
+	test("returns null for malformed or unsupported values", () => {
+		expect(stringToGitLabAccountIdentifier("patUsername")).toBeNull();
+		expect(stringToGitLabAccountIdentifier("enterprise\u001Fhost\u001Fuser")).toBeNull();
+		expect(stringToGitLabAccountIdentifier(`selfHosted${UNIT_SEP}only-host`)).toBeNull();
+	});
+});
+
+describe("gitlab account identifier round-trip", () => {
+	test("round-trips supported account types", () => {
+		const accounts: GitlabAccountIdentifier[] = [
+			{
+				type: "patUsername",
+				info: {
+					username: "octocat",
+				},
+			},
+			{
+				type: "selfHosted",
+				info: {
+					host: "gitlab.example.com",
+					username: "alice",
+				},
+			},
+		];
+
+		for (const account of accounts) {
+			const serialized = gitlabAccountIdentifierToString(account);
+			expect(stringToGitLabAccountIdentifier(serialized)).toStrictEqual(account);
+		}
+	});
+});


### PR DESCRIPTION
Modified GitHub and GitLab user service modules to introduce explicit type maps (exhaustiveGitHubMap, exhaustiveGitLabMap) for validating account identifier types, replacing previous string comparison logic. Added corresponding test files for both modules, covering serialization, deserialization, and round-trip integrity for supported account identifier types and malformed values. All changes are localized to the provider user service modules and their tests.

Fixes https://github.com/gitbutlerapp/gitbutler/issues/13333