### PR TITLE
Prevent scrolling when focus falls back after unmount

### DIFF
--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -1008,7 +1008,7 @@ export class FocusManager {
 		if (!element || !element.isConnected) return;
 
 		if (element.tabIndex !== -1) {
-			element.focus();
+			element.focus({ preventScroll: skipScroll });
 		} else {
 			const activeElement = document.activeElement;
 			if (activeElement instanceof HTMLElement && !element.contains(activeElement)) {


### PR DESCRIPTION
When a focused element was unmounted, the focus manager would fall back
to the previous element in the history. If that element's parent in the
focus hierarchy was off-screen, the browser's native focus() call would
scroll it into view, causing a sudden and disruptive jump for the user.

Pass preventScroll to focus() when restoring focus during unregister so
the viewport stays where it is.