### PR TITLE
refactor svelte app: replace stack reorder with commit move

### DIFF
--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -3,7 +3,7 @@ import { withStackBusy, type UiState } from "$lib/state/uiState.svelte";
 import { InjectionToken } from "@gitbutler/core/context";
 import type { DropzoneHandler } from "$lib/dragging/handler";
 import type { StackService } from "$lib/stacks/stackService.svelte";
-import type { StackOrder } from "@gitbutler/but-sdk";
+import type { RelativeTo } from "@gitbutler/but-sdk";
 
 export class ReorderCommitDzHandler implements DropzoneHandler {
 	constructor(
@@ -32,27 +32,24 @@ export class ReorderCommitDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: CommitDropData) {
-		const stackOrder = buildNewStackOrder(
-			this.series,
-			this.currentSeriesName,
-			data.commit.id,
-			this.commitId,
+		const { side, relativeTo } = toCommitMovePlacement({
+			targetBranchName: this.currentSeriesName,
+			targetCommitId: this.commitId,
+		});
+		await withStackBusy(
+			this.uiState,
+			this.projectId,
+			{ commitId: data.commit.id, stackIds: [data.stackId] },
+			async () => {
+				await this.stackService.commitMove({
+					projectId: this.projectId,
+					subjectCommitIds: [data.commit.id],
+					relativeTo,
+					side,
+					dryRun: false,
+				});
+			},
 		);
-
-		if (stackOrder) {
-			await withStackBusy(
-				this.uiState,
-				this.projectId,
-				{ commitId: data.commit.id, stackIds: [data.stackId] },
-				async () => {
-					await this.stackService.reorderStack({
-						projectId: this.projectId,
-						stackId: data.stackId,
-						stackOrder,
-					});
-				},
-			);
-		}
 	}
 }
 
@@ -123,52 +120,6 @@ export class ReorderDropzoneFactory {
 	}
 }
 
-function buildNewStackOrder(
-	allSeries: { name: string; commitIds: string[] }[],
-	currentSeriesName: string,
-	actorCommitId: string,
-	targetCommitId: string,
-): StackOrder | undefined {
-	const branches = allSeries.map((s) => ({
-		name: s.name,
-		commitIds: s.commitIds,
-	}));
-
-	const allCommitIds = branches.flatMap((s) => s.commitIds);
-
-	if (
-		targetCommitId !== "top" &&
-		(!allCommitIds.includes(actorCommitId) || !allCommitIds.includes(targetCommitId))
-	) {
-		throw new Error("Commit not found in series");
-	}
-
-	const currentSeriesIndex = branches.findIndex((s) => s.name === currentSeriesName);
-	if (currentSeriesIndex === -1) return undefined;
-
-	// Remove actorCommitId from its current position
-	branches.forEach((s) => {
-		s.commitIds = s.commitIds.filter((id) => id !== actorCommitId);
-	});
-
-	const updatedCurrentSeries = branches[currentSeriesIndex];
-	if (!updatedCurrentSeries) return undefined;
-
-	// Put actorCommtId in its new position
-	if (targetCommitId === "top") {
-		updatedCurrentSeries.commitIds.unshift(actorCommitId);
-	} else {
-		const targetIndex = updatedCurrentSeries.commitIds.indexOf(targetCommitId);
-		updatedCurrentSeries.commitIds.splice(targetIndex + 1, 0, actorCommitId);
-	}
-
-	branches[currentSeriesIndex] = updatedCurrentSeries;
-
-	return {
-		series: branches,
-	};
-}
-
 function distanceBetweenDropzones(
 	allSeries: { name: string; commitIds: string[] }[],
 	actorDropzoneId: string,
@@ -190,4 +141,34 @@ function distanceBetweenDropzones(
 	const targetIndex = dropzoneIds.indexOf(targetDropzoneId);
 
 	return actorIndex - targetIndex;
+}
+
+function normalizeReferenceSubject(referenceName: string): string {
+	return referenceName.startsWith("refs/") ? referenceName : `refs/heads/${referenceName}`;
+}
+
+function toCommitMovePlacement(args: {
+	targetBranchName: string;
+	targetCommitId: string | "top";
+}): {
+	relativeTo: RelativeTo;
+	side: "above" | "below";
+} {
+	if (args.targetCommitId === "top") {
+		return {
+			relativeTo: {
+				type: "reference",
+				subject: normalizeReferenceSubject(args.targetBranchName),
+			},
+			side: "below",
+		};
+	}
+
+	return {
+		relativeTo: {
+			type: "commit",
+			subject: args.targetCommitId,
+		},
+		side: "below",
+	};
 }

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -19,7 +19,6 @@ import type {
 } from "$lib/stacks/stack";
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 import type {
-	StackOrder,
 	AbsorptionTarget,
 	CommitAbsorption,
 	StackDetails,
@@ -37,6 +36,8 @@ import type {
 	CommitInsertBlankResult,
 	RejectionReason,
 	CommitUndoResult,
+	InsertSide,
+	RelativeTo,
 } from "@gitbutler/but-sdk";
 
 export type BranchParams = {
@@ -128,16 +129,6 @@ export type CreateCommitOutcome = {
 	commitMapping: ReplacedCommit[];
 };
 
-export type RelativeTo =
-	| {
-			type: "commit";
-			subject: string;
-	  }
-	| {
-			type: "reference";
-			subject: string;
-	  };
-
 export function normalizeCreateCommitOutcome(response: CommitCreateResult): CreateCommitOutcome {
 	return {
 		newCommit: response.newCommit ?? null,
@@ -167,14 +158,15 @@ export function toCommitCreatePlacement(args: CreateCommitRequest): {
 	return {
 		relativeTo: {
 			type: "reference",
-			subject: args.stackBranchName.startsWith("refs/")
-				? args.stackBranchName
-				: `refs/heads/${args.stackBranchName}`,
+			subject: normalizeReferenceSubject(args.stackBranchName),
 		},
 		side: "below",
 	};
 }
 
+function normalizeReferenceSubject(referenceName: string): string {
+	return referenceName.startsWith("refs/") ? referenceName : `refs/heads/${referenceName}`;
+}
 // Entity adapters and selectors
 
 export const stackAdapter = createEntityAdapter<Stack, string>({
@@ -705,18 +697,21 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.BranchListing),
 			],
 		}),
-		reorderStack: build.mutation<
+		commitMove: build.mutation<
 			void,
-			{ projectId: string; stackId: string; stackOrder: StackOrder }
+			{
+				projectId: string;
+				subjectCommitIds: Array<string>;
+				relativeTo: RelativeTo;
+				side: InsertSide;
+				dryRun: boolean;
+			}
 		>({
 			extraOptions: {
-				command: "reorder_stack",
+				command: "commit_move",
 				actionName: "Reorder Stack",
 			},
 			query: (args) => args,
-			invalidatesTags: (_result, _error, args) => [
-				invalidatesItem(ReduxTag.StackDetails, args.stackId), // This is probably still needed
-			],
 		}),
 		moveCommit: build.mutation<
 			MoveCommitIllegalAction | null,

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -667,8 +667,8 @@ export class StackService {
 		return this.backendApi.endpoints.removeBranch.useMutation();
 	}
 
-	get reorderStack() {
-		return this.backendApi.endpoints.reorderStack.mutate;
+	get commitMove() {
+		return this.backendApi.endpoints.commitMove.mutate;
 	}
 
 	get moveCommit() {

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -1156,6 +1156,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         )
         .route("/commit_amend", but_post(commit::amend::commit_amend_cmd))
         .route(
+            "/commit_move",
+            but_post(commit::move_commit::commit_move_cmd),
+        )
+        .route(
             "/commit_move_changes_between",
             but_post(commit::move_changes::commit_move_changes_between_cmd),
         )

--- a/crates/gitbutler-tauri/permissions/default.toml
+++ b/crates/gitbutler-tauri/permissions/default.toml
@@ -49,6 +49,7 @@ commands.allow = [
   "commit_details",
   "commit_details_with_line_stats",
   "commit_insert_blank",
+  "commit_move",
   "commit_move_changes_between",
   "commit_reword",
   "commit_undo",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -539,6 +539,7 @@ fn main() -> anyhow::Result<()> {
                 commit::insert_blank::tauri_commit_insert_blank::commit_insert_blank,
                 commit::create::tauri_commit_create::commit_create,
                 commit::amend::tauri_commit_amend::commit_amend,
+                commit::move_commit::tauri_commit_move::commit_move,
                 commit::move_changes::tauri_commit_move_changes_between::commit_move_changes_between,
                 commit::uncommit::tauri_commit_uncommit_changes::commit_uncommit_changes,
                 commit::undo::tauri_commit_undo::commit_undo,


### PR DESCRIPTION
Note: it appears that commit_move is experiencing performance issues. That is to be addressed in a separate PR.

cc @estib-vega 