### PR TITLE
feat(but): apply theme to `but branch` commands

### DIFF
--- a/crates/but/src/command/branch/move_branch.rs
+++ b/crates/but/src/command/branch/move_branch.rs
@@ -1,6 +1,11 @@
 use but_core::{DryRun, sync::RepoExclusive};
 
-use crate::{CliId, IdMap, id::parser::parse_sources, utils::OutputChannel};
+use crate::{
+    CliId, IdMap,
+    id::parser::parse_sources,
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 use anyhow::{Context, bail};
 
 /// Move a branch on top of another
@@ -33,6 +38,8 @@ pub(crate) fn move_branch_by_name_with_perm(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
+
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
     let target_ref_name_str = &format!("refs/heads/{target_branch_name}");
 
@@ -47,7 +54,9 @@ pub(crate) fn move_branch_by_name_with_perm(
     if let Some(out) = out.for_human() {
         writeln!(
             out,
-            "Moved branch '{branch_name}' on top of '{target_branch_name}'."
+            "Moved branch {} on top of {}.",
+            t.local_branch.paint(branch_name),
+            t.local_branch.paint(target_branch_name),
         )?;
     }
 
@@ -73,6 +82,7 @@ pub(crate) fn tear_off_branch_by_name_with_perm(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
+    let t = theme::get();
     let branch_ref_name_str = &format!("refs/heads/{branch_name}");
 
     but_api::branch::tear_off_branch_with_perm(
@@ -83,7 +93,11 @@ pub(crate) fn tear_off_branch_by_name_with_perm(
     )?;
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "Unstacked branch '{branch_name}'.")?;
+        writeln!(
+            out,
+            "Unstacked branch {}.",
+            t.local_branch.paint(branch_name)
+        )?;
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
 
 use but_ctx::Context;
-use colored::Colorize;
 use gitbutler_branch_actions::BranchListingFilter;
 
-use crate::{command::legacy::workspace_target, utils::OutputChannel};
+use crate::{
+    command::legacy::workspace_target,
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
 
 #[expect(clippy::too_many_arguments)]
 pub fn list(
@@ -209,7 +212,7 @@ pub fn list(
     } else if let Some(out) = out.for_human() {
         // Print applied branches section with header
         if !applied_stacks.is_empty() {
-            writeln!(out, "{}", "Applied Branches".green())?;
+            writeln!(out, "Applied branches")?;
             print_applied_branches_table(
                 &applied_stacks,
                 &branch_review_map,
@@ -544,6 +547,8 @@ fn print_applied_branches_table(
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
 
+    let t = theme::get();
+
     if applied_stacks.is_empty() {
         return Ok(());
     }
@@ -583,38 +588,60 @@ fn print_applied_branches_table(
             };
 
             // Type column
-            let type_str = "active".green().to_string();
+            let type_str = "active".to_string();
 
             // Ahead column
             let ahead_str = commits_ahead_map
                 .and_then(|map| map.get(&branch.name.to_string()))
-                .map(|count| format!("↑{count}").bright_cyan().to_string())
+                .map(|count| t.info.paint(format!("↑{count}")))
                 .unwrap_or_default();
 
             // Merge status indicator
             let merge_status_str = if let Some(map) = merge_status_map {
                 match map.get(&branch.name.to_string()) {
-                    Some(true) => "✓ ".green().to_string(),
-                    Some(false) => "✗ ".red().to_string(),
+                    Some(true) => format!("{} ", t.sym().success),
+                    Some(false) => format!("{} ", t.sym().error),
                     None => String::new(),
                 }
             } else {
                 String::new()
             };
 
+            let painted_branch_name = t.local_branch.paint(branch.name.to_string());
+
             // Branch name with tree prefix and merge status
             let branch_with_prefix = if is_single_branch {
-                format!("{}{}{}", merge_status_str, "*".green(), branch.name)
+                format!(
+                    "{}{}{}",
+                    merge_status_str,
+                    t.hint.paint("*"),
+                    painted_branch_name
+                )
             } else if let (Some(first), Some(last)) = (first_branch, last_branch) {
                 if branch.name == first.name {
-                    format!("{}{}{}", merge_status_str, "*-".green(), branch.name)
+                    format!(
+                        "{}{}{}",
+                        merge_status_str,
+                        t.hint.paint("*-"),
+                        painted_branch_name
+                    )
                 } else if branch.name == last.name {
-                    format!("{}{}{}", merge_status_str, "└─".green(), branch.name)
+                    format!(
+                        "{}{}{}",
+                        merge_status_str,
+                        t.hint.paint("└─"),
+                        painted_branch_name
+                    )
                 } else {
-                    format!("{}{}{}", merge_status_str, "├─".green(), branch.name)
+                    format!(
+                        "{}{}{}",
+                        merge_status_str,
+                        t.hint.paint("├─"),
+                        painted_branch_name
+                    )
                 }
             } else {
-                format!("{}{}", merge_status_str, branch.name)
+                format!("{merge_status_str}{painted_branch_name}")
             };
 
             // Get PR/review info
@@ -625,7 +652,7 @@ fn print_applied_branches_table(
                     .map(|r| format!("{}{}", r.unit_symbol, r.number))
                     .collect::<Vec<String>>()
                     .join(", ");
-                format!(" ({review_numbers})").blue().to_string()
+                t.info.paint(format!(" ({review_numbers})"))
             } else {
                 String::new()
             };
@@ -636,8 +663,8 @@ fn print_applied_branches_table(
                 Cell::new(type_str),
                 Cell::new(branch_str),
                 Cell::new(ahead_str),
-                Cell::new(date_str.dimmed().to_string()),
-                Cell::new(author_str.dimmed().to_string()),
+                Cell::new(t.hint.paint(date_str)),
+                Cell::new(t.hint.paint(author_str)),
             ]);
         }
     }
@@ -654,6 +681,7 @@ fn print_branches_table(
     out: &mut (dyn std::fmt::Write + 'static),
 ) -> Result<(), anyhow::Error> {
     use crate::tui::{Table, table::Cell};
+    let t = theme::get();
 
     if branches.is_empty() {
         return Ok(());
@@ -673,24 +701,17 @@ fn print_branches_table(
     let mut table = Table::new(headers);
 
     for branch in branches {
-        // Type column
-        let type_str = if branch.has_local {
-            "local".normal().to_string()
-        } else {
-            "remote".dimmed().to_string()
-        };
-
         // Ahead column
         let ahead_str = commits_ahead_map
             .and_then(|map| map.get(&branch.name.to_string()))
-            .map(|count| format!("↑{count}").bright_cyan().to_string())
+            .map(|count| t.info.paint(format!("↑{count}")).to_string())
             .unwrap_or_default();
 
         // Merge status indicator
         let merge_status_str = if let Some(map) = merge_status_map {
             match map.get(&branch.name.to_string()) {
-                Some(true) => "✓ ".green().to_string(),
-                Some(false) => "✗ ".red().to_string(),
+                Some(true) => format!("{} ", t.sym().success),
+                Some(false) => format!("{} ", t.sym().error),
                 None => String::new(),
             }
         } else {
@@ -716,19 +737,30 @@ fn print_branches_table(
                 .map(|r| format!("{}{}", r.unit_symbol, r.number))
                 .collect::<Vec<String>>()
                 .join(", ");
-            format!(" ({review_numbers})").blue().to_string()
+            t.info.paint(format!(" ({review_numbers})"))
         } else {
             String::new()
         };
 
-        let branch_str = format!("{}{}{}", merge_status_str, branch.name, reviews_str);
+        let (type_str, branch_name) = if branch.has_local {
+            (
+                "local".to_string(),
+                t.local_branch.paint(branch.name.to_string()),
+            )
+        } else {
+            (
+                t.hint.paint("remote"),
+                t.remote_branch.paint(branch.name.to_string()),
+            )
+        };
+        let branch_str = format!("{merge_status_str}{branch_name}{reviews_str}");
 
         table.add_row(vec![
             Cell::new(type_str),
             Cell::new(branch_str),
             Cell::new(ahead_str),
-            Cell::new(date_str.dimmed().to_string()),
-            Cell::new(author_str.dimmed().to_string()),
+            Cell::new(t.hint.paint(date_str)),
+            Cell::new(t.hint.paint(author_str)),
         ]);
     }
 

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,10 +1,10 @@
 use anyhow::bail;
 use but_api::json::HexHash;
 use but_core::{ref_metadata::StackId, sync::RepoExclusive};
-use colored::Colorize;
 
 use crate::{
     CliId, IdMap,
+    theme::{self, Paint},
     utils::{Confirm, ConfirmDefault, OutputChannel, shorten_object_id},
 };
 
@@ -55,6 +55,8 @@ pub fn new(
     branch_name: Option<String>,
     anchor: Option<String>,
 ) -> Result<(), anyhow::Error> {
+    let t = theme::get();
+
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     // Get branch name or use canned name
@@ -132,17 +134,17 @@ pub fn new(
         if let Some(anchor_name) = anchor_display {
             writeln!(
                 out,
-                "{} {} stacked on {}",
-                "✓ Created branch".green(),
-                branch_name.yellow(),
-                anchor_name.dimmed()
+                "{} Created branch {} stacked on {}",
+                t.sym().success,
+                t.local_branch.paint(branch_name),
+                t.hint.paint(anchor_name),
             )?;
         } else {
             writeln!(
                 out,
-                "{} {}",
-                "✓ Created branch".green(),
-                branch_name.yellow()
+                "{} Created branch {}",
+                t.sym().success,
+                t.local_branch.paint(branch_name),
             )?;
         }
     } else if let Some(out) = out.for_shell() {
@@ -210,10 +212,14 @@ fn confirm_branch_deletion(
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
 ) -> Result<(), anyhow::Error> {
+    let t = theme::get();
     if !force
         && let Some(mut inout) = out.prepare_for_terminal_input()
         && inout.confirm(
-            format!("Are you sure you want to delete branch '{branch_name}'?"),
+            format!(
+                "Are you sure you want to delete branch {}?",
+                t.local_branch.paint(branch_name)
+            ),
             ConfirmDefault::No,
         )? == Confirm::No
     {
@@ -223,7 +229,7 @@ fn confirm_branch_deletion(
     but_api::legacy::stack::remove_branch_with_perm(ctx, sid, branch_name.to_owned(), perm)?;
 
     if let Some(out) = out.for_human() {
-        writeln!(out, "Deleted branch {branch_name}")?;
+        writeln!(out, "Deleted branch {}", t.local_branch.paint(branch_name))?;
     }
     Ok(())
 }

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -2,11 +2,11 @@ use super::super::FileChange;
 use bstr::ByteSlice;
 use but_ctx::Context;
 use but_llm::ChatMessage;
-use colored::Colorize;
 use tracing::instrument;
 
 use crate::{
     command::legacy::workspace_target,
+    theme::{self, Paint},
     utils::{OutputChannel, shorten_object_id},
 };
 
@@ -489,6 +489,9 @@ fn output_human(
     out: &mut dyn std::fmt::Write,
 ) -> anyhow::Result<()> {
     use std::fmt::Write;
+
+    let t = theme::get();
+
     // Build output as a string first
     let mut buf = String::new();
 
@@ -499,7 +502,7 @@ fn output_human(
             .map(|r| format!("{}{}", r.unit_symbol, r.number))
             .collect::<Vec<String>>()
             .join(", ");
-        format!(" ({review_numbers})").blue().to_string()
+        t.info.paint(format!(" ({review_numbers})"))
     } else {
         String::new()
     };
@@ -507,10 +510,10 @@ fn output_human(
     writeln!(
         buf,
         "{} {}{} ({} commits ahead)",
-        "Branch:".bold(),
-        branch_name.green(),
+        t.important.paint("Branch:"),
+        t.local_branch.paint(branch_name),
         reviews_str,
-        commits.len().to_string().cyan()
+        t.info.paint(commits.len().to_string()),
     )?;
     writeln!(buf)?;
 
@@ -518,12 +521,17 @@ fn output_human(
         writeln!(buf, "No commits ahead of base branch.")?;
     } else {
         for (i, commit) in commits.iter().enumerate() {
-            writeln!(buf, "{} {}", commit.short_sha.yellow(), commit.message)?;
+            writeln!(
+                buf,
+                "{} {}",
+                t.commit_id.paint(&commit.short_sha),
+                commit.message
+            )?;
             writeln!(
                 buf,
                 "    {} by {}",
-                format_timestamp(commit.timestamp).dimmed(),
-                commit.author_name.dimmed()
+                t.hint.paint(format_timestamp(commit.timestamp)),
+                t.hint.paint(&commit.author_name)
             )?;
 
             // Show diff stats
@@ -536,17 +544,17 @@ fn output_human(
                 commit.deletions,
                 if commit.deletions == 1 { "" } else { "s" }
             );
-            writeln!(buf, "    {}", stats_str.dimmed())?;
+            writeln!(buf, "    {}", t.hint.paint(stats_str))?;
 
             // Show per-file changes if available
             if !commit.files.is_empty() {
                 writeln!(buf)?;
                 for file in &commit.files {
                     let status_color = match file.status.as_str() {
-                        "added" => file.path.green(),
-                        "deleted" => file.path.red(),
-                        "modified" => file.path.yellow(),
-                        _ => file.path.normal(),
+                        "added" => t.addition.paint(&file.path),
+                        "deleted" => t.deletion.paint(&file.path),
+                        "modified" => t.modification.paint(&file.path),
+                        _ => file.path.to_string(),
                     };
 
                     let change_str = if file.status == "added" {
@@ -575,9 +583,9 @@ fn output_human(
     if !unassigned_files.is_empty() {
         writeln!(buf)?;
         writeln!(buf)?;
-        writeln!(buf, "{}", "Unstaged Files:".bold())?;
+        writeln!(buf, "{}", t.important.paint("Unassigned Files:"))?;
         for file in unassigned_files {
-            writeln!(buf, "  {}", file.yellow())?;
+            writeln!(buf, "  {}", t.attention.paint(file))?;
         }
     }
 
@@ -585,23 +593,28 @@ fn output_human(
     if !reviews.is_empty() {
         writeln!(buf)?;
         writeln!(buf)?;
-        writeln!(buf, "{}", "Reviews:".bold())?;
+        writeln!(buf, "{}", t.important.paint("Reviews:"))?;
         for review in reviews {
             writeln!(buf)?;
             writeln!(
                 buf,
                 "  {} {}{}",
-                "PR/MR:".dimmed(),
+                t.hint.paint("PR/MR:"),
                 review.unit_symbol,
                 review.number
             )?;
-            writeln!(buf, "  {} {}", "Title:".dimmed(), review.title)?;
-            writeln!(buf, "  {} {}", "URL:".dimmed(), review.html_url.cyan())?;
+            writeln!(buf, "  {} {}", t.hint.paint("Title:"), review.title)?;
+            writeln!(
+                buf,
+                "  {} {}",
+                t.hint.paint("URL:"),
+                t.link.paint(&review.html_url)
+            )?;
 
             if let Some(body) = &review.body
                 && !body.is_empty()
             {
-                writeln!(buf, "  {}", "Description:".dimmed())?;
+                writeln!(buf, "  {}", t.hint.paint("Description:"))?;
                 // Indent each line of the description
                 for line in body.lines() {
                     writeln!(buf, "    {line}")?;
@@ -609,7 +622,12 @@ fn output_human(
             }
 
             if review.draft {
-                writeln!(buf, "  {} {}", "Status:".dimmed(), "Draft".yellow())?;
+                writeln!(
+                    buf,
+                    "  {} {}",
+                    t.hint.paint("Status:"),
+                    t.attention.paint("Draft")
+                )?;
             }
         }
     }
@@ -618,7 +636,7 @@ fn output_human(
     if let Some(summary) = ai_summary {
         writeln!(buf)?;
         writeln!(buf)?;
-        writeln!(buf, "{}", "AI Summary:".bold().cyan())?;
+        writeln!(buf, "{}", t.info.paint("AI Summary:"))?;
         writeln!(buf, "{summary}")?;
         writeln!(buf)?;
     }
@@ -631,15 +649,15 @@ fn output_human(
             writeln!(
                 buf,
                 "{} {}",
-                "Merge Check:".bold(),
-                "Merges cleanly into upstream".green()
+                t.important.paint("Merge Check:"),
+                t.success.paint("Merges cleanly into upstream")
             )?;
         } else {
             writeln!(
                 buf,
                 "{} {}",
-                "Merge Check:".bold(),
-                "Conflicts detected".red().bold()
+                t.important.paint("Merge Check:"),
+                t.error.paint("Conflicts detected"),
             )?;
             writeln!(buf)?;
             writeln!(
@@ -660,18 +678,23 @@ fn output_human(
             writeln!(buf)?;
 
             for file in &check.conflicting_files {
-                writeln!(buf, "  {}", file.path.yellow().bold())?;
+                writeln!(buf, "  {}", t.attention.paint(&file.path))?;
 
                 // Show branch commits that modified this file
                 if !file.branch_commits.is_empty() {
                     writeln!(buf, "    Modified by this branch:")?;
                     for commit in &file.branch_commits {
-                        writeln!(buf, "      {} {}", commit.short_sha.cyan(), commit.message)?;
+                        writeln!(
+                            buf,
+                            "      {} {}",
+                            t.commit_id.paint(&commit.short_sha),
+                            commit.message
+                        )?;
                         writeln!(
                             buf,
                             "        {} by {}",
-                            format_timestamp(commit.timestamp).dimmed(),
-                            commit.author_name.dimmed()
+                            t.hint.paint(format_timestamp(commit.timestamp)),
+                            t.hint.paint(&commit.author_name)
                         )?;
                     }
                     writeln!(buf)?;
@@ -684,14 +707,14 @@ fn output_human(
                         writeln!(
                             buf,
                             "      {} {}",
-                            commit.short_sha.magenta(),
+                            t.commit_id.paint(&commit.short_sha),
                             commit.message
                         )?;
                         writeln!(
                             buf,
                             "        {} by {}",
-                            format_timestamp(commit.timestamp).dimmed(),
-                            commit.author_name.dimmed()
+                            t.hint.paint(format_timestamp(commit.timestamp)),
+                            t.hint.paint(&commit.author_name)
                         )?;
                     }
                     writeln!(buf)?;

--- a/crates/but/tests/but/command/branch/move_branch.rs
+++ b/crates/but/tests/but/command/branch/move_branch.rs
@@ -46,7 +46,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'A' on top of 'C'.
+Moved branch A on top of C.
 
 "#]])
         .stderr_eq(str![""]);
@@ -122,7 +122,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'A' on top of 'C'.
+Moved branch A on top of C.
 
 "#]])
         .stderr_eq(str![""]);
@@ -198,7 +198,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'A' on top of 'B'.
+Moved branch A on top of B.
 
 "#]])
         .stderr_eq(str![""]);
@@ -274,7 +274,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'B' on top of 'A'.
+Moved branch B on top of A.
 
 "#]])
         .stderr_eq(str![""]);
@@ -351,7 +351,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'B' on top of 'C'.
+Moved branch B on top of C.
 
 "#]])
         .stderr_eq(str![""]);
@@ -421,7 +421,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'B' on top of 'A'.
+Moved branch B on top of A.
 
 "#]])
         .stderr_eq(str![""]);
@@ -486,7 +486,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'A' on top of 'B'.
+Moved branch A on top of B.
 
 "#]])
         .stderr_eq(str![""]);
@@ -560,7 +560,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'B' on top of 'A'.
+Moved branch B on top of A.
 
 "#]])
         .stderr_eq(str![""]);
@@ -645,7 +645,7 @@ Hint: run `but diff` to see uncommitted changes and `but stage <file>` to stage 
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'B' on top of 'A'.
+Moved branch B on top of A.
 
 "#]])
         .stderr_eq(str![""]);

--- a/crates/but/tests/but/command/branch/tear_off.rs
+++ b/crates/but/tests/but/command/branch/tear_off.rs
@@ -14,7 +14,7 @@ fn tear_off_by_name() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Unstacked branch 'C'.
+Unstacked branch C.
 
 "#]])
         .stderr_eq(str![""]);
@@ -59,7 +59,7 @@ fn tear_off_by_cli_id() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Unstacked branch 'C'.
+Unstacked branch C.
 
 "#]])
         .stderr_eq(str![""]);
@@ -104,7 +104,7 @@ fn tear_off_single_branch_stack_succeeds() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Unstacked branch 'A'.
+Unstacked branch A.
 
 "#]])
         .stderr_eq(str![""]);

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -362,7 +362,7 @@ Hint: run `but help` for all commands
 "#]]);
 
     env.but("move A C").assert().success().stdout_eq(str![[r#"
-Moved branch 'A' on top of 'C'.
+Moved branch A on top of C.
 
 "#]]);
 
@@ -443,7 +443,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved branch 'A' on top of 'C'.
+Moved branch A on top of C.
 
 "#]]);
 
@@ -513,7 +513,7 @@ Hint: run `but help` for all commands
 "#]]);
 
     env.but("move C zz").assert().success().stdout_eq(str![[r#"
-Unstacked branch 'C'.
+Unstacked branch C.
 
 "#]]);
 

--- a/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
+++ b/crates/but/tests/but/snapshots/from-workspace/branch01.stdout.term.svg
@@ -7,7 +7,8 @@
       padding: 0 10px;
       line-height: 18px;
     }
-    .dimmed { opacity: 0.4; }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -18,11 +19,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green">Applied Branches</tspan>
+    <tspan x="10px" y="28px"><tspan>Applied branches</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>A          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
+    <tspan x="10px" y="46px"><tspan>active  </tspan><tspan class="fg-green bold">✓</tspan><tspan> </tspan><tspan class="dimmed">*</tspan><tspan class="fg-green">A</tspan><tspan>          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green">active</tspan><tspan>  </tspan><tspan class="fg-green">✓ </tspan><tspan class="fg-green">*</tspan><tspan>B          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
+    <tspan x="10px" y="64px"><tspan>active  </tspan><tspan class="fg-green bold">✓</tspan><tspan> </tspan><tspan class="dimmed">*</tspan><tspan class="fg-green">B</tspan><tspan>          </tspan><tspan class="dimmed">26y ago</tspan><tspan>    </tspan><tspan class="dimmed">author</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>


### PR DESCRIPTION
## 🧢 Changes
Apply the theme to all `but branch` commands.

Also reduces some color on non-object stuff and adds color to some previously
uncolored objects.

The styling is mostly unchanged, except that I've reduced the use of "non-object" color in some places, and added object color to `but branch move` and `but branch delete`.

The most significantly changed command is `but branch list` where I've applied a bunch of object colors to the branches.

> **Note:** We still haven't committed to the colors of objects, e.g. remote branches being magenta and local branches being green.

## Before
<img width="837" height="994" alt="but-branch-list-before" src="https://github.com/user-attachments/assets/88e05681-ac49-444e-8a4a-08d6b2423e33" />

## After
<img width="838" height="1027" alt="but-branch-list-after" src="https://github.com/user-attachments/assets/6e8adea3-12b9-44aa-b981-205818abb0b8" />