### PR TITLE
Disable rename detection when merging stack trees

### DIFF
--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -35,6 +35,22 @@ pub enum CherryPickOutcome {
     },
 }
 
+/// Controls how parent trees are merged during cherry-pick.
+///
+/// When cherry-picking a commit with multiple parents, both the old parents
+/// (base) and the new parents (ontos) are merged pairwise. This enum controls
+/// the merge options used for that pairwise merging.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum TreeMergeMode {
+    /// Merge with rename detection enabled (default).
+    #[default]
+    WithRenames,
+    /// Merge with rename detection disabled.
+    /// Useful when parents are independent and renames detected across them
+    /// would be false positives.
+    WithoutRenames,
+}
+
 /// Controls when a commit is cherry-picked during a rebase.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PickMode {
@@ -65,12 +81,14 @@ pub enum PickMode {
 /// X's "base" sub-tree as the base.
 ///
 /// `pick_mode` - controls how to determine if a commit should be cherry-picked.
+/// `tree_merge_mode` - controls how parent trees are merged for merge commits.
 /// `sign_commit` - controls how the resulting commit is signed.
 pub fn cherry_pick(
     repo: &gix::Repository,
     target: gix::ObjectId,
     ontos: &[gix::ObjectId],
     pick_mode: PickMode,
+    tree_merge_mode: TreeMergeMode,
     sign_commit: SignCommit,
 ) -> Result<CherryPickOutcome> {
     let target = but_core::Commit::from_id(target.attach(repo))?;
@@ -80,11 +98,11 @@ pub fn cherry_pick(
         return Ok(CherryPickOutcome::Identity(target.id.detach()));
     }
 
-    let base_t = find_base_tree(&target)?;
+    let base_t = find_base_tree(&target, tree_merge_mode)?;
     // We always want the "theirs-ist" side of the target if it's conflicted.
     let target_t = find_real_tree(&target, TreeKind::Theirs)?;
     // We want to cherry-pick onto the merge result.
-    let onto_t = tree_from_merging_commits(repo, ontos, TreeKind::AutoResolution)?;
+    let onto_t = merged_tree_from_commits(repo, ontos, tree_merge_mode, TreeKind::AutoResolution)?;
 
     match (&base_t, &onto_t) {
         (MergeOutcome::NoCommit, MergeOutcome::NoCommit) if pick_mode == PickMode::Force => {
@@ -191,20 +209,29 @@ impl MergeOutcome {
     }
 }
 
-fn find_base_tree(target: &but_core::Commit) -> Result<MergeOutcome> {
+fn find_base_tree(
+    target: &but_core::Commit,
+    tree_merge_mode: TreeMergeMode,
+) -> Result<MergeOutcome> {
     if target.is_conflicted() {
         Ok(MergeOutcome::Success(
             find_real_tree(target, TreeKind::Base)?.detach(),
         ))
     } else {
-        tree_from_merging_commits(target.id.repo, &target.parents, TreeKind::AutoResolution)
+        merged_tree_from_commits(
+            target.id.repo,
+            &target.parents,
+            tree_merge_mode,
+            TreeKind::AutoResolution,
+        )
     }
 }
 
-/// Merge together many commits, making use of the preferenced tree.
-fn tree_from_merging_commits(
+/// Merge together many commits, making use of the preferred tree.
+fn merged_tree_from_commits(
     repo: &gix::Repository,
     commits: &[gix::ObjectId],
+    tree_merge_mode: TreeMergeMode,
     preference: TreeKind,
 ) -> Result<MergeOutcome> {
     let mut to_merge = commits.to_vec();
@@ -231,7 +258,12 @@ fn tree_from_merging_commits(
 
         let commit = but_core::Commit::from_id(commit.attach(repo))?;
         let tree = find_real_tree(&commit, preference)?;
-        let (options, conflicts) = repo.merge_options_fail_fast()?;
+        // When parents are independent, rename detection can produce false
+        // positives across them, silently swallowing clean file deletions.
+        let (options, conflicts) = match tree_merge_mode {
+            TreeMergeMode::WithRenames => repo.merge_options_fail_fast()?,
+            TreeMergeMode::WithoutRenames => repo.merge_options_no_rewrites_fail_fast()?,
+        };
 
         let mut output = repo.merge_trees(
             peel_to_tree_or_empty(repo, base)?,

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -16,7 +16,7 @@ use gix::refs::transaction::RefEdit;
 
 use crate::graph_rebase::util::collect_ordered_parents;
 
-use crate::graph_rebase::cherry_pick::PickMode;
+use crate::graph_rebase::cherry_pick::{PickMode, TreeMergeMode};
 pub mod cherry_pick;
 pub mod commit;
 pub mod materialize;
@@ -39,9 +39,6 @@ pub struct Pick {
     /// If this is Some, the commit WILL NOT be picked onto the parents the
     /// graph implies but instead on to the parents listed here.
     pub preserved_parents: Option<Vec<gix::ObjectId>>,
-    /// If set to false, a rebase will fail if this commit results in a
-    /// conflicted state.
-    pub conflictable: bool,
     /// Controls under what circumstances the commit is cherry-picked.
     pub pick_mode: PickMode,
     /// Controls whether the resulting commit is signed.
@@ -55,6 +52,13 @@ pub struct Pick {
     /// creating a new commit since the the mappings will be non-sensical to the
     /// frontend consumers.
     pub exclude_from_tracking: bool,
+    /// If set to false, the rebase will fail if this commit results in a
+    /// conflicted state. The cherry-pick still runs and creates the
+    /// conflicted commit — this check happens afterwards in [`Editor::rebase`].
+    pub conflictable: bool,
+    /// Controls how parent trees are merged during cherry-pick.
+    /// See [`TreeMergeMode`] for details.
+    pub tree_merge_mode: TreeMergeMode,
 }
 
 impl Pick {
@@ -63,10 +67,11 @@ impl Pick {
         Self {
             id,
             preserved_parents: None,
-            conflictable: true,
             pick_mode: PickMode::IfChanged,
             sign_commit: SignCommit::IfSignCommitsEnabled,
             exclude_from_tracking: false,
+            conflictable: true,
+            tree_merge_mode: TreeMergeMode::WithRenames,
         }
     }
 
@@ -85,10 +90,11 @@ impl Pick {
         Self {
             id,
             preserved_parents: None,
-            conflictable: false,
             pick_mode: PickMode::IfChanged,
             sign_commit: SignCommit::No,
             exclude_from_tracking: false,
+            conflictable: false,
+            tree_merge_mode: TreeMergeMode::WithoutRenames,
         }
     }
 }
@@ -435,7 +441,10 @@ mod test {
 
     use but_core::commit::SignCommit;
 
-    use crate::graph_rebase::{Pick, cherry_pick::PickMode};
+    use crate::graph_rebase::{
+        Pick,
+        cherry_pick::{PickMode, TreeMergeMode},
+    };
 
     #[test]
     fn workspace_commit_defaults() -> anyhow::Result<()> {
@@ -446,10 +455,11 @@ mod test {
             Pick {
                 id: object_id,
                 preserved_parents: None,
-                conflictable: false,
                 pick_mode: PickMode::IfChanged,
                 sign_commit: SignCommit::No,
-                exclude_from_tracking: false
+                exclude_from_tracking: false,
+                conflictable: false,
+                tree_merge_mode: TreeMergeMode::WithoutRenames,
             }
         );
 
@@ -465,10 +475,11 @@ mod test {
             Pick {
                 id: object_id,
                 preserved_parents: None,
-                conflictable: true,
                 pick_mode: PickMode::IfChanged,
                 sign_commit: SignCommit::IfSignCommitsEnabled,
-                exclude_from_tracking: false
+                exclude_from_tracking: false,
+                conflictable: true,
+                tree_merge_mode: TreeMergeMode::WithRenames,
             }
         );
 

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -73,6 +73,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                         pick.id,
                         &ontos,
                         pick.pick_mode,
+                        pick.tree_merge_mode,
                         pick.sign_commit,
                     )?;
 

--- a/crates/but-rebase/tests/fixtures/scenario/cherry-pick-rename-detection.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/cherry-pick-rename-detection.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Fixture for testing that workspace merges (TreeMergeMode::WithoutRenames) correctly
+# surface delete-vs-modify conflicts instead of hiding them behind rename detection.
+#
+# Setup:
+#   base has: file-a.txt, file-b.txt
+#   stack-1: modifies file-b.txt (leaves file-a.txt unchanged)
+#   stack-2-after: deletes file-a.txt AND file-b.txt, adds file-combined.txt
+#
+# file-combined.txt has content similar to file-b.txt, which would cause gix's
+# rename detection to match file-b → file-combined as a rename. With rename
+# detection enabled, this hides the delete-vs-modify conflict on file-b.txt
+# and silently drops file-a.txt's deletion.
+
+set -eu -o pipefail
+
+git init
+
+# Base commit with two files
+# file-b has content that is very similar to what file-combined will have,
+# so rename detection may heuristically match file-b → file-combined as a rename.
+# file-a is different content, so it should just be a clean delete.
+cat > file-a.txt << 'CONTENT'
+This is file A with unique content.
+It has nothing in common with the combined file.
+Alpha beta gamma delta.
+Epsilon zeta eta theta.
+CONTENT
+
+cat > file-b.txt << 'CONTENT'
+This is the test runner configuration.
+It sets up the playwright test environment.
+Line 3 of the config.
+Line 4 of the config.
+Line 5 of the config.
+CONTENT
+
+git add . && git commit -m "base"
+git branch base
+
+# stack-1: modifies file-b.txt, leaves file-a.txt unchanged
+git checkout -b stack-1
+cat > file-b.txt << 'CONTENT'
+This is the test runner configuration.
+It sets up the playwright test environment.
+Line 3 of the config - updated by stack 1.
+Line 4 of the config.
+Line 5 of the config.
+CONTENT
+git add . && git commit -m "stack-1: modify file-b"
+
+# stack-2-before: a benign change unrelated to file-a or file-b
+git checkout -b stack-2-before
+git reset --hard base
+echo "unrelated" > other-file.txt && git add . && git commit -m "stack-2-before: unrelated change"
+
+# stack-2-after: deletes both files and creates combined file
+# file-combined has content very similar to file-b (rename detection target)
+git checkout -b stack-2-after
+git reset --hard base
+rm file-a.txt file-b.txt
+cat > file-combined.txt << 'CONTENT'
+This is the test runner configuration.
+It sets up the playwright test environment.
+Line 3 of the config.
+Line 4 of the config.
+Line 5 of the config.
+Additional combined content from both files.
+CONTENT
+git add . && git commit -m "stack-2-after: combine files"
+
+# Create the workspace commit: merge of stack-1 and stack-2-before
+git checkout -b workspace-before
+git reset --hard stack-1
+git merge stack-2-before --no-edit -m "GitButler Workspace Commit"

--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, bail};
 use but_core::commit::SignCommit;
-use but_rebase::graph_rebase::cherry_pick::{CherryPickOutcome, PickMode, cherry_pick};
+use but_rebase::graph_rebase::cherry_pick::{
+    CherryPickOutcome, PickMode, TreeMergeMode, cherry_pick,
+};
 use but_testsupport::{visualize_commit_graph_all, visualize_tree};
 use gix::prelude::ObjectIdExt;
 
@@ -27,6 +29,7 @@ fn basic_cherry_pick_clean() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -64,6 +67,7 @@ fn basic_cherry_pick_cp_conflicts() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -113,6 +117,7 @@ fn basic_cherry_pick_identity() -> Result<()> {
         target.detach(),
         &parents,
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -138,6 +143,7 @@ fn single_parent_to_multiple_parents_clean() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -178,6 +184,7 @@ fn single_parent_to_multiple_parents_cp_conflicts() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -233,6 +240,7 @@ fn single_parent_to_multiple_parents_parents_conflict() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -266,6 +274,7 @@ fn multiple_parents_to_single_parent_clean() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -304,6 +313,7 @@ fn multiple_parents_to_single_parent_cp_conflicts() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -359,6 +369,7 @@ fn multiple_parents_to_single_parent_parents_conflict() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -393,6 +404,7 @@ fn multiple_parents_to_multiple_parents_clean() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -433,6 +445,7 @@ fn multiple_parents_to_multiple_parents_cp_conflicts() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -492,6 +505,7 @@ fn multiple_parents_to_multiple_parents_base_parents_conflict() -> Result<()> {
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -525,6 +539,7 @@ fn multiple_parents_to_multiple_parents_target_parents_conflict() -> Result<()> 
         target,
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -558,6 +573,7 @@ fn multiple_parents_to_multiple_parents_identity() -> Result<()> {
         target.detach(),
         &parents,
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -582,6 +598,7 @@ fn no_parents_identity() -> Result<()> {
         target.detach(),
         &[],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -606,6 +623,7 @@ fn single_parent_to_no_parents_clean() -> Result<()> {
         target,
         &[],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -642,6 +660,7 @@ fn no_parents_to_single_parent_clean() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -679,6 +698,7 @@ fn no_parents_to_single_parent_cp_conflicts() -> Result<()> {
         target,
         &[onto],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -728,6 +748,7 @@ fn cherry_pick_back_to_original_parents_unconflicts() -> Result<()> {
         target.detach(),
         &[onto, onto2],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -748,6 +769,7 @@ fn cherry_pick_back_to_original_parents_unconflicts() -> Result<()> {
         id,
         &parents,
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -799,6 +821,7 @@ fn cherry_pick_recursive_merge() -> Result<()> {
         target.detach(),
         &[onto, onto2, onto3],
         PickMode::IfChanged,
+        TreeMergeMode::WithRenames,
         SignCommit::IfSignCommitsEnabled,
     )?;
 
@@ -819,6 +842,64 @@ fn cherry_pick_recursive_merge() -> Result<()> {
     ├── base-f:100644:718e7e9 "a\nx\nc\nd\n"
     └── foo-f:100644:2d07937 "1\nx\n2\n"
     "#);
+
+    Ok(())
+}
+
+/// Workspace merges surface delete-vs-modify conflicts instead of hiding
+/// them behind false-positive renames.
+///
+/// Scenario: two stacks share a common base with file-a.txt and file-b.txt.
+/// - Stack 1 modifies file-b.txt
+/// - Stack 2 deletes both files and adds file-combined.txt (similar content to file-b.txt)
+///
+/// With rename detection enabled, gix would match file-b.txt to
+/// file-combined.txt as a rename, hiding the real delete-vs-modify conflict
+/// and silently dropping file-a.txt's deletion. With `TreeMergeMode::WithoutRenames`
+/// (which disables rename detection), the conflict is correctly surfaced.
+#[test]
+fn workspace_merge_surfaces_delete_vs_modify_conflict() -> Result<()> {
+    let (repo, _tmpdir, _meta) = fixture_writable("cherry-pick-rename-detection")?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 8ef051f (stack-2-after) stack-2-after: combine files
+    | *   978e614 (HEAD -> workspace-before) GitButler Workspace Commit
+    | |\  
+    | | * b8f64ac (stack-2-before) stack-2-before: unrelated change
+    | |/  
+    |/|   
+    | * f02613a (stack-1) stack-1: modify file-b
+    |/  
+    * 57993f6 (main, base) base
+    ");
+
+    let workspace = repo.rev_parse_single("workspace-before")?.detach();
+    let stack1 = repo.rev_parse_single("stack-1")?.detach();
+    let stack2_after = repo.rev_parse_single("stack-2-after")?.detach();
+
+    // The workspace commit currently has parents [stack-1, stack-2-before].
+    // We want to rebase it onto [stack-1, stack-2-after] where stack-2-after
+    // deletes file-a.txt and file-b.txt, replacing them with file-combined.txt.
+    //
+    // Stack-1 modifies file-b.txt while stack-2-after deletes it — this is a
+    // genuine cross-stack conflict. Previously, rename detection hid this conflict
+    // by treating file-b → file-combined as a rename, producing a wrong tree
+    // where file-a.txt's deletion was silently dropped.
+    //
+    // With rename detection disabled, this correctly reports a conflict.
+    let result = cherry_pick(
+        &repo,
+        workspace,
+        &[stack1, stack2_after],
+        PickMode::Force,
+        TreeMergeMode::WithoutRenames,
+        SignCommit::IfSignCommitsEnabled,
+    )?;
+
+    assert!(
+        matches!(result, CherryPickOutcome::FailedToMergeBases { .. }),
+        "Expected a conflict due to delete-vs-modify on file-b.txt, got: {result:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

When rebuilding the workspace commit, `merged_tree_from_commits` merges stack tip trees pairwise using a 3-way merge. gix's rename detection matches deleted files to newly added files based on content similarity — and this produces **false-positive renames across independent stacks**, silently corrupting the workspace tree.

### Example scenario

Two stacks share a base with `file-a.txt` and `file-b.txt`:

- **Stack 1** modifies `file-b.txt`
- **Stack 2** deletes both files and adds `file-combined.txt` (content similar to `file-b.txt`)

When merging these stack trees, gix sees `file-b.txt → file-combined.txt` as a rename (high content similarity). This has two effects:

1. The real **delete-vs-modify conflict** on `file-b.txt` is hidden — gix treats it as a rename+content merge instead
2. `file-a.txt`'s clean deletion is **silently dropped** from the result tree

**Without the fix**, the workspace tree contains:
```
├── file-a.txt          ← should have been deleted by stack 2
├── file-combined.txt
└── other-file.txt
```

**With the fix**, the delete-vs-modify conflict on `file-b.txt` is correctly surfaced as `FailedToMergeBases`, preventing the silent data loss.

## Fix

Introduce a `TreeMergeMode` enum (`WithRenames` / `WithoutRenames`) threaded through `cherry_pick` and `merged_tree_from_commits`:

- **`TreeMergeMode::WithoutRenames`** — disables rename detection via `merge_options_no_rewrites_fail_fast`. Used for workspace commits whose parents are independent stack heads.
- **`TreeMergeMode::WithRenames`** — keeps rename detection enabled, maintaining parity with git for regular merge commits.

### Why is this safe?

`merged_tree_from_commits` is only called when merging **multiple parents** of a commit. For single-parent (linear) commits, the merge loop never executes and the options are never used.

The actual cherry-pick 3-way merge (base → onto → target) uses `merge_options_force_ours`, which is a completely separate code path unaffected by this change. Rename detection remains fully active there.

Since stacks are independent by definition, a rename detected *between* two stack trees is always a false positive. Disabling it here is correct.

### Other changes

- Rename `tree_from_merging_commits` → `merged_tree_from_commits` for clarity
- Clarify `conflictable` field docs to specify it's checked during rebase, not merge

## Test plan

- Added a regression test (`workspace_merge_surfaces_delete_vs_modify_conflict`) with a fixture that reproduces the exact scenario
- The test verifies the conflict is surfaced rather than silently producing a wrong tree
- All 102 existing tests continue to pass