### PR TITLE
napi: Use the right N-API async runtime

### DIFF
--- a/crates/but-napi/Cargo.toml
+++ b/crates/but-napi/Cargo.toml
@@ -35,7 +35,7 @@ but-ctx.workspace = true
 but-path.workspace = true
 but-settings.workspace = true
 gitbutler-watcher.workspace = true
-napi = { version = "3", features = ["serde-json", "async"] }
+napi = { version = "3", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3"
 serde_json.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
We should use tokio runtimes up-in-here