### PR TITLE
tui: show warning if tui reloads twice during one update

### DIFF
--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -286,12 +286,21 @@ where
         });
 
     // handle messages
+    let mut did_reload = false;
     messages.append(&mut app.delayed_messages);
     loop {
         if messages.is_empty() {
             break;
         }
         for msg in messages.drain(..) {
+            if matches!(msg, Message::Reload(_)) {
+                if did_reload && cfg!(feature = "tui-profiling") && !cfg!(test) {
+                    app.toasts
+                        .insert(ToastKind::Error, "Double reload".to_owned());
+                } else {
+                    did_reload = true;
+                }
+            }
             app.handle_message(ctx, out, mode, terminal_guard, other_messages, msg)
                 .await;
         }


### PR DESCRIPTION
Its technically possible for the TUI to reload twice during one update and with how we chain messages it might be hard to discover. So this adds a debug warning for it.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #13420 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #13419
- <kbd>&nbsp;2&nbsp;</kbd> #13418
- <kbd>&nbsp;1&nbsp;</kbd> #13417
<!-- GitButler Footer Boundary Bottom -->