### PR TITLE
tui: add a few misc branch picker key binds

### DIFF
--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -126,6 +126,22 @@ pub(super) fn branch_picker_key_binds() -> KeyBinds {
     });
 
     key_binds.register(KeyBindDef {
+        short_description: "down",
+        key_matcher: press().control().code(KeyCode::Char('n')),
+        modes: all_modes.clone(),
+        message: Message::BranchPicker(BranchPickerMessage::MoveCursorDown),
+        hide_from_hotbar: true,
+    });
+
+    key_binds.register(KeyBindDef {
+        short_description: "up",
+        key_matcher: press().control().code(KeyCode::Char('p')),
+        modes: all_modes.clone(),
+        message: Message::BranchPicker(BranchPickerMessage::MoveCursorUp),
+        hide_from_hotbar: true,
+    });
+
+    key_binds.register(KeyBindDef {
         short_description: "confirm",
         key_matcher: press().code(KeyCode::Enter),
         modes: all_modes.clone(),

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -157,6 +157,14 @@ pub(super) fn branch_picker_key_binds() -> KeyBinds {
         hide_from_hotbar: false,
     });
 
+    key_binds.register(KeyBindDef {
+        short_description: "back",
+        key_matcher: press().control().code(KeyCode::Char('[')),
+        modes: all_modes.clone(),
+        message: Message::BranchPicker(BranchPickerMessage::Close),
+        hide_from_hotbar: true,
+    });
+
     key_binds
 }
 


### PR DESCRIPTION
ctrl+n/p to move up/down and ctrl+[ to close the picker.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #13420
- <kbd>&nbsp;3&nbsp;</kbd> #13419
- <kbd>&nbsp;2&nbsp;</kbd> #13418 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #13417
<!-- GitButler Footer Boundary Bottom -->