### PR TITLE
id: use cached stacks instead of generating RefInfo

### DIFF
--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -498,6 +498,9 @@ pub fn graph_to_ref_info(
             // TODO: validate that this is still correct to do here if the workspace
             //       was generated from 'virtual' stacks only, i.e. stacks not from real
             //       merges.
+            // If we change the order of iteration,
+            // stacks_info_without_short_ids() in
+            // crates/but/src/id/stacks_info.rs should be changed too.
             .rev()
             .map(|stack| branch::Stack::try_from_graph_stack(stack, repo))
             .collect::<anyhow::Result<_>>()?,

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -9,6 +9,11 @@
 //! Non-goals:
 //! - Completeness: The output structures do not include all the data that the internal but-api has.
 
+use std::collections::HashMap;
+
+use anyhow::Context as _;
+use but_graph::SegmentIndex;
+use but_workspace::ref_info::{LocalCommit, Segment};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
@@ -292,10 +297,14 @@ impl From<Vec<but_forge::CiCheck>> for Ci {
 }
 
 impl Branch {
+    #[allow(clippy::too_many_arguments)]
     pub fn from_branch_details(
         repo: &gix::Repository,
         cli_id: String,
         segment: SegmentWithId,
+        segments_by_id: &HashMap<SegmentIndex, Segment>,
+        local_commits_by_id: &HashMap<gix::ObjectId, LocalCommit>,
+        remote_commits_by_id: &HashMap<gix::ObjectId, but_workspace::ref_info::Commit>,
         review_id: Option<String>,
         show_files: FilesStatusFlag,
         ci: Option<Vec<but_forge::CiCheck>>,
@@ -304,21 +313,41 @@ impl Branch {
         let commits = segment
             .workspace_commits
             .iter()
-            .map(|c| Commit::from_local_commit(repo, c.short_id.clone(), c.clone(), show_files))
+            .map(|c| {
+                Commit::from_local_commit(
+                    repo,
+                    c.short_id.clone(),
+                    c.clone(),
+                    local_commits_by_id,
+                    show_files,
+                )
+            })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         let upstream_commits = segment
             .remote_commits
             .iter()
-            .map(|c| Commit::from_remote_commit(c.short_id.clone(), c.clone(), None))
-            .collect();
+            .filter_map(|c| {
+                Commit::from_remote_commit(
+                    c.short_id.clone(),
+                    c.clone(),
+                    remote_commits_by_id,
+                    None,
+                )
+                .transpose()
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
+        let push_status = segments_by_id
+            .get(&segment.inner.id)
+            .context("BUG: head_info does not have segment that graph has")?
+            .push_status;
         Ok(Branch {
             cli_id,
             name: segment.branch_name().unwrap_or_default().to_string(),
             commits,
             upstream_commits,
-            branch_status: segment.inner.push_status.into(),
+            branch_status: push_status.into(),
             review_id,
             ci: ci.map(Ci::from),
             merge_status,
@@ -341,6 +370,7 @@ impl Commit {
         repo: &gix::Repository,
         cli_id: String,
         commit: WorkspaceCommitWithId,
+        local_commits_by_id: &HashMap<gix::ObjectId, LocalCommit>,
         show_files: FilesStatusFlag,
     ) -> anyhow::Result<Self> {
         let changes = if show_files.show_files_for(commit.inner.id) {
@@ -357,7 +387,10 @@ impl Commit {
             None
         };
 
-        let commit = &commit.inner.inner;
+        let commit = &local_commits_by_id
+            .get(&commit.commit_id())
+            .context("BUG: head_info does not have local commit that graph has")?
+            .inner;
         Ok(Commit {
             cli_id,
             commit_id: commit.id.to_string(),
@@ -375,10 +408,15 @@ impl Commit {
     pub fn from_remote_commit(
         cli_id: String,
         commit: RemoteCommitWithId,
+        remote_commits_by_id: &HashMap<gix::ObjectId, but_workspace::ref_info::Commit>,
         changes: Option<Vec<FileChange>>,
-    ) -> Self {
-        let commit = &commit.inner;
-        Commit {
+    ) -> anyhow::Result<Option<Self>> {
+        let Some(commit) = remote_commits_by_id.get(&commit.commit_id()) else {
+            // This was filtered out because there is a corresponding local
+            // commit, so don't show it.
+            return Ok(None);
+        };
+        Ok(Some(Commit {
             cli_id,
             commit_id: commit.id.to_string(),
             created_at: gix_time_to_rfc3339(&commit.author.time),
@@ -388,7 +426,7 @@ impl Commit {
             conflicted: None,
             review_id: None,
             changes,
-        }
+        }))
     }
     /// A commit not obtained from a stack. `IdMap` does not know
     /// about this commit, so it will not have a CLI ID.
@@ -516,6 +554,9 @@ fn convert_branch_to_json(
         repo,
         cli_id,
         segment.clone(),
+        &status_ctx.segments_by_id,
+        &status_ctx.local_commits_by_id,
+        &status_ctx.remote_commits_by_id,
         review_id,
         status_ctx.flags.show_files,
         ci,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -3,7 +3,7 @@
     reason = "VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
 )]
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Context as _;
 use assignment::FileAssignment;
@@ -12,7 +12,11 @@ use but_api::diff::ComputeLineStats;
 use but_core::{RepositoryExt, TreeStatus, ui};
 use but_ctx::Context;
 use but_forge::ForgeReview;
-use but_workspace::{ref_info::LocalCommitRelation, ui::PushStatus};
+use but_graph::SegmentIndex;
+use but_workspace::{
+    ref_info::{Commit, LocalCommit, LocalCommitRelation, Segment},
+    ui::PushStatus,
+};
 use gitbutler_branch_actions::upstream_integration::BranchStatus as UpstreamBranchStatus;
 use gitbutler_operating_modes::OperatingMode;
 use gitbutler_stack::StackId;
@@ -170,6 +174,9 @@ struct StatusContext<'a> {
     is_paged: bool,
     should_truncate_for_terminal: bool,
     id_map: IdMap,
+    segments_by_id: HashMap<SegmentIndex, Segment>,
+    local_commits_by_id: HashMap<gix::ObjectId, LocalCommit>,
+    remote_commits_by_id: HashMap<gix::ObjectId, Commit>,
     base_branch: Option<gitbutler_branch_actions::BaseBranch>,
     mode: &'a gitbutler_operating_modes::OperatingMode,
 }
@@ -245,21 +252,43 @@ async fn build_status_context<'a>(
     render_mode: StatusRenderMode,
 ) -> anyhow::Result<StatusContext<'a>> {
     // Process rules with exclusive access to create repo and workspace
-    let head_info = {
+    let (segments_by_id, local_commits_by_id, remote_commits_by_id, stacks) = {
         let mut guard = ctx.exclusive_worktree_access();
         but_rules::process_rules(ctx, guard.write_permission()).ok(); // TODO: this is doing double work (hunk-dependencies can be reused)
 
         // TODO: use this for JSON status information (regular status information
         //       already uses this)
         let meta = ctx.meta()?;
-        but_workspace::head_info(
+        let head_info = but_workspace::head_info(
             &*ctx.repo.get()?,
             &meta,
             but_workspace::ref_info::Options {
                 expensive_commit_info: true,
                 ..Default::default()
             },
-        )?
+        )?;
+        let mut segments_by_id = HashMap::<SegmentIndex, Segment>::new();
+        let mut local_commits_by_id = HashMap::<gix::ObjectId, LocalCommit>::new();
+        let mut remote_commits_by_id = HashMap::<gix::ObjectId, Commit>::new();
+        for stack in head_info.stacks {
+            for segment in stack.segments {
+                for local_commit in segment.commits.clone() {
+                    local_commits_by_id.insert(local_commit.id, local_commit);
+                }
+                for remote_commit in segment.commits_on_remote.clone() {
+                    remote_commits_by_id.insert(remote_commit.id, remote_commit);
+                }
+                segments_by_id.insert(segment.id, segment);
+            }
+        }
+
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        (
+            segments_by_id,
+            local_commits_by_id,
+            remote_commits_by_id,
+            ws.stacks.clone(),
+        )
     };
 
     let cache_config = if flags.refresh_prs {
@@ -271,7 +300,7 @@ async fn build_status_context<'a>(
 
     let worktree_changes = but_api::diff::changes_in_worktree(ctx)?;
 
-    let id_map = IdMap::new(head_info.stacks, worktree_changes.assignments.clone())?;
+    let id_map = IdMap::new(stacks, worktree_changes.assignments.clone())?;
 
     let stacks = id_map.stacks();
     // Store the count of stacks for hint logic later
@@ -288,7 +317,7 @@ async fn build_status_context<'a>(
         let assignments = assignment::filter_by_stack_id(assignments_by_file.values(), &stack.id);
         stack_details.push((stack.id, (Some(stack.clone()), assignments)));
     }
-    let ci_map = ci_map(ctx, &cache_config, &stack_details)?;
+    let ci_map = ci_map(ctx, &cache_config, &stack_details, &segments_by_id)?;
 
     // Calculate common_merge_base data and upstream state in a scope
     // to ensure repo reference is dropped before any async operations
@@ -398,6 +427,9 @@ async fn build_status_context<'a>(
         is_paged,
         should_truncate_for_terminal,
         id_map,
+        segments_by_id,
+        local_commits_by_id,
+        remote_commits_by_id,
         base_branch,
         mode,
     })
@@ -685,13 +717,17 @@ fn ci_map(
     ctx: &Context,
     cache_config: &but_forge::CacheConfig,
     stack_details: &[StackEntry],
+    segments_by_id: &HashMap<SegmentIndex, Segment>,
 ) -> Result<BTreeMap<String, Vec<but_forge::CiCheck>>, anyhow::Error> {
     let mut ci_map = BTreeMap::new();
     for (_, (stack_with_id, _)) in stack_details {
         if let Some(stack_with_id) = stack_with_id {
             for segment in &stack_with_id.segments {
+                let inner = segments_by_id
+                    .get(&segment.inner.id)
+                    .context("BUG: head_info does not contain segment that graph has")?;
                 if segment.pr_number().is_some()
-                    && !matches!(segment.inner.push_status, PushStatus::Integrated)
+                    && !matches!(inner.push_status, PushStatus::Integrated)
                     && let Some(branch_name) = segment.branch_name()
                     && let Ok(checks) = but_api::legacy::forge::list_ci_checks_and_update_cache(
                         ctx,
@@ -966,7 +1002,13 @@ fn print_group(
                     )]),
                 )?;
             }
+            let mut remote_commit_printed = false;
             for commit in &segment.remote_commits {
+                let Some(inner) = status_ctx.remote_commits_by_id.get(&commit.commit_id()) else {
+                    // This was filtered out because there is a corresponding
+                    // local commit, so don't show it.
+                    continue;
+                };
                 let details =
                     but_api::diff::commit_details(ctx, commit.commit_id(), ComputeLineStats::No)?;
                 print_commit(
@@ -974,24 +1016,29 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
-                    &commit.inner,
+                    inner,
                     CommitChanges::Remote(&details.diff_with_first_parent),
                     CommitClassification::Upstream,
                     false,
                     None,
                     output,
                 )?;
+                remote_commit_printed = true;
             }
-            if !segment.remote_commits.is_empty() {
+            if remote_commit_printed {
                 output.connector(Vec::from([Span::raw("┊-")]))?;
             }
             for commit in segment.workspace_commits.iter() {
+                let inner = status_ctx
+                    .local_commits_by_id
+                    .get(&commit.commit_id())
+                    .context("BUG: head_info does not contain local commit that graph has")?;
                 let marked = crate::command::legacy::mark::commit_marked(
                     ctx,
                     commit.commit_id().to_string(),
                 )
                 .unwrap_or_default();
-                let classification = match commit.relation() {
+                let classification = match inner.relation {
                     LocalCommitRelation::LocalOnly => CommitClassification::LocalOnly,
                     LocalCommitRelation::LocalAndRemote(object_id) => {
                         if object_id == commit.commit_id() {
@@ -1008,7 +1055,7 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
-                    &commit.inner.inner,
+                    &inner.inner,
                     CommitChanges::Workspace(&commit.tree_changes_using_repo(&repo)?),
                     classification,
                     marked,

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -13,8 +13,8 @@ use bstr::{BStr, BString, ByteSlice};
 use but_core::sync::RepoShared;
 use but_core::{ChangeId, ref_metadata::StackId};
 use but_ctx::Context;
+use but_graph::projection::{Stack, StackCommit, StackSegment};
 use but_hunk_assignment::HunkAssignment;
-use but_workspace::{branch::Stack, ref_info::LocalCommitRelation};
 use nonempty::NonEmpty;
 use self_cell::self_cell;
 
@@ -154,20 +154,16 @@ pub struct WorkspaceCommitWithId {
     /// The short ID.
     pub short_id: ShortId,
     /// The original workspace commit.
-    pub inner: but_workspace::ref_info::LocalCommit,
+    pub inner: StackCommit,
 }
 impl WorkspaceCommitWithId {
     /// The object ID of the commit.
     pub fn commit_id(&self) -> gix::ObjectId {
-        self.inner.inner.id
+        self.inner.id
     }
     /// The ID of the first parent if the commit has parents.
     pub fn first_parent_id(&self) -> Option<gix::ObjectId> {
-        self.inner.inner.parent_ids.first().cloned()
-    }
-    /// State in relation to its remote tracking branch.
-    pub fn relation(&self) -> LocalCommitRelation {
-        self.inner.relation
+        self.inner.parent_ids.first().cloned()
     }
 }
 /// Methods to calculate the short IDs of committed files.
@@ -251,7 +247,7 @@ pub struct RemoteCommitWithId {
     /// The short ID.
     pub short_id: ShortId,
     /// The original remote commit.
-    pub inner: but_workspace::ref_info::Commit,
+    pub inner: StackCommit,
 }
 impl RemoteCommitWithId {
     /// The object ID of the commit.
@@ -291,7 +287,7 @@ pub struct SegmentWithId {
     pub is_auto_id: bool,
     /// The original segment except that `commits` and `commits_on_remote` are
     /// blank to save memory.
-    pub inner: but_workspace::ref_info::Segment,
+    pub inner: StackSegment,
     /// The original `inner.commits` with additional information.
     pub workspace_commits: Vec<WorkspaceCommitWithId>,
     /// The original `inner.commits_on_remote` with additional information.
@@ -555,18 +551,6 @@ impl IdMap {
         assignments: Option<Vec<HunkAssignment>>,
         perm: &RepoShared,
     ) -> anyhow::Result<Self> {
-        let meta = ctx.meta()?;
-        let head_info = {
-            let repo = ctx.clone_repo_for_merging_non_persisting()?;
-            but_workspace::head_info(
-                &repo,
-                &meta,
-                but_workspace::ref_info::Options {
-                    expensive_commit_info: false,
-                    ..Default::default()
-                },
-            )?
-        };
         let context_lines = ctx.settings.context_lines;
         let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
 
@@ -585,7 +569,7 @@ impl IdMap {
             }
         };
 
-        Self::new(head_info.stacks, hunk_assignments)
+        Self::new(ws.stacks.clone(), hunk_assignments)
     }
 }
 

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use bstr::BString;
-use but_workspace::branch::Stack;
+use but_graph::projection::Stack;
 
 use crate::id::{
     RemoteCommitWithId, SegmentWithId, ShortId, StackWithId, UNASSIGNED, WorkspaceCommitWithId,
@@ -14,7 +14,9 @@ fn stacks_info_without_short_ids(stacks: Vec<Stack>) -> StacksInfo {
         id_usage: IdUsage::default(),
         short_ids_to_count: HashMap::new(),
     };
-    for stack in stacks {
+    // Reverse the stacks to match graph_to_ref_info() in
+    // crates/but-workspace/src/ref_info.rs.
+    for stack in stacks.into_iter().rev() {
         let mut stack_with_id = StackWithId {
             id: stack.id,
             segments: Vec::with_capacity(stack.segments.len()),

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1,8 +1,8 @@
 use anyhow::bail;
 use but_core::ref_metadata::StackId;
+use but_graph::projection::Stack;
 use but_hunk_assignment::HunkAssignment;
 use but_testsupport::{hex_to_id, hunk_header};
-use but_workspace::branch::Stack;
 
 use crate::{CliId, IdMap, id::id_usage::UintId};
 
@@ -1503,11 +1503,8 @@ mod util {
     use anyhow::bail;
     use bstr::BString;
     use but_core::ref_metadata::StackId;
+    use but_graph::projection::{Stack, StackCommit, StackSegment};
     use but_hunk_assignment::HunkAssignment;
-    use but_workspace::{
-        branch::Stack,
-        ref_info::{Commit, LocalCommit, Segment},
-    };
     use itertools::Itertools;
 
     use crate::{CliId, IdMap};
@@ -1521,18 +1518,13 @@ mod util {
         local_commit_ids: [gix::ObjectId; N1],
         base: Option<gix::ObjectId>,
         remote_commit_ids: [gix::ObjectId; N2],
-    ) -> Segment {
-        fn commit(id: gix::ObjectId, parent_id: Option<gix::ObjectId>) -> Commit {
-            Commit {
+    ) -> StackSegment {
+        fn commit(id: gix::ObjectId, parent_id: Option<gix::ObjectId>) -> StackCommit {
+            StackCommit {
                 id,
                 parent_ids: parent_id.into_iter().collect::<Vec<gix::ObjectId>>(),
-                tree_id: gix::index::hash::Kind::Sha1.empty_tree(),
-                message: Default::default(),
-                author: Default::default(),
                 refs: Vec::new(),
                 flags: Default::default(),
-                has_conflicts: false,
-                change_id: None,
             }
         }
 
@@ -1541,38 +1533,36 @@ mod util {
                 .expect("could not generate ref name"),
             worktree: None,
         });
-        let mut commits: Vec<LocalCommit> = Vec::new();
+        let mut commits: Vec<StackCommit> = Vec::new();
         for (i, id) in local_commit_ids.iter().enumerate() {
             let parent_id = local_commit_ids.get(i + 1).or(base.as_ref());
-            commits.push(LocalCommit {
-                inner: commit(*id, parent_id.cloned()),
-                relation: Default::default(),
-            });
+            commits.push(commit(*id, parent_id.cloned()));
         }
-        let mut commits_on_remote: Vec<Commit> = Vec::new();
+        let mut commits_on_remote: Vec<StackCommit> = Vec::new();
         for id in remote_commit_ids {
             commits_on_remote.push(commit(id, None))
         }
-        Segment {
+        StackSegment {
             ref_info,
-            id: Default::default(),
             remote_tracking_ref_name: None,
+            sibling_segment_id: None,
             remote_tracking_branch_segment_id: None,
+            id: Default::default(),
             commits,
-            commits_on_remote,
             commits_outside: None,
+            base,
+            base_segment_id: None,
+            commits_by_segment: Vec::new(),
+            commits_on_remote,
             metadata: None,
             is_entrypoint: false,
-            push_status: but_workspace::ui::PushStatus::NothingToPush,
-            base,
         }
     }
 
-    pub fn stack<const N: usize>(segments: [Segment; N]) -> Stack {
+    pub fn stack<const N: usize>(segments: [StackSegment; N]) -> Stack {
         Stack {
             id: None,
-            base: None,
-            segments: segments.into_iter().collect::<Vec<Segment>>(),
+            segments: segments.into_iter().collect::<Vec<StackSegment>>(),
         }
     }
 


### PR DESCRIPTION
Generate CLI IDs from the stacks in the workspace struct instead of generating a RefInfo struct. This improves performance for commands that do not need the extra information in RefInfo, which is all commands except for `status`.

Currently, stacks information is copied, but I'm looking into reducing the number of copies (probably by using Rc). This will be done in another PR.

Note that there are some algorithmic changes that had to be done as a result of migrating to the stacks in the workspace struct:
 - The order of stacks are reversed in RefInfo but not the workspace struct, so IdMap is changed to also reverse them.
 - Remote commits that match local commits are not in RefInfo but are in the workspace struct, so `status` is changed to also filter them out.
