### PR TITLE
fix: remove unused dev profile option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,6 @@ incremental = false
 [profile.dev.package]
 foldhash = { opt-level = 3 }
 gix-imara-diff = { opt-level = 3 }
-gix-imara-diff-01 = { opt-level = 3 }
 but-graph = { opt-level = 3 }
 gix = { opt-level = 3 }
 gix-diff = { opt-level = 3 }


### PR DESCRIPTION
## 🧢 Changes
`cargo` is constantly warning me that there is no package with this name. Seems safe to remove.