### PR TITLE
feat(but): apply theme to `but commit`

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -9,13 +9,13 @@ use but_api::{
 };
 use but_core::{DiffSpec, DryRun, sync::RepoExclusive, ui::TreeChange};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
-use colored::Colorize;
 use gitbutler_repo::hooks;
 
 use super::{ShowDiffInEditor, estimate_diff_blob_size};
 use crate::{
     CliId, IdMap,
     command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
+    theme::{self, Paint},
     tui,
     utils::{InputOutputChannel, OutputChannel, shorten_object_id},
 };
@@ -305,6 +305,8 @@ pub(crate) fn commit(
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
+    let t = theme::get();
+
     // Get all stacks using but-api
     let stack_entries = workspace::stacks(ctx, None)?;
     let stacks: Vec<(
@@ -493,8 +495,8 @@ pub(crate) fn commit(
         if let Some(out) = out.for_human() {
             writeln!(
                 out,
-                "{}",
-                "Warning: Some selected changes could not be committed.".yellow()
+                "{} Some selected changes could not be committed.",
+                t.attention.paint("Warning:"),
             )?;
         }
     }
@@ -506,11 +508,10 @@ pub(crate) fn commit(
         };
         writeln!(
             out,
-            "{} {} {} {}",
-            "✓ Created commit".green(),
-            commit_short.magenta(),
-            "on branch".green(),
-            target_branch.name.to_str_lossy().yellow()
+            "{} Created commit {} on branch {}",
+            t.sym().success,
+            t.commit_id.paint(commit_short),
+            t.local_branch.paint(target_branch.name.to_str_lossy()),
         )?;
     } else if let Some(json_out) = out.for_json() {
         let commit_data = serde_json::json!({
@@ -532,7 +533,11 @@ pub(crate) fn commit(
             hooks::HookResult::Failure(error_data) => {
                 // Warn the user but don't fail since the commit is already created
                 if let Some(out) = out.for_human() {
-                    writeln!(out, "\n{}", "Warning: post-commit hook failed:".yellow())?;
+                    writeln!(
+                        out,
+                        "\n{} post-commit hook failed:",
+                        t.attention.paint("Warning:")
+                    )?;
                     writeln!(out, "{}", error_data.error)?;
                 }
             }
@@ -678,10 +683,17 @@ fn prompt_for_stack_selection(
     but_workspace::ui::StackDetails,
 )> {
     use std::fmt::Write;
+
+    let t = theme::get();
     writeln!(inout, "Multiple stacks found. Choose one to commit to:")?;
 
     for (i, (_stack_id, stack_details)) in stacks.iter().enumerate() {
-        writeln!(inout, "  {}. {}", i + 1, stack_details.derived_name.green())?;
+        writeln!(
+            inout,
+            "  {}. {}",
+            i + 1,
+            t.local_branch.paint(&stack_details.derived_name)
+        )?;
     }
 
     let selection: usize = inout


### PR DESCRIPTION
## 🧢 Changes
Applies theme to `but commit`.

Most importantly changes the success output from barfing colors to the screen, to something a bit more laid back.

## Before
<img width="723" height="331" alt="commit-before" src="https://github.com/user-attachments/assets/76d2f901-7062-4b04-b2bb-0ff23c4ef0f6" />

## After
<img width="733" height="363" alt="commit_after" src="https://github.com/user-attachments/assets/7f99e15a-1bc4-4503-a2e5-f39698b38da6" />
