### PR TITLE
Skip e2e jobs on unrelated changes

### DIFF
--- a/.github/workflows/check-e2e-changes.yml
+++ b/.github/workflows/check-e2e-changes.yml
@@ -1,0 +1,42 @@
+name: Check E2E-relevant changes
+on:
+  workflow_call:
+    outputs:
+      should_run:
+        description: "Whether the e2e job should run"
+        value: ${{ jobs.changes.outputs.should_run }}
+
+jobs:
+  changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.e2e == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - '**'
+              - '!**/*.md'
+              - '!.cargo/**'
+              - '!.claude/**'
+              - '!.vscode/**'
+              - '!.oxlintrc.json'
+              - '!deny.toml'
+              - '!scripts/**'
+              - '!apps/web/**'
+              - '!apps/lite/**'
+              - '!crates/but/**'
+              - '!crates/but-clap/**'
+              - '!crates/but-debugging/**'
+              - '!crates/but-installer/**'

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -4,21 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - "*.md"
-      - ".cargo/**"
-      - ".claude/**"
-      - ".vscode/**"
-      - ".oxlintrc.json"
-      - "deny.toml"
-      - "scripts/**"
-      - "apps/web/**"
-      - "apps/lite/**"
-      - "crates/but/**"
-      - "crates/but-clap/**"
-      - "crates/but-debugging/**"
-      - "crates/but-installer/**"
-      - "crates/but-testing/**"
   workflow_dispatch:
     inputs:
       sha:
@@ -27,8 +12,16 @@ on:
         description: Target SHA
 
 jobs:
+  changes:
+    uses: ./.github/workflows/check-e2e-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   test:
     name: e2e-blackbox
+    needs: changes
+    if: ${{ needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -4,21 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - "*.md"
-      - ".cargo/**"
-      - ".claude/**"
-      - ".vscode/**"
-      - ".oxlintrc.json"
-      - "deny.toml"
-      - "scripts/**"
-      - "apps/web/**"
-      - "apps/lite/**"
-      - "crates/gitbutler-cli/**"
-      - "crates/but/**"
-      - "crates/but-clap/**"
-      - "crates/but-debugging/**"
-      - "crates/but-installer/**"
   workflow_dispatch:
     inputs:
       sha:
@@ -27,8 +12,16 @@ on:
         description: Target SHA
 
 jobs:
+  changes:
+    uses: ./.github/workflows/check-e2e-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   test:
     name: e2e-playwright
+    needs: changes
+    if: ${{ needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Extract a reusable `check-e2e-changes` workflow that uses `dorny/paths-filter` to detect whether e2e-relevant files changed. Both `test-e2e-playwright` and `test-e2e-blackbox` now call it as a gate job, skipping the heavy test job when only irrelevant paths are touched (docs, apps/lite, apps/web, tooling crates, etc.).

This replaces the previous `paths-ignore` trigger filter, which prevented the workflow from running entirely — making it impossible to keep the check required in branch protection. A skipped job still reports a status, so the checks can remain required.