### PR TITLE
Fix video recording path for e2e tests

### DIFF
--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -90,8 +90,12 @@ jobs:
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
-          name: WebdriverIO Artifacts
+          name: e2e-videos
           overwrite: true
-          path: |
-            ./e2e/blackbox/videos
-            ~/.config/com.gitbutler.app*/logs
+          path: ./e2e/blackbox/videos
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: e2e-logs
+          overwrite: true
+          path: ~/.config/com.gitbutler.app*/logs

--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -39,7 +39,7 @@ export const config = {
 	connectionRetryCount: 3,
 
 	beforeTest: async function (test: Frameworks.Test) {
-		const videoPath = path.join(import.meta.dirname, "/e2e/videos");
+		const videoPath = path.join(import.meta.dirname, "videos");
 		videoRecorder.start(test, videoPath);
 	},
 


### PR DESCRIPTION
Correct the path used for storing test video recordings by removing the
leading "/e2e/" segment and using "videos" relative to the current
directory. This fixes the incorrect path construction that likely
prevented videos from being written to the expected artifacts directory
and helps debug flaky test video capture.