### PR TITLE
Reject cross-stack file deletions during amend

### DIFF
--- a/crates/but-api/src/commit/amend.rs
+++ b/crates/but-api/src/commit/amend.rs
@@ -42,6 +42,7 @@ pub(crate) fn commit_amend_only_impl(
 ) -> anyhow::Result<CommitCreateResult> {
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    but_workspace::commit::reject_cross_stack_file_deletions(&ws, &repo, commit_id, &changes)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
     let but_workspace::commit::CommitAmendOutcome {

--- a/crates/but-workspace/src/commit/commit_amend.rs
+++ b/crates/but-workspace/src/commit/commit_amend.rs
@@ -1,6 +1,9 @@
 //! An action to amend an existing commit with selected changes.
 
+use std::collections::BTreeSet;
+
 use anyhow::{Result, bail};
+use bstr::BString;
 use but_core::{DiffSpec, RefMetadata};
 use but_rebase::graph_rebase::{Editor, Selector, Step, SuccessfulRebase, ToCommitSelector};
 
@@ -75,4 +78,60 @@ pub fn commit_amend<'ws, 'meta, M: RefMetadata>(
         commit_selector: Some(target_selector),
         rejected_specs: create_out.rejected_specs,
     })
+}
+
+/// Reject whole-file deletions that target a file already committed in another
+/// stack. Hunk-level amends naturally fail when the content doesn't match, but
+/// a file deletion removes the tree entry regardless of content — so it can
+/// silently create a modify/delete conflict across stacks, causing the
+/// workspace merge to skip the deleting stack entirely.
+pub fn reject_cross_stack_file_deletions(
+    ws: &but_graph::projection::Workspace,
+    repo: &gix::Repository,
+    target_commit_id: gix::ObjectId,
+    changes: &[DiffSpec],
+) -> Result<()> {
+    // A deletion is a DiffSpec with a path but no hunk_headers and no
+    // previous_path (not a rename).
+    let deleted_paths: BTreeSet<&BString> = changes
+        .iter()
+        .filter(|c| c.hunk_headers.is_empty() && c.previous_path.is_none())
+        .map(|c| &c.path)
+        .collect();
+    if deleted_paths.is_empty() {
+        return Ok(());
+    }
+
+    let target_stack = ws.find_commit_and_containers(target_commit_id);
+
+    for stack in &ws.stacks {
+        if let Some((target_stack, ..)) = target_stack
+            && std::ptr::eq(stack, target_stack)
+        {
+            continue;
+        }
+
+        let Some(tip) = stack.tip() else { continue };
+        let base = stack.base();
+
+        let stack_changes = but_core::diff::tree_changes(repo, base, tip)?;
+        for change in &stack_changes {
+            if deleted_paths.contains(&change.path) {
+                let stack_name = stack
+                    .segments
+                    .first()
+                    .and_then(|s| s.ref_name())
+                    .map(|n| n.shorten().to_string())
+                    .unwrap_or_else(|| "another stack".into());
+                bail!(
+                    "Cannot delete '{}' here — it is already committed in \
+                     '{stack_name}'. Deleting it in a different stack would \
+                     create a modify/delete conflict in the workspace.",
+                    change.path,
+                );
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -9,7 +9,7 @@ pub use reword::reword;
 pub mod commit_create;
 pub use commit_create::{CommitCreateOutcome, commit_create};
 pub mod commit_amend;
-pub use commit_amend::{CommitAmendOutcome, commit_amend};
+pub use commit_amend::{CommitAmendOutcome, commit_amend, reject_cross_stack_file_deletions};
 pub mod insert_blank_commit;
 pub use insert_blank_commit::insert_blank_commit;
 pub mod move_changes;

--- a/crates/but-workspace/tests/fixtures/scenario/merge-with-modify-delete-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/merge-with-modify-delete-conflict.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# Two independent stacks branching from main.
+# Stack "modify-shared" modifies a file ("shared-file") that also exists on main.
+# Stack "delete-shared" deletes that same "shared-file" AND also deletes a
+# second file ("also-deleted") that the other stack doesn't touch.
+#
+# This reproduces a cross-stack modify/delete conflict: when merging the
+# stacks into a workspace tree, the modify/delete on "shared-file" must NOT
+# prevent other changes from "delete-shared" (like the deletion of
+# "also-deleted") from being applied.
+git init
+
+echo "base content" > shared-file && git add shared-file
+echo "keep this" > also-deleted && git add also-deleted
+echo "untouched" > untouched && git add untouched
+git commit -m "init"
+
+# Stack A: modifies shared-file (but doesn't touch also-deleted).
+git checkout -b modify-shared main
+  echo "modified content" > shared-file && git add shared-file
+  git commit -m "modify shared-file"
+
+# Stack B: deletes shared-file AND also-deleted.
+git checkout -b delete-shared main
+  git rm shared-file && git rm also-deleted
+  git commit -m "delete shared-file and also-deleted"
+
+# Build a workspace merge commit manually via commit-tree.
+# We can't use `git merge` because it would fail on the modify/delete
+# conflict. GitButler constructs the workspace commit programmatically
+# anyway, so we just need a merge commit with the right parents.
+# Use modify-shared's tree as a stand-in (the test rebuilds the tree itself).
+git checkout -b gitbutler/workspace
+workspace_tree=$(git rev-parse modify-shared^{tree})
+workspace_commit=$(git commit-tree "$workspace_tree" \
+  -p modify-shared \
+  -p delete-shared \
+  -m "GitButler Workspace Commit")
+git update-ref HEAD "$workspace_commit"

--- a/crates/but-workspace/tests/workspace/commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/commit/mod.rs
@@ -525,6 +525,48 @@ mod from_new_merge_with_metadata {
         Ok(())
     }
 
+    /// Amending a whole-file deletion into a stack that doesn't own the file
+    /// would silently create a modify/delete conflict in the workspace merge.
+    /// `reject_cross_stack_file_deletions` must catch this and return an error.
+    #[test]
+    fn reject_file_deletion_targeting_path_committed_in_another_stack() {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("merge-with-modify-delete-conflict", "").unwrap();
+        insta::assert_snapshot!(
+            "modify-delete-graph",
+            visualize_commit_graph_all(&repo).unwrap()
+        );
+
+        let stacks = ["modify-shared", "delete-shared"];
+        add_stacks(&mut meta, stacks);
+        let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited()).unwrap();
+        let ws = graph.into_workspace().unwrap();
+
+        // Try to delete "shared-file" targeting a commit in delete-shared.
+        // modify-shared already commits changes to that file, so this must be rejected.
+        let delete_shared_tip = repo.rev_parse_single("delete-shared").unwrap().detach();
+        let deletion_spec = but_core::DiffSpec {
+            path: "shared-file".into(),
+            previous_path: None,
+            hunk_headers: vec![],
+        };
+        let err = but_workspace::commit::reject_cross_stack_file_deletions(
+            &ws,
+            &repo,
+            delete_shared_tip,
+            &[deletion_spec],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("shared-file"),
+            "error should mention the conflicting file, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("modify-shared"),
+            "error should mention the stack that owns the file, got: {err}"
+        );
+    }
+
     mod utils {
         use but_core::ref_metadata::{
             StackId, WorkspaceCommitRelation::Merged, WorkspaceStack, WorkspaceStackBranch,

--- a/crates/but-workspace/tests/workspace/commit/snapshots/workspace__commit__from_new_merge_with_metadata__modify-delete-graph.snap
+++ b/crates/but-workspace/tests/workspace/commit/snapshots/workspace__commit__from_new_merge_with_metadata__modify-delete-graph.snap
@@ -1,0 +1,10 @@
+---
+source: crates/but-workspace/tests/workspace/commit/mod.rs
+expression: visualize_commit_graph_all(&repo)?
+---
+*   b3efcfb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|\  
+| * 8d26d4d (delete-shared) delete shared-file and also-deleted
+* | b2d5bd5 (modify-shared) modify shared-file
+|/  
+* fbab7b5 (main) init

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -54,6 +54,10 @@ fn amend_diff_specs(
     oid: ObjectId,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CreateCommitOutcome> {
+    {
+        let (repo, ws, _) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+        but_workspace::commit::reject_cross_stack_file_deletions(&ws, &repo, oid, &diff_specs)?;
+    }
     but_workspace::legacy::commit_engine::create_commit_and_update_refs_with_project(
         &*ctx.repo.get()?,
         &ctx.project_data_dir(),


### PR DESCRIPTION
## Summary

- Add `reject_cross_stack_file_deletions` guard in `but-workspace` that prevents amending a whole-file deletion into a stack when that file is already committed in another stack.
- The guard is called from both amend paths:
  - **New path** (`but rub`, frontend/Tauri) → `but_api::commit_amend()` → `but_workspace::commit::commit_amend()` → `create_commit()` → `create_tree()`
  - **Legacy path** (`but amend`) → `amend_diff_specs()` → `create_commit_and_update_refs_with_project()` → `create_commit()` → `create_tree()`
  
  Both converge on the same `create_commit()` → `create_tree()`, which is where the deletion is applied. The guard is placed before this shared code in each entry point.
- Hunk-level amends are unaffected — their content naturally won't match the target commit's tree, so they already fail safely.
- Include a test that constructs a workspace with two stacks (one modifying a file, one deleting it), calls the guard directly, and asserts it rejects with an error mentioning the conflicting file and the owning stack.

## Context

When a file is committed in stack A and you delete it on disk, then amend that deletion into stack B, the amend succeeds silently. But the resulting workspace merge sees a modify/delete conflict and skips stack B entirely — losing all of B's other changes from the workspace tree.

`create_tree()` has a cherry-pick merge that catches modify/delete conflicts when file content differs between the workspace tree and the target commit tree. But when the target stack never modified the file (content is identical), the cherry-pick cleanly applies the deletion — silently creating the bad state. The guard catches this case by checking whether the deleted path appears in any other stack's diff.

## Test plan

- [x] `cargo test -p but-workspace reject_file_deletion` passes
- [x] Guard rejects cross-stack file deletions in both amend paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)