### PR TITLE
refactor: remove vendored openssl from git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7591,15 +7591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7607,7 +7598,6 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,10 +221,7 @@ gix-testtools = { version = "0.19.0", git = "https://github.com/GitoxideLabs/git
 
 
 insta = { version = "1.45.1", features = ["json"] }
-git2 = { version = "0.20.4", features = [
-    "vendored-openssl",
-    "vendored-libgit2",
-] }
+git2 = { version = "0.20.4", default-features = false, features = ["vendored-libgit2"] }
 uuid = { version = "1.22", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive", "std"] }
 serde_json = "1.0.148"


### PR DESCRIPTION
This should no longer be needed at this point