### PR TITLE
Increase WebDriverIO connection retry count

### DIFF
--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -36,7 +36,7 @@ export const config = {
 
 	waitforTimeout: 10000,
 	connectionRetryTimeout: 120000,
-	connectionRetryCount: 0,
+	connectionRetryCount: 3,
 
 	beforeTest: async function (test: Frameworks.Test) {
 		const videoPath = path.join(import.meta.dirname, "/e2e/videos");


### PR DESCRIPTION
Tests are flaky due to intermittent connection issues during e2e runs.
Increase the WebDriverIO connectionRetryCount from 0 to 3 to allow
transient connection failures to be retried, reducing flakiness and
improving overall test stability.