### PR TITLE
Unify E2E test workflows into single file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -226,8 +226,7 @@ Located in `.github/workflows/`:
 
 - `push.yaml`: Main CI for linting, building, and testing on push
 - `publish.yaml`: Release builds for different platforms
-- `test-e2e-playwright.yml`: E2E tests with Playwright
-- `test-e2e-blackbox.yml`: E2E blackbox tests
+- `test-e2e.yml`: E2E tests (Playwright and blackbox)
 - `test-client-fe-integration.yml`: Frontend integration tests
 
 ### Pre-commit Checks

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,4 @@
-name: E2E Tests Playwright
+name: E2E Tests
 on:
   push:
     branches:
@@ -18,7 +18,82 @@ jobs:
       contents: read
       pull-requests: read
 
-  test:
+  blackbox:
+    name: e2e-blackbox
+    needs: changes
+    if: ${{ needs.changes.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/gitbutlerapp/ci-base-image@sha256:c0ab58bb5f1cd99beb36861f460895be77515f4dd252df736c27c117a8e04a92
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        name: Checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        name: Checkout (specific commit from manual dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: e2e-blackbox-rust-binaries
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Setup node environment
+        uses: ./.github/actions/init-env-node
+        if: ${{ github.ref != 'refs/heads/master' }}
+      - name: Build CLI, SvelteKit, and tauri-driver
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: |
+          cargo build -p gitbutler-cli &
+          cargo_pid=$!
+          pnpm build:desktop -- --mode development &
+          pnpm_pid=$!
+          td_pid=""
+          if [ ! -e "$HOME/.cargo/bin/tauri-driver" ]; then
+            cargo install tauri-driver &
+            td_pid=$!
+          fi
+          status=0
+          wait "$cargo_pid" || status=1
+          wait "$pnpm_pid" || status=1
+          [ -n "$td_pid" ] && { wait "$td_pid" || status=1; }
+          exit "$status"
+      - name: Build Tauri
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: pnpm build:test
+      - name: Build CLI (cache warming)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: cargo build -p gitbutler-cli
+
+      # Run it through `xvfb-run` to have a fake display server which allows our
+      # application to run headless without any changes to the code
+      - name: WebdriverIO
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: xvfb-run pnpm test:e2e:blackbox
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: e2e-videos
+          overwrite: true
+          path: ./e2e/blackbox/videos
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: e2e-logs
+          overwrite: true
+          path: ~/.config/com.gitbutler.app*/logs
+
+  playwright:
     name: e2e-playwright
     needs: changes
     if: ${{ needs.changes.outputs.should_run == 'true' }}
@@ -100,5 +175,7 @@ jobs:
           name: playwright-report
           path: |
             ./e2e/playwright-report/
-            ./e2e/test-results/
+            ./e2e/test-results/**/trace.zip
+            ./e2e/test-results/**/video.webm
+            ./e2e/test-results/**/error-context.md
           retention-days: 30

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -359,8 +359,7 @@ e2e/
 
 E2E tests run in CI via GitHub Actions:
 
-- `.github/workflows/test-e2e-playwright.yml`: Playwright tests
-- `.github/workflows/test-e2e-blackbox.yml`: Blackbox tests
+- `.github/workflows/test-e2e.yml`: E2E tests (Playwright and blackbox)
 
 Tests run on push and pull requests with:
 


### PR DESCRIPTION
## Summary

Unifies the two separate E2E workflow files (`test-e2e-playwright.yml` and `test-e2e-blackbox.yml`) into a single `test-e2e.yml`. The main motivation is to avoid duplicating the path-based change detection logic across two workflow files — with a single file, the e2e change detection only needs to be defined once.

## Notes

- Branch protection rules will need updating to reference the new job names from `test-e2e.yml` instead of the old workflow files.

## Test plan

- [x] Verify unified workflow triggers correctly on e2e-related changes
- [x] Verify both Playwright and blackbox tests run within the single workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)