### PR TITLE
Also refetch PR data when CI badge is clicked

### DIFF
--- a/apps/desktop/src/components/branch/BranchCard.svelte
+++ b/apps/desktop/src/components/branch/BranchCard.svelte
@@ -273,6 +273,9 @@
 										mergeableState={pr.mergeableState}
 										isFork={pr.fork}
 										isMerged={pr.merged}
+										onrefetch={() => {
+											if (args.prNumber) prService?.fetch(args.prNumber, { forceRefetch: true });
+										}}
 									/>
 								{/if}
 							{/if}

--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -15,6 +15,7 @@
 		hasChecks?: boolean;
 		isFork?: boolean;
 		isMerged?: boolean;
+		onrefetch?: () => void;
 	};
 
 	type StatusInfo = {
@@ -34,6 +35,7 @@
 		isFork,
 		isMerged,
 		hasChecks = $bindable(),
+		onrefetch,
 	}: Props = $props();
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
@@ -232,6 +234,7 @@
 			elapsedMs = 0;
 		}
 		checksQuery?.result.refetch();
+		onrefetch?.();
 	}}
 >
 	<span data-pr-text={checksTagInfo.reducedText} class="truncate">


### PR DESCRIPTION
Checks and PR data use independent Redux cache tags (ReduxTag.Checks vs
ReduxTag.PullRequests), so refetching checks never invalidates the PR
cache — tag invalidation only fires from mutation endpoints, not from
query refetches. Add an onrefetch callback so BranchCard can explicitly
refetch the PR when the badge is clicked, ensuring mergeableState and
other PR-derived fields stay current.