### PR TITLE
refactor(svelte): remove legacy rebase engine access

### DIFF
--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fModeEnabled, useNewRebaseEngine } from "$lib/config/uiFeatureFlags";
+	import { fModeEnabled } from "$lib/config/uiFeatureFlags";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { USER } from "$lib/user/user";
 	import { inject } from "@gitbutler/core/context";
@@ -46,21 +46,6 @@
 				id="f-mode"
 				checked={$fModeEnabled}
 				onclick={() => fModeEnabled.set(!$fModeEnabled)}
-			/>
-		{/snippet}
-	</CardGroup.Item>
-	<CardGroup.Item labelFor="new-rebase-engine">
-		{#snippet title()}
-			New rebase engine
-		{/snippet}
-		{#snippet caption()}
-			Use the new graph-based rebase engine for stack operations.
-		{/snippet}
-		{#snippet actions()}
-			<Toggle
-				id="new-rebase-engine"
-				checked={$useNewRebaseEngine}
-				onclick={() => useNewRebaseEngine.set(!$useNewRebaseEngine)}
 			/>
 		{/snippet}
 	</CardGroup.Item>

--- a/apps/desktop/src/lib/analytics/commitAnalytics.ts
+++ b/apps/desktop/src/lib/analytics/commitAnalytics.ts
@@ -145,9 +145,11 @@ export class CommitAnalytics {
 
 	private getLanesWithAssignments(stacks: Stack[], assignments: HunkAssignment[]): Stack[] {
 		const assignedStacks = new Set<string>();
-		assignments
-			.filter((assignment) => assignment.stackId !== null)
-			.forEach((assignment) => assignedStacks.add(assignment.stackId!));
+		assignments.forEach((assignment) => {
+			if (assignment.stackId !== null) {
+				assignedStacks.add(assignment.stackId);
+			}
+		});
 
 		return stacks.filter((stack) => stack.id && assignedStacks.has(stack.id));
 	}

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -4,15 +4,7 @@
  *
  * @module appSettings
  */
-import {
-	getBooleanStorageItem,
-	persisted,
-	persistWithExpiration,
-	setBooleanStorageItem,
-} from "@gitbutler/shared/persisted";
-
-const USE_NEW_REBASE_ENGINE_KEY = "feature-use-new-rebase-engine";
-const USE_NEW_REBASE_ENGINE_MIGRATION_KEY = "feature-use-new-rebase-engine-default-true-migrated";
+import { persisted, persistWithExpiration } from "@gitbutler/shared/persisted";
 
 export const autoSelectBranchNameFeature = persisted(false, "autoSelectBranchLaneContentsFeature");
 export const autoSelectBranchCreationFeature = persisted(false, "autoSelectBranchCreationFeature");
@@ -22,23 +14,3 @@ export type StagingBehavior = "all" | "selection" | "none";
 export const stagingBehaviorFeature = persisted<StagingBehavior>("all", "feature-staging-behavior");
 export const fModeEnabled = persisted(true, "f-mode");
 export const newlineOnEnter = persisted(false, "feature-newline-on-enter");
-export const useNewRebaseEngine = persisted(false, USE_NEW_REBASE_ENGINE_KEY);
-
-/**
- * Migrate users into the new rebase engine once.
- * This can always be reversed, and that decision will be respected
- */
-export function migrateUseNewRebaseEngineDefaultToTrue(): void {
-	// Skip if migrated already.
-	if (getBooleanStorageItem(USE_NEW_REBASE_ENGINE_MIGRATION_KEY) === true) {
-		return;
-	}
-
-	// Migrate only if they haven't yet enabled it.
-	if (getBooleanStorageItem(USE_NEW_REBASE_ENGINE_KEY) !== true) {
-		useNewRebaseEngine.set(true);
-	}
-
-	// Mark as migrated.
-	setBooleanStorageItem(USE_NEW_REBASE_ENGINE_MIGRATION_KEY, true);
-}

--- a/apps/desktop/src/lib/files/filetreeV3.ts
+++ b/apps/desktop/src/lib/files/filetreeV3.ts
@@ -96,7 +96,12 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		const minLength = Math.min(partsA.length, partsB.length);
 
 		for (let i = 0; i < minLength - 1; i++) {
-			const comparison = partsA[i]!.localeCompare(partsB[i]!, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
+			const partA = partsA[i];
+			const partB = partsB[i];
+			if (partA === undefined || partB === undefined) {
+				continue;
+			}
+			const comparison = partA.localeCompare(partB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 			if (comparison !== 0) {
 				return comparison;
 			}
@@ -108,11 +113,12 @@ export function sortLikeFileTree(changes: TreeChange[]): TreeChange[] {
 		}
 
 		// Same depth, compare final component
-		return partsA[partsA.length - 1]!.localeCompare(
-			partsB[partsB.length - 1]!,
-			FILE_SORT_LOCALE,
-			FILE_SORT_CONFIG,
-		);
+		const lastPartA = partsA[partsA.length - 1];
+		const lastPartB = partsB[partsB.length - 1];
+		if (lastPartA === undefined || lastPartB === undefined) {
+			return partsA.length - partsB.length;
+		}
+		return lastPartA.localeCompare(lastPartB, FILE_SORT_LOCALE, FILE_SORT_CONFIG);
 	});
 }
 

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -251,7 +251,8 @@ export function canBePartiallySelected(patch: Patch): boolean {
 		return false;
 	}
 
-	if (patch.hunks.length === 1 && isFileDeletionHunk(patch.hunks[0]!)) {
+	const onlyHunk = patch.hunks[0];
+	if (patch.hunks.length === 1 && onlyHunk && isFileDeletionHunk(onlyHunk)) {
 		// Only one hunk and it's a file deletion
 		return false;
 	}

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -9,7 +9,6 @@ import {
 	providesList,
 	ReduxTag,
 } from "$lib/state/tags";
-import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import { createEntityAdapter, type EntityState } from "@reduxjs/toolkit";
 import type { MoveCommitIllegalAction } from "$lib/commits/commit";
 import type {
@@ -341,21 +340,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.BranchListing),
 			],
 		}),
-		legacyCreateCommit: build.mutation<
-			CreateCommitOutcome,
-			{ projectId: string } & CreateCommitRequest
-		>({
-			extraOptions: {
-				command: "create_commit_from_worktree_changes",
-				actionName: "Commit",
-			},
-			query: (args) => args,
-			invalidatesTags: [
-				invalidatesList(ReduxTag.WorktreeChanges),
-				invalidatesList(ReduxTag.UpstreamIntegrationStatus),
-				invalidatesList(ReduxTag.HeadSha),
-			],
-		}),
 		commitCreate: build.mutation<CreateCommitOutcome, { projectId: string } & CreateCommitRequest>({
 			extraOptions: {
 				command: "commit_create",
@@ -426,17 +410,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				};
 			},
 		}),
-		legacyUpdateCommitMessage: build.mutation<
-			string,
-			{ projectId: string; stackId: string; commitId: string; message: string }
-		>({
-			extraOptions: {
-				command: "update_commit_message",
-				actionName: "Update Commit Message",
-			},
-			query: (args) => args,
-			invalidatesTags: [invalidatesList(ReduxTag.HeadSha)],
-		}),
 		updateCommitMessage: build.mutation<
 			string,
 			{ projectId: string; stackId: string; commitId: string; message: string; dryRun: boolean }
@@ -482,26 +455,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			invalidatesTags: (_result, _error, args) => [
 				invalidatesItem(ReduxTag.BranchChanges, args.stackId),
 				invalidatesList(ReduxTag.WorktreeChanges),
-				invalidatesList(ReduxTag.HeadSha),
-			],
-		}),
-		legacyAmendCommit: build.mutation<
-			string /** Return value is the updated commit id. */,
-			{
-				projectId: string;
-				stackId: string;
-				commitId: string;
-				worktreeChanges: DiffSpec[];
-			}
-		>({
-			extraOptions: {
-				command: "amend_virtual_branch",
-				actionName: "Amend Commit",
-			},
-			query: (args) => args,
-			invalidatesTags: (_result, _error, args) => [
-				invalidatesList(ReduxTag.WorktreeChanges),
-				invalidatesItem(ReduxTag.BranchChanges, args.stackId),
 				invalidatesList(ReduxTag.HeadSha),
 			],
 		}),
@@ -600,36 +553,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			query: (args) => args,
 			invalidatesTags: [invalidatesList(ReduxTag.WorktreeChanges)],
 		}),
-		legacyMoveChangesBetweenCommits: build.mutation<
-			{ replacedCommits: [string, string][] },
-			{
-				projectId: string;
-				changes: DiffSpec[];
-				sourceCommitId: string;
-				sourceStackId: string;
-				destinationCommitId: string;
-				destinationStackId: string;
-			}
-		>({
-			extraOptions: {
-				command: "move_changes_between_commits",
-				actionName: "Move Changes Between Commits",
-			},
-			query: (args) => args,
-			invalidatesTags(result, _error, arg) {
-				const commitChangesTags = [arg.sourceCommitId, arg.destinationCommitId]
-					.map((id) => result?.replacedCommits.find(([oldId]) => oldId === id)?.[1])
-					.filter(isDefined)
-					.map((id) => invalidatesItem(ReduxTag.CommitChanges, id));
-				return [
-					invalidatesList(ReduxTag.HeadSha),
-					invalidatesList(ReduxTag.WorktreeChanges),
-					invalidatesItem(ReduxTag.BranchChanges, arg.sourceStackId),
-					invalidatesItem(ReduxTag.BranchChanges, arg.destinationStackId),
-					...commitChangesTags,
-				];
-			},
-		}),
 		commitMoveChangesBetween: build.mutation<
 			MoveChangesResult,
 			{
@@ -656,29 +579,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.CommitChanges),
 			],
-		}),
-		legacyUncommitChanges: build.mutation<
-			{ replacedCommits: [string, string][] },
-			{
-				projectId: string;
-				changes: DiffSpec[];
-				commitId: string;
-				stackId: string;
-				assignTo?: string;
-			}
-		>({
-			extraOptions: {
-				command: "uncommit_changes",
-				actionName: "Uncommit Changes",
-			},
-			query: (args) => args,
-			invalidatesTags(_result, _error, args) {
-				return [
-					invalidatesList(ReduxTag.HeadSha),
-					invalidatesList(ReduxTag.WorktreeChanges),
-					invalidatesItem(ReduxTag.BranchChanges, args.stackId),
-				];
-			},
 		}),
 		commitUncommitChanges: build.mutation<
 			MoveChangesResult,

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1,5 +1,4 @@
 import { getBranchNameFromRef } from "$lib/branches/branchUtils";
-import { useNewRebaseEngine } from "$lib/config/uiFeatureFlags";
 import { sortLikeFileTree } from "$lib/files/filetreeV3";
 import { showToast } from "$lib/notifications/toasts";
 import {
@@ -21,24 +20,20 @@ import { type UiState } from "$lib/state/uiState.svelte";
 import { InjectionToken } from "@gitbutler/core/context";
 import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 import { isDefined } from "@gitbutler/ui/utils/typeguards";
-import { get } from "svelte/store";
 import type { ReduxError } from "$lib/error/reduxError";
 import type { DefaultForgeFactory } from "$lib/forge/forgeFactory.svelte";
 import type { BackendApi } from "$lib/state/backendApi";
 import type { AppDispatch } from "$lib/state/clientState.svelte";
-import type { AbsorptionTarget, DiffSpec, RefInfo, StackDetails } from "@gitbutler/but-sdk";
+import type { AbsorptionTarget, DiffSpec, StackDetails } from "@gitbutler/but-sdk";
 
 export { REJECTTION_REASONS } from "$lib/stacks/stackEndpoints";
 
-type LegacyResult = {
-	replacedCommits: [string, string][];
-};
-
-type NormalizedResult = {
-	workspace: {
-		replacedCommits: Record<string, string>;
-		headInfo?: RefInfo;
-	};
+type AmendCommitRequest = {
+	projectId: string;
+	stackId: string;
+	commitId: string;
+	worktreeChanges: DiffSpec[];
+	dryRun: boolean;
 };
 
 export const STACK_SERVICE = new InjectionToken<StackService>("StackService");
@@ -437,19 +432,11 @@ export class StackService {
 	}
 
 	createCommit() {
-		if (get(useNewRebaseEngine)) {
-			return this.backendApi.endpoints.commitCreate.useMutation();
-		} else {
-			return this.backendApi.endpoints.legacyCreateCommit.useMutation();
-		}
+		return this.backendApi.endpoints.commitCreate.useMutation();
 	}
 
 	get createCommitMutation() {
-		if (get(useNewRebaseEngine)) {
-			return this.backendApi.endpoints.commitCreate.mutate;
-		} else {
-			return this.backendApi.endpoints.legacyCreateCommit.mutate;
-		}
+		return this.backendApi.endpoints.commitCreate.mutate;
 	}
 
 	filePathsChangedInCommits(projectId: string, commitIds: string[]) {
@@ -567,11 +554,7 @@ export class StackService {
 	}
 
 	get updateCommitMessage() {
-		if (get(useNewRebaseEngine)) {
-			return this.backendApi.endpoints.updateCommitMessage.useMutation();
-		} else {
-			return this.backendApi.endpoints.legacyUpdateCommitMessage.useMutation();
-		}
+		return this.backendApi.endpoints.updateCommitMessage.useMutation();
 	}
 
 	get newBranch() {
@@ -604,15 +587,6 @@ export class StackService {
 		return this.backendApi.endpoints.discardChanges.mutate;
 	}
 
-	private normalizeResult(result: LegacyResult | NormalizedResult): NormalizedResult {
-		if ("workspace" in result) return result;
-		return {
-			workspace: {
-				replacedCommits: Object.fromEntries(result.replacedCommits),
-			},
-		};
-	}
-
 	async moveChangesBetweenCommits(args: {
 		projectId: string;
 		changes: DiffSpec[];
@@ -622,21 +596,13 @@ export class StackService {
 		destinationStackId: string;
 		dryRun: boolean;
 	}) {
-		if (get(useNewRebaseEngine)) {
-			return this.normalizeResult(
-				await this.backendApi.endpoints.commitMoveChangesBetween.mutate({
-					projectId: args.projectId,
-					changes: args.changes,
-					sourceCommitId: args.sourceCommitId,
-					destinationCommitId: args.destinationCommitId,
-					dryRun: args.dryRun,
-				}),
-			);
-		} else {
-			return this.normalizeResult(
-				await this.backendApi.endpoints.legacyMoveChangesBetweenCommits.mutate(args),
-			);
-		}
+		return await this.backendApi.endpoints.commitMoveChangesBetween.mutate({
+			projectId: args.projectId,
+			changes: args.changes,
+			sourceCommitId: args.sourceCommitId,
+			destinationCommitId: args.destinationCommitId,
+			dryRun: args.dryRun,
+		});
 	}
 
 	async uncommitChanges(args: {
@@ -647,21 +613,13 @@ export class StackService {
 		assignTo?: string;
 		dryRun: boolean;
 	}) {
-		if (get(useNewRebaseEngine)) {
-			return this.normalizeResult(
-				await this.backendApi.endpoints.commitUncommitChanges.mutate({
-					projectId: args.projectId,
-					changes: args.changes,
-					commitId: args.commitId,
-					assignTo: args.assignTo,
-					dryRun: args.dryRun,
-				}),
-			);
-		} else {
-			return this.normalizeResult(
-				await this.backendApi.endpoints.legacyUncommitChanges.mutate(args),
-			);
-		}
+		return await this.backendApi.endpoints.commitUncommitChanges.mutate({
+			projectId: args.projectId,
+			changes: args.changes,
+			commitId: args.commitId,
+			assignTo: args.assignTo,
+			dryRun: args.dryRun,
+		});
 	}
 
 	get stashIntoBranch() {
@@ -759,19 +717,27 @@ export class StackService {
 	}
 
 	get amendCommit() {
-		if (get(useNewRebaseEngine)) {
-			return this.backendApi.endpoints.commitAmend.useMutation();
-		} else {
-			return this.backendApi.endpoints.legacyAmendCommit.useMutation();
-		}
+		const [amendCommit, amendCommitQuery] = this.backendApi.endpoints.commitAmend.useMutation();
+		return [
+			(args: AmendCommitRequest) =>
+				amendCommit({
+					projectId: args.projectId,
+					commitId: args.commitId,
+					worktreeChanges: args.worktreeChanges,
+					dryRun: args.dryRun,
+				}),
+			amendCommitQuery,
+		] as const;
 	}
 
 	get amendCommitMutation() {
-		if (get(useNewRebaseEngine)) {
-			return this.backendApi.endpoints.commitAmend.mutate;
-		} else {
-			return this.backendApi.endpoints.legacyAmendCommit.mutate;
-		}
+		return (args: AmendCommitRequest) =>
+			this.backendApi.endpoints.commitAmend.mutate({
+				projectId: args.projectId,
+				commitId: args.commitId,
+				worktreeChanges: args.worktreeChanges,
+				dryRun: args.dryRun,
+			});
 	}
 
 	/** Squash all the commits in a branch together */

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -90,7 +90,6 @@ export function getStackServiceMock() {
 	StackServiceMock.prototype.updateStackOrder = [vi.fn(), reactive(() => mockReduxFulfilled({}))];
 	StackServiceMock.prototype.pushStack = [vi.fn(), reactive(() => mockReduxFulfilled({}))];
 	StackServiceMock.prototype.createCommit = [vi.fn(), reactive(() => mockReduxFulfilled({}))];
-	StackServiceMock.prototype.createCommitLegacy = [vi.fn(), reactive(() => mockReduxFulfilled({}))];
 	StackServiceMock.prototype.updateCommitMessage = [
 		vi.fn(),
 		reactive(() => mockReduxFulfilled({})),

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
 	import { initDependencies } from "$lib/bootstrap/deps";
 	import { MessageQueueProcessor } from "$lib/codegen/messageQueue.svelte";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
-	import { fModeEnabled, migrateUseNewRebaseEngineDefaultToTrue } from "$lib/config/uiFeatureFlags";
+	import { fModeEnabled } from "$lib/config/uiFeatureFlags";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { createKeybind } from "$lib/shortcuts/hotkeys";
@@ -106,11 +106,6 @@
 	// IRC connections are managed by the Rust backend (irc_lifecycle.rs).
 	// The backend handles auto-connect on startup and reacts to settings changes.
 	// Frontend queries IRC state via RTKQ endpoints (ircApi.ts).
-
-	// Migrate into the new rebase engine, once.
-	$effect(() => {
-		migrateUseNewRebaseEngineDefaultToTrue();
-	});
 
 	// =============================================================================
 	// DEBUG & DEVELOPMENT TOOLS


### PR DESCRIPTION
Removing the feature branch and execution fork.

Backend cleanup in a separate PR