### PR TITLE
[experiment] Add cross-platform Playwright e2e scripts and Windows runner

### DIFF
--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -102,3 +102,80 @@ jobs:
             ./e2e/playwright-report/
             ./e2e/test-results/
           retention-days: 30
+
+  playwright-windows:
+    name: e2e-playwright-windows
+    needs: changes
+    if: ${{ needs.changes.outputs.should_run == 'true' }}
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    timeout-minutes: 90
+    env:
+      DESKTOP_PORT: 3000
+      BUTLER_PORT: 6978
+      VITE_E2E: "true"
+      VITE_BUTLER_PORT: 6978
+      VITE_BUTLER_HOST: "localhost"
+      VITE_BUILD_TARGET: "web"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: e2e-playwright-windows-rust-binaries
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Preset Git Configuration and but-testing location
+        shell: pwsh
+        run: |
+          "GIT_CONFIG_GLOBAL=$PWD\e2e\playwright\fixtures\.gitconfig" | Out-File -Append $env:GITHUB_ENV
+          "BUT_TESTING=$PWD\target\debug\but-testing.exe" | Out-File -Append $env:GITHUB_ENV
+      - name: Setup node environment
+        uses: ./.github/actions/init-env-node
+        if: ${{ github.ref != 'refs/heads/master' }}
+      - id: get_playwright_version
+        uses: eviden-actions/get-playwright-version@c83e8a285b395cc1e3d99df43d4ddaa0c889d8ff # v1
+        if: ${{ github.ref != 'refs/heads/master' }}
+      - name: Cache playwright binaries
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        id: playwright-cache
+        with:
+          path: |
+            ~\AppData\Local\ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
+      - name: Build Rust binaries
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: cargo build -p gitbutler-git -p but-server -p but-testing
+      - name: Build SvelteKit
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: pnpm build:desktop
+      - name: Install Playwright browsers
+        if: ${{ github.ref != 'refs/heads/master' && steps.playwright-cache.outputs.cache-hit != 'true' }}
+        run: cd e2e && pnpm exec playwright install chromium webkit
+      - name: Build Rust binaries (cache warming)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: cargo build -p gitbutler-git -p but-server -p but-testing
+      - name: Run Playwright tests
+        run: pnpm exec turbo run test:e2e:playwright
+        if: ${{ github.ref != 'refs/heads/master' }}
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: playwright-report-windows
+          path: |
+            ./e2e/playwright-report/
+            ./e2e/test-results/**/trace.zip
+            ./e2e/test-results/**/video.webm
+            ./e2e/test-results/**/error-context.md
+          retention-days: 30

--- a/e2e/playwright/scripts/apply-upstream-branch.ts
+++ b/e2e/playwright/scripts/apply-upstream-branch.ts
@@ -1,0 +1,14 @@
+import { logEnv, args, pushd, popd, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+const branch = args[0];
+const directory = args[1];
+
+console.log(`BRANCH TO APPLY: ${branch}`);
+console.log(`DIRECTORY: ${directory}`);
+
+// Apply remote branch to the workspace.
+pushd(directory);
+butTestingIn(".", "-j", "stack-branches", "-u", "-b", branch);
+popd();

--- a/e2e/playwright/scripts/create-allowed-file.ts
+++ b/e2e/playwright/scripts/create-allowed-file.ts
@@ -1,0 +1,6 @@
+import { pushd, popd, writeLine } from "./lib.ts";
+
+// Create a file with allowed content
+pushd("local-with-hooks");
+writeLine("allowed.txt", "This is allowed content");
+popd();

--- a/e2e/playwright/scripts/create-forbidden-file.ts
+++ b/e2e/playwright/scripts/create-forbidden-file.ts
@@ -1,0 +1,6 @@
+import { pushd, popd, writeLine } from "./lib.ts";
+
+// Create a file with forbidden content
+pushd("local-with-hooks");
+writeLine("forbidden.txt", "This contains FORBIDDEN content");
+popd();

--- a/e2e/playwright/scripts/create-postcommit-fail-marker.ts
+++ b/e2e/playwright/scripts/create-postcommit-fail-marker.ts
@@ -1,0 +1,6 @@
+import { pushd, popd, touch } from "./lib.ts";
+
+// Create a marker file to trigger post-commit failure
+pushd("local-with-hooks");
+touch("FAIL_POST_COMMIT");
+popd();

--- a/e2e/playwright/scripts/lib.ts
+++ b/e2e/playwright/scripts/lib.ts
@@ -1,0 +1,139 @@
+/**
+ * Cross-platform helpers for e2e setup scripts.
+ *
+ * Each script is executed by Node with `--experimental-strip-types`,
+ * so plain TypeScript (no enums / const-enums / namespaces) is fine.
+ */
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { appendFileSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import path from "node:path";
+
+/* ------------------------------------------------------------------ */
+/*  Environment                                                       */
+/* ------------------------------------------------------------------ */
+
+export const BUT_TESTING: string = process.env.BUT_TESTING ?? "";
+export const GIT_CONFIG_GLOBAL: string = process.env.GIT_CONFIG_GLOBAL ?? "";
+export const GITBUTLER_CLI_DATA_DIR: string = process.env.GITBUTLER_CLI_DATA_DIR ?? "";
+
+/** Script arguments (after `node <script>`). */
+export const args: string[] = process.argv.slice(2);
+
+/* ------------------------------------------------------------------ */
+/*  Logging                                                           */
+/* ------------------------------------------------------------------ */
+
+export function logEnv(): void {
+	console.log(`GIT CONFIG ${GIT_CONFIG_GLOBAL}`);
+	console.log(`DATA DIR ${GITBUTLER_CLI_DATA_DIR}`);
+	console.log(`BUT_TESTING ${BUT_TESTING}`);
+}
+
+/* ------------------------------------------------------------------ */
+/*  File helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+export function mkdir(dir: string): void {
+	mkdirSync(dir, { recursive: true });
+}
+
+/** Append text followed by a newline, like `echo "text" >> file`. */
+export function appendLine(file: string, text: string): void {
+	appendFileSync(file, text + "\n");
+}
+
+/** Write text to a file, like `echo "text" > file`. */
+export function writeLine(file: string, text: string): void {
+	writeFileSync(file, text + "\n");
+}
+
+/** Create an empty file, like `touch file`. */
+export function touch(file: string): void {
+	writeFileSync(file, "");
+}
+
+/** Make a file executable (no-op on Windows where it isn't needed). */
+export function makeExecutable(file: string): void {
+	if (process.platform !== "win32") {
+		chmodSync(file, 0o755);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/*  Command execution                                                 */
+/* ------------------------------------------------------------------ */
+
+const defaultExecOpts: ExecFileSyncOptions = { stdio: "inherit" };
+
+/** Run an arbitrary command synchronously, inheriting stdio. */
+export function run(cmd: string, cmdArgs: string[], cwd?: string): void {
+	execFileSync(cmd, cmdArgs, { ...defaultExecOpts, cwd });
+}
+
+/** Shorthand for running git commands. */
+export function git(...gitArgs: string[]): void {
+	execFileSync("git", gitArgs, defaultExecOpts);
+}
+
+/** Run git in a specific directory. */
+export function gitIn(cwd: string, ...gitArgs: string[]): void {
+	execFileSync("git", gitArgs, { ...defaultExecOpts, cwd });
+}
+
+/** Run git and capture stdout (trimmed). */
+export function gitOutput(...gitArgs: string[]): string {
+	return execFileSync("git", gitArgs, { encoding: "utf-8" }).trim();
+}
+
+/** Run git in a specific directory and capture stdout (trimmed). */
+export function gitOutputIn(cwd: string, ...gitArgs: string[]): string {
+	return execFileSync("git", gitArgs, { cwd, encoding: "utf-8" }).trim();
+}
+
+/** Run the but-testing binary. */
+export function butTesting(...btArgs: string[]): void {
+	if (!BUT_TESTING) {
+		throw new Error("BUT_TESTING environment variable is not set");
+	}
+	execFileSync(BUT_TESTING, btArgs, defaultExecOpts);
+}
+
+/** Run the but-testing binary in a specific directory. */
+export function butTestingIn(cwd: string, ...btArgs: string[]): void {
+	if (!BUT_TESTING) {
+		throw new Error("BUT_TESTING environment variable is not set");
+	}
+	execFileSync(BUT_TESTING, btArgs, { ...defaultExecOpts, cwd });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Directory helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+const dirStack: string[] = [];
+
+/** Change to `dir`, pushing the current directory onto a stack. */
+export function pushd(dir: string): void {
+	dirStack.push(process.cwd());
+	process.chdir(dir);
+}
+
+/** Return to the directory saved by the last `pushd`. */
+export function popd(): void {
+	const prev = dirStack.pop();
+	if (prev === undefined) {
+		throw new Error("popd: directory stack is empty");
+	}
+	process.chdir(prev);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Git hook helpers                                                  */
+/* ------------------------------------------------------------------ */
+
+/** Write a git hook file and make it executable. */
+export function writeHook(hooksDir: string, hookName: string, content: string): void {
+	const hookPath = path.join(hooksDir, hookName);
+	writeFileSync(hookPath, content);
+	makeExecutable(hookPath);
+}

--- a/e2e/playwright/scripts/merge-upstream-branch-to-base.ts
+++ b/e2e/playwright/scripts/merge-upstream-branch-to-base.ts
@@ -1,0 +1,13 @@
+import { logEnv, args, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+const branch = args[0];
+console.log(`BRANCH TO MERGE: ${branch}`);
+
+// Merge the upstream branch into master and delete the upstream branch
+pushd("remote-project");
+git("checkout", "master");
+git("merge", "--no-ff", "-m", `Merging upstream branch ${branch} into base`, branch);
+git("branch", "-d", branch);
+popd();

--- a/e2e/playwright/scripts/move-branch.ts
+++ b/e2e/playwright/scripts/move-branch.ts
@@ -1,0 +1,16 @@
+import { logEnv, args, pushd, popd, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+const destination = args[0];
+const branchToMove = args[1];
+const directory = args[2];
+
+console.log(`BRANCH DESTINATION: ${destination}`);
+console.log(`BRANCH TO MOVE: ${branchToMove}`);
+console.log(`DIRECTORY: ${directory}`);
+
+// Move branch using but-testing CLI.
+pushd(directory);
+butTestingIn(".", "-j", "move-branch", destination, branchToMove);
+popd();

--- a/e2e/playwright/scripts/project-with-commit-and-uncommitted-changes.ts
+++ b/e2e/playwright/scripts/project-with-commit-and-uncommitted-changes.ts
@@ -1,0 +1,27 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+mkdir("remote-with-changes");
+pushd("remote-with-changes");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("initial_file.txt", "Initial content");
+git("add", "initial_file.txt");
+git("commit", "-am", "Initial commit");
+popd();
+
+// Clone the remote into a folder
+git("clone", "remote-with-changes", "local-with-changes");
+pushd("local-with-changes");
+git("checkout", "master");
+
+// Add an extra commit on the main branch
+appendLine("second_file.txt", "Second commit content");
+git("add", "second_file.txt");
+git("commit", "-am", "Second commit on main branch");
+
+// Add some uncommitted changes
+appendLine("uncommitted.txt", "Uncommitted changes");
+appendLine("initial_file.txt", "Modified initial file");
+popd();

--- a/e2e/playwright/scripts/project-with-commit-hooks.ts
+++ b/e2e/playwright/scripts/project-with-commit-hooks.ts
@@ -1,0 +1,78 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git, gitOutputIn, butTestingIn, writeHook } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project
+mkdir("remote-with-hooks");
+pushd("remote-with-hooks");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("initial_file.txt", "Initial content");
+git("add", "initial_file.txt");
+git("commit", "-am", "Initial commit");
+popd();
+
+// Clone the remote into a folder
+git("clone", "remote-with-hooks", "local-with-hooks");
+pushd("local-with-hooks");
+git("checkout", "master");
+
+// Create hooks directory
+mkdir(".git/hooks");
+
+// Create a commit-msg hook that modifies the message
+writeHook(".git/hooks", "commit-msg", `#!/bin/sh
+# This hook modifies commit messages by adding a prefix
+MESSAGE_FILE="$1"
+ORIGINAL_MESSAGE=$(cat "$MESSAGE_FILE")
+
+# If message contains "REJECT", reject it
+if echo "$ORIGINAL_MESSAGE" | grep -q "REJECT"; then
+  echo "Error: Commit message contains forbidden word REJECT"
+  exit 1
+fi
+
+# If message contains "MODIFY", add a prefix
+if echo "$ORIGINAL_MESSAGE" | grep -q "MODIFY"; then
+  echo "[MODIFIED] $ORIGINAL_MESSAGE" > "$MESSAGE_FILE"
+fi
+`);
+
+// Create a pre-commit hook that checks for forbidden content
+writeHook(".git/hooks", "pre-commit", `#!/bin/sh
+# This hook checks staged files for forbidden content
+
+# Get the list of staged files
+STAGED_FILES=$(git diff --cached --name-only)
+
+# Check each staged file for FORBIDDEN content
+for file in $STAGED_FILES; do
+  if [ -f "$file" ]; then
+    if grep -q "FORBIDDEN" "$file"; then
+      echo "Error: File $file contains FORBIDDEN content"
+      exit 1
+    fi
+  fi
+done
+
+exit 0
+`);
+
+// Create a post-commit hook that can be triggered to fail
+writeHook(".git/hooks", "post-commit", `#!/bin/sh
+# This hook checks if a marker file exists to trigger failure
+
+if [ -f "FAIL_POST_COMMIT" ]; then
+  echo "Error: Post-commit hook failed due to FAIL_POST_COMMIT marker"
+  exit 1
+fi
+
+exit 0
+`);
+
+// Add some uncommitted changes for testing
+appendLine("uncommitted.txt", "Uncommitted changes");
+
+// Add the project to GitButler
+const upstream = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream);
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches.ts
@@ -1,0 +1,47 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git, gitOutputIn, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+mkdir("remote-project");
+pushd("remote-project");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("a_file", "foo");
+appendLine("a_file", "bar");
+appendLine("a_file", "baz");
+git("add", "a_file");
+git("commit", "-am", "Hey, look! A commit.");
+
+// Create branch 1
+git("checkout", "-b", "branch1");
+appendLine("a_file", "branch1 commit 1");
+git("commit", "-am", "branch1: first commit");
+appendLine("a_file", "branch1 commit 2");
+git("commit", "-am", "branch1: second commit");
+git("checkout", "master");
+
+// Create branch 2
+git("checkout", "-b", "branch2");
+appendLine("a_file", "branch2 commit 1");
+git("commit", "-am", "branch2: first commit");
+appendLine("a_file", "branch2 commit 2");
+git("commit", "-am", "branch2: second commit");
+git("checkout", "master");
+popd();
+
+// Create branch3
+pushd("remote-project");
+git("checkout", "-b", "branch3");
+appendLine("b_file", "branch3 commit 1");
+git("add", "b_file");
+git("commit", "-am", "branch3: first commit");
+git("checkout", "master");
+popd();
+
+// Clone the remote into a folder and add the project to the application.
+git("clone", "remote-project", "local-clone");
+pushd("local-clone");
+git("checkout", "master");
+const upstream = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream);
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base-and-branch.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base-and-branch.ts
@@ -1,0 +1,19 @@
+import { logEnv, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+pushd("remote-project");
+// Checkout branch 1
+git("checkout", "master");
+appendLine("b_file", "create file b");
+git("add", "b_file");
+git("commit", "-am", "commit in base");
+
+git("checkout", "branch1");
+git("rebase", "master");
+appendLine("b_file", "update file b");
+git("add", "b_file");
+git("commit", "-am", "branch1: update after base change");
+
+git("checkout", "master");
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base.ts
@@ -1,0 +1,11 @@
+import { logEnv, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+pushd("remote-project");
+// Checkout branch 1
+git("checkout", "master");
+appendLine("a_file", "Update to main branch");
+git("add", "b_file");
+git("commit", "-am", "commit in base");
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-remote-branch.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-remote-branch.ts
@@ -1,0 +1,12 @@
+import { logEnv, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+pushd("remote-project");
+// Checkout branch 1
+git("checkout", "branch1");
+appendLine("a_file", "branch1 commit 3");
+git("commit", "-am", "branch1: third commit");
+
+git("checkout", "master");
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__add-submodule.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-submodule.ts
@@ -1,0 +1,17 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+// Create a simple repository to use as a submodule
+mkdir("submodule-repo");
+pushd("submodule-repo");
+git("init", "-b", "main", "--object-format=sha1");
+appendLine("submodule_file", "submodule content");
+git("add", "submodule_file");
+git("commit", "-m", "Initial submodule commit");
+popd();
+
+// Add a submodule to the local clone
+pushd("local-clone");
+git("submodule", "add", "../submodule-repo", "my-submodule");
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__clone-into-new-project.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__clone-into-new-project.ts
@@ -1,0 +1,14 @@
+import { logEnv, args, pushd, popd, git, gitOutputIn, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+const projectPath = args[0];
+console.log(`PROJECT PATH: ${projectPath}`);
+
+// Clone the remote into a folder and add the project to the application.
+git("clone", "remote-project", projectPath);
+pushd(projectPath);
+git("checkout", "master");
+const upstream = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream);
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__commit-file-into-remote-base.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__commit-file-into-remote-base.ts
@@ -1,0 +1,19 @@
+import { logEnv, args, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+const commitMessage = args[0];
+const filePath = args[1];
+const fileContent = args[2];
+
+console.log(`COMMIT MESSAGE: ${commitMessage}`);
+console.log(`FILE PATH: ${filePath}`);
+console.log(`FILE CONTENT: ${fileContent}`);
+
+// Create a new branch in the remote project, add a file, and commit it.
+pushd("remote-project");
+git("checkout", "master");
+appendLine(filePath, fileContent);
+git("add", filePath);
+git("commit", "-m", commitMessage);
+popd();

--- a/e2e/playwright/scripts/project-with-remote-branches__delete-project.ts
+++ b/e2e/playwright/scripts/project-with-remote-branches__delete-project.ts
@@ -1,0 +1,9 @@
+import { logEnv, args, butTesting } from "./lib.ts";
+
+logEnv();
+
+const projectName = args[0];
+console.log(`PROJECT NAME: ${projectName}`);
+
+// Remove the project from the application.
+butTesting("remove-project", projectName);

--- a/e2e/playwright/scripts/project-with-stacks.ts
+++ b/e2e/playwright/scripts/project-with-stacks.ts
@@ -1,0 +1,52 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git, gitOutputIn, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+mkdir("remote-project");
+pushd("remote-project");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("a_file", "foo");
+appendLine("a_file", "bar");
+appendLine("a_file", "baz");
+git("add", "a_file");
+git("commit", "-am", "Hey, look! A commit.");
+
+// Create branch 1
+git("checkout", "-b", "branch1");
+appendLine("a_file", "branch1 commit 1");
+git("commit", "-am", "branch1: first commit");
+appendLine("a_file", "branch1 commit 2");
+git("commit", "-am", "branch1: second commit");
+appendLine("a_file", "branch1 commit 1");
+git("commit", "-am", "branch1: third commit");
+appendLine("a_file", "branch1 commit 2");
+git("commit", "-am", "branch1: fourth commit");
+git("checkout", "master");
+
+// Create branch 2 (independent)
+git("checkout", "-b", "branch2");
+appendLine("b_file", "branch2 commit 1");
+git("add", "b_file");
+git("commit", "-am", "branch2: first commit");
+appendLine("b_file", "branch2 commit 2");
+git("commit", "-am", "branch2: second commit");
+git("checkout", "master");
+
+// Create branch 3 (also independent)
+git("checkout", "-b", "branch3");
+appendLine("c_file", "branch3 commit 1");
+git("add", "c_file");
+git("commit", "-am", "branch3: first commit");
+appendLine("c_file", "branch3 commit 2");
+git("commit", "-am", "branch3: second commit");
+git("checkout", "master");
+popd();
+
+// Clone the remote into a folder and add the project to the application.
+git("clone", "remote-project", "local-clone");
+pushd("local-clone");
+git("checkout", "master");
+const upstream = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream);
+popd();

--- a/e2e/playwright/scripts/setup-empty-project-bare.ts
+++ b/e2e/playwright/scripts/setup-empty-project-bare.ts
@@ -1,0 +1,17 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+mkdir("remote-project");
+pushd("remote-project");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("a_file", "foo");
+appendLine("a_file", "bar");
+appendLine("a_file", "baz");
+git("add", "a_file");
+git("commit", "-am", "Hey, look! A commit.");
+popd();
+
+// Clone the remote into a folder.
+git("clone", "remote-project", "local-clone");

--- a/e2e/playwright/scripts/setup-empty-project.ts
+++ b/e2e/playwright/scripts/setup-empty-project.ts
@@ -1,0 +1,26 @@
+import { logEnv, mkdir, appendLine, writeLine, pushd, popd, git } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+// GitButler currently requires projects to have a remote
+mkdir("remote-project");
+pushd("remote-project");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("a_file", "foo");
+appendLine("a_file", "bar");
+appendLine("a_file", "baz");
+git("add", "a_file");
+git("commit", "-am", "Hey, look! A commit.");
+popd();
+
+// Clone the remote into a folder.
+// This is what we are going to add in the client
+git("clone", "remote-project", "local-clone");
+
+mkdir("not-a-git-repo");
+pushd("not-a-git-repo");
+writeLine("another_file", "I am not a git repository");
+popd();
+
+mkdir("empty-dir");

--- a/e2e/playwright/scripts/two-projects-with-remote-branches.ts
+++ b/e2e/playwright/scripts/two-projects-with-remote-branches.ts
@@ -1,0 +1,46 @@
+import { logEnv, mkdir, appendLine, pushd, popd, git, gitOutputIn, butTestingIn } from "./lib.ts";
+
+logEnv();
+
+// Setup a remote project.
+mkdir("remote-project");
+pushd("remote-project");
+git("init", "-b", "master", "--object-format=sha1");
+appendLine("a_file", "foo");
+appendLine("a_file", "bar");
+appendLine("a_file", "baz");
+git("add", "a_file");
+git("commit", "-am", "Hey, look! A commit.");
+
+// Create branch 1
+git("checkout", "-b", "branch1");
+appendLine("a_file", "branch1 commit 1");
+git("commit", "-am", "branch1: first commit");
+appendLine("a_file", "branch1 commit 2");
+git("commit", "-am", "branch1: second commit");
+git("checkout", "master");
+
+// Create branch 2
+git("checkout", "-b", "branch2");
+appendLine("a_file", "branch2 commit 1");
+git("commit", "-am", "branch2: first commit");
+appendLine("a_file", "branch2 commit 2");
+git("commit", "-am", "branch2: second commit");
+git("checkout", "master");
+popd();
+
+// Clone the remote into a folder and add the project to the application.
+git("clone", "remote-project", "local-clone");
+pushd("local-clone");
+git("checkout", "master");
+const upstream1 = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream1);
+popd();
+
+// Clone the remote into another folder and add the project as well.
+git("clone", "remote-project", "local-clone-2");
+pushd("local-clone-2");
+git("checkout", "master");
+const upstream2 = gitOutputIn(".", "rev-parse", "--symbolic-full-name", "@{u}");
+butTestingIn(".", "add-project", "--switch-to-workspace", upstream2);
+popd();

--- a/e2e/playwright/src/env.ts
+++ b/e2e/playwright/src/env.ts
@@ -3,11 +3,17 @@ import path from "node:path";
 const ROOT = path.resolve(import.meta.dirname, "../../..");
 const E2E_DIR = path.resolve(ROOT, "e2e/playwright");
 
+/** Append `.exe` on Windows when building a default binary path. */
+function binaryPath(...segments: string[]): string {
+	const p = path.join(...segments);
+	return process.platform === "win32" ? p + ".exe" : p;
+}
+
 export const BUT_SERVER_PORT = process.env.BUTLER_PORT || "6978";
 export const DESKTOP_PORT = process.env.DESKTOP_PORT || "3000";
 export const BUT_TESTING =
-	process.env.BUT_TESTING || path.join(ROOT, "target", "debug", "but-testing");
+	process.env.BUT_TESTING || binaryPath(ROOT, "target", "debug", "but-testing");
 export const BUT_SERVER =
-	process.env.BUT_SERVER || path.join(ROOT, "target", "debug", "but-server");
+	process.env.BUT_SERVER || binaryPath(ROOT, "target", "debug", "but-server");
 export const GIT_CONFIG_GLOBAL =
 	process.env.GIT_CONFIG_GLOBAL || path.join(E2E_DIR, "fixtures", ".gitconfig");

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -7,7 +7,7 @@ import {
 	GIT_CONFIG_GLOBAL,
 } from "./env.ts";
 import { type BrowserContext } from "@playwright/test";
-import { ChildProcess, spawn } from "node:child_process";
+import { ChildProcess, execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { Socket } from "node:net";
 import path from "node:path";
@@ -117,16 +117,16 @@ class GitButlerManager implements GitButler {
 
 			const forceKillTimer = setTimeout(() => {
 				if (settled) return;
-				log(`but-server did not stop after ${shutdownTimeoutMs}ms, sending SIGKILL...`, colors.red);
+				log(`but-server did not stop after ${shutdownTimeoutMs}ms, force killing...`, colors.red);
 				try {
-					this.butServerProcess.kill("SIGKILL");
+					forceKillProcess(this.butServerProcess);
 				} catch {
 					finish();
 				}
 			}, shutdownTimeoutMs);
 
 			try {
-				const killed = this.butServerProcess.kill("SIGTERM");
+				const killed = gracefulKillProcess(this.butServerProcess);
 				if (!killed) {
 					finish();
 				}
@@ -145,7 +145,7 @@ class GitButlerManager implements GitButler {
 		args?: string[],
 		env?: Record<string, string>,
 	): Promise<void> {
-		const scriptPath = path.resolve(this.scriptsDir, scriptName);
+		const scriptPath = resolveScript(this.scriptsDir, scriptName);
 		if (!existsSync(scriptPath)) log(`Script not found: ${scriptPath}`, colors.red);
 		const scriptArgs = args ?? [];
 
@@ -157,7 +157,12 @@ class GitButlerManager implements GitButler {
 			...env,
 		};
 
-		await runCommand("bash", [scriptPath, ...scriptArgs], this.workdir, envVars);
+		await runCommand(
+			process.execPath,
+			["--experimental-strip-types", "--no-warnings", scriptPath, ...scriptArgs],
+			this.workdir,
+			envVars,
+		);
 	}
 }
 
@@ -186,6 +191,56 @@ function createButServerProcess(rootDir: string, serverEnv: Record<string, strin
 
 function getButlerDataDir(configDir: string): string {
 	return path.join(configDir, "com.gitbutler.app");
+}
+
+/**
+ * Resolve a script name, mapping `.sh` references to `.ts` files.
+ * This allows existing test files to keep using `.sh` names while
+ * the actual scripts are now cross-platform TypeScript.
+ */
+function resolveScript(scriptsDir: string, scriptName: string): string {
+	// If the caller asks for a .sh, try the .ts equivalent first.
+	if (scriptName.endsWith(".sh")) {
+		const tsName = scriptName.replace(/\.sh$/, ".ts");
+		const tsPath = path.resolve(scriptsDir, tsName);
+		if (existsSync(tsPath)) {
+			return tsPath;
+		}
+	}
+	return path.resolve(scriptsDir, scriptName);
+}
+
+/**
+ * Gracefully stop a child process (cross-platform).
+ * On Windows, SIGTERM is not reliable, so we use `taskkill`.
+ */
+function gracefulKillProcess(child: ChildProcess): boolean {
+	if (process.platform === "win32") {
+		if (child.pid === undefined) return false;
+		try {
+			execFileSync("taskkill", ["/pid", child.pid.toString()]);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	return child.kill("SIGTERM");
+}
+
+/**
+ * Force-kill a child process (cross-platform).
+ */
+function forceKillProcess(child: ChildProcess): void {
+	if (process.platform === "win32") {
+		if (child.pid === undefined) return;
+		try {
+			execFileSync("taskkill", ["/F", "/pid", child.pid.toString()]);
+		} catch {
+			// Process may already be gone.
+		}
+		return;
+	}
+	child.kill("SIGKILL");
 }
 
 async function waitForServer(port: string, host = "localhost", maxAttempts = 500) {


### PR DESCRIPTION
Introduce a comprehensive set of cross-platform TypeScript helper
scripts and many test fixtures for the Playwright e2e suite, plus a
Windows CI job and runtime improvements to support running tests on
Windows. This change was needed to make the e2e test suite
cross-platform (especially Windows) by:

- Adding a new GitHub Actions job (playwright-windows) to run e2e tests on windows-latest with appropriate environment and caching.
- Adding numerous TypeScript scripts under e2e/playwright/scripts to create test repositories, branches, hooks, and helper actions used by tests.
- Introducing a lib.ts with cross-platform helpers for filesystem, process execution, git wrappers, directory stack, and hook management.
- Updating runtime helpers (env.ts and setup.ts) to resolve .exe binaries on Windows, run .ts scripts via Node with --experimental-strip-types, and provide cross-platform process termination (gracefulKillProcess/forceKillProcess) and script resolution logic.

These changes enable consistent test execution across platforms and
allow existing .sh-based test references to map to new .ts scripts for
better portability.