### PR TITLE
refactor(but): add symbols to theme

### DIFF
--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -5,7 +5,7 @@ use but_settings::AppSettings;
 use but_update::{AppName, CheckUpdateStatus, check_status};
 use colored::Colorize;
 
-use crate::{args::update, utils::OutputChannel};
+use crate::{args::update, theme, utils::OutputChannel};
 
 pub fn handle(
     cmd: update::Subcommands,
@@ -46,11 +46,12 @@ fn check_for_updates(out: &mut OutputChannel, app_settings: &AppSettings) -> Res
 }
 
 fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStatus) -> Result<()> {
+    let t = theme::get();
     if status.up_to_date {
         writeln!(
             writer,
             "{} You're running the latest version ({})",
-            "✓".green().bold(),
+            t.sym().success,
             status.latest_version.bold()
         )?;
     } else {
@@ -100,6 +101,7 @@ fn suppress_updates(out: &mut OutputChannel, days: u32) -> Result<()> {
     // Convert days to hours (the API uses hours)
     // Note: days is already validated to be 1-30 by clap, so no overflow possible
     let hours = days * 24;
+    let t = theme::get();
 
     // Call the suppress_update function
     let mut cache = but_ctx::Context::app_cache();
@@ -109,7 +111,7 @@ fn suppress_updates(out: &mut OutputChannel, days: u32) -> Result<()> {
         writeln!(
             writer,
             "{} Update notifications suppressed for {} {}",
-            "✓".green().bold(),
+            t.sym().success,
             days,
             if days == 1 { "day" } else { "days" }
         )?;

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -27,10 +27,13 @@
 //! Missing fields in a user-supplied file fall back to the built-in defaults thanks to
 //! `#[serde(default)]`.
 
-use std::{path::Path, sync::OnceLock};
+use std::{fmt::Display, path::Path, sync::OnceLock};
 
 use colored::{ColoredString, Colorize as _};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::Span,
+};
 use serde::{Deserialize, Serialize};
 
 /// Global theme instance, initialized once at startup.
@@ -241,6 +244,15 @@ pub struct Theme {
     pub important: Style,
     /// Suggested command the user can run (e.g. `but config target …`).
     pub command_suggestion: Style,
+
+    #[serde(skip_serializing, skip_deserializing)]
+    // This is a bit weird. We need the theme itself to initialize these nested symbols, so we
+    // initialize them after all of the colors have been initialized and make the type an Option.
+    // But in practice, these symbols _must_ be here after initialization.
+    //
+    // This weirdness can be fixed by splitting the theme into two substructs: symbols and
+    // styles.
+    symbols: Option<ThemeSymbols>,
 }
 
 /// Helper — builds a [`Style`] with the given foreground color.
@@ -256,7 +268,7 @@ const fn style_fg_bold(fg: Color) -> Style {
 impl Default for Theme {
     /// Produces the canonical color palette.
     fn default() -> Self {
-        Self {
+        let mut t = Self {
             // Concrete "things"
             local_branch: style_fg(Color::Green),
             remote_branch: style_fg(Color::Magenta),
@@ -285,7 +297,68 @@ impl Default for Theme {
             hint: Style::new().add_modifier(Modifier::DIM),
             important: Style::new().add_modifier(Modifier::BOLD),
             command_suggestion: Style::new().fg(Color::Blue).add_modifier(Modifier::DIM),
+
+            // Symbols initialized below
+            symbols: None,
+        };
+        t.symbols = Some(ThemeSymbols::new(&t));
+        t
+    }
+}
+
+impl Theme {
+    /// Get the symbols for this theme.
+    pub fn sym(&self) -> &ThemeSymbols {
+        self.symbols
+            .as_ref()
+            .expect("symbols must always be initialized")
+    }
+}
+
+/// Symbols styled with a [`Theme`].
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ThemeSymbols {
+    /// Successful state.
+    pub success: StyledSymbol,
+    /// Error state.
+    pub error: StyledSymbol,
+}
+
+impl ThemeSymbols {
+    fn new(t: &Theme) -> Self {
+        Self {
+            success: StyledSymbol::new("✓", t.success.add_modifier(Modifier::BOLD)),
+            error: StyledSymbol::new("✗", t.error.add_modifier(Modifier::BOLD)),
         }
+    }
+}
+
+/// An abstract symbol that can be turned into either a raw ANSI-escaped [`String`] or a styled
+/// Ratatui [`Span`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyledSymbol {
+    content: String,
+    style: Style,
+}
+
+impl StyledSymbol {
+    /// Create a new [`StyledSymbol`].
+    pub fn new<S: AsRef<str>>(content: S, style: Style) -> Self {
+        StyledSymbol {
+            content: content.as_ref().to_string(),
+            style,
+        }
+    }
+
+    /// Convert the [`StyledSymbol`] into a styled [`Span`].
+    pub fn span(&self) -> Span<'_> {
+        Span::styled(&self.content, self.style)
+    }
+}
+
+impl Display for StyledSymbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.style.paint(&self.content))
     }
 }
 


### PR DESCRIPTION
## 🧢 Changes
An abstraction to provide symbols styled with the current theme that can either be turned into raw ANSI-escaped strings or a Ratatui Spans.