### PR TITLE
tui: commit with inline reword directly

### DIFF
--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -10,8 +10,8 @@ use crate::{
         CommitClassification, FilesStatusFlag,
         output::{StatusOutputContent, StatusOutputLine, StatusOutputLineData},
         tui::{
-            CommitMode, CommitSource, InlineRewordMode, Mode, RubMode, RubSource,
-            SelectAfterReload, mode::UnassignedCommitSource,
+            CommitMessageComposer, CommitMode, CommitSource, InlineRewordMode, Mode, RubMode,
+            RubSource, SelectAfterReload, mode::UnassignedCommitSource,
         },
     },
 };
@@ -1527,7 +1527,7 @@ fn is_selectable_in_commit_mode_scopes_commit_targets_to_stack() {
             id: "zz".into(),
         })),
         scope_to_stack: Some(scoped_stack_id),
-        empty_message: false,
+        message_composer: CommitMessageComposer::default(),
     });
 
     let same_stack_commit_line = line(StatusOutputLineData::Commit {

--- a/crates/but/src/command/legacy/status/tui/details/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/details/mod.rs
@@ -216,7 +216,7 @@ impl Details {
 
             Message::Commit(commit_message) => match commit_message {
                 CommitMessage::Confirm | CommitMessage::CreateEmpty => true,
-                CommitMessage::Start | CommitMessage::ToggleEmptyMessage => false,
+                CommitMessage::Start | CommitMessage::ToggleMessageComposer(..) => false,
             },
             Message::Rub(rub_message) => match rub_message {
                 RubMessage::Start

--- a/crates/but/src/command/legacy/status/tui/key_bind.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind.rs
@@ -4,8 +4,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use strum::IntoEnumIterator;
 
 use crate::command::legacy::status::tui::{
-    BranchPickerMessage, CommandMessage, ConfirmMessage, Message, Mode, RewordMessage, RubMessage,
-    mode::ModeDiscriminant,
+    BranchPickerMessage, CommandMessage, CommitMessageComposer, ConfirmMessage, Message, Mode,
+    RewordMessage, RubMessage, mode::ModeDiscriminant,
 };
 
 use super::{CommandModeKind, CommitMessage, DetailsMessage, FilesMessage, MoveMessage};
@@ -595,7 +595,19 @@ fn register_commit_mode_key_binds(key_binds: &mut KeyBinds) {
         short_description: "empty message",
         key_matcher: press().code(KeyCode::Char('e')),
         modes: Vec::from([ModeDiscriminant::Commit]),
-        message: Message::Commit(CommitMessage::ToggleEmptyMessage),
+        message: Message::Commit(CommitMessage::ToggleMessageComposer(
+            CommitMessageComposer::Empty,
+        )),
+        hide_from_hotbar: false,
+    });
+
+    key_binds.register(KeyBindDef {
+        short_description: "reword inline",
+        key_matcher: press().code(KeyCode::Char('i')),
+        modes: Vec::from([ModeDiscriminant::Commit]),
+        message: Message::Commit(CommitMessage::ToggleMessageComposer(
+            CommitMessageComposer::Inline,
+        )),
         hide_from_hotbar: false,
     });
 

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -54,9 +54,9 @@ use crate::{
                 },
                 message_on_drop::MessageOnDrop,
                 mode::{
-                    CommandMode, CommandModeKind, CommitMode, CommitSource, InlineRewordMode, Mode,
-                    MoveMode, MoveSource, RubMode, RubSource, StackCommitSource,
-                    UnassignedCommitSource,
+                    CommandMode, CommandModeKind, CommitMessageComposer, CommitMode, CommitSource,
+                    InlineRewordMode, Mode, MoveMode, MoveSource, RubMode, RubSource,
+                    StackCommitSource, UnassignedCommitSource,
                 },
                 operations::stack_has_assigned_changes,
                 toast::{ToastKind, Toasts},
@@ -675,8 +675,8 @@ impl App {
                 CommitMessage::CreateEmpty => self.handle_commit_create_empty(ctx, messages)?,
                 CommitMessage::Start => self.handle_commit_start(ctx)?,
                 CommitMessage::Confirm => self.handle_commit_confirm(ctx, messages)?,
-                CommitMessage::ToggleEmptyMessage => {
-                    self.handle_commit_toggle_empty_message();
+                CommitMessage::ToggleMessageComposer(composer) => {
+                    self.handle_commit_toggle_message_composer(composer);
                 }
             },
             Message::Reword(reword_message) => match reword_message {
@@ -1387,7 +1387,7 @@ impl App {
                 CommitMode {
                     source: Arc::new(source),
                     scope_to_stack: None,
-                    empty_message: false,
+                    message_composer: CommitMessageComposer::default(),
                 }
             }
             StatusOutputLineData::UnassignedFile { cli_id }
@@ -1400,7 +1400,7 @@ impl App {
                 CommitMode {
                     source: Arc::new(source),
                     scope_to_stack: cli_id.stack_id(),
-                    empty_message: false,
+                    message_composer: CommitMessageComposer::default(),
                 }
             }
             StatusOutputLineData::Commit { stack_id, .. } => {
@@ -1421,7 +1421,7 @@ impl App {
                 };
                 CommitMode {
                     scope_to_stack,
-                    empty_message: false,
+                    message_composer: CommitMessageComposer::default(),
                     source: Arc::new(source),
                 }
             }
@@ -1447,7 +1447,7 @@ impl App {
                 CommitMode {
                     source: Arc::new(source),
                     scope_to_stack,
-                    empty_message: false,
+                    message_composer: CommitMessageComposer::default(),
                 }
             }
             StatusOutputLineData::UpdateNotice
@@ -1475,7 +1475,7 @@ impl App {
         let Mode::Commit(CommitMode {
             source,
             scope_to_stack,
-            empty_message,
+            message_composer,
         }) = &self.mode
         else {
             return Ok(());
@@ -1581,10 +1581,19 @@ impl App {
             // TODO(david): don't use a separate reword step, instead get message before creating
             // commit. However that requires computing the diff which I haven't yet figured out how
             // to do
-            .chain(
-                (!empty_message && commit_create_result.new_commit.is_some())
-                    .then_some(Message::Reword(RewordMessage::WithEditor)),
-            )
+            .chain(if commit_create_result.new_commit.is_some() {
+                match message_composer {
+                    CommitMessageComposer::Editor => {
+                        Some(Message::Reword(RewordMessage::WithEditor))
+                    }
+                    CommitMessageComposer::Inline => {
+                        Some(Message::Reword(RewordMessage::InlineStart))
+                    }
+                    CommitMessageComposer::Empty => None,
+                }
+            } else {
+                None
+            })
             .chain(rejected_specs_error_msg.map(|text| Message::ShowToast {
                 kind: ToastKind::Error,
                 text,
@@ -1594,9 +1603,29 @@ impl App {
         Ok(())
     }
 
-    fn handle_commit_toggle_empty_message(&mut self) {
+    fn handle_commit_toggle_message_composer(&mut self, composer: CommitMessageComposer) {
         if let Mode::Commit(mode) = &mut self.mode {
-            mode.empty_message = !mode.empty_message;
+            match composer {
+                CommitMessageComposer::Editor => {
+                    // you can't toggle the editor composer, that is always the default
+                }
+                CommitMessageComposer::Empty => {
+                    mode.message_composer = match mode.message_composer {
+                        CommitMessageComposer::Editor | CommitMessageComposer::Inline => {
+                            CommitMessageComposer::Empty
+                        }
+                        CommitMessageComposer::Empty => CommitMessageComposer::Editor,
+                    };
+                }
+                CommitMessageComposer::Inline => {
+                    mode.message_composer = match mode.message_composer {
+                        CommitMessageComposer::Editor | CommitMessageComposer::Empty => {
+                            CommitMessageComposer::Inline
+                        }
+                        CommitMessageComposer::Inline => CommitMessageComposer::Editor,
+                    };
+                }
+            }
         }
     }
 
@@ -2589,10 +2618,15 @@ impl App {
                     Span::raw(NOOP).mode_colors(&self.mode),
                 ]
                 .into_iter()
-                .chain(
-                    mode.empty_message
-                        .then(|| Span::raw(" (empty message)").mode_colors(&self.mode)),
-                )
+                .chain(match mode.message_composer {
+                    CommitMessageComposer::Editor => None,
+                    CommitMessageComposer::Empty => {
+                        Some(Span::raw(" (empty message)").mode_colors(&self.mode))
+                    }
+                    CommitMessageComposer::Inline => {
+                        Some(Span::raw(" (reword inline)").mode_colors(&self.mode))
+                    }
+                })
                 .chain([Span::raw(" >>").mode_colors(&self.mode), Span::raw(" ")]),
             );
         } else if let Some(display) = commit_operation_display(data, mode) {
@@ -2602,10 +2636,15 @@ impl App {
                     Span::raw(display).mode_colors(&self.mode),
                 ]
                 .into_iter()
-                .chain(
-                    mode.empty_message
-                        .then(|| Span::raw(" (empty message)").mode_colors(&self.mode)),
-                )
+                .chain(match mode.message_composer {
+                    CommitMessageComposer::Editor => None,
+                    CommitMessageComposer::Empty => {
+                        Some(Span::raw(" (empty message)").mode_colors(&self.mode))
+                    }
+                    CommitMessageComposer::Inline => {
+                        Some(Span::raw(" (reword inline)").mode_colors(&self.mode))
+                    }
+                })
                 .chain([Span::raw(" >>").mode_colors(&self.mode), Span::raw(" ")]),
             );
         }
@@ -3068,7 +3107,7 @@ enum CommandMessage {
 enum CommitMessage {
     CreateEmpty,
     Start,
-    ToggleEmptyMessage,
+    ToggleMessageComposer(CommitMessageComposer),
     Confirm,
 }
 

--- a/crates/but/src/command/legacy/status/tui/mode.rs
+++ b/crates/but/src/command/legacy/status/tui/mode.rs
@@ -131,10 +131,8 @@ pub(super) struct CommitMode {
     ///
     /// Used when committing changes staged to a specific stack
     pub(super) scope_to_stack: Option<StackId>,
-    /// Create the commit with an empty message.
-    ///
-    /// By default an editor is opened for the user to write a commit message.
-    pub(super) empty_message: bool,
+    /// How to compose the commit message.
+    pub(super) message_composer: CommitMessageComposer,
 }
 
 /// A subset of [`CliId`] that supports being committed
@@ -143,6 +141,17 @@ pub(super) enum CommitSource {
     Unassigned(UnassignedCommitSource),
     Uncommitted(Box<UncommittedCliId>),
     Stack(StackCommitSource),
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub(super) enum CommitMessageComposer {
+    /// Open an editor to compose the commit message.
+    #[default]
+    Editor,
+    /// Use an inline editor to compose the commit message.
+    Inline,
+    /// Create the commit with an empty message.
+    Empty,
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -361,3 +361,43 @@ fn commit_mode_from_staged_changes_stays_within_current_stack() {
             "snapshots/commit_mode_from_staged_changes_stays_within_current_stack_final.svg"
         ]);
 }
+
+#[test]
+fn commit_with_inline_reword() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack").unwrap();
+    env.setup_metadata(&["A"]).unwrap();
+
+    let mut tui = test_tui(env);
+
+    tui.env().file("test.txt", "content");
+
+    tui.input_then_render(None)
+        .assert_current_line_eq(str!["╭┄zz [unassigned changes]"]);
+
+    tui.input_then_render('c')
+        .assert_current_line_eq(str!["╭┄<< source >> << noop >> zz [unassigned changes]"]);
+
+    tui.input_then_render(KeyCode::Down)
+        .assert_current_line_eq(str!["┊│ << insert commit >>"]);
+
+    tui.input_then_render('e')
+        .assert_current_line_eq(str!["┊│ << insert commit (empty message) >>"]);
+
+    tui.input_then_render('i')
+        .assert_current_line_eq(str!["┊│ << insert commit (reword inline) >>"]);
+
+    tui.input_then_render('i')
+        .assert_current_line_eq(str!["┊│ << insert commit >>"]);
+
+    tui.input_then_render('i')
+        .assert_current_line_eq(str!["┊│ << insert commit (reword inline) >>"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..]"]);
+
+    tui.input_then_render("commit message here")
+        .assert_current_line_eq(str!["┊●   [..] commit message here"]);
+
+    tui.input_then_render(KeyCode::Enter)
+        .assert_current_line_eq(str!["┊●   [..] commit message here"]);
+}


### PR DESCRIPTION
Pressing `i` in commit mode will use inline reword to write the commit message, for cases where you don't want to open an editor.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #13420
- <kbd>&nbsp;3&nbsp;</kbd> #13419 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #13418
- <kbd>&nbsp;1&nbsp;</kbd> #13417
<!-- GitButler Footer Boundary Bottom -->