### PR TITLE
Show rejected changes modal when amending commits

### DIFF
--- a/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
+++ b/apps/desktop/src/components/commit/CommitFailedModalContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CommitFailedFileEntry from "$components/commit/CommitFailedFileEntry.svelte";
 	import AppScrollableContainer from "$components/shared/AppScrollableContainer.svelte";
+	import { readableRejectionReason } from "$lib/stacks/stackEndpoints";
 	import { REJECTTION_REASONS } from "$lib/stacks/stackService.svelte";
 	import { type RejectionReason } from "$lib/state/uiState.svelte";
 	import { Icon, ModalHeader, TestId, Tooltip } from "@gitbutler/ui";
@@ -20,31 +21,6 @@
 		paths: string[];
 	};
 
-	function getReadableRejectionReason(reason: RejectionReason): string {
-		switch (reason) {
-			case "cherryPickMergeConflict":
-				return "Cherry-pick merge conflict";
-			case "noEffectiveChanges":
-				return "No effective changes";
-			case "workspaceMergeConflict":
-				return "Workspace merge conflict";
-			case "workspaceMergeConflictOfUnrelatedFile":
-				return "Workspace merge conflict of unrelated file";
-			case "worktreeFileMissingForObjectConversion":
-				return "Worktree file missing for object conversion";
-			case "fileToLargeOrBinary":
-				return "File too large or binary";
-			case "pathNotFoundInBaseTree":
-				return "Path not found in base tree";
-			case "unsupportedDirectoryEntry":
-				return "Unsupported directory entry";
-			case "unsupportedTreeEntry":
-				return "Unsupported tree entry";
-			case "missingDiffSpecAssociation":
-				return "Missing diff spec association";
-		}
-	}
-
 	function groupByReason(data: CommitFailedModalState): ReasonGroup[] {
 		const grouped: Partial<Record<RejectionReason, string[]>> = {};
 
@@ -59,7 +35,7 @@
 		for (const reason of REJECTTION_REASONS) {
 			const paths = grouped[reason];
 			if (!paths) continue;
-			result.push({ reason, reasonReadable: getReadableRejectionReason(reason), paths });
+			result.push({ reason, reasonReadable: readableRejectionReason(reason), paths });
 		}
 
 		return result;

--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -17,6 +17,8 @@ import { UI_STATE, withStackBusy, type UiState } from "$lib/state/uiState.svelte
 import { inject } from "@gitbutler/core/context";
 import { untrack } from "svelte";
 import type { DropzoneHandler } from "$lib/dragging/handler";
+import type { CreateCommitOutcome } from "$lib/stacks/stackEndpoints";
+import type { RejectionReason } from "@gitbutler/but-sdk";
 
 /** Details about a commit belonging to a drop zone. */
 export type DzCommitData = {
@@ -162,15 +164,19 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 					}
 				}
 
-				this.onresult(
-					await this.stackService.amendCommitMutation({
-						projectId: this.projectId,
-						stackId: this.stackId,
-						commitId: this.commit.id,
-						worktreeChanges: worktreeChanges,
-						dryRun: false,
-					}),
-				);
+				const outcome = await this.stackService.amendCommitMutation({
+					projectId: this.projectId,
+					stackId: this.stackId,
+					commitId: this.commit.id,
+					worktreeChanges: worktreeChanges,
+					dryRun: false,
+				});
+
+				if (outcome.newCommit) {
+					this.onresult(outcome.newCommit);
+				}
+
+				handleRejectedChanges(this.uiState, this.projectId, outcome);
 
 				if (this.runHooks) {
 					try {
@@ -401,13 +407,15 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 					return;
 				}
 			}
-			this.stackService.amendCommitMutation({
+			const outcome = await this.stackService.amendCommitMutation({
 				projectId,
 				stackId,
 				commitId: commit.id,
 				worktreeChanges,
 				dryRun: false,
 			});
+
+			handleRejectedChanges(this.uiState, projectId, outcome);
 			if (runHooks) {
 				try {
 					await this.hooksService.runPostCommitHooks(projectId);
@@ -464,6 +472,27 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 			);
 		}
 	}
+}
+
+function handleRejectedChanges(uiState: UiState, projectId: string, outcome: CreateCommitOutcome) {
+	if (outcome.rejectedChanges.length === 0) return;
+
+	const pathsToRejectedChanges = outcome.rejectedChanges.reduce(
+		(acc: Record<string, RejectionReason>, { reason, path }) => {
+			acc[path] = reason;
+			return acc;
+		},
+		{},
+	);
+
+	uiState.global.modal.set({
+		type: "commit-failed",
+		projectId,
+		targetBranchName: "",
+		newCommitId: outcome.newCommit ?? undefined,
+		commitTitle: undefined,
+		pathsToRejectedChanges,
+	});
 }
 
 function updateUiState(

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -1,6 +1,4 @@
-import { SilentError } from "$lib/error/error";
 import { ConflictEntries, type ConflictEntriesObj } from "$lib/files/conflicts";
-import { showToast } from "$lib/notifications/toasts";
 import { createSelectByIds, createSelectNth } from "$lib/state/customSelectors";
 import {
 	invalidatesItem,
@@ -20,7 +18,6 @@ import type {
 	GerritPushFlag,
 } from "$lib/stacks/stack";
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
-import type { RejectionReason } from "$lib/state/uiState.svelte";
 import type {
 	StackOrder,
 	AbsorptionTarget,
@@ -38,6 +35,7 @@ import type {
 	CommitCreateResult,
 	CommitRewordResult,
 	CommitInsertBlankResult,
+	RejectionReason,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -97,6 +95,31 @@ type BackendRejectedChange = {
 	reason: RejectionReason;
 	path: string;
 };
+
+export function readableRejectionReason(reason: RejectionReason): string {
+	switch (reason) {
+		case "cherryPickMergeConflict":
+			return "Cherry-pick merge conflict";
+		case "noEffectiveChanges":
+			return "No effective changes";
+		case "workspaceMergeConflict":
+			return "Workspace merge conflict";
+		case "workspaceMergeConflictOfUnrelatedFile":
+			return "Workspace merge conflict of unrelated file";
+		case "worktreeFileMissingForObjectConversion":
+			return "Worktree file missing for object conversion";
+		case "fileToLargeOrBinary":
+			return "File too large or binary";
+		case "pathNotFoundInBaseTree":
+			return "Path not found in base tree";
+		case "unsupportedDirectoryEntry":
+			return "Unsupported directory entry";
+		case "unsupportedTreeEntry":
+			return "Unsupported tree entry";
+		case "missingDiffSpecAssociation":
+			return "Missing diff spec association";
+	}
+}
 
 export type CreateCommitOutcome = {
 	newCommit: string | null;
@@ -459,7 +482,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			],
 		}),
 		commitAmend: build.mutation<
-			string /** Return value is the updated commit id. */,
+			CreateCommitOutcome,
 			{
 				projectId: string;
 				commitId: string;
@@ -477,31 +500,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				changes: worktreeChanges,
 				dryRun,
 			}),
-			transformResponse: (response: CommitCreateResult) => {
-				const normalizedResponse = normalizeCreateCommitOutcome(response);
-				if (normalizedResponse.newCommit) {
-					return normalizedResponse.newCommit;
-				}
-
-				const allNoEffect = normalizedResponse.rejectedChanges.every(
-					({ reason }) => reason === "noEffectiveChanges",
-				);
-				if (allNoEffect) {
-					showToast({
-						title: "No changes to amend",
-						message:
-							"The selected changes are already part of this commit, so amending had no effect.",
-						style: "info",
-					});
-					throw new SilentError("No effective changes to amend");
-				}
-
-				const rejected = normalizedResponse.rejectedChanges
-					.map(({ reason, path }) => `${reason}: ${path}`)
-					.join(", ");
-				const details = rejected ? ` Rejected changes: ${rejected}` : "";
-				throw new Error(`Failed to amend commit: no commit was created.${details}`);
-			},
+			transformResponse: normalizeCreateCommitOutcome,
 			invalidatesTags: [
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.BranchChanges),


### PR DESCRIPTION
## Summary

When amending commits, the backend can return rejected changes (e.g. merge conflicts, files too large). Previously, `commitAmend` handled this entirely in `transformResponse` — showing toasts or throwing errors — while `commitCreate` returned the full outcome and let callers display a modal. This inconsistency meant amend rejections were shown as error toasts instead of the detailed commit-failed modal.

- Change `commitAmend` to return `CreateCommitOutcome` (like `commitCreate`), moving UI decisions out of the endpoint layer
- Handle rejected changes in the drop handler call sites by showing the commit-failed modal
- Extract `readableRejectionReason` into a shared helper in `stackEndpoints.ts`, removing the duplicate from `CommitFailedModalContent.svelte`
- Import `RejectionReason` type from `@gitbutler/but-sdk` instead of the hand-maintained copy

## Test plan

- [ ] Amend a commit via drag-and-drop where some changes get rejected — verify the commit-failed modal appears (not an error toast)
- [ ] Amend a commit where all changes succeed — verify no modal appears
- [ ] Create a new commit with rejected changes — verify the commit-failed modal still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)