### PR TITLE
Commit ordering: Use the edge weights for ordering

### DIFF
--- a/crates/but-rebase/docs/commit_parentage.md
+++ b/crates/but-rebase/docs/commit_parentage.md
@@ -34,108 +34,99 @@ This means:
 
 ## High-Level Pipeline
 
-The algorithm has five phases.
+The current algorithm has three phases.
 
 1. Normalize and deduplicate input
 - Resolve each incoming selector to `(Selector, CommitOwned)` with `editor.find_selectable_commit`.
 - Keep only the first occurrence of each commit id.
+- Preserve `input_order` for deterministic tie-breaking.
 
-2. Compute deterministic fallback rank
+2. Build rank map from editor traversal
 
-  Build a map: `commit_id -> rank` from editor step graph structure.
+Build a map `commit_id -> rank` by traversing the entire editor step graph from all child-most nodes.
 
-  Implementation notes:
+Implementation notes:
 
-  - Consider only `Step::Pick` nodes.
-  - Build pick-to-pick parent/child relations from ordered step-graph parents.
-  - Perform deterministic topological ranking.
-  - Tie-break ready nodes by graph node index for stability.
+- Seed traversal with `editor.graph.externals(Direction::Incoming)`, i.e. all nodes with no children.
+- Sort these traversal entrypoints by graph index for deterministic iteration.
+- Traverse parent-direction edges using `collect_ordered_parents`, which respects parent edge weights.
+- Push parents onto the traversal stack in that same order (no reversal).
+- Use iterative DFS with post-order assignment so parents are ranked before descendants.
+- Use a global `seen` set so overlapping traversals do not revisit or re-rank nodes seen earlier.
+- Consider only selected commit ids (non-selected picks are ignored).
+- Stop traversal early once all selected commit ids have a rank.
 
-  - This rank is used only when ancestry does not constrain order.
+3. Sort selected commits by rank
+- Sort selected commits by `(rank, input_order)`.
+- `rank` is the sole ancestry source of truth for ordering.
+- `input_order` only breaks ties if equal ranks appear.
 
-3. Build ancestry constraint graph
-- For every selected pair `(left, right)`, determine relation.
-- If `left` is ancestor of `right`, add directed edge `left -> right`.
-- If `right` is ancestor of `left`, add directed edge `right -> left`.
-- If unrelated, add no edge.
+## Example
 
-Ancestry relation is computed by reachability in the editor step graph:
+Given a graph
 
-- Starting at the candidate descendant node, walk parent-direction edges (`Outgoing` in this graph representation).
-- If the ancestor selector id is reachable, it is an ancestor.
+```sh
+*-.   1348870 (HEAD -> main) Merge branches 'A', 'B' and 'C'
+|\ \
+| | * 930563a (C) C: add another 10 lines to new file
+| | * 68a2fc3 C: add 10 lines to new file
+| | * 984fd1c C: new file with 10 lines
+| * | a748762 (B) B: another 10 lines at the bottom
+| * | 62e05ba B: 10 lines at the bottom
+| |/
+* / add59d2 (A) A: 10 lines on top
+|/
+* 8f0d338 (tag: base) base
+```
 
-4. Topological sort with stable tie-breaking
-- Use Kahn's algorithm over indegrees.
-- Keep all currently ready nodes in a min-priority structure keyed by:
-  - `(step_graph_rank, input_order)`
-- Repeatedly pop the best ready node, emit it, and reduce indegree of its children.
+And the user asks to order selectors in this input sequence:
 
-5. Validate completeness
-- If output length is smaller than selected length, constraints were cyclic/inconsistent.
-- Return an explicit error in that case.
+- `a748762`
+- `add59d2`
+- `62e05ba`
 
-### Kahn's Algo
+The ranked would produce
 
-We use Kahn's algorithm to topologically sort the nodes.
+- `8f0d338` (`base`) = 0
+- `add59d2` (`A`) = 1
+- `62e05ba` (`B~`) = 2
+- `a748762` (`B`) = 3
+- `984fd1c` (`C~2`) = 4
+- `68a2fc3` (`C~`) = 5
+- `930563a` (`C`) = 6
+- STOP
 
-Indegree:
-- In a directed graph, indegree of a node = how many arrows point into it.
-- If node B has edges A → B and C → B, then indegree(B) = 2.
-- Intuition: indegree tells you how many prerequisites a node still has.
+The rank is assigned in post-order while traversing from all child-most nodes toward parents.
+This means all nodes in the editor graph are eligible for ranking, not only those reachable from checkout roots.
 
-Kahn’s algorithm:
-- It is a way to do topological sorting.
-- Topological sort means ordering nodes so every prerequisite appears before what depends on it.
-- Works only if there is no cycle
+Then sorting by `(rank, input_order)` returns:
 
-How Kahn’s algorithm works:
-1. Compute indegree for every node.
-2. Put all nodes with indegree 0 into a queue (or priority queue if you want deterministic tie-breaking).
-3. Repeatedly:
-   1. Remove one node from the queue and add it to output.
-   2. For each outgoing edge from that node to neighbor N, reduce indegree(N) by 1.
-   3. If indegree(N) becomes 0, push N into the queue.
-4. When done:
-   - If output contains all nodes, that is a valid topological order.
-   - If not, the graph has a cycle (some nodes never reached indegree 0).
+- `add59d2` (rank 1)
+- `62e05ba` (rank 2)
+- `a748762` (rank 3)
 
-Why indegree is the key:
-- Indegree 0 means no remaining unmet dependencies.
-- Removing a node simulates “completing” that task, which can unlock others.
-
-Tiny example:
-- Edges: A → C, B → C, C → D
-- Initial indegrees: A=0, B=0, C=2, D=1
-- Start queue: A, B
-- Pop A: C becomes 1
-- Pop B: C becomes 0, enqueue C
-- Pop C: D becomes 0, enqueue D
-- Pop D
-- Order could be A, B, C, D (or B, A, C, D depending on queue policy)
+If two commits had the same rank, the one that appeared earlier in input would come first.
 
 ## Complexity
 
 Let `n` be number of selected unique commits.
 
-- Pairwise relation discovery: `O(n^2)` comparisons.
-- Topological processing:
-  - each push/pop on ready queue: `O(log n)`
-  - overall typically `O((n + e) log n)` where `e` is number of ancestry edges.
-
-Total dominated by pairwise relation checks plus heap operations.
+- Ranking traversal is linear in the visited subgraph: `O(V + E)`.
+- Sorting selected commits is `O(n log n)`.
+- With early-exit ranking, traversal can end before visiting the full graph when selected commits are found early.
 
 ## Determinism Guarantees
 
 Determinism is achieved by:
 
 - deduping by first occurrence,
-- using step-graph-derived rank for unrelated commits,
+- deriving rank from ordered-parent traversal,
 - using `input_order` as secondary tiebreaker.
 
 So repeated runs with the same inputs and editor graph state produce the same output.
 
 ## Notes for Future Changes
 
-If behavior needs to include commits currently not represented in the editor graph,
-that must be solved before ordering (for example by changing editor graph construction).
-Ordering itself intentionally operates only on what the editor graph already contains.
+Ordering intentionally operates only on commits represented in the editor graph.
+If behavior needs to include commits not represented there, that must be solved before ordering
+(for example by changing editor graph construction).

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -315,9 +315,9 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
     /// the `skip_reconnect_step` is set to true.
     ///
     /// Returns an error when:
-    /// - `parents_to_disconnect` is `SelectorSet::None`
-    /// - `parents_to_disconnect` contains any parent that is not a direct parent of `target.parent`
-    /// - `children_to_disconnect` contains any child that is not a direct parent of `target.child`
+    /// - `parents_to_disconnect` is `SelectorSet::None` and `skip_reconnect_step` is false.
+    /// - `parents_to_disconnect` contains any parent that is not a direct parent of `target.parent`.
+    /// - `children_to_disconnect` contains any child that is not a direct parent of `target.child`.
     pub fn disconnect_segment_from<C, P>(
         &mut self,
         target: SegmentDelimiter<C, P>,
@@ -350,9 +350,13 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         let parents_to_disconnect = match parents_to_disconnect {
             SelectorSet::All => None,
             SelectorSet::None => {
-                return Err(anyhow!(
-                    "Invalid parents to disconnect: SelectorSet::None is not allowed"
-                ));
+                if skip_reconnect_step {
+                    Some(Vec::new())
+                } else {
+                    return Err(anyhow!(
+                        "Invalid parents to disconnect: SelectorSet::None is not allowed"
+                    ));
+                }
             }
             SelectorSet::Some(parents) => Some(
                 parents

--- a/crates/but-rebase/src/graph_rebase/ordering.rs
+++ b/crates/but-rebase/src/graph_rebase/ordering.rs
@@ -1,22 +1,25 @@
 #![doc = include_str!("../../docs/commit_parentage.md")]
 
-use std::{
-    cmp::Reverse,
-    collections::{BinaryHeap, HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use but_core::RefMetadata;
-use petgraph::visit::EdgeRef as _;
+use petgraph::Direction;
 
 use crate::graph_rebase::{Editor, Pick, Selector, Step, StepGraphIndex, ToCommitSelector, util};
 
 impl<M: RefMetadata> Editor<'_, '_, M> {
     /// Order commit selectors by parentage, with parents first and children last.
     ///
-    /// If two commits are unrelated by ancestry, their relative order is determined by
-    /// deterministic editor graph order. Duplicate selectors are deduplicated by commit-id
-    /// with first occurrence winning.
+    /// Duplicate selectors are deduplicated by commit-id with first occurrence winning.
+    ///
+    /// Ordering is derived from a deterministic rank map built from the editor step graph.
+    /// The rank is computed by traversing from all child-most graph nodes in ordered-parent
+    /// post-order (parents are pushed in `collect_ordered_parents` order, without reversing),
+    /// then sorting selected commits by `(rank, input_order)`.
+    ///
+    /// The ranker considers only selected commit ids and exits traversal early once all selected
+    /// commits have been ranked.
     pub fn order_commit_selectors_by_parentage<I, S>(&self, selectors: I) -> Result<Vec<Selector>>
     where
         I: IntoIterator<Item = S>,
@@ -40,92 +43,34 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             return Ok(selected.into_iter().map(|s| s.selector).collect());
         }
 
-        // Build a deterministic fallback rank from editor step-graph order for unrelated commits.
-        let step_graph_rank = step_graph_parent_to_child_rank(self);
-
-        // Build a DAG over selected commits where edges always point ancestor -> descendant.
-        let mut adjacency = vec![Vec::<usize>::new(); selected.len()];
-        let mut indegree = vec![0usize; selected.len()];
-
-        for (i, left_commit) in selected.iter().enumerate() {
-            for (offset, right_commit) in selected.iter().skip(i + 1).enumerate() {
-                let j = i + 1 + offset;
-                match ancestry_relation(self, left_commit, right_commit) {
-                    Relation::LeftIsAncestorOfRight => {
-                        adjacency
-                            .get_mut(i)
-                            .context("BUG: adjacency index should always be valid")?
-                            .push(j);
-                        *indegree
-                            .get_mut(j)
-                            .context("BUG: indegree index should always be valid")? += 1;
-                    }
-                    Relation::RightIsAncestorOfLeft => {
-                        adjacency
-                            .get_mut(j)
-                            .context("BUG: adjacency index should always be valid")?
-                            .push(i);
-                        *indegree
-                            .get_mut(i)
-                            .context("BUG: indegree index should always be valid")? += 1;
-                    }
-                    Relation::Unrelated => {}
-                }
-            }
-        }
-
-        // Kahn topological sort with a min-priority queue so output order is stable across unrelated nodes.
-        let mut output = Vec::with_capacity(selected.len());
-        let mut ready: BinaryHeap<Reverse<(usize, usize, usize)>> = indegree
+        // Build a deterministic rank from editor step-graph order.
+        let selected_ids = selected
             .iter()
-            .enumerate()
-            .filter_map(|(idx, degree)| {
-                if *degree != 0 {
-                    return None;
-                }
-                let commit = selected.get(idx)?;
-                let rank = *step_graph_rank
-                    .get(&commit.id)
-                    .context("BUG: selected commit should be rankable in editor graph")
-                    .ok()?;
-                Some(Reverse((rank, commit.input_order, idx)))
-            })
-            .collect();
+            .map(|commit| commit.id)
+            .collect::<HashSet<_>>();
+        let step_graph_rank = step_graph_parent_to_child_rank(self, &selected_ids)?;
 
-        // Repeatedly emit the best available node and unlock its descendants.
-        while let Some(Reverse((_, _, next))) = ready.pop() {
-            output.push(
-                selected
-                    .get(next)
-                    .context("BUG: ready index should be in-bounds")?
-                    .selector,
-            );
-            for &child in adjacency
-                .get(next)
-                .context("BUG: adjacency index should be in-bounds")?
-            {
-                let degree = indegree
-                    .get_mut(child)
-                    .context("BUG: child index should be in-bounds")?;
-                *degree -= 1;
-                if *degree == 0 {
-                    let commit = selected
-                        .get(child)
-                        .context("BUG: child index should point to selected commits")?;
-                    let rank = *step_graph_rank
-                        .get(&commit.id)
-                        .context("BUG: selected child commit should be rankable in editor graph")?;
-                    ready.push(Reverse((rank, commit.input_order, child)));
-                }
+        // Preserve the Result contract: unreachable selected commits are a runtime error,
+        // not an internal panic.
+        for commit in &selected {
+            if !step_graph_rank.contains_key(&commit.id) {
+                bail!(
+                    "Cannot order selected commits by parentage: selected commit {} could not be ranked from editor graph nodes",
+                    commit.id
+                );
             }
         }
 
-        // Any leftovers indicate impossible/cyclic constraints in what should be a DAG.
-        if output.len() != selected.len() {
-            bail!("Cannot order selected commits by parentage due to cyclic ancestry constraints")
-        }
+        // The rank map is the sole source of truth for deterministic parent-before-child ordering.
+        selected.sort_by_key(|commit| {
+            let rank = step_graph_rank
+                .get(&commit.id)
+                .copied()
+                .unwrap_or(usize::MAX);
+            (rank, commit.input_order)
+        });
 
-        Ok(output)
+        Ok(selected.into_iter().map(|s| s.selector).collect())
     }
 }
 
@@ -136,130 +81,60 @@ struct SelectedCommit {
     input_order: usize,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum Relation {
-    LeftIsAncestorOfRight,
-    RightIsAncestorOfLeft,
-    Unrelated,
-}
-
-fn ancestry_relation(
-    editor: &Editor<'_, '_, impl RefMetadata>,
-    left: &SelectedCommit,
-    right: &SelectedCommit,
-) -> Relation {
-    if is_pick_ancestor(editor, left.selector.id, right.selector.id) {
-        return Relation::LeftIsAncestorOfRight;
-    }
-    if is_pick_ancestor(editor, right.selector.id, left.selector.id) {
-        return Relation::RightIsAncestorOfLeft;
-    }
-    Relation::Unrelated
-}
-
-fn is_pick_ancestor(
-    editor: &Editor<'_, '_, impl RefMetadata>,
-    ancestor: StepGraphIndex,
-    descendant: StepGraphIndex,
-) -> bool {
-    let mut stack = vec![descendant];
-    let mut seen = HashSet::from([descendant]);
-
-    while let Some(node) = stack.pop() {
-        for edge in editor
-            .graph
-            .edges_directed(node, petgraph::Direction::Outgoing)
-        {
-            let parent = edge.target();
-            if parent == ancestor {
-                return true;
-            }
-            if seen.insert(parent) {
-                stack.push(parent);
-            }
-        }
-    }
-
-    false
-}
-
 fn step_graph_parent_to_child_rank<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
-) -> HashMap<gix::ObjectId, usize> {
-    let pick_nodes: Vec<StepGraphIndex> = editor
-        .graph
-        .node_indices()
-        .filter(|idx| matches!(editor.graph[*idx], Step::Pick(_)))
-        .collect();
-
-    let pick_pos_by_idx: HashMap<StepGraphIndex, usize> = pick_nodes
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(pos, idx)| (idx, pos))
-        .collect();
-
-    // Build parent -> child edges between pick nodes only.
-    let mut adjacency = vec![Vec::<usize>::new(); pick_nodes.len()];
-    let mut indegree = vec![0usize; pick_nodes.len()];
-
-    for (child_pos, child_idx) in pick_nodes.iter().copied().enumerate() {
-        for parent_idx in util::collect_ordered_parents(&editor.graph, child_idx) {
-            let Some(parent_pos) = pick_pos_by_idx.get(&parent_idx).copied() else {
-                continue;
-            };
-            adjacency[parent_pos].push(child_pos);
-            indegree[child_pos] += 1;
-        }
-    }
-
-    // Deterministic tie-break on node index keeps ranking stable.
-    let mut ready: BinaryHeap<Reverse<(usize, usize)>> = indegree
-        .iter()
-        .enumerate()
-        .filter_map(|(pos, degree)| {
-            (*degree == 0).then_some(Reverse((pick_nodes[pos].index(), pos)))
-        })
-        .collect();
-
+    selected_ids: &HashSet<gix::ObjectId>,
+) -> Result<HashMap<gix::ObjectId, usize>> {
     let mut rank_by_id = HashMap::<gix::ObjectId, usize>::new();
     let mut next_rank = 0usize;
+    let mut seen = HashSet::<StepGraphIndex>::new();
 
-    while let Some(Reverse((_, pos))) = ready.pop() {
-        if let Step::Pick(Pick { id, .. }) = editor.graph[pick_nodes[pos]] {
-            rank_by_id.entry(id).or_insert_with(|| {
-                let rank = next_rank;
-                next_rank += 1;
-                rank
-            });
+    let mut roots = editor
+        .graph
+        .externals(Direction::Incoming)
+        .collect::<Vec<StepGraphIndex>>();
+    roots.sort_unstable_by_key(|idx| idx.index());
+
+    // Traverse from all child-most entrypoints (graph nodes without children), assigning
+    // rank in post-order so parent commits always rank before descendants. Parents are
+    // pushed in collect_ordered_parents order (not reversed). The seen-set handles nodes
+    // reachable from multiple entrypoints, and traversal stops once all selected commits
+    // have ranks.
+    for root in roots {
+        if rank_by_id.len() == selected_ids.len() {
+            break;
         }
 
-        for &child in &adjacency[pos] {
-            let degree = &mut indegree[child];
-            *degree -= 1;
-            if *degree == 0 {
-                ready.push(Reverse((pick_nodes[child].index(), child)));
+        let mut stack = vec![(root, false)];
+        while let Some((node, expanded)) = stack.pop() {
+            if rank_by_id.len() == selected_ids.len() {
+                break;
+            }
+
+            if expanded {
+                if let Step::Pick(Pick { id, .. }) = editor.graph[node]
+                    && selected_ids.contains(&id)
+                {
+                    rank_by_id.entry(id).or_insert_with(|| {
+                        let rank = next_rank;
+                        next_rank += 1;
+                        rank
+                    });
+                }
+                continue;
+            }
+
+            if !seen.insert(node) {
+                continue;
+            }
+
+            let parents = util::collect_ordered_parents(&editor.graph, node);
+            stack.push((node, true));
+            for parent_idx in parents.into_iter() {
+                stack.push((parent_idx, false));
             }
         }
     }
 
-    // Step-graph cycles are unexpected; rank any leftovers deterministically.
-    let mut leftovers: Vec<usize> = indegree
-        .iter()
-        .enumerate()
-        .filter_map(|(pos, degree)| (*degree > 0).then_some(pos))
-        .collect();
-    leftovers.sort_by_key(|pos| pick_nodes[*pos].index());
-
-    for pos in leftovers {
-        if let Step::Pick(Pick { id, .. }) = editor.graph[pick_nodes[pos]] {
-            rank_by_id.entry(id).or_insert_with(|| {
-                let rank = next_rank;
-                next_rank += 1;
-                rank
-            });
-        }
-    }
-
-    rank_by_id
+    Ok(rank_by_id)
 }

--- a/crates/but-rebase/tests/fixtures/scenario/two-branches-shared-bottom-two.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/two-branches-shared-bottom-two.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"
+echo "shared" >shared && git add . && git commit -m "shared"
+
+git branch right
+
+echo "left-head" >left && git add . && git commit -m "left: head"
+git branch left
+
+git checkout right
+echo "right-head" >right && git add . && git commit -m "right: head"
+
+git checkout main
+git merge right -m "merge right into main"

--- a/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/order_commit_selectors_by_parentage.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, LookupStep, Step, testing::Testing as _};
+use but_rebase::graph_rebase::{Editor, LookupStep, Step, mutate, testing::Testing as _};
 use but_testsupport::visualize_commit_graph_all;
 
 use crate::utils::{fixture, fixture_writable, standard_options};
@@ -16,6 +16,10 @@ fn short_ids(
             Ok(id.to_hex_with_len(7).to_string())
         })
         .collect()
+}
+
+fn short_id(id: gix::ObjectId) -> String {
+    id.to_hex_with_len(7).to_string()
 }
 
 fn trim_trailing_whitespace(input: &str) -> String {
@@ -333,6 +337,126 @@ fn orders_commit_present_in_editor_graph_even_if_workspace_projection_stale() ->
         "1787cd0",
     ]
     "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_commit_disconnected_from_checkout_roots_if_still_in_editor_graph() -> Result<()> {
+    let (repo, mut meta) = fixture("four-commits")?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let b = repo.rev_parse_single("HEAD~1")?.detach();
+    let b_selector = editor.select_commit(b)?;
+
+    editor.disconnect_segment_from(
+        mutate::SegmentDelimiter {
+            child: b_selector,
+            parent: b_selector,
+        },
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::All,
+        true,
+    )?;
+
+    let ordered = editor.order_commit_selectors_by_parentage([b])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    insta::assert_debug_snapshot!(ordered_ids, @r#"
+    [
+        "a96434e",
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn orders_all_commits_in_y_shaped_two_branch_fixture() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("two-branches-shared-bottom-two")?;
+
+    let graph = trim_trailing_whitespace(&visualize_commit_graph_all(&repo)?);
+    insta::assert_snapshot!(graph, @r"
+    *   3127e18 (HEAD -> main) merge right into main
+    |\
+    | * ce0d74d (right) right: head
+    * | c3a0d4c (left) left: head
+    |/
+    * 67a0a68 shared
+    * 35b8235 base
+    ");
+    let right_ref: gix::refs::FullName = "refs/heads/right".try_into()?;
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let merge = repo.rev_parse_single("HEAD")?.detach();
+    let left = repo.rev_parse_single("left")?.detach();
+    let shared = repo.rev_parse_single("right~")?.detach();
+    let base = repo.rev_parse_single("right~2")?.detach();
+
+    let right = repo.rev_parse_single("right")?.detach();
+    let right_ref_selector = editor.select_reference(right_ref.as_ref())?;
+    let right_selector = editor.select_commit(right)?;
+
+    let ordered = editor.order_commit_selectors_by_parentage([merge, right, left, shared, base])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    assert_eq!(
+        ordered_ids,
+        vec![
+            short_id(base),
+            short_id(shared),
+            short_id(right),
+            short_id(left),
+            short_id(merge),
+        ]
+    );
+
+    // Disconnect the 'right' branch from the merge commit, making it a leaf node, but keeping it in the editor
+    // graph.
+    editor.disconnect_segment_from(
+        mutate::SegmentDelimiter {
+            child: right_ref_selector,
+            parent: right_selector,
+        },
+        mutate::SelectorSet::All,
+        mutate::SelectorSet::None,
+        true,
+    )?;
+
+    // The right reference should still exist, but its tip commit should no longer have commit children.
+    assert_eq!(editor.lookup_reference(right_ref_selector)?, right_ref);
+    let right_children = editor.direct_children(right_ref_selector)?;
+    assert!(
+        right_children.is_empty(),
+        "right should be a leaf commit after disconnecting its children"
+    );
+
+    let right = repo.rev_parse_single("right")?.detach();
+    let merge = repo.rev_parse_single("HEAD")?.detach();
+    let left = repo.rev_parse_single("left")?.detach();
+    let shared = repo.rev_parse_single("right~")?.detach();
+    let base = repo.rev_parse_single("right~2")?.detach();
+
+    let ordered = editor.order_commit_selectors_by_parentage([merge, right, left, shared, base])?;
+    let ordered_ids = short_ids(&editor, &ordered)?;
+    assert_eq!(
+        ordered_ids,
+        vec![
+            short_id(base),
+            short_id(shared),
+            short_id(left),
+            short_id(merge),
+            short_id(right),
+        ]
+    );
+
+    let leaf_ordered = editor.order_commit_selectors_by_parentage([merge, right])?;
+    let leaf_ordered_ids = short_ids(&editor, &leaf_ordered)?;
+    assert_eq!(leaf_ordered_ids, vec![short_id(merge), short_id(right)]);
 
     Ok(())
 }


### PR DESCRIPTION
We need to respect the edge weights when determining the commit
ordering.

- Traverse the graph from the root, respecting the weight of the edges.
- Ignore commits not reachable from the root.
- Terminate early once all commits have been found.