### PR TITLE
Allow creating a new branch from `[unassigned changes]`

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -1761,12 +1761,13 @@ impl App {
                 };
                 operations::create_branch_anchored_legacy(ctx, name.to_owned())?
             }
-            StatusOutputLineData::MergeBase => operations::create_branch_legacy(ctx)?,
+            StatusOutputLineData::UnassignedChanges { .. } | StatusOutputLineData::MergeBase => {
+                operations::create_branch_legacy(ctx)?
+            }
             StatusOutputLineData::UpdateNotice
             | StatusOutputLineData::Connector
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
-            | StatusOutputLineData::UnassignedChanges { .. }
             | StatusOutputLineData::UnassignedFile { .. }
             | StatusOutputLineData::Commit { .. }
             | StatusOutputLineData::CommitMessage

--- a/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/branch_tests.rs
@@ -5,7 +5,7 @@ use snapbox::str;
 use crate::command::legacy::status::tui::tests::utils::test_tui;
 
 #[test]
-fn branch_key_from_unassigned_is_noop() {
+fn branch_key_from_unassigned_creates_new_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
     env.setup_metadata(&["A"]).unwrap();
 
@@ -15,7 +15,7 @@ fn branch_key_from_unassigned_is_noop() {
         .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);
 
     tui.input_then_render('b')
-        .assert_current_line_eq(str!["╭┄zz [unassigned changes] (no changes)"]);
+        .assert_current_line_eq(str!["┊╭┄br [c-branch-1] (no commits)"]);
 }
 
 #[test]


### PR DESCRIPTION
Before it was only allowed from the merge base but its annoying having to go all the way to the bottom to create a new branch.