### PR TITLE
Simplify ContextMenu by replacing imperative API with mount/unmount

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenApprovalToolCall.svelte
+++ b/apps/desktop/src/components/codegen/CodegenApprovalToolCall.svelte
@@ -27,7 +27,6 @@
 	let allowDropdownButton = $state<ReturnType<typeof DropdownButton>>();
 	let denyDropdownButton = $state<ReturnType<typeof DropdownButton>>();
 	let wildcardButton = $state<HTMLElement>();
-	let wildcardContextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let wildcardMenuOpen = $state(false);
 
 	type AllowDecision = "allowOnce" | "allowSession" | "allowProject" | "allowAlways";
@@ -120,31 +119,35 @@
 				dropdownOpen={wildcardMenuOpen}
 				shrinkable
 				onclick={() => {
-					wildcardContextMenu?.toggle();
+					wildcardMenuOpen = !wildcardMenuOpen;
 				}}
 			>
 				{wildcardSelector.options.find((opt) => opt.value === selectedWildcardDecision)?.label ||
 					"Select scope"}
 			</Button>
 
-			<ContextMenu
-				bind:this={wildcardContextMenu}
-				leftClickTrigger={wildcardButton}
-				ontoggle={(isOpen) => (wildcardMenuOpen = isOpen)}
-			>
-				<ContextMenuSection>
-					{#each wildcardSelector.options as option}
-						<ContextMenuItem
-							label={option.label}
-							selected={option.value === selectedWildcardDecision}
-							onclick={() => {
-								selectedWildcardDecision = option.value;
-								wildcardContextMenu?.close();
-							}}
-						/>
-					{/each}
-				</ContextMenuSection>
-			</ContextMenu>
+			{#if wildcardMenuOpen}
+				<ContextMenu
+					target={wildcardButton}
+					leftClickTrigger={wildcardButton}
+					onclose={() => {
+						wildcardMenuOpen = false;
+					}}
+				>
+					<ContextMenuSection>
+						{#each wildcardSelector.options as option}
+							<ContextMenuItem
+								label={option.label}
+								selected={option.value === selectedWildcardDecision}
+								onclick={() => {
+									selectedWildcardDecision = option.value;
+									wildcardMenuOpen = false;
+								}}
+							/>
+						{/each}
+					</ContextMenuSection>
+				</ContextMenu>
+			{/if}
 		{/if}
 
 		<DropdownButton

--- a/apps/desktop/src/components/codegen/CodegenMessages.svelte
+++ b/apps/desktop/src/components/codegen/CodegenMessages.svelte
@@ -92,13 +92,13 @@
 	const canEnterChat = $derived(!!projectRegistered);
 
 	let clearContextModal = $state<Modal>();
-	let modelContextMenu = $state<ContextMenu>();
+	let modelMenuOpen = $state(false);
 	let modelTrigger = $state<HTMLButtonElement>();
-	let thinkingModeContextMenu = $state<ContextMenu>();
+	let thinkingModeMenuOpen = $state(false);
 	let thinkingModeTrigger = $state<HTMLButtonElement>();
-	let permissionModeContextMenu = $state<ContextMenu>();
+	let permissionModeMenuOpen = $state(false);
 	let permissionModeTrigger = $state<HTMLButtonElement>();
-	let templateContextMenu = $state<ContextMenu>();
+	let templateMenuOpen = $state(false);
 	let templateTrigger = $state<HTMLButtonElement>();
 
 	let promptConfigModal = $state<CodegenPromptConfigModal>();
@@ -188,17 +188,17 @@
 
 	function selectModel(model: ModelType) {
 		controller.projectState.selectedModel.set(model);
-		modelContextMenu?.close();
+		modelMenuOpen = false;
 	}
 
 	function selectThinkingLevel(level: ThinkingLevel) {
 		controller.projectState.thinkingLevel.set(level);
-		thinkingModeContextMenu?.close();
+		thinkingModeMenuOpen = false;
 	}
 
 	function selectPermissionMode(mode: PermissionMode) {
 		controller.laneState.permissionMode.set(mode);
-		permissionModeContextMenu?.close();
+		permissionModeMenuOpen = false;
 	}
 
 	function getPermissionModeIcon(
@@ -227,7 +227,7 @@
 		const newPrompt = currentPrompt + (currentPrompt ? "\n\n" : "") + templateContent;
 		messageSender?.setPrompt(newPrompt);
 		inputRef?.setText(newPrompt);
-		templateContextMenu?.close();
+		templateMenuOpen = false;
 	}
 
 	async function onAbort() {
@@ -633,14 +633,14 @@
 											kind="ghost"
 											icon="script"
 											tooltip="Insert template"
-											onclick={(e) => templateContextMenu?.toggle(e)}
+											onclick={() => (templateMenuOpen = !templateMenuOpen)}
 										/>
 										<Button
 											bind:el={thinkingModeTrigger}
 											kind="ghost"
 											icon="thinking"
 											reversedDirection
-											onclick={() => thinkingModeContextMenu?.toggle()}
+											onclick={() => (thinkingModeMenuOpen = !thinkingModeMenuOpen)}
 											tooltip="Thinking mode"
 											children={selectedThinkingLevel === "normal" ? undefined : thinkingBtnText}
 										/>
@@ -649,7 +649,7 @@
 											kind="ghost"
 											icon={getPermissionModeIcon(selectedPermissionMode)}
 											shrinkable
-											onclick={() => permissionModeContextMenu?.toggle()}
+											onclick={() => (permissionModeMenuOpen = !permissionModeMenuOpen)}
 											tooltip={$settingsService?.claude.dangerouslyAllowAllPermissions
 												? "Permission modes disable when all permissions are allowed"
 												: permissionModeLabel}
@@ -665,7 +665,7 @@
 											kind="ghost"
 											icon="chevron-down"
 											shrinkable
-											onclick={() => modelContextMenu?.toggle()}
+											onclick={() => (modelMenuOpen = !modelMenuOpen)}
 										>
 											{modelOptions.find((a) => a.value === selectedModel)?.label}
 										</Button>
@@ -703,87 +703,112 @@
 	{/snippet}
 </Modal>
 
-<ContextMenu bind:this={modelContextMenu} leftClickTrigger={modelTrigger} side="top" align="end">
-	<ContextMenuSection>
-		{#each modelOptions as option}
+{#if modelMenuOpen}
+	<ContextMenu
+		target={modelTrigger}
+		leftClickTrigger={modelTrigger}
+		side="top"
+		align="end"
+		onclose={() => {
+			modelMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			{#each modelOptions as option}
+				<ContextMenuItem
+					label={option.label}
+					selected={selectedModel === option.value}
+					onclick={() => selectModel(option.value)}
+				/>
+			{/each}
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
+
+{#if thinkingModeMenuOpen}
+	<ContextMenu
+		target={thinkingModeTrigger}
+		leftClickTrigger={thinkingModeTrigger}
+		align="start"
+		side="top"
+		onclose={() => {
+			thinkingModeMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			{#each thinkingLevels as level}
+				<ContextMenuItem
+					label={level.label}
+					selected={selectedThinkingLevel === level.value}
+					onclick={() => selectThinkingLevel(level.value)}
+				/>
+			{/each}
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
+
+{#if permissionModeMenuOpen}
+	<ContextMenu
+		target={permissionModeTrigger}
+		leftClickTrigger={permissionModeTrigger}
+		align="start"
+		side="top"
+		onclose={() => {
+			permissionModeMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			{#each permissionModeOptions as option}
+				<ContextMenuItem
+					label={option.label}
+					selected={selectedPermissionMode === option.value}
+					onclick={() => selectPermissionMode(option.value)}
+				/>
+			{/each}
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
+
+{#if templateMenuOpen}
+	<ContextMenu
+		target={templateTrigger}
+		leftClickTrigger={templateTrigger}
+		side="top"
+		align="start"
+		onclose={() => {
+			templateMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			<ReduxResult result={promptTemplates.result} {projectId}>
+				{#snippet children(_promptTemplates, { projectId: _projectId })}
+					{#each parsedTemplates as template}
+						{@const displayName = template.parsed.name || template.fileName}
+
+						<ContextMenuItem
+							label={displayName}
+							emoji={template.parsed.emoji || undefined}
+							icon={template.parsed.emoji ? undefined : "script"}
+							onclick={() => {
+								insertTemplate(template.parsed.content);
+							}}
+						/>
+					{/each}
+				{/snippet}
+			</ReduxResult>
+		</ContextMenuSection>
+		<ContextMenuSection>
 			<ContextMenuItem
-				label={option.label}
-				selected={selectedModel === option.value}
-				onclick={() => selectModel(option.value)}
+				label="Edit templates…"
+				icon="edit"
+				onclick={() => {
+					promptConfigModal?.show();
+					templateMenuOpen = false;
+				}}
 			/>
-		{/each}
-	</ContextMenuSection>
-</ContextMenu>
-
-<ContextMenu
-	bind:this={thinkingModeContextMenu}
-	leftClickTrigger={thinkingModeTrigger}
-	align="start"
-	side="top"
->
-	<ContextMenuSection>
-		{#each thinkingLevels as level}
-			<ContextMenuItem
-				label={level.label}
-				selected={selectedThinkingLevel === level.value}
-				onclick={() => selectThinkingLevel(level.value)}
-			/>
-		{/each}
-	</ContextMenuSection>
-</ContextMenu>
-
-<ContextMenu
-	bind:this={permissionModeContextMenu}
-	leftClickTrigger={permissionModeTrigger}
-	align="start"
-	side="top"
->
-	<ContextMenuSection>
-		{#each permissionModeOptions as option}
-			<ContextMenuItem
-				label={option.label}
-				selected={selectedPermissionMode === option.value}
-				onclick={() => selectPermissionMode(option.value)}
-			/>
-		{/each}
-	</ContextMenuSection>
-</ContextMenu>
-
-<ContextMenu
-	bind:this={templateContextMenu}
-	leftClickTrigger={templateTrigger}
-	side="top"
-	align="start"
->
-	<ContextMenuSection>
-		<ReduxResult result={promptTemplates.result} {projectId}>
-			{#snippet children(_promptTemplates, { projectId: _projectId })}
-				{#each parsedTemplates as template}
-					{@const displayName = template.parsed.name || template.fileName}
-
-					<ContextMenuItem
-						label={displayName}
-						emoji={template.parsed.emoji || undefined}
-						icon={template.parsed.emoji ? undefined : "script"}
-						onclick={() => {
-							insertTemplate(template.parsed.content);
-						}}
-					/>
-				{/each}
-			{/snippet}
-		</ReduxResult>
-	</ContextMenuSection>
-	<ContextMenuSection>
-		<ContextMenuItem
-			label="Edit templates…"
-			icon="edit"
-			onclick={() => {
-				promptConfigModal?.show();
-				templateContextMenu?.close();
-			}}
-		/>
-	</ContextMenuSection>
-</ContextMenu>
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
 
 {#if promptDirs.response}
 	<CodegenPromptConfigModal

--- a/apps/desktop/src/components/diff/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/diff/HunkContextMenu.svelte
@@ -56,7 +56,9 @@
 	const userSettings = inject(SETTINGS);
 
 	const filePath = $derived(change.path);
-	let contextMenu: ReturnType<typeof ContextMenu> | undefined;
+	let menuOpen = $state(false);
+	let menuTarget = $state<MouseEvent | HTMLElement>();
+	let menuItem = $state<HunkContextItem>();
 
 	function getDiscardLineLabel(item: HunkContextItem) {
 		const { selectedLines } = item;
@@ -108,22 +110,28 @@
 	}
 
 	export function open(e: MouseEvent | HTMLElement | undefined, item: HunkContextItem) {
-		contextMenu?.open(e, item);
+		menuTarget = e;
+		menuItem = item;
+		menuOpen = true;
 	}
 
 	export function close() {
-		contextMenu?.close();
+		menuOpen = false;
 	}
 </script>
 
-<ContextMenu
-	testId={TestId.HunkContextMenu}
-	bind:this={contextMenu}
-	rightClickTrigger={trigger}
-	align="start"
-	side="bottom"
->
-	{#snippet children(item)}
+{#if menuOpen && menuItem}
+	{@const item = menuItem}
+	<ContextMenu
+		testId={TestId.HunkContextMenu}
+		rightClickTrigger={trigger}
+		align="start"
+		side="bottom"
+		target={menuTarget}
+		onclose={() => {
+			menuOpen = false;
+		}}
+	>
 		{#if isHunkContextItem(item)}
 			{#if discardable}
 				<ContextMenuSection>
@@ -133,7 +141,7 @@
 						icon="bin"
 						onclick={() => {
 							discardHunk(item);
-							contextMenu?.close();
+							menuOpen = false;
 						}}
 					/>
 					{#if item.selectedLines !== undefined && item.selectedLines.length > 0 && change.status.type !== "Addition" && change.status.type !== "Deletion"}
@@ -143,7 +151,7 @@
 							icon="checklist-remove"
 							onclick={() => {
 								discardHunkLines(item);
-								contextMenu?.close();
+								menuOpen = false;
 							}}
 						/>
 					{/if}
@@ -167,7 +175,7 @@
 							});
 							urlService.openExternalUrl(path);
 						}
-						contextMenu?.close();
+						menuOpen = false;
 					}}
 				/>
 			</ContextMenuSection>
@@ -182,7 +190,7 @@
 						data,
 					});
 				}}
-				closeMenu={() => contextMenu?.close()}
+				closeMenu={() => (menuOpen = false)}
 			/>
 
 			{#if selectable}
@@ -193,7 +201,7 @@
 						icon="select-all"
 						onclick={() => {
 							selectAllHunkLines(item.hunk);
-							contextMenu?.close();
+							menuOpen = false;
 						}}
 					/>
 					<ContextMenuItem
@@ -202,7 +210,7 @@
 						icon="select-all-remove"
 						onclick={() => {
 							unselectAllHunkLines(item.hunk);
-							contextMenu?.close();
+							menuOpen = false;
 						}}
 					/>
 					<ContextMenuItem
@@ -211,7 +219,7 @@
 						icon="select-all-inverse"
 						onclick={() => {
 							invertHunkSelection(item.hunk);
-							contextMenu?.close();
+							menuOpen = false;
 						}}
 					/>
 				</ContextMenuSection>
@@ -219,5 +227,5 @@
 		{:else}
 			<p class="text-12 text-semibold clr-text-2">Malformed item (·•᷄‎ࡇ•᷅ )</p>
 		{/if}
-	{/snippet}
-</ContextMenu>
+	</ContextMenu>
+{/if}

--- a/apps/desktop/src/components/forge/PullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/PullRequestCard.svelte
@@ -59,7 +59,8 @@
 		button,
 	}: Props = $props();
 
-	let contextMenuEl = $state<ReturnType<typeof ContextMenu>>();
+	let contextMenuOpen = $state(false);
+	let contextMenuTarget = $state<MouseEvent | HTMLElement>();
 	let container = $state<HTMLElement>();
 	let hasChecks = $state(false);
 
@@ -138,62 +139,69 @@
 			<PrStatusPoller number={pr.number} />
 		{/if}
 
-		<ContextMenu bind:this={contextMenuEl} rightClickTrigger={container}>
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Open in browser"
-					onclick={() => {
-						urlService.openExternalUrl(pr.htmlUrl);
-						contextMenuEl?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Copy link"
-					onclick={() => {
-						clipboardService.write(pr.htmlUrl, { message: `${abbr} link copied` });
-						contextMenuEl?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Refetch status"
-					onclick={() => {
-						prService?.fetch(pr.number, { forceRefetch: true });
-						contextMenuEl?.close();
-						if (hasChecks) {
-							checksService?.fetch(pr.sourceBranch, { forceRefetch: true });
-						}
-					}}
-				/>
-				{#if pr.state === "open" && !pr.mergedAt}
-					<ContextMenuItem
-						label={pr.draft ? "Ready for review" : "Convert to draft"}
-						disabled={draftToggling}
-						onclick={async () => {
-							contextMenuEl?.close();
-							await handleSetDraft(!pr.draft);
-						}}
-					/>
-				{/if}
-			</ContextMenuSection>
-			{#if hasChecks}
+		{#if contextMenuOpen}
+			<ContextMenu
+				target={contextMenuTarget}
+				onclose={() => {
+					contextMenuOpen = false;
+				}}
+			>
 				<ContextMenuSection>
 					<ContextMenuItem
-						label="Open checks"
+						label="Open in browser"
 						onclick={() => {
-							urlService.openExternalUrl(`${pr.htmlUrl}/checks`);
-							contextMenuEl?.close();
+							contextMenuOpen = false;
+							urlService.openExternalUrl(pr.htmlUrl);
 						}}
 					/>
 					<ContextMenuItem
-						label="Copy checks"
+						label="Copy link"
 						onclick={() => {
-							clipboardService.write(`${pr.htmlUrl}/checks`, { message: "Checks link copied" });
-							contextMenuEl?.close();
+							contextMenuOpen = false;
+							clipboardService.write(pr.htmlUrl, { message: `${abbr} link copied` });
 						}}
 					/>
+					<ContextMenuItem
+						label="Refetch status"
+						onclick={() => {
+							contextMenuOpen = false;
+							prService?.fetch(pr.number, { forceRefetch: true });
+							if (hasChecks) {
+								checksService?.fetch(pr.sourceBranch, { forceRefetch: true });
+							}
+						}}
+					/>
+					{#if pr.state === "open" && !pr.mergedAt}
+						<ContextMenuItem
+							label={pr.draft ? "Ready for review" : "Convert to draft"}
+							disabled={draftToggling}
+							onclick={async () => {
+								contextMenuOpen = false;
+								await handleSetDraft(!pr.draft);
+							}}
+						/>
+					{/if}
 				</ContextMenuSection>
-			{/if}
-		</ContextMenu>
+				{#if hasChecks}
+					<ContextMenuSection>
+						<ContextMenuItem
+							label="Open checks"
+							onclick={() => {
+								contextMenuOpen = false;
+								urlService.openExternalUrl(`${pr.htmlUrl}/checks`);
+							}}
+						/>
+						<ContextMenuItem
+							label="Copy checks"
+							onclick={() => {
+								contextMenuOpen = false;
+								clipboardService.write(`${pr.htmlUrl}/checks`, { message: "Checks link copied" });
+							}}
+						/>
+					</ContextMenuSection>
+				{/if}
+			</ContextMenu>
+		{/if}
 
 		<div
 			data-testid={testId}
@@ -203,7 +211,8 @@
 			oncontextmenu={(e: MouseEvent) => {
 				e.preventDefault();
 				e.stopPropagation();
-				contextMenuEl?.open(e);
+				contextMenuTarget = e;
+				contextMenuOpen = true;
 			}}
 		>
 			<div class="pr-actions">

--- a/apps/desktop/src/components/irc/IrcMessageActions.svelte
+++ b/apps/desktop/src/components/irc/IrcMessageActions.svelte
@@ -22,13 +22,13 @@
 
 	const quickEmojis = $derived(getInitialEmojis().slice(0, QUICK_EMOJI_COUNT));
 
-	let pickerMenu = $state<ReturnType<typeof ContextMenu>>();
 	let pickerTrigger = $state<HTMLButtonElement>();
+	let pickerOpen = $state(false);
 
 	function handleEmojiPick(emoji: EmojiInfo) {
 		markRecentlyUsedEmoji(emoji);
 		onReact(msg, emoji.unicode);
-		pickerMenu?.close();
+		pickerOpen = false;
 	}
 </script>
 
@@ -52,7 +52,10 @@
 		class="action-btn"
 		title="More reactions"
 		bind:this={pickerTrigger}
-		onclick={() => pickerMenu?.toggle()}>+</button
+		onclick={() => {
+			pickerOpen = !pickerOpen;
+			onPickerToggle?.(pickerOpen);
+		}}>+</button
 	>
 	{#if isOwn && onDelete}
 		<button
@@ -64,17 +67,20 @@
 	{/if}
 </div>
 
-<ContextMenu
-	bind:this={pickerMenu}
-	leftClickTrigger={pickerTrigger}
-	side="top"
-	align="end"
-	ontoggle={(isOpen) => {
-		onPickerToggle?.(isOpen);
-	}}
->
-	<EmojiPicker onEmojiSelect={handleEmojiPick} />
-</ContextMenu>
+{#if pickerOpen}
+	<ContextMenu
+		leftClickTrigger={pickerTrigger}
+		target={pickerTrigger}
+		side="top"
+		align="end"
+		onclose={() => {
+			pickerOpen = false;
+			onPickerToggle?.(false);
+		}}
+	>
+		<EmojiPicker onEmojiSelect={handleEmojiPick} />
+	</ContextMenu>
+{/if}
 
 <style lang="postcss">
 	.message-actions {

--- a/apps/desktop/src/components/irc/IrcMessages.svelte
+++ b/apps/desktop/src/components/irc/IrcMessages.svelte
@@ -105,7 +105,9 @@
 
 	const userSettings = inject(SETTINGS);
 
-	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
+	let contextMenuOpen = $state(false);
+	let contextMenuTarget = $state<MouseEvent | HTMLElement>();
+	let contextMenuItem = $state<{ filePath: string; lineNumber?: number }>();
 	let messagesEl = $state<HTMLDivElement>();
 
 	// ── Single shared IrcMessageActions instance ────────────────────────
@@ -249,7 +251,9 @@
 					change={data.change}
 					diff={data.diff}
 					onLineContextMenu={({ event, target, filePath, lineNumber }) => {
-						contextMenu?.open(event || target, { filePath, lineNumber });
+						contextMenuTarget = event || target;
+						contextMenuItem = { filePath, lineNumber };
+						contextMenuOpen = true;
 					}}
 				/>
 			{:else}
@@ -358,22 +362,27 @@
 	</div>
 {/if}
 
-{#if onOpenInEditor}
-	<ContextMenu bind:this={contextMenu} rightClickTrigger={messagesEl} align="start" side="right">
-		{#snippet children(item)}
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Open in {editorName ?? 'Editor'}"
-					icon="open-in-ide"
-					onclick={() => {
-						if (item.filePath) {
-							onOpenInEditor(item.filePath, item.lineNumber);
-						}
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-		{/snippet}
+{#if onOpenInEditor && contextMenuOpen}
+	<ContextMenu
+		target={contextMenuTarget}
+		align="start"
+		side="right"
+		onclose={() => {
+			contextMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			<ContextMenuItem
+				label="Open in {editorName ?? 'Editor'}"
+				icon="open-in-ide"
+				onclick={() => {
+					if (contextMenuItem?.filePath) {
+						onOpenInEditor(contextMenuItem.filePath, contextMenuItem.lineNumber);
+					}
+					contextMenuOpen = false;
+				}}
+			/>
+		</ContextMenuSection>
 	</ContextMenu>
 {/if}
 

--- a/apps/desktop/src/components/rules/NewRuleMenu.svelte
+++ b/apps/desktop/src/components/rules/NewRuleMenu.svelte
@@ -11,7 +11,8 @@
 
 	const { addFromFilter, trigger, addEmpty, addedFilterTypes }: Props = $props();
 
-	let contextMenu = $state<ContextMenu>();
+	let menuOpen = $state(false);
+	let menuTarget = $state<MouseEvent>();
 
 	function filterHasBeenAdded(type: RuleFilterType): boolean {
 		return addedFilterTypes.includes(type);
@@ -19,57 +20,66 @@
 
 	function handleAddFilter(type: RuleFilterType) {
 		addFromFilter(type);
-		contextMenu?.close();
+		menuOpen = false;
 	}
 
 	function handleAddEmpty() {
 		addEmpty?.();
-		contextMenu?.close();
+		menuOpen = false;
 	}
 
 	export function toggle(e: MouseEvent) {
-		contextMenu?.toggle(e);
+		menuOpen = !menuOpen;
+		menuTarget = e;
 	}
 </script>
 
-<ContextMenu bind:this={contextMenu} leftClickTrigger={trigger}>
-	<ContextMenuSection>
-		<ContextMenuItem
-			icon="folder"
-			label="File or folder path"
-			disabled={filterHasBeenAdded("pathMatchesRegex")}
-			onclick={() => {
-				handleAddFilter("pathMatchesRegex");
-			}}
-		/>
-		<ContextMenuItem
-			icon="text-contain"
-			label="Contains text"
-			disabled={filterHasBeenAdded("contentMatchesRegex")}
-			onclick={() => {
-				handleAddFilter("contentMatchesRegex");
-			}}
-		/>
-		<ContextMenuItem
-			icon="file-diff"
-			label="Change type (coming soon)"
-			disabled={filterHasBeenAdded("fileChangeType") || true}
-			onclick={() => {
-				handleAddFilter("fileChangeType");
-			}}
-		/>
-		<ContextMenuItem
-			icon="tag"
-			label="Work category (coming soon)"
-			disabled={filterHasBeenAdded("semanticType") || true}
-			onclick={() => {
-				handleAddFilter("semanticType");
-			}}
-		/>
-	</ContextMenuSection>
-	{#if addEmpty}
+{#if menuOpen}
+	<ContextMenu
+		target={menuTarget ?? trigger}
+		leftClickTrigger={trigger}
+		onclose={() => {
+			menuOpen = false;
+		}}
+	>
 		<ContextMenuSection>
-			<ContextMenuItem icon="arrow-right" label="Stage all to branch" onclick={handleAddEmpty} />
+			<ContextMenuItem
+				icon="folder"
+				label="File or folder path"
+				disabled={filterHasBeenAdded("pathMatchesRegex")}
+				onclick={() => {
+					handleAddFilter("pathMatchesRegex");
+				}}
+			/>
+			<ContextMenuItem
+				icon="text-contain"
+				label="Contains text"
+				disabled={filterHasBeenAdded("contentMatchesRegex")}
+				onclick={() => {
+					handleAddFilter("contentMatchesRegex");
+				}}
+			/>
+			<ContextMenuItem
+				icon="file-diff"
+				label="Change type (coming soon)"
+				disabled={filterHasBeenAdded("fileChangeType") || true}
+				onclick={() => {
+					handleAddFilter("fileChangeType");
+				}}
+			/>
+			<ContextMenuItem
+				icon="tag"
+				label="Work category (coming soon)"
+				disabled={filterHasBeenAdded("semanticType") || true}
+				onclick={() => {
+					handleAddFilter("semanticType");
+				}}
+			/>
 		</ContextMenuSection>
-	{/if}
-</ContextMenu>
+		{#if addEmpty}
+			<ContextMenuSection>
+				<ContextMenuItem icon="arrow-right" label="Stage all to branch" onclick={handleAddEmpty} />
+			</ContextMenuSection>
+		{/if}
+	</ContextMenu>
+{/if}

--- a/apps/desktop/src/components/shared/ChangedFilesContextMenu.svelte
+++ b/apps/desktop/src/components/shared/ChangedFilesContextMenu.svelte
@@ -114,7 +114,10 @@
 		}
 	})();
 
-	let contextMenu: ReturnType<typeof ContextMenu>;
+	let menuOpen = $state(false);
+	let menuTarget = $state<MouseEvent | HTMLElement>();
+	let menuItem = $state<ChangedFilesItem>();
+
 	let discardModal: ReturnType<typeof DiscardChangesModal>;
 	let stashModal: ReturnType<typeof StashIntoBranchModal>;
 	let absorbModal: ReturnType<typeof AbsorbPlanModal>;
@@ -146,18 +149,21 @@
 		return null;
 	}
 
-	export function open(e: MouseEvent | HTMLElement, item: ChangedFilesItem) {
-		contextMenu.open(e, item);
+	export function open(e: MouseEvent | HTMLElement, newItem: ChangedFilesItem) {
+		menuTarget = e;
+		menuItem = newItem;
+		menuOpen = true;
 		aiService.validateGitButlerAPIConfiguration().then((value) => {
 			aiConfigurationValid = value;
 		});
 	}
 
 	export function close() {
-		contextMenu.close();
+		menuOpen = false;
 	}
 
 	async function uncommitChanges(stackId: string, commitId: string, changes: TreeChange[]) {
+		menuOpen = false;
 		await withStackBusy(uiState, projectId, { commitId, stackIds: [stackId] }, async () => {
 			const { workspace } = await stackService.uncommitChanges({
 				projectId,
@@ -179,7 +185,6 @@
 				uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId, previewOpen });
 			}
 		});
-		contextMenu.close();
 	}
 
 	async function triggerAutoCommit(changes: TreeChange[]) {
@@ -305,19 +310,23 @@
 	}
 </script>
 
-<ContextMenu
-	bind:this={contextMenu}
-	{leftClickTrigger}
-	rightClickTrigger={trigger}
-	side="bottom"
-	{align}
-	{onopen}
-	{onclose}
->
-	{#snippet children(item: unknown)}
+{#if menuOpen && menuItem}
+	{@const item = menuItem}
+	{@const deletion = isDeleted(item)}
+	{@const itemPath = getItemPath(item)}
+	<ContextMenu
+		{leftClickTrigger}
+		rightClickTrigger={trigger}
+		side="bottom"
+		{align}
+		target={menuTarget}
+		{onopen}
+		onclose={() => {
+			menuOpen = false;
+			onclose?.();
+		}}
+	>
 		{#if isChangedFilesItem(item)}
-			{@const deletion = isDeleted(item)}
-			{@const itemPath = getItemPath(item)}
 			{#if item.changes.length > 0 && !editMode}
 				<ContextMenuSection>
 					{@const changes = item.changes}
@@ -328,7 +337,7 @@
 							icon="bin"
 							onclick={() => {
 								discardModal.show(item);
-								contextMenu.close();
+								menuOpen = false;
 							}}
 						/>
 						<ContextMenuItem
@@ -336,7 +345,7 @@
 							icon="branch-bottom-up-arrow"
 							onclick={() => {
 								stashModal.show(item);
-								contextMenu.close();
+								menuOpen = false;
 							}}
 						/>
 						<ContextMenuItem
@@ -345,15 +354,15 @@
 							testId={TestId.FileListItemContextMenu_Absorb}
 							onclick={() => {
 								absorbModal.show(item.changes);
-								contextMenu.close();
+								menuOpen = false;
 							}}
 							disabled={absorbingChanges.current.isLoading}
 						/>
 						<ContextMenuItem
 							label="Auto commit"
 							icon="commit-ai"
-							onclick={async () => {
-								contextMenu.close();
+							onclick={() => {
+								menuOpen = false;
 								triggerAutoCommit(changes);
 							}}
 							disabled={autoCommitting.current.isLoading}
@@ -381,16 +390,16 @@
 										label="Split off changes"
 										icon="split"
 										onclick={() => {
+											menuOpen = false;
 											split(changes);
-											contextMenu.close();
 										}}
 									/>
 									<ContextMenuItem
 										label="Split into dependent branch"
 										icon="stack-plus"
 										onclick={() => {
+											menuOpen = false;
 											splitIntoDependentBranch(changes);
-											contextMenu.close();
 										}}
 									/>
 								{/if}
@@ -403,11 +412,12 @@
 			{#if itemPath}
 				<ContextMenuSection>
 					<ContextMenuItemSubmenu label="Copy path" icon="copy">
-						{#snippet submenu({ close: closeSubmenu })}
+						{#snippet submenu(_sub)}
 							<ContextMenuSection>
 								<ContextMenuItem
 									label="Copy path"
 									onclick={async () => {
+										menuOpen = false;
 										const project = await projectService.fetchProject(projectId);
 										const projectPath = project?.path;
 										if (projectPath) {
@@ -418,19 +428,16 @@
 												errorMessage: "Failed to copy absolute path",
 											});
 										}
-										closeSubmenu();
-										contextMenu.close();
 									}}
 								/>
 								<ContextMenuItem
 									label="Copy relative path"
 									onclick={async () => {
+										menuOpen = false;
 										await clipboardService.write(itemPath, {
 											message: "Relative path copied",
 											errorMessage: "Failed to copy relative path",
 										});
-										closeSubmenu();
-										contextMenu.close();
 									}}
 								/>
 							</ContextMenuSection>
@@ -446,6 +453,7 @@
 						icon="open-in-ide"
 						disabled={deletion}
 						onclick={async () => {
+							menuOpen = false;
 							try {
 								const project = await projectService.fetchProject(projectId);
 								const projectPath = project?.path;
@@ -458,7 +466,6 @@
 										urlService.openExternalUrl(path);
 									}
 								}
-								contextMenu.close();
 							} catch {
 								chipToasts.error("Failed to open in editor");
 								console.error("Failed to open in editor");
@@ -471,13 +478,13 @@
 						label={showInFolderLabel}
 						icon="open-in-folder"
 						onclick={async () => {
+							menuOpen = false;
 							const project = await projectService.fetchProject(projectId);
 							const projectPath = project?.path;
 							if (projectPath) {
 								const absPath = await backend.joinPath(projectPath, itemPath);
 								await fileService.showFileInFolder(absPath);
 							}
-							contextMenu.close();
 						}}
 					/>
 				{/if}
@@ -486,13 +493,12 @@
 			{#if canUseGBAI && isUncommitted}
 				<ContextMenuSection>
 					<ContextMenuItemSubmenu label="Experimental AI" icon="lab">
-						{#snippet submenu({ close: closeSubmenu })}
+						{#snippet submenu(_sub)}
 							<ContextMenuSection>
 								<ContextMenuItem
 									label="Branch changes"
 									onclick={() => {
-										closeSubmenu();
-										contextMenu.close();
+										menuOpen = false;
 										triggerBranchChanges(item.changes);
 									}}
 									disabled={branchingChanges.current.isLoading}
@@ -507,8 +513,8 @@
 				<p class="text-13">'Woops! Malformed data :(</p>
 			</ContextMenuSection>
 		{/if}
-	{/snippet}
-</ContextMenu>
+	</ContextMenu>
+{/if}
 
 <DiscardChangesModal bind:this={discardModal} {projectId} {selectionId} />
 <StashIntoBranchModal bind:this={stashModal} {projectId} />

--- a/apps/desktop/src/components/views/AppSidebar.svelte
+++ b/apps/desktop/src/components/views/AppSidebar.svelte
@@ -31,7 +31,7 @@
 	const { projectId, disabled = false }: { projectId: string; disabled?: boolean } = $props();
 
 	let contextTriggerButton = $state<HTMLButtonElement | undefined>();
-	let contextMenuEl = $state<ContextMenu>();
+	let contextMenuOpen = $state(false);
 	let shareIssueModal = $state<ShareIssueModal>();
 
 	const userSettings = inject(SETTINGS);
@@ -276,55 +276,60 @@
 	</div>
 </div>
 
-<ContextMenu
-	bind:this={contextMenuEl}
-	leftClickTrigger={contextTriggerButton}
-	side="right"
-	align="start"
->
-	<ContextMenuSection>
-		<ContextMenuItem
-			label="Global settings"
-			onclick={() => {
-				openGeneralSettings();
-				contextMenuEl?.close();
-			}}
-			keyboardShortcut="⌘,"
-		/>
-	</ContextMenuSection>
-	<ContextMenuSection title="Theme (⌘T)">
-		<ContextMenuItem
-			label="Dark"
-			onclick={async () => {
-				userSettings.update((s) => ({
-					...s,
-					theme: "dark",
-				}));
-				contextMenuEl?.close();
-			}}
-		/>
-		<ContextMenuItem
-			label="Light"
-			onclick={async () => {
-				userSettings.update((s) => ({
-					...s,
-					theme: "light",
-				}));
-				contextMenuEl?.close();
-			}}
-		/>
-		<ContextMenuItem
-			label="System"
-			onclick={async () => {
-				userSettings.update((s) => ({
-					...s,
-					theme: "system",
-				}));
-				contextMenuEl?.close();
-			}}
-		/>
-	</ContextMenuSection>
-</ContextMenu>
+{#if contextMenuOpen}
+	<ContextMenu
+		target={contextTriggerButton}
+		leftClickTrigger={contextTriggerButton}
+		side="right"
+		align="start"
+		onclose={() => {
+			contextMenuOpen = false;
+		}}
+	>
+		<ContextMenuSection>
+			<ContextMenuItem
+				label="Global settings"
+				onclick={() => {
+					openGeneralSettings();
+					contextMenuOpen = false;
+				}}
+				keyboardShortcut="⌘,"
+			/>
+		</ContextMenuSection>
+		<ContextMenuSection title="Theme (⌘T)">
+			<ContextMenuItem
+				label="Dark"
+				onclick={async () => {
+					userSettings.update((s) => ({
+						...s,
+						theme: "dark",
+					}));
+					contextMenuOpen = false;
+				}}
+			/>
+			<ContextMenuItem
+				label="Light"
+				onclick={async () => {
+					userSettings.update((s) => ({
+						...s,
+						theme: "light",
+					}));
+					contextMenuOpen = false;
+				}}
+			/>
+			<ContextMenuItem
+				label="System"
+				onclick={async () => {
+					userSettings.update((s) => ({
+						...s,
+						theme: "system",
+					}));
+					contextMenuOpen = false;
+				}}
+			/>
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
 
 <ShareIssueModal bind:this={shareIssueModal} />
 

--- a/apps/web/src/lib/components/chat/Message.svelte
+++ b/apps/web/src/lib/components/chat/Message.svelte
@@ -64,8 +64,8 @@
 
 	let kebabMenuTrigger = $state<HTMLButtonElement>();
 	let emojiPickerTrigger = $state<HTMLButtonElement>();
-	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
-	let emojiPicker = $state<ReturnType<typeof ContextMenu>>();
+	let contextMenuOpen = $state(false);
+	let emojiPickerOpen = $state(false);
 	let isOpenedByKebabButton = $state(false);
 	let isOpenedByEmojiPicker = $state(false);
 	let recentlyUsedEmojis = $state<EmojiInfo[]>([]);
@@ -129,7 +129,7 @@
 
 	function onEmojiSelect(emoji: EmojiInfo) {
 		handleReaction(emoji);
-		emojiPicker?.close();
+		emojiPickerOpen = false;
 	}
 	async function handleClickOnExistingReaction(unicode: string) {
 		const emojiInfo = findEmojiByUnicode(unicode);
@@ -270,7 +270,7 @@
 				thin
 				overrideYScroll={0}
 				onclick={() => {
-					emojiPicker?.toggle();
+					emojiPickerOpen = !emojiPickerOpen;
 				}}
 			/>
 
@@ -291,7 +291,7 @@
 				tooltip="More options"
 				thin
 				onclick={() => {
-					contextMenu?.toggle();
+					contextMenuOpen = !contextMenuOpen;
 				}}
 				overrideYScroll={0}
 			/>
@@ -300,20 +300,34 @@
 </div>
 
 <MessageContextMenu
-	bind:menu={contextMenu}
+	open={contextMenuOpen}
 	leftClickTrigger={kebabMenuTrigger}
 	{message}
 	{projectSlug}
-	onToggle={(isOpen) => (isOpenedByKebabButton = isOpen)}
+	onclose={() => {
+		contextMenuOpen = false;
+		isOpenedByKebabButton = false;
+	}}
+	onopen={() => {
+		isOpenedByKebabButton = true;
+	}}
 />
 
-<ContextMenu
-	bind:this={emojiPicker}
-	leftClickTrigger={emojiPickerTrigger}
-	ontoggle={(isOpen) => (isOpenedByEmojiPicker = isOpen)}
->
-	<EmojiPicker {onEmojiSelect} />
-</ContextMenu>
+{#if emojiPickerOpen}
+	<ContextMenu
+		leftClickTrigger={emojiPickerTrigger}
+		target={emojiPickerTrigger}
+		onclose={() => {
+			emojiPickerOpen = false;
+			isOpenedByEmojiPicker = false;
+		}}
+		onopen={() => {
+			isOpenedByEmojiPicker = true;
+		}}
+	>
+		<EmojiPicker {onEmojiSelect} />
+	</ContextMenu>
+{/if}
 
 <style lang="postcss">
 	@keyframes temporary-highlight {

--- a/apps/web/src/lib/components/chat/MessageContextMenu.svelte
+++ b/apps/web/src/lib/components/chat/MessageContextMenu.svelte
@@ -6,14 +6,15 @@
 	import type { ChatMessage } from "@gitbutler/shared/chat/types";
 
 	type Props = {
-		menu: ReturnType<typeof ContextMenu> | undefined;
+		open: boolean;
 		leftClickTrigger: HTMLElement | undefined;
 		projectSlug: string;
 		message: ChatMessage;
-		onToggle?: (isOpen: boolean, isLeftClick: boolean) => void;
+		onclose?: () => void;
+		onopen?: () => void;
 	};
 
-	let { menu = $bindable(), leftClickTrigger, message, projectSlug, onToggle }: Props = $props();
+	let { open, leftClickTrigger, message, projectSlug, onclose, onopen }: Props = $props();
 
 	let rulesModal = $state<RulesModal>();
 
@@ -21,22 +22,24 @@
 		const url = new URL(window.location.href);
 		url.searchParams.set("m", message.uuid);
 		copyToClipboard(url.toString());
-		menu?.close();
+		onclose?.();
 	}
 
 	function openRulesModal() {
 		rulesModal?.show();
-		menu?.close();
+		onclose?.();
 	}
 </script>
 
-<ContextMenu bind:this={menu} {leftClickTrigger} ontoggle={onToggle}>
-	<ContextMenuSection>
-		<ContextMenuItem label="Copy link" onclick={copyLink} />
-	</ContextMenuSection>
-	<ContextMenuSection>
-		<ContextMenuItem label="Create a rule" onclick={openRulesModal} />
-	</ContextMenuSection>
-</ContextMenu>
+{#if open}
+	<ContextMenu {leftClickTrigger} target={leftClickTrigger} {onclose} {onopen}>
+		<ContextMenuSection>
+			<ContextMenuItem label="Copy link" onclick={copyLink} />
+		</ContextMenuSection>
+		<ContextMenuSection>
+			<ContextMenuItem label="Create a rule" onclick={openRulesModal} />
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}
 
 <RulesModal {message} {projectSlug} bind:this={rulesModal} />

--- a/packages/ui/src/lib/components/AddForgeAccountButton.svelte
+++ b/packages/ui/src/lib/components/AddForgeAccountButton.svelte
@@ -21,7 +21,7 @@
 	let { noAccounts, disabled = false, loading = false, menuItems }: Props = $props();
 
 	let addProfileButtonRef = $state<HTMLElement>();
-	let addAccountContextMenu = $state<ContextMenu>();
+	let menuOpen = $state(false);
 
 	const buttonText = $derived(noAccounts ? "Add account" : "Add another account");
 </script>
@@ -29,7 +29,7 @@
 <Button
 	bind:el={addProfileButtonRef}
 	kind="outline"
-	onclick={() => addAccountContextMenu?.toggle()}
+	onclick={() => (menuOpen = !menuOpen)}
 	{disabled}
 	{loading}
 	icon="plus"
@@ -37,17 +37,23 @@
 	{buttonText}
 </Button>
 
-<ContextMenu bind:this={addAccountContextMenu} leftClickTrigger={addProfileButtonRef}>
-	<ContextMenuSection>
-		{#each menuItems as item}
-			<ContextMenuItem
-				label={item.label}
-				icon={item.icon}
-				onclick={() => {
-					item.onclick();
-					addAccountContextMenu?.close();
-				}}
-			/>
-		{/each}
-	</ContextMenuSection>
-</ContextMenu>
+{#if menuOpen}
+	<ContextMenu
+		target={addProfileButtonRef}
+		leftClickTrigger={addProfileButtonRef}
+		onclose={() => (menuOpen = false)}
+	>
+		<ContextMenuSection>
+			{#each menuItems as item}
+				<ContextMenuItem
+					label={item.label}
+					icon={item.icon}
+					onclick={() => {
+						item.onclick();
+						menuOpen = false;
+					}}
+				/>
+			{/each}
+		</ContextMenuSection>
+	</ContextMenu>
+{/if}

--- a/packages/ui/src/lib/components/ContextMenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenu.svelte
@@ -1,8 +1,8 @@
-<script lang="ts" generics="T = any">
+<script lang="ts">
 	import { focusable } from "$lib/focus/focusable";
 	import { menuManager } from "$lib/utils/menuManager";
 	import { portal } from "$lib/utils/portal";
-	import { setContext, onDestroy, tick } from "svelte";
+	import { onMount, setContext, onDestroy, tick } from "svelte";
 	import { type Snippet } from "svelte";
 
 	// Context key for submenu coordination
@@ -11,20 +11,23 @@
 	// Constants
 	const ANIMATION_SHIFT = "6px";
 
-	interface Props<T = any> {
+	interface Props {
 		testId?: string;
-		children?: Snippet<[item: T]>;
+		children?: Snippet;
 		leftClickTrigger?: HTMLElement;
 		rightClickTrigger?: HTMLElement;
 		parentMenuId?: string;
 		onclose?: () => void;
 		onopen?: () => void;
-		ontoggle?: (isOpen: boolean, isLeftClick: boolean) => void;
 		onclick?: () => void;
 		onkeypress?: () => void;
-		menu?: Snippet<[{ close: () => void }]>;
 		side?: "top" | "bottom" | "left" | "right";
 		align?: "start" | "center" | "end";
+		/**
+		 * Positioning target for the menu. The menu is positioned relative
+		 * to this element or mouse event.
+		 */
+		target?: MouseEvent | HTMLElement;
 	}
 
 	let {
@@ -37,15 +40,12 @@
 		children,
 		onclose,
 		onopen,
-		ontoggle,
 		onclick,
 		onkeypress,
-		menu,
-	}: Props<T> = $props();
+		target,
+	}: Props = $props();
 
 	let menuContainer: HTMLElement | undefined = $state();
-	let item = $state<T>();
-	let isVisible = $state(false);
 	let menuPosition = $state({ x: 0, y: 0 });
 
 	// Generate unique menu ID
@@ -72,11 +72,38 @@
 
 	setContext(SUBMENU_CONTEXT_KEY, submenuCoordination);
 
-	// Cleanup on destroy
 	onDestroy(() => {
-		if (isVisible) {
-			menuManager.unregister(menuId);
+		menuManager.unregister(menuId);
+	});
+
+	onMount(async () => {
+		// Save the target for repositioning after layout
+		if (target instanceof MouseEvent || target instanceof PointerEvent) {
+			savedMouseEvent = target;
+		} else if (target instanceof HTMLElement) {
+			savedElement = target;
 		}
+
+		await tick();
+
+		if (target) setPosition(target);
+
+		// Register with menu manager once the menu is rendered
+		setTimeout(() => {
+			if (menuContainer) {
+				menuManager.register({
+					id: menuId,
+					element: menuContainer,
+					triggerElement: leftClickTrigger ?? savedElement,
+					parentMenuId,
+					close: () => {
+						onclose?.();
+					},
+				});
+			}
+		}, 0);
+
+		onopen?.();
 	});
 
 	function calculatePosition(target: HTMLElement | MouseEvent): { x: number; y: number } {
@@ -164,15 +191,6 @@
 		return { x, y };
 	}
 
-	function executeByTrigger(callback: (isOpened: boolean, isLeftClick: boolean) => void) {
-		const isLeftClick = Boolean(leftClickTrigger);
-		const isRightClick = Boolean(rightClickTrigger);
-
-		if (isLeftClick || isRightClick) {
-			callback(isVisible, isLeftClick);
-		}
-	}
-
 	function setPosition(target: MouseEvent | HTMLElement) {
 		const basePosition = calculatePosition(target);
 		menuPosition = menuContainer ? constrainToViewport(basePosition) : basePosition;
@@ -180,12 +198,7 @@
 
 	// Recalculate position when menu dimensions become available
 	$effect(() => {
-		if (
-			isVisible &&
-			menuContainer &&
-			menuContainer.offsetWidth > 0 &&
-			menuContainer.offsetHeight > 0
-		) {
+		if (menuContainer && menuContainer.offsetWidth > 0 && menuContainer.offsetHeight > 0) {
 			const target = savedMouseEvent ?? savedElement ?? leftClickTrigger ?? rightClickTrigger;
 			if (target) {
 				setPosition(target);
@@ -195,68 +208,6 @@
 
 	let savedMouseEvent: MouseEvent | undefined = $state();
 	let savedElement: HTMLElement | undefined = $state();
-
-	export async function open(e?: MouseEvent | HTMLElement, newItem?: T) {
-		if (isVisible) return;
-
-		// Save the open target for repositioning after layout
-		if (e instanceof MouseEvent || e instanceof PointerEvent) {
-			savedMouseEvent = e;
-			savedElement = undefined;
-		} else if (e instanceof HTMLElement) {
-			savedElement = e;
-			savedMouseEvent = undefined;
-		}
-
-		isVisible = true;
-		if (newItem !== undefined) item = newItem;
-		await tick();
-
-		if (e) setPosition(e);
-
-		// Register with menu manager once the menu is rendered
-		setTimeout(() => {
-			if (menuContainer) {
-				menuManager.register({
-					id: menuId,
-					element: menuContainer,
-					triggerElement: leftClickTrigger ?? savedElement,
-					parentMenuId,
-					close: () => {
-						isVisible = false;
-						savedMouseEvent = undefined;
-						savedElement = undefined;
-						onclose?.();
-						if (ontoggle) executeByTrigger(ontoggle);
-					},
-				});
-			}
-		}, 0);
-
-		onopen?.();
-		if (ontoggle) executeByTrigger(ontoggle);
-	}
-
-	export function close() {
-		if (!isVisible) return;
-
-		// Unregister from menu manager
-		menuManager.unregister(menuId);
-
-		isVisible = false;
-		savedMouseEvent = undefined;
-		savedElement = undefined;
-		onclose?.();
-		if (ontoggle) executeByTrigger(ontoggle);
-	}
-
-	export function toggle(e?: MouseEvent, newItem?: T) {
-		if (isVisible) {
-			close();
-		} else {
-			open(e, newItem);
-		}
-	}
 
 	function getTransformOrigin(): string {
 		// Calculate origin based on side and alignment
@@ -285,25 +236,19 @@
 		return `${verticalOrigin} ${horizontalOrigin}`;
 	}
 
-	export function isOpen() {
-		return isVisible;
-	}
-
 	function handleKeyNavigation(e: KeyboardEvent) {
 		if (e.key === "Escape") {
 			e.preventDefault();
-			close();
+			onclose?.();
 		}
 	}
 
 	// Close on any scroll event (use capture since scroll doesn't bubble).
 	$effect(() => {
-		if (!isVisible) return;
-
 		function onScroll(e: Event) {
 			// Don't close if the scroll is inside the menu itself.
 			if (menuContainer?.contains(e.target as Node)) return;
-			close();
+			onclose?.();
 		}
 
 		document.addEventListener("scroll", onScroll, true);
@@ -320,7 +265,7 @@
 					// Only reposition if we don't have open submenus
 					// This prevents the menu from jumping when submenus open
 					const target = savedMouseEvent ?? savedElement;
-					if (isVisible && target && !submenuCoordination.hasOpenSubmenus()) {
+					if (target && !submenuCoordination.hasOpenSubmenus()) {
 						setPosition(target);
 					}
 				}
@@ -332,39 +277,35 @@
 	});
 </script>
 
-{#if isVisible}
-	<div class="portal-wrap" use:portal={"body"}>
-		<!-- svelte-ignore a11y_autofocus -->
-		<div
-			data-testid={testId}
-			bind:this={menuContainer}
-			tabindex="-1"
-			use:focusable={{ activate: true, isolate: true, focusable: true, dim: true, trap: true }}
-			autofocus
-			{onclick}
-			{onkeypress}
-			onkeydown={handleKeyNavigation}
-			class="context-menu hide-native-scrollbar"
-			class:top-oriented={side === "top"}
-			class:bottom-oriented={side === "bottom"}
-			class:left-oriented={side === "left"}
-			class:right-oriented={side === "right"}
-			style:top="{menuPosition.y}px"
-			style:left="{menuPosition.x}px"
-			style:transform-origin={getTransformOrigin()}
-			style:--animation-transform-y-shift={side === "top"
-				? ANIMATION_SHIFT
-				: side === "bottom"
-					? `-${ANIMATION_SHIFT}`
-					: "0"}
-			role="menu"
-		>
-			{@render children?.(item as T)}
-			<!-- TODO: refactor `children` and combine with this snippet. -->
-			{@render menu?.({ close })}
-		</div>
+<div class="portal-wrap" use:portal={"body"}>
+	<!-- svelte-ignore a11y_autofocus -->
+	<div
+		data-testid={testId}
+		bind:this={menuContainer}
+		tabindex="-1"
+		use:focusable={{ activate: true, isolate: true, focusable: true, dim: true, trap: true }}
+		autofocus
+		{onclick}
+		{onkeypress}
+		onkeydown={handleKeyNavigation}
+		class="context-menu hide-native-scrollbar"
+		class:top-oriented={side === "top"}
+		class:bottom-oriented={side === "bottom"}
+		class:left-oriented={side === "left"}
+		class:right-oriented={side === "right"}
+		style:top="{menuPosition.y}px"
+		style:left="{menuPosition.x}px"
+		style:transform-origin={getTransformOrigin()}
+		style:--animation-transform-y-shift={side === "top"
+			? ANIMATION_SHIFT
+			: side === "bottom"
+				? `-${ANIMATION_SHIFT}`
+				: "0"}
+		role="menu"
+	>
+		{@render children?.()}
 	</div>
-{/if}
+</div>
 
 <style lang="postcss">
 	.portal-wrap {

--- a/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
@@ -32,7 +32,6 @@
 	}: Props = $props();
 
 	let menuItemElement: HTMLDivElement | undefined = $state();
-	let contextMenu: ReturnType<typeof ContextMenu> | undefined = $state();
 	let isSubmenuOpen = $state(false);
 	let hoverTimeout: NodeJS.Timeout | undefined = $state();
 
@@ -82,7 +81,6 @@
 			submenuCoordination.closeAll();
 
 			isSubmenuOpen = true;
-			contextMenu?.open();
 		}, 100);
 	}
 
@@ -101,12 +99,10 @@
 		if (disabled) return;
 
 		isSubmenuOpen = !isSubmenuOpen;
-		contextMenu?.toggle();
 	}
 
 	function closeSubmenu() {
 		isSubmenuOpen = false;
-		contextMenu?.close();
 	}
 
 	// Handle arrow key navigation
@@ -119,7 +115,6 @@
 					e.preventDefault();
 					e.stopPropagation();
 					isSubmenuOpen = true;
-					contextMenu?.open();
 				}
 				break;
 			case "ArrowLeft":
@@ -127,7 +122,6 @@
 					e.preventDefault();
 					e.stopPropagation();
 					isSubmenuOpen = true;
-					contextMenu?.open();
 				}
 				break;
 			case "Enter":
@@ -137,7 +131,6 @@
 				if (disabled) return;
 
 				isSubmenuOpen = !isSubmenuOpen;
-				contextMenu?.toggle();
 				break;
 		}
 	}
@@ -164,19 +157,21 @@
 	</ContextMenuItem>
 </div>
 
-<ContextMenu
-	bind:this={contextMenu}
-	leftClickTrigger={menuItemElement}
-	parentMenuId={submenuCoordination.getMenuId()}
-	side={submenuSide}
-	align={submenuVerticalAlign === "top" ? "start" : "end"}
-	onclose={() => {
-		isSubmenuOpen = false;
-		menuItemElement?.focus();
-	}}
->
-	{@render submenu({ close: closeSubmenu })}
-</ContextMenu>
+{#if isSubmenuOpen}
+	<ContextMenu
+		leftClickTrigger={menuItemElement}
+		parentMenuId={submenuCoordination.getMenuId()}
+		side={submenuSide}
+		align={submenuVerticalAlign === "top" ? "start" : "end"}
+		target={menuItemElement}
+		onclose={() => {
+			isSubmenuOpen = false;
+			menuItemElement?.focus();
+		}}
+	>
+		{@render submenu({ close: closeSubmenu })}
+	</ContextMenu>
+{/if}
 
 <style lang="postcss">
 	.submenu-wrapper {

--- a/packages/ui/src/lib/components/DropdownButton.svelte
+++ b/packages/ui/src/lib/components/DropdownButton.svelte
@@ -48,7 +48,6 @@
 		onclick,
 	}: Props = $props();
 
-	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let iconEl = $state<HTMLElement>();
 	let visible = $state(false);
 
@@ -59,12 +58,10 @@
 
 	export function show() {
 		visible = true;
-		contextMenu?.open();
 	}
 
 	export function close() {
 		visible = false;
-		contextMenu?.close();
 	}
 </script>
 
@@ -97,31 +94,32 @@
 			dropdownChild
 			onclick={() => {
 				visible = !visible;
-				contextMenu?.toggle();
 			}}
 			oncontextmenu={preventContextMenu}
 		/>
 	</div>
-	<ContextMenu
-		bind:this={contextMenu}
-		leftClickTrigger={iconEl}
-		side={menuSide}
-		onclose={() => {
-			visible = false;
-		}}
-		onclick={() => {
-			if (autoClose) {
-				contextMenu?.close();
-			}
-		}}
-		onkeypress={() => {
-			if (autoClose) {
-				contextMenu?.close();
-			}
-		}}
-	>
-		{@render contextMenuSlot()}
-	</ContextMenu>
+	{#if visible}
+		<ContextMenu
+			target={iconEl}
+			leftClickTrigger={iconEl}
+			side={menuSide}
+			onclose={() => {
+				visible = false;
+			}}
+			onclick={() => {
+				if (autoClose) {
+					visible = false;
+				}
+			}}
+			onkeypress={() => {
+				if (autoClose) {
+					visible = false;
+				}
+			}}
+		>
+			{@render contextMenuSlot()}
+		</ContextMenu>
+	{/if}
 </Tooltip>
 
 <style lang="postcss">

--- a/packages/ui/src/lib/components/KebabButton.svelte
+++ b/packages/ui/src/lib/components/KebabButton.svelte
@@ -39,8 +39,8 @@
 
 	let visible = $state(false);
 	let buttonElement = $state<HTMLElement>();
-	let internalContextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let isMenuOpen = $state(false);
+	let menuTarget = $state<MouseEvent | HTMLElement>();
 
 	function onMouseEnter() {
 		if (!showOnHover) return;
@@ -63,18 +63,22 @@
 	}
 
 	function onContextMenu(e: MouseEvent) {
-		e.preventDefault(); // Prevent default to avoid browser context menu
-		internalContextMenu?.open(e);
+		e.preventDefault();
+		menuTarget = e;
+		isMenuOpen = true;
+		onMenuToggle?.(true, false);
 	}
 
 	function onClick(e: MouseEvent) {
 		e.stopPropagation();
 		e.preventDefault();
-		internalContextMenu?.open();
+		menuTarget = buttonElement;
+		isMenuOpen = true;
+		onMenuToggle?.(true, true);
 	}
 
 	function closeMenu() {
-		internalContextMenu?.close();
+		isMenuOpen = false;
 	}
 
 	$effect(() => {
@@ -124,28 +128,25 @@
 	/>
 {/if}
 
-<ContextMenu
-	bind:this={internalContextMenu}
-	leftClickTrigger={buttonElement}
-	rightClickTrigger={contextElement}
-	side={menuSide}
-	align={menuAlign}
-	testId={contextMenuTestId}
-	onclose={() => {
-		isMenuOpen = false;
-		onMenuClose?.();
-	}}
-	onopen={() => {
-		isMenuOpen = true;
-		onMenuOpen?.();
-	}}
-	ontoggle={(isOpen, isLeftClick) => {
-		isMenuOpen = isOpen;
-		onMenuToggle?.(isOpen, isLeftClick);
-	}}
->
-	{@render contextMenuSnippet({ close: closeMenu })}
-</ContextMenu>
+{#if isMenuOpen}
+	<ContextMenu
+		target={menuTarget}
+		leftClickTrigger={buttonElement}
+		rightClickTrigger={contextElement}
+		side={menuSide}
+		align={menuAlign}
+		testId={contextMenuTestId}
+		onclose={() => {
+			isMenuOpen = false;
+			onMenuClose?.();
+		}}
+		onopen={() => {
+			onMenuOpen?.();
+		}}
+	>
+		{@render contextMenuSnippet({ close: closeMenu })}
+	</ContextMenu>
+{/if}
 
 <style lang="postcss">
 	.kebab-btn {

--- a/packages/ui/src/lib/components/emoji/EmojiPickerButton.svelte
+++ b/packages/ui/src/lib/components/emoji/EmojiPickerButton.svelte
@@ -11,15 +11,15 @@
 	let { onEmojiSelect: callback }: Props = $props();
 
 	let leftClickTrigger = $state<HTMLDivElement>();
-	let picker = $state<ReturnType<typeof ContextMenu>>();
+	let pickerOpen = $state(false);
 
 	function handleClick() {
-		picker?.toggle();
+		pickerOpen = !pickerOpen;
 	}
 
 	function onEmojiSelect(emoji: EmojiInfo) {
 		callback(emoji);
-		picker?.close();
+		pickerOpen = false;
 	}
 </script>
 
@@ -27,6 +27,16 @@
 	<Button kind="ghost" icon="smile" onclick={handleClick} />
 </div>
 
-<ContextMenu bind:this={picker} {leftClickTrigger} side="top" align="start">
-	<EmojiPicker {onEmojiSelect} />
-</ContextMenu>
+{#if pickerOpen}
+	<ContextMenu
+		{leftClickTrigger}
+		side="top"
+		align="start"
+		target={leftClickTrigger}
+		onclose={() => {
+			pickerOpen = false;
+		}}
+	>
+		<EmojiPicker {onEmojiSelect} />
+	</ContextMenu>
+{/if}

--- a/packages/ui/src/stories/components/ContextMenu.stories.svelte
+++ b/packages/ui/src/stories/components/ContextMenu.stories.svelte
@@ -31,8 +31,21 @@
 		},
 	});
 
-	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
-	let contextTrigger = $state<HTMLButtonElement | undefined>();
+	let leftClickMenuOpen = $state(false);
+	let leftClickTrigger = $state<HTMLButtonElement | undefined>();
+
+	let rightClickMenuOpen = $state(false);
+	let rightClickTrigger = $state<HTMLButtonElement | undefined>();
+	let rightClickEvent = $state<MouseEvent | undefined>();
+
+	let flickeringMenuOpen = $state(false);
+	let flickeringTrigger = $state<HTMLButtonElement | undefined>();
+
+	let submenuMenuOpen = $state(false);
+	let submenuTrigger = $state<HTMLButtonElement | undefined>();
+
+	let captionMenuOpen = $state(false);
+	let captionTrigger = $state<HTMLButtonElement | undefined>();
 </script>
 
 <script lang="ts">
@@ -43,80 +56,89 @@
 		<div class="wrap">
 			<Button
 				kind="outline"
-				bind:el={contextTrigger}
+				bind:el={leftClickTrigger}
 				onclick={() => {
-					contextMenu?.toggle();
+					leftClickMenuOpen = !leftClickMenuOpen;
 				}}>Toggle context menu</Button
 			>
 		</div>
 
-		<ContextMenu bind:this={contextMenu} leftClickTrigger={contextTrigger} {...args}>
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Commit and bleep"
-					icon="commit"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-					keyboardShortcut="⌘+Enter"
-				/>
-				<ContextMenuItem
-					label="Commit"
-					icon="text-contain"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-			<ContextMenuSection title="More">
-				<ContextMenuItem
-					label="Another commit"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Amend"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Revert"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Squash"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-			<ContextMenuSection title="Danger zone">
-				<ContextMenuItem
-					label="Delete"
-					onclick={() => {
-						// eslint-disable-next-line no-console
-						console.log("Commit and bleep");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-		</ContextMenu>
+		{#if leftClickMenuOpen}
+			<ContextMenu
+				target={leftClickTrigger}
+				{leftClickTrigger}
+				onclose={() => {
+					leftClickMenuOpen = false;
+				}}
+				{...args}
+			>
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Commit and bleep"
+						icon="commit"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+						keyboardShortcut="⌘+Enter"
+					/>
+					<ContextMenuItem
+						label="Commit"
+						icon="text-contain"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection title="More">
+					<ContextMenuItem
+						label="Another commit"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Amend"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Revert"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Squash"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection title="Danger zone">
+					<ContextMenuItem
+						label="Delete"
+						onclick={() => {
+							// eslint-disable-next-line no-console
+							console.log("Commit and bleep");
+							leftClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/if}
 	{/snippet}
 </Story>
 
@@ -126,137 +148,147 @@
 		<div class="wrap">
 			<Button
 				kind="outline"
-				bind:el={contextTrigger}
+				bind:el={rightClickTrigger}
 				oncontextmenu={(e) => {
 					e.preventDefault();
-					contextMenu?.toggle(e);
+					rightClickEvent = e;
+					rightClickMenuOpen = !rightClickMenuOpen;
 				}}>Right-click for scrollable menu</Button
 			>
 		</div>
 
-		<ContextMenu bind:this={contextMenu} rightClickTrigger={contextTrigger} {...args}>
-			<ContextMenuSection title="Quick actions">
-				<ContextMenuItem
-					label="Commit"
-					onclick={() => {
-						console.log("Commit");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Push"
-					onclick={() => {
-						console.log("Push");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Pull"
-					onclick={() => {
-						console.log("Pull");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Fetch"
-					onclick={() => {
-						console.log("Fetch");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Merge"
-					onclick={() => {
-						console.log("Merge");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItemSubmenu label="More actions">
-					{#snippet submenu({ close })}
-						<ContextMenuSection>
-							<ContextMenuItem
-								label="Cherry-pick"
-								onclick={() => {
-									console.log("Cherry-pick");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Rebase"
-								onclick={() => {
-									console.log("Rebase");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-						</ContextMenuSection>
-					{/snippet}
-				</ContextMenuItemSubmenu>
-			</ContextMenuSection>
-			<ContextMenuSection title="Branch operations">
-				<ContextMenuItem
-					label="Create branch"
-					onclick={() => {
-						console.log("Create branch");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Switch branch"
-					onclick={() => {
-						console.log("Switch branch");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Stage changes"
-					onclick={() => {
-						console.log("Stage changes");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Unstage changes"
-					onclick={() => {
-						console.log("Unstage changes");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Discard changes"
-					onclick={() => {
-						console.log("Discard changes");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Bisect"
-					onclick={() => {
-						console.log("Bisect");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Reflog"
-					onclick={() => {
-						console.log("Reflog");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Worktree"
-					onclick={() => {
-						console.log("Worktree");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-		</ContextMenu>
+		{#if rightClickMenuOpen}
+			<ContextMenu
+				target={rightClickEvent}
+				{rightClickTrigger}
+				onclose={() => {
+					rightClickMenuOpen = false;
+				}}
+				{...args}
+			>
+				<ContextMenuSection title="Quick actions">
+					<ContextMenuItem
+						label="Commit"
+						onclick={() => {
+							console.log("Commit");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Push"
+						onclick={() => {
+							console.log("Push");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Pull"
+						onclick={() => {
+							console.log("Pull");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Fetch"
+						onclick={() => {
+							console.log("Fetch");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Merge"
+						onclick={() => {
+							console.log("Merge");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItemSubmenu label="More actions">
+						{#snippet submenu({ close })}
+							<ContextMenuSection>
+								<ContextMenuItem
+									label="Cherry-pick"
+									onclick={() => {
+										console.log("Cherry-pick");
+										close();
+										rightClickMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Rebase"
+									onclick={() => {
+										console.log("Rebase");
+										close();
+										rightClickMenuOpen = false;
+									}}
+								/>
+							</ContextMenuSection>
+						{/snippet}
+					</ContextMenuItemSubmenu>
+				</ContextMenuSection>
+				<ContextMenuSection title="Branch operations">
+					<ContextMenuItem
+						label="Create branch"
+						onclick={() => {
+							console.log("Create branch");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Switch branch"
+						onclick={() => {
+							console.log("Switch branch");
+							rightClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Stage changes"
+						onclick={() => {
+							console.log("Stage changes");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Unstage changes"
+						onclick={() => {
+							console.log("Unstage changes");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Discard changes"
+						onclick={() => {
+							console.log("Discard changes");
+							rightClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Bisect"
+						onclick={() => {
+							console.log("Bisect");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Reflog"
+						onclick={() => {
+							console.log("Reflog");
+							rightClickMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Worktree"
+						onclick={() => {
+							console.log("Worktree");
+							rightClickMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/if}
 	{/snippet}
 </Story>
 
@@ -266,122 +298,132 @@
 		<div class="wrap" style="margin-top: 200px;">
 			<Button
 				kind="outline"
-				bind:el={contextTrigger}
+				bind:el={flickeringTrigger}
 				onclick={() => {
-					contextMenu?.toggle();
+					flickeringMenuOpen = !flickeringMenuOpen;
 				}}>Test flickering fix</Button
 			>
 		</div>
 
-		<ContextMenu bind:this={contextMenu} leftClickTrigger={contextTrigger} side="bottom" {...args}>
-			<ContextMenuSection title="Many items to force scrolling">
-				<ContextMenuItem
-					label="Item 1"
-					onclick={() => {
-						console.log("Item 1");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 2"
-					onclick={() => {
-						console.log("Item 2");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 3"
-					onclick={() => {
-						console.log("Item 3");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 4"
-					onclick={() => {
-						console.log("Item 4");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 5"
-					onclick={() => {
-						console.log("Item 5");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 6"
-					onclick={() => {
-						console.log("Item 6");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 7"
-					onclick={() => {
-						console.log("Item 7");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 8"
-					onclick={() => {
-						console.log("Item 8");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 9"
-					onclick={() => {
-						console.log("Item 9");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 10"
-					onclick={() => {
-						console.log("Item 10");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 11"
-					onclick={() => {
-						console.log("Item 11");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 12"
-					onclick={() => {
-						console.log("Item 12");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 13"
-					onclick={() => {
-						console.log("Item 13");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 14"
-					onclick={() => {
-						console.log("Item 14");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Item 15"
-					onclick={() => {
-						console.log("Item 15");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-		</ContextMenu>
+		{#if flickeringMenuOpen}
+			<ContextMenu
+				target={flickeringTrigger}
+				leftClickTrigger={flickeringTrigger}
+				side="bottom"
+				onclose={() => {
+					flickeringMenuOpen = false;
+				}}
+				{...args}
+			>
+				<ContextMenuSection title="Many items to force scrolling">
+					<ContextMenuItem
+						label="Item 1"
+						onclick={() => {
+							console.log("Item 1");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 2"
+						onclick={() => {
+							console.log("Item 2");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 3"
+						onclick={() => {
+							console.log("Item 3");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 4"
+						onclick={() => {
+							console.log("Item 4");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 5"
+						onclick={() => {
+							console.log("Item 5");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 6"
+						onclick={() => {
+							console.log("Item 6");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 7"
+						onclick={() => {
+							console.log("Item 7");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 8"
+						onclick={() => {
+							console.log("Item 8");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 9"
+						onclick={() => {
+							console.log("Item 9");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 10"
+						onclick={() => {
+							console.log("Item 10");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 11"
+						onclick={() => {
+							console.log("Item 11");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 12"
+						onclick={() => {
+							console.log("Item 12");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 13"
+						onclick={() => {
+							console.log("Item 13");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 14"
+						onclick={() => {
+							console.log("Item 14");
+							flickeringMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Item 15"
+						onclick={() => {
+							console.log("Item 15");
+							flickeringMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/if}
 	{/snippet}
 </Story>
 
@@ -390,126 +432,136 @@
 		<div class="wrap">
 			<Button
 				kind="outline"
-				bind:el={contextTrigger}
+				bind:el={submenuTrigger}
 				onclick={() => {
-					contextMenu?.toggle();
+					submenuMenuOpen = !submenuMenuOpen;
 				}}>Context menu with submenus</Button
 			>
 		</div>
 
-		<ContextMenu bind:this={contextMenu} leftClickTrigger={contextTrigger} side="bottom" {...args}>
-			<ContextMenuSection title="Basic actions">
-				<ContextMenuItem
-					label="Copy"
-					onclick={() => {
-						console.log("Copy");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Paste"
-					onclick={() => {
-						console.log("Paste");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Cut"
-					onclick={() => {
-						console.log("Cut");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-			<ContextMenuSection title="Advanced">
-				<ContextMenuItemSubmenu label="Format" icon="text-block">
-					{#snippet submenu({ close })}
-						<ContextMenuSection>
-							<ContextMenuItem
-								label="Bold"
-								onclick={() => {
-									console.log("Bold");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Italic"
-								onclick={() => {
-									console.log("Italic");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Underline"
-								onclick={() => {
-									console.log("Underline");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-						</ContextMenuSection>
-						<ContextMenuSection title="Alignment">
-							<ContextMenuItem
-								label="Left"
-								onclick={() => {
-									console.log("Left");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Center"
-								onclick={() => {
-									console.log("Center");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Right"
-								onclick={() => {
-									console.log("Right");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-						</ContextMenuSection>
-					{/snippet}
-				</ContextMenuItemSubmenu>
-				<ContextMenuItemSubmenu label="Insert" icon="plus">
-					{#snippet submenu({ close })}
-						<ContextMenuSection>
-							<ContextMenuItem
-								label="Image"
-								onclick={() => {
-									console.log("Image");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Link"
-								onclick={() => {
-									console.log("Link");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Table"
-								onclick={() => {
-									console.log("Table");
-									close();
-									contextMenu?.close();
-								}}
-							/>
-						</ContextMenuSection>
-					{/snippet}
-				</ContextMenuItemSubmenu>
-			</ContextMenuSection>
-		</ContextMenu>
+		{#if submenuMenuOpen}
+			<ContextMenu
+				target={submenuTrigger}
+				leftClickTrigger={submenuTrigger}
+				side="bottom"
+				onclose={() => {
+					submenuMenuOpen = false;
+				}}
+				{...args}
+			>
+				<ContextMenuSection title="Basic actions">
+					<ContextMenuItem
+						label="Copy"
+						onclick={() => {
+							console.log("Copy");
+							submenuMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Paste"
+						onclick={() => {
+							console.log("Paste");
+							submenuMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Cut"
+						onclick={() => {
+							console.log("Cut");
+							submenuMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection title="Advanced">
+					<ContextMenuItemSubmenu label="Format" icon="text-block">
+						{#snippet submenu({ close })}
+							<ContextMenuSection>
+								<ContextMenuItem
+									label="Bold"
+									onclick={() => {
+										console.log("Bold");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Italic"
+									onclick={() => {
+										console.log("Italic");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Underline"
+									onclick={() => {
+										console.log("Underline");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+							</ContextMenuSection>
+							<ContextMenuSection title="Alignment">
+								<ContextMenuItem
+									label="Left"
+									onclick={() => {
+										console.log("Left");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Center"
+									onclick={() => {
+										console.log("Center");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Right"
+									onclick={() => {
+										console.log("Right");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+							</ContextMenuSection>
+						{/snippet}
+					</ContextMenuItemSubmenu>
+					<ContextMenuItemSubmenu label="Insert" icon="plus">
+						{#snippet submenu({ close })}
+							<ContextMenuSection>
+								<ContextMenuItem
+									label="Image"
+									onclick={() => {
+										console.log("Image");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Link"
+									onclick={() => {
+										console.log("Link");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+								<ContextMenuItem
+									label="Table"
+									onclick={() => {
+										console.log("Table");
+										close();
+										submenuMenuOpen = false;
+									}}
+								/>
+							</ContextMenuSection>
+						{/snippet}
+					</ContextMenuItemSubmenu>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/if}
 	{/snippet}
 </Story>
 
@@ -518,33 +570,43 @@
 		<div class="wrap">
 			<Button
 				kind="outline"
-				bind:el={contextTrigger}
+				bind:el={captionTrigger}
 				onclick={() => {
-					contextMenu?.toggle();
+					captionMenuOpen = !captionMenuOpen;
 				}}>Context menu with caption</Button
 			>
 		</div>
 
-		<ContextMenu bind:this={contextMenu} leftClickTrigger={contextTrigger} side="bottom" {...args}>
-			<ContextMenuSection title="Item with caption">
-				<ContextMenuItem
-					label="Rebase"
-					caption="Move your commits on top of upstream changes. Creates clean, linear history."
-					onclick={() => {
-						console.log("Copy");
-						contextMenu?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Paste"
-					caption="Paste from clipboard"
-					onclick={() => {
-						console.log("Paste");
-						contextMenu?.close();
-					}}
-				/>
-			</ContextMenuSection>
-		</ContextMenu>
+		{#if captionMenuOpen}
+			<ContextMenu
+				target={captionTrigger}
+				leftClickTrigger={captionTrigger}
+				side="bottom"
+				onclose={() => {
+					captionMenuOpen = false;
+				}}
+				{...args}
+			>
+				<ContextMenuSection title="Item with caption">
+					<ContextMenuItem
+						label="Rebase"
+						caption="Move your commits on top of upstream changes. Creates clean, linear history."
+						onclick={() => {
+							console.log("Copy");
+							captionMenuOpen = false;
+						}}
+					/>
+					<ContextMenuItem
+						label="Paste"
+						caption="Paste from clipboard"
+						onclick={() => {
+							console.log("Paste");
+							captionMenuOpen = false;
+						}}
+					/>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/if}
 	{/snippet}
 </Story>
 


### PR DESCRIPTION
ContextMenu had exported open/close/toggle methods, internal visibility
state, a generic item parameter, and an ontoggle callback — all managed
through bind:this refs that could be nulled during Svelte teardown,
causing TypeError crashes in async handlers.

Replace all of this with a single pattern: parents gate ContextMenu
rendering with {#if} and pass a target prop for positioning. The
component renders unconditionally when mounted and tells the parent
to unmount it via onclose. This removes the entire imperative surface
area and the class of bugs that came with it.