### PR TITLE
refactor: simplify legacy stack access patterns

### DIFF
--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -23,7 +23,7 @@
 //!   - otherwise, it can be applied anywhere
 #![expect(
     deprecated,
-    reason = "calls but_workspace::legacy::stacks_v3; VirtualBranchesHandle should be replaced with ctx.workspace_* helpers"
+    reason = "calls but_workspace::legacy::stacks_v3, stack_ext::StackExt, and legacy stack methods; these should be replaced with ctx.workspace_* helpers"
 )]
 
 use anyhow::{Context as _, Result, bail};
@@ -34,8 +34,7 @@ use but_ctx::{
 };
 use but_rebase::Rebase;
 use but_workspace::legacy::{StacksFilter, stack_ext::StackExt, stacks_v3};
-use gitbutler_branch_actions::update_workspace_commit_with_vb_state;
-use gitbutler_stack::VirtualBranchesHandle;
+use gitbutler_branch_actions::{stack::get_stack, update_workspace_commit};
 use gitbutler_workspace::branch_trees::{WorkspaceState, update_uncommitted_changes};
 use gix::{ObjectId, Repository};
 use serde::Serialize;
@@ -126,8 +125,7 @@ pub fn cherry_apply(
     };
 
     let repo = ctx.repo.get()?.clone().for_tree_diffing()?;
-    let vb_state = VirtualBranchesHandle::new(ctx.project_data_dir());
-    let mut stack = vb_state.get_stack(target)?;
+    let mut stack = get_stack(ctx, target)?;
     let mut steps = stack.as_rebase_steps(ctx)?;
     // Insert before the head references (len - 1)
     steps.insert(
@@ -148,7 +146,7 @@ pub fn cherry_apply(
         update_uncommitted_changes(ctx, old_workspace, new_workspace, perm)?;
     }
 
-    update_workspace_commit_with_vb_state(&vb_state, ctx, false)?;
+    update_workspace_commit(ctx, false)?;
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -14,6 +14,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::{VirtualBranchesExt, actions::Verify, r#virtual::IsCommitIntegrated};
 
+/// Return the legacy stack identified by `stack_id`.
+///
+/// This keeps legacy virtual-branches access encapsulated within
+/// `gitbutler-branch-actions` for callers that still operate on
+/// `gitbutler_stack::Stack`.
+pub fn get_stack(ctx: &Context, stack_id: StackId) -> Result<Stack> {
+    ctx.virtual_branches().get_stack(stack_id)
+}
+
 /// Adds a new "series/branch" to the Stack.
 /// This is in fact just creating a new  GitButler patch reference (head) and associates it with the stack.
 /// The name cannot be the same as existing git references or existing patch references.


### PR DESCRIPTION
Not a full cleanup but at least reducing the VirtualBranchesHandle surface area