### PR TITLE
Add multi-commit selection, context menu actions, and drag-and-drop

### DIFF
--- a/apps/desktop/src/components/commit/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/commit/CommitContextMenu.svelte
@@ -12,6 +12,12 @@
 		stackId?: string;
 		onUncommitClick: (event: MouseEvent) => void;
 		onEditMessageClick: (event: MouseEvent) => void;
+		/** When set, indicates multiple commits are selected. */
+		multiSelect?: {
+			commitIds: string[];
+			onSquashSelected: () => void;
+			onUncommitSelected: () => void;
+		};
 	}
 
 	interface RemoteCommitContextData extends BaseContextData {
@@ -182,169 +188,208 @@
 	>
 		{#snippet contextMenu({ close })}
 			{@const { commitId, commitUrl, commitMessage } = contextData}
-			{#if contextData.commitStatus === "LocalAndRemote" || contextData.commitStatus === "LocalOnly"}
-				{@const { onUncommitClick, onEditMessageClick } = contextData}
+			{@const isLocal =
+				contextData.commitStatus === "LocalAndRemote" || contextData.commitStatus === "LocalOnly"}
+			{@const multiSelect = isLocal ? contextData.multiSelect : undefined}
+			{@const isMultiSelect = multiSelect && multiSelect.commitIds.length > 1}
+
+			{#if isLocal}
+				{#if isMultiSelect}
+					<!-- Multi-select actions -->
+					<ContextMenuSection>
+						<ContextMenuItem
+							label="Squash {multiSelect.commitIds.length} commits"
+							icon="commit-double-chevron-down"
+							testId={TestId.CommitRowContextMenu_SquashSelected}
+							disabled={isReadOnly}
+							onclick={() => {
+								if (!isReadOnly) {
+									multiSelect.onSquashSelected();
+									close();
+								}
+							}}
+						/>
+						<ContextMenuItem
+							label="Uncommit {multiSelect.commitIds.length} commits"
+							icon="undo"
+							testId={TestId.CommitRowContextMenu_UncommitSelected}
+							disabled={isReadOnly}
+							onclick={() => {
+								if (!isReadOnly) {
+									multiSelect.onUncommitSelected();
+									close();
+								}
+							}}
+						/>
+					</ContextMenuSection>
+				{:else}
+					<!-- Single-commit actions -->
+					{@const { onUncommitClick, onEditMessageClick } = contextData}
+					<ContextMenuSection>
+						<ContextMenuItem
+							label="Uncommit"
+							icon="undo"
+							testId={TestId.CommitRowContextMenu_UncommitMenuButton}
+							disabled={isReadOnly}
+							onclick={(e: MouseEvent) => {
+								if (!isReadOnly) {
+									onUncommitClick?.(e);
+									close();
+								}
+							}}
+						/>
+						<ContextMenuItem
+							label="Reword commit"
+							icon="edit"
+							testId={TestId.CommitRowContextMenu_EditMessageMenuButton}
+							disabled={isReadOnly}
+							onclick={(e: MouseEvent) => {
+								if (!isReadOnly) {
+									onEditMessageClick?.(e);
+									close();
+								}
+							}}
+						/>
+						<ContextMenuItem
+							label="Edit commit"
+							icon="commit-edit"
+							testId={TestId.CommitRowContextMenu_EditCommit}
+							disabled={isReadOnly}
+							onclick={async () => {
+								if (!isReadOnly && contextData.stackId) {
+									await handleEditPatch(commitId, contextData.stackId);
+									close();
+								}
+							}}
+						/>
+					</ContextMenuSection>
+				{/if}
+			{/if}
+
+			{#if !isMultiSelect}
+				<ContextMenuSection>
+					{#if commitUrl}
+						<ContextMenuItem
+							label="Open in browser"
+							icon="open-in-browser"
+							onclick={async () => {
+								await urlService.openExternalUrl(commitUrl);
+								close();
+							}}
+						/>
+					{/if}
+					<ContextMenuItemSubmenu label="Copy" icon="copy">
+						{#snippet submenu({ close: closeSubmenu })}
+							<ContextMenuSection>
+								{#if commitUrl}
+									<ContextMenuItem
+										label="Copy commit link"
+										onclick={() => {
+											clipboardService.write(commitUrl, { message: "Commit link copied" });
+											closeSubmenu();
+											close();
+										}}
+									/>
+								{/if}
+								<ContextMenuItem
+									label="Copy commit hash"
+									onclick={() => {
+										clipboardService.write(commitId, { message: "Commit hash copied" });
+										closeSubmenu();
+										close();
+									}}
+								/>
+								<ContextMenuItem
+									label="Copy commit message"
+									onclick={() => {
+										clipboardService.write(commitMessage, { message: "Commit message copied" });
+										closeSubmenu();
+										close();
+									}}
+								/>
+							</ContextMenuSection>
+						{/snippet}
+					</ContextMenuItemSubmenu>
+					{#if isLocal}
+						{@const stackId = contextData.stackId}
+
+						<ContextMenuItemSubmenu label="Add empty commit" icon="commit-plus">
+							{#snippet submenu({ close: closeSubmenu })}
+								<ContextMenuSection>
+									<ContextMenuItem
+										label="Add empty commit above"
+										disabled={isReadOnly || commitInsertion.current.isLoading}
+										onclick={() => {
+											insertBlankCommit(ensureValue(stackId), commitId, "above");
+											closeSubmenu();
+											close();
+										}}
+									/>
+									<ContextMenuItem
+										label="Add empty commit below"
+										disabled={isReadOnly || commitInsertion.current.isLoading}
+										onclick={() => {
+											insertBlankCommit(ensureValue(stackId), commitId, "below");
+											closeSubmenu();
+											close();
+										}}
+									/>
+								</ContextMenuSection>
+							{/snippet}
+						</ContextMenuItemSubmenu>
+						<ContextMenuItemSubmenu label="Create branch" icon="branch">
+							{#snippet submenu({ close: closeSubmenu })}
+								<ContextMenuSection>
+									<ContextMenuItem
+										label="Add branch above"
+										disabled={isReadOnly || refCreation.current.isLoading}
+										onclick={async () => {
+											if (!isReadOnly) {
+												await handleCreateNewRef(ensureValue(stackId), commitId, "Above");
+												closeSubmenu();
+												close();
+											}
+										}}
+									/>
+									<ContextMenuItem
+										label="Add branch below"
+										disabled={isReadOnly || refCreation.current.isLoading}
+										onclick={async () => {
+											if (!isReadOnly) {
+												await handleCreateNewRef(ensureValue(stackId), commitId, "Below");
+												closeSubmenu();
+												close();
+											}
+										}}
+									/>
+								</ContextMenuSection>
+							{/snippet}
+						</ContextMenuItemSubmenu>
+					{/if}
+				</ContextMenuSection>
+
+				{#if "stackId" in contextData && contextData.stackId}
+					{@const ctxStackId = contextData.stackId}
+					<IrcSendToSubmenus
+						{projectId}
+						disabled={sending}
+						onSend={(target) => sendCommitToChannel(target, commitId, commitMessage, ctxStackId)}
+						closeMenu={close}
+					/>
+				{/if}
+
 				<ContextMenuSection>
 					<ContextMenuItem
-						label="Uncommit"
-						icon="undo"
-						testId={TestId.CommitRowContextMenu_UncommitMenuButton}
-						disabled={isReadOnly}
-						onclick={(e: MouseEvent) => {
-							if (!isReadOnly) {
-								onUncommitClick?.(e);
-								close();
-							}
-						}}
-					/>
-					<ContextMenuItem
-						label="Reword commit"
-						icon="edit"
-						testId={TestId.CommitRowContextMenu_EditMessageMenuButton}
-						disabled={isReadOnly}
-						onclick={(e: MouseEvent) => {
-							if (!isReadOnly) {
-								onEditMessageClick?.(e);
-								close();
-							}
-						}}
-					/>
-					<ContextMenuItem
-						label="Edit commit"
-						icon="commit-edit"
-						testId={TestId.CommitRowContextMenu_EditCommit}
-						disabled={isReadOnly}
-						onclick={async () => {
-							if (!isReadOnly && contextData.stackId) {
-								await handleEditPatch(commitId, contextData.stackId);
-								close();
-							}
+						label={$rewrapCommitMessage ? "Show original wrapping" : "Rewrap message"}
+						icon="text-wrap"
+						disabled={commitInsertion.current.isLoading}
+						onclick={() => {
+							rewrapCommitMessage.set(!$rewrapCommitMessage);
+							close();
 						}}
 					/>
 				</ContextMenuSection>
 			{/if}
-			<ContextMenuSection>
-				{#if commitUrl}
-					<ContextMenuItem
-						label="Open in browser"
-						icon="open-in-browser"
-						onclick={async () => {
-							await urlService.openExternalUrl(commitUrl);
-							close();
-						}}
-					/>
-				{/if}
-				<ContextMenuItemSubmenu label="Copy" icon="copy">
-					{#snippet submenu({ close: closeSubmenu })}
-						<ContextMenuSection>
-							{#if commitUrl}
-								<ContextMenuItem
-									label="Copy commit link"
-									onclick={() => {
-										clipboardService.write(commitUrl, { message: "Commit link copied" });
-										closeSubmenu();
-										close();
-									}}
-								/>
-							{/if}
-							<ContextMenuItem
-								label="Copy commit hash"
-								onclick={() => {
-									clipboardService.write(commitId, { message: "Commit hash copied" });
-									closeSubmenu();
-									close();
-								}}
-							/>
-							<ContextMenuItem
-								label="Copy commit message"
-								onclick={() => {
-									clipboardService.write(commitMessage, { message: "Commit message copied" });
-									closeSubmenu();
-									close();
-								}}
-							/>
-						</ContextMenuSection>
-					{/snippet}
-				</ContextMenuItemSubmenu>
-				{#if contextData.commitStatus === "LocalAndRemote" || contextData.commitStatus === "LocalOnly"}
-					{@const stackId = contextData.stackId}
-
-					<ContextMenuItemSubmenu label="Add empty commit" icon="commit-plus">
-						{#snippet submenu({ close: closeSubmenu })}
-							<ContextMenuSection>
-								<ContextMenuItem
-									label="Add empty commit above"
-									disabled={isReadOnly || commitInsertion.current.isLoading}
-									onclick={() => {
-										insertBlankCommit(ensureValue(stackId), commitId, "above");
-										closeSubmenu();
-										close();
-									}}
-								/>
-								<ContextMenuItem
-									label="Add empty commit below"
-									disabled={isReadOnly || commitInsertion.current.isLoading}
-									onclick={() => {
-										insertBlankCommit(ensureValue(stackId), commitId, "below");
-										closeSubmenu();
-										close();
-									}}
-								/>
-							</ContextMenuSection>
-						{/snippet}
-					</ContextMenuItemSubmenu>
-					<ContextMenuItemSubmenu label="Create branch" icon="branch">
-						{#snippet submenu({ close: closeSubmenu })}
-							<ContextMenuSection>
-								<ContextMenuItem
-									label="Add branch above"
-									disabled={isReadOnly || refCreation.current.isLoading}
-									onclick={async () => {
-										if (!isReadOnly) {
-											await handleCreateNewRef(ensureValue(stackId), commitId, "Above");
-											closeSubmenu();
-											close();
-										}
-									}}
-								/>
-								<ContextMenuItem
-									label="Add branch below"
-									disabled={isReadOnly || refCreation.current.isLoading}
-									onclick={async () => {
-										if (!isReadOnly) {
-											await handleCreateNewRef(ensureValue(stackId), commitId, "Below");
-											closeSubmenu();
-											close();
-										}
-									}}
-								/>
-							</ContextMenuSection>
-						{/snippet}
-					</ContextMenuItemSubmenu>
-				{/if}
-			</ContextMenuSection>
-
-			{#if "stackId" in contextData && contextData.stackId}
-				{@const ctxStackId = contextData.stackId}
-				<IrcSendToSubmenus
-					{projectId}
-					disabled={sending}
-					onSend={(target) => sendCommitToChannel(target, commitId, commitMessage, ctxStackId)}
-					closeMenu={close}
-				/>
-			{/if}
-
-			<ContextMenuSection>
-				<ContextMenuItem
-					label={$rewrapCommitMessage ? "Show original wrapping" : "Rewrap message"}
-					icon="text-wrap"
-					disabled={commitInsertion.current.isLoading}
-					onclick={() => {
-						rewrapCommitMessage.set(!$rewrapCommitMessage);
-						close();
-					}}
-				/>
-			</ContextMenuSection>
 		{/snippet}
 	</KebabButton>
 {/if}

--- a/apps/desktop/src/components/commit/CommitListItem.svelte
+++ b/apps/desktop/src/components/commit/CommitListItem.svelte
@@ -23,6 +23,8 @@
 		lastCommit?: boolean;
 		lastBranch?: boolean;
 		selected?: boolean;
+		/** When true, expand the changed files panel. Defaults to `selected`. */
+		expandChangedFiles?: boolean;
 		opacity?: number;
 		borderTop?: boolean;
 		disableCommitActions?: boolean;
@@ -35,7 +37,7 @@
 		reactions?: Reaction[];
 		menu?: Snippet<[{ rightClickTrigger: HTMLElement }]>;
 		changedFiles?: Snippet;
-		onclick?: () => void;
+		onclick?: (event: MouseEvent) => void;
 	};
 
 	type RemoteStatusProps = {
@@ -75,6 +77,7 @@
 		lastCommit,
 		lastBranch,
 		selected,
+		expandChangedFiles,
 		opacity,
 		borderTop,
 		disabled,
@@ -89,6 +92,8 @@
 		changedFiles,
 		...args
 	}: Props = $props();
+
+	const shouldExpandFiles = $derived(expandChangedFiles ?? selected);
 
 	let container = $state<HTMLDivElement>();
 
@@ -126,7 +131,7 @@
 		class:disabled
 		{onclick}
 		use:focusable={{
-			onAction: () => onclick?.(),
+			onAction: () => onclick?.(new MouseEvent("click")),
 			focusable: true,
 		}}
 	>
@@ -226,7 +231,7 @@
 		</div>
 	</div>
 
-	{#if selected && changedFiles}
+	{#if shouldExpandFiles && changedFiles}
 		<div class="changed-files-container">
 			<CommitTimelineNode commitStatus={args.type} hideDot height="0.375rem" />
 			{@render changedFiles()}

--- a/apps/desktop/src/components/views/BranchCommitList.svelte
+++ b/apps/desktop/src/components/views/BranchCommitList.svelte
@@ -90,13 +90,89 @@
 		stackService.upstreamCommits(projectId, stackId, branchName),
 	);
 
-	async function handleCommitClick(commitId: string, upstream: boolean) {
+	/**
+	 * Returns a flat ordered list of all commit IDs in this branch
+	 * (upstream-only first, then local-and-remote), used for Shift+Click range selection.
+	 */
+	function getAllCommitIds(): string[] {
+		const ups = upstreamOnlyCommits.response ?? [];
+		const local = localAndRemoteCommits.response ?? [];
+		return [...ups.map((c) => c.id), ...local.map((c) => c.id)];
+	}
+
+	async function handleCommitClick(commitId: string, upstream: boolean, event?: MouseEvent) {
 		const currentSelection = controller.selection.current;
-		// Toggle: if this exact commit is already selected, clear the selection
-		if (currentSelection?.commitId === commitId && currentSelection?.branchName === branchName) {
-			controller.selection.set(undefined);
+		const isMetaKey = event?.metaKey || event?.ctrlKey;
+		const isShiftKey = event?.shiftKey;
+		const isSameBranch = currentSelection?.branchName === branchName;
+
+		if (isMetaKey) {
+			// Cmd/Ctrl+Click: toggle this commit in/out of multi-selection
+			if (!isSameBranch) {
+				// Clicking in a different branch — start fresh selection here
+				controller.selection.set({
+					branchName,
+					commitId,
+					commitIds: [commitId],
+					upstream,
+					previewOpen: true,
+				});
+			} else {
+				const currentIds = controller.selectedCommitIds;
+				const alreadySelected = currentIds.includes(commitId);
+
+				if (alreadySelected && currentIds.length === 1) {
+					// Deselecting the only selected commit — clear selection
+					controller.selection.set(undefined);
+				} else if (alreadySelected) {
+					const newIds = currentIds.filter((id) => id !== commitId);
+					const newPrimary = newIds[newIds.length - 1]!;
+					controller.selection.set({
+						branchName,
+						commitId: newPrimary,
+						commitIds: newIds,
+						upstream: currentSelection?.upstream ?? upstream,
+						previewOpen: true,
+					});
+				} else {
+					const newIds = [...currentIds, commitId];
+					controller.selection.set({
+						branchName,
+						commitId,
+						commitIds: newIds,
+						upstream,
+						previewOpen: true,
+					});
+				}
+			}
+		} else if (isShiftKey && currentSelection?.commitId && isSameBranch) {
+			// Shift+Click: range select from primary commit to this one
+			const allIds = getAllCommitIds();
+			const anchorIdx = allIds.indexOf(currentSelection.commitId);
+			const targetIdx = allIds.indexOf(commitId);
+
+			if (anchorIdx !== -1 && targetIdx !== -1) {
+				const start = Math.min(anchorIdx, targetIdx);
+				const end = Math.max(anchorIdx, targetIdx);
+				const rangeIds = allIds.slice(start, end + 1);
+				controller.selection.set({
+					branchName,
+					commitId,
+					commitIds: rangeIds,
+					upstream,
+					previewOpen: true,
+				});
+			} else {
+				// Fallback: just select this commit
+				controller.selection.set({ branchName, commitId, upstream, previewOpen: true });
+			}
 		} else {
-			controller.selection.set({ branchName, commitId, upstream, previewOpen: true });
+			// Regular click: toggle single commit (same as before)
+			if (currentSelection?.commitId === commitId && currentSelection?.branchName === branchName) {
+				controller.selection.set(undefined);
+			} else {
+				controller.selection.set({ branchName, commitId, upstream, previewOpen: true });
+			}
 		}
 		controller.clearWorktreeSelection();
 	}
@@ -110,6 +186,77 @@
 				commitId,
 			});
 		});
+	}
+
+	async function handleUncommitSelected(selectedIds?: string[]) {
+		const targetStackId = ensureValue(stackId);
+		const commitIds = selectedIds ?? controller.selectedCommitIds;
+		if (commitIds.length === 0) return;
+
+		// Uncommit from top to bottom so each undo removes a leaf commit.
+		// Filter to only IDs present in this branch to avoid invalid operations.
+		const allIds = getAllCommitIds();
+		const sorted = commitIds
+			.filter((id) => allIds.includes(id))
+			.sort((a, b) => allIds.indexOf(a) - allIds.indexOf(b));
+
+		await withStackBusy(uiState, projectId, { stackIds: [targetStackId] }, async () => {
+			for (const id of sorted) {
+				await stackService.uncommit({
+					projectId,
+					stackId: targetStackId,
+					commitId: id,
+				});
+			}
+		});
+		controller.selection.set(undefined);
+	}
+
+	async function handleSquashSelected(selectedIds?: string[]) {
+		const targetStackId = ensureValue(stackId);
+		const commitIds = selectedIds ?? controller.selectedCommitIds;
+
+		// Filter to only IDs present in this branch to avoid invalid operations.
+		const allIds = getAllCommitIds();
+		const sorted = commitIds
+			.filter((id) => allIds.includes(id))
+			.sort((a, b) => allIds.indexOf(a) - allIds.indexOf(b));
+		if (sorted.length < 2) return;
+		const targetCommitId = sorted[sorted.length - 1]!;
+		const sourceCommitIds = sorted.slice(0, -1);
+
+		await withStackBusy(uiState, projectId, { stackIds: [targetStackId] }, async () => {
+			await stackService.squashCommits({
+				projectId,
+				stackId: targetStackId,
+				sourceCommitIds,
+				targetCommitId,
+			});
+		});
+		controller.selection.set(undefined);
+	}
+
+	/**
+	 * When a commit is part of a multi-selection, build the allCommits array
+	 * for drag data. Returns undefined for single-commit drags.
+	 */
+	function getDragAllCommits(commitId: string): DzCommitData[] | undefined {
+		const selectedIds = controller.selectedCommitIds;
+		if (selectedIds.length <= 1 || !selectedIds.includes(commitId)) return undefined;
+
+		const allCommits = localAndRemoteCommits.response ?? [];
+		return selectedIds
+			.map((id) => {
+				const c = allCommits.find((c) => c.id === id);
+				if (!c) return undefined;
+				return {
+					id: c.id,
+					isRemote: isUpstreamCommit(c),
+					isIntegrated: isLocalAndRemoteCommit(c) && c.state.type === "Integrated",
+					hasConflicts: isLocalAndRemoteCommit(c) && c.hasConflicts,
+				} satisfies DzCommitData;
+			})
+			.filter((c): c is DzCommitData => c !== undefined);
 	}
 
 	function startEditingCommitMessage(commitId: string) {
@@ -154,7 +301,8 @@
 					{#each upstreamOnlyCommits as commit, i (commit.id)}
 						{@const first = i === 0}
 						{@const lastCommit = i === upstreamOnlyCommits.length - 1}
-						{@const selected = commit.id === selectedCommitId && branchName === selectedBranchName}
+						{@const selected =
+							controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
 						{@const commitId = commit.id}
 						{#if !controller.isCommitting}
 							<CommitListItem
@@ -168,9 +316,9 @@
 								{first}
 								{lastCommit}
 								{selected}
-								active={controller.active}
+								active={controller.active && commit.id === selectedCommitId}
 								reactions={commitReactions[commit.id]}
-								onclick={() => handleCommitClick(commit.id, true)}
+								onclick={(e) => handleCommitClick(commit.id, true, e)}
 								disableCommitActions={false}
 								editable={!!stackId}
 							/>
@@ -191,7 +339,8 @@
 				<LazyList items={localAndRemoteCommits} chunkSize={100}>
 					{#snippet template(commit, { first, last })}
 						{@const commitId = commit.id}
-						{@const selected = commit.id === selectedCommitId && branchName === selectedBranchName}
+						{@const selected =
+							controller.isCommitSelected(commit.id) && branchName === selectedBranchName}
 						{#if controller.isCommitting}
 							<!-- Only commits to the base can be `last`, see next `CommitPositionIndicator`. -->
 							<CommitPositionIndicator
@@ -262,6 +411,7 @@
 												},
 												false,
 												branchName,
+												getDragAllCommits(commitId),
 											)
 										: undefined,
 									dropzoneRegistry,
@@ -284,14 +434,22 @@
 									lastCommit={last}
 									{lastBranch}
 									{selected}
+									expandChangedFiles={commit.id === selectedCommitId &&
+										branchName === selectedBranchName &&
+										controller.selectedCommitIds.length <= 1}
 									{tooltip}
-									active={controller.active}
+									active={controller.active && commit.id === selectedCommitId}
 									reactions={commitReactions[commit.id]}
-									onclick={() => handleCommitClick(commit.id, false)}
+									onclick={(e) => handleCommitClick(commit.id, false, e)}
 									disableCommitActions={false}
 									editable={!!stackId}
 								>
 									{#snippet menu({ rightClickTrigger })}
+										{@const selectedIds = controller.selectedCommitIds}
+										{@const isMultiSelect =
+											selectedIds.length > 1 &&
+											branchName === selectedBranchName &&
+											selectedIds.includes(commitId)}
 										{@const data = {
 											stackId,
 											commitId,
@@ -300,6 +458,13 @@
 											commitUrl: forge.current.commitUrl(commitId),
 											onUncommitClick: () => handleUncommit(commit.id),
 											onEditMessageClick: () => startEditingCommitMessage(commit.id),
+											multiSelect: isMultiSelect
+												? {
+														commitIds: selectedIds,
+														onSquashSelected: () => handleSquashSelected(selectedIds),
+														onUncommitSelected: () => handleUncommitSelected(selectedIds),
+													}
+												: undefined,
 										}}
 										<CommitContextMenu
 											showOnHover

--- a/apps/desktop/src/lib/dragging/DragClone.svelte
+++ b/apps/desktop/src/lib/dragging/DragClone.svelte
@@ -77,7 +77,12 @@
 			commitType !== "Base"}
 		style:--commit-color={commitColor}
 	>
-		<div class="drag-animation-wrapper" class:activated={$dropLabel !== undefined}>
+		<div
+			class="drag-animation-wrapper"
+			class:activated={$dropLabel !== undefined}
+			class:commit-two={childrenAmount === 2}
+			class:commit-multiple={childrenAmount > 2}
+		>
 			{@render dropLabelSnippet({ label: $dropLabel, amount: childrenAmount })}
 			<div class="draggable-commit-indicator"></div>
 			<div class="truncate text-13 text-semibold draggable-commit-label">
@@ -374,6 +379,41 @@
 		height: 10px;
 		outline: 3px solid var(--bg-1);
 		background-color: var(--commit-color);
+	}
+
+	/* if dragging more than one commit */
+	.drag-animation-wrapper.commit-two::after,
+	.drag-animation-wrapper.commit-multiple::before,
+	.drag-animation-wrapper.commit-multiple::after {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		border: 1px solid var(--border-2);
+		border-radius: var(--radius-m);
+		background-color: var(--bg-1);
+		content: "";
+	}
+
+	.drag-animation-wrapper.commit-two {
+		&::after {
+			z-index: -1;
+			top: 6px;
+			left: 6px;
+		}
+	}
+
+	.drag-animation-wrapper.commit-multiple {
+		&::before {
+			z-index: -1;
+			top: 6px;
+			left: 6px;
+		}
+
+		&::after {
+			z-index: -2;
+			top: 12px;
+			left: 12px;
+		}
 	}
 
 	.draggable-commit-local {

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -1,6 +1,7 @@
 import { type CommitStatusType } from "$lib/commits/commit";
 import DragClone from "$lib/dragging/DragClone.svelte";
 import { FileChangeDropData, type DropData } from "$lib/dragging/draggables";
+import { CommitDropData } from "$lib/dragging/dropHandlers/commitDropHandler";
 import { pxToRem } from "@gitbutler/ui/utils/pxToRem";
 import { mount } from "svelte";
 import type { DropzoneRegistry } from "$lib/dragging/registry";
@@ -324,6 +325,17 @@ function setupDragHandlers(
 			}
 		}
 
+		// Handle multi-selection for commits
+		if (opts.data instanceof CommitDropData && opts.data.isMultiCommit) {
+			selectedElements = [];
+			for (const commit of opts.data.allCommits) {
+				const element = parentNode.querySelector(`[data-commit-id="${commit.id}"]`);
+				if (element) {
+					selectedElements.push(element);
+				}
+			}
+		}
+
 		if (selectedElements.length === 0) {
 			selectedElements = [node];
 		}
@@ -550,10 +562,12 @@ export function draggableBranch(node: HTMLElement, initialOpts: DraggableConfig)
 export function draggableCommitV3(node: HTMLElement, initialOpts: DraggableConfig) {
 	function createClone(opts: DraggableConfig) {
 		if (opts.disabled) return;
+		const commitData = opts.data instanceof CommitDropData ? opts.data : undefined;
 		return createSvelteDragClone({
 			type: "commit",
 			commitType: opts.commitType,
 			label: opts.label,
+			childrenAmount: commitData?.allCommits.length,
 			dragStateService: opts.dragStateService,
 		});
 	}

--- a/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
+++ b/apps/desktop/src/lib/dragging/dropHandlers/commitDropHandler.ts
@@ -30,12 +30,22 @@ export type DzCommitData = {
 
 /** Details about a commit that can be dropped into a drop zone. */
 export class CommitDropData {
+	/** All commits being dragged (for multi-select). Defaults to just `[commit]`. */
+	readonly allCommits: DzCommitData[];
+
 	constructor(
 		readonly stackId: string,
 		readonly commit: DzCommitData,
 		readonly isHeadCommit: boolean,
 		readonly branchName?: string,
-	) {}
+		allCommits?: DzCommitData[],
+	) {
+		this.allCommits = allCommits && allCommits.length > 0 ? allCommits : [commit];
+	}
+
+	get isMultiCommit(): boolean {
+		return this.allCommits.length > 1;
+	}
 }
 
 /** Handler that can move commits between stacks. */
@@ -50,7 +60,10 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 
 	accepts(data: unknown): boolean {
 		return (
-			data instanceof CommitDropData && data.stackId !== this.stackId && !data.commit.hasConflicts
+			data instanceof CommitDropData &&
+			!data.isMultiCommit &&
+			data.stackId !== this.stackId &&
+			!data.commit.hasConflicts
 		);
 	}
 
@@ -448,8 +461,11 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 		if (!(data instanceof CommitDropData)) return false;
 		if (data.stackId !== stackId) return false;
 
-		if (commit.hasConflicts || data.commit.hasConflicts) return false;
-		if (commit.id === data.commit.id) return false;
+		if (commit.hasConflicts) return false;
+		if (data.allCommits.some((c) => c.hasConflicts)) return false;
+
+		// Don't show dropzone on any of the commits being dragged
+		if (data.allCommits.some((c) => c.id === commit.id)) return false;
 
 		return true;
 	}
@@ -457,6 +473,9 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 	async ondrop(data: unknown) {
 		const { projectId, stackId, commit } = this.args;
 		if (data instanceof CommitDropData) {
+			const sourceCommitIds = data.allCommits.map((c) => c.id).filter((id) => id !== commit.id);
+			if (sourceCommitIds.length === 0) return;
+
 			await withStackBusy(
 				this.uiState,
 				projectId,
@@ -465,7 +484,7 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 					await this.stackService.squashCommits({
 						projectId,
 						stackId,
-						sourceCommitIds: [data.commit.id],
+						sourceCommitIds,
 						targetCommitId: commit.id,
 					});
 				},

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -18,6 +18,7 @@ export class ReorderCommitDzHandler implements DropzoneHandler {
 
 	accepts(data: unknown) {
 		if (!(data instanceof CommitDropData)) return false;
+		if (data.isMultiCommit) return false;
 		if (data.stackId !== this.branchId) return false;
 
 		// Do not show dropzones directly above or below the commit in question

--- a/apps/desktop/src/lib/stacks/stackController.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackController.svelte.ts
@@ -116,6 +116,18 @@ export class StackController {
 		return this.selection.current?.commitId;
 	}
 
+	/** All selected commit IDs. Falls back to `[commitId]` when multi-select isn't active. */
+	get selectedCommitIds(): string[] {
+		const sel = this.selection.current;
+		if (sel?.commitIds && sel.commitIds.length > 0) return sel.commitIds;
+		if (sel?.commitId) return [sel.commitId];
+		return [];
+	}
+
+	isCommitSelected(commitId: string): boolean {
+		return this.selectedCommitIds.includes(commitId);
+	}
+
 	get branchName(): string | undefined {
 		return this.selection.current?.branchName;
 	}

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -36,7 +36,10 @@ export type RejectionReason =
 
 export type StackSelection = {
 	branchName?: string;
+	/** The primary selected commit (drives the preview pane). */
 	commitId?: string;
+	/** All selected commit IDs (for multi-select). When undefined, only `commitId` is selected. */
+	commitIds?: string[];
 	upstream?: boolean;
 	previewOpen: boolean;
 	codegen?: boolean;

--- a/e2e/playwright/tests/multiCommitSelection.spec.ts
+++ b/e2e/playwright/tests/multiCommitSelection.spec.ts
@@ -1,0 +1,309 @@
+import { getBaseURL, type GitButler, startGitButler } from "../src/setup.ts";
+import { test } from "../src/test.ts";
+import { getByTestId, waitForElementToStabilize, waitForTestId } from "../src/util.ts";
+import { expect, type Page } from "@playwright/test";
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL(),
+});
+
+test.afterEach(async () => {
+	await gitbutler?.destroy();
+});
+
+/**
+ * Set up a workspace with branch1 applied (4 commits from project-with-stacks).
+ */
+async function setupWorkspaceWithCommits(page: Page, context: any, testInfo: any) {
+	const workdir = testInfo.outputPath("workdir");
+	const configdir = testInfo.outputPath("config");
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript("project-with-stacks.sh");
+	await gitbutler.runScript("apply-upstream-branch.sh", ["branch1", "local-clone"]);
+
+	await page.goto("/");
+	await waitForTestId(page, "workspace-view");
+
+	// Verify we have our expected commits
+	const commits = getByTestId(page, "commit-row");
+	await expect(commits).toHaveCount(4);
+}
+
+/**
+ * Get the modifier key for multi-select (Meta on macOS, Control elsewhere).
+ */
+function getModifierKey(): "Meta" | "Control" {
+	return process.platform === "darwin" ? "Meta" : "Control";
+}
+
+test("should select multiple commits with Cmd/Ctrl+Click", async ({ page, context }, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const thirdCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: third commit",
+	});
+
+	// Click the first commit to select it
+	await firstCommit.click();
+
+	// Verify the commit drawer opens for the first commit
+	const drawer = getByTestId(page, "commit-drawer");
+	await expect(drawer).toBeVisible();
+
+	// Cmd/Ctrl+Click the third commit to add it to selection
+	const modKey = getModifierKey();
+	await thirdCommit.click({ modifiers: [modKey] });
+
+	// Both commits should have the selected visual state
+	await expect(firstCommit).toHaveClass(/\bselected\b/);
+	await expect(thirdCommit).toHaveClass(/\bselected\b/);
+
+	// The second commit should NOT be selected
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+	await expect(secondCommit).not.toHaveClass(/\bselected\b/);
+});
+
+test("should select a range of commits with Shift+Click", async ({ page, context }, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const fourthCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: fourth commit",
+	});
+
+	// Click the fourth commit (top of list) to select it
+	await fourthCommit.click();
+
+	// Shift+Click the first commit to select the range
+	await firstCommit.click({ modifiers: ["Shift"] });
+
+	// All four commits should be selected
+	const allCommits = getByTestId(page, "commit-row");
+	const count = await allCommits.count();
+	for (let i = 0; i < count; i++) {
+		await expect(allCommits.nth(i)).toHaveClass(/\bselected\b/);
+	}
+});
+
+test("should toggle individual commits with Cmd/Ctrl+Click", async ({
+	page,
+	context,
+}, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+
+	const modKey = getModifierKey();
+
+	// Click to select first commit
+	await firstCommit.click();
+	await expect(firstCommit).toHaveClass(/\bselected\b/);
+
+	// Cmd/Ctrl+Click to add second commit
+	await secondCommit.click({ modifiers: [modKey] });
+	await expect(firstCommit).toHaveClass(/\bselected\b/);
+	await expect(secondCommit).toHaveClass(/\bselected\b/);
+
+	// Cmd/Ctrl+Click first commit again to deselect it
+	await firstCommit.click({ modifiers: [modKey] });
+	await expect(firstCommit).not.toHaveClass(/\bselected\b/);
+	await expect(secondCommit).toHaveClass(/\bselected\b/);
+});
+
+test("should show multi-select context menu with squash and uncommit", async ({
+	page,
+	context,
+}, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+
+	const modKey = getModifierKey();
+
+	// Select two commits
+	await firstCommit.click();
+	await secondCommit.click({ modifiers: [modKey] });
+
+	// Right-click a selected commit row to open the multi-select context menu
+	await firstCommit.click({ button: "right" });
+
+	// Wait for context menu to stabilize
+	const squashItem = await waitForTestId(page, "commit-row-context-menu-squash-selected");
+	await waitForElementToStabilize(page, squashItem);
+
+	// Verify multi-select menu items are visible
+	await expect(squashItem).toBeVisible();
+	await expect(squashItem).toContainText("Squash 2 commits");
+
+	const uncommitItem = getByTestId(page, "commit-row-context-menu-uncommit-selected");
+	await expect(uncommitItem).toBeVisible();
+	await expect(uncommitItem).toContainText("Uncommit 2 commits");
+
+	// Single-commit items should NOT be visible
+	const editMessageBtn = page.getByTestId("commit-row-context-menu-edit-message-menu-btn");
+	await expect(editMessageBtn).toHaveCount(0);
+
+	const editCommitBtn = page.getByTestId("commit-row-context-menu-edit-commit");
+	await expect(editCommitBtn).toHaveCount(0);
+});
+
+test("should collapse changed files when multiple commits are selected", async ({
+	page,
+	context,
+}, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+
+	// Click first commit — changed files should be visible
+	await firstCommit.click();
+
+	// Verify changed files are shown for the selected commit
+	const changedFilesContainer = page.locator(".changed-files-container");
+	await expect(changedFilesContainer).toBeVisible();
+
+	// Now Cmd/Ctrl+Click to add second commit
+	const modKey = getModifierKey();
+	await secondCommit.click({ modifiers: [modKey] });
+
+	// Changed files container should no longer be visible
+	await expect(changedFilesContainer).not.toBeVisible();
+});
+
+test("should squash 3 selected commits via context menu", async ({ page, context }, testInfo) => {
+	test.setTimeout(120_000);
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+	const thirdCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: third commit",
+	});
+	const fourthCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: fourth commit",
+	});
+
+	const modKey = getModifierKey();
+
+	// Select three commits
+	await secondCommit.click();
+	await thirdCommit.click({ modifiers: [modKey] });
+	await fourthCommit.click({ modifiers: [modKey] });
+
+	// Right-click a selected commit row to open the multi-select context menu
+	await secondCommit.click({ button: "right" });
+
+	const squashItem = await waitForTestId(page, "commit-row-context-menu-squash-selected");
+	await waitForElementToStabilize(page, squashItem);
+	await expect(squashItem).toContainText("Squash 3 commits");
+	await squashItem.click();
+
+	// After squashing, the branch should show an upstream divergence section
+	// because local history changed. The "Upstream has new commits" indicator confirms
+	// the squash was successful.
+	const upstreamSection = page.locator("text=Upstream has new commits");
+	await expect(upstreamSection).toBeVisible({ timeout: 15_000 });
+
+	// The first commit should still be present (it was not part of the squash)
+	const remainingFirst = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	await expect(remainingFirst).toBeVisible();
+});
+
+test("should uncommit 3 selected commits via context menu", async ({ page, context }, testInfo) => {
+	test.setTimeout(120_000);
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+	const thirdCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: third commit",
+	});
+	const fourthCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: fourth commit",
+	});
+
+	const modKey = getModifierKey();
+
+	// Select the top three commits
+	await fourthCommit.click();
+	await thirdCommit.click({ modifiers: [modKey] });
+	await secondCommit.click({ modifiers: [modKey] });
+
+	// Right-click a selected commit row to open the multi-select context menu
+	await fourthCommit.click({ button: "right" });
+
+	const uncommitItem = await waitForTestId(page, "commit-row-context-menu-uncommit-selected");
+	await waitForElementToStabilize(page, uncommitItem);
+	await expect(uncommitItem).toContainText("Uncommit 3 commits");
+	await uncommitItem.click();
+
+	// After uncommitting, the uncommitted changes should contain the files
+	const uncommittedHeader = getByTestId(page, "uncommitted-changes-header");
+	await expect(uncommittedHeader).toBeVisible({ timeout: 15_000 });
+
+	// The first commit should still exist (it was not selected)
+	const remainingFirst = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	await expect(remainingFirst).toBeVisible();
+});
+
+test("should deselect all when clicking a commit without modifier", async ({
+	page,
+	context,
+}, testInfo) => {
+	await setupWorkspaceWithCommits(page, context, testInfo);
+
+	const firstCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: first commit",
+	});
+	const secondCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: second commit",
+	});
+	const thirdCommit = getByTestId(page, "commit-row").filter({
+		hasText: "branch1: third commit",
+	});
+
+	const modKey = getModifierKey();
+
+	// Select multiple commits
+	await firstCommit.click();
+	await secondCommit.click({ modifiers: [modKey] });
+	await expect(firstCommit).toHaveClass(/\bselected\b/);
+	await expect(secondCommit).toHaveClass(/\bselected\b/);
+
+	// Plain click on third commit should deselect everything and select only third
+	await thirdCommit.click();
+	await expect(thirdCommit).toHaveClass(/\bselected\b/);
+	await expect(firstCommit).not.toHaveClass(/\bselected\b/);
+	await expect(secondCommit).not.toHaveClass(/\bselected\b/);
+});

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -46,6 +46,8 @@ export enum TestId {
 	CommitRowContextMenu_UncommitMenuButton = "commit-row-context-menu-uncommit-menu-btn",
 	CommitRowContextMenu_EditMessageMenuButton = "commit-row-context-menu-edit-message-menu-btn",
 	CommitRowContextMenu_EditCommit = "commit-row-context-menu-edit-commit",
+	CommitRowContextMenu_SquashSelected = "commit-row-context-menu-squash-selected",
+	CommitRowContextMenu_UncommitSelected = "commit-row-context-menu-uncommit-selected",
 	NewCommitView = "new-commit-view",
 	StackDraft = "draft-stack",
 	YourCommitGoesHere = "your-commit-goes-here",


### PR DESCRIPTION
## Summary

- Adds multi-commit selection via Cmd/Ctrl+Click (toggle) and Shift+Click (range) in commit lists
- Selection is scoped to a single branch — cross-branch clicks reset to a fresh selection, and batch operations filter to valid commit IDs
- Adapts commit context menu to show batch "Squash N commits" and "Uncommit N commits" when multiple commits are selected, hiding single-commit-only options (reword, edit)
- Context menu multi-select actions are gated on branch membership and commit inclusion
- Extends drag-and-drop to support multi-commit drags with stacked card visuals, disabling reorder/move dropzones while allowing squash targets
- Collapses changed files panel when multiple commits are selected
- Adds Playwright e2e tests for selection mechanics, context menu adaptation, file collapse, and batch squash/uncommit operations

## E2E test coverage (`multiCommitSelection.spec.ts`)

| Test | What it verifies |
|------|-----------------|
| Cmd/Ctrl+Click selection | Non-contiguous multi-select; unselected commits don't get `.selected` class |
| Shift+Click range | Selects all 4 commits between anchor and target |
| Toggle with Cmd/Ctrl+Click | Add then remove individual commits; selection state updates correctly |
| Multi-select context menu | "Squash 2 commits" and "Uncommit 2 commits" appear; reword/edit hidden |
| Collapse changed files | File list visible for single select, collapses on multi-select |
| Squash 3 commits | Squash executes via context menu; upstream divergence confirms rewrite; first commit preserved |
| Uncommit 3 commits | Uncommit executes via context menu; uncommitted changes header appears; first commit preserved |
| Deselect on plain click | Plain click resets multi-selection to single commit |

## Test plan

- [x] Cmd/Ctrl+Click toggles individual commits in/out of selection
- [x] Cmd/Ctrl+Click in a different branch resets to fresh selection
- [x] Shift+Click selects a contiguous range (same branch only)
- [x] Plain click resets to single selection
- [x] Context menu shows "Squash N commits" / "Uncommit N commits" for multi-select
- [x] Context menu hides reword/edit options during multi-select
- [x] Changed files panel collapses when multiple commits selected
- [x] Squash 3 selected commits via context menu
- [x] Uncommit 3 selected commits via context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)