### PR TITLE
move multiple commits

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -113,7 +113,7 @@ export interface CommitSquashParams {
 
 export interface CommitMoveParams {
 	projectId: string;
-	subjectCommitId: string;
+	subjectCommitIds: Array<string>;
 	relativeTo: RelativeTo;
 	side: InsertSide;
 	dryRun: boolean;

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -133,8 +133,8 @@ const registerIpcHandlers = (): void => {
 	);
 	ipcMain.handle(
 		liteIpcChannels.commitMove,
-		(_e, { projectId, subjectCommitId, relativeTo, side, dryRun }: CommitMoveParams) =>
-			commitMove(projectId, subjectCommitId, relativeTo, side, dryRun),
+		(_e, { projectId, subjectCommitIds, relativeTo, side, dryRun }: CommitMoveParams) =>
+			commitMove(projectId, subjectCommitIds, relativeTo, side, dryRun),
 	);
 	ipcMain.handle(
 		liteIpcChannels.commitSquash,

--- a/apps/lite/ui/src/Operation.ts
+++ b/apps/lite/ui/src/Operation.ts
@@ -286,7 +286,7 @@ export const useRunOperation = () => {
 				CommitMove: (operation) => {
 					commitMove.mutate({
 						projectId,
-						subjectCommitId: operation.subjectCommitId,
+						subjectCommitIds: operation.subjectCommitIds,
 						relativeTo: operation.relativeTo,
 						side: operation.side,
 						dryRun: operation.dryRun,

--- a/apps/lite/ui/src/routes/project/$id/workspace/ResolvedOperationSource.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ResolvedOperationSource.ts
@@ -336,7 +336,7 @@ const getCommitTargetMoveOperation = ({
 		Match.tags({
 			Commit: (source) =>
 				commitMoveOperation({
-					subjectCommitId: source.commitId,
+					subjectCommitIds: [source.commitId],
 					relativeTo: { type: "commit", subject: commitId },
 					side,
 					dryRun: false,
@@ -388,7 +388,7 @@ const getBranchTargetOperation = ({
 				}),
 			Commit: ({ commitId }) =>
 				commitMoveOperation({
-					subjectCommitId: commitId,
+					subjectCommitIds: [commitId],
 					relativeTo: {
 						type: "referenceBytes",
 						subject: branchRef,

--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -1,8 +1,9 @@
+use anyhow::bail;
 use but_api_macros::but_api;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::{
-    Editor,
+    Editor, LookupStep as _,
     mutate::{InsertSide, RelativeTo},
 };
 use tracing::instrument;
@@ -11,7 +12,7 @@ use crate::WorkspaceState;
 
 use super::types::CommitMoveResult;
 
-/// Moves `subject_commit_id` to `side` of `relative_to`.
+/// Moves `subject_commit_ids` to `side` of `relative_to`.
 ///
 /// This acquires exclusive worktree access from `ctx` before moving the
 /// commit.
@@ -22,7 +23,7 @@ use super::types::CommitMoveResult;
 #[but_api(try_from = crate::commit::json::CommitMoveResult)]
 pub fn commit_move_only(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
     dry_run: DryRun,
@@ -30,7 +31,7 @@ pub fn commit_move_only(
     let mut guard = ctx.exclusive_worktree_access();
     commit_move_only_with_perm(
         ctx,
-        subject_commit_id,
+        subject_commit_ids,
         relative_to,
         side,
         dry_run,
@@ -38,7 +39,7 @@ pub fn commit_move_only(
     )
 }
 
-/// Move `subject_commit_id` to the `side` of `relative_to` under
+/// Move `subject_commit_ids` to the `side` of `relative_to` under
 /// caller-held exclusive repository access.
 ///
 /// This returns the post-operation workspace view without creating an oplog
@@ -47,24 +48,72 @@ pub fn commit_move_only(
 /// implementation details, see [`but_workspace::commit::move_commit()`].
 pub fn commit_move_only_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     relative_to: RelativeTo,
     side: InsertSide,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
+    if subject_commit_ids.is_empty() {
+        bail!("No commits were provided to move")
+    }
+
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
 
-    let rebase = but_workspace::commit::move_commit(editor, subject_commit_id, relative_to, side)?;
+    let ordered_selectors = editor.order_commit_selectors_by_parentage(subject_commit_ids)?;
+    let mut ordered_ids = ordered_selectors
+        .iter()
+        .map(|selector| editor.lookup_pick(*selector))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let ordered_ids = if matches!(side, InsertSide::Above) {
+        ordered_ids.reverse();
+        ordered_ids
+    } else {
+        ordered_ids
+    };
+
+    let mut subjects = ordered_ids.into_iter();
+    let first_subject = subjects
+        .next()
+        .expect("non-empty commit list always has a first subject");
+
+    let mut rebase =
+        but_workspace::commit::move_commit(editor, first_subject, relative_to.clone(), side)?;
+
+    for original_subject_id in subjects {
+        let remapped_ids = rebase.history.commit_mappings();
+        let subject_id = remapped_ids
+            .get(&original_subject_id)
+            .copied()
+            .unwrap_or(original_subject_id);
+
+        let remapped_relative_to = match &relative_to {
+            RelativeTo::Commit(target_commit_id) => RelativeTo::Commit(
+                remapped_ids
+                    .get(target_commit_id)
+                    .copied()
+                    .unwrap_or(*target_commit_id),
+            ),
+            RelativeTo::Reference(reference_name) => RelativeTo::Reference(reference_name.clone()),
+        };
+
+        rebase = but_workspace::commit::move_commit(
+            rebase.into_editor(),
+            subject_id,
+            remapped_relative_to,
+            side,
+        )?;
+    }
 
     Ok(CommitMoveResult {
         workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,
     })
 }
 
-/// Moves `subject_commit_id` to `side` of `relative_to` and records an oplog
+/// Moves `subject_commit_ids` to `side` of `relative_to` and records an oplog
 /// snapshot on success.
 ///
 /// This acquires exclusive worktree access from `ctx` before moving the
@@ -76,7 +125,7 @@ pub fn commit_move_only_with_perm(
 #[instrument(err(Debug))]
 pub fn commit_move(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     #[but_api(crate::commit::json::RelativeTo)] relative_to: RelativeTo,
     side: InsertSide,
     dry_run: DryRun,
@@ -84,7 +133,7 @@ pub fn commit_move(
     let mut guard = ctx.exclusive_worktree_access();
     commit_move_with_perm(
         ctx,
-        subject_commit_id,
+        subject_commit_ids,
         relative_to,
         side,
         dry_run,
@@ -92,7 +141,7 @@ pub fn commit_move(
     )
 }
 
-/// Moves `subject_commit_id` to `side` of `relative_to` under caller-held
+/// Moves `subject_commit_ids` to `side` of `relative_to` under caller-held
 /// exclusive repository access and records an oplog snapshot on success.
 ///
 /// It prepares a best-effort `MoveCommit` oplog snapshot, performs the move,
@@ -102,7 +151,7 @@ pub fn commit_move(
 /// [`but_workspace::commit::move_commit()`].
 pub fn commit_move_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     relative_to: RelativeTo,
     side: InsertSide,
     dry_run: DryRun,
@@ -115,7 +164,7 @@ pub fn commit_move_with_perm(
         dry_run,
     );
 
-    let res = commit_move_only_with_perm(ctx, subject_commit_id, relative_to, side, dry_run, perm);
+    let res = commit_move_only_with_perm(ctx, subject_commit_ids, relative_to, side, dry_run, perm);
     if let Some(snapshot) = maybe_oplog_entry
         && res.is_ok()
     {

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -52,6 +52,52 @@ pub(crate) fn handle_resolved_with_perm(
     operation.execute_with_perm(ctx, out, perm)
 }
 
+pub(crate) fn handle_multiple_resolved_with_perm(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    source_ids: &[CliId],
+    target_id: &CliId,
+    after: bool,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<()> {
+    if source_ids.is_empty() {
+        bail!("No source commits provided.");
+    }
+
+    let sources = source_ids
+        .iter()
+        .map(|id| match id {
+            CliId::Commit { commit_id, .. } => Ok(*commit_id),
+            _ => bail!(
+                "Cannot move {} as part of a multi-commit operation. Only commits are supported.",
+                id.to_short_string().blue().bold()
+            ),
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    match target_id {
+        CliId::Commit { commit_id, .. } => {
+            move_commit_to_commit_with_perm(ctx, sources, *commit_id, after, out, perm)
+        }
+        CliId::Branch { name, .. } => {
+            if after {
+                bail!(
+                    "The {} flag only makes sense when moving a commit to another commit.\n\
+                    When moving to a branch, the commit is placed at the top of the stack by default.",
+                    "--after"
+                );
+            }
+            move_commit_to_branch_with_perm(ctx, sources, name, out, perm)
+        }
+        _ => bail!(
+            "Cannot move multiple commits to {} ({}).\n\
+            Valid multi-commit moves: commit→commit or commit→branch",
+            target_id.to_short_string().blue().bold(),
+            target_id.kind_for_humans().yellow()
+        ),
+    }
+}
+
 /// Represents the operation to perform for a given source and target combination in `but move`.
 #[derive(Debug)]
 enum MoveOperation<'a> {
@@ -87,11 +133,11 @@ impl<'a> MoveOperation<'a> {
                 source,
                 target,
                 after,
-            } => move_commit_to_commit_with_perm(ctx, source, target, after, out, perm),
+            } => move_commit_to_commit_with_perm(ctx, vec![source], target, after, out, perm),
             MoveOperation::CommitToBranch {
                 source,
                 target_branch,
-            } => move_commit_to_branch_with_perm(ctx, source, target_branch, out, perm),
+            } => move_commit_to_branch_with_perm(ctx, vec![source], target_branch, out, perm),
             MoveOperation::CommittedFileToCommit {
                 path,
                 source_commit,
@@ -108,10 +154,10 @@ impl<'a> MoveOperation<'a> {
     }
 }
 
-/// Mova a commit to a new position relative to another one.
+/// Move a commit to a new position relative to another one.
 pub fn move_commit_to_commit_with_perm(
     ctx: &mut Context,
-    source: gix::ObjectId,
+    sources: Vec<gix::ObjectId>,
     target: gix::ObjectId,
     after: bool,
     out: &mut OutputChannel,
@@ -123,10 +169,16 @@ pub fn move_commit_to_commit_with_perm(
         InsertSide::Below
     };
 
-    // Check if source and target are the same commit
-    if source == target {
+    if sources.contains(&target) {
         if let Some(out) = out.for_human() {
-            writeln!(out, "Source and target are the same commit. Nothing to do.")?;
+            if sources.len() == 1 {
+                writeln!(out, "Source and target are the same commit. Nothing to do.")?;
+            } else {
+                writeln!(
+                    out,
+                    "At least one source commit is the same as the target commit. Nothing to do."
+                )?;
+            }
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({"ok": true}))?;
         }
@@ -135,7 +187,7 @@ pub fn move_commit_to_commit_with_perm(
 
     but_api::commit::move_commit::commit_move_with_perm(
         ctx,
-        source,
+        sources.clone(),
         RelativeTo::Commit(target),
         side,
         DryRun::No,
@@ -145,13 +197,24 @@ pub fn move_commit_to_commit_with_perm(
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
         let action = if after { "after" } else { "before" };
-        writeln!(
-            out,
-            "Moved {} → {} {}",
-            shorten_object_id(&repo, source).blue(),
-            action,
-            shorten_object_id(&repo, target).green(),
-        )?;
+        if sources.len() == 1 {
+            let source = sources[0];
+            writeln!(
+                out,
+                "Moved {} → {} {}",
+                shorten_object_id(&repo, source).blue(),
+                action,
+                shorten_object_id(&repo, target).green(),
+            )?;
+        } else {
+            writeln!(
+                out,
+                "Moved {} commits → {} {}",
+                sources.len().to_string().blue(),
+                action,
+                shorten_object_id(&repo, target).green(),
+            )?;
+        }
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({"ok": true}))?;
     }
@@ -160,7 +223,7 @@ pub fn move_commit_to_commit_with_perm(
 
 pub fn move_commit_to_branch_with_perm(
     ctx: &mut Context,
-    source: gix::ObjectId,
+    sources: Vec<gix::ObjectId>,
     target_branch: &str,
     out: &mut OutputChannel,
     perm: &mut RepoExclusive,
@@ -168,7 +231,7 @@ pub fn move_commit_to_branch_with_perm(
     let target_full_name = gix::refs::FullName::try_from(format!("refs/heads/{target_branch}"))?;
     but_api::commit::move_commit::commit_move_with_perm(
         ctx,
-        source,
+        sources.clone(),
         RelativeTo::Reference(target_full_name),
         InsertSide::Below,
         DryRun::No,
@@ -177,12 +240,22 @@ pub fn move_commit_to_branch_with_perm(
 
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
-        writeln!(
-            out,
-            "Moved {} → {}",
-            shorten_object_id(&repo, source).blue(),
-            format!("[{target_branch}]").green()
-        )?;
+        if sources.len() == 1 {
+            let source = sources[0];
+            writeln!(
+                out,
+                "Moved {} → {}",
+                shorten_object_id(&repo, source).blue(),
+                format!("[{target_branch}]").green()
+            )?;
+        } else {
+            writeln!(
+                out,
+                "Moved {} commits → {}",
+                sources.len().to_string().blue(),
+                format!("[{target_branch}]").green()
+            )?;
+        }
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({"ok": true}))?;
     }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -662,7 +662,7 @@ impl<'a> MoveCommitToBranchOperation<'a> {
         let target_full_name = FullName::try_from(format!("refs/heads/{}", self.name))?;
         but_api::commit::move_commit::commit_move(
             ctx,
-            self.oid,
+            vec![self.oid],
             RelativeTo::Reference(target_full_name),
             InsertSide::Below,
             DryRun::No,

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -281,7 +281,7 @@ pub(super) fn move_commit_to_branch(
     drop(repo);
     but_api::commit::move_commit::commit_move(
         ctx,
-        subject_commit_id,
+        vec![subject_commit_id],
         RelativeTo::Reference(target_branch_name),
         InsertSide::Below,
         DryRun::No,
@@ -297,7 +297,7 @@ pub(super) fn move_commit_to_commit(
 ) -> anyhow::Result<but_api::commit::types::CommitMoveResult> {
     but_api::commit::move_commit::commit_move(
         ctx,
-        subject_commit_id,
+        vec![subject_commit_id],
         RelativeTo::Commit(target_commit_id),
         insert_side,
         DryRun::No,

--- a/crates/but/src/command/move.rs
+++ b/crates/but/src/command/move.rs
@@ -11,10 +11,28 @@ pub(crate) fn handle(
 ) -> anyhow::Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
-    let source_id =
-        resolve_single(&id_map, ctx, source, "Source").context("Failed to move commit.")?;
+    let source_ids =
+        resolve_many(&id_map, ctx, source, "Source").context("Failed to move commit.")?;
     let target_id =
         resolve_single(&id_map, ctx, target, "Target").context("Failed to move commit.")?;
+
+    if source_ids.is_empty() {
+        anyhow::bail!("Source must include at least one selector")
+    }
+
+    if source_ids.len() > 1 {
+        return super::commit::r#move::handle_multiple_resolved_with_perm(
+            ctx,
+            out,
+            &source_ids,
+            &target_id,
+            after,
+            guard.write_permission(),
+        )
+        .context("Failed to move commit.");
+    }
+
+    let source_id = source_ids[0].clone();
 
     let branch_route = matches!(
         (&source_id, &target_id),
@@ -95,4 +113,18 @@ fn resolve_single(
         );
     }
     Ok(matches[0].clone())
+}
+
+fn resolve_many(
+    id_map: &IdMap,
+    ctx: &but_ctx::Context,
+    selectors: &str,
+    kind: &str,
+) -> anyhow::Result<Vec<CliId>> {
+    selectors
+        .split(',')
+        .map(str::trim)
+        .filter(|selector| !selector.is_empty())
+        .map(|selector| resolve_single(id_map, ctx, selector, kind))
+        .collect()
 }

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -1,4 +1,5 @@
 //! Put command-specific tests here. They should be focused on what's important for each command.
+//!
 //! Ideally they *show* the initial state, and the *post* state, to validate the commands actually do what they claim.
 //! **Only** test the *happy path* of a typical user journey, while keeping details in unit tests with private module access.
 #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use snapbox::str;
 
 use crate::{
-    command::util::commit_two_files_as_two_hunks_each,
+    command::util::{commit_two_files_as_two_hunks_each, find_branch},
     utils::{CommandExt, Sandbox},
 };
 
@@ -87,6 +87,450 @@ Moved fce8ecc → after 23e1bf8
 
     // Should still have 4 commits (3 we created + initial "add A")
     assert_eq!(commits_after.as_array().unwrap().len(), 4);
+
+    Ok(())
+}
+
+#[test]
+fn move_multiple_commits_before_another_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.setup_metadata(&["A"])?;
+
+    // Create three commits
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
+    commit_two_files_as_two_hunks_each(&env, "A", "c.txt", "d.txt", "second commit");
+    commit_two_files_as_two_hunks_each(&env, "A", "e.txt", "f.txt", "third commit");
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   23e1bf8 create e.txt and f.txt
+┊●   de41286 create c.txt and d.txt
+┊●   fce8ecc create a.txt and b.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    // Commits are ordered newest first.
+    let status_output = env.but("--json status").allow_json().output()?;
+    let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+    let commits = &status_json["stacks"][0]["branches"][0]["commits"];
+
+    let third_commit_id = commits[0]["cliId"].as_str().unwrap();
+    let second_commit_id = commits[1]["cliId"].as_str().unwrap();
+    let first_commit_id = commits[2]["cliId"].as_str().unwrap();
+
+    env.but(format!(
+        "move {second_commit_id},{third_commit_id} {first_commit_id}"
+    ))
+    .assert()
+    .success()
+    .stdout_eq(str![[r#"
+Moved 2 commits → before fce8ecc
+
+"#]]);
+
+    let status_output = env.but("--json status").allow_json().output()?;
+    let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+    let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
+
+    assert_eq!(commits_after.as_array().unwrap().len(), 4);
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   0e08d58 create a.txt and b.txt
+┊●   7887784 create e.txt and f.txt
+┊●   078d9e6 create c.txt and d.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_multiple_commits_after_another_commit() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack")?;
+
+    env.setup_metadata(&["A"])?;
+
+    // Create three commits
+    commit_two_files_as_two_hunks_each(&env, "A", "a.txt", "b.txt", "first commit");
+    commit_two_files_as_two_hunks_each(&env, "A", "c.txt", "d.txt", "second commit");
+    commit_two_files_as_two_hunks_each(&env, "A", "e.txt", "f.txt", "third commit");
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   23e1bf8 create e.txt and f.txt
+┊●   de41286 create c.txt and d.txt
+┊●   fce8ecc create a.txt and b.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+    // Commits are ordered newest first.
+    let status_output = env.but("--json status").allow_json().output()?;
+    let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+    let commits = &status_json["stacks"][0]["branches"][0]["commits"];
+
+    let third_commit_id = commits[0]["cliId"].as_str().unwrap();
+    let second_commit_id = commits[1]["cliId"].as_str().unwrap();
+    let first_commit_id = commits[2]["cliId"].as_str().unwrap();
+
+    env.but(format!(
+        "move {first_commit_id},{second_commit_id} {third_commit_id} --after"
+    ))
+    .assert()
+    .success()
+    .stdout_eq(str![[r#"
+Moved 2 commits → after 23e1bf8
+
+"#]]);
+
+    let status_output = env.but("--json status").allow_json().output()?;
+    let status_json: serde_json::Value = serde_json::from_slice(&status_output.stdout)?;
+    let commits_after = &status_json["stacks"][0]["branches"][0]["commits"];
+
+    assert_eq!(commits_after.as_array().unwrap().len(), 4);
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   05b04e5 create c.txt and d.txt
+┊●   9f54aec create a.txt and b.txt
+┊●   d7e5fc7 create e.txt and f.txt
+┊●   9477ae7 add A
+├╯
+┊
+┴ 0dc3733 [origin/main] 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_multiple_commits_from_different_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+
+    env.setup_metadata(&["A", "B", "C"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   add59d2 A: 10 lines on top
+├╯
+┊
+┊╭┄h0 [B]
+┊●   a748762 B: another 10 lines at the bottom
+┊●   62e05ba B: 10 lines at the bottom
+├╯
+┊
+┊╭┄i0 [C]
+┊●   930563a C: add another 10 lines to new file
+┊●   68a2fc3 C: add 10 lines to new file
+┊●   984fd1c C: new file with 10 lines
+├╯
+┊
+┴ 8f0d338 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let status_before = status_json(&env)?;
+
+    let branch_a = find_branch(&status_before, "A")?;
+    let branch_b = find_branch(&status_before, "B")?;
+    let branch_c = find_branch(&status_before, "C")?;
+
+    let a_commits = branch_a["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+    let b_commits = branch_b["commits"]
+        .as_array()
+        .context("Missing commits for branch B")?;
+    let c_commits = branch_c["commits"]
+        .as_array()
+        .context("Missing commits for branch C")?;
+
+    let mut source_commit_ids = Vec::with_capacity(4);
+    source_commit_ids.push(
+        a_commits[0]["cliId"]
+            .as_str()
+            .context("Missing cliId for A commit")?,
+    );
+    for commit in c_commits {
+        source_commit_ids.push(
+            commit["cliId"]
+                .as_str()
+                .context("Missing cliId for C commit")?,
+        );
+    }
+
+    let b_tip_commit_id = b_commits[0]["cliId"]
+        .as_str()
+        .context("Missing cliId for B tip commit")?;
+
+    env.but(format!(
+        "move {} {b_tip_commit_id}",
+        source_commit_ids.join(",")
+    ))
+    .assert()
+    .success()
+    .stdout_eq(str![[r#"
+Moved 4 commits → before [..]
+
+"#]]);
+
+    let status_after = status_json(&env)?;
+    let branch_b_after = find_branch(&status_after, "B")?;
+    let b_commits_after = branch_b_after["commits"]
+        .as_array()
+        .context("Missing commits for branch B after move")?;
+
+    assert_eq!(
+        b_commits_after.len(),
+        6,
+        "B should contain its original 2 commits plus the 4 moved commits"
+    );
+
+    let b_messages_after = b_commits_after
+        .iter()
+        .map(|commit| {
+            commit["message"]
+                .as_str()
+                .map(|message| message.trim_end())
+                .context("Missing commit message")
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    assert_eq!(
+        b_messages_after,
+        vec![
+            "B: another 10 lines at the bottom",
+            "A: 10 lines on top",
+            "C: add another 10 lines to new file",
+            "C: add 10 lines to new file",
+            "C: new file with 10 lines",
+            "B: 10 lines at the bottom"
+        ]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B]
+┊●   c399e25 B: another 10 lines at the bottom
+┊●   72227c2 A: 10 lines on top
+┊●   c26fa8e C: add another 10 lines to new file
+┊●   640a48b C: add 10 lines to new file
+┊●   fc29de6 C: new file with 10 lines
+┊●   62e05ba B: 10 lines at the bottom
+├╯
+┊
+┊╭┄i0 [C] (no commits)
+├╯
+┊
+┴ 8f0d338 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_multiple_commits_from_different_branches_after() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("three-stacks")?;
+
+    env.setup_metadata(&["A", "B", "C"])?;
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   add59d2 A: 10 lines on top
+├╯
+┊
+┊╭┄h0 [B]
+┊●   a748762 B: another 10 lines at the bottom
+┊●   62e05ba B: 10 lines at the bottom
+├╯
+┊
+┊╭┄i0 [C]
+┊●   930563a C: add another 10 lines to new file
+┊●   68a2fc3 C: add 10 lines to new file
+┊●   984fd1c C: new file with 10 lines
+├╯
+┊
+┴ 8f0d338 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let status_before = status_json(&env)?;
+
+    let branch_a = find_branch(&status_before, "A")?;
+    let branch_b = find_branch(&status_before, "B")?;
+    let branch_c = find_branch(&status_before, "C")?;
+
+    let a_commits = branch_a["commits"]
+        .as_array()
+        .context("Missing commits for branch A")?;
+    let b_commits = branch_b["commits"]
+        .as_array()
+        .context("Missing commits for branch B")?;
+    let c_commits = branch_c["commits"]
+        .as_array()
+        .context("Missing commits for branch C")?;
+
+    let mut source_commit_ids = Vec::with_capacity(4);
+    source_commit_ids.push(
+        a_commits[0]["cliId"]
+            .as_str()
+            .context("Missing cliId for A commit")?,
+    );
+    for commit in c_commits {
+        source_commit_ids.push(
+            commit["cliId"]
+                .as_str()
+                .context("Missing cliId for C commit")?,
+        );
+    }
+
+    let b_tip_commit_id = b_commits[0]["cliId"]
+        .as_str()
+        .context("Missing cliId for B tip commit")?;
+
+    env.but(format!(
+        "move {} {b_tip_commit_id} --after",
+        source_commit_ids.join(",")
+    ))
+    .assert()
+    .success()
+    .stdout_eq(str![[r#"
+Moved 4 commits → after a748762
+
+"#]]);
+
+    let status_after = status_json(&env)?;
+    let branch_b_after = find_branch(&status_after, "B")?;
+    let b_commits_after = branch_b_after["commits"]
+        .as_array()
+        .context("Missing commits for branch B after move")?;
+
+    assert_eq!(
+        b_commits_after.len(),
+        6,
+        "B should contain its original 2 commits plus the 4 moved commits"
+    );
+
+    let b_messages_after = b_commits_after
+        .iter()
+        .map(|commit| {
+            commit["message"]
+                .as_str()
+                .map(|message| message.trim_end())
+                .context("Missing commit message")
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    assert_eq!(
+        b_messages_after,
+        vec![
+            "A: 10 lines on top",
+            "C: add another 10 lines to new file",
+            "C: add 10 lines to new file",
+            "C: new file with 10 lines",
+            "B: another 10 lines at the bottom",
+            "B: 10 lines at the bottom"
+        ]
+    );
+
+    env.but("st")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [unassigned changes] (no changes)
+┊
+┊╭┄g0 [A] (no commits)
+├╯
+┊
+┊╭┄h0 [B]
+┊●   a42a7dc A: 10 lines on top
+┊●   48bd306 C: add another 10 lines to new file
+┊●   99b8c8b C: add 10 lines to new file
+┊●   b665de5 C: new file with 10 lines
+┊●   a748762 B: another 10 lines at the bottom
+┊●   62e05ba B: 10 lines at the bottom
+├╯
+┊
+┊╭┄i0 [C] (no commits)
+├╯
+┊
+┴ 8f0d338 [origin/main] 2000-01-02 base
+
+Hint: run `but help` for all commands
+
+"#]]);
 
     Ok(())
 }

--- a/crates/but/tests/fixtures/scenario/three-stacks.sh
+++ b/crates/but/tests/fixtures/scenario/three-stacks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit with three stacks inside.
+# Stack A prepends lines to `file`.
+# Stack B appends lines to `file` in two commits.
+# Stack C creates `new-file` and extends it in two more commits.
+git-init-frozen
+
+seq 50 60 >file && git add . && git commit -m "base" && git tag base
+setup_target_to_match_main
+
+git branch B
+git branch C
+
+git checkout -b A
+{ seq 10; seq 50 60; } >file && git add . && git commit -m "A: 10 lines on top"
+
+git checkout B
+{ seq 50 60; seq 61 70; } >file && git add . && git commit -m "B: 10 lines at the bottom"
+{ seq 50 60; seq 61 80; } >file && git add . && git commit -m "B: another 10 lines at the bottom"
+
+git checkout C
+seq 10 >new-file && git add . && git commit -m "C: new file with 10 lines"
+seq 20 >new-file && git add . && git commit -m "C: add 10 lines to new file"
+seq 30 >new-file && git add . && git commit -m "C: add another 10 lines to new file"
+
+create_workspace_commit_once A B C

--- a/packages/but-sdk/src/generated/index.d.ts
+++ b/packages/but-sdk/src/generated/index.d.ts
@@ -122,7 +122,7 @@ export declare function commitDiscard(projectId: string, subjectCommitId: string
 export declare function commitInsertBlank(projectId: string, relativeTo: RelativeTo, side: InsertSide, dryRun: boolean): Promise<CommitInsertBlankResult>
 
 /**
- * Moves `subject_commit_id` to `side` of `relative_to` and records an oplog
+ * Moves `subject_commit_ids` to `side` of `relative_to` and records an oplog
  * snapshot on success.
  *
  * This acquires exclusive worktree access from `ctx` before moving the
@@ -131,7 +131,7 @@ export declare function commitInsertBlank(projectId: string, relativeTo: Relativ
  * When `dry_run` is enabled, the returned workspace previews the moved commit
  * and no oplog entry is persisted. For details, see [`commit_move_with_perm()`].
  */
-export declare function commitMove(projectId: string, subjectCommitId: string, relativeTo: RelativeTo, side: InsertSide, dryRun: boolean): Promise<CommitMoveResult>
+export declare function commitMove(projectId: string, subjectCommitIds: Array<string>, relativeTo: RelativeTo, side: InsertSide, dryRun: boolean): Promise<CommitMoveResult>
 
 /**
  * Moves `changes` from `source_commit_id` to `destination_commit_id` and


### PR DESCRIPTION
Add the ability to move multiple commits in a single swoop.

- Use the ordering funtion to correctly move the commits in the right order
- But uses the new function, test it
- Lite uses the new function