### PR TITLE
Watch remote tracking refs to refresh UI after push

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -269,6 +269,14 @@
 					clientState.backendApi.util.invalidateTags([invalidatesList(ReduxTag.WorkspaceRules)]),
 				);
 			}),
+			backend.listen(`project://${projectId}/git/remote-activity`, () => {
+				clientState.dispatch(
+					clientState.backendApi.util.invalidateTags([
+						invalidatesList(ReduxTag.StackDetails),
+						invalidatesList(ReduxTag.BranchListing),
+					]),
+				);
+			}),
 		),
 	);
 

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -17,6 +17,8 @@ pub enum WatcherPayload {
     GitHead(WatcherGitHeadPayload),
     /// Git HEAD changed or there were changes to ref files.
     GitActivity(WatcherGitActivityPayload),
+    /// Remote tracking refs changed (e.g. after a push).
+    GitRemoteActivity(WatcherGitRemoteActivityPayload),
     /// There were changes in the files inside of the repository.
     WorktreeChanges(WatcherWorktreeChangesPayload),
 }
@@ -55,6 +57,14 @@ pub struct WatcherGitActivityPayload {
 
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(WatcherGitActivityPayload);
+
+/// Remote tracking refs changed (e.g. after a push or external git operation).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherGitRemoteActivityPayload;
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(WatcherGitRemoteActivityPayload);
 
 /// Worktree files changes.
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/crates/but-napi/src/lib.rs
+++ b/crates/but-napi/src/lib.rs
@@ -23,8 +23,8 @@ use napi_derive::napi;
 use but_api::{
     self as _,
     watcher::{
-        WatcherGitActivityPayload, WatcherGitFetchPayload, WatcherGitHeadPayload, WatcherPayload,
-        WatcherWorktreeChangesPayload,
+        WatcherGitActivityPayload, WatcherGitFetchPayload, WatcherGitHeadPayload,
+        WatcherGitRemoteActivityPayload, WatcherPayload, WatcherWorktreeChangesPayload,
     },
 };
 
@@ -113,6 +113,12 @@ fn event_from_change(change: gitbutler_watcher::Change) -> WatcherEvent {
             payload: serde_json::json!(WatcherPayload::GitActivity(WatcherGitActivityPayload {
                 head_sha
             })),
+        },
+        gitbutler_watcher::Change::GitRemoteActivity { project_id } => WatcherEvent {
+            name: format!("project://{project_id}/git/remote-activity"),
+            payload: serde_json::json!(WatcherPayload::GitRemoteActivity(
+                WatcherGitRemoteActivityPayload
+            )),
         },
         gitbutler_watcher::Change::WorktreeChanges {
             project_id,

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -79,6 +79,10 @@ impl ActiveProjects {
                             "headSha": head_sha,
                         }),
                     },
+                    Change::GitRemoteActivity { project_id } => FrontendEvent {
+                        name: format!("project://{project_id}/git/remote-activity"),
+                        payload: serde_json::json!({}),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         ref changes,

--- a/crates/gitbutler-filemonitor/src/file_monitor.rs
+++ b/crates/gitbutler-filemonitor/src/file_monitor.rs
@@ -590,6 +590,7 @@ fn backoff_err_to_anyhow(
 }
 
 pub const LOCAL_REFS_DIR: &str = "refs/heads/";
+pub const REMOTE_REFS_DIR: &str = "refs/remotes/";
 pub const FETCH_HEAD: &str = "FETCH_HEAD";
 pub const HEAD: &str = "HEAD";
 pub const HEAD_ACTIVITY: &str = "logs/HEAD";
@@ -617,6 +618,7 @@ fn classify_file(git_dir: &Path, file_path: &Path) -> FileKind {
             || check_file_path == Path::new(GB_FLUSH)
             || check_file_path == Path::new(INDEX)
             || check_file_path.starts_with(LOCAL_REFS_DIR)
+            || check_file_path.starts_with(REMOTE_REFS_DIR)
         {
             FileKind::Git
         } else {
@@ -624,5 +626,66 @@ fn classify_file(git_dir: &Path, file_path: &Path) -> FileKind {
         }
     } else {
         FileKind::Project
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn git_dir() -> &'static Path {
+        Path::new("/repo/.git")
+    }
+
+    #[test]
+    fn classify_local_ref() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/.git/refs/heads/main")),
+            FileKind::Git
+        );
+    }
+
+    #[test]
+    fn classify_remote_ref() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/.git/refs/remotes/origin/main")),
+            FileKind::Git
+        );
+    }
+
+    #[test]
+    fn classify_nested_remote_ref() {
+        assert_eq!(
+            classify_file(
+                git_dir(),
+                Path::new("/repo/.git/refs/remotes/origin/feature/branch")
+            ),
+            FileKind::Git
+        );
+    }
+
+    #[test]
+    fn classify_head() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/.git/HEAD")),
+            FileKind::Git
+        );
+    }
+
+    #[test]
+    fn classify_objects_as_uninteresting() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/.git/objects/ab/cdef1234567890")),
+            FileKind::GitUninteresting
+        );
+    }
+
+    #[test]
+    fn classify_worktree_file() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/src/main.rs")),
+            FileKind::Project
+        );
     }
 }

--- a/crates/gitbutler-filemonitor/src/lib.rs
+++ b/crates/gitbutler-filemonitor/src/lib.rs
@@ -9,5 +9,6 @@ pub use events::InternalEvent;
 
 mod file_monitor;
 pub use file_monitor::{
-    FETCH_HEAD, FileMonitorHandle, HEAD, HEAD_ACTIVITY, INDEX, LOCAL_REFS_DIR, WatchMode, spawn,
+    FETCH_HEAD, FileMonitorHandle, HEAD, HEAD_ACTIVITY, INDEX, LOCAL_REFS_DIR, REMOTE_REFS_DIR,
+    WatchMode, spawn,
 };

--- a/crates/gitbutler-filemonitor/src/watch_plan/mod.rs
+++ b/crates/gitbutler-filemonitor/src/watch_plan/mod.rs
@@ -119,6 +119,14 @@ fn emit_git_dir_watches(
     if refs_heads_dir.is_dir() && visit_dir(&refs_heads_dir, RecursiveMode::Recursive)?.is_break() {
         return Ok(ControlFlow::Break(()));
     }
+    let refs_remotes_dir = git_dir.join("refs").join("remotes");
+    // Watch remote tracking refs so that pushes (which update `refs/remotes/<remote>/<branch>`)
+    // are detected and can trigger a UI refresh.
+    if refs_remotes_dir.is_dir()
+        && visit_dir(&refs_remotes_dir, RecursiveMode::Recursive)?.is_break()
+    {
+        return Ok(ControlFlow::Break(()));
+    }
     Ok(ControlFlow::Continue(()))
 }
 

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -46,6 +46,10 @@ pub(crate) mod state {
                             "headSha": head_sha,
                         }),
                     },
+                    Change::GitRemoteActivity { project_id } => ChangeForFrontend {
+                        name: format!("project://{project_id}/git/remote-activity"),
+                        payload: serde_json::json!({}),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         changes,

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -15,6 +15,9 @@ pub enum Change {
         project_id: ProjectHandleOrLegacyProjectId,
         head_sha: String,
     },
+    GitRemoteActivity {
+        project_id: ProjectHandleOrLegacyProjectId,
+    },
     WorktreeChanges {
         project_id: ProjectHandleOrLegacyProjectId,
         changes: but_hunk_assignment::WorktreeChanges,

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -8,7 +8,7 @@ use but_hunk_assignment::HunkAssignment;
 use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
 use but_settings::{AppSettings, AppSettingsWithDiskSync};
 use gitbutler_filemonitor::{
-    FETCH_HEAD, HEAD, HEAD_ACTIVITY, INDEX, InternalEvent, LOCAL_REFS_DIR,
+    FETCH_HEAD, HEAD, HEAD_ACTIVITY, INDEX, InternalEvent, LOCAL_REFS_DIR, REMOTE_REFS_DIR,
 };
 use gitbutler_operating_modes::operating_mode;
 use gix::bstr::ByteSlice as _;
@@ -164,6 +164,7 @@ impl Handler {
         perm: &mut RepoExclusive,
     ) -> Result<()> {
         let (head_ref_name, head_sha) = head_info(ctx)?;
+        let mut saw_remote_activity = false;
         for path in paths {
             let Some(file_name) = path.to_str() else {
                 continue;
@@ -178,6 +179,10 @@ impl Handler {
                         project_id: project_id.clone(),
                         head_sha: head_sha.clone(),
                     })?;
+                }
+                // Track remote ref changes to emit a single event after the loop.
+                _ if file_name.starts_with(REMOTE_REFS_DIR) => {
+                    saw_remote_activity = true;
                 }
                 HEAD_ACTIVITY => {
                     self.emit_app_event(Change::GitActivity {
@@ -201,6 +206,9 @@ impl Handler {
                 }
                 _ => { /* Ignore other files */ }
             }
+        }
+        if saw_remote_activity {
+            self.emit_app_event(Change::GitRemoteActivity { project_id })?;
         }
         Ok(())
     }


### PR DESCRIPTION
Previously, `but push` (or any external push) updated
`.git/refs/remotes/` but the file monitor only watched
`.git/refs/heads/`, so the UI never noticed.

This adds a dedicated `git/remote-activity` event, separate from the
existing `git/activity` signal, so the frontend can invalidate only
the relevant caches (StackDetails, BranchListing) without triggering
unnecessary refetches on unrelated git activity like local ref changes.

- Watch `.git/refs/remotes/` recursively in the file monitor watch plan
- Classify remote ref paths as interesting in `classify_file`
- Emit `Change::GitRemoteActivity` from the watcher handler
- Plumb the new event through but-server, tauri, and napi layers
- Listen for `git/remote-activity` in the frontend layout to
  invalidate stack details and branch listings
- Add unit tests for `classify_file` covering local refs, remote refs,
  HEAD, uninteresting objects, and worktree files