### PR TITLE
tsconfig update: bundler module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"allowJs": true,
 		"checkJs": true,
 		"noEmit": true,


### PR DESCRIPTION
The module resolution `node` is deprecated. Use the recommended
standard.